### PR TITLE
fix: incorrect typing for isFeatureEnabled

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -440,7 +440,7 @@ declare class posthog {
      * @param {Object|String} prop Key of the feature flag.
      * @param {Object|String} options (optional) If {send_event: false}, we won't send an $feature_flag_call event to PostHog.
      */
-    static isFeatureEnabled(key: string, options: posthog.isFeatureEnabledOptions): boolean
+    static isFeatureEnabled(key: string, options?: posthog.isFeatureEnabledOptions): boolean
 
     /*
      * See if feature flags are available.


### PR DESCRIPTION
## Changes

According to documents, code, and jsdoc comments, second parameter of `isFeatureEnabled` is optional. This PR fixes the typing to reflect that.

## Checklist
- [ ] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
