### PR TITLE
Capture actions if using toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.2 - 2020-08-11
+- Capture actions even if toolbar is in used 
+
 ## 1.4.1 - 2020-08-10
 - Remove unused parameter for `.reloadFeatureFlags()` 
 

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -822,12 +822,6 @@ describe('Autocapture system', () => {
             expect(autocapture._addDomEventHandlers.called).toBe(false)
         })
 
-        it('should NOT call _addDomEventHandlders when loading editor', () => {
-            _maybeLoadEditorStub.returns(true)
-            autocapture.init(lib)
-            expect(autocapture._addDomEventHandlers.calledOnce).toBe(false)
-        })
-
         it('should NOT call _addDomEventHandlders when enable_collect_everything is "false"', () => {
             lib._send_request = sandbox.spy((url, params, options, callback) =>
                 callback({ config: { enable_collect_everything: false } })

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -227,7 +227,7 @@ var autocapture = {
 
     _customProperties: {},
     init: function (instance) {
-        if (this._maybeLoadEditor(instance)) return // don't autocapture actions when the editor is enabled
+        this._maybeLoadEditor(instance)
 
         var token = instance.get_config('token')
         if (this._initializedTokens.indexOf(token) > -1) {


### PR DESCRIPTION
## Changes

Resolves: https://github.com/PostHog/posthog/issues/1352

Personally I'm only 80% convinced of this. It makes sense in a demo setting ("my actions aren't showing up"), but on sites with low traffic, a few admins browsing around can massively skew the numbers on the heatmap in one direction or another.

That said, I understand the task and I'm fine with merging this in. However I'd be more confident if there was a "recommended path" to ignore my own actions without having to resort to manually and frequently clearing my person's data.

Could we document some commands that would allow admins to opt out of capturing? Theoretically it *should* be as easy as just calling `posthog.opt_out_capturing()` if you're an admin and that's that?

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
