### PR TITLE
Sentry integration

### DIFF
--- a/playground/flags/demo.html
+++ b/playground/flags/demo.html
@@ -1,6 +1,6 @@
 <script src="../../dist/array.js"></script>
 <script>
-    posthog.init('TLA2XwOD2SB7lqXU1YeBAT2mQd2LQ4LidKHw6JRODi8', {api_host: 'http://127.0.0.1:8000', debug: true, persistence: 'disabled', loaded: function(posthog) { posthog.identify('test')}})
+    posthog.init('sTMFPsFhdP1Ssg', {api_host: 'http://127.0.0.1:8000', debug: true, persistence: 'disabled', loaded: function(posthog) { posthog.identify('test')}})
 </script>
 <h2>Demo site</h2>
 <button>Here's a button you could click if you want to</button><br /><br />

--- a/playground/flags/demo.html
+++ b/playground/flags/demo.html
@@ -1,6 +1,6 @@
 <script src="../../dist/array.js"></script>
 <script>
-    posthog.init('sTMFPsFhdP1Ssg', {api_host: 'http://127.0.0.1:8000', debug: true})
+    posthog.init('TLA2XwOD2SB7lqXU1YeBAT2mQd2LQ4LidKHw6JRODi8', {api_host: 'http://127.0.0.1:8000', debug: true, persistence: 'disabled', loaded: function(posthog) { posthog.identify('test')}})
 </script>
 <h2>Demo site</h2>
 <button>Here's a button you could click if you want to</button><br /><br />

--- a/playground/sentry.html
+++ b/playground/sentry.html
@@ -1,0 +1,31 @@
+<script
+  src="https://browser.sentry-cdn.com/5.25.0/bundle.min.js"
+  integrity="sha384-2p7fXoWSRPG49ZgmmJlTEI/01BY1LgxCNFQFiWpImAERmS/bROOQm+cJMdq/kmWS"
+  crossorigin="anonymous"
+></script>
+
+<h2>This page triggers a sentry error</h2>
+
+<script src="../dist/array.js"></script>
+<script>
+    posthog.init('TLA2XwOD2SB7lqXU1YeBAT2mQd2LQ4LidKHw6JRODi8', {api_host: 'http://127.0.0.1:8000', debug: true, loaded: function(posthog) { posthog.identify('test')}})
+
+  Sentry.init({
+    dsn: 'https://9946c76f89aa406da74bd05f66030c37@o344752.ingest.sentry.io/5455536',
+    integrations: [
+        new posthog.SentryIntegration(posthog)
+    ]
+
+    });
+</script>
+
+<script>
+    window.addEventListener('load', function() {
+        setTimeout(function() {
+
+
+var coolNumber = 12123/0;
+alert(ddd)
+        }, 1000)
+})
+</script>

--- a/playground/sentry.html
+++ b/playground/sentry.html
@@ -10,12 +10,11 @@
 <script>
     posthog.init('TLA2XwOD2SB7lqXU1YeBAT2mQd2LQ4LidKHw6JRODi8', {api_host: 'http://127.0.0.1:8000', debug: true, loaded: function(posthog) { posthog.identify('test')}})
 
-  Sentry.init({
-    dsn: 'https://9946c76f89aa406da74bd05f66030c37@o344752.ingest.sentry.io/5455536',
-    integrations: [
-        new posthog.SentryIntegration(posthog)
-    ]
-
+    Sentry.init({
+        dsn: 'https://example',
+        integrations: [
+            new posthog.SentryIntegration(posthog, 'posthog', 5455536)
+        ]
     });
 </script>
 

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1544,6 +1544,7 @@ PostHogLib.prototype.clear_opt_in_out_captureing = function (options) {
  * @param {Number} [projectId] Optional: The Sentry project id, used to send a direct link from PostHog to Sentry
  */
 PostHogLib.prototype.sentry_integration = function (_posthog, organization, projectId) {
+    // setupOnce gets called by Sentry when it intializes the plugin
     this.setupOnce = function (addGlobalEventProcessor) {
         // Poll for PostHog to load
         function poll() {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1541,6 +1541,7 @@ PostHogLib.prototype.sentry_integration = function (_posthog) {
         addGlobalEventProcessor((event) => {
             if (event.level === 'error')
                 _posthog.capture('$exception', { $sentry_event_id: event.event_id, $sentry_exception: event.exception })
+            return event
         })
     }
 }


### PR DESCRIPTION
## Changes

Integrate this with Sentry:
```js
Sentry.init({
    dsn: 'https://example',
    integrations: [
        new posthog.SentryIntegration(posthog)
    ]
});
```

It'll send a `PostHog URL` tag to Sentry that allows you to instantly go to the correct person in PostHog: 
![image](https://user-images.githubusercontent.com/1727427/95345425-fe667980-08ba-11eb-9194-85df5bf36d92.png)

Also sends an `$exception` event to PostHog:
![image](https://user-images.githubusercontent.com/1727427/95345490-0f16ef80-08bb-11eb-9795-88b9d5208bb7.png)

Annoyingly we can't get a clickable Sentry URL from just a Sentry Event ID

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
