### PR TITLE
refactor: change properties to record type

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -451,7 +451,7 @@ declare class posthog {
 declare namespace posthog {
     /* eslint-disable @typescript-eslint/no-explicit-any */
     type Property = any
-    type Properties = { [key: string]: Property }
+    type Properties = Record<string, Property>
     type CaptureResult = { event: string; properties: Properties } | undefined
     type CaptureCallback = (response: any, data: any) => void
     /* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
## Changes
Update to posthog.Properties type to use `Record` type instead of `[key: string]`.

Another potential change you could make is changing the `Property` type to `unknown` instead of using `any`. However at quick glance I can't see whether this would affect the wider typings.

## Checklist
- [x] Tests for new code (if applicable) **N/A**
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable) 
