### PR TITLE
Store auth token in localStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.7 - 2020-07-28
+- Store toolbar session in localStorage (instead of sessionStorage) so you don't need to authorize in every tab you have open
+
 ## 1.3.6 - 2020-07-27
 - Fix a parameter in the type definition
 

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -885,7 +885,7 @@ describe('Autocapture system', () => {
             lib = {}
 
         beforeEach(() => {
-            window.sessionStorage.clear()
+            window.localStorage.clear()
 
             testContext.clock = sinon.useFakeTimers()
 
@@ -930,7 +930,7 @@ describe('Autocapture system', () => {
             autocapture._maybeLoadEditor(lib)
             expect(autocapture._loadEditor.calledOnce).toBe(true)
             expect(autocapture._loadEditor.calledWith(lib, editorParams)).toBe(true)
-            expect(JSON.parse(window.sessionStorage.getItem('_postHogEditorParams'))).toEqual(editorParams)
+            expect(JSON.parse(window.localStorage.getItem('_postHogEditorParams'))).toEqual(editorParams)
         })
 
         it('should initialize the visual editor when the hash state contains action "ph_authorize"', () => {
@@ -950,15 +950,15 @@ describe('Autocapture system', () => {
             autocapture._maybeLoadEditor(lib)
             expect(autocapture._loadEditor.calledOnce).toBe(true)
             expect(autocapture._loadEditor.calledWith(lib, editorParams)).toBe(true)
-            expect(JSON.parse(window.sessionStorage.getItem('_postHogEditorParams'))).toEqual(editorParams)
+            expect(JSON.parse(window.localStorage.getItem('_postHogEditorParams'))).toEqual(editorParams)
         })
 
         it('should initialize the visual editor when there are editor params in the session', () => {
-            window.sessionStorage.setItem('_postHogEditorParams', JSON.stringify(editorParams))
+            window.localStorage.setItem('_postHogEditorParams', JSON.stringify(editorParams))
             autocapture._maybeLoadEditor(lib)
             expect(autocapture._loadEditor.calledOnce).toBe(true)
             expect(autocapture._loadEditor.calledWith(lib, editorParams)).toBe(true)
-            expect(JSON.parse(window.sessionStorage.getItem('_postHogEditorParams'))).toEqual(editorParams)
+            expect(JSON.parse(window.localStorage.getItem('_postHogEditorParams'))).toEqual(editorParams)
         })
 
         it('should NOT initialize the visual editor when the activation query param does not exist', () => {
@@ -994,7 +994,7 @@ describe('Autocapture system', () => {
             autocapture._maybeLoadEditor(lib)
             expect(autocapture._loadEditor.calledOnce).toBe(true)
             expect(autocapture._loadEditor.calledWith(lib, editorParams)).toBe(true)
-            expect(JSON.parse(window.sessionStorage.getItem('_postHogEditorParams'))).toEqual(editorParams)
+            expect(JSON.parse(window.localStorage.getItem('_postHogEditorParams'))).toEqual(editorParams)
         })
     })
 

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -9,8 +9,8 @@ import {
     shouldCaptureElement,
     shouldCaptureValue,
     usefulElements,
-    isSensitiveElement
-} from './autocapture-utils';
+    isSensitiveElement,
+} from './autocapture-utils'
 
 var autocapture = {
     _initializedTokens: [],
@@ -52,7 +52,7 @@ var autocapture = {
 
         _.each(elem.attributes, function (attr) {
             // Only capture attributes we know are safe
-            if(isSensitiveElement(elem) && ['name', 'id', 'class'].indexOf(attr.name) === -1) return;
+            if (isSensitiveElement(elem) && ['name', 'id', 'class'].indexOf(attr.name) === -1) return
             if (shouldCaptureValue(attr.value)) {
                 props['attr__' + attr.name] = attr.value
             }
@@ -318,7 +318,7 @@ var autocapture = {
                 editorParams = state
 
                 if (editorParams && Object.keys(editorParams).length > 0) {
-                    window.sessionStorage.setItem('_postHogEditorParams', JSON.stringify(editorParams))
+                    window.localStorage.setItem('_postHogEditorParams', JSON.stringify(editorParams))
 
                     if (state['desiredHash']) {
                         // hash that was in the url before the redirect
@@ -330,8 +330,8 @@ var autocapture = {
                     }
                 }
             } else {
-                // get credentials from sessionStorage from a previous initialzation
-                editorParams = JSON.parse(window.sessionStorage.getItem('_postHogEditorParams') || '{}')
+                // get credentials from localStorage from a previous initialzation
+                editorParams = JSON.parse(window.localStorage.getItem('_postHogEditorParams') || '{}')
 
                 // delete "add-action" or other intent from editorParams, otherwise we'll have the same intent
                 // every time we open the page (e.g. you just visiting your own site an hour later)


### PR DESCRIPTION
## Changes

It was stored in sessionStorage until now, leading to a situation where you had to authorize every tab you had open with the toolbar.

TODO for later:
- Better control of toolbar tokens (connect to personal API tokens?), so you can see what browsers/devices are currently logged in in the toolbar
- Log out for the session in the toolbar (currently it can just be closed, but you can't log out). 

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
