### PR TITLE
Bundle module.js in ES5

### DIFF
--- a/.github/workflows/ssr-es-check.yml
+++ b/.github/workflows/ssr-es-check.yml
@@ -1,4 +1,4 @@
-name: Requiring module in SSR
+name: Server-side rendering and ES5
 
 on:
   - pull_request
@@ -13,7 +13,10 @@ jobs:
         with:
           node-version: 14
 
-      - run: yarn install && yarn build-module
+      - run: yarn install && yarn build-module && yarn build
+
+      - name: Run es-check to check if our bundle is ES5 compatible
+        run: yarn add es-check; npx es-check es5 dist/*.js
 
       - name: Require module via node
         run: cd dist; node -e "require('./module')"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "start": "parcel watch src/loader-globals.js --out-file dist/array.js",
         "serve": "parcel serve src/loader-globals.js --port 3001 --out-file dist/array.js",
         "build": "parcel build src/loader-globals.js --out-file dist/array.js --no-source-maps",
-        "build-module": "./node_modules/.bin/rollup -i src/loader-module.js -f cjs -o dist/module.js -c rollup.config.js",
+        "build-module": "npx rollup -i src/loader-module.js -f cjs -o dist/module.js -c rollup.config.js",
         "process-types": "mkdir -p dist; eslint src --ext .ts -c .eslintrc.ts.js --fix && tsc && cp -f src/*.d.ts dist/",
         "lint": "eslint src --fix",
         "prepublishOnly": "yarn lint && yarn test && yarn build && yarn build-module && yarn process-types",
@@ -25,6 +25,7 @@
     "devDependencies": {
         "@babel/core": "^7.0.0",
         "@babel/preset-env": "^7.0.0",
+        "@rollup/plugin-babel": "^5.2.1",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^8.1.0",
         "@typescript-eslint/eslint-plugin": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "start": "parcel watch src/loader-globals.js --out-file dist/array.js",
         "serve": "parcel serve src/loader-globals.js --port 3001 --out-file dist/array.js",
         "build": "parcel build src/loader-globals.js --out-file dist/array.js --no-source-maps",
-        "build-module": "npx rollup -i src/loader-module.js -f cjs -o dist/module.js -c rollup.config.js",
+        "build-module": "rollup -i src/loader-module.js -f cjs -o dist/module.js -c rollup.config.js",
         "process-types": "mkdir -p dist; eslint src --ext .ts -c .eslintrc.ts.js --fix && tsc && cp -f src/*.d.ts dist/",
         "lint": "eslint src --fix",
         "prepublishOnly": "yarn lint && yarn test && yarn build && yarn build-module && yarn process-types",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,13 +1,11 @@
-import resolve from '@rollup/plugin-node-resolve'
+import babel from '@rollup/plugin-babel'
 import json from '@rollup/plugin-json'
+import resolve from '@rollup/plugin-node-resolve'
 
 export default {
     plugins: [
         json(),
-        resolve({
-            browser: true,
-            main: true,
-            jsnext: true,
-        }),
+        resolve({ browser: true, modulesOnly: true }),
+        babel({ babelHelpers: 'bundled', presets: ['@babel/preset-env'] }),
     ],
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,8 @@
-import pkg from '../package.json'
+import { version } from '../package.json'
 
 var Config = {
     DEBUG: false,
-    LIB_VERSION: pkg.version,
+    LIB_VERSION: version,
 }
 
 export default Config


### PR DESCRIPTION
## Changes

Turns out dist/module.js was not bundled in es5, which would cause issues in IE11. [An user pointed this out in a comment under an old commit](https://github.com/PostHog/posthog-js/commit/f2742ede4c4c5837e64e351e198f50ce7c94f802).

This is an attempt towards fixing this + adding tests for the future.

Note: I know next to nothing about library bundling in node world, but the solution seems still less than ideal. @mariusandra do you know any libraries we could 'borrow' inspiration from on how to bundle things properly?

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
