### PR TITLE
Clean up how editor params are stored

### DIFF
--- a/tests/unit/autocapture.js
+++ b/tests/unit/autocapture.js
@@ -848,7 +848,7 @@ describe('Autocapture system', function() {
         flag_1: 0,
         flag_2: 1,
       }
-      const state = {
+      editorParams = {
         action: 'mpeditor',
         desiredHash: '#myhash',
         projectId: 3,
@@ -860,20 +860,8 @@ describe('Autocapture system', function() {
       };
       const hashParams = {
         access_token: 'test_access_token',
-        state: encodeURIComponent(JSON.stringify(state)),
+        state: encodeURIComponent(JSON.stringify(editorParams)),
         expires_in: 3600,
-      };
-      editorParams = {
-        action: 'mpeditor',
-        desiredHash: '#myhash',
-        projectId: 3,
-        projectOwnerId: 722725,
-        readOnly: false,
-        token: 'test_token',
-        userFlags,
-        userId: 12345,
-        accessToken: 'test_access_token',
-        accessTokenExpiresAt: 3600000,
       };
 
       hash = Object.keys(hashParams).map(k => `${k}=${hashParams[k]}`).join('&');
@@ -889,15 +877,15 @@ describe('Autocapture system', function() {
       autocapture._maybeLoadEditor(lib);
       expect(autocapture._loadEditor.calledOnce).to.equal(true);
       expect(autocapture._loadEditor.calledWith(lib, editorParams)).to.equal(true);
-      expect(JSON.parse(window.sessionStorage.getItem('editorParams'))).to.deep.equal(editorParams);
+      expect(JSON.parse(window.sessionStorage.getItem('_postHogEditorParams'))).to.deep.equal(editorParams);
     });
 
-    it('should initialize the visual editor when the hash was parsed by the snippet', function() {
-      window.sessionStorage.setItem('_mpcehash', `#${hash}`);
+    it('should initialize the visual editor when there are editor params in the session', function() {
+      window.sessionStorage.setItem('_postHogEditorParams', JSON.stringify(editorParams));
       autocapture._maybeLoadEditor(lib);
       expect(autocapture._loadEditor.calledOnce).to.equal(true);
       expect(autocapture._loadEditor.calledWith(lib, editorParams)).to.equal(true);
-      expect(JSON.parse(window.sessionStorage.getItem('editorParams'))).to.deep.equal(editorParams);
+      expect(JSON.parse(window.sessionStorage.getItem('_postHogEditorParams'))).to.deep.equal(editorParams);
     });
 
     it('should NOT initialize the visual editor when the activation query param does not exist', function() {

--- a/tests/unit/loader.js
+++ b/tests/unit/loader.js
@@ -13,6 +13,7 @@ describe(`Module-based loader in Node env`, function() {
   it("should load and capture the pageview event", function() {
     const sandbox = sinon.createSandbox();
     let loaded = false
+    posthog._originalCapture = posthog.capture
     posthog.capture = sandbox.spy()
     posthog.init(`test-token`, {
       debug: true,
@@ -29,6 +30,9 @@ describe(`Module-based loader in Node env`, function() {
     const props = captureArgs[1];
     expect(event).to.equal("$pageview");
     expect(loaded).to.equal(true)
+
+    posthog.capture = posthog._originalCapture
+    delete posthog._originalCapture
   });
 
   it(`supports identify()`, function() {


### PR DESCRIPTION
This needs some tests 😅 ... but otherwise here's a bit of cleanup regarding storing the toolbar params in sessionStorage.

This was mainly done for the `delete editorParams.userIntent` part.