### PR TITLE
Capture information on failed/in-flight requests

### DIFF
--- a/src/__tests__/capture-metrics.js
+++ b/src/__tests__/capture-metrics.js
@@ -1,0 +1,92 @@
+import { CaptureMetrics } from '../capture-metrics'
+
+import { _ } from '../utils'
+
+jest.mock('../utils')
+
+describe('CaptureMetrics()', () => {
+    given('captureMetrics', () => new CaptureMetrics(given.enabled, given.capture, given.getTime))
+
+    given('enabled', () => true)
+    given('capture', () => jest.fn())
+
+    given('getTime', () => jest.fn())
+
+    describe('incr() and decr()', () => {
+        it('supports incrementing and decrementing metrics', () => {
+            given.captureMetrics.incr('key')
+            given.captureMetrics.incr('key2')
+            given.captureMetrics.incr('key', 3)
+            given.captureMetrics.decr('key')
+
+            expect(given.captureMetrics.metrics).toEqual({ 'phjs-key': 3, 'phjs-key2': 1 })
+        })
+
+        it('does nothing when not enabled', () => {
+            given('enabled', () => false)
+
+            given.captureMetrics.incr('key')
+
+            expect(given.captureMetrics.metrics).toEqual({})
+        })
+    })
+
+    describe('tracking requests', () => {
+        beforeEach(() => {
+            let i = 0
+            _.UUID.mockImplementation(() => i++)
+        })
+
+        it('handles starting and finishing a request', () => {
+            given.getTime.mockReturnValue(5000)
+            const id = given.captureMetrics.startRequest({ size: 123 })
+
+            given.getTime.mockReturnValue(5100)
+            const payload = given.captureMetrics.finishRequest(id)
+
+            expect(id).toEqual(0)
+            expect(payload).toEqual({ size: 123, duration: 100 })
+        })
+
+        it('handles marking a request as failed', () => {
+            given.captureMetrics.markRequestFailed({ foo: 'bar' })
+
+            expect(given.capture).toHaveBeenCalledWith('$capture_failed_request', { foo: 'bar' })
+        })
+
+        it('handles marking all in-flight requests as failed', () => {
+            given.getTime.mockReturnValue(5000)
+            given.captureMetrics.startRequest({ size: 100 })
+
+            given.getTime.mockReturnValue(5100)
+            given.captureMetrics.startRequest({ size: 200 })
+
+            given.getTime.mockReturnValue(5500)
+
+            given.captureMetrics.captureInProgressRequests()
+
+            expect(given.capture).toHaveBeenCalledTimes(2)
+            expect(given.capture).toHaveBeenCalledWith('$capture_failed_request', {
+                size: 100,
+                duration: 500,
+                type: 'inflight_at_unload',
+            })
+            expect(given.capture).toHaveBeenCalledWith('$capture_failed_request', {
+                size: 200,
+                duration: 400,
+                type: 'inflight_at_unload',
+            })
+        })
+
+        it('does nothing if not enabled', () => {
+            given('enabled', () => false)
+
+            given.captureMetrics.startRequest({ size: 100 })
+            given.captureMetrics.captureInProgressRequests()
+            given.captureMetrics.markRequestFailed({ foo: 'bar' })
+            given.captureMetrics.finishRequest(null)
+
+            expect(given.capture).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -99,6 +99,7 @@ describe('SessionRecording', () => {
                     compression: 'lz64',
                     _noTruncate: true,
                     _batchKey: 'sessionRecording',
+                    _metrics: expect.anything(),
                 }
             )
             expect(given.posthog.capture).toHaveBeenCalledWith(
@@ -114,6 +115,7 @@ describe('SessionRecording', () => {
                     compression: 'lz64',
                     _noTruncate: true,
                     _batchKey: 'sessionRecording',
+                    _metrics: expect.anything(),
                 }
             )
         })

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -1,4 +1,5 @@
 import { PostHogLib } from '../posthog-core'
+import { CaptureMetrics } from '../capture-metrics'
 import { _ } from '../utils'
 
 given('lib', () => Object.assign(new PostHogLib(), given.overrides))
@@ -111,9 +112,7 @@ describe('capture()', () => {
             properties: jest.fn(),
         },
         compression: {},
-        _captureMetrics: {
-            incr: jest.fn(),
-        },
+        _captureMetrics: new CaptureMetrics(),
         __captureHooks: [],
     }))
 

--- a/src/capture-metrics.js
+++ b/src/capture-metrics.js
@@ -1,20 +1,59 @@
+import { _ } from './utils'
+
 export class CaptureMetrics {
-    constructor(capture) {
+    constructor(enabled, capture, getTime = () => new Date().getTime()) {
+        this.enabled = enabled
         this.capture = capture
+        this.getTime = getTime
         this.metrics = {}
+        this.requests = {}
     }
 
     incr(key, by = 1) {
-        if (this.capture) {
+        if (this.enabled) {
             key = `phjs-${key}`
             this.metrics[key] = (this.metrics[key] || 0) + by
         }
     }
 
     decr(key) {
-        if (this.capture) {
+        if (this.enabled) {
             key = `phjs-${key}`
             this.metrics[key] = (this.metrics[key] || 0) - 1
+        }
+    }
+
+    startRequest(payload) {
+        if (this.enabled) {
+            const requestId = _.UUID()
+
+            this.requests[requestId] = [this.getTime(), payload]
+
+            return requestId
+        }
+    }
+
+    finishRequest(requestId) {
+        if (this.enabled) {
+            const [startTime, payload] = this.requests[requestId]
+            payload['duration'] = this.getTime() - startTime
+            delete this.requests[requestId]
+            return payload
+        }
+    }
+
+    markRequestFailed(payload) {
+        if (this.enabled) {
+            this.capture('$capture_failed_request', payload)
+        }
+    }
+
+    captureInProgressRequests() {
+        if (this.enabled) {
+            Object.keys(this.requests).forEach((requestId) => {
+                const payload = this.finishRequest(requestId)
+                this.markRequestFailed({ ...payload, type: 'inflight_at_unload' })
+            })
         }
     }
 }

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -88,6 +88,9 @@ export class SessionRecording {
             compression: 'lz64', // Force lz64 even if /decide endpoint has not yet responded
             _noTruncate: true,
             _batchKey: 'sessionRecording',
+            _metrics: {
+                rrweb_full_snapshot: properties.$snapshot_data.type === 2,
+            },
         })
     }
 }

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -373,7 +373,11 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
     this._captureMetrics.incr('_send_request')
     this._captureMetrics.incr('_send_request_inflight')
 
-    const requestId = this._captureMetrics.startRequest({ size: data.length })
+    const requestId = this._captureMetrics.startRequest({
+        size: data.length,
+        endpoint: url.slice(url.length - 2),
+        ...options._metrics,
+    })
 
     // needed to correctly format responses
     var verbose_mode = this.get_config('verbose')
@@ -472,7 +476,12 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
                         var error = 'Bad HTTP status: ' + req.status + ' ' + req.statusText
                         console.error(error)
 
-                        this._captureMetrics.markRequestFailed({ ...data, type: 'non_200', status: req.status })
+                        this._captureMetrics.markRequestFailed({
+                            ...data,
+                            type: 'non_200',
+                            status: req.status,
+                            statusText: req.statusText,
+                        })
 
                         if (callback) {
                             if (verbose_mode) {

--- a/src/request-queue.js
+++ b/src/request-queue.js
@@ -98,7 +98,14 @@ export class RequestQueue {
         _.each(this._event_queue, (request) => {
             const { url, data, options } = request
             const key = (options ? options._batchKey : null) || url
-            if (requests[key] === undefined) requests[key] = { data: [], url, options }
+            if (requests[key] === undefined) {
+                requests[key] = { data: [], url, options }
+            }
+
+            // :TRICKY: Metrics-only code
+            if (options && requests[key].options && requests[key].options._metrics) {
+                requests[key].options._metrics['rrweb_full_snapshot'] ||= options._metrics['rrweb_full_snapshot']
+            }
             requests[key].data.push(data)
         })
         return requests


### PR DESCRIPTION
Both size and duration should help indicate whether issues are with full snapshots or not.

Based on reading up on HTTP status 0 which has been plaguing it, it can
happen both when browser cancels queries (timeouts) and when CORS hits.
We do set proper headers when we successfully handle requests, but I'm
thinking that failed/timed out requests likely get a different
treatment.

This change will only affect our own team.

I have yet to test this manually, so please don't merge - will do so tomorrow morning. It's still ready for a review though.

## Changes
...

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
