### PR TITLE
Update LIB_VERSION automatically, expose on window.posthog

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "devDependencies": {
         "@babel/core": "^7.0.0",
         "@babel/preset-env": "^7.0.0",
+        "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^8.1.0",
         "@typescript-eslint/eslint-plugin": "^3.5.0",
         "@typescript-eslint/parser": "^3.5.0",
@@ -60,6 +61,10 @@
         ]
     },
     "jest": {
+        "moduleFileExtensions": [
+            "js",
+            "json"
+        ],
         "setupFilesAfterEnv": [
             "given2/setup"
         ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,9 @@
 import resolve from '@rollup/plugin-node-resolve'
+import json from '@rollup/plugin-json'
 
 export default {
     plugins: [
+        json(),
         resolve({
             browser: true,
             main: true,

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,8 @@
+import pkg from '../package.json'
+
 var Config = {
     DEBUG: false,
-    LIB_VERSION: '1.0.0',
+    LIB_VERSION: pkg.version,
 }
 
 export default Config

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1565,6 +1565,7 @@ PostHogLib.prototype['reloadFeatureFlags'] = PostHogLib.prototype.reloadFeatureF
 PostHogLib.prototype['onFeatureFlags'] = PostHogLib.prototype.onFeatureFlags
 PostHogLib.prototype['decodeLZ64'] = PostHogLib.prototype.decodeLZ64
 PostHogLib.prototype['SentryIntegration'] = PostHogLib.prototype.sentry_integration
+PostHogLib.prototype['LIB_VERSION'] = Config.LIB_VERSION
 
 // PostHogPersistence Exports
 PostHogPersistence.prototype['properties'] = PostHogPersistence.prototype.properties

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
         "noImplicitReturns": true,
         "noUnusedParameters": true,
         "sourceMap": true,
-        "inlineSources": true
+        "inlineSources": true,
+        "resolveJsonModule": true
     },
     "include": ["src/*.ts"]
 }


### PR DESCRIPTION
## Changes

`npm version` now automatically bumps LIB_VERSION and it is exposed on window.posthog.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
