### PR TITLE
Experiment: don't compress json sent to the server

### DIFF
--- a/src/__tests__/__snapshots__/send-request.test.js.snap
+++ b/src/__tests__/__snapshots__/send-request.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`encodePostDataBody() handles arrays 1`] = `"data=foo%2Cbar"`;
+exports[`formEncodePostData() handles arrays 1`] = `"data=foo%2Cbar"`;
 
-exports[`encodePostDataBody() handles data with compression 1`] = `"data=content&compression=lz64"`;
+exports[`formEncodePostData() handles data with compression 1`] = `"data=content&compression=lz64"`;
 
-exports[`encodePostDataBody() handles objects 1`] = `"data=content"`;
+exports[`formEncodePostData() handles objects 1`] = `"data=content"`;

--- a/src/__tests__/__snapshots__/send-request.test.js.snap
+++ b/src/__tests__/__snapshots__/send-request.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`encodePostDataBody() handles arrays 1`] = `"data=foo%2Cbar"`;
+
+exports[`encodePostDataBody() handles data with compression 1`] = `"data=content&compression=lz64"`;
+
+exports[`encodePostDataBody() handles objects 1`] = `"data=content"`;

--- a/src/__tests__/send-request.test.js
+++ b/src/__tests__/send-request.test.js
@@ -1,0 +1,23 @@
+import { encodePostDataBody } from '../send-request'
+
+describe('encodePostDataBody()', () => {
+    given('subject', () => encodePostDataBody(given.data))
+
+    it('handles arrays', () => {
+        given('data', () => ['foo', 'bar'])
+
+        expect(given.subject).toMatchSnapshot()
+    })
+
+    it('handles objects', () => {
+        given('data', () => ({ data: 'content' }))
+
+        expect(given.subject).toMatchSnapshot()
+    })
+
+    it('handles data with compression', () => {
+        given('data', () => ({ data: 'content', compression: 'lz64' }))
+
+        expect(given.subject).toMatchSnapshot()
+    })
+})

--- a/src/__tests__/send-request.test.js
+++ b/src/__tests__/send-request.test.js
@@ -1,7 +1,7 @@
-import { encodePostDataBody } from '../send-request'
+import { formEncodePostData } from '../send-request'
 
-describe('encodePostDataBody()', () => {
-    given('subject', () => encodePostDataBody(given.data))
+describe('formEncodePostData()', () => {
+    given('subject', () => formEncodePostData(given.data))
 
     it('handles arrays', () => {
         given('data', () => ['foo', 'bar'])

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -66,7 +66,6 @@ export class SessionRecording {
                     this.snapshots.push(properties)
                 }
             },
-            inlineStylesheet: !this.instance.get_config('_capture_metrics'),
             blockClass: 'ph-no-capture', // Does not capture the element at all
             ignoreClass: 'ph-ignore-input', // Ignores content of input but still records the input element
         })

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -395,7 +395,7 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
 
     url += '?' + _.HTTPBuildQuery(args)
 
-    if ('img' in data) {
+    if (_.isObject(data) && 'img' in data) {
         var img = document.createElement('img')
         img.src = url
         document.body.appendChild(img)

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -1,0 +1,16 @@
+export const encodePostDataBody = (data) => {
+    let body_data
+    if (Array.isArray(data)) {
+        body_data = 'data=' + encodeURIComponent(data)
+    } else {
+        body_data = 'data=' + encodeURIComponent(data['data'])
+    }
+    // delete data['data']
+
+    if (data['compression']) {
+        body_data += '&compression=' + data['compression']
+        // delete data['compression']
+    }
+
+    return body_data
+}

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -1,3 +1,5 @@
+import { _, console } from './utils'
+
 export const encodePostDataBody = (data) => {
     let body_data
     if (Array.isArray(data)) {
@@ -5,12 +7,78 @@ export const encodePostDataBody = (data) => {
     } else {
         body_data = 'data=' + encodeURIComponent(data['data'])
     }
-    // delete data['data']
 
     if (data['compression']) {
         body_data += '&compression=' + data['compression']
-        // delete data['compression']
     }
 
     return body_data
+}
+
+export const xhr = (url, method, data, headers, verbose, captureMetrics, callback) => {
+    const body = method === 'POST' ? encodePostDataBody(data) : null
+
+    this._captureMetrics.incr('_send_request')
+    this._captureMetrics.incr('_send_request_inflight')
+
+    const requestId = this._captureMetrics.startRequest({
+        data_size: body && body.length,
+        endpoint: url.slice(url.length - 2),
+        ...options._metrics,
+    })
+
+    const req = new XMLHttpRequest()
+    req.open(method, url, true)
+    if (method === 'POST') {
+        headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    }
+    _.each(headers, function (headerValue, headerName) {
+        req.setRequestHeader(headerName, headerValue)
+    })
+
+    // send the ph_optout cookie
+    // withCredentials cannot be modified until after calling .open on Android and Mobile Safari
+    req.withCredentials = true
+    req.onreadystatechange = () => {
+        if (req.readyState === 4) {
+            captureMetrics.incr(`xhr-response`)
+            captureMetrics.incr(`xhr-response-${req.status}`)
+            captureMetrics.decr('_send_request_inflight')
+
+            const data = captureMetrics.finishRequest(requestId)
+
+            // XMLHttpRequest.DONE == 4, except in safari 4
+            if (req.status === 200) {
+                if (callback) {
+                    let response
+                    try {
+                        response = JSON.parse(req.responseText)
+                    } catch (e) {
+                        console.error(e)
+                        return
+                    }
+                    callback(response)
+                }
+            } else {
+                const error = 'Bad HTTP status: ' + req.status + ' ' + req.statusText
+                console.error(error)
+
+                captureMetrics.markRequestFailed({
+                    ...data,
+                    type: 'non_200',
+                    status: req.status,
+                    statusText: req.statusText,
+                })
+
+                if (callback) {
+                    if (verbose) {
+                        callback({ status: 0, error: error })
+                    } else {
+                        callback(0)
+                    }
+                }
+            }
+        }
+    }
+    req.send(body)
 }


### PR DESCRIPTION
- Extract code to encode post body
- Copy xhr logic to a different file
- Experiment: Don't compress json sent to the server
    
    lzstring has performance problems on the server-side, causing issues for
    session recording: see https://github.com/PostHog/posthog/issues/2560
    
    Note that this is not a backwards-compatible change, requires a change
    on posthog side to support plain/text header as well.
    
    We can't use application/json as content-type as that would trigger CORS
    requests for every xhr request as that's considered a custom header.

    Will test this out for if it does the trick for us (no other users will be affected).


## Changes
...

## Checklist
- [x] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
