### PR TITLE
Typescript: Add type for instance of posthog

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -23,7 +23,7 @@ declare class posthog {
      * Clears super properties and generates a new random distinct_id for this instance.
      * Useful for clearing data when a user logs out.
      */
-    static reset(reset_device_id: boolean): void
+    static reset(reset_device_id?: boolean): void
 
     /**
      * Capture an event. This is the most important and

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -710,4 +710,6 @@ declare namespace posthog {
     export class feature_flags extends featureFlags {}
 }
 
+export type PostHog = typeof posthog
+
 export default posthog


### PR DESCRIPTION
- Fix `.reset` typing
- Add better typing for posthog.js

## Changes

Now users can do `const posthog: Posthog = (window as any).posthog` for example. This did not work previously.

This allows us to use the types in our main repo.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
