### PR TITLE
Posthog Toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+## 1.1.0 - 2020-06-04
+- Support loading new PostHog toolbar
+
+## 1.0.6 - 2020-03-09
+- Send beacon on $pageleave
+- Clean up a bunch of code
+- Don't reset device id on reset
+
+## 1.0.4 - 2020-03-04
+- Fix Heroku App Cookie Bug
+- Batch Event Posts
+- Support TurboLinks
+- Send Timestamp with events
+
+## 1.0.0 - 2020-02-20
+First Release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "posthog-js",
-  "version": "1.0.6",
+  "name": "@mariusandra/posthog-js",
+  "version": "1.1.0-beta.2",
   "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
   "repository": "https://github.com/PostHog/posthog-js",
   "author": "hey@posthog.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mariusandra/posthog-js",
-  "version": "1.1.0-beta.3",
+  "version": "1.1.0-beta.4",
   "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
   "repository": "https://github.com/PostHog/posthog-js",
   "author": "hey@posthog.com",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mariusandra/posthog-js",
+  "name": "posthog-js",
   "version": "1.1.0-beta.4",
   "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
   "repository": "https://github.com/PostHog/posthog-js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mariusandra/posthog-js",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
   "repository": "https://github.com/PostHog/posthog-js",
   "author": "hey@posthog.com",

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -221,7 +221,7 @@ var autocapture = {
 
         if (!this._maybeLoadEditor(instance)) { // don't autocapture actions when the editor is enabled
             var parseDecideResponse = _.bind(function(response) {
-                if(response['is_authenticated']) {
+                if(response['is_authenticated'] && response['toolbarVersion'].indexOf('toolbar') === 0) {
                     this._loadEditor(instance, {
                         apiURL: instance.get_config('api_host'),
                         jsURL: response['jsURL'] || instance.get_config('api_host'),

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -222,7 +222,7 @@ var autocapture = {
         if (!this._maybeLoadEditor(instance)) { // don't autocapture actions when the editor is enabled
             var parseDecideResponse = _.bind(function(response) {
                 if(response['is_authenticated']) {
-                    this._loadEditor(instance, {apiURL: instance.get_config('api_host')})
+                    this._loadEditor(instance, {apiURL: instance.get_config('api_host'), jsURL: response['jsURL'] || instance.get_config('api_host')})
                     instance.set_config({debug: true})
                 }
                 if (response && response['config'] && response['config']['enable_collect_everything'] === true) {
@@ -263,6 +263,7 @@ var autocapture = {
                 'actionId': state['actionId'],
                 'projectToken': state['token'],
                 'apiURL': state['apiURL'],
+                'jsURL': state['jsURL'] || state['apiURL'],
                 'temporaryToken': state['temporaryToken']
             };
             window.sessionStorage.setItem('editorParams', JSON.stringify(editorParams));
@@ -322,8 +323,9 @@ var autocapture = {
         var _this = this;
         if (!window['_mpEditorLoaded']) { // only load the codeless event editor once, even if there are multiple instances of PostHogLib
             window['_mpEditorLoaded'] = true;
-            var editorUrl = instance.get_config('api_host')
-              + '/static/editor.js?_ts='
+            var host = (editorParams['jsURL'] || editorParams['apiURL'] || instance.get_config('api_host'))
+            var editorUrl = host + (host.endsWith('/') ? '' : '/')
+              + 'static/editor.js?_ts='
               + (new Date()).getTime();
             this._loadScript(editorUrl, function() {
                 window['ph_load_editor'](editorParams);

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -221,7 +221,7 @@ var autocapture = {
 
         if (!this._maybeLoadEditor(instance)) { // don't autocapture actions when the editor is enabled
             var parseDecideResponse = _.bind(function(response) {
-                if(response['is_authenticated'] && response['toolbarVersion'].indexOf('toolbar') === 0) {
+                if(response['isAuthenticated'] && response['toolbarVersion'].indexOf('toolbar') === 0) {
                     this._loadEditor(instance, {
                         apiURL: instance.get_config('api_host'),
                         jsURL: response['jsURL'] || instance.get_config('api_host'),

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -222,7 +222,11 @@ var autocapture = {
         if (!this._maybeLoadEditor(instance)) { // don't autocapture actions when the editor is enabled
             var parseDecideResponse = _.bind(function(response) {
                 if(response['is_authenticated']) {
-                    this._loadEditor(instance, {apiURL: instance.get_config('api_host'), jsURL: response['jsURL'] || instance.get_config('api_host')})
+                    this._loadEditor(instance, {
+                        apiURL: instance.get_config('api_host'),
+                        jsURL: response['jsURL'] || instance.get_config('api_host'),
+                        toolbarVersion: response['toolbarVersion']
+                    })
                     instance.set_config({debug: true})
                 }
                 if (response && response['config'] && response['config']['enable_collect_everything'] === true) {
@@ -264,6 +268,7 @@ var autocapture = {
                 'projectToken': state['token'],
                 'apiURL': state['apiURL'],
                 'jsURL': state['jsURL'] || state['apiURL'],
+                'toolbarVersion': state['toolbarVersion'],
                 'temporaryToken': state['temporaryToken']
             };
             window.sessionStorage.setItem('editorParams', JSON.stringify(editorParams));
@@ -324,9 +329,9 @@ var autocapture = {
         if (!window['_mpEditorLoaded']) { // only load the codeless event editor once, even if there are multiple instances of PostHogLib
             window['_mpEditorLoaded'] = true;
             var host = (editorParams['jsURL'] || editorParams['apiURL'] || instance.get_config('api_host'))
+            var toolbarScript = editorParams['toolbarVersion'].indexOf('toolbar') === 0 ? 'toolbar.js' : 'editor.js'
             var editorUrl = host + (host.endsWith('/') ? '' : '/')
-              + 'static/editor.js?_ts='
-              + (new Date()).getTime();
+              + 'static/' + toolbarScript + '?_ts=' + (new Date()).getTime();
             this._loadScript(editorUrl, function() {
                 window['ph_load_editor'](editorParams);
             });

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -221,6 +221,10 @@ var autocapture = {
 
         if (!this._maybeLoadEditor(instance)) { // don't autocapture actions when the editor is enabled
             var parseDecideResponse = _.bind(function(response) {
+                if(response['is_authenticated']) {
+                    this._loadEditor(instance, {apiURL: instance.get_config('api_host')})
+                    instance.set_config({debug: true})
+                }
                 if (response && response['config'] && response['config']['enable_collect_everything'] === true) {
 
                     if (response['custom_properties']) {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -366,7 +366,6 @@ PostHogLib.prototype._event_queue_poll = function () {
                 _.each(data, function(value, key) {
                     data[key]['offset'] = Math.abs(data[key]['timestamp'] - new Date());
                     delete data[key]['timestamp'];
-                    console.log(data[key])
                 })
                 var json_data = _.JSONEncode(data);
                 var encoded_data = _.base64Encode(json_data);

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -889,7 +889,6 @@ PostHogLib.prototype._register_single = function(prop, value) {
  * at the same time can cause a race condition, so it is best
  * practice to call identify on the original, anonymous ID
  * right after you've aliased it.
- * <a href="https://posthog.com/help/questions/articles/how-should-i-handle-my-user-identity-with-the-posthog-javascript-library">Learn more about how posthog.identify and posthog.alias can be used</a>.
  *
  * @param {String} [unique_id] A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.
  */

--- a/src/posthog-people.js
+++ b/src/posthog-people.js
@@ -124,9 +124,6 @@ PostHogPeople.prototype._send_request = function(data, callback) {
         return truncated_data;
     }
 
-    console.log('POSTHOG PEOPLE REQUEST:');
-    console.log(truncated_data);
-
     this._posthog._send_request(
         this._get_config('api_host') + '/engage/',
         {'data': encoded_data},

--- a/src/posthog-persistence.js
+++ b/src/posthog-persistence.js
@@ -326,9 +326,6 @@ PostHogPersistence.prototype._add_to_people_queue = function(queue, data) {
         });
     }
 
-    console.log('POSTHOG PEOPLE REQUEST (QUEUED, PENDING IDENTIFY):');
-    console.log(data);
-
     this.save();
 };
 


### PR DESCRIPTION
This adds supports for launching the new posthog toolbar.js when `toolbarVersion` starts with `toolbar` (and in the future `toolbar.v1` or so). Also adds `jsURL` for enabling HMR support.

I'd release 1.1.0 once this is in.

Also, I noticed that posthog-js is quite noisy. Printing error messages I get, yet some of these `console.log`s here are for sure leftover debug statements:

![image](https://user-images.githubusercontent.com/53387/83739005-4fd4d280-a655-11ea-8d39-2cde64034839.png)

I'd remove them before pushing out 1.1.0. @timgl any opinion?