### PR TITLE
Don't inline css for session recordings

### DIFF
--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -66,6 +66,7 @@ export class SessionRecording {
                     this.snapshots.push(properties)
                 }
             },
+            inlineStylesheet: !this.instance.get_config('_capture_metrics'),
             blockClass: 'ph-no-capture', // Does not capture the element at all
             ignoreClass: 'ph-ignore-input', // Ignores content of input but still records the input element
         })


### PR DESCRIPTION
This is another experiment to see how it affects session recording
reliability.

This should significantly reduce payload sizes and thus reduce failure
rates. On the flip side it will make it harder view css if it changes so
it can't really become the default everywhere, I think.

Will roll this back as we do the next release.

## Changes
...

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
