### PR TITLE
44 remove event batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.2 - 2020-06-15
+- Allow setting properties on anonymous users
+
 ## 1.2.1 - 2020-06-09
 - Simplify passing of API token to editor
 

--- a/demo.html
+++ b/demo.html
@@ -4,4 +4,24 @@
 </script>
 <h2>Demo site</h2>
 <button>Here's a button you could click if you want to</button><br /><br />
-<a href='https://posthog.com'>Here's a link to the outside world</a>
+<body class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+    <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
+        <a href='https://posthog.com'>Here's a link to the outside world</a>
+    </div>
+
+</body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-js",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
   "repository": "https://github.com/PostHog/posthog-js",
   "author": "hey@posthog.com",

--- a/src/autocapture-utils.js
+++ b/src/autocapture-utils.js
@@ -42,7 +42,7 @@ export function getSafeText(el) {
         });
     }
 
-    return _.trim(elText);
+    return _.trim(elText).substring(0, 400);
 }
 
 /*

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1415,7 +1415,6 @@ var add_dom_loaded_handler = function() {
         dom_loaded_handler.done = true;
 
         DOM_LOADED = true;
-        ENQUEUE_REQUESTS = false;
 
         _.each(instances, function(inst) {
             inst._dom_loaded();

--- a/src/posthog-people.js
+++ b/src/posthog-people.js
@@ -129,17 +129,6 @@ PostHogPeople.prototype._identify_called = function() {
     return this._posthog._flags.identify_called === true;
 };
 
-// Queue up engage operations if identify hasn't been called yet.
-PostHogPeople.prototype._enqueue = function(data) {
-    if (SET_ACTION in data) {
-        this._posthog['persistence']._add_to_people_queue(SET_ACTION, data);
-    } else if (SET_ONCE_ACTION in data) {
-        this._posthog['persistence']._add_to_people_queue(SET_ONCE_ACTION, data);
-    } else {
-        console.error('Invalid call to _enqueue():', data);
-    }
-};
-
 PostHogPeople.prototype._flush_one_queue = function(action, action_method, callback, queue_to_params_fn) {
     var _this = this;
     var queued_data = _.extend({}, this._posthog['persistence']._get_queue(action));


### PR DESCRIPTION
We introduced batching a while ago, with the intent of decreasing the number of requests being sent out from PostHog.

Looking back, I'm not sure that was ever a real problem. However, batching definitely causes us to lose a lot of clicks on buttons, and definitely makes us lose a lot of $pageleave events (see [our sessions](https://app.posthog.com/sessions) for example, lots of sessions with just a $pageview, but no $pageleave event).

This PR removes batching. Thoughts? This needs to be QA'd quite thoroughly 