### PR TITLE
Add types for sentry integration

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -660,6 +660,26 @@ declare namespace posthog {
     }
 
     export class feature_flags extends featureFlags {}
+
+    /**
+     * Integrate Sentry with PostHog. This will add a direct link to the person in Sentry, and an $exception event in PostHog
+     *
+     * ### Usage
+     *
+     *     Sentry.init({
+     *          dsn: 'https://example',
+     *          integrations: [
+     *              new posthog.SentryIntegration(posthog)
+     *          ]
+     *     })
+     *
+     * @param {Object} [posthog] The posthog object
+     * @param {string} [organization] Optional: The Sentry organization, used to send a direct link from PostHog to Sentry
+     * @param {Number} [projectId] Optional: The Sentry project id, used to send a direct link from PostHog to Sentry
+     */
+    export class SentryIntegration {
+        constructor(_posthog: PostHog, organization: string, projectId: string)
+    }
 }
 
 export type PostHog = typeof posthog


### PR DESCRIPTION
## Changes

We hadn't typed the sentry integration causing errors. I'm not actually sure this is the right way to type this.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
