### PR TITLE
Track first pageview in a session

### DIFF
--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -629,7 +629,14 @@ PostHogLib.prototype.capture_pageview = function (page) {
     if (_.isUndefined(page)) {
         page = document.location.href
     }
-    this.capture('$pageview')
+    const isFirstPageviewInSession = !window.sessionStorage.getItem('captured-first-pageview')
+    const pageviewProps = isFirstPageviewInSession ? { $is_first_pageview: true } : {}
+
+    if (isFirstPageviewInSession) {
+        window.sessionStorage.setItem('captured-first-pageview', '1')
+    }
+
+    this.capture('$pageview', pageviewProps)
 }
 
 /**


### PR DESCRIPTION
## Changes


PRs over issues.

This tracks the first pageview in a session so I can see where my users landed. 

Could also be set as a super prop like we do with referrers?

User request.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
