### PR TITLE
Fix parcel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.2 - 2021-01-11
+
+- Event names must be strings in `posthog.capture`
+
 ## 1.8.1 - 2021-01-08
 
 - Increase compatibility with IE 11

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/src/request-queue.js
+++ b/src/request-queue.js
@@ -107,7 +107,7 @@ export class RequestQueue {
                 options &&
                 requests[key].options &&
                 requests[key].options._metrics &&
-                typeof requests[key].options._metrics['rrweb_full_snapshot'] === 'undefined'
+                !requests[key].options._metrics['rrweb_full_snapshot']
             ) {
                 requests[key].options._metrics['rrweb_full_snapshot'] = options._metrics['rrweb_full_snapshot']
             }

--- a/src/request-queue.js
+++ b/src/request-queue.js
@@ -103,8 +103,13 @@ export class RequestQueue {
             }
 
             // :TRICKY: Metrics-only code
-            if (options && requests[key].options && requests[key].options._metrics) {
-                requests[key].options._metrics['rrweb_full_snapshot'] ||= options._metrics['rrweb_full_snapshot']
+            if (
+                options &&
+                requests[key].options &&
+                requests[key].options._metrics &&
+                typeof requests[key].options._metrics['rrweb_full_snapshot'] === 'undefined'
+            ) {
+                requests[key].options._metrics['rrweb_full_snapshot'] = options._metrics['rrweb_full_snapshot']
             }
             requests[key].data.push(data)
         })


### PR DESCRIPTION
## Changes

I just could not get the `||=` working with `parcel` no matter what I tried. Went for the easy solution for now.
The released `1.8.2` already includes this change.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
