### PR TITLE
make session recording possible

### DIFF
--- a/src/__tests__/autocapture-utils.js
+++ b/src/__tests__/autocapture-utils.js
@@ -6,9 +6,14 @@ import {
     shouldCaptureElement,
     isSensitiveElement,
     shouldCaptureValue,
+    loadScript,
 } from '../autocapture-utils'
 
 describe(`Autocapture utility functions`, () => {
+    afterEach(() => {
+        document.getElementsByTagName('html')[0].innerHTML = ''
+    })
+
     describe(`getSafeText`, () => {
         it(`should collect and normalize text from elements`, () => {
             const el = document.createElement(`div`)
@@ -322,6 +327,33 @@ describe(`Autocapture utility functions`, () => {
 
         it(`should not include values that look like social security numbers`, () => {
             expect(shouldCaptureValue(`123-45-6789`)).toBe(false)
+        })
+    })
+
+    describe('loadScript', () => {
+        it('should insert the given script before the one already on the page', () => {
+            document.body.appendChild(document.createElement('script'))
+            const callback = (_) => _
+            loadScript('https://fake_url', callback)
+            const scripts = document.getElementsByTagName('script')
+            const new_script = scripts[0]
+
+            expect(scripts.length).toBe(2)
+            expect(new_script.type).toBe('text/javascript')
+            expect(new_script.src).toBe('https://fake_url/')
+            expect(new_script.onload).toBe(callback)
+        })
+
+        it("should add the script to the page when there aren't any preexisting scripts on the page", () => {
+            const callback = (_) => _
+            loadScript('https://fake_url', callback)
+            const scripts = document.getElementsByTagName('script')
+            const new_script = scripts[0]
+
+            expect(scripts.length).toBe(1)
+            expect(new_script.type).toBe('text/javascript')
+            expect(new_script.src).toBe('https://fake_url/')
+            expect(new_script.onload).toBe(callback)
         })
     })
 })

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -3,6 +3,7 @@ import sinon from 'sinon'
 import { autocapture } from '../autocapture'
 
 import { _ } from '../utils'
+import * as utils from '../autocapture-utils'
 
 const triggerMouseEvent = function (node, eventType) {
     node.dispatchEvent(
@@ -158,33 +159,6 @@ describe('Autocapture system', () => {
             div.appendChild(document.createTextNode('some text'))
             div.appendChild(child)
             expect(autocapture._previousElementSibling(child)).toBeNull()
-        })
-    })
-
-    describe('_loadScript', () => {
-        it('should insert the given script before the one already on the page', () => {
-            document.body.appendChild(document.createElement('script'))
-            const callback = (_) => _
-            autocapture._loadScript('https://fake_url', callback)
-            const scripts = document.getElementsByTagName('script')
-            const new_script = scripts[0]
-
-            expect(scripts.length).toBe(2)
-            expect(new_script.type).toBe('text/javascript')
-            expect(new_script.src).toBe('https://fake_url/')
-            expect(new_script.onload).toBe(callback)
-        })
-
-        it("should add the script to the page when there aren't any preexisting scripts on the page", () => {
-            const callback = (_) => _
-            autocapture._loadScript('https://fake_url', callback)
-            const scripts = document.getElementsByTagName('script')
-            const new_script = scripts[0]
-
-            expect(scripts.length).toBe(1)
-            expect(new_script.type).toBe('text/javascript')
-            expect(new_script.src).toBe('https://fake_url/')
-            expect(new_script.onload).toBe(callback)
         })
     })
 
@@ -1017,7 +991,7 @@ describe('Autocapture system', () => {
         beforeEach(() => {
             autocapture._editorLoaded = false
             sandbox = sinon.createSandbox()
-            sandbox.stub(autocapture, '_loadScript').callsFake((path, callback) => callback())
+            sandbox.stub(utils, 'loadScript').callsFake((path, callback) => callback())
             lib.get_config = sandbox.stub()
             lib.get_config.withArgs('app_host').returns('example.com')
             lib.get_config.withArgs('token').returns('token')

--- a/src/autocapture-utils.js
+++ b/src/autocapture-utils.js
@@ -237,3 +237,17 @@ export function shouldCaptureValue(value) {
 
     return true
 }
+
+export function loadScript(scriptUrlToLoad, callback) {
+    var scriptTag = document.createElement('script')
+    scriptTag.type = 'text/javascript'
+    scriptTag.src = scriptUrlToLoad
+    scriptTag.onload = callback
+
+    var scripts = document.getElementsByTagName('script')
+    if (scripts.length > 0) {
+        scripts[0].parentNode.insertBefore(scriptTag, scripts[0])
+    } else {
+        document.body.appendChild(scriptTag)
+    }
+}

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -12,6 +12,7 @@ import {
     shouldCaptureValue,
     usefulElements,
 } from './autocapture-utils'
+import { PosthogSessionRecording } from './posthog-sessionrecording'
 
 var autocapture = {
     _initializedTokens: [],
@@ -279,6 +280,11 @@ var autocapture = {
                 instance['compression'] = compression
             } else {
                 instance['compression'] = {}
+            }
+
+            if (response['sessionRecording']) {
+                instance['session_recording'] = new PosthogSessionRecording(instance)
+                instance['session_recording'].init()
             }
         }, this)
 

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -3,13 +3,14 @@ import {
     getClassName,
     getSafeText,
     isElementNode,
+    isSensitiveElement,
     isTag,
     isTextNode,
+    loadScript,
     shouldCaptureDomEvent,
     shouldCaptureElement,
     shouldCaptureValue,
     usefulElements,
-    isSensitiveElement,
 } from './autocapture-utils'
 
 var autocapture = {
@@ -23,20 +24,6 @@ var autocapture = {
                 el = el.previousSibling
             } while (el && !isElementNode(el))
             return el
-        }
-    },
-
-    _loadScript: function (scriptUrlToLoad, callback) {
-        var scriptTag = document.createElement('script')
-        scriptTag.type = 'text/javascript'
-        scriptTag.src = scriptUrlToLoad
-        scriptTag.onload = callback
-
-        var scripts = document.getElementsByTagName('script')
-        if (scripts.length > 0) {
-            scripts[0].parentNode.insertBefore(scriptTag, scripts[0])
-        } else {
-            document.body.appendChild(scriptTag)
         }
     },
 
@@ -371,7 +358,7 @@ var autocapture = {
                     : 'editor.js'
             var editorUrl =
                 host + (host.endsWith('/') ? '' : '/') + 'static/' + toolbarScript + '?_ts=' + new Date().getTime()
-            this._loadScript(editorUrl, function () {
+            loadScript(editorUrl, function () {
                 window['ph_load_editor'](editorParams)
             })
             // Turbolinks doesn't fire an onload event but does replace the entire page, including the toolbar

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -3,6 +3,7 @@ import { LZString } from './lz-string'
 import Config from './config'
 import { _, console, userAgent, window, document, navigator } from './utils'
 import { autocapture } from './autocapture'
+import { PosthogSessionRecording } from './posthog-sessionrecording'
 import { LinkCapture } from './dom-capture'
 import { PostHogPeople } from './posthog-people'
 import { PostHogFeatureFlags } from './posthog-featureflags'
@@ -145,6 +146,11 @@ var create_mplib = function (token, config, name) {
         } else {
             autocapture.init(instance)
         }
+    }
+
+    if (instance.get_config('sessionrecording')) {
+        instance['sessionrecording'] = new PosthogSessionRecording(instance)
+        instance['sessionrecording'].init()
     }
 
     // if target is not defined, we called init after the lib already

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -3,7 +3,6 @@ import { LZString } from './lz-string'
 import Config from './config'
 import { _, console, userAgent, window, document, navigator } from './utils'
 import { autocapture } from './autocapture'
-import { PosthogSessionRecording } from './posthog-sessionrecording'
 import { LinkCapture } from './dom-capture'
 import { PostHogPeople } from './posthog-people'
 import { PostHogFeatureFlags } from './posthog-featureflags'
@@ -146,11 +145,6 @@ var create_mplib = function (token, config, name) {
         } else {
             autocapture.init(instance)
         }
-    }
-
-    if (instance.get_config('sessionrecording')) {
-        instance['sessionrecording'] = new PosthogSessionRecording(instance)
-        instance['sessionrecording'].init()
     }
 
     // if target is not defined, we called init after the lib already

--- a/src/posthog-sessionrecording.js
+++ b/src/posthog-sessionrecording.js
@@ -12,7 +12,7 @@ export class PosthogSessionRecording {
     _onScriptLoaded() {
         window.rrweb.record({
             emit(data) {
-                posthog.capture('$snapshot', { data })
+                posthog.capture('$snapshot', { $snapshot_data: data })
             },
         })
     }

--- a/src/posthog-sessionrecording.js
+++ b/src/posthog-sessionrecording.js
@@ -1,0 +1,19 @@
+import { loadScript } from './autocapture-utils'
+
+export class PosthogSessionRecording {
+    constructor(instance) {
+        this.instance = instance
+    }
+
+    init() {
+        loadScript(this.instance.get_config('api_host') + '/static/recorder.js', this._onScriptLoaded)
+    }
+
+    _onScriptLoaded() {
+        window.rrweb.record({
+            emit(data) {
+                posthog.capture('$snapshot', { data })
+            },
+        })
+    }
+}


### PR DESCRIPTION
## Changes

How it works:

- posthog.js hits /decide endpoint
- if `sessionRecording` is true from /decide:
  - load rrweb script from posthog
  - start recording
  - emit events as $snapshot events to posthog

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
