### PR TITLE
Send/create $session_id on $snapshot events

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,5 @@
             "given2/setup"
         ],
         "clearMocks": true
-    },
-    "dependencies": {
-        "nanoid": "^3.1.12"
     }
 }

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
             "given2/setup"
         ],
         "clearMocks": true
+    },
+    "dependencies": {
+        "nanoid": "^3.1.12"
     }
 }

--- a/src/__tests__/extensions/sessionid.js
+++ b/src/__tests__/extensions/sessionid.js
@@ -1,0 +1,43 @@
+import sessionIdGenerator from '../../extensions/sessionid'
+import { SESSION_ID } from '../../posthog-persistence'
+import { nanoid } from 'nanoid'
+
+jest.mock('nanoid')
+
+describe('Session ID generation', () => {
+    given('subject', () => sessionIdGenerator(given.persistence, given.timestamp))
+
+    given('timestamp', () => 1603107479471)
+
+    given('persistence', () => ({
+        props: { [SESSION_ID]: given.recordedData },
+        register: jest.fn(),
+    }))
+
+    beforeEach(() => {
+        nanoid.mockReturnValue('newSessionId')
+    })
+
+    describe('no stored session data', () => {
+        it('generates a new session id, saves it', () => {
+            expect(given.subject).toEqual('newSessionId')
+            expect(given.persistence.register).toHaveBeenCalledWith({ [SESSION_ID]: [given.timestamp, 'newSessionId'] })
+        })
+    })
+
+    describe('stored session data', () => {
+        it('reuses old session data', () => {
+            given('recordedData', () => [1603107460000, 'oldSessionId'])
+
+            expect(given.subject).toEqual('oldSessionId')
+            expect(given.persistence.register).toHaveBeenCalledWith({ [SESSION_ID]: [given.timestamp, 'oldSessionId'] })
+        })
+
+        it('generates a new session id, saves it when too long since last event', () => {
+            given('recordedData', () => [1603007460000, 'oldSessionId'])
+
+            expect(given.subject).toEqual('newSessionId')
+            expect(given.persistence.register).toHaveBeenCalledWith({ [SESSION_ID]: [given.timestamp, 'newSessionId'] })
+        })
+    })
+})

--- a/src/__tests__/extensions/sessionid.js
+++ b/src/__tests__/extensions/sessionid.js
@@ -1,8 +1,8 @@
 import sessionIdGenerator from '../../extensions/sessionid'
 import { SESSION_ID } from '../../posthog-persistence'
-import { nanoid } from 'nanoid'
+import { _ } from '../../utils'
 
-jest.mock('nanoid')
+jest.mock('../../utils')
 
 describe('Session ID generation', () => {
     given('subject', () => sessionIdGenerator(given.persistence, given.timestamp))
@@ -15,7 +15,7 @@ describe('Session ID generation', () => {
     }))
 
     beforeEach(() => {
-        nanoid.mockReturnValue('newSessionId')
+        _.UUID.mockReturnValue('newSessionId')
     })
 
     describe('no stored session data', () => {

--- a/src/extensions/sessionid.js
+++ b/src/extensions/sessionid.js
@@ -1,5 +1,5 @@
 import { SESSION_ID } from '../posthog-persistence'
-import { nanoid } from 'nanoid'
+import { _ } from '../utils'
 
 const SESSION_CHANGE_TIMEOUT = 30 * 60 * 1000 // 30 mins
 
@@ -7,7 +7,7 @@ export default (persistence, timestamp) => {
     let [lastTimestamp, sessionId] = persistence['props'][SESSION_ID] || [0, null]
 
     if (Math.abs(timestamp - lastTimestamp) > SESSION_CHANGE_TIMEOUT) {
-        sessionId = nanoid()
+        sessionId = _.UUID()
     }
 
     persistence.register({ [SESSION_ID]: [timestamp, sessionId] })

--- a/src/extensions/sessionid.js
+++ b/src/extensions/sessionid.js
@@ -1,12 +1,12 @@
 import { SESSION_ID } from '../posthog-persistence'
 import { _ } from '../utils'
 
-const SESSION_CHANGE_TIMEOUT = 30 * 60 * 1000 // 30 mins
+const SESSION_CHANGE_THRESHOLD = 30 * 60 * 1000 // 30 mins
 
 export default (persistence, timestamp) => {
     let [lastTimestamp, sessionId] = persistence['props'][SESSION_ID] || [0, null]
 
-    if (Math.abs(timestamp - lastTimestamp) > SESSION_CHANGE_TIMEOUT) {
+    if (Math.abs(timestamp - lastTimestamp) > SESSION_CHANGE_THRESHOLD) {
         sessionId = _.UUID()
     }
 

--- a/src/extensions/sessionid.js
+++ b/src/extensions/sessionid.js
@@ -1,0 +1,15 @@
+import { SESSION_ID } from '../posthog-persistence'
+import { nanoid } from 'nanoid'
+
+const SESSION_CHANGE_TIMEOUT = 30 * 60 * 1000 // 30 mins
+
+export default (persistence, timestamp) => {
+    let [lastTimestamp, sessionId] = persistence['props'][SESSION_ID] || [0, null]
+
+    if (Math.abs(timestamp - lastTimestamp) > SESSION_CHANGE_TIMEOUT) {
+        sessionId = nanoid()
+    }
+
+    persistence.register({ [SESSION_ID]: [timestamp, sessionId] })
+    return sessionId
+}

--- a/src/posthog-persistence.js
+++ b/src/posthog-persistence.js
@@ -20,6 +20,7 @@ import { _, console } from './utils'
 /** @const */ var CAMPAIGN_IDS_KEY = '__cmpns'
 /** @const */ var EVENT_TIMERS_KEY = '__timers'
 /** @const */ var SESSION_RECORDING_ENABLED = '$session_recording_enabled'
+/** @const */ var SESSION_ID = '$sesid'
 /** @const */ var RESERVED_PROPERTIES = [
     SET_QUEUE_KEY,
     SET_ONCE_QUEUE_KEY,
@@ -33,6 +34,7 @@ import { _, console } from './utils'
     CAMPAIGN_IDS_KEY,
     EVENT_TIMERS_KEY,
     SESSION_RECORDING_ENABLED,
+    SESSION_ID,
 ]
 
 /**
@@ -412,4 +414,5 @@ export {
     CAMPAIGN_IDS_KEY,
     EVENT_TIMERS_KEY,
     SESSION_RECORDING_ENABLED,
+    SESSION_ID,
 }


### PR DESCRIPTION
Semantics of session id:
- 30 minutes without an event = new session (same as main repo session calculations)
- Two tabs will share the same session id
- Incognito/not incognito/different browser will not share session_id

These may change long-term.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
