### PR TITLE
Typeof fix for IE11 where Symbol is undefined

### DIFF
--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -41,6 +41,16 @@ export class SessionRecording {
     }
 
     _startCapture() {
+        // According to the rrweb docs, rrweb is not supported on IE11 and below:
+        // "rrweb does not support IE11 and below because it uses the MutationObserver API which was supported by these browsers."
+        // https://github.com/rrweb-io/rrweb/blob/master/guide.md#compatibility-note
+        //
+        // However, MutationObserver does exist on IE11, it just doesn't work well and does not detect all changes.
+        // Instead, when we load "recorder.js", the first JS error is about "Object.assign" being undefined.
+        // Thus instead of MutationObserver, we look for this function and block recording if it's undefined.
+        if (typeof Object.assign === 'undefined') {
+            return
+        }
         if (!this.captureStarted && !this.instance.get_config('disable_session_recording')) {
             this.captureStarted = true
             loadScript(

--- a/src/utils.js
+++ b/src/utils.js
@@ -297,7 +297,8 @@ _.strip_empty_properties = function (p) {
 // Deep copies an object.
 // It handles cycles by replacing all references to them with `undefined`
 // Also supports customizing native values
-const COPY_IN_PROGRESS_ATTRIBUTE = Symbol ? Symbol('__deepCircularCopyInProgress__') : '__deepCircularCopyInProgress__'
+const COPY_IN_PROGRESS_ATTRIBUTE =
+    typeof Symbol !== 'undefined' ? Symbol('__deepCircularCopyInProgress__') : '__deepCircularCopyInProgress__'
 
 function deepCircularCopy(value, customizer) {
     if (value !== Object(value)) return customizer ? customizer(value) : value // primitive value


### PR DESCRIPTION
## Changes

Fixes this:

<img width="1105" alt="Screenshot 2021-01-08 at 10 41 36" src="https://user-images.githubusercontent.com/53387/104000345-64a2b700-519e-11eb-881e-2192638b418e.png">


## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
