### PR TITLE
Support $set_once with identify

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -5,7 +5,7 @@ import { _ } from '../utils'
 given('lib', () => Object.assign(new PostHogLib(), given.overrides))
 
 describe('identify()', () => {
-    given('subject', () => () => given.lib.identify(given.identity, given.userProperties))
+    given('subject', () => () => given.lib.identify(given.identity, given.userProperties, given.setOnce))
 
     given('identity', () => 'a-new-id')
 
@@ -18,6 +18,7 @@ describe('identify()', () => {
         get_property: () => given.deviceId,
         people: {
             set: jest.fn(),
+            set_once: jest.fn(),
         },
         _flags: {},
         _captureMetrics: {
@@ -88,6 +89,22 @@ describe('identify()', () => {
                 $anon_distinct_id: 'oldIdentity',
             },
             { $set: { email: 'john@example.com' } }
+        )
+    })
+
+    it('calls capture with $set_once if setOnce is true', () => {
+        given('userProperties', () => ({ email: 'john@example.com' }))
+        given('setOnce', () => true)
+
+        given.subject()
+
+        expect(given.overrides.capture).toHaveBeenCalledWith(
+            '$identify',
+            {
+                distinct_id: 'a-new-id',
+                $anon_distinct_id: 'oldIdentity',
+            },
+            { $set_once: { email: 'john@example.com' } }
         )
     })
 

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -5,7 +5,9 @@ import { _ } from '../utils'
 given('lib', () => Object.assign(new PostHogLib(), given.overrides))
 
 describe('identify()', () => {
-    given('subject', () => () => given.lib.identify(given.identity, given.userProperties, given.setOnce))
+    given('subject', () => () =>
+        given.lib.identify(given.identity, given.userPropertiesToSet, given.userPropertiesToSetOnce)
+    )
 
     given('identity', () => 'a-new-id')
 
@@ -47,7 +49,8 @@ describe('identify()', () => {
                 distinct_id: 'a-new-id',
                 $anon_distinct_id: 'oldIdentity',
             },
-            { $set: {} }
+            { $set: {} },
+            { $set_once: {} }
         )
         expect(given.overrides.people.set).not.toHaveBeenCalled()
     })
@@ -63,7 +66,8 @@ describe('identify()', () => {
                 distinct_id: 'a-new-id',
                 $anon_distinct_id: 'oldIdentity',
             },
-            { $set: {} }
+            { $set: {} },
+            { $set_once: {} }
         )
         expect(given.overrides.people.set).not.toHaveBeenCalled()
     })
@@ -78,7 +82,8 @@ describe('identify()', () => {
     })
 
     it('calls capture with user properties if passed', () => {
-        given('userProperties', () => ({ email: 'john@example.com' }))
+        given('userPropertiesToSet', () => ({ email: 'john@example.com' }))
+        given('userPropertiesToSetOnce', () => ({ howOftenAmISet: 'once!' }))
 
         given.subject()
 
@@ -88,23 +93,8 @@ describe('identify()', () => {
                 distinct_id: 'a-new-id',
                 $anon_distinct_id: 'oldIdentity',
             },
-            { $set: { email: 'john@example.com' } }
-        )
-    })
-
-    it('calls capture with $set_once if setOnce is true', () => {
-        given('userProperties', () => ({ email: 'john@example.com' }))
-        given('setOnce', () => true)
-
-        given.subject()
-
-        expect(given.overrides.capture).toHaveBeenCalledWith(
-            '$identify',
-            {
-                distinct_id: 'a-new-id',
-                $anon_distinct_id: 'oldIdentity',
-            },
-            { $set_once: { email: 'john@example.com' } }
+            { $set: { email: 'john@example.com' } },
+            { $set_once: { howOftenAmISet: 'once!' } }
         )
     })
 
@@ -119,12 +109,14 @@ describe('identify()', () => {
         })
 
         it('calls people.set when user properties passed', () => {
-            given('userProperties', () => ({ email: 'john@example.com' }))
+            given('userPropertiesToSet', () => ({ email: 'john@example.com' }))
+            given('userPropertiesToSetOnce', () => ({ howOftenAmISet: 'once!' }))
 
             given.subject()
 
             expect(given.overrides.capture).not.toHaveBeenCalled()
             expect(given.overrides.people.set).toHaveBeenCalledWith({ email: 'john@example.com' })
+            expect(given.overrides.people.set_once).toHaveBeenCalledWith({ howOftenAmISet: 'once!' })
         })
     })
 

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -144,7 +144,11 @@ declare class posthog {
      * @param {String} [unique_id] A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.
      * @param {Object} [userProperties] Optional: An associative array of properties to store about the user
      */
-    static identify(unique_id?: string, userProperties?: posthog.Properties, setOnce?: boolean): void
+    static identify(
+        unique_id?: string,
+        userPropertiesToSet?: posthog.Properties,
+        userPropertiesToSetOnce?: posthog.Properties
+    ): void
 
     /**
      * Create an alias, which PostHog will use to link two distinct_ids going forward (not retroactively).

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -144,7 +144,7 @@ declare class posthog {
      * @param {String} [unique_id] A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.
      * @param {Object} [userProperties] Optional: An associative array of properties to store about the user
      */
-    static identify(unique_id?: string, userProperties?: posthog.Properties): void
+    static identify(unique_id?: string, userProperties?: posthog.Properties, setOnce?: boolean): void
 
     /**
      * Create an alias, which PostHog will use to link two distinct_ids going forward (not retroactively).

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -766,7 +766,7 @@ PostHogLib.prototype.onFeatureFlags = function (callback) {
  * @param {String} [unique_id] A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.
  * @param {Object} [userProperties] Optional: An associative array of properties to store about the user
  */
-PostHogLib.prototype.identify = function (new_distinct_id, userProperties, setOnce = false) {
+PostHogLib.prototype.identify = function (new_distinct_id, userPropertiesToSet, userPropertiesToSetOnce) {
     //if the new_distinct_id has not been set ignore the identify event
     if (!new_distinct_id) {
         console.error('Unique user id has not been set in posthog.identify')
@@ -804,20 +804,21 @@ PostHogLib.prototype.identify = function (new_distinct_id, userProperties, setOn
         new_distinct_id !== previous_distinct_id &&
         (!this.get_property('$device_id') || previous_distinct_id === this.get_property('$device_id'))
     ) {
-        const setProperties = setOnce ? { $set_once: userProperties || {} } : { $set: userProperties || {} }
         this.capture(
             '$identify',
             {
                 distinct_id: new_distinct_id,
                 $anon_distinct_id: previous_distinct_id,
             },
-            setProperties
+            { $set: userPropertiesToSet || {} },
+            { $set_once: userPropertiesToSetOnce || {} }
         )
-    } else if (userProperties) {
-        if (setOnce) {
-            this['people'].set_once(userProperties)
-        } else {
-            this['people'].set(userProperties)
+    } else {
+        if (userPropertiesToSet) {
+            this['people'].set(userPropertiesToSet)
+        }
+        if (userPropertiesToSetOnce) {
+            this['people'].set_once(userPropertiesToSetOnce)
         }
     }
 

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -766,7 +766,7 @@ PostHogLib.prototype.onFeatureFlags = function (callback) {
  * @param {String} [unique_id] A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.
  * @param {Object} [userProperties] Optional: An associative array of properties to store about the user
  */
-PostHogLib.prototype.identify = function (new_distinct_id, userProperties) {
+PostHogLib.prototype.identify = function (new_distinct_id, userProperties, setOnce = false) {
     //if the new_distinct_id has not been set ignore the identify event
     if (!new_distinct_id) {
         console.error('Unique user id has not been set in posthog.identify')
@@ -804,16 +804,21 @@ PostHogLib.prototype.identify = function (new_distinct_id, userProperties) {
         new_distinct_id !== previous_distinct_id &&
         (!this.get_property('$device_id') || previous_distinct_id === this.get_property('$device_id'))
     ) {
+        const setProperties = setOnce ? { $set_once: userProperties || {} } : { $set: userProperties || {} }
         this.capture(
             '$identify',
             {
                 distinct_id: new_distinct_id,
                 $anon_distinct_id: previous_distinct_id,
             },
-            { $set: userProperties || {} }
+            setProperties
         )
     } else if (userProperties) {
-        this['people'].set(userProperties)
+        if (setOnce) {
+            this['people'].set_once(userProperties)
+        } else {
+            this['people'].set(userProperties)
+        }
     }
 
     this.reloadFeatureFlags()


### PR DESCRIPTION
## Changes

Inspired by a user question on Slack.

Adds support for doing identify with `$set_once` instead of `$set`. 

Backwards compatible/non-breaking.

## Checklist
- [x] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
