### PR TITLE
Referrer first and last touch

### DIFF
--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -1,6 +1,6 @@
 import { PostHogFeatureFlags } from '../posthog-featureflags'
 
-fdescribe('featureflags', () => {
+describe('featureflags', () => {
     given('properties', () => ({ $override_feature_flags: false, $active_feature_flags: ['beta-feature'] }))
 
     given('instance', () => ({

--- a/src/__tests__/posthog-persistence.js
+++ b/src/__tests__/posthog-persistence.js
@@ -1,0 +1,30 @@
+import { PostHogPersistence } from '../posthog-persistence'
+
+given('lib', () => Object.assign(new PostHogPersistence({ name: 'bla', persistence: 'cookie' }), given.overrides))
+
+fdescribe('persistence', () => {
+    it('should set referrer', () => {
+        // Initial visit
+        given.lib.update_referrer_info('https://www.google.com')
+
+        expect(given.lib.props['$initial_referring_domain']).toBe('www.google.com')
+        expect(given.lib.props['$referring_domain']).toBe('www.google.com')
+        expect(given.lib.props['$referrer']).toBe('https://www.google.com')
+
+        //subsequent visit
+        given.lib.update_referrer_info('https://www.facebook.com')
+        // first touch
+        expect(given.lib.props['$initial_referring_domain']).toBe('www.google.com')
+
+        // last touch
+        expect(given.lib.props['$referring_domain']).toBe('www.facebook.com')
+        expect(given.lib.props['$referrer']).toBe('https://www.facebook.com')
+
+        // page visit that doesn't have direct referrer
+        given.lib.update_referrer_info('')
+        expect(given.lib.props['$initial_referring_domain']).toBe('www.google.com')
+        // last touch should still be set to facebook
+        expect(given.lib.props['$referring_domain']).toBe('www.facebook.com')
+        expect(given.lib.props['$referrer']).toBe('https://www.facebook.com')
+    })
+})

--- a/src/__tests__/posthog-persistence.js
+++ b/src/__tests__/posthog-persistence.js
@@ -1,8 +1,8 @@
 import { PostHogPersistence } from '../posthog-persistence'
 
-given('lib', () => Object.assign(new PostHogPersistence({ name: 'bla', persistence: 'cookie' }), given.overrides))
+given('lib', () => new PostHogPersistence({ name: 'bla', persistence: 'cookie' }))
 
-fdescribe('persistence', () => {
+describe('persistence', () => {
     it('should set referrer', () => {
         // Initial visit
         given.lib.update_referrer_info('https://www.google.com')

--- a/src/posthog-persistence.js
+++ b/src/posthog-persistence.js
@@ -269,6 +269,7 @@ PostHogPersistence.prototype.update_search_keyword = function (referrer) {
 // EXPORTED METHOD, we test this directly.
 PostHogPersistence.prototype.update_referrer_info = function (referrer) {
     // If referrer doesn't exist, we want to note the fact that it was type-in traffic.
+    // Register once, so first touch
     this.register_once(
         {
             $initial_referrer: referrer || '$direct',
@@ -276,6 +277,11 @@ PostHogPersistence.prototype.update_referrer_info = function (referrer) {
         },
         ''
     )
+    // Register the current referrer but override if it's different, hence register
+    this.register({
+        $referrer: referrer || this['props']['$referrer'] || '$direct',
+        $referring_domain: _.info.referringDomain(referrer) || this['props']['$referring_domain'] || '$direct',
+    })
 }
 
 PostHogPersistence.prototype.get_referrer_info = function () {

--- a/src/utils.js
+++ b/src/utils.js
@@ -814,8 +814,6 @@ _.info = {
             _.strip_empty_properties({
                 $os: _.info.os(),
                 $browser: _.info.browser(userAgent, navigator.vendor, window.opera),
-                $referrer: document.referrer,
-                $referring_domain: _.info.referringDomain(document.referrer),
                 $device: _.info.device(userAgent),
             }),
             {


### PR DESCRIPTION
## Changes

Based on a conversation with a user, they were interested in knowing what last touch referrer led to a purchase. This wasn't possible, as we only set the referrer on the first page visit, but not on subsequent page visits within that session.

This correctly sets the $referrer and $referrer_domain in persistence so that it's always set to the last touch referrer.

In the interface this is how we explain this behaviour as well, but turns out we aren't doing this correctly: 
![image](https://user-images.githubusercontent.com/1727427/100606795-42e62280-330a-11eb-8f39-c24e24edaf4e.png)


cc @jamesefhawkins as you know more about first/last touch than me. Does this sound right to you?

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
