### PR TITLE
Proposal: Change semantics of $feature_flag_called to be once per pageview

### DIFF
--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -8,21 +8,25 @@ describe('featureflags', () => {
         capture: () => {},
     }))
 
-    given('feature_flags', () => new PostHogFeatureFlags(given.instance))
+    given('featureFlags', () => new PostHogFeatureFlags(given.instance))
 
     beforeEach(() => {
         jest.spyOn(given.instance, 'capture').mockReturnValue()
     })
 
     it('should return the right feature flag and call capture', () => {
-        expect(given.feature_flags.getFlags()).toEqual(['beta-feature'])
-        expect(given.feature_flags.isFeatureEnabled('beta-feature')).toEqual(true)
-        expect(given.feature_flags.isFeatureEnabled('random')).toEqual(false)
-        expect(given.instance.capture).toHaveBeenCalled()
+        expect(given.featureFlags.getFlags()).toEqual(['beta-feature'])
+        expect(given.featureFlags.isFeatureEnabled('beta-feature')).toEqual(true)
+        expect(given.featureFlags.isFeatureEnabled('random')).toEqual(false)
+        expect(given.instance.capture).toHaveBeenCalledTimes(2)
+
+        // It should not call `capture` on subsequent calls
+        expect(given.featureFlags.isFeatureEnabled('beta-feature')).toEqual(true)
+        expect(given.instance.capture).toHaveBeenCalledTimes(2)
     })
 
     it('should return the right feature flag and not call capture', () => {
-        expect(given.feature_flags.isFeatureEnabled('beta-feature', { send_event: false })).toEqual(true)
+        expect(given.featureFlags.isFeatureEnabled('beta-feature', { send_event: false })).toEqual(true)
         expect(given.instance.capture).not.toHaveBeenCalled()
     })
 })

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -4,6 +4,7 @@ export class PostHogFeatureFlags {
     constructor(instance) {
         this.instance = instance
         this._override_warning = false
+        this.flagCallReported = {}
     }
 
     getFlags() {
@@ -59,7 +60,8 @@ export class PostHogFeatureFlags {
             return false
         }
         const flagEnabled = this.getFlags().indexOf(key) > -1
-        if (options.send_event || !('send_event' in options)) {
+        if ((options.send_event || !('send_event' in options)) && !this.flagCallReported[key]) {
+            this.flagCallReported[key] = true
             this.instance.capture('$feature_flag_called', { $feature_flag: key, $feature_flag_response: flagEnabled })
         }
         return flagEnabled


### PR DESCRIPTION
Our users are making use of posthog-js heavily in react contexts,
$feature_flag_called introduces gotchas if ever called in a react render
loop.

We have provided some tooling around this previously but it's a gotcha
for our customers. I propose getting rid of the gotcha all-together.

Now $feature_flag_called will be captured once per posthog.init (e.g.
pageview or session in a react context). Thoughts?

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
