### PR TITLE
Force session recording to use lz64

### DIFF
--- a/cypress/integration/capture.spec.js
+++ b/cypress/integration/capture.spec.js
@@ -1,5 +1,8 @@
 /// <reference types="cypress" />
 
+import { version } from '../../package.json'
+import { LZString } from '../../src/lz-string'
+
 describe('Event capture', () => {
     given('options', () => ({}))
     given('sessionRecording', () => false)
@@ -116,6 +119,28 @@ describe('Event capture', () => {
 
             cy.get('[data-cy-custom-event-button]').click()
             cy.phCaptures().should('deep.equal', [])
+        })
+    })
+
+    describe('decoding the payload', () => {
+        it('contains the correct headers and payload after an event', () => {
+            start()
+
+            cy.get('[data-cy-custom-event-button]').click()
+            cy.phCaptures().should('deep.equal', ['$pageview', '$autocapture', 'custom-event'])
+
+            cy.wait('@capture').its('request.headers').should('deep.equal', {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                PosthogJs: version,
+                PosthogCompression: 'lz64',
+            })
+
+            cy.get('@capture').should(({ request }) => {
+                const data = decodeURIComponent(request.body.match(/data=(.*)&compression=lz64/)[1])
+                const captures = JSON.parse(LZString.decompressFromBase64(data))
+
+                expect(captures.map(({ event }) => event)).to.deep.equal(['$pageview', '$autocapture', 'custom-event'])
+            })
         })
     })
 })

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@typescript-eslint/parser": "^3.5.0",
         "babel-eslint": "^10.1.0",
         "babel-jest": "^26.1.0",
-        "cypress": "^5.5.0",
+        "cypress": "^6.0.0",
         "eslint": "^7.3.1",
         "eslint-plugin-prettier": "^3.1.4",
         "given2": "^2.1.7",

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -95,6 +95,7 @@ describe('SessionRecording', () => {
                     method: 'POST',
                     transport: 'XHR',
                     endpoint: '/e/',
+                    compression: 'lz64',
                     _noTruncate: true,
                     _batchKey: 'sessionRecording',
                 }
@@ -109,6 +110,7 @@ describe('SessionRecording', () => {
                     method: 'POST',
                     transport: 'XHR',
                     endpoint: '/e/',
+                    compression: 'lz64',
                     _noTruncate: true,
                     _batchKey: 'sessionRecording',
                 }

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -82,6 +82,7 @@ export class SessionRecording {
             transport: 'XHR',
             method: 'POST',
             endpoint: this.endpoint,
+            compression: 'lz64', // Force lz64 even if /decide endpoint has not yet responded
             _noTruncate: true,
             _batchKey: 'sessionRecording',
         })

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -391,6 +391,7 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
     var args = {}
     args['ip'] = this.get_config('ip') ? 1 : 0
     args['_'] = new Date().getTime().toString()
+    const compression = data['compression'] || 'base64'
 
     if (use_post) {
         if (Array.isArray(data)) {
@@ -426,6 +427,8 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
             var headers = this.get_config('xhr_headers')
             if (use_post) {
                 headers['Content-Type'] = 'application/x-www-form-urlencoded'
+                headers['PosthogJs'] = Config.LIB_VERSION
+                headers['PosthogCompression'] = compression
             }
             _.each(headers, function (headerValue, headerName) {
                 req.setRequestHeader(headerName, headerValue)

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -329,7 +329,7 @@ PostHogLib.prototype._handle_queued_event = function (url, data, options) {
 }
 
 PostHogLib.prototype.__compress_and_send_json_request = function (url, jsonData, options, callback) {
-    if (this.compression['lz64']) {
+    if (this.compression['lz64'] || (options.compression && options.compression === 'lz64')) {
         this._send_request(url, { data: LZString.compressToBase64(jsonData), compression: 'lz64' }, options, callback)
     } else {
         this._send_request(url, { data: _.base64Encode(jsonData) }, options, callback)


### PR DESCRIPTION
## Changes

- Force session recording to use lz64 (as it would use base64 before /decide endpoint response)
- Send library version + compression as headers
- Add tests for payload sent to server

## Checklist
- [x] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
