### PR TITLE
Session recording: capture $pageviews as custom rrweb events

### DIFF
--- a/cypress/integration/capture.spec.js
+++ b/cypress/integration/capture.spec.js
@@ -30,10 +30,10 @@ describe('Event capture', () => {
         start()
 
         cy.get('[data-cy-custom-event-button]').click()
-        cy.phCaptures('event').should('deep.equal', ['$pageview', '$autocapture', 'custom-event'])
+        cy.phCaptures().should('deep.equal', ['$pageview', '$autocapture', 'custom-event'])
 
         cy.reload()
-        cy.phCaptures('event').should('deep.equal', ['$pageview', '$autocapture', 'custom-event', '$pageleave'])
+        cy.phCaptures().should('deep.equal', ['$pageview', '$autocapture', 'custom-event', '$pageleave'])
     })
 
     it('captures $feature_flag_called', () => {
@@ -41,7 +41,7 @@ describe('Event capture', () => {
 
         cy.get('[data-cy-feature-flag-button]').click()
 
-        cy.phCaptures('event').should('include', '$feature_flag_called')
+        cy.phCaptures().should('include', '$feature_flag_called')
     })
 
     describe('session recording enabled from API', () => {
@@ -52,7 +52,7 @@ describe('Event capture', () => {
         it('captures $snapshot events', () => {
             start()
 
-            cy.phCaptures('event').should('include', '$snapshot')
+            cy.phCaptures().should('include', '$snapshot')
         })
 
         describe('but disabled from config', () => {
@@ -63,7 +63,7 @@ describe('Event capture', () => {
 
                 cy.wait(1000)
 
-                cy.phCaptures('event').should('not.include', '$snapshot')
+                cy.phCaptures().should('not.include', '$snapshot')
             })
         })
     })
@@ -76,7 +76,7 @@ describe('Event capture', () => {
 
             cy.wait(50)
             cy.get('[data-cy-custom-event-button]').click()
-            cy.phCaptures('event').should('deep.equal', ['$pageview', 'custom-event'])
+            cy.phCaptures().should('deep.equal', ['$pageview', 'custom-event'])
         })
     })
 
@@ -89,7 +89,7 @@ describe('Event capture', () => {
             cy.get('[data-cy-custom-event-button]').click()
             cy.reload()
 
-            cy.phCaptures('event').should('deep.equal', ['$autocapture', 'custom-event'])
+            cy.phCaptures().should('deep.equal', ['$autocapture', 'custom-event'])
         })
     })
 
@@ -103,7 +103,7 @@ describe('Event capture', () => {
             cy.get('[data-cy-feature-flag-button]').click()
             cy.reload()
 
-            cy.phCaptures('event').should('deep.equal', ['$pageview'])
+            cy.phCaptures().should('deep.equal', ['$pageview'])
         })
 
         it('does not send session recording events', () => {
@@ -115,7 +115,7 @@ describe('Event capture', () => {
             cy.resetPhCaptures()
 
             cy.get('[data-cy-custom-event-button]').click()
-            cy.phCaptures('event').should('deep.equal', [])
+            cy.phCaptures().should('deep.equal', [])
         })
     })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -41,11 +41,9 @@ Cypress.Commands.add('posthogInit', (options) => {
     })
 })
 
-Cypress.Commands.add('phCaptures', (attribute = null, options = {}) => {
+Cypress.Commands.add('phCaptures', (options = {}) => {
     function resolve() {
-        const values = $captures.map((event) => event[attribute])
-
-        return cy.verifyUpcomingAssertions(values, options, {
+        return cy.verifyUpcomingAssertions($captures, options, {
             onRetry: resolve,
         })
     }

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -16,6 +16,7 @@ describe('SessionRecording', () => {
         capture: jest.fn(),
         persistence: { register: jest.fn() },
         _requestQueue: { setPollInterval: jest.fn() },
+        _addCaptureHook: jest.fn(),
     }))
     given('config', () => ({ api_host: 'https://test.com', disable_session_recording: given.disabled }))
 

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -108,6 +108,7 @@ describe('capture()', () => {
             properties: jest.fn(),
         },
         compression: {},
+        __captureHooks: [],
     }))
 
     it('handles recursive objects', () => {
@@ -118,6 +119,16 @@ describe('capture()', () => {
         })
 
         expect(() => given.subject()).not.toThrow()
+    })
+
+    it('calls callbacks added via _addCaptureHook', () => {
+        const hook = jest.fn()
+
+        given.lib._addCaptureHook(hook)
+
+        given.subject()
+
+        expect(hook).toHaveBeenCalledWith('$event')
     })
 })
 

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -66,6 +66,14 @@ export class SessionRecording {
             blockClass: 'ph-no-capture', // Does not capture the element at all
             ignoreClass: 'ph-ignore-input', // Ignores content of input but still records the input element
         })
+
+        // :TRICKY: rrweb does not capture navigation within SPA-s, so hook into our $pageview events to get access to all events.
+        //   Dropping the initial event is fine (it's always captured by rrweb).
+        this.instance._addCaptureHook((eventName) => {
+            if (eventName === '$pageview') {
+                window.rrweb.record.addCustomEvent('$pageview', { href: window.location.href })
+            }
+        })
     }
 
     _captureSnapshot(properties) {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -691,10 +691,6 @@ PostHogLib.prototype._calculate_event_properties = function (event_name, event_p
     return properties
 }
 
-PostHogLib.prototype._create_map_key = function (group_key, group_id) {
-    return group_key + '_' + JSON.stringify(group_id)
-}
-
 /**
  * Capture a page view event.
  * This function is called by default on page load unless the

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -223,6 +223,7 @@ PostHogLib.prototype._init = function (token, config, name) {
     this['_jsc'] = function () {}
 
     this._requestQueue = new RequestQueue(_.bind(this._handle_queued_event, this))
+    this.__captureHooks = []
     this.__request_queue = []
 
     this['persistence'] = new PostHogPersistence(this['config'])
@@ -645,10 +646,19 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
         this.__compress_and_send_json_request(url, jsonData, options, cb)
     }
 
-    this.config._onCapture(data)
+    this._invokeCaptureHooks(event_name)
 
     return data
 })
+
+PostHogLib.prototype._addCaptureHook = function (callback) {
+    this.__captureHooks.push(callback)
+}
+
+PostHogLib.prototype._invokeCaptureHooks = function (eventName) {
+    this.config._onCapture(eventName)
+    _.each(this.__captureHooks, (callback) => callback(eventName))
+}
 
 PostHogLib.prototype._calculate_event_properties = function (event_name, event_properties, start_timestamp) {
     // set defaults


### PR DESCRIPTION
- Delete dead code
- Hook into $pageview events in rrweb

rrweb does not capture navigation on SPA-s (e.g. posthog.com/docs), with this
we will still show the correct events in the new design if events are properly
hooked up.

## Checklist
- [x] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
