### PR TITLE
add prefix argument to sentry integration

### DIFF
--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1326,6 +1326,7 @@ PostHogLib.prototype.clear_opt_in_out_captureing = function (options) {
  * @param {Object} [posthog] The posthog object
  * @param {string} [organization] Optional: The Sentry organization, used to send a direct link from PostHog to Sentry
  * @param {Number} [projectId] Optional: The Sentry project id, used to send a direct link from PostHog to Sentry
+ * @param {string} [prefix] Optional: Url of a self-hosted sentry instance (default: https://sentry.io/organizations/)
  */
 PostHogLib.prototype.sentry_integration = function (_posthog, organization, projectId, prefix) {
     // setupOnce gets called by Sentry when it intializes the plugin

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1327,7 +1327,7 @@ PostHogLib.prototype.clear_opt_in_out_captureing = function (options) {
  * @param {string} [organization] Optional: The Sentry organization, used to send a direct link from PostHog to Sentry
  * @param {Number} [projectId] Optional: The Sentry project id, used to send a direct link from PostHog to Sentry
  */
-PostHogLib.prototype.sentry_integration = function (_posthog, organization, projectId) {
+PostHogLib.prototype.sentry_integration = function (_posthog, organization, projectId, prefix) {
     // setupOnce gets called by Sentry when it intializes the plugin
     this.setupOnce = function (addGlobalEventProcessor) {
         addGlobalEventProcessor((event) => {
@@ -1340,7 +1340,7 @@ PostHogLib.prototype.sentry_integration = function (_posthog, organization, proj
             }
             if (organization && projectId)
                 data['$sentry_url'] =
-                    'https://sentry.io/organizations/' +
+                    (prefix || 'https://sentry.io/organizations/') +
                     organization +
                     '/issues/?project=' +
                     projectId +


### PR DESCRIPTION
## Changes
adds `prefix` as the 4th parameter to sentry integration
use as such:
```
posthog.SentryIntegration(
        posthog,
        organization,
        projectId,
        prefix
      ),
```
results in the following sentry link: `https://<prefix>/<organization>/issues/?project=<projectId>&query=<eventid>`
`prefix` defaults to `https://sentry.io/organizations/`