### PR TITLE
Remove empty class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Please see the main [PostHog docs](https://posthog.com/docs).
 
 Specifically, the [JS integration](https://posthog.com/docs/integrations/js-integration) details.
 
-## [Internal] Releasing a new version
+## Testing
+
+Run `yarn test`
+
+## Releasing a new version
 
 To release a new version, make sure you're logged in to NPM (`npm login`)
 

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -26,7 +26,7 @@ describe('Autocapture system', () => {
         let div, div2, input, sensitiveInput, hidden, password
         beforeEach(() => {
             div = document.createElement('div')
-            div.className = 'class1 class2 class3'
+            div.className = 'class1 class2 class3          ' // Lots of spaces might mess things up
             div.innerHTML = 'my <span>sweet <i>inner</i></span> text'
 
             input = document.createElement('input')

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -35,7 +35,10 @@ var autocapture = {
         if (usefulElements.indexOf(tag_name) > -1) props['$el_text'] = getSafeText(elem)
 
         var classes = getClassName(elem)
-        if (classes.length > 0) props['classes'] = classes.split(' ')
+        if (classes.length > 0)
+            props['classes'] = classes.split(' ').filter(function (c) {
+                return c !== ''
+            })
 
         _.each(elem.attributes, function (attr) {
             // Only capture attributes we know are safe


### PR DESCRIPTION
## Changes

We had a ton of `button......btn` in the elements_chain. Turns out posthog-js sends a bunch of empty classnames if you have spaces in your class attribute. This filters that out.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
