### PR TITLE
Add `#__posthog={}` as an option for state params

### DIFF
--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -933,6 +933,26 @@ describe('Autocapture system', () => {
             expect(JSON.parse(window.sessionStorage.getItem('_postHogEditorParams'))).toEqual(editorParams)
         })
 
+        it('should initialize the visual editor when the hash state contains action "ph_authorize"', () => {
+            editorParams = {
+                ...editorParams,
+                action: 'ph_authorize',
+            }
+            const hashParams = {
+                state: encodeURIComponent(JSON.stringify(editorParams)),
+            }
+
+            hash = Object.keys(hashParams)
+                .map((k) => `${k}=${hashParams[k]}`)
+                .join('&')
+
+            window.location.hash = `#${hash}`
+            autocapture._maybeLoadEditor(lib)
+            expect(autocapture._loadEditor.calledOnce).toBe(true)
+            expect(autocapture._loadEditor.calledWith(lib, editorParams)).toBe(true)
+            expect(JSON.parse(window.sessionStorage.getItem('_postHogEditorParams'))).toEqual(editorParams)
+        })
+
         it('should initialize the visual editor when there are editor params in the session', () => {
             window.sessionStorage.setItem('_postHogEditorParams', JSON.stringify(editorParams))
             autocapture._maybeLoadEditor(lib)

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -960,6 +960,22 @@ describe('Autocapture system', () => {
             spy(lib)
             expect(spy.returned(false)).toBe(true)
         })
+
+        it('should work if calling editor params `__posthog`', () => {
+            const hashParams = {
+                access_token: 'test_access_token',
+                __posthog: encodeURIComponent(JSON.stringify(editorParams)),
+                expires_in: 3600,
+            }
+            hash = Object.keys(hashParams)
+                .map((k) => `${k}=${hashParams[k]}`)
+                .join('&')
+            window.location.hash = `#${hash}`
+            autocapture._maybeLoadEditor(lib)
+            expect(autocapture._loadEditor.calledOnce).toBe(true)
+            expect(autocapture._loadEditor.calledWith(lib, editorParams)).toBe(true)
+            expect(JSON.parse(window.sessionStorage.getItem('_postHogEditorParams'))).toEqual(editorParams)
+        })
     })
 
     describe('load and close editor', () => {

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -298,7 +298,7 @@ var autocapture = {
             var stateHash =
                 _.getHashParam(window.location.hash, '__posthog') || _.getHashParam(window.location.hash, 'state')
             var state = stateHash ? JSON.parse(decodeURIComponent(stateHash)) : null
-            var parseFromUrl = state && state['action'] === 'mpeditor'
+            var parseFromUrl = state && (state['action'] === 'mpeditor' || state['action'] === 'ph_authorize')
             var editorParams
 
             if (parseFromUrl) {

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -288,16 +288,6 @@ var autocapture = {
         )
     },
 
-    _editorParamsFromHash: function (instance, hash) {
-        try {
-            var state = _.getHashParam(hash, 'state')
-            return JSON.parse(decodeURIComponent(state))
-        } catch (e) {
-            console.error('Unable to parse data from hash', e)
-        }
-        return {}
-    },
-
     /**
      * To load the visual editor, we need an access token and other state. That state comes from one of three places:
      * 1. In the URL hash params if the customer is using an old snippet
@@ -305,7 +295,8 @@ var autocapture = {
      */
     _maybeLoadEditor: function (instance) {
         try {
-            var stateHash = _.getHashParam(window.location.hash, 'state')
+            var stateHash =
+                _.getHashParam(window.location.hash, '__posthog') || _.getHashParam(window.location.hash, 'state')
             var state = stateHash ? JSON.parse(decodeURIComponent(stateHash)) : null
             var parseFromUrl = state && state['action'] === 'mpeditor'
             var editorParams


### PR DESCRIPTION
## Changes

This makes the editor load when the URL contains the string `__posthog={editorParams}` in addition to the existing `state={editorParams}`. The latter caused problems with google tag manager... or something.

## Checklist
- [x] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
