### PR TITLE
Always send distinct_id to server to avoid 400 status

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -22,7 +22,7 @@ describe('_calculate_event_properties()', () => {
         given.posthog.get_config = (key) => given.config[key]
 
         given.posthog.persistence = {}
-        given.posthog.persistence.properties = () => ({ persistent: 'prop' })
+        given.posthog.persistence.properties = () => ({ distinct_id: 'abc', persistent: 'prop' })
     })
 
     it('returns calculated properties', () => {
@@ -30,6 +30,7 @@ describe('_calculate_event_properties()', () => {
             token: 'testtoken',
             event: 'prop',
             $lib: 'web',
+            distinct_id: 'abc',
             persistent: 'prop',
         })
     })
@@ -40,6 +41,7 @@ describe('_calculate_event_properties()', () => {
         expect(given.subject).toEqual({
             token: 'testtoken',
             event: 'prop',
+            distinct_id: 'abc',
         })
     })
 
@@ -59,6 +61,7 @@ describe('_calculate_event_properties()', () => {
         expect(given.subject).toEqual({
             token: 'testtoken',
             $snapshot_data: {},
+            distinct_id: 'abc',
         })
     })
 })

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -751,6 +751,8 @@ PostHogLib.prototype._calculate_event_properties = function (event_name, event_p
     properties['token'] = this.get_config('token')
 
     if (event_name === '$snapshot') {
+        const persistenceProps = this.persistence.properties()
+        properties['distinct_id'] = persistenceProps.distinct_id
         return properties
     }
 


### PR DESCRIPTION
This was broken in commit 72ceba32d4954ab38fd34778201c6830bf0f9b91 by yours truly

## Changes
...

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
