### PR TITLE
Include library version in recorder.js request

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -32,6 +32,6 @@ beforeEach(() => {
     })
 
     cy.readFile('node_modules/rrweb/dist/rrweb.min.js').then((body) => {
-        cy.intercept('**/static/recorder.js', { body }).as('recorder')
+        cy.intercept('**/static/recorder.js*', { body }).as('recorder')
     })
 })

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -5,6 +5,7 @@ import sessionIdGenerator from '../../extensions/sessionid'
 
 jest.mock('../../autocapture-utils')
 jest.mock('../../extensions/sessionid')
+jest.mock('../../config', () => ({ LIB_VERSION: 'v0.0.1' }))
 
 describe('SessionRecording', () => {
     let _emit
@@ -117,7 +118,7 @@ describe('SessionRecording', () => {
         it('loads recording script from right place', () => {
             given.sessionRecording.startRecordingIfEnabled()
 
-            expect(loadScript).toHaveBeenCalledWith('https://test.com/static/recorder.js', expect.anything())
+            expect(loadScript).toHaveBeenCalledWith('https://test.com/static/recorder.js?v=v0.0.1', expect.anything())
         })
 
         it('loads script after `submitRecordings` if not previously loaded', () => {

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -2,6 +2,7 @@ import { loadScript } from '../autocapture-utils'
 import { _ } from '../utils'
 import { SESSION_RECORDING_ENABLED } from '../posthog-persistence'
 import sessionIdGenerator from './sessionid'
+import Config from '../config'
 
 const BASE_ENDPOINT = '/e/'
 
@@ -42,7 +43,10 @@ export class SessionRecording {
     _startCapture() {
         if (!this.captureStarted && !this.instance.get_config('disable_session_recording')) {
             this.captureStarted = true
-            loadScript(this.instance.get_config('api_host') + '/static/recorder.js', _.bind(this._onScriptLoaded, this))
+            loadScript(
+                this.instance.get_config('api_host') + '/static/recorder.js?v=' + Config.LIB_VERSION,
+                _.bind(this._onScriptLoaded, this)
+            )
         }
     }
 


### PR DESCRIPTION
I'm planning on starting to cache recorder.js - but we need a cache busting mechanism. This is it.

## Checklist
- [x] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
