### PR TITLE
Solve a rare edge case where capture_metrics fails

### DIFF
--- a/src/capture-metrics.js
+++ b/src/capture-metrics.js
@@ -34,7 +34,7 @@ export class CaptureMetrics {
     }
 
     finishRequest(requestId) {
-        if (this.enabled) {
+        if (this.enabled && this.requests[requestId]) {
             const [startTime, payload] = this.requests[requestId]
             payload['duration'] = this.getTime() - startTime
             delete this.requests[requestId]


### PR DESCRIPTION
Sentry error: https://sentry.io/organizations/posthog/issues/2198691106/?project=1899813&query=is%3Aunassigned+is%3Aunresolved

```
TypeError
Invalid attempt to destructure non-iterable instance.
In order to be iterable, non-array objects must have a [Symbol.iterator]() method.
```

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
