### PR TITLE
Automatically set UTM tags as person properties #120

### DIFF
--- a/src/posthog-persistence.js
+++ b/src/posthog-persistence.js
@@ -3,6 +3,7 @@
 import Config from './config'
 import { _, console } from './utils'
 import { cookieStore, localStore, memoryStore } from './storage'
+import { PostHogPeople } from './posthog-people'
 
 /*
  * Constants
@@ -259,6 +260,7 @@ PostHogPersistence.prototype.update_campaign_params = function () {
     if (!this.campaign_params_saved) {
         this.register_once(_.info.campaignParams())
         this.campaign_params_saved = true
+        PostHogPeople.prototype.set_once("UTM tags", _.info.campaignParams())
     }
 }
 


### PR DESCRIPTION
## Changes
...

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)

I was not able to test due to yarn not being updated for MacOS 11.0.1, lesson learned, always wait to upgrade. 