### PR TITLE
LZ-String compression

### DIFF
--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -829,7 +829,7 @@ describe('Autocapture system', () => {
         })
 
         it('should NOT call _addDomEventHandlders when enable_collect_everything is "false"', () => {
-            lib._send_request = sandbox.spy((url, params, callback) =>
+            lib._send_request = sandbox.spy((url, params, options, callback) =>
                 callback({ config: { enable_collect_everything: false } })
             )
             autocapture.init(lib)

--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -1,0 +1,50 @@
+import sinon from 'sinon'
+import { autocapture } from '../autocapture'
+
+describe('Payload Compression', () => {
+    afterEach(() => {
+        document.getElementsByTagName('html')[0].innerHTML = ''
+    })
+
+    describe('compression', () => {
+        let lib, sandbox
+
+        beforeEach(() => {
+            document.title = 'test page'
+            sandbox = sinon.createSandbox()
+            autocapture._initializedTokens = []
+            lib = {
+                debug: true,
+                _prepare_callback: sandbox.spy((callback) => callback),
+                _send_request: sandbox.spy((url, params, options, callback) => {
+                    if (url === 'https://test.com/decide/') {
+                        callback({ config: { enable_collect_everything: true }, supportedCompression: ['lz64'] })
+                    } else {
+                        console.log('would be great to get here!')
+                    }
+                }),
+                get_config: sandbox.spy(function (key) {
+                    switch (key) {
+                        case 'api_host':
+                            return 'https://test.com'
+                        case 'token':
+                            return 'testtoken'
+                    }
+                }),
+                token: 'testtoken',
+                get_distinct_id() {
+                    return 'distinctid'
+                },
+            }
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('should save supported compression in instance', () => {
+            autocapture.init(lib)
+            expect(lib.compression).toEqual({ lz64: true })
+        })
+    })
+})

--- a/src/__tests__/gdpr-utils.js
+++ b/src/__tests__/gdpr-utils.js
@@ -56,7 +56,7 @@ describe(`GDPR utils`, () => {
             it(`should set a cookie marking the user as opted-in for a given token`, () => {
                 TOKENS.forEach((token) => {
                     gdpr.optIn(token, { persistenceType })
-                    console.log(token, persistenceType)
+                    // console.log(token, persistenceType)
                     assertPersistenceValue(persistenceType, token, 1)
                 })
             })

--- a/src/__tests__/gdpr-utils.js
+++ b/src/__tests__/gdpr-utils.js
@@ -507,13 +507,14 @@ describe(`GDPR utils`, () => {
         const captureProperties = { '𝖕𝖗𝖔𝖕𝖊𝖗𝖙𝖞': `𝓿𝓪𝓵𝓾𝓮` }
         let getConfig, capture, postHogLib
 
-        function setupMocks(getConfigFunc, options) {
+        function setupMocks(getConfigFunc, silenceErrors = false) {
             getConfig = sinon.spy((name) => getConfigFunc()[name])
             capture = sinon.spy()
             postHogLib = {
                 get_config: getConfig,
-                capture: gdpr.addOptOutCheckPostHogLib(capture, options),
+                capture: undefined,
             }
+            postHogLib.capture = gdpr.addOptOutCheckPostHogLib(capture, silenceErrors).bind(postHogLib)
         }
 
         forPersistenceTypes(function (persistenceType) {
@@ -599,7 +600,7 @@ describe(`GDPR utils`, () => {
                 TOKENS.forEach((token) => {
                     setupMocks(() => {
                         throw new Error(`Unexpected error!`)
-                    })
+                    }, true)
 
                     gdpr.optIn(token, { persistenceType })
                     postHogLib.capture(captureEventName, captureProperties)
@@ -640,13 +641,14 @@ describe(`GDPR utils`, () => {
         const setPropertyValue = `𝓿𝓪𝓵𝓾𝓮`
         let getConfig, set, postHogPeople
 
-        function setupMocks(getConfigFunc, options) {
+        function setupMocks(getConfigFunc, silenceErrors = false) {
             getConfig = sinon.spy((name) => getConfigFunc()[name])
             set = sinon.spy()
             postHogPeople = {
                 _get_config: getConfig,
-                set: gdpr.addOptOutCheckPostHogPeople(set, options),
+                set: undefined,
             }
+            postHogPeople.set = gdpr.addOptOutCheckPostHogPeople(set, silenceErrors).bind(postHogPeople)
         }
 
         forPersistenceTypes(function (persistenceType) {
@@ -732,7 +734,7 @@ describe(`GDPR utils`, () => {
                 TOKENS.forEach((token) => {
                     setupMocks(() => {
                         throw new Error(`Unexpected error!`)
-                    })
+                    }, true)
 
                     gdpr.optIn(token, { persistenceType })
                     postHogPeople.set(setPropertyName, setPropertyValue)

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -269,9 +269,10 @@ var autocapture = {
             }
 
             if (response['featureFlags'] && response['featureFlags'].length > 0) {
-                instance.persistence.register({ $active_feature_flags: response['featureFlags'] })
+                instance.persistence &&
+                    instance.persistence.register({ $active_feature_flags: response['featureFlags'] })
             } else {
-                instance.persistence.unregister('$active_feature_flags')
+                instance.persistence && instance.persistence.unregister('$active_feature_flags')
             }
 
             if (response['supportedCompression']) {

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -281,6 +281,8 @@ var autocapture = {
                     compression[method] = true
                 }
                 instance['compression'] = compression
+            } else {
+                instance['compression'] = {}
             }
         }, this)
 

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -273,6 +273,14 @@ var autocapture = {
             } else {
                 instance.persistence.unregister('$active_feature_flags')
             }
+
+            if (response['supportedCompression']) {
+                let compression = {}
+                for (const method of response['supportedCompression']) {
+                    compression[method] = true
+                }
+                instance['compression'] = compression
+            }
         }, this)
 
         var json_data = _.JSONEncode({

--- a/src/lz-string.js
+++ b/src/lz-string.js
@@ -1,0 +1,492 @@
+// Copyright (c) 2013 Pieroxy <pieroxy@pieroxy.net>
+// This work is free. You can redistribute it and/or modify it
+// under the terms of the WTFPL, Version 2
+// For more information see LICENSE.txt or http://www.wtfpl.net/
+//
+// For more information, the home page:
+// http://pieroxy.net/blog/pages/lz-string/testing.html
+//
+// LZ-based compression algorithm, version 1.4.4
+
+// private property
+var f = String.fromCharCode;
+var keyStrBase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+var keyStrUriSafe = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-$";
+var baseReverseDic = {};
+
+function getBaseValue(alphabet, character) {
+  if (!baseReverseDic[alphabet]) {
+    baseReverseDic[alphabet] = {};
+    for (var i=0 ; i<alphabet.length ; i++) {
+      baseReverseDic[alphabet][alphabet.charAt(i)] = i;
+    }
+  }
+  return baseReverseDic[alphabet][character];
+}
+
+export var LZString = {
+  compressToBase64 : function (input) {
+    if (input == null) return "";
+    var res = LZString._compress(input, 6, function(a){return keyStrBase64.charAt(a);});
+    switch (res.length % 4) { // To produce valid Base64
+    default: // When could this happen ?
+    case 0 : return res;
+    case 1 : return res+"===";
+    case 2 : return res+"==";
+    case 3 : return res+"=";
+    }
+  },
+
+  decompressFromBase64 : function (input) {
+    if (input == null) return "";
+    if (input == "") return null;
+    return LZString._decompress(input.length, 32, function(index) { return getBaseValue(keyStrBase64, input.charAt(index)); });
+  },
+
+  compressToUTF16 : function (input) {
+    if (input == null) return "";
+    return LZString._compress(input, 15, function(a){return f(a+32);}) + " ";
+  },
+
+  decompressFromUTF16: function (compressed) {
+    if (compressed == null) return "";
+    if (compressed == "") return null;
+    return LZString._decompress(compressed.length, 16384, function(index) { return compressed.charCodeAt(index) - 32; });
+  },
+
+  //compress into uint8array (UCS-2 big endian format)
+  compressToUint8Array: function (uncompressed) {
+    var compressed = LZString.compress(uncompressed);
+    var buf=new Uint8Array(compressed.length*2); // 2 bytes per character
+
+    for (var i=0, TotalLen=compressed.length; i<TotalLen; i++) {
+      var current_value = compressed.charCodeAt(i);
+      buf[i*2] = current_value >>> 8;
+      buf[i*2+1] = current_value % 256;
+    }
+    return buf;
+  },
+
+  //decompress from uint8array (UCS-2 big endian format)
+  decompressFromUint8Array:function (compressed) {
+    if (compressed===null || compressed===undefined){
+        return LZString.decompress(compressed);
+    } else {
+        var buf=new Array(compressed.length/2); // 2 bytes per character
+        for (var i=0, TotalLen=buf.length; i<TotalLen; i++) {
+          buf[i]=compressed[i*2]*256+compressed[i*2+1];
+        }
+
+        var result = [];
+        buf.forEach(function (c) {
+          result.push(f(c));
+        });
+        return LZString.decompress(result.join(''));
+
+    }
+
+  },
+
+
+  //compress into a string that is already URI encoded
+  compressToEncodedURIComponent: function (input) {
+    if (input == null) return "";
+    return LZString._compress(input, 6, function(a){return keyStrUriSafe.charAt(a);});
+  },
+
+  //decompress from an output of compressToEncodedURIComponent
+  decompressFromEncodedURIComponent:function (input) {
+    if (input == null) return "";
+    if (input == "") return null;
+    input = input.replace(/ /g, "+");
+    return LZString._decompress(input.length, 32, function(index) { return getBaseValue(keyStrUriSafe, input.charAt(index)); });
+  },
+
+  compress: function (uncompressed) {
+    return LZString._compress(uncompressed, 16, function(a){return f(a);});
+  },
+  _compress: function (uncompressed, bitsPerChar, getCharFromInt) {
+    if (uncompressed == null) return "";
+    var i, value,
+        context_dictionary= {},
+        context_dictionaryToCreate= {},
+        context_c="",
+        context_wc="",
+        context_w="",
+        context_enlargeIn= 2, // Compensate for the first entry which should not count
+        context_dictSize= 3,
+        context_numBits= 2,
+        context_data=[],
+        context_data_val=0,
+        context_data_position=0,
+        ii;
+
+    for (ii = 0; ii < uncompressed.length; ii += 1) {
+      context_c = uncompressed.charAt(ii);
+      if (!Object.prototype.hasOwnProperty.call(context_dictionary,context_c)) {
+        context_dictionary[context_c] = context_dictSize++;
+        context_dictionaryToCreate[context_c] = true;
+      }
+
+      context_wc = context_w + context_c;
+      if (Object.prototype.hasOwnProperty.call(context_dictionary,context_wc)) {
+        context_w = context_wc;
+      } else {
+        if (Object.prototype.hasOwnProperty.call(context_dictionaryToCreate,context_w)) {
+          if (context_w.charCodeAt(0)<256) {
+            for (i=0 ; i<context_numBits ; i++) {
+              context_data_val = (context_data_val << 1);
+              if (context_data_position == bitsPerChar-1) {
+                context_data_position = 0;
+                context_data.push(getCharFromInt(context_data_val));
+                context_data_val = 0;
+              } else {
+                context_data_position++;
+              }
+            }
+            value = context_w.charCodeAt(0);
+            for (i=0 ; i<8 ; i++) {
+              context_data_val = (context_data_val << 1) | (value&1);
+              if (context_data_position == bitsPerChar-1) {
+                context_data_position = 0;
+                context_data.push(getCharFromInt(context_data_val));
+                context_data_val = 0;
+              } else {
+                context_data_position++;
+              }
+              value = value >> 1;
+            }
+          } else {
+            value = 1;
+            for (i=0 ; i<context_numBits ; i++) {
+              context_data_val = (context_data_val << 1) | value;
+              if (context_data_position ==bitsPerChar-1) {
+                context_data_position = 0;
+                context_data.push(getCharFromInt(context_data_val));
+                context_data_val = 0;
+              } else {
+                context_data_position++;
+              }
+              value = 0;
+            }
+            value = context_w.charCodeAt(0);
+            for (i=0 ; i<16 ; i++) {
+              context_data_val = (context_data_val << 1) | (value&1);
+              if (context_data_position == bitsPerChar-1) {
+                context_data_position = 0;
+                context_data.push(getCharFromInt(context_data_val));
+                context_data_val = 0;
+              } else {
+                context_data_position++;
+              }
+              value = value >> 1;
+            }
+          }
+          context_enlargeIn--;
+          if (context_enlargeIn == 0) {
+            context_enlargeIn = Math.pow(2, context_numBits);
+            context_numBits++;
+          }
+          delete context_dictionaryToCreate[context_w];
+        } else {
+          value = context_dictionary[context_w];
+          for (i=0 ; i<context_numBits ; i++) {
+            context_data_val = (context_data_val << 1) | (value&1);
+            if (context_data_position == bitsPerChar-1) {
+              context_data_position = 0;
+              context_data.push(getCharFromInt(context_data_val));
+              context_data_val = 0;
+            } else {
+              context_data_position++;
+            }
+            value = value >> 1;
+          }
+
+
+        }
+        context_enlargeIn--;
+        if (context_enlargeIn == 0) {
+          context_enlargeIn = Math.pow(2, context_numBits);
+          context_numBits++;
+        }
+        // Add wc to the dictionary.
+        context_dictionary[context_wc] = context_dictSize++;
+        context_w = String(context_c);
+      }
+    }
+
+    // Output the code for w.
+    if (context_w !== "") {
+      if (Object.prototype.hasOwnProperty.call(context_dictionaryToCreate,context_w)) {
+        if (context_w.charCodeAt(0)<256) {
+          for (i=0 ; i<context_numBits ; i++) {
+            context_data_val = (context_data_val << 1);
+            if (context_data_position == bitsPerChar-1) {
+              context_data_position = 0;
+              context_data.push(getCharFromInt(context_data_val));
+              context_data_val = 0;
+            } else {
+              context_data_position++;
+            }
+          }
+          value = context_w.charCodeAt(0);
+          for (i=0 ; i<8 ; i++) {
+            context_data_val = (context_data_val << 1) | (value&1);
+            if (context_data_position == bitsPerChar-1) {
+              context_data_position = 0;
+              context_data.push(getCharFromInt(context_data_val));
+              context_data_val = 0;
+            } else {
+              context_data_position++;
+            }
+            value = value >> 1;
+          }
+        } else {
+          value = 1;
+          for (i=0 ; i<context_numBits ; i++) {
+            context_data_val = (context_data_val << 1) | value;
+            if (context_data_position == bitsPerChar-1) {
+              context_data_position = 0;
+              context_data.push(getCharFromInt(context_data_val));
+              context_data_val = 0;
+            } else {
+              context_data_position++;
+            }
+            value = 0;
+          }
+          value = context_w.charCodeAt(0);
+          for (i=0 ; i<16 ; i++) {
+            context_data_val = (context_data_val << 1) | (value&1);
+            if (context_data_position == bitsPerChar-1) {
+              context_data_position = 0;
+              context_data.push(getCharFromInt(context_data_val));
+              context_data_val = 0;
+            } else {
+              context_data_position++;
+            }
+            value = value >> 1;
+          }
+        }
+        context_enlargeIn--;
+        if (context_enlargeIn == 0) {
+          context_enlargeIn = Math.pow(2, context_numBits);
+          context_numBits++;
+        }
+        delete context_dictionaryToCreate[context_w];
+      } else {
+        value = context_dictionary[context_w];
+        for (i=0 ; i<context_numBits ; i++) {
+          context_data_val = (context_data_val << 1) | (value&1);
+          if (context_data_position == bitsPerChar-1) {
+            context_data_position = 0;
+            context_data.push(getCharFromInt(context_data_val));
+            context_data_val = 0;
+          } else {
+            context_data_position++;
+          }
+          value = value >> 1;
+        }
+
+
+      }
+      context_enlargeIn--;
+      if (context_enlargeIn == 0) {
+        context_enlargeIn = Math.pow(2, context_numBits);
+        context_numBits++;
+      }
+    }
+
+    // Mark the end of the stream
+    value = 2;
+    for (i=0 ; i<context_numBits ; i++) {
+      context_data_val = (context_data_val << 1) | (value&1);
+      if (context_data_position == bitsPerChar-1) {
+        context_data_position = 0;
+        context_data.push(getCharFromInt(context_data_val));
+        context_data_val = 0;
+      } else {
+        context_data_position++;
+      }
+      value = value >> 1;
+    }
+
+    // Flush the last char
+    while (true) {
+      context_data_val = (context_data_val << 1);
+      if (context_data_position == bitsPerChar-1) {
+        context_data.push(getCharFromInt(context_data_val));
+        break;
+      }
+      else context_data_position++;
+    }
+    return context_data.join('');
+  },
+
+  decompress: function (compressed) {
+    if (compressed == null) return "";
+    if (compressed == "") return null;
+    return LZString._decompress(compressed.length, 32768, function(index) { return compressed.charCodeAt(index); });
+  },
+
+  _decompress: function (length, resetValue, getNextValue) {
+    var dictionary = [],
+        next,
+        enlargeIn = 4,
+        dictSize = 4,
+        numBits = 3,
+        entry = "",
+        result = [],
+        i,
+        w,
+        bits, resb, maxpower, power,
+        c,
+        data = {val:getNextValue(0), position:resetValue, index:1};
+
+    for (i = 0; i < 3; i += 1) {
+      dictionary[i] = i;
+    }
+
+    bits = 0;
+    maxpower = Math.pow(2,2);
+    power=1;
+    while (power!=maxpower) {
+      resb = data.val & data.position;
+      data.position >>= 1;
+      if (data.position == 0) {
+        data.position = resetValue;
+        data.val = getNextValue(data.index++);
+      }
+      bits |= (resb>0 ? 1 : 0) * power;
+      power <<= 1;
+    }
+
+    switch (next = bits) {
+      case 0:
+          bits = 0;
+          maxpower = Math.pow(2,8);
+          power=1;
+          while (power!=maxpower) {
+            resb = data.val & data.position;
+            data.position >>= 1;
+            if (data.position == 0) {
+              data.position = resetValue;
+              data.val = getNextValue(data.index++);
+            }
+            bits |= (resb>0 ? 1 : 0) * power;
+            power <<= 1;
+          }
+        c = f(bits);
+        break;
+      case 1:
+          bits = 0;
+          maxpower = Math.pow(2,16);
+          power=1;
+          while (power!=maxpower) {
+            resb = data.val & data.position;
+            data.position >>= 1;
+            if (data.position == 0) {
+              data.position = resetValue;
+              data.val = getNextValue(data.index++);
+            }
+            bits |= (resb>0 ? 1 : 0) * power;
+            power <<= 1;
+          }
+        c = f(bits);
+        break;
+      case 2:
+        return "";
+    }
+    dictionary[3] = c;
+    w = c;
+    result.push(c);
+    while (true) {
+      if (data.index > length) {
+        return "";
+      }
+
+      bits = 0;
+      maxpower = Math.pow(2,numBits);
+      power=1;
+      while (power!=maxpower) {
+        resb = data.val & data.position;
+        data.position >>= 1;
+        if (data.position == 0) {
+          data.position = resetValue;
+          data.val = getNextValue(data.index++);
+        }
+        bits |= (resb>0 ? 1 : 0) * power;
+        power <<= 1;
+      }
+
+      switch (c = bits) {
+        case 0:
+          bits = 0;
+          maxpower = Math.pow(2,8);
+          power=1;
+          while (power!=maxpower) {
+            resb = data.val & data.position;
+            data.position >>= 1;
+            if (data.position == 0) {
+              data.position = resetValue;
+              data.val = getNextValue(data.index++);
+            }
+            bits |= (resb>0 ? 1 : 0) * power;
+            power <<= 1;
+          }
+
+          dictionary[dictSize++] = f(bits);
+          c = dictSize-1;
+          enlargeIn--;
+          break;
+        case 1:
+          bits = 0;
+          maxpower = Math.pow(2,16);
+          power=1;
+          while (power!=maxpower) {
+            resb = data.val & data.position;
+            data.position >>= 1;
+            if (data.position == 0) {
+              data.position = resetValue;
+              data.val = getNextValue(data.index++);
+            }
+            bits |= (resb>0 ? 1 : 0) * power;
+            power <<= 1;
+          }
+          dictionary[dictSize++] = f(bits);
+          c = dictSize-1;
+          enlargeIn--;
+          break;
+        case 2:
+          return result.join('');
+      }
+
+      if (enlargeIn == 0) {
+        enlargeIn = Math.pow(2, numBits);
+        numBits++;
+      }
+
+      if (dictionary[c]) {
+        entry = dictionary[c];
+      } else {
+        if (c === dictSize) {
+          entry = w + w.charAt(0);
+        } else {
+          return null;
+        }
+      }
+      result.push(entry);
+
+      // Add w+entry[0] to the dictionary.
+      dictionary[dictSize++] = w + entry.charAt(0);
+      enlargeIn--;
+
+      w = entry;
+
+      if (enlargeIn == 0) {
+        enlargeIn = Math.pow(2, numBits);
+        numBits++;
+      }
+
+    }
+  }
+};

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1514,6 +1514,8 @@ function deprecate_warning(method) {
     )
 }
 
+PostHogLib.prototype.decodeLZ64 = LZString.decompressFromBase64
+
 // EXPORTS (for closure compiler)
 
 // PostHogLib Exports
@@ -1545,6 +1547,7 @@ PostHogLib.prototype['has_opted_in_capturing'] = PostHogLib.prototype.has_opted_
 PostHogLib.prototype['clear_opt_in_out_capturing'] = PostHogLib.prototype.clear_opt_in_out_capturing
 PostHogLib.prototype['isFeatureEnabled'] = PostHogLib.prototype.isFeatureEnabled
 PostHogLib.prototype['onFeatureFlags'] = PostHogLib.prototype.onFeatureFlags
+PostHogLib.prototype['decodeLZ64'] = PostHogLib.prototype.decodeLZ64
 
 // PostHogPersistence Exports
 PostHogPersistence.prototype['properties'] = PostHogPersistence.prototype.properties

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -29,7 +29,7 @@ var posthog_master // main posthog instance / object
 var INIT_MODULE = 0
 var INIT_SNIPPET = 1
 // some globals for comparisons
-var __NOOP = function() {}
+var __NOOP = function () {}
 var __NOOPTIONS = {}
 
 /** @const */ var PRIMARY_INSTANCE_NAME = 'posthog'
@@ -65,7 +65,7 @@ var DEFAULT_CONFIG = {
     persistence: 'cookie',
     persistence_name: '',
     cookie_name: '',
-    loaded: function() {},
+    loaded: function () {},
     store_google: true,
     save_referrer: true,
     test: false,
@@ -97,7 +97,7 @@ var DOM_LOADED = false
  * PostHog Library Object
  * @constructor
  */
-var PostHogLib = function() {}
+var PostHogLib = function () {}
 
 /**
  * create_mplib(token:string, config:object, name:string)
@@ -107,7 +107,7 @@ var PostHogLib = function() {}
  * initializes document.posthog as well as any additional instances
  * declared before this file has loaded).
  */
-var create_mplib = function(token, config, name) {
+var create_mplib = function (token, config, name) {
     var instance,
         target = name === PRIMARY_INSTANCE_NAME ? posthog_master : posthog_master[name]
 
@@ -182,7 +182,7 @@ var create_mplib = function(token, config, name) {
  * @param {Object} [config]  A dictionary of config options to override. <a href="https://github.com/posthog/posthog-js/blob/6e0e873/src/posthog-core.js#L57-L91">See a list of default config options</a>.
  * @param {String} [name]    The name for the new posthog instance that you want created
  */
-PostHogLib.prototype.init = function(token, config, name) {
+PostHogLib.prototype.init = function (token, config, name) {
     if (_.isUndefined(name)) {
         console.error('You must name your new library: init(token, config, name)')
         return
@@ -206,7 +206,7 @@ PostHogLib.prototype.init = function(token, config, name) {
 // method is this one initializes the actual instance, whereas the
 // init(...) method sets up a new library and calls _init on it.
 //
-PostHogLib.prototype._init = function(token, config, name) {
+PostHogLib.prototype._init = function (token, config, name) {
     this['__loaded'] = true
     this['config'] = {}
     this['_triggered_notifs'] = []
@@ -219,13 +219,13 @@ PostHogLib.prototype._init = function(token, config, name) {
         })
     )
 
-    this['_jsc'] = function() {}
+    this['_jsc'] = function () {}
 
     // batching requests variabls
     this._event_queue = []
     this._empty_queue_count = 0 // to track empty polls
     this._should_poll = true // flag to continue to recursively poll or not
-    this._poller = function() {} // to become interval for reference to clear later
+    this._poller = function () {} // to become interval for reference to clear later
 
     this.__dom_loaded_queue = []
     this.__request_queue = []
@@ -257,7 +257,7 @@ PostHogLib.prototype._init = function(token, config, name) {
 
 // Private methods
 
-PostHogLib.prototype._loaded = function() {
+PostHogLib.prototype._loaded = function () {
     this.get_config('loaded')(this)
 
     // this happens after so a user can call identify in
@@ -267,10 +267,10 @@ PostHogLib.prototype._loaded = function() {
     }
 }
 
-PostHogLib.prototype._dom_loaded = function() {
+PostHogLib.prototype._dom_loaded = function () {
     _.each(
         this.__dom_loaded_queue,
-        function(item) {
+        function (item) {
             this._capture_dom.apply(this, item)
         },
         this
@@ -279,7 +279,7 @@ PostHogLib.prototype._dom_loaded = function() {
     if (!this.has_opted_out_capturing()) {
         _.each(
             this.__request_queue,
-            function(item) {
+            function (item) {
                 this._send_request.apply(this, item)
             },
             this
@@ -293,7 +293,7 @@ PostHogLib.prototype._dom_loaded = function() {
     delete this.__request_queue
 }
 
-PostHogLib.prototype._capture_dom = function(DomClass, args) {
+PostHogLib.prototype._capture_dom = function (DomClass, args) {
     if (this.get_config('img')) {
         console.error("You can't use DOM capturing functions with img = true.")
         return false
@@ -317,13 +317,13 @@ PostHogLib.prototype._capture_dom = function(DomClass, args) {
  * If we are going to use script tags, this returns a string to use as the
  * callback GET param.
  */
-PostHogLib.prototype._prepare_callback = function(callback, data) {
+PostHogLib.prototype._prepare_callback = function (callback, data) {
     if (_.isUndefined(callback)) {
         return null
     }
 
     if (USE_XHR) {
-        var callback_function = function(response) {
+        var callback_function = function (response) {
             callback(response, data)
         }
         return callback_function
@@ -334,7 +334,7 @@ PostHogLib.prototype._prepare_callback = function(callback, data) {
         var jsc = this['_jsc']
         var randomized_cb = '' + Math.floor(Math.random() * 100000000)
         var callback_string = this.get_config('callback_fn') + '[' + randomized_cb + ']'
-        jsc[randomized_cb] = function(response) {
+        jsc[randomized_cb] = function (response) {
             delete jsc[randomized_cb]
             callback(response, data)
         }
@@ -342,7 +342,7 @@ PostHogLib.prototype._prepare_callback = function(callback, data) {
     }
 }
 
-PostHogLib.prototype._event_enqueue = function(url, data, options, callback) {
+PostHogLib.prototype._event_enqueue = function (url, data, options, callback) {
     this._event_queue.push({ url, data, options, callback })
 
     if (!this._should_poll) {
@@ -351,9 +351,9 @@ PostHogLib.prototype._event_enqueue = function(url, data, options, callback) {
     }
 }
 
-PostHogLib.prototype._format_event_queue_data = function() {
+PostHogLib.prototype._format_event_queue_data = function () {
     const requests = {}
-    _.each(this._event_queue, request => {
+    _.each(this._event_queue, (request) => {
         const { url, data } = request
         if (requests[url] === undefined) requests[url] = []
         requests[url].push(data)
@@ -361,14 +361,14 @@ PostHogLib.prototype._format_event_queue_data = function() {
     return requests
 }
 
-PostHogLib.prototype._event_queue_poll = function() {
+PostHogLib.prototype._event_queue_poll = function () {
     const POLL_INTERVAL = 3000
     this._poller = setTimeout(() => {
         if (this._event_queue.length > 0) {
             const requests = this._format_event_queue_data()
             for (let url in requests) {
                 let data = requests[url]
-                _.each(data, function(value, key) {
+                _.each(data, function (value, key) {
                     data[key]['offset'] = Math.abs(data[key]['timestamp'] - new Date())
                     delete data[key]['timestamp']
                 })
@@ -399,7 +399,7 @@ PostHogLib.prototype._event_queue_poll = function() {
     }, POLL_INTERVAL)
 }
 
-PostHogLib.prototype._handle_unload = function() {
+PostHogLib.prototype._handle_unload = function () {
     if (!this.get_config('request_batching')) {
         this.capture('$pageleave', null, { transport: 'sendbeacon' })
         return
@@ -420,7 +420,7 @@ PostHogLib.prototype._handle_unload = function() {
     }
 }
 
-PostHogLib.prototype._send_request = function(url, data, options, callback) {
+PostHogLib.prototype._send_request = function (url, data, options, callback) {
     if (ENQUEUE_REQUESTS) {
         this.__request_queue.push(arguments)
         return
@@ -511,14 +511,14 @@ PostHogLib.prototype._send_request = function(url, data, options, callback) {
             if (use_post) {
                 headers['Content-Type'] = 'application/x-www-form-urlencoded'
             }
-            _.each(headers, function(headerValue, headerName) {
+            _.each(headers, function (headerValue, headerName) {
                 req.setRequestHeader(headerName, headerValue)
             })
 
             // send the ph_optout cookie
             // withCredentials cannot be modified until after calling .open on Android and Mobile Safari
             req.withCredentials = true
-            req.onreadystatechange = function() {
+            req.onreadystatechange = function () {
                 if (req.readyState === 4) {
                     // XMLHttpRequest.DONE == 4, except in safari 4
                     if (req.status === 200) {
@@ -572,14 +572,14 @@ PostHogLib.prototype._send_request = function(url, data, options, callback) {
  *
  * @param {Array} array
  */
-PostHogLib.prototype._execute_array = function(array) {
+PostHogLib.prototype._execute_array = function (array) {
     var fn_name,
         alias_calls = [],
         other_calls = [],
         capturing_calls = []
     _.each(
         array,
-        function(item) {
+        function (item) {
             if (item) {
                 fn_name = item[0]
                 if (_.isArray(fn_name)) {
@@ -602,14 +602,14 @@ PostHogLib.prototype._execute_array = function(array) {
         this
     )
 
-    var execute = function(calls, context) {
+    var execute = function (calls, context) {
         _.each(
             calls,
-            function(item) {
+            function (item) {
                 if (_.isArray(item[0])) {
                     // chained call
                     var caller = context
-                    _.each(item, function(call) {
+                    _.each(item, function (call) {
                         caller = caller[call[0]].apply(caller, call.slice(1))
                     })
                 } else {
@@ -637,7 +637,7 @@ PostHogLib.prototype._execute_array = function(array) {
  *
  * @param {Array} item A [function_name, args...] array to be executed
  */
-PostHogLib.prototype.push = function(item) {
+PostHogLib.prototype.push = function (item) {
     this._execute_array([item])
 }
 
@@ -661,7 +661,7 @@ PostHogLib.prototype.push = function(item) {
  * @param {String} [options.transport] Transport method for network request ('xhr' or 'sendBeacon').
  * @param {Function} [callback] If provided, the callback function will be called after capturing the event.
  */
-PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function(event_name, properties, options, callback) {
+PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, properties, options, callback) {
     if (!callback && typeof options === 'function') {
         callback = options
         options = null
@@ -715,7 +715,7 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function(event_name, pro
 
     var property_blacklist = this.get_config('property_blacklist')
     if (_.isArray(property_blacklist)) {
-        _.each(property_blacklist, function(blacklisted_prop) {
+        _.each(property_blacklist, function (blacklisted_prop) {
             delete properties[blacklisted_prop]
         })
     } else {
@@ -746,11 +746,11 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function(event_name, pro
     return truncated_data
 })
 
-PostHogLib.prototype._create_map_key = function(group_key, group_id) {
+PostHogLib.prototype._create_map_key = function (group_key, group_id) {
     return group_key + '_' + JSON.stringify(group_id)
 }
 
-PostHogLib.prototype._remove_group_from_cache = function(group_key, group_id) {
+PostHogLib.prototype._remove_group_from_cache = function (group_key, group_id) {
     delete this._cached_groups[this._create_map_key(group_key, group_id)]
 }
 
@@ -762,7 +762,7 @@ PostHogLib.prototype._remove_group_from_cache = function(group_key, group_id) {
  * @param {String} [page] The url of the page to record. If you don't include this, it defaults to the current url.
  * @api private
  */
-PostHogLib.prototype.capture_pageview = function(page) {
+PostHogLib.prototype.capture_pageview = function (page) {
     if (_.isUndefined(page)) {
         page = document.location.href
     }
@@ -797,7 +797,7 @@ PostHogLib.prototype.capture_pageview = function(page) {
  * @param {String} event_name The name of the event to capture
  * @param {Object|Function} [properties] A properties object or function that returns a dictionary of properties when passed a DOMElement
  */
-PostHogLib.prototype.capture_links = function() {
+PostHogLib.prototype.capture_links = function () {
     return this._capture_dom.call(this, LinkCapture, arguments)
 }
 
@@ -828,7 +828,7 @@ PostHogLib.prototype.capture_links = function() {
  * @param {String} event_name The name of the event to capture
  * @param {Object|Function} [properties] This can be a set of properties, or a function that returns a set of properties after being passed a DOMElement
  */
-PostHogLib.prototype.capture_forms = function() {
+PostHogLib.prototype.capture_forms = function () {
     return this._capture_dom.call(this, FormCaptureer, arguments)
 }
 
@@ -850,7 +850,7 @@ PostHogLib.prototype.capture_forms = function() {
  * @param {Object} properties An associative array of properties to store about the user
  * @param {Number} [days] How many days since the user's last visit to store the super properties
  */
-PostHogLib.prototype.register = function(props, days) {
+PostHogLib.prototype.register = function (props, days) {
     this['persistence'].register(props, days)
 }
 
@@ -874,7 +874,7 @@ PostHogLib.prototype.register = function(props, days) {
  * @param {*} [default_value] Value to override if already set in super properties (ex: 'False') Default: 'None'
  * @param {Number} [days] How many days since the users last visit to store the super properties
  */
-PostHogLib.prototype.register_once = function(props, default_value, days) {
+PostHogLib.prototype.register_once = function (props, default_value, days) {
     this['persistence'].register_once(props, default_value, days)
 }
 
@@ -883,11 +883,11 @@ PostHogLib.prototype.register_once = function(props, default_value, days) {
  *
  * @param {String} property The name of the super property to remove
  */
-PostHogLib.prototype.unregister = function(property) {
+PostHogLib.prototype.unregister = function (property) {
     this['persistence'].unregister(property)
 }
 
-PostHogLib.prototype._register_single = function(prop, value) {
+PostHogLib.prototype._register_single = function (prop, value) {
     var props = {}
     props[prop] = value
     this.register(props)
@@ -902,7 +902,7 @@ PostHogLib.prototype._register_single = function(prop, value) {
  *
  * @param {Object|String} prop Key of the feature flag.
  */
-PostHogLib.prototype.isFeatureEnabled = function(key) {
+PostHogLib.prototype.isFeatureEnabled = function (key) {
     return this.feature_flags.isFeatureEnabled(key)
 }
 
@@ -915,7 +915,7 @@ PostHogLib.prototype.isFeatureEnabled = function(key) {
  *
  * @param {Function} [callback] The callback function will be called once the feature flags are ready. It'll return a list of feature flags enabled for the user.
  */
-PostHogLib.prototype.onFeatureFlags = function(callback) {
+PostHogLib.prototype.onFeatureFlags = function (callback) {
     return this.feature_flags.onFeatureFlags(callback)
 }
 
@@ -946,7 +946,7 @@ PostHogLib.prototype.onFeatureFlags = function(callback) {
  *
  * @param {String} [unique_id] A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.
  */
-PostHogLib.prototype.identify = function(new_distinct_id, _set_callback, _set_once_callback) {
+PostHogLib.prototype.identify = function (new_distinct_id, _set_callback, _set_once_callback) {
     // Optional Parameters
     //  _set_callback:function  A callback to be run if and when the People set queue is flushed
     //  _set_once_callback:function  A callback to be run if and when the People set_once queue is flushed
@@ -994,7 +994,7 @@ PostHogLib.prototype.identify = function(new_distinct_id, _set_callback, _set_on
  * Clears super properties and generates a new random distinct_id for this instance.
  * Useful for clearing data when a user logs out.
  */
-PostHogLib.prototype.reset = function(reset_device_id) {
+PostHogLib.prototype.reset = function (reset_device_id) {
     let device_id = this.get_property('$device_id')
     this['persistence'].clear()
     this._flags.identify_called = false
@@ -1024,7 +1024,7 @@ PostHogLib.prototype.reset = function(reset_device_id) {
  *         }
  *     });
  */
-PostHogLib.prototype.get_distinct_id = function() {
+PostHogLib.prototype.get_distinct_id = function () {
     return this.get_property('distinct_id')
 }
 
@@ -1049,7 +1049,7 @@ PostHogLib.prototype.get_distinct_id = function() {
  * @param {String} alias A unique identifier that you want to use for this user in the future.
  * @param {String} [original] The current identifier being used for this user.
  */
-PostHogLib.prototype.alias = function(alias, original) {
+PostHogLib.prototype.alias = function (alias, original) {
     // If the $people_distinct_id key exists in persistence, there has been a previous
     // posthog.people.identify() call made for this user. It is VERY BAD to make an alias with
     // this ID, as it will duplicate users.
@@ -1064,7 +1064,7 @@ PostHogLib.prototype.alias = function(alias, original) {
     }
     if (alias !== original) {
         this._register_single(ALIAS_ID_KEY, alias)
-        return this.capture('$create_alias', { alias: alias, distinct_id: original }, function() {
+        return this.capture('$create_alias', { alias: alias, distinct_id: original }, function () {
             // Flush the people queue
             _this.identify(alias)
         })
@@ -1171,7 +1171,7 @@ PostHogLib.prototype.alias = function(alias, original) {
  *
  * @param {Object} config A dictionary of new configuration values to update
  */
-PostHogLib.prototype.set_config = function(config) {
+PostHogLib.prototype.set_config = function (config) {
     if (_.isObject(config)) {
         _.extend(this['config'], config)
 
@@ -1192,7 +1192,7 @@ PostHogLib.prototype.set_config = function(config) {
 /**
  * returns the current config object for the library.
  */
-PostHogLib.prototype.get_config = function(prop_name) {
+PostHogLib.prototype.get_config = function (prop_name) {
     return this['config'][prop_name]
 }
 
@@ -1214,11 +1214,11 @@ PostHogLib.prototype.get_config = function(prop_name) {
  *
  * @param {String} property_name The name of the super property you want to retrieve
  */
-PostHogLib.prototype.get_property = function(property_name) {
+PostHogLib.prototype.get_property = function (property_name) {
     return this['persistence']['props'][property_name]
 }
 
-PostHogLib.prototype.toString = function() {
+PostHogLib.prototype.toString = function () {
     var name = this.get_config('name')
     if (name !== PRIMARY_INSTANCE_NAME) {
         name = PRIMARY_INSTANCE_NAME + '.' + name
@@ -1226,12 +1226,12 @@ PostHogLib.prototype.toString = function() {
     return name
 }
 
-PostHogLib.prototype._event_is_disabled = function(event_name) {
+PostHogLib.prototype._event_is_disabled = function (event_name) {
     return _.isBlockedUA(userAgent) || this._flags.disable_all_events || _.include(this.__disabled_events, event_name)
 }
 
 // perform some housekeeping around GDPR opt-in/out state
-PostHogLib.prototype._gdpr_init = function() {
+PostHogLib.prototype._gdpr_init = function () {
     var is_localStorage_requested = this.get_config('opt_out_capturing_persistence_type') === 'localStorage'
 
     // try to convert opt-in/out cookies to localStorage if possible
@@ -1272,7 +1272,7 @@ PostHogLib.prototype._gdpr_init = function() {
  * @param {boolean} [options.clear_persistence] If true, will delete all data stored by the sdk in persistence and disable it
  * @param {boolean} [options.enable_persistence] If true, will re-enable sdk persistence
  */
-PostHogLib.prototype._gdpr_update_persistence = function(options) {
+PostHogLib.prototype._gdpr_update_persistence = function (options) {
     var disabled
     if (options && options['clear_persistence']) {
         disabled = true
@@ -1288,7 +1288,7 @@ PostHogLib.prototype._gdpr_update_persistence = function(options) {
 }
 
 // call a base gdpr function after constructing the appropriate token and options args
-PostHogLib.prototype._gdpr_call_func = function(func, options) {
+PostHogLib.prototype._gdpr_call_func = function (func, options) {
     options = _.extend(
         {
             capture: _.bind(this.capture, this),
@@ -1347,7 +1347,7 @@ PostHogLib.prototype._gdpr_call_func = function(func, options) {
  * @param {boolean} [options.cross_subdomain_cookie] Whether the opt-in cookie is set as cross-subdomain or not (overrides value specified in this PostHog instance's config)
  * @param {boolean} [options.secure_cookie] Whether the opt-in cookie is set as secure or not (overrides value specified in this PostHog instance's config)
  */
-PostHogLib.prototype.opt_in_capturing = function(options) {
+PostHogLib.prototype.opt_in_capturing = function (options) {
     options = _.extend(
         {
             enable_persistence: true,
@@ -1358,7 +1358,7 @@ PostHogLib.prototype.opt_in_capturing = function(options) {
     this._gdpr_call_func(optIn, options)
     this._gdpr_update_persistence(options)
 }
-PostHogLib.prototype.opt_in_captureing = function(options) {
+PostHogLib.prototype.opt_in_captureing = function (options) {
     deprecate_warning('opt_in_captureing')
     this.opt_in_capturing(options)
 }
@@ -1386,7 +1386,7 @@ PostHogLib.prototype.opt_in_captureing = function(options) {
  * @param {boolean} [options.cross_subdomain_cookie] Whether the opt-in cookie is set as cross-subdomain or not (overrides value specified in this PostHog instance's config)
  * @param {boolean} [options.secure_cookie] Whether the opt-in cookie is set as secure or not (overrides value specified in this PostHog instance's config)
  */
-PostHogLib.prototype.opt_out_capturing = function(options) {
+PostHogLib.prototype.opt_out_capturing = function (options) {
     options = _.extend(
         {
             clear_persistence: true,
@@ -1404,7 +1404,7 @@ PostHogLib.prototype.opt_out_capturing = function(options) {
     this._gdpr_call_func(optOut, options)
     this._gdpr_update_persistence(options)
 }
-PostHogLib.prototype.opt_out_captureing = function(options) {
+PostHogLib.prototype.opt_out_captureing = function (options) {
     deprecate_warning('opt_out_captureing')
     this.opt_out_capturing(options)
 }
@@ -1422,10 +1422,10 @@ PostHogLib.prototype.opt_out_captureing = function(options) {
  * @param {string} [options.cookie_prefix=__ph_opt_in_out] Custom prefix to be used in the cookie/localstorage name
  * @returns {boolean} current opt-in status
  */
-PostHogLib.prototype.has_opted_in_capturing = function(options) {
+PostHogLib.prototype.has_opted_in_capturing = function (options) {
     return this._gdpr_call_func(hasOptedIn, options)
 }
-PostHogLib.prototype.has_opted_in_captureing = function(options) {
+PostHogLib.prototype.has_opted_in_captureing = function (options) {
     deprecate_warning('has_opted_in_captureing')
     return this.has_opted_in_capturing(options)
 }
@@ -1443,10 +1443,10 @@ PostHogLib.prototype.has_opted_in_captureing = function(options) {
  * @param {string} [options.cookie_prefix=__ph_opt_in_out] Custom prefix to be used in the cookie/localstorage name
  * @returns {boolean} current opt-out status
  */
-PostHogLib.prototype.has_opted_out_capturing = function(options) {
+PostHogLib.prototype.has_opted_out_capturing = function (options) {
     return this._gdpr_call_func(hasOptedOut, options)
 }
-PostHogLib.prototype.has_opted_out_captureing = function(options) {
+PostHogLib.prototype.has_opted_out_captureing = function (options) {
     deprecate_warning('has_opted_out_captureing')
     return this.has_opted_out_capturing(options)
 }
@@ -1474,7 +1474,7 @@ PostHogLib.prototype.has_opted_out_captureing = function(options) {
  * @param {boolean} [options.cross_subdomain_cookie] Whether the opt-in cookie is set as cross-subdomain or not (overrides value specified in this PostHog instance's config)
  * @param {boolean} [options.secure_cookie] Whether the opt-in cookie is set as secure or not (overrides value specified in this PostHog instance's config)
  */
-PostHogLib.prototype.clear_opt_in_out_capturing = function(options) {
+PostHogLib.prototype.clear_opt_in_out_capturing = function (options) {
     options = _.extend(
         {
             enable_persistence: true,
@@ -1485,7 +1485,7 @@ PostHogLib.prototype.clear_opt_in_out_capturing = function(options) {
     this._gdpr_call_func(clearOptInOut, options)
     this._gdpr_update_persistence(options)
 }
-PostHogLib.prototype.clear_opt_in_out_captureing = function(options) {
+PostHogLib.prototype.clear_opt_in_out_captureing = function (options) {
     deprecate_warning('clear_opt_in_out_captureing')
     this.clear_opt_in_out_capturing(options)
 }
@@ -1542,9 +1542,9 @@ PostHogPersistence.prototype['clear'] = PostHogPersistence.prototype.clear
 _.safewrap_class(PostHogLib, ['identify'])
 
 var instances = {}
-var extend_mp = function() {
+var extend_mp = function () {
     // add all the sub posthog instances
-    _.each(instances, function(instance, name) {
+    _.each(instances, function (instance, name) {
         if (name !== PRIMARY_INSTANCE_NAME) {
             posthog_master[name] = instance
         }
@@ -1554,10 +1554,10 @@ var extend_mp = function() {
     posthog_master['_'] = _
 }
 
-var override_ph_init_func = function() {
+var override_ph_init_func = function () {
     // we override the snippets init function to handle the case where a
     // user initializes the posthog library after the script loads & runs
-    posthog_master['init'] = function(token, config, name) {
+    posthog_master['init'] = function (token, config, name) {
         if (name) {
             // initialize a sub library
             if (!posthog_master[name]) {
@@ -1587,7 +1587,7 @@ var override_ph_init_func = function() {
     }
 }
 
-var add_dom_loaded_handler = function() {
+var add_dom_loaded_handler = function () {
     // Cross browser DOM Loaded support
     function dom_loaded_handler() {
         // function flag since we only want to execute this once
@@ -1599,7 +1599,7 @@ var add_dom_loaded_handler = function() {
         DOM_LOADED = true
         ENQUEUE_REQUESTS = false
 
-        _.each(instances, function(inst) {
+        _.each(instances, function (inst) {
             inst._dom_loaded()
         })
     }
@@ -1657,7 +1657,7 @@ export function init_from_snippet() {
         return
     }
     // Load instances of the PostHog Library
-    _.each(posthog_master['_i'], function(item) {
+    _.each(posthog_master['_i'], function (item) {
         if (item && _.isArray(item)) {
             instances[item[item.length - 1]] = create_mplib.apply(this, item)
         }
@@ -1667,7 +1667,7 @@ export function init_from_snippet() {
     posthog_master['init']()
 
     // Fire loaded events after updating the window's posthog object
-    _.each(instances, function(instance) {
+    _.each(instances, function (instance) {
         instance._loaded()
     })
 

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -376,7 +376,7 @@ PostHogLib.prototype._event_queue_poll = function () {
                 var json_data = _.JSONEncode(data)
                 if (this.compression['lz64']) {
                     var encoded_data = LZString.compressToBase64(json_data)
-                    this._send_request(url, { data: encoded_data, compression: 'lz-string' }, __NOOPTIONS, __NOOP)
+                    this._send_request(url, { data: encoded_data, compression: 'lz64' }, __NOOPTIONS, __NOOP)
                 } else {
                     var encoded_data = _.base64Encode(json_data)
                     this._send_request(url, { data: encoded_data }, __NOOPTIONS, __NOOP)

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1,4 +1,5 @@
 /* eslint camelcase: "off" */
+import { LZString } from './lz-string'
 import Config from './config'
 import { _, console, userAgent, window, document, navigator } from './utils'
 import { autocapture } from './autocapture'
@@ -28,7 +29,7 @@ var posthog_master // main posthog instance / object
 var INIT_MODULE = 0
 var INIT_SNIPPET = 1
 // some globals for comparisons
-var __NOOP = function () {}
+var __NOOP = function() {}
 var __NOOPTIONS = {}
 
 /** @const */ var PRIMARY_INSTANCE_NAME = 'posthog'
@@ -64,7 +65,7 @@ var DEFAULT_CONFIG = {
     persistence: 'cookie',
     persistence_name: '',
     cookie_name: '',
-    loaded: function () {},
+    loaded: function() {},
     store_google: true,
     save_referrer: true,
     test: false,
@@ -96,7 +97,7 @@ var DOM_LOADED = false
  * PostHog Library Object
  * @constructor
  */
-var PostHogLib = function () {}
+var PostHogLib = function() {}
 
 /**
  * create_mplib(token:string, config:object, name:string)
@@ -106,7 +107,7 @@ var PostHogLib = function () {}
  * initializes document.posthog as well as any additional instances
  * declared before this file has loaded).
  */
-var create_mplib = function (token, config, name) {
+var create_mplib = function(token, config, name) {
     var instance,
         target = name === PRIMARY_INSTANCE_NAME ? posthog_master : posthog_master[name]
 
@@ -181,7 +182,7 @@ var create_mplib = function (token, config, name) {
  * @param {Object} [config]  A dictionary of config options to override. <a href="https://github.com/posthog/posthog-js/blob/6e0e873/src/posthog-core.js#L57-L91">See a list of default config options</a>.
  * @param {String} [name]    The name for the new posthog instance that you want created
  */
-PostHogLib.prototype.init = function (token, config, name) {
+PostHogLib.prototype.init = function(token, config, name) {
     if (_.isUndefined(name)) {
         console.error('You must name your new library: init(token, config, name)')
         return
@@ -205,7 +206,7 @@ PostHogLib.prototype.init = function (token, config, name) {
 // method is this one initializes the actual instance, whereas the
 // init(...) method sets up a new library and calls _init on it.
 //
-PostHogLib.prototype._init = function (token, config, name) {
+PostHogLib.prototype._init = function(token, config, name) {
     this['__loaded'] = true
     this['config'] = {}
     this['_triggered_notifs'] = []
@@ -218,13 +219,13 @@ PostHogLib.prototype._init = function (token, config, name) {
         })
     )
 
-    this['_jsc'] = function () {}
+    this['_jsc'] = function() {}
 
     // batching requests variabls
     this._event_queue = []
     this._empty_queue_count = 0 // to track empty polls
     this._should_poll = true // flag to continue to recursively poll or not
-    this._poller = function () {} // to become interval for reference to clear later
+    this._poller = function() {} // to become interval for reference to clear later
 
     this.__dom_loaded_queue = []
     this.__request_queue = []
@@ -256,7 +257,7 @@ PostHogLib.prototype._init = function (token, config, name) {
 
 // Private methods
 
-PostHogLib.prototype._loaded = function () {
+PostHogLib.prototype._loaded = function() {
     this.get_config('loaded')(this)
 
     // this happens after so a user can call identify in
@@ -266,10 +267,10 @@ PostHogLib.prototype._loaded = function () {
     }
 }
 
-PostHogLib.prototype._dom_loaded = function () {
+PostHogLib.prototype._dom_loaded = function() {
     _.each(
         this.__dom_loaded_queue,
-        function (item) {
+        function(item) {
             this._capture_dom.apply(this, item)
         },
         this
@@ -278,7 +279,7 @@ PostHogLib.prototype._dom_loaded = function () {
     if (!this.has_opted_out_capturing()) {
         _.each(
             this.__request_queue,
-            function (item) {
+            function(item) {
                 this._send_request.apply(this, item)
             },
             this
@@ -292,7 +293,7 @@ PostHogLib.prototype._dom_loaded = function () {
     delete this.__request_queue
 }
 
-PostHogLib.prototype._capture_dom = function (DomClass, args) {
+PostHogLib.prototype._capture_dom = function(DomClass, args) {
     if (this.get_config('img')) {
         console.error("You can't use DOM capturing functions with img = true.")
         return false
@@ -316,13 +317,13 @@ PostHogLib.prototype._capture_dom = function (DomClass, args) {
  * If we are going to use script tags, this returns a string to use as the
  * callback GET param.
  */
-PostHogLib.prototype._prepare_callback = function (callback, data) {
+PostHogLib.prototype._prepare_callback = function(callback, data) {
     if (_.isUndefined(callback)) {
         return null
     }
 
     if (USE_XHR) {
-        var callback_function = function (response) {
+        var callback_function = function(response) {
             callback(response, data)
         }
         return callback_function
@@ -333,7 +334,7 @@ PostHogLib.prototype._prepare_callback = function (callback, data) {
         var jsc = this['_jsc']
         var randomized_cb = '' + Math.floor(Math.random() * 100000000)
         var callback_string = this.get_config('callback_fn') + '[' + randomized_cb + ']'
-        jsc[randomized_cb] = function (response) {
+        jsc[randomized_cb] = function(response) {
             delete jsc[randomized_cb]
             callback(response, data)
         }
@@ -341,7 +342,7 @@ PostHogLib.prototype._prepare_callback = function (callback, data) {
     }
 }
 
-PostHogLib.prototype._event_enqueue = function (url, data, options, callback) {
+PostHogLib.prototype._event_enqueue = function(url, data, options, callback) {
     this._event_queue.push({ url, data, options, callback })
 
     if (!this._should_poll) {
@@ -350,9 +351,9 @@ PostHogLib.prototype._event_enqueue = function (url, data, options, callback) {
     }
 }
 
-PostHogLib.prototype._format_event_queue_data = function () {
+PostHogLib.prototype._format_event_queue_data = function() {
     const requests = {}
-    _.each(this._event_queue, (request) => {
+    _.each(this._event_queue, request => {
         const { url, data } = request
         if (requests[url] === undefined) requests[url] = []
         requests[url].push(data)
@@ -360,20 +361,20 @@ PostHogLib.prototype._format_event_queue_data = function () {
     return requests
 }
 
-PostHogLib.prototype._event_queue_poll = function () {
+PostHogLib.prototype._event_queue_poll = function() {
     const POLL_INTERVAL = 3000
     this._poller = setTimeout(() => {
         if (this._event_queue.length > 0) {
             const requests = this._format_event_queue_data()
             for (let url in requests) {
                 let data = requests[url]
-                _.each(data, function (value, key) {
+                _.each(data, function(value, key) {
                     data[key]['offset'] = Math.abs(data[key]['timestamp'] - new Date())
                     delete data[key]['timestamp']
                 })
                 var json_data = _.JSONEncode(data)
-                var encoded_data = _.base64Encode(json_data)
-                this._send_request(url, { data: encoded_data }, __NOOPTIONS, __NOOP)
+                var encoded_data = LZString.compressToBase64(json_data)
+                this._send_request(url, { data: encoded_data, compression: 'lz-string' }, __NOOPTIONS, __NOOP)
             }
             this._event_queue.length = 0 // flush the _event_queue
         } else {
@@ -398,7 +399,7 @@ PostHogLib.prototype._event_queue_poll = function () {
     }, POLL_INTERVAL)
 }
 
-PostHogLib.prototype._handle_unload = function () {
+PostHogLib.prototype._handle_unload = function() {
     if (!this.get_config('request_batching')) {
         this.capture('$pageleave', null, { transport: 'sendbeacon' })
         return
@@ -414,12 +415,12 @@ PostHogLib.prototype._handle_unload = function () {
     for (let url in data) {
         // sendbeacon has some hard requirments and cant be treated
         // like a normal post request. Because of that it needs to be encoded
-        const encoded_data = _.base64Encode(_.JSONEncode(data[url]))
-        this._send_request(url, { data: encoded_data }, { transport: 'sendbeacon' }, __NOOP)
+        var encoded_data = LZString.compressToBase64(_.JSONEncode(data[url]))
+        this._send_request(url, { data: encoded_data, compression: 'lz-string' }, { transport: 'sendbeacon' }, __NOOP)
     }
 }
 
-PostHogLib.prototype._send_request = function (url, data, options, callback) {
+PostHogLib.prototype._send_request = function(url, data, options, callback) {
     if (ENQUEUE_REQUESTS) {
         this.__request_queue.push(arguments)
         return
@@ -477,11 +478,16 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
 
     if (use_post) {
         if (Array.isArray(data)) {
-            body_data = 'data=' + data
+            body_data = 'data=' + encodeURIComponent(data)
         } else {
-            body_data = 'data=' + data['data']
+            body_data = 'data=' + encodeURIComponent(data['data'])
         }
         delete data['data']
+
+        if (data['compression']) {
+            body_data += '&compression=' + data['compression']
+            delete data['compression']
+        }
     }
 
     url += '?' + _.HTTPBuildQuery(args)
@@ -505,14 +511,14 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
             if (use_post) {
                 headers['Content-Type'] = 'application/x-www-form-urlencoded'
             }
-            _.each(headers, function (headerValue, headerName) {
+            _.each(headers, function(headerValue, headerName) {
                 req.setRequestHeader(headerName, headerValue)
             })
 
             // send the ph_optout cookie
             // withCredentials cannot be modified until after calling .open on Android and Mobile Safari
             req.withCredentials = true
-            req.onreadystatechange = function () {
+            req.onreadystatechange = function() {
                 if (req.readyState === 4) {
                     // XMLHttpRequest.DONE == 4, except in safari 4
                     if (req.status === 200) {
@@ -566,14 +572,14 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
  *
  * @param {Array} array
  */
-PostHogLib.prototype._execute_array = function (array) {
+PostHogLib.prototype._execute_array = function(array) {
     var fn_name,
         alias_calls = [],
         other_calls = [],
         capturing_calls = []
     _.each(
         array,
-        function (item) {
+        function(item) {
             if (item) {
                 fn_name = item[0]
                 if (_.isArray(fn_name)) {
@@ -596,14 +602,14 @@ PostHogLib.prototype._execute_array = function (array) {
         this
     )
 
-    var execute = function (calls, context) {
+    var execute = function(calls, context) {
         _.each(
             calls,
-            function (item) {
+            function(item) {
                 if (_.isArray(item[0])) {
                     // chained call
                     var caller = context
-                    _.each(item, function (call) {
+                    _.each(item, function(call) {
                         caller = caller[call[0]].apply(caller, call.slice(1))
                     })
                 } else {
@@ -631,7 +637,7 @@ PostHogLib.prototype._execute_array = function (array) {
  *
  * @param {Array} item A [function_name, args...] array to be executed
  */
-PostHogLib.prototype.push = function (item) {
+PostHogLib.prototype.push = function(item) {
     this._execute_array([item])
 }
 
@@ -655,7 +661,7 @@ PostHogLib.prototype.push = function (item) {
  * @param {String} [options.transport] Transport method for network request ('xhr' or 'sendBeacon').
  * @param {Function} [callback] If provided, the callback function will be called after capturing the event.
  */
-PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, properties, options, callback) {
+PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function(event_name, properties, options, callback) {
     if (!callback && typeof options === 'function') {
         callback = options
         options = null
@@ -709,7 +715,7 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
 
     var property_blacklist = this.get_config('property_blacklist')
     if (_.isArray(property_blacklist)) {
-        _.each(property_blacklist, function (blacklisted_prop) {
+        _.each(property_blacklist, function(blacklisted_prop) {
             delete properties[blacklisted_prop]
         })
     } else {
@@ -723,7 +729,6 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
 
     var truncated_data = _.truncate(data, 255)
     var json_data = _.JSONEncode(truncated_data)
-    var encoded_data = _.base64Encode(json_data)
 
     const url = this.get_config('api_host') + '/e/'
     const cb = this._prepare_callback(callback, truncated_data)
@@ -731,7 +736,8 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
     const has_unique_traits = callback !== __NOOP || options !== __NOOPTIONS
 
     if (!this.get_config('request_batching') || has_unique_traits) {
-        this._send_request(url, { data: encoded_data }, options, cb)
+        var encoded_data = LZString.compressToBase64(json_data)
+        this._send_request(url, { data: encoded_data, compression: 'lz-string' }, options, cb)
     } else {
         data['timestamp'] = new Date()
         this._event_enqueue(url, data, options, cb)
@@ -740,11 +746,11 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
     return truncated_data
 })
 
-PostHogLib.prototype._create_map_key = function (group_key, group_id) {
+PostHogLib.prototype._create_map_key = function(group_key, group_id) {
     return group_key + '_' + JSON.stringify(group_id)
 }
 
-PostHogLib.prototype._remove_group_from_cache = function (group_key, group_id) {
+PostHogLib.prototype._remove_group_from_cache = function(group_key, group_id) {
     delete this._cached_groups[this._create_map_key(group_key, group_id)]
 }
 
@@ -756,7 +762,7 @@ PostHogLib.prototype._remove_group_from_cache = function (group_key, group_id) {
  * @param {String} [page] The url of the page to record. If you don't include this, it defaults to the current url.
  * @api private
  */
-PostHogLib.prototype.capture_pageview = function (page) {
+PostHogLib.prototype.capture_pageview = function(page) {
     if (_.isUndefined(page)) {
         page = document.location.href
     }
@@ -791,7 +797,7 @@ PostHogLib.prototype.capture_pageview = function (page) {
  * @param {String} event_name The name of the event to capture
  * @param {Object|Function} [properties] A properties object or function that returns a dictionary of properties when passed a DOMElement
  */
-PostHogLib.prototype.capture_links = function () {
+PostHogLib.prototype.capture_links = function() {
     return this._capture_dom.call(this, LinkCapture, arguments)
 }
 
@@ -822,7 +828,7 @@ PostHogLib.prototype.capture_links = function () {
  * @param {String} event_name The name of the event to capture
  * @param {Object|Function} [properties] This can be a set of properties, or a function that returns a set of properties after being passed a DOMElement
  */
-PostHogLib.prototype.capture_forms = function () {
+PostHogLib.prototype.capture_forms = function() {
     return this._capture_dom.call(this, FormCaptureer, arguments)
 }
 
@@ -844,7 +850,7 @@ PostHogLib.prototype.capture_forms = function () {
  * @param {Object} properties An associative array of properties to store about the user
  * @param {Number} [days] How many days since the user's last visit to store the super properties
  */
-PostHogLib.prototype.register = function (props, days) {
+PostHogLib.prototype.register = function(props, days) {
     this['persistence'].register(props, days)
 }
 
@@ -868,7 +874,7 @@ PostHogLib.prototype.register = function (props, days) {
  * @param {*} [default_value] Value to override if already set in super properties (ex: 'False') Default: 'None'
  * @param {Number} [days] How many days since the users last visit to store the super properties
  */
-PostHogLib.prototype.register_once = function (props, default_value, days) {
+PostHogLib.prototype.register_once = function(props, default_value, days) {
     this['persistence'].register_once(props, default_value, days)
 }
 
@@ -877,11 +883,11 @@ PostHogLib.prototype.register_once = function (props, default_value, days) {
  *
  * @param {String} property The name of the super property to remove
  */
-PostHogLib.prototype.unregister = function (property) {
+PostHogLib.prototype.unregister = function(property) {
     this['persistence'].unregister(property)
 }
 
-PostHogLib.prototype._register_single = function (prop, value) {
+PostHogLib.prototype._register_single = function(prop, value) {
     var props = {}
     props[prop] = value
     this.register(props)
@@ -896,7 +902,7 @@ PostHogLib.prototype._register_single = function (prop, value) {
  *
  * @param {Object|String} prop Key of the feature flag.
  */
-PostHogLib.prototype.isFeatureEnabled = function (key) {
+PostHogLib.prototype.isFeatureEnabled = function(key) {
     return this.feature_flags.isFeatureEnabled(key)
 }
 
@@ -909,7 +915,7 @@ PostHogLib.prototype.isFeatureEnabled = function (key) {
  *
  * @param {Function} [callback] The callback function will be called once the feature flags are ready. It'll return a list of feature flags enabled for the user.
  */
-PostHogLib.prototype.onFeatureFlags = function (callback) {
+PostHogLib.prototype.onFeatureFlags = function(callback) {
     return this.feature_flags.onFeatureFlags(callback)
 }
 
@@ -940,7 +946,7 @@ PostHogLib.prototype.onFeatureFlags = function (callback) {
  *
  * @param {String} [unique_id] A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.
  */
-PostHogLib.prototype.identify = function (new_distinct_id, _set_callback, _set_once_callback) {
+PostHogLib.prototype.identify = function(new_distinct_id, _set_callback, _set_once_callback) {
     // Optional Parameters
     //  _set_callback:function  A callback to be run if and when the People set queue is flushed
     //  _set_once_callback:function  A callback to be run if and when the People set_once queue is flushed
@@ -988,7 +994,7 @@ PostHogLib.prototype.identify = function (new_distinct_id, _set_callback, _set_o
  * Clears super properties and generates a new random distinct_id for this instance.
  * Useful for clearing data when a user logs out.
  */
-PostHogLib.prototype.reset = function (reset_device_id) {
+PostHogLib.prototype.reset = function(reset_device_id) {
     let device_id = this.get_property('$device_id')
     this['persistence'].clear()
     this._flags.identify_called = false
@@ -1018,7 +1024,7 @@ PostHogLib.prototype.reset = function (reset_device_id) {
  *         }
  *     });
  */
-PostHogLib.prototype.get_distinct_id = function () {
+PostHogLib.prototype.get_distinct_id = function() {
     return this.get_property('distinct_id')
 }
 
@@ -1043,7 +1049,7 @@ PostHogLib.prototype.get_distinct_id = function () {
  * @param {String} alias A unique identifier that you want to use for this user in the future.
  * @param {String} [original] The current identifier being used for this user.
  */
-PostHogLib.prototype.alias = function (alias, original) {
+PostHogLib.prototype.alias = function(alias, original) {
     // If the $people_distinct_id key exists in persistence, there has been a previous
     // posthog.people.identify() call made for this user. It is VERY BAD to make an alias with
     // this ID, as it will duplicate users.
@@ -1058,7 +1064,7 @@ PostHogLib.prototype.alias = function (alias, original) {
     }
     if (alias !== original) {
         this._register_single(ALIAS_ID_KEY, alias)
-        return this.capture('$create_alias', { alias: alias, distinct_id: original }, function () {
+        return this.capture('$create_alias', { alias: alias, distinct_id: original }, function() {
             // Flush the people queue
             _this.identify(alias)
         })
@@ -1165,7 +1171,7 @@ PostHogLib.prototype.alias = function (alias, original) {
  *
  * @param {Object} config A dictionary of new configuration values to update
  */
-PostHogLib.prototype.set_config = function (config) {
+PostHogLib.prototype.set_config = function(config) {
     if (_.isObject(config)) {
         _.extend(this['config'], config)
 
@@ -1186,7 +1192,7 @@ PostHogLib.prototype.set_config = function (config) {
 /**
  * returns the current config object for the library.
  */
-PostHogLib.prototype.get_config = function (prop_name) {
+PostHogLib.prototype.get_config = function(prop_name) {
     return this['config'][prop_name]
 }
 
@@ -1208,11 +1214,11 @@ PostHogLib.prototype.get_config = function (prop_name) {
  *
  * @param {String} property_name The name of the super property you want to retrieve
  */
-PostHogLib.prototype.get_property = function (property_name) {
+PostHogLib.prototype.get_property = function(property_name) {
     return this['persistence']['props'][property_name]
 }
 
-PostHogLib.prototype.toString = function () {
+PostHogLib.prototype.toString = function() {
     var name = this.get_config('name')
     if (name !== PRIMARY_INSTANCE_NAME) {
         name = PRIMARY_INSTANCE_NAME + '.' + name
@@ -1220,12 +1226,12 @@ PostHogLib.prototype.toString = function () {
     return name
 }
 
-PostHogLib.prototype._event_is_disabled = function (event_name) {
+PostHogLib.prototype._event_is_disabled = function(event_name) {
     return _.isBlockedUA(userAgent) || this._flags.disable_all_events || _.include(this.__disabled_events, event_name)
 }
 
 // perform some housekeeping around GDPR opt-in/out state
-PostHogLib.prototype._gdpr_init = function () {
+PostHogLib.prototype._gdpr_init = function() {
     var is_localStorage_requested = this.get_config('opt_out_capturing_persistence_type') === 'localStorage'
 
     // try to convert opt-in/out cookies to localStorage if possible
@@ -1266,7 +1272,7 @@ PostHogLib.prototype._gdpr_init = function () {
  * @param {boolean} [options.clear_persistence] If true, will delete all data stored by the sdk in persistence and disable it
  * @param {boolean} [options.enable_persistence] If true, will re-enable sdk persistence
  */
-PostHogLib.prototype._gdpr_update_persistence = function (options) {
+PostHogLib.prototype._gdpr_update_persistence = function(options) {
     var disabled
     if (options && options['clear_persistence']) {
         disabled = true
@@ -1282,7 +1288,7 @@ PostHogLib.prototype._gdpr_update_persistence = function (options) {
 }
 
 // call a base gdpr function after constructing the appropriate token and options args
-PostHogLib.prototype._gdpr_call_func = function (func, options) {
+PostHogLib.prototype._gdpr_call_func = function(func, options) {
     options = _.extend(
         {
             capture: _.bind(this.capture, this),
@@ -1341,7 +1347,7 @@ PostHogLib.prototype._gdpr_call_func = function (func, options) {
  * @param {boolean} [options.cross_subdomain_cookie] Whether the opt-in cookie is set as cross-subdomain or not (overrides value specified in this PostHog instance's config)
  * @param {boolean} [options.secure_cookie] Whether the opt-in cookie is set as secure or not (overrides value specified in this PostHog instance's config)
  */
-PostHogLib.prototype.opt_in_capturing = function (options) {
+PostHogLib.prototype.opt_in_capturing = function(options) {
     options = _.extend(
         {
             enable_persistence: true,
@@ -1352,7 +1358,7 @@ PostHogLib.prototype.opt_in_capturing = function (options) {
     this._gdpr_call_func(optIn, options)
     this._gdpr_update_persistence(options)
 }
-PostHogLib.prototype.opt_in_captureing = function (options) {
+PostHogLib.prototype.opt_in_captureing = function(options) {
     deprecate_warning('opt_in_captureing')
     this.opt_in_capturing(options)
 }
@@ -1380,7 +1386,7 @@ PostHogLib.prototype.opt_in_captureing = function (options) {
  * @param {boolean} [options.cross_subdomain_cookie] Whether the opt-in cookie is set as cross-subdomain or not (overrides value specified in this PostHog instance's config)
  * @param {boolean} [options.secure_cookie] Whether the opt-in cookie is set as secure or not (overrides value specified in this PostHog instance's config)
  */
-PostHogLib.prototype.opt_out_capturing = function (options) {
+PostHogLib.prototype.opt_out_capturing = function(options) {
     options = _.extend(
         {
             clear_persistence: true,
@@ -1398,7 +1404,7 @@ PostHogLib.prototype.opt_out_capturing = function (options) {
     this._gdpr_call_func(optOut, options)
     this._gdpr_update_persistence(options)
 }
-PostHogLib.prototype.opt_out_captureing = function (options) {
+PostHogLib.prototype.opt_out_captureing = function(options) {
     deprecate_warning('opt_out_captureing')
     this.opt_out_capturing(options)
 }
@@ -1416,10 +1422,10 @@ PostHogLib.prototype.opt_out_captureing = function (options) {
  * @param {string} [options.cookie_prefix=__ph_opt_in_out] Custom prefix to be used in the cookie/localstorage name
  * @returns {boolean} current opt-in status
  */
-PostHogLib.prototype.has_opted_in_capturing = function (options) {
+PostHogLib.prototype.has_opted_in_capturing = function(options) {
     return this._gdpr_call_func(hasOptedIn, options)
 }
-PostHogLib.prototype.has_opted_in_captureing = function (options) {
+PostHogLib.prototype.has_opted_in_captureing = function(options) {
     deprecate_warning('has_opted_in_captureing')
     return this.has_opted_in_capturing(options)
 }
@@ -1437,10 +1443,10 @@ PostHogLib.prototype.has_opted_in_captureing = function (options) {
  * @param {string} [options.cookie_prefix=__ph_opt_in_out] Custom prefix to be used in the cookie/localstorage name
  * @returns {boolean} current opt-out status
  */
-PostHogLib.prototype.has_opted_out_capturing = function (options) {
+PostHogLib.prototype.has_opted_out_capturing = function(options) {
     return this._gdpr_call_func(hasOptedOut, options)
 }
-PostHogLib.prototype.has_opted_out_captureing = function (options) {
+PostHogLib.prototype.has_opted_out_captureing = function(options) {
     deprecate_warning('has_opted_out_captureing')
     return this.has_opted_out_capturing(options)
 }
@@ -1468,7 +1474,7 @@ PostHogLib.prototype.has_opted_out_captureing = function (options) {
  * @param {boolean} [options.cross_subdomain_cookie] Whether the opt-in cookie is set as cross-subdomain or not (overrides value specified in this PostHog instance's config)
  * @param {boolean} [options.secure_cookie] Whether the opt-in cookie is set as secure or not (overrides value specified in this PostHog instance's config)
  */
-PostHogLib.prototype.clear_opt_in_out_capturing = function (options) {
+PostHogLib.prototype.clear_opt_in_out_capturing = function(options) {
     options = _.extend(
         {
             enable_persistence: true,
@@ -1479,7 +1485,7 @@ PostHogLib.prototype.clear_opt_in_out_capturing = function (options) {
     this._gdpr_call_func(clearOptInOut, options)
     this._gdpr_update_persistence(options)
 }
-PostHogLib.prototype.clear_opt_in_out_captureing = function (options) {
+PostHogLib.prototype.clear_opt_in_out_captureing = function(options) {
     deprecate_warning('clear_opt_in_out_captureing')
     this.clear_opt_in_out_capturing(options)
 }
@@ -1536,9 +1542,9 @@ PostHogPersistence.prototype['clear'] = PostHogPersistence.prototype.clear
 _.safewrap_class(PostHogLib, ['identify'])
 
 var instances = {}
-var extend_mp = function () {
+var extend_mp = function() {
     // add all the sub posthog instances
-    _.each(instances, function (instance, name) {
+    _.each(instances, function(instance, name) {
         if (name !== PRIMARY_INSTANCE_NAME) {
             posthog_master[name] = instance
         }
@@ -1548,10 +1554,10 @@ var extend_mp = function () {
     posthog_master['_'] = _
 }
 
-var override_ph_init_func = function () {
+var override_ph_init_func = function() {
     // we override the snippets init function to handle the case where a
     // user initializes the posthog library after the script loads & runs
-    posthog_master['init'] = function (token, config, name) {
+    posthog_master['init'] = function(token, config, name) {
         if (name) {
             // initialize a sub library
             if (!posthog_master[name]) {
@@ -1581,7 +1587,7 @@ var override_ph_init_func = function () {
     }
 }
 
-var add_dom_loaded_handler = function () {
+var add_dom_loaded_handler = function() {
     // Cross browser DOM Loaded support
     function dom_loaded_handler() {
         // function flag since we only want to execute this once
@@ -1593,7 +1599,7 @@ var add_dom_loaded_handler = function () {
         DOM_LOADED = true
         ENQUEUE_REQUESTS = false
 
-        _.each(instances, function (inst) {
+        _.each(instances, function(inst) {
             inst._dom_loaded()
         })
     }
@@ -1651,7 +1657,7 @@ export function init_from_snippet() {
         return
     }
     // Load instances of the PostHog Library
-    _.each(posthog_master['_i'], function (item) {
+    _.each(posthog_master['_i'], function(item) {
         if (item && _.isArray(item)) {
             instances[item[item.length - 1]] = create_mplib.apply(this, item)
         }
@@ -1661,7 +1667,7 @@ export function init_from_snippet() {
     posthog_master['init']()
 
     // Fire loaded events after updating the window's posthog object
-    _.each(instances, function (instance) {
+    _.each(instances, function(instance) {
         instance._loaded()
     })
 


### PR DESCRIPTION
I implemented compression for the JS payloads. It's still sent as base64, just compressed with [lz-string](https://pieroxy.net/blog/pages/lz-string/index.html) before encoding.

Preliminary results are very promising! Here are the sizes of the base64 before and after compression:

![image](https://user-images.githubusercontent.com/53387/85133533-27df9480-b23b-11ea-8463-ac8f15d92790.png)

These are events with batching enabled. The size difference is especially pronounced when I just clicked a lot on the same thing, generating multiple very similar events.

I'll post an issue soon for the python counterpart to this.

However... this is probably still a bit WIP since there's an open question: How should we solve the case that if you're using an older version of posthog, the newer snippet will stop working? Ideally we should do some "compression protocol negotiation", where the "/decide" endpoint also returns "ok to compress with lz-string".