### PR TITLE
Set props on anonymous users and always set utm tags

### DIFF
--- a/.github/workflows/ssr-es-check.yml
+++ b/.github/workflows/ssr-es-check.yml
@@ -16,7 +16,7 @@ jobs:
       - run: yarn install && yarn build-module && yarn build
 
       - name: Run es-check to check if our bundle is ES5 compatible
-        run: yarn add es-check; npx es-check es5 dist/{array,module}.js
+        run: yarn add es-check@5.2.0; npx es-check es5 dist/{array,module}.js
 
       - name: Require module via node
         run: cd dist; node -e "require('./module')"

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -335,19 +335,30 @@ describe('__compress_and_send_json_request', () => {
     })
 })
 
-describe('utm tags', () => {
+describe('capture_pageview()', () => {
+    given('subject', () => () => given.lib.capture_pageview())
+
     given('overrides', () => ({
         get_config: (key) => given.config[key],
         capture: jest.fn(),
     }))
 
-    it('should pass utm tags to person', () => {
-        given.lib.init('token', {})
+    it('should capture a pageview', () => {
+        Object.defineProperty(window, 'location', {
+            writable: true,
+            value: { href: 'https://test.org/' },
+        })
+        given.subject()
+        expect(given.overrides.capture).toHaveBeenCalledWith('$pageview', {})
+    })
+
+    it('should set utm tags on the person', () => {
         Object.defineProperty(window, 'location', {
             writable: true,
             value: { href: 'https://test.org/?utm_medium=twitter' },
         })
-        given.lib.capture_pageview()
+
+        given.subject()
         expect(given.overrides.capture).toHaveBeenCalledWith('$pageview', {
             $set_once: {
                 initial_utm_medium: 'twitter',
@@ -356,14 +367,5 @@ describe('utm tags', () => {
                 utm_medium: 'twitter',
             },
         })
-    })
-    it('should not pass utm tags if none set', () => {
-        given('url', () => 'https://test.com')
-        Object.defineProperty(window, 'location', {
-            writable: true,
-            value: { href: 'https://test.org/' },
-        })
-        given.lib.capture_pageview()
-        expect(given.overrides.capture).toHaveBeenCalledWith('$pageview', {})
     })
 })

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -55,7 +55,6 @@ declare class posthog {
      * This function is called by default on page load unless the
      * capture_pageview configuration variable is false.
      *
-     * @param {String} [page] The url of the page to record. If you don't include this, it defaults to the current url.
      * @api private
      */
     static capture_pageview(page?: string): void

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -629,7 +629,19 @@ PostHogLib.prototype.capture_pageview = function (page) {
     if (_.isUndefined(page)) {
         page = document.location.href
     }
-    this.capture('$pageview')
+    var params = _.info.campaignParams()
+    var set_once = {}
+    for (var key in params) {
+        set_once['initial_' + key] = params[key]
+    }
+
+    if (Object.keys(params).length > 0) {
+        params = {
+            $set_once: set_once,
+            $set: params,
+        }
+    }
+    this.capture('$pageview', params)
 }
 
 /**

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -629,18 +629,19 @@ PostHogLib.prototype.capture_pageview = function (page) {
     if (_.isUndefined(page)) {
         page = document.location.href
     }
-    var params = _.info.campaignParams()
+    var set = _.info.campaignParams()
     var set_once = {}
-    for (var key in params) {
-        set_once['initial_' + key] = params[key]
+    for (var key in set) {
+        set_once['initial_' + key] = set[key]
     }
 
-    if (Object.keys(params).length > 0) {
-        params = {
-            $set_once: set_once,
-            $set: params,
-        }
-    }
+    var params =
+        Object.keys(set).length > 0
+            ? {
+                  $set_once: set_once,
+                  $set: set,
+              }
+            : {}
     this.capture('$pageview', params)
 }
 

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -622,26 +622,16 @@ PostHogLib.prototype._calculate_event_properties = function (event_name, event_p
  * This function is called by default on page load unless the
  * capture_pageview configuration variable is false.
  *
- * @param {String} [page] The url of the page to record. If you don't include this, it defaults to the current url.
  * @api private
  */
-PostHogLib.prototype.capture_pageview = function (page) {
-    if (_.isUndefined(page)) {
-        page = document.location.href
-    }
-    var set = _.info.campaignParams()
-    var set_once = {}
-    for (var key in set) {
-        set_once['initial_' + key] = set[key]
+PostHogLib.prototype.capture_pageview = function () {
+    const $set = _.info.campaignParams()
+    const $set_once = {}
+    for (const key in $set) {
+        $set_once['initial_' + key] = $set[key]
     }
 
-    var params =
-        Object.keys(set).length > 0
-            ? {
-                  $set_once: set_once,
-                  $set: set,
-              }
-            : {}
+    const params = Object.keys($set).length > 0 ? { $set_once, $set } : {}
     this.capture('$pageview', params)
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -633,7 +633,7 @@ _.info = {
             kw = '',
             params = {}
         _.each(campaign_keywords, function (kwkey) {
-            kw = _.getQueryParam(document.URL, kwkey)
+            kw = _.getQueryParam(window.location.href, kwkey)
             if (kw.length) {
                 params[kwkey] = kw
             }


### PR DESCRIPTION
## Changes

- Allow calling `posthog.people.set` even on un-identified users (no difference to our backend)
- Always set utm tags, both as first touch (initial_utm_medium) and last touch (utm_medium).

## Checklist
- [x] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
