### PR TITLE
Adding an undefined check on new_distinct_id for identify events

### DIFF
--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -900,6 +900,12 @@ PostHogLib.prototype.identify = function(
     //  _set_callback:function  A callback to be run if and when the People set queue is flushed
     //  _set_once_callback:function  A callback to be run if and when the People set_once queue is flushed
 
+    //if the new_distinct_id has not been set ignore the identify event
+    if (!new_distinct_id) {
+        console.error('Unique user id has not been set in posthog.identify')
+        return;
+    }
+
     var previous_distinct_id = this.get_distinct_id();
     this.register({'$user_id': new_distinct_id});
 


### PR DESCRIPTION
We noticed that if we don't set the user id in the `posthog.identify` call, then all the affected user ids get merged under the `None` distinct ID

This took a while to debug from our side. So this issue hopefully addresses 2 things. Ignores undefined user ids and warns the user via console.error

Some additional context here -> https://github.com/PostHog/posthog/issues/876