### PR TITLE
Allow properties on anonymous users

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -3,4 +3,5 @@
     posthog.init('sTMFPsFhdP1Ssg', {api_host: 'http://127.0.0.1:8000', debug: true})
 </script>
 <h2>Demo site</h2>
-<button>Here's a button you could click if you want to</button>
+<button>Here's a button you could click if you want to</button><br /><br />
+<a href='https://posthog.com'>Here's a link to the outside world</a>

--- a/src/posthog-people.js
+++ b/src/posthog-people.js
@@ -112,18 +112,6 @@ PostHogPeople.prototype._send_request = function(data, callback) {
     var json_data         = _.JSONEncode(date_encoded_data);
     var encoded_data      = _.base64Encode(json_data);
 
-    if (!this._identify_called()) {
-        this._enqueue(data);
-        if (!_.isUndefined(callback)) {
-            if (this._get_config('verbose')) {
-                callback({status: -1, error: null});
-            } else {
-                callback(-1);
-            }
-        }
-        return truncated_data;
-    }
-
     this._posthog._send_request(
         this._get_config('api_host') + '/engage/',
         {'data': encoded_data},


### PR DESCRIPTION
This will allow you to call `people.set()` at any time, even on anonymous users.

@mariusandra, I'm not sure whether this is going to cause race conditions in capture.py. I don't *think* so...