### PR TITLE
Improve feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased - 2020-08-10
+- Add option `.reloadFeatureFlags()`. Pass it a callback to get the flags array upon reload.
+
 ## 1.3.8 - 2020-08-07
 - Set `secure_cookie` config to `true` if the page is running over https 
 

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -900,7 +900,7 @@ describe('Autocapture system', () => {
                 flag_2: 1,
             }
             editorParams = {
-                action: 'mpeditor',
+                action: 'ph_authorize',
                 desiredHash: '#myhash',
                 projectId: 3,
                 projectOwnerId: 722725,
@@ -908,6 +908,7 @@ describe('Autocapture system', () => {
                 token: 'test_token',
                 userFlags,
                 userId: 12345,
+                apiURL: lib.get_config('api_host'),
             }
             const hashParams = {
                 access_token: 'test_access_token',

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -269,7 +269,7 @@ var autocapture = {
                 instance['__autocapture_enabled'] = false
             }
 
-            if (response['featureFlags'] && response['featureFlags'].length > 0) {
+            if (response['featureFlags']) {
                 instance.persistence &&
                     instance.persistence.register({ $active_feature_flags: response['featureFlags'] })
             } else {

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -338,6 +338,8 @@ var autocapture = {
                 delete editorParams.userIntent
             }
 
+            editorParams['apiURL'] = instance.get_config('api_host')
+
             if (editorParams['token'] && instance.get_config('token') === editorParams['token']) {
                 this._loadEditor(instance, editorParams)
                 return true

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -681,6 +681,8 @@ declare namespace posthog {
     export class feature_flags {
         static getFlags(): string[]
 
+        static reloadFeatureFlags(callback: (flags: string[]) => any): void
+
         /*
          * See if feature flag is enabled for user.
          *

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -930,6 +930,10 @@ PostHogLib.prototype.isFeatureEnabled = function (key) {
     return this.feature_flags.isFeatureEnabled(key)
 }
 
+PostHogLib.prototype.reloadFeatureFlags = function (callback) {
+    return this.feature_flags.reloadFeatureFlags(callback)
+}
+
 /*
  * See if feature flags are available.
  *
@@ -1556,6 +1560,7 @@ PostHogLib.prototype['has_opted_out_capturing'] = PostHogLib.prototype.has_opted
 PostHogLib.prototype['has_opted_in_capturing'] = PostHogLib.prototype.has_opted_in_capturing
 PostHogLib.prototype['clear_opt_in_out_capturing'] = PostHogLib.prototype.clear_opt_in_out_capturing
 PostHogLib.prototype['isFeatureEnabled'] = PostHogLib.prototype.isFeatureEnabled
+PostHogLib.prototype['reloadFeatureFlags'] = PostHogLib.prototype.reloadFeatureFlags
 PostHogLib.prototype['onFeatureFlags'] = PostHogLib.prototype.onFeatureFlags
 PostHogLib.prototype['decodeLZ64'] = PostHogLib.prototype.decodeLZ64
 

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -944,7 +944,7 @@ PostHogLib.prototype.reloadFeatureFlags = function (callback) {
  * @param {Function} [callback] The callback function will be called once the feature flags are ready. It'll return a list of feature flags enabled for the user.
  */
 PostHogLib.prototype.onFeatureFlags = function (callback) {
-    return this.feature_flags.onFeatureFlags(callback)
+    return this.persistence.addFeatureFlagsHandler(callback)
 }
 
 /**
@@ -1016,6 +1016,8 @@ PostHogLib.prototype.identify = function (new_distinct_id, _set_callback, _set_o
     if (new_distinct_id !== previous_distinct_id) {
         this.capture('$identify', { distinct_id: new_distinct_id, $anon_distinct_id: previous_distinct_id })
     }
+
+    this.reloadFeatureFlags()
 }
 
 /**

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -936,6 +936,7 @@ PostHogLib.prototype.reloadFeatureFlags = function (callback) {
 
 /*
  * Register an event listener that runs when feature flags become available or when they change.
+ * If there are flags, the listener is called immediately in addition to being called on future changes.
  *
  * ### Usage:
  *
@@ -945,7 +946,12 @@ PostHogLib.prototype.reloadFeatureFlags = function (callback) {
  *                              It'll return a list of feature flags enabled for the user.
  */
 PostHogLib.prototype.onFeatureFlags = function (callback) {
-    return this.persistence.addFeatureFlagsHandler(callback)
+    this.persistence.addFeatureFlagsHandler(callback)
+
+    const flags = this.feature_flags.getFlags()
+    if (flags) {
+        callback(flags)
+    }
 }
 
 /**

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -9,11 +9,6 @@ import { PostHogFeatureFlags } from './posthog-featureflags'
 import { PostHogPersistence, PEOPLE_DISTINCT_ID_KEY, ALIAS_ID_KEY } from './posthog-persistence'
 import { optIn, optOut, hasOptedIn, hasOptedOut, clearOptInOut, addOptOutCheckPostHogLib } from './gdpr-utils'
 
-// ==ClosureCompiler==
-// @compilation_level ADVANCED_OPTIMIZATIONS
-// @output_file_name posthog-2.8.min.js
-// ==/ClosureCompiler==
-
 /*
 SIMPLE STYLE GUIDE:
 
@@ -56,11 +51,10 @@ if (sendBeacon) {
  * Module-level globals
  */
 var DEFAULT_CONFIG = {
-    api_host: 'https://t.posthog.com',
+    api_host: 'https://app.posthog.com',
     api_method: 'POST',
     api_transport: 'XHR',
     autocapture: true,
-    cdn: 'https://cdn.posthog.com',
     cross_subdomain_cookie: document.location.hostname.indexOf('herokuapp.com') === -1,
     persistence: 'cookie',
     persistence_name: '',
@@ -935,13 +929,14 @@ PostHogLib.prototype.reloadFeatureFlags = function (callback) {
 }
 
 /*
- * See if feature flags are available.
+ * Register an event listener that runs when feature flags become available or when they change.
  *
  * ### Usage:
  *
  *     posthog.onFeatureFlags(function(featureFlags) { // do something })
  *
- * @param {Function} [callback] The callback function will be called once the feature flags are ready. It'll return a list of feature flags enabled for the user.
+ * @param {Function} [callback] The callback function will be called once the feature flags are ready or when they are updated.
+ *                              It'll return a list of feature flags enabled for the user.
  */
 PostHogLib.prototype.onFeatureFlags = function (callback) {
     return this.persistence.addFeatureFlagsHandler(callback)

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -22,13 +22,11 @@ PostHogFeatureFlags.prototype.getFlags = function () {
     return this._posthog.persistence.props['$active_feature_flags']
 }
 
-PostHogFeatureFlags.prototype.reloadFeatureFlags = function (callback) {
+PostHogFeatureFlags.prototype.reloadFeatureFlags = function () {
     var posthog = this._posthog
     var parseDecideResponse = _.bind(function (response) {
         if (response['featureFlags']) {
             posthog.persistence && posthog.persistence.register({ $active_feature_flags: response['featureFlags'] })
-
-            callback && callback(response['featureFlags'])
         } else {
             posthog.persistence && posthog.persistence.unregister('$active_feature_flags')
         }

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -64,29 +64,6 @@ PostHogFeatureFlags.prototype.isFeatureEnabled = function (key) {
 }
 
 /*
- * See if feature flags are available.
- *
- * ### Usage:
- *
- *     posthog.onFeatureFlags(function(featureFlags) { // do something })
- *
- * @param {Function} [callback] The callback function will be called once the feature flags are ready. It'll return a list of feature flags enabled for the user.
- */
-PostHogFeatureFlags.prototype.onFeatureFlags = function (callback) {
-    if (!this.getFlags()) {
-        setTimeout(
-            _.bind(function () {
-                this._posthog.feature_flags.onFeatureFlags(callback)
-            }, this),
-            100
-        )
-        return false
-    }
-    callback(this.getFlags())
-}
-export { PostHogFeatureFlags }
-
-/*
  * Override feature flags for debugging.
  *
  * ### Usage:
@@ -99,3 +76,5 @@ PostHogFeatureFlags.prototype.override = function (flags) {
     if (flags === false) return this._posthog.persistence.unregister('$override_feature_flags')
     this._posthog.persistence.register('$override_feature_flags', flags)
 }
+
+export { PostHogFeatureFlags }


### PR DESCRIPTION
## Changes

- Fixes #57
- Adds `.reloadFeatureFlags()` to `posthog`. Calling that updates all feature flags for the current user. (Fixes #70)
- Pass a callback to get the new flags after they reload: `.reloadFeatureFlags(flags => console.log(flags))`

No tests since there are no tests for feature flags... and I don't have time to add any now before the day is over :).

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
