### PR TITLE
Add user properties updating to `.identify`

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -1,15 +1,115 @@
 import { PostHogLib } from '../posthog-core'
 import { _ } from '../utils'
 
+given('lib', () => Object.assign(new PostHogLib(), given.overrides))
+
+describe('identify()', () => {
+    given('subject', () => () => given.lib.identify(given.identity, given.userProperties))
+
+    given('identity', () => 'a-new-id')
+
+    given('overrides', () => ({
+        get_distinct_id: () => given.oldIdentity,
+        capture: jest.fn(),
+        register: jest.fn(),
+        register_once: jest.fn(),
+        unregister: jest.fn(),
+        get_property: jest.fn(),
+        people: {
+            set: jest.fn(),
+            _flush: jest.fn(),
+        },
+        _flags: {},
+        reloadFeatureFlags: jest.fn(),
+    }))
+
+    given('properties', () => ({ $device_id: '123', __alias: 'efg' }))
+    given('oldIdentity', () => 'oldIdentity')
+
+    it('registers new user id and updates alias', () => {
+        given.subject()
+
+        expect(given.overrides.register).toHaveBeenCalledWith({ $user_id: 'a-new-id' })
+        expect(given.overrides.register).toHaveBeenCalledWith({ distinct_id: 'a-new-id' })
+    })
+
+    it('calls capture when identity changes', () => {
+        given.subject()
+
+        expect(given.overrides.capture).toHaveBeenCalledWith(
+            '$identify',
+            {
+                distinct_id: 'a-new-id',
+                $anon_distinct_id: 'oldIdentity',
+            },
+            { $set: {} }
+        )
+        expect(given.overrides.people.set).not.toHaveBeenCalled()
+    })
+
+    it('calls capture with user properties if passed', () => {
+        given('userProperties', () => ({ email: 'john@example.com' }))
+
+        given.subject()
+
+        expect(given.overrides.capture).toHaveBeenCalledWith(
+            '$identify',
+            {
+                distinct_id: 'a-new-id',
+                $anon_distinct_id: 'oldIdentity',
+            },
+            { $set: { email: 'john@example.com' } }
+        )
+    })
+
+    describe('identity did not change', () => {
+        given('oldIdentity', () => given.identity)
+
+        it('does not capture or set user properties', () => {
+            given.subject()
+
+            expect(given.overrides.capture).not.toHaveBeenCalled()
+            expect(given.overrides.people.set).not.toHaveBeenCalled()
+        })
+
+        it('calls people.set when user properties passed', () => {
+            given('userProperties', () => ({ email: 'john@example.com' }))
+
+            given.subject()
+
+            expect(given.overrides.capture).not.toHaveBeenCalled()
+            expect(given.overrides.people.set).toHaveBeenCalledWith({ email: 'john@example.com' })
+        })
+    })
+
+    describe('invalid id passed', () => {
+        given('identity', () => null)
+
+        it('does not update user', () => {
+            given.subject()
+
+            expect(given.overrides.capture).not.toHaveBeenCalled()
+            expect(given.overrides.register).not.toHaveBeenCalled()
+            expect(given.overrides.people._flush).not.toHaveBeenCalled()
+        })
+    })
+})
+
 describe('_calculate_event_properties()', () => {
     given('subject', () =>
-        given.posthog._calculate_event_properties(given.event_name, given.properties, given.start_timestamp)
+        given.lib._calculate_event_properties(given.event_name, given.properties, given.start_timestamp)
     )
 
     given('event_name', () => 'custom_event')
     given('properties', () => ({ event: 'prop' }))
 
-    given('posthog', () => new PostHogLib())
+    given('overrides', () => ({
+        get_config: (key) => given.config[key],
+        persistence: {
+            properties: () => ({ distinct_id: 'abc', persistent: 'prop' }),
+        },
+    }))
+
     given('config', () => ({
         token: 'testtoken',
         property_blacklist: given.property_blacklist,
@@ -18,11 +118,6 @@ describe('_calculate_event_properties()', () => {
 
     beforeEach(() => {
         jest.spyOn(_.info, 'properties').mockReturnValue({ $lib: 'web' })
-
-        given.posthog.get_config = (key) => given.config[key]
-
-        given.posthog.persistence = {}
-        given.posthog.persistence.properties = () => ({ distinct_id: 'abc', persistent: 'prop' })
     })
 
     it('returns calculated properties', () => {

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -184,6 +184,13 @@ declare class posthog {
      * then unique visitors will be identified by a UUID generated
      * the first time they visit the site.
      *
+     * If user properties are passed, they are also sent to posthog.
+     *
+     * ### Usage:
+     *
+     *      posthog.identify('[user unique id]')
+     *      posthog.identify('[user unique id]', { email: 'john@example.com' })
+     *
      * ### Notes:
      *
      * You can call this function to overwrite a previously set
@@ -204,8 +211,9 @@ declare class posthog {
      * right after you've aliased it.
      *
      * @param {String} [unique_id] A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.
+     * @param {Object} [userProperties] Optional: An associative array of properties to store about the user
      */
-    static identify(unique_id?: string): void
+    static identify(unique_id?: string, userProperties?: posthog.Properties): void
 
     /**
      * Create an alias, which PostHog will use to link two distinct_ids going forward (not retroactively).

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1001,11 +1001,7 @@ PostHogLib.prototype.onFeatureFlags = function (callback) {
  *
  * @param {String} [unique_id] A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.
  */
-PostHogLib.prototype.identify = function (new_distinct_id, _set_callback, _set_once_callback) {
-    // Optional Parameters
-    //  _set_callback:function  A callback to be run if and when the People set queue is flushed
-    //  _set_once_callback:function  A callback to be run if and when the People set_once queue is flushed
-
+PostHogLib.prototype.identify = function (new_distinct_id) {
     //if the new_distinct_id has not been set ignore the identify event
     if (!new_distinct_id) {
         console.error('Unique user id has not been set in posthog.identify')
@@ -1036,7 +1032,7 @@ PostHogLib.prototype.identify = function (new_distinct_id, _set_callback, _set_o
     }
     this._flags.identify_called = true
     // Flush any queued up people requests
-    this['people']._flush(_set_callback, _set_once_callback)
+    this['people']._flush()
 
     // send an $identify event any time the distinct_id is changing - logic on the server
     // will determine whether or not to do anything with it.

--- a/src/posthog-people.js
+++ b/src/posthog-people.js
@@ -143,7 +143,7 @@ PostHogPeople.prototype._flush_one_queue = function (action, action_method) {
 
     if (!_.isUndefined(queued_data) && _.isObject(queued_data) && !_.isEmptyObject(queued_data)) {
         _this._posthog['persistence']._pop_from_people_queue(action, queued_data)
-        action_method.call(_this, action_params, function (response, data) {
+        action_method.call(_this, action_params, function (response) {
             // on bad response, we want to add it back to the queue
             if (response === 0) {
                 _this._posthog['persistence']._add_to_people_queue(action, queued_data)

--- a/src/posthog-people.js
+++ b/src/posthog-people.js
@@ -136,23 +136,17 @@ PostHogPeople.prototype._enqueue = function (data) {
     }
 }
 
-PostHogPeople.prototype._flush_one_queue = function (action, action_method, callback, queue_to_params_fn) {
+PostHogPeople.prototype._flush_one_queue = function (action, action_method) {
     var _this = this
     var queued_data = _.extend({}, this._posthog['persistence']._get_queue(action))
     var action_params = queued_data
 
     if (!_.isUndefined(queued_data) && _.isObject(queued_data) && !_.isEmptyObject(queued_data)) {
         _this._posthog['persistence']._pop_from_people_queue(action, queued_data)
-        if (queue_to_params_fn) {
-            action_params = queue_to_params_fn(queued_data)
-        }
         action_method.call(_this, action_params, function (response, data) {
             // on bad response, we want to add it back to the queue
             if (response === 0) {
                 _this._posthog['persistence']._add_to_people_queue(action, queued_data)
-            }
-            if (!_.isUndefined(callback)) {
-                callback(response, data)
             }
         })
     }
@@ -160,9 +154,9 @@ PostHogPeople.prototype._flush_one_queue = function (action, action_method, call
 
 // Flush queued engage operations - order does not matter,
 // and there are network level race conditions anyway
-PostHogPeople.prototype._flush = function (_set_callback, _set_once_callback) {
-    this._flush_one_queue(SET_ACTION, this.set, _set_callback)
-    this._flush_one_queue(SET_ONCE_ACTION, this.set_once, _set_once_callback)
+PostHogPeople.prototype._flush = function () {
+    this._flush_one_queue(SET_ACTION, this.set)
+    this._flush_one_queue(SET_ONCE_ACTION, this.set_once)
 }
 
 PostHogPeople.prototype._is_reserved_property = function (prop) {


### PR DESCRIPTION
- Delete a bunch of dead code around `.identify` and flushing person props
- Kill dead code
- Add user properties when calling posthog.identify()

I got sent down a deep rabbit hole when investigating what `people.set(props)` does. 

Namely it also calls capture $identify, just via a different endpoint and different payloads.
The effect of the two calls is the same, so there's likely room to perhaps kill/merge a lot of 
repeated logic.

Solves #102, related to https://github.com/PostHog/posthog/issues/1955

## Checklist
- [x] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
