### PR TITLE
Don't truncate strings for session recording

### DIFF
--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -86,7 +86,7 @@ describe('SessionRecording', () => {
                     $session_id: 'sid',
                     $snapshot_data: { event: 1 },
                 },
-                { method: 'POST', transport: 'XHR', endpoint: '/e/' }
+                { method: 'POST', transport: 'XHR', endpoint: '/e/', _noTruncate: true }
             )
             expect(given.posthog.capture).toHaveBeenCalledWith(
                 '$snapshot',
@@ -94,7 +94,7 @@ describe('SessionRecording', () => {
                     $session_id: 'sid',
                     $snapshot_data: { event: 2 },
                 },
-                { method: 'POST', transport: 'XHR', endpoint: '/e/' }
+                { method: 'POST', transport: 'XHR', endpoint: '/e/', _noTruncate: true }
             )
         })
 

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -65,7 +65,12 @@ export class SessionRecording {
     }
 
     _captureSnapshot(properties) {
-        // :TRICKY: Make sure we don't batch these requests and use a custom endpoint
-        this.instance.capture('$snapshot', properties, { transport: 'XHR', method: 'POST', endpoint: this.endpoint })
+        // :TRICKY: Make sure we don't batch these requests, use a custom endpoint and don't truncate the strings.
+        this.instance.capture('$snapshot', properties, {
+            transport: 'XHR',
+            method: 'POST',
+            endpoint: this.endpoint,
+            _noTruncate: true,
+        })
     }
 }

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -656,11 +656,13 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
         data['$set'] = options['$set']
     }
 
-    var truncated_data = _.truncate(data, 255)
-    var json_data = _.JSONEncode(truncated_data)
+    if (!options._noTruncate) {
+        data = _.truncate(data, 255)
+    }
+    var json_data = _.JSONEncode(data)
 
     const url = this.get_config('api_host') + (options.endpoint || '/e/')
-    const cb = this._prepare_callback(callback, truncated_data)
+    const cb = this._prepare_callback(callback, data)
 
     const has_unique_traits = callback !== __NOOP || options !== __NOOPTIONS
 
@@ -677,7 +679,7 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
 
     this.config._onCapture(data)
 
-    return truncated_data
+    return data
 })
 
 PostHogLib.prototype._calculate_event_properties = function (event_name, event_properties, start_timestamp) {


### PR DESCRIPTION
## Changes

    This caused repeatable problem where layout got broken by session
    recording as css got cut off.
    
    This didn't happen when we had batching because we send untruncated data
    when batching for some reason. This 'fixes' that as well.


## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
