### PR TITLE
Add properties_string_max_length = 65535

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -131,7 +131,7 @@ describe('capture()', () => {
     )
 
     given('overrides', () => ({
-        get_config: jest.fn(),
+        get_config: (key) => given.config?.[key],
         config: {
             _onCapture: jest.fn(),
         },
@@ -184,6 +184,28 @@ describe('capture()', () => {
 
         expect(() => given.subject()).not.toThrow()
         expect(hook).not.toHaveBeenCalled()
+    })
+
+    it('truncates long properties', () => {
+        given('config', () => ({
+            properties_string_max_length: 1000,
+        }))
+        given('eventProperties', () => ({
+            key: 'value'.repeat(10000),
+        }))
+        const event = given.subject()
+        expect(event.properties.key.length).toBe(1000)
+    })
+
+    it('keeps long properties if null', () => {
+        given('config', () => ({
+            properties_string_max_length: null,
+        }))
+        given('eventProperties', () => ({
+            key: 'value'.repeat(10000),
+        }))
+        const event = given.subject()
+        expect(event.properties.key.length).toBe(50000)
     })
 })
 

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -492,6 +492,7 @@ declare namespace posthog {
         inapp_link_new_window?: boolean
         request_batching?: boolean
         sanitize_properties?: (properties: posthog.Properties, event_name: string) => posthog.Properties
+        properties_string_max_length?: number
     }
 
     interface OptInOutCapturingOptions {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -82,6 +82,7 @@ const defaultConfig = () => ({
     inapp_protocol: '//',
     inapp_link_new_window: false,
     request_batching: true,
+    properties_string_max_length: 65535,
     // Used for internal testing
     _onCapture: () => {},
     _capture_metrics: false,
@@ -547,7 +548,7 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
         data['$set'] = options['$set']
     }
 
-    data = _.copyAndTruncateStrings(data, options._noTruncate ? null : 255)
+    data = _.copyAndTruncateStrings(data, options._noTruncate ? null : this.get_config('properties_string_max_length'))
     if (this.get_config('debug')) {
         console.log('PostHog.js send', data)
     }

--- a/src/posthog-people.js
+++ b/src/posthog-people.js
@@ -104,7 +104,7 @@ PostHogPeople.prototype._send_request = function (data, callback) {
     }
 
     var date_encoded_data = _.encodeDates(data)
-    var truncated_data = _.copyAndTruncateStrings(date_encoded_data, 255)
+    var truncated_data = _.copyAndTruncateStrings(date_encoded_data, this._get_config('properties_string_max_length'))
     var json_data = JSON.stringify(date_encoded_data)
     var encoded_data = _.base64Encode(json_data)
 


### PR DESCRIPTION
## Changes

- Sets the limit of a string that can be sent in a property to 64KB (up from 255 bytes)
- Adds an option `properties_string_max_length` that can be changed to change or remove (`== null`) this limit.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
