### PR TITLE
Set `secure_cookie` default from browser protocol

### DIFF
--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -78,7 +78,7 @@ var DEFAULT_CONFIG = {
     upgrade: false,
     disable_persistence: false,
     disable_cookie: false,
-    secure_cookie: false,
+    secure_cookie: window.location.protocol === 'https:',
     ip: true,
     opt_out_capturing_by_default: false,
     opt_out_persistence_by_default: false,


### PR DESCRIPTION
## Changes

Sets the ph_* cookie to secure if the used protocol is https. Can always be overriden in the config.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
