### PR TITLE
Batch session recording events

### DIFF
--- a/cypress/integration/session-recording.spec.js
+++ b/cypress/integration/session-recording.spec.js
@@ -32,7 +32,7 @@ describe('Session recording', () => {
             .type('hello posthog!')
             .then(() => {
                 const requests = cy.state('requests').filter(({ alias }) => alias === 'session-recording')
-                expect(requests.length).to.be.above(2).and.to.be.below(50)
+                expect(requests.length).to.be.above(1).and.to.be.below(8)
             })
     })
 })

--- a/cypress/integration/session-recording.spec.js
+++ b/cypress/integration/session-recording.spec.js
@@ -3,7 +3,6 @@
 describe('Session recording', () => {
     given('options', () => ({}))
 
-    // :TRICKY: Use a custom start command over beforeEach to deal with given2 not being ready yet.
     beforeEach(() => {
         cy.route({
             method: 'POST',

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -15,6 +15,7 @@ describe('SessionRecording', () => {
         get_config: jest.fn().mockImplementation((key) => given.config[key]),
         capture: jest.fn(),
         persistence: { register: jest.fn() },
+        _requestQueue: { setPollInterval: jest.fn() },
     }))
     given('config', () => ({ api_host: 'https://test.com', disable_session_recording: given.disabled }))
 
@@ -32,6 +33,7 @@ describe('SessionRecording', () => {
 
             expect(given.sessionRecording.submitRecordings).toHaveBeenCalled()
             expect(given.posthog.persistence.register).toHaveBeenCalledWith({ [SESSION_RECORDING_ENABLED]: true })
+            expect(given.posthog._requestQueue.setPollInterval).toHaveBeenCalledWith(300)
         })
 
         it('starts session recording, saves setting and endpoint when enabled', () => {
@@ -42,6 +44,7 @@ describe('SessionRecording', () => {
             expect(given.sessionRecording.submitRecordings).toHaveBeenCalled()
             expect(given.posthog.persistence.register).toHaveBeenCalledWith({ [SESSION_RECORDING_ENABLED]: true })
             expect(given.sessionRecording.endpoint).toEqual('/ses/')
+            expect(given.posthog._requestQueue.setPollInterval).toHaveBeenCalledWith(300)
         })
 
         it('does not start recording if not allowed', () => {
@@ -51,6 +54,7 @@ describe('SessionRecording', () => {
 
             expect(given.sessionRecording.submitRecordings).not.toHaveBeenCalled()
             expect(given.posthog.persistence.register).toHaveBeenCalledWith({ [SESSION_RECORDING_ENABLED]: false })
+            expect(given.posthog._requestQueue.setPollInterval).not.toHaveBeenCalled()
         })
     })
 

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -90,7 +90,7 @@ describe('SessionRecording', () => {
                     $session_id: 'sid',
                     $snapshot_data: { event: 1 },
                 },
-                { method: 'POST', transport: 'XHR', endpoint: '/e/', _noTruncate: true }
+                { method: 'POST', transport: 'XHR', endpoint: '/e/', _noTruncate: true, _batchWithOptions: false }
             )
             expect(given.posthog.capture).toHaveBeenCalledWith(
                 '$snapshot',
@@ -98,7 +98,26 @@ describe('SessionRecording', () => {
                     $session_id: 'sid',
                     $snapshot_data: { event: 2 },
                 },
-                { method: 'POST', transport: 'XHR', endpoint: '/e/', _noTruncate: true }
+                { method: 'POST', transport: 'XHR', endpoint: '/e/', _noTruncate: true, _batchWithOptions: false }
+            )
+        })
+
+        it('sends as batches when different endpoint', () => {
+            given.sessionRecording.endpoint = '/s/'
+
+            given.sessionRecording.startRecordingIfEnabled()
+
+            _emit({ event: 1 })
+
+            given.sessionRecording.submitRecordings()
+
+            expect(given.posthog.capture).toHaveBeenCalledWith(
+                '$snapshot',
+                {
+                    $session_id: 'sid',
+                    $snapshot_data: { event: 1 },
+                },
+                { method: 'POST', transport: 'XHR', endpoint: '/s/', _noTruncate: true, _batchWithOptions: true }
             )
         })
 

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -90,7 +90,13 @@ describe('SessionRecording', () => {
                     $session_id: 'sid',
                     $snapshot_data: { event: 1 },
                 },
-                { method: 'POST', transport: 'XHR', endpoint: '/e/', _noTruncate: true, _batchWithOptions: false }
+                {
+                    method: 'POST',
+                    transport: 'XHR',
+                    endpoint: '/e/',
+                    _noTruncate: true,
+                    _batchKey: 'sessionRecording',
+                }
             )
             expect(given.posthog.capture).toHaveBeenCalledWith(
                 '$snapshot',
@@ -98,26 +104,13 @@ describe('SessionRecording', () => {
                     $session_id: 'sid',
                     $snapshot_data: { event: 2 },
                 },
-                { method: 'POST', transport: 'XHR', endpoint: '/e/', _noTruncate: true, _batchWithOptions: false }
-            )
-        })
-
-        it('sends as batches when different endpoint', () => {
-            given.sessionRecording.endpoint = '/s/'
-
-            given.sessionRecording.startRecordingIfEnabled()
-
-            _emit({ event: 1 })
-
-            given.sessionRecording.submitRecordings()
-
-            expect(given.posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
                 {
-                    $session_id: 'sid',
-                    $snapshot_data: { event: 1 },
-                },
-                { method: 'POST', transport: 'XHR', endpoint: '/s/', _noTruncate: true, _batchWithOptions: true }
+                    method: 'POST',
+                    transport: 'XHR',
+                    endpoint: '/e/',
+                    _noTruncate: true,
+                    _batchKey: 'sessionRecording',
+                }
             )
         })
 

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -194,7 +194,7 @@ describe('_handle_unload()', () => {
         get_config: (key) => given.config[key],
         capture: jest.fn(),
         compression: {},
-        __requestQueue: {
+        _requestQueue: {
             unload: jest.fn(),
         },
     }))
@@ -224,7 +224,7 @@ describe('_handle_unload()', () => {
     it('calls requestQueue unload', () => {
         given.subject()
 
-        expect(given.overrides.__requestQueue.unload).toHaveBeenCalledTimes(1)
+        expect(given.overrides._requestQueue.unload).toHaveBeenCalledTimes(1)
     })
 
     describe('without batching', () => {

--- a/src/__tests__/request-queue.js
+++ b/src/__tests__/request-queue.js
@@ -16,6 +16,7 @@ describe('RequestQueue', () => {
         given.queue.enqueue('/e', { event: 'foo', timestamp: EPOCH - 3000 }, { transport: 'XHR' })
         given.queue.enqueue('/identify', { event: '$identify', timestamp: EPOCH - 2000 })
         given.queue.enqueue('/e', { event: 'bar', timestamp: EPOCH - 1000 })
+        given.queue.enqueue('/e', { event: 'zeta', timestamp: EPOCH }, { _batchKey: 'sessionRecording' })
 
         given.queue.poll()
 
@@ -23,7 +24,7 @@ describe('RequestQueue', () => {
 
         jest.runOnlyPendingTimers()
 
-        expect(given.handlePollRequest).toHaveBeenCalledTimes(2)
+        expect(given.handlePollRequest).toHaveBeenCalledTimes(3)
         expect(given.handlePollRequest).toHaveBeenCalledWith(
             '/e',
             [
@@ -37,6 +38,9 @@ describe('RequestQueue', () => {
             [{ event: '$identify', offset: 2000 }],
             undefined
         )
+        expect(given.handlePollRequest).toHaveBeenCalledWith('/e', [{ event: 'zeta', offset: 0 }], {
+            _batchKey: 'sessionRecording',
+        })
     })
 
     it('clears polling flag after 4 empty iterations', () => {

--- a/src/__tests__/request-queue.js
+++ b/src/__tests__/request-queue.js
@@ -13,7 +13,7 @@ describe('RequestQueue', () => {
     })
 
     it('handles poll after enqueueing requests', () => {
-        given.queue.enqueue('/e', { event: 'foo', timestamp: EPOCH - 3000 })
+        given.queue.enqueue('/e', { event: 'foo', timestamp: EPOCH - 3000 }, { transport: 'XHR' })
         given.queue.enqueue('/identify', { event: '$identify', timestamp: EPOCH - 2000 })
         given.queue.enqueue('/e', { event: 'bar', timestamp: EPOCH - 1000 })
 
@@ -24,11 +24,19 @@ describe('RequestQueue', () => {
         jest.runOnlyPendingTimers()
 
         expect(given.handlePollRequest).toHaveBeenCalledTimes(2)
-        expect(given.handlePollRequest).toHaveBeenCalledWith('/e', [
-            { event: 'foo', offset: 3000 },
-            { event: 'bar', offset: 1000 },
-        ])
-        expect(given.handlePollRequest).toHaveBeenCalledWith('/identify', [{ event: '$identify', offset: 2000 }])
+        expect(given.handlePollRequest).toHaveBeenCalledWith(
+            '/e',
+            [
+                { event: 'foo', offset: 3000 },
+                { event: 'bar', offset: 1000 },
+            ],
+            { transport: 'XHR' }
+        )
+        expect(given.handlePollRequest).toHaveBeenCalledWith(
+            '/identify',
+            [{ event: '$identify', offset: 2000 }],
+            undefined
+        )
     })
 
     it('clears polling flag after 4 empty iterations', () => {
@@ -61,12 +69,12 @@ describe('RequestQueue', () => {
                 { event: 'foo', timestamp: 1_610_000_000 },
                 { event: 'bar', timestamp: 1_630_000_000 },
             ],
-            { unload: true }
+            { transport: 'sendbeacon' }
         )
         expect(given.handlePollRequest).toHaveBeenCalledWith(
             '/identify',
             [{ event: '$identify', timestamp: 1_620_000_000 }],
-            { unload: true }
+            { transport: 'sendbeacon' }
         )
     })
 })

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -75,8 +75,7 @@ export class SessionRecording {
             method: 'POST',
             endpoint: this.endpoint,
             _noTruncate: true,
-            // Allow batching session recordings only on newer versions of posthog to respect other properties
-            _batchWithOptions: this.endpoint !== BASE_ENDPOINT,
+            _batchKey: 'sessionRecording',
         })
     }
 }

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -35,6 +35,8 @@ export class SessionRecording {
         this.emit = true
         this._startCapture()
         this.snapshots.forEach((properties) => this._captureSnapshot(properties))
+        // If session recording is enabled, we send events to server more frequently
+        this.instance._requestQueue.setPollInterval(300)
     }
 
     _startCapture() {

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -3,13 +3,15 @@ import { _ } from '../utils'
 import { SESSION_RECORDING_ENABLED } from '../posthog-persistence'
 import sessionIdGenerator from './sessionid'
 
+const BASE_ENDPOINT = '/e/'
+
 export class SessionRecording {
     constructor(instance) {
         this.instance = instance
         this.captureStarted = false
         this.snapshots = []
         this.emit = false
-        this.endpoint = '/e/'
+        this.endpoint = BASE_ENDPOINT
     }
 
     startRecordingIfEnabled() {
@@ -67,12 +69,14 @@ export class SessionRecording {
     }
 
     _captureSnapshot(properties) {
-        // :TRICKY: Make sure we don't batch these requests, use a custom endpoint and don't truncate the strings.
+        // :TRICKY: Make sure we batch these requests, use a custom endpoint and don't truncate the strings.
         this.instance.capture('$snapshot', properties, {
             transport: 'XHR',
             method: 'POST',
             endpoint: this.endpoint,
             _noTruncate: true,
+            // Allow batching session recordings only on newer versions of posthog to respect other properties
+            _batchWithOptions: this.endpoint !== BASE_ENDPOINT,
         })
     }
 }

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -638,11 +638,11 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
 
     const has_unique_traits = callback !== __NOOP || options !== __NOOPTIONS
 
-    if (!this.get_config('request_batching') || has_unique_traits) {
-        this.__compress_and_send_json_request(url, jsonData, options, cb)
-    } else {
+    if (this.get_config('request_batching') && (!has_unique_traits || options._batchWithOptions)) {
         data['timestamp'] = new Date()
         this._requestQueue.enqueue(url, data, options)
+    } else {
+        this.__compress_and_send_json_request(url, jsonData, options, cb)
     }
 
     this.config._onCapture(data)

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -222,7 +222,7 @@ PostHogLib.prototype._init = function (token, config, name) {
 
     this['_jsc'] = function () {}
 
-    this.__requestQueue = new RequestQueue(_.bind(this._handle_queued_event, this))
+    this._requestQueue = new RequestQueue(_.bind(this._handle_queued_event, this))
     this.__request_queue = []
 
     this['persistence'] = new PostHogPersistence(this['config'])
@@ -262,7 +262,7 @@ PostHogLib.prototype._loaded = function () {
 PostHogLib.prototype._start_queue_if_opted_in = function () {
     if (!this.has_opted_out_capturing()) {
         if (this.get_config('request_batching')) {
-            this.__requestQueue.poll()
+            this._requestQueue.poll()
         }
     }
 }
@@ -328,7 +328,7 @@ PostHogLib.prototype._handle_unload = function () {
     if (this.get_config('capture_pageview')) {
         this.capture('$pageleave')
     }
-    this.__requestQueue.unload()
+    this._requestQueue.unload()
 }
 
 PostHogLib.prototype._handle_queued_event = function (url, data, { unload = false } = {}) {
@@ -643,7 +643,7 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
         this.__compress_and_send_json_request(url, jsonData, options, cb)
     } else {
         data['timestamp'] = new Date()
-        this.__requestQueue.enqueue(url, data)
+        this._requestQueue.enqueue(url, data)
     }
 
     this.config._onCapture(data)

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -638,7 +638,7 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
 
     const has_unique_traits = callback !== __NOOP || options !== __NOOPTIONS
 
-    if (this.get_config('request_batching') && (!has_unique_traits || options._batchWithOptions)) {
+    if (this.get_config('request_batching') && (!has_unique_traits || options._batchKey)) {
         data['timestamp'] = new Date()
         this._requestQueue.enqueue(url, data, options)
     } else {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -331,10 +331,9 @@ PostHogLib.prototype._handle_unload = function () {
     this._requestQueue.unload()
 }
 
-PostHogLib.prototype._handle_queued_event = function (url, data, { unload = false } = {}) {
+PostHogLib.prototype._handle_queued_event = function (url, data, options) {
     const jsonData = JSON.stringify(data)
-    const options = unload ? { transport: 'sendbeacon' } : __NOOPTIONS
-    this.__compress_and_send_json_request(url, jsonData, options, __NOOP)
+    this.__compress_and_send_json_request(url, jsonData, options || __NOOPTIONS, __NOOP)
 }
 
 PostHogLib.prototype.__compress_and_send_json_request = function (url, jsonData, options, callback) {
@@ -643,7 +642,7 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
         this.__compress_and_send_json_request(url, jsonData, options, cb)
     } else {
         data['timestamp'] = new Date()
-        this._requestQueue.enqueue(url, data)
+        this._requestQueue.enqueue(url, data, options)
     }
 
     this.config._onCapture(data)

--- a/src/request-queue.js
+++ b/src/request-queue.js
@@ -6,7 +6,6 @@ export class RequestQueue {
         this.isPolling = true // flag to continue to recursively poll or not
         this._event_queue = []
         this._empty_queue_count = 0 // to track empty polls
-        this.pollInterval = pollInterval
         this._poller = function () {} // to become interval for reference to clear later
         this._pollInterval = pollInterval
     }
@@ -78,7 +77,7 @@ export class RequestQueue {
         const requests = {}
         _.each(this._event_queue, (request) => {
             const { url, data, options } = request
-            const key = options?._batchKey || url
+            const key = (options ? options._batchKey : null) || url
             if (requests[key] === undefined) requests[key] = { data: [], url, options }
             requests[key].data.push(data)
         })

--- a/src/request-queue.js
+++ b/src/request-queue.js
@@ -1,14 +1,22 @@
 import { _ } from './utils'
 
-const POLL_INTERVAL = 3000
-
 export class RequestQueue {
-    constructor(handlePollRequest) {
+    constructor(handlePollRequest, pollInterval = 3000) {
         this.handlePollRequest = handlePollRequest
         this.isPolling = true // flag to continue to recursively poll or not
         this._event_queue = []
         this._empty_queue_count = 0 // to track empty polls
+        this.pollInterval = pollInterval
         this._poller = function () {} // to become interval for reference to clear later
+        this._pollInterval = pollInterval
+    }
+
+    setPollInterval(interval) {
+        this._pollInterval = interval
+        // Reset interval if running already
+        if (this.isPolling) {
+            this.poll()
+        }
     }
 
     enqueue(url, data) {
@@ -53,7 +61,7 @@ export class RequestQueue {
             if (this.isPolling) {
                 this.poll()
             }
-        }, POLL_INTERVAL)
+        }, this._pollInterval)
     }
 
     unload() {

--- a/src/request-queue.js
+++ b/src/request-queue.js
@@ -21,7 +21,7 @@ export class RequestQueue {
     }
 
     poll() {
-        clearInterval(this._poller)
+        clearTimeout(this._poller)
         this._poller = setTimeout(() => {
             if (this._event_queue.length > 0) {
                 const requests = this.formatQueue()
@@ -57,7 +57,7 @@ export class RequestQueue {
     }
 
     unload() {
-        clearInterval(this._poller)
+        clearTimeout(this._poller)
         const requests = this._event_queue.length > 0 ? this.formatQueue() : {}
         this._event_queue.length = 0
         for (let url in requests) {

--- a/src/request-queue.js
+++ b/src/request-queue.js
@@ -33,11 +33,11 @@ export class RequestQueue {
         this._poller = setTimeout(() => {
             if (this._event_queue.length > 0) {
                 const requests = this.formatQueue()
-                for (let url in requests) {
-                    let { data, options } = requests[url]
-                    _.each(data, (_, key) => {
-                        data[key]['offset'] = Math.abs(data[key]['timestamp'] - this.getTime())
-                        delete data[key]['timestamp']
+                for (let key in requests) {
+                    let { url, data, options } = requests[key]
+                    _.each(data, (_, dataKey) => {
+                        data[dataKey]['offset'] = Math.abs(data[dataKey]['timestamp'] - this.getTime())
+                        delete data[dataKey]['timestamp']
                     })
                     this.handlePollRequest(url, data, options)
                 }
@@ -78,8 +78,9 @@ export class RequestQueue {
         const requests = {}
         _.each(this._event_queue, (request) => {
             const { url, data, options } = request
-            if (requests[url] === undefined) requests[url] = { data: [], options }
-            requests[url].data.push(data)
+            const key = options?._batchKey || url
+            if (requests[key] === undefined) requests[key] = { data: [], url, options }
+            requests[key].data.push(data)
         })
         return requests
     }


### PR DESCRIPTION
## Changes

Session recording events are sent separately from rest of batches to make sure transport options are enforced and we now send events every 300ms when session recording is on (to avoid dropped events).

## Checklist
- [x] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
