### PR TITLE
Deprecate calling posthog.capture with a callback

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -41,7 +41,7 @@ declare class posthog {
      * @param {Object} [properties] A set of properties to include with the event you're sending. These describe the user who did the event or details about the event itself.
      * @param {Object} [options] Optional configuration for this capture request.
      * @param {String} [options.transport] Transport method for network request ('XHR' or 'sendBeacon').
-     * @param {Function} [callback] If provided, the callback function will be called after capturing the event.
+     * @param {Function} [callback] [Deprecated] If provided, the callback function will be called after capturing the event.
      */
     static capture(
         event_name: string,

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -582,7 +582,7 @@ PostHogLib.prototype.push = function (item) {
  * @param {Object} [properties] A set of properties to include with the event you're sending. These describe the user who did the event or details about the event itself.
  * @param {Object} [options] Optional configuration for this capture request.
  * @param {String} [options.transport] Transport method for network request ('XHR' or 'sendBeacon').
- * @param {Function} [callback] If provided, the callback function will be called after capturing the event.
+ * @param {Function} [callback] [Deprecated] If provided, the callback function will be called after capturing the event.
  */
 PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, properties, options, callback) {
     if (!callback && typeof options === 'function') {
@@ -596,6 +596,8 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
     }
     if (typeof callback !== 'function') {
         callback = __NOOP
+    } else {
+        window.console.warn('WARNING! Calling posthog.capture with a callback is deprecated and will be removed soon!')
     }
 
     if (_.isUndefined(event_name)) {


### PR DESCRIPTION
Killing this eventually will allow killing much unneeded cruft \o/ It also didn't really work with batching.

## Checklist
- [x] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
