### PR TITLE
Fix buttons in shadowroot not being captured (resolves PostHog/posthog#1469)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "lint": "eslint src tests --fix",
         "integration-test": "echo 'Browse to localhost:3000/tests' && node testServer.js",
         "prepublish": "yarn test && yarn build && yarn build-module && yarn process-types",
-        "test": "jest",
+        "test": "nodemon --ext js --exec 'yarn jest'",
         "unit-test": "BABEL_ENV=test mocha --require babel-core/register tests/unit/*.js"
     },
     "main": "dist/module.js",
@@ -38,6 +38,7 @@
         "jsdom-global": "3.0.2",
         "lint-staged": "^10.2.11",
         "localStorage": "1.0.4",
+        "nodemon": "^2.0.4",
         "parcel": "^1.12.4",
         "prettier": "^2.0.5",
         "rollup": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "lint": "eslint src tests --fix",
         "integration-test": "echo 'Browse to localhost:3000/tests' && node testServer.js",
         "prepublish": "yarn test && yarn build && yarn build-module && yarn process-types",
-        "test": "nodemon --ext js --exec 'yarn jest'",
+        "test": "jest",
+        "test-watch": "jest --watch",
         "unit-test": "BABEL_ENV=test mocha --require babel-core/register tests/unit/*.js"
     },
     "main": "dist/module.js",
@@ -38,7 +39,6 @@
         "jsdom-global": "3.0.2",
         "lint-staged": "^10.2.11",
         "localStorage": "1.0.4",
-        "nodemon": "^2.0.4",
         "parcel": "^1.12.4",
         "prettier": "^2.0.5",
         "rollup": "^2.18.2",

--- a/playground/flags/demo.html
+++ b/playground/flags/demo.html
@@ -23,9 +23,16 @@
     <div class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
         <a href='https://posthog.com'>Here's a link to the outside world</a>
     </div>
+    <div id="shadow" ></div>
 
     <div style="padding: 2rem;background:green;display:none;color:white" id="feature"><h2>Look, a new beta feature</h2></div>
     <script>
+        const header = document.createElement('header');
+        const shadowRoot = header.attachShadow({mode: 'open'});
+        shadowRoot.innerHTML = '<h2>shadowroot</h2><button>bla</button>'
+        document.body.appendChild(header)
+
+
         console.log(posthog.isFeatureEnabled('beta-feature'))
         posthog.onFeatureFlags(function(featureFlags) {
             console.log(featureFlags)

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -717,6 +717,23 @@ describe('Autocapture system', () => {
             expect(props['$event_type']).toBe('click')
         })
 
+        it('should capture a click event inside a shadowroot', () => {
+            var main_el = document.createElement('some-element')
+            var shadowRoot = main_el.attachShadow({ mode: 'open' })
+            var button = document.createElement('a')
+            button.innerHTML = 'bla'
+            shadowRoot.appendChild(button)
+            const e = {
+                target: main_el,
+                path: [button, main_el],
+                type: 'click',
+            }
+            autocapture._captureEvent(e, lib)
+            expect(lib.capture.calledOnce).toBe(true)
+            const props = getCapturedProps(lib.capture)
+            expect(props['$event_type']).toBe('click')
+        })
+
         it('should never capture an element with `ph-no-capture` class', () => {
             const a = document.createElement('a')
             const span = document.createElement('span')

--- a/src/autocapture-utils.js
+++ b/src/autocapture-utils.js
@@ -96,19 +96,28 @@ export function shouldCaptureDomEvent(el, event) {
 
     var parentIsUsefulElement = false
     var targetElementList = [el]
+    var parentNode = true
     var curEl = el
     while (curEl.parentNode && !isTag(curEl, 'body')) {
-        if (usefulElements.indexOf(curEl.parentNode.tagName.toLowerCase()) > -1) {
+        // If element is a shadow root, we skip it
+        if (curEl.parentNode.nodeType === 11) {
+            targetElementList.push(curEl.parentNode.host)
+            curEl = curEl.parentNode.host
+            continue
+        }
+        parentNode = curEl.parentNode
+        if (!parentNode) break
+        if (usefulElements.indexOf(parentNode.tagName.toLowerCase()) > -1) {
             parentIsUsefulElement = true
         } else {
-            let compStyles = window.getComputedStyle(curEl.parentNode)
+            let compStyles = window.getComputedStyle(parentNode)
             if (compStyles && compStyles.getPropertyValue('cursor') === 'pointer') {
                 parentIsUsefulElement = true
             }
         }
 
-        targetElementList.push(curEl.parentNode)
-        curEl = curEl.parentNode
+        targetElementList.push(parentNode)
+        curEl = parentNode
     }
 
     let compStyles = window.getComputedStyle(el)

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -131,6 +131,9 @@ var autocapture = {
         if (typeof e.target === 'undefined') {
             return e.srcElement
         } else {
+            if (e.target.shadowRoot) {
+                return e.path[0]
+            }
             return e.target
         }
     },
@@ -147,6 +150,11 @@ var autocapture = {
             var targetElementList = [target]
             var curEl = target
             while (curEl.parentNode && !isTag(curEl, 'body')) {
+                if (curEl.parentNode.nodeType === 11) {
+                    targetElementList.push(curEl.parentNode.host)
+                    curEl = curEl.parentNode.host
+                    continue
+                }
                 targetElementList.push(curEl.parentNode)
                 curEl = curEl.parentNode
             }


### PR DESCRIPTION
## Changes

Previously we weren't capturing clicks within shadowroots. See playground/flags/demo.html for an example testcase.

## Checklist
- [x] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
