### PR TITLE
Add posthog.debug() to types, remove bad docstring

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -450,6 +450,8 @@ declare class posthog {
     static onFeatureFlags(callback: (flags: string[]) => void): false | undefined
 
     static toString(): string
+
+    static debug(): void
 }
 
 declare namespace posthog {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1369,23 +1369,6 @@ PostHogLib.prototype.sentry_integration = function (_posthog, organization, proj
     }
 }
 
-/**
- * Integrate Sentry with PostHog. This will add a direct link to the person in Sentry, and an $exception event in PostHog
- *
- * ### Usage
- *
- *     Sentry.init({
- *          dsn: 'https://example',
- *          integrations: [
- *              new posthog.SentryIntegration(posthog)
- *          ]
- *     })
- *
- * @param {Object} [posthog] The posthog object
- * @param {string} [organization] Optional: The Sentry organization, used to send a direct link from PostHog to Sentry
- * @param {Number} [projectId] Optional: The Sentry project id, used to send a direct link from PostHog to Sentry
- * @param {string} [prefix] Optional: Url of a self-hosted sentry instance (default: https://sentry.io/organizations/)
- */
 PostHogLib.prototype.debug = function (debug) {
     if (debug === false) {
         window.console.log("You've disabled debug mode.")


### PR DESCRIPTION
Only thing worse than an absent docstring is a wrong one

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
