### PR TITLE
Refactor /decide enpoint & allow recording without autocapture

### DIFF
--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -10,6 +10,7 @@ env:
   BROWSERSTACK_DEBUG: 'true'
   BROWSERSTACK_NETWORK_LOGS: 'true'
   BROWSERSTACK_CONSOLE: 'info'
+  PLUGIN_SERVER_INGESTION: 'true'
 
 jobs:
   testcafe:

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -55,7 +55,7 @@ jobs:
             node-version: 14
 
       - name: Install requirements.txt dependencies with pip
-        run: python -m pip install --upgrade pip && python -m pip install -r posthog/requirements.txt
+        run: python -m pip install --upgrade pip && python -m pip install -r posthog/requirements.txt && python -m pip install freezegun fakeredis pytest pytest-mock pytest-django
 
       - name: Set up databases
         env:
@@ -69,7 +69,13 @@ jobs:
         run: yarn; yarn build-array; mkdir -p posthog/frontend/dist; cp dist/array.js posthog/frontend/dist; python posthog/manage.py collectstatic --noinput
 
       - name: Start server
-        run: cd posthog; python manage.py setup_dev --no-data; bin/docker &
+        run: |
+          cd posthog
+          python manage.py setup_dev --no-data
+          ./bin/docker-migrate
+          ./bin/plugin-server &> plugin_logs &
+          ./bin/docker-worker-celery --with-scheduler &> worker_logs &
+          ./bin/docker-server &> server_logs &
 
       - name: Run chrome test
         run: npx testcafe "browserstack:chrome" testcafe/*.spec.js
@@ -79,3 +85,13 @@ jobs:
 
       - name: Run safari test
         run: npx testcafe "browserstack:safari" testcafe/*.spec.js
+
+      - name: PostHog plugin server logs
+        if: ${{ failure() }}
+        run: cat posthog/plugin_logs
+      - name: PostHog worker logs
+        if: ${{ failure() }}
+        run: cat posthog/worker_logs
+      - name: PostHog server logs
+        if: ${{ failure() }}
+        run: cat posthog/server_logs

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -4,13 +4,14 @@ env:
   BROWSERSTACK_ACCESS_KEY: "${{ secrets.BROWSERSTACK_ACCESS_KEY }}"
   BROWSERSTACK_USERNAME: "${{ secrets.BROWSERSTACK_USERNAME }}"
   SECRET_KEY: 'abcdef' # unsafe - for testing only
-  DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/test_posthog'
+  DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/test_posthog'
   REDIS_URL: 'redis://localhost'
   TEST: 'true'
   BROWSERSTACK_DEBUG: 'true'
   BROWSERSTACK_NETWORK_LOGS: 'true'
   BROWSERSTACK_CONSOLE: 'info'
   PLUGIN_SERVER_INGESTION: 'true'
+  DISABLE_MMDB: 'true'
 
 jobs:
   testcafe:
@@ -19,8 +20,8 @@ jobs:
         postgres:
             image: postgres:12
             env:
-                POSTGRES_USER: postgres
-                POSTGRES_PASSWORD: postgres
+                POSTGRES_USER: posthog
+                POSTGRES_PASSWORD: posthog
                 POSTGRES_DB: test_posthog
             ports: ['5432:5432']
             options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
@@ -43,6 +44,7 @@ jobs:
         with:
             repository: 'PostHog/posthog'
             path: 'posthog/'
+            ref: server-debugging
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -59,7 +61,7 @@ jobs:
 
       - name: Set up databases
         env:
-            DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/posthog' # override for setup_test_environment command
+            DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog' # override for setup_test_environment command
         run: cd posthog && python manage.py setup_test_environment
 
       - name: Serve static files

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Specifically, the [JS integration](https://posthog.com/docs/integrations/js-inte
 ## Testing
 
 Unit tests: run `yarn test`
-Cypress: `yarn cypress`
+Cypress: run `yarn serve` to have a test server running and separately `yarn cypress` to launch Cypress test engine
 
 ### Running TestCafe E2E tests with BrowserStack
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Cypress: run `yarn serve` to have a test server running and separately `yarn cyp
 
 Testing on IE11 requires a bit more setup.
 
-1. Run `posthog` locally on port 8000
+1. Run `posthog` locally on port 8000 (`DEBUG=1 TEST=1 ./bin/start`)
 2. Run `python manage.py setup_dev --no-data` on posthog repo, which sets up a demo account
 3. Optional: rebuild array.js on changes: `nodemon -w src/ --exec bash -c "yarn build-array"`
 4. Export browserstack credentials: `export BROWSERSTACK_USERNAME=xxx BROWSERSTACK_ACCESS_KEY=xxx`

--- a/cypress/integration/capture.spec.js
+++ b/cypress/integration/capture.spec.js
@@ -177,4 +177,33 @@ describe('Event capture', () => {
             })
         })
     })
+
+    describe('advanced_disable_decide config', () => {
+        given('options', () => ({ advanced_disable_decide: true }))
+        it('does not autocapture anything when /decide is disabled', () => {
+            start({ waitForDecide: false })
+
+            cy.get('body').click(100, 100).click(98, 102).click(101, 103)
+            cy.get('[data-cy-custom-event-button]').click()
+
+            // No autocapture events, still captures custom events
+            cy.phCaptures().should('deep.equal', ['$pageview', 'custom-event'])
+        })
+
+        it('does not capture session recordings', () => {
+            start({ waitForDecide: false })
+
+            cy.get('[data-cy-custom-event-button]').click()
+            cy.wait('@capture')
+
+            cy.get('[data-cy-input]')
+                .type('hello posthog!')
+                .then(() => {
+                    const requests = cy
+                        .state('requests')
+                        .filter(({ alias }) => alias === 'session-recording' || alias === 'recorder')
+                    expect(requests.length).to.be.equal(0)
+                })
+        })
+    })
 })

--- a/cypress/integration/session-recording.spec.js
+++ b/cypress/integration/session-recording.spec.js
@@ -8,7 +8,7 @@ describe('Session recording', () => {
             method: 'POST',
             url: '**/decide/*',
             response: {
-                config: { enable_collect_everything: true },
+                config: { enable_collect_everything: false },
                 editorParams: {},
                 featureFlags: ['session-recording-player'],
                 isAuthenticated: false,

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -2,8 +2,6 @@ import sinon from 'sinon'
 
 import { autocapture } from '../autocapture'
 
-import { _ } from '../utils'
-
 const triggerMouseEvent = function (node, eventType) {
     node.dispatchEvent(
         new MouseEvent(eventType, {

--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -1,6 +1,7 @@
 import sinon from 'sinon'
 import { autocapture } from '../autocapture'
 import { decideCompression, compressData } from '../compression'
+import { decide } from '../decide'
 
 describe('decideCompression()', () => {
     given('subject', () => decideCompression(given.compressionSupport))
@@ -98,6 +99,7 @@ describe('Payload Compression', () => {
         })
 
         it('should save supported compression in instance', () => {
+            decide.init(lib)
             autocapture.init(lib)
             expect(lib.compression).toEqual({ lz64: true })
         })

--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -99,7 +99,7 @@ describe('Payload Compression', () => {
         })
 
         it('should save supported compression in instance', () => {
-            const decide = new Decide(lib).call()
+            new Decide(lib).call()
             autocapture.init(lib)
             expect(lib.compression).toEqual({ lz64: true })
         })

--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon'
 import { autocapture } from '../autocapture'
 import { decideCompression, compressData } from '../compression'
-import { decide } from '../decide'
+import { Decide } from '../decide'
 
 describe('decideCompression()', () => {
     given('subject', () => decideCompression(given.compressionSupport))
@@ -99,7 +99,8 @@ describe('Payload Compression', () => {
         })
 
         it('should save supported compression in instance', () => {
-            decide.init(lib)
+            const decide = new Decide(lib)
+            decide.callDecide()
             autocapture.init(lib)
             expect(lib.compression).toEqual({ lz64: true })
         })

--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -100,7 +100,7 @@ describe('Payload Compression', () => {
 
         it('should save supported compression in instance', () => {
             const decide = new Decide(lib)
-            decide.callDecide()
+            decide.call()
             autocapture.init(lib)
             expect(lib.compression).toEqual({ lz64: true })
         })

--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -99,8 +99,7 @@ describe('Payload Compression', () => {
         })
 
         it('should save supported compression in instance', () => {
-            const decide = new Decide(lib)
-            decide.call()
+            const decide = new Decide(lib).call()
             autocapture.init(lib)
             expect(lib.compression).toEqual({ lz64: true })
         })

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -1,3 +1,4 @@
+import { autocapture } from '../autocapture'
 import { Decide } from '../decide'
 import { _ } from '../utils'
 
@@ -28,6 +29,8 @@ describe('Decide', () => {
 
     given('config', () => ({ api_host: 'https://test.com' }))
 
+    jest.spyOn(autocapture, 'afterDecideResponse').mockImplementation()
+
     describe('constructor', () => {
         given('subject', () => () => given.decide.call())
 
@@ -52,6 +55,36 @@ describe('Decide', () => {
                 { method: 'POST' },
                 expect.any(Function)
             )
+        })
+    })
+
+    describe('parseDecideResponse', () => {
+        given('subject', () => () => given.decide.parseDecideResponse(given.decideResponse))
+
+        it('properly parses decide response', () => {
+            given('decideResponse', () => ({ enable_collect_everything: true }))
+            given.subject()
+
+            expect(given.posthog.sessionRecording.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
+            expect(given.posthog.toolbar.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
+            expect(autocapture.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse, given.posthog)
+        })
+
+        it('enables compression from decide response', () => {
+            given('decideResponse', () => ({ supportedCompression: ['gzip', 'lz64'] }))
+            given.subject()
+
+            expect(given.posthog.compression['gzip']).toBe(true)
+            expect(given.posthog.compression['lz64']).toBe(true)
+        })
+
+        it('enables feature flags from decide response', () => {
+            given('decideResponse', () => ({ featureFlags: ['beta-feature', 'alpha-feature-2'] }))
+            given.subject()
+
+            expect(given.posthog.persistence.register).toHaveBeenLastCalledWith({
+                $active_feature_flags: ['beta-feature', 'alpha-feature-2'],
+            })
         })
     })
 })

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -1,0 +1,59 @@
+import { decide } from '../decide'
+import { _ } from '../utils'
+
+describe('decide', () => {
+    given('decide', () => decide.init(given.posthog))
+    given('posthog', () => ({
+        get_config: jest.fn().mockImplementation((key) => given.config[key]),
+        capture: jest.fn(),
+        persistence: { register: jest.fn() },
+        _captureMetrics: { incr: jest.fn() },
+        _addCaptureHook: jest.fn(),
+        _prepare_callback: jest.fn().mockImplementation((callback) => callback),
+        get_distinct_id: jest.fn().mockImplementation(() => 'distinctid'),
+        _send_request: jest
+            .fn()
+            .mockImplementation((url, params, options, callback) =>
+                callback({ config: given.decideResponse }, given.posthog)
+            ),
+        toolbar: {
+            maybeLoadEditor: jest.fn(),
+            afterDecideResponse: jest.fn(),
+        },
+        sessionRecording: {
+            afterDecideResponse: jest.fn(),
+        },
+        persistence: { register: jest.fn(), unregister: jest.fn() },
+    }))
+
+    given('decideResponse', () => ({ enable_collect_everything: true }))
+
+    given('config', () => ({ api_host: 'https://test.com' }))
+
+    describe('constructor', () => {
+        given('subject', () => () => given.decide)
+
+        given('config', () => ({
+            api_host: 'https://test.com',
+            token: 'testtoken',
+        }))
+
+        it('should call instance._send_request on decide.init()', () => {
+            given.subject()
+
+            expect(given.posthog._send_request).toHaveBeenCalledWith(
+                'https://test.com/decide/',
+                {
+                    data: _.base64Encode(
+                        JSON.stringify({
+                            token: 'testtoken',
+                            distinct_id: 'distinctid',
+                        })
+                    ),
+                },
+                { method: 'POST' },
+                expect.any(Function)
+            )
+        })
+    })
+})

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -1,8 +1,8 @@
-import { decide } from '../decide'
+import { Decide } from '../decide'
 import { _ } from '../utils'
 
-describe('decide', () => {
-    given('decide', () => decide.init(given.posthog))
+describe('Decide', () => {
+    given('decide', () => new Decide(given.posthog))
     given('posthog', () => ({
         get_config: jest.fn().mockImplementation((key) => given.config[key]),
         capture: jest.fn(),
@@ -13,9 +13,7 @@ describe('decide', () => {
         get_distinct_id: jest.fn().mockImplementation(() => 'distinctid'),
         _send_request: jest
             .fn()
-            .mockImplementation((url, params, options, callback) =>
-                callback({ config: given.decideResponse }, given.posthog)
-            ),
+            .mockImplementation((url, params, options, callback) => callback({ config: given.decideResponse })),
         toolbar: {
             maybeLoadEditor: jest.fn(),
             afterDecideResponse: jest.fn(),
@@ -31,14 +29,14 @@ describe('decide', () => {
     given('config', () => ({ api_host: 'https://test.com' }))
 
     describe('constructor', () => {
-        given('subject', () => () => given.decide)
+        given('subject', () => () => given.decide.callDecide())
 
         given('config', () => ({
             api_host: 'https://test.com',
             token: 'testtoken',
         }))
 
-        it('should call instance._send_request on decide.init()', () => {
+        it('should call instance._send_request on constructor', () => {
             given.subject()
 
             expect(given.posthog._send_request).toHaveBeenCalledWith(

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -29,7 +29,7 @@ describe('Decide', () => {
     given('config', () => ({ api_host: 'https://test.com' }))
 
     describe('constructor', () => {
-        given('subject', () => () => given.decide.callDecide())
+        given('subject', () => () => given.decide.call())
 
         given('config', () => ({
             api_host: 'https://test.com',

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -29,7 +29,9 @@ describe('Decide', () => {
 
     given('config', () => ({ api_host: 'https://test.com' }))
 
-    jest.spyOn(autocapture, 'afterDecideResponse').mockImplementation()
+    beforeEach(() => {
+        jest.spyOn(autocapture, 'afterDecideResponse').mockImplementation()
+    })
 
     describe('constructor', () => {
         given('subject', () => () => given.decide.call())

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -19,24 +19,12 @@ describe('SessionRecording', () => {
         persistence: { register: jest.fn() },
         _captureMetrics: { incr: jest.fn() },
         _addCaptureHook: jest.fn(),
-        autocapture: false, // Assert that session recording works even if `autocapture = false`
     }))
-
     given('config', () => ({
         api_host: 'https://test.com',
         disable_session_recording: given.disabled,
-        session_recording: {
-            maskAllInputs: true,
-            recordCanvas: true,
-            someUnregisteredProp: 'abc',
-        },
+        autocapture: false, // Assert that session recording works even if `autocapture = false`
     }))
-
-    beforeEach(() => {
-        window.rrweb = {
-            record: jest.fn(),
-        }
-    })
 
     describe('afterDecideResponse()', () => {
         given('subject', () => () => given.sessionRecording.afterDecideResponse(given.response))

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -19,6 +19,7 @@ describe('SessionRecording', () => {
         persistence: { register: jest.fn() },
         _captureMetrics: { incr: jest.fn() },
         _addCaptureHook: jest.fn(),
+        autocapture: false, // Assert that session recording works even if `autocapture = false`
     }))
 
     given('config', () => ({

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -24,7 +24,18 @@ describe('SessionRecording', () => {
         api_host: 'https://test.com',
         disable_session_recording: given.disabled,
         autocapture: false, // Assert that session recording works even if `autocapture = false`
+        session_recording: {
+            maskAllInputs: true,
+            recordCanvas: true,
+            someUnregisteredProp: 'abc',
+        },
     }))
+
+    beforeEach(() => {
+        window.rrweb = {
+            record: jest.fn(),
+        }
+    })
 
     describe('afterDecideResponse()', () => {
         given('subject', () => () => given.sessionRecording.afterDecideResponse(given.response))

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -240,57 +240,19 @@ var autocapture = {
         }
         this._initializedTokens.push(token)
         this.rageclicks = new RageClick(instance)
+    },
 
-        var parseDecideResponse = _.bind(function (response) {
-            if (!(document && document.body)) {
-                console.log('document not ready yet, trying again in 500 milliseconds...')
-                setTimeout(function () {
-                    parseDecideResponse(response)
-                }, 500)
-                return
+    afterDecideResponse: function (response, instance) {
+        console.log('-------------------afterDecideResponse----------')
+        console.log(response)
+        if (response && response['config'] && response['config']['enable_collect_everything'] === true) {
+            if (response['custom_properties']) {
+                this._customProperties = response['custom_properties']
             }
-
-            instance.toolbar.afterDecideResponse(response)
-            instance.sessionRecording.afterDecideResponse(response)
-
-            if (response && response['config'] && response['config']['enable_collect_everything'] === true) {
-                if (response['custom_properties']) {
-                    this._customProperties = response['custom_properties']
-                }
-                this._addDomEventHandlers(instance)
-            } else {
-                instance['__autocapture_enabled'] = false
-            }
-
-            if (response['featureFlags']) {
-                instance.persistence &&
-                    instance.persistence.register({ $active_feature_flags: response['featureFlags'] })
-            } else {
-                instance.persistence && instance.persistence.unregister('$active_feature_flags')
-            }
-
-            if (response['supportedCompression']) {
-                let compression = {}
-                for (const method of response['supportedCompression']) {
-                    compression[method] = true
-                }
-                instance['compression'] = compression
-            } else {
-                instance['compression'] = {}
-            }
-        }, this)
-
-        var json_data = JSON.stringify({
-            token: token,
-            distinct_id: instance.get_distinct_id(),
-        })
-        var encoded_data = _.base64Encode(json_data)
-        instance._send_request(
-            instance.get_config('api_host') + '/decide/',
-            { data: encoded_data },
-            { method: 'POST' },
-            instance._prepare_callback(parseDecideResponse)
-        )
+            this._addDomEventHandlers(instance)
+        } else {
+            instance['__autocapture_enabled'] = false
+        }
     },
 
     // this is a mechanism to ramp up CE with no server-side interaction.

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -232,19 +232,18 @@ var autocapture = {
     _customProperties: {},
     init: function (instance) {
         instance.toolbar.maybeLoadEditor()
+        this.rageclicks = new RageClick(instance)
+    },
 
+    afterDecideResponse: function (response, instance) {
         var token = instance.get_config('token')
         if (this._initializedTokens.indexOf(token) > -1) {
             console.log('autocapture already initialized for token "' + token + '"')
             return
         }
-        this._initializedTokens.push(token)
-        this.rageclicks = new RageClick(instance)
-    },
 
-    afterDecideResponse: function (response, instance) {
-        console.log('-------------------afterDecideResponse----------')
-        console.log(response)
+        this._initializedTokens.push(token)
+
         if (response && response['config'] && response['config']['enable_collect_everything'] === true) {
             if (response['custom_properties']) {
                 this._customProperties = response['custom_properties']

--- a/src/decide.js
+++ b/src/decide.js
@@ -6,7 +6,10 @@ export class Decide {
         this.instance = instance
     }
 
-    callDecide() {
+    call() {
+        /*
+        Calls /decide endpoint to fetch options for autocapture, session recording, feature flags & compression.
+        */
         const json_data = JSON.stringify({
             token: this.instance.get_config('token'),
             distinct_id: this.instance.get_distinct_id(),
@@ -42,7 +45,7 @@ export class Decide {
         }
 
         if (response['supportedCompression']) {
-            let compression = {}
+            const compression = {}
             for (const method of response['supportedCompression']) {
                 compression[method] = true
             }

--- a/src/decide.js
+++ b/src/decide.js
@@ -1,30 +1,31 @@
 import { autocapture } from './autocapture'
 import { _ } from './utils'
 
-const decide = {
-    instance: null,
-
-    init: function (instance) {
+export class Decide {
+    constructor(instance) {
         this.instance = instance
-        var json_data = JSON.stringify({
-            token: instance.get_config('token'),
-            distinct_id: instance.get_distinct_id(),
+    }
+
+    callDecide() {
+        const json_data = JSON.stringify({
+            token: this.instance.get_config('token'),
+            distinct_id: this.instance.get_distinct_id(),
         })
 
-        var encoded_data = _.base64Encode(json_data)
-        instance._send_request(
-            instance.get_config('api_host') + '/decide/',
+        const encoded_data = _.base64Encode(json_data)
+        this.instance._send_request(
+            this.instance.get_config('api_host') + '/decide/',
             { data: encoded_data },
             { method: 'POST' },
-            instance._prepare_callback(this.parseDecideResponse)
+            (response) => this.parseDecideResponse(response)
         )
-    },
+    }
 
     parseDecideResponse(response) {
         if (!(document && document.body)) {
             console.log('document not ready yet, trying again in 500 milliseconds...')
             setTimeout(function () {
-                parseDecideResponse(response)
+                this.parseDecideResponse(response)
             }, 500)
             return
         }
@@ -49,8 +50,5 @@ const decide = {
         } else {
             this.instance['compression'] = {}
         }
-    },
+    }
 }
-_.bind_instance_methods(decide)
-
-export { decide }

--- a/src/decide.js
+++ b/src/decide.js
@@ -1,0 +1,56 @@
+import { autocapture } from './autocapture'
+import { _ } from './utils'
+
+const decide = {
+    instance: null,
+
+    init: function (instance) {
+        this.instance = instance
+        var json_data = JSON.stringify({
+            token: instance.get_config('token'),
+            distinct_id: instance.get_distinct_id(),
+        })
+
+        var encoded_data = _.base64Encode(json_data)
+        instance._send_request(
+            instance.get_config('api_host') + '/decide/',
+            { data: encoded_data },
+            { method: 'POST' },
+            instance._prepare_callback(this.parseDecideResponse)
+        )
+    },
+
+    parseDecideResponse(response) {
+        if (!(document && document.body)) {
+            console.log('document not ready yet, trying again in 500 milliseconds...')
+            setTimeout(function () {
+                parseDecideResponse(response)
+            }, 500)
+            return
+        }
+
+        this.instance.toolbar.afterDecideResponse(response)
+        this.instance.sessionRecording.afterDecideResponse(response)
+        autocapture.afterDecideResponse(response, this.instance)
+
+        if (response['featureFlags']) {
+            this.instance.persistence &&
+                this.instance.persistence.register({ $active_feature_flags: response['featureFlags'] })
+        } else {
+            this.instance.persistence && this.instance.persistence.unregister('$active_feature_flags')
+        }
+
+        if (response['supportedCompression']) {
+            let compression = {}
+            for (const method of response['supportedCompression']) {
+                compression[method] = true
+            }
+            this.instance['compression'] = compression
+        } else {
+            this.instance['compression'] = {}
+        }
+    },
+}
+_.bind_instance_methods(decide)
+
+export { decide }

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -99,9 +99,7 @@ export class SessionRecording {
                     this.snapshots.push(properties)
                 }
             },
-            blockClass: 'ph-no-capture', // Does not capture the element at all
-            ignoreClass: 'ph-ignore-input', // Ignores content of input but still records the input element
-            maskAllInputs: this.instance.get_config('mask_all_inputs'),
+            ...sessionRecordingOptions,
         })
 
         // :TRICKY: rrweb does not capture navigation within SPA-s, so hook into our $pageview events to get access to all events.

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -99,7 +99,9 @@ export class SessionRecording {
                     this.snapshots.push(properties)
                 }
             },
-            ...sessionRecordingOptions,
+            blockClass: 'ph-no-capture', // Does not capture the element at all
+            ignoreClass: 'ph-ignore-input', // Ignores content of input but still records the input element
+            maskAllInputs: this.instance.get_config('mask_all_inputs'),
         })
 
         // :TRICKY: rrweb does not capture navigation within SPA-s, so hook into our $pageview events to get access to all events.

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -291,6 +291,10 @@ declare class posthog {
      *      // prevent autocapture from capturing textContent on all elements
      *      mask_all_text: false
      *
+     *      // will disable requests to the /decide endpoint (please review documentation for details)
+     *      // autocapture, feature flags, compression and session recording will be disabled when set to `true`
+     *      advanced_disable_decide: false
+     *
      *     }
      *
      *
@@ -547,6 +551,7 @@ declare namespace posthog {
         session_recording?: SessionRecordingOptions
         mask_all_element_attributes?: boolean
         mask_all_text?: boolean
+        advanced_disable_decide?: boolean
     }
 
     interface OptInOutCapturingOptions {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -7,7 +7,7 @@ import { PostHogPeople } from './posthog-people'
 import { PostHogFeatureFlags } from './posthog-featureflags'
 import { PostHogPersistence, PEOPLE_DISTINCT_ID_KEY, ALIAS_ID_KEY } from './posthog-persistence'
 import { SessionRecording } from './extensions/sessionrecording'
-import { decide } from './decide'
+import { Decide } from './decide'
 import { Toolbar } from './extensions/toolbar'
 import { optIn, optOut, hasOptedIn, hasOptedOut, clearOptInOut, addOptOutCheckPostHogLib } from './gdpr-utils'
 import { cookieStore, localStore } from './storage'
@@ -145,7 +145,8 @@ var create_mplib = function (token, config, name) {
     instance.sessionRecording = new SessionRecording(instance)
     instance.sessionRecording.startRecordingIfEnabled()
 
-    decide.init(instance)
+    instance.decide = new Decide(instance)
+    instance.decide.callDecide()
 
     // if any instance on the page has debug = true, we set the
     // global debug to be true

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -146,7 +146,7 @@ var create_mplib = function (token, config, name) {
     instance.sessionRecording.startRecordingIfEnabled()
 
     instance.decide = new Decide(instance)
-    instance.decide.callDecide()
+    instance.decide.call()
 
     // if any instance on the page has debug = true, we set the
     // global debug to be true

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -732,7 +732,13 @@ PostHogLib.prototype._register_single = function (prop, value) {
  * @param {Object|String} options (optional) If {send_event: false}, we won't send an $feature_flag_call event to PostHog.
  */
 PostHogLib.prototype.isFeatureEnabled = function (key, options = {}) {
-    return this.feature_flags.isFeatureEnabled(key, options)
+    if (!this.featureFlags) {
+        window.console.warn(
+            'Feature flags are not enabled. Maybe the decide endpoint is disabled. Try setting advanced_disable_decide = false.'
+        )
+        return undefined
+    }
+    return this.featureFlags.isFeatureEnabled(key, options)
 }
 
 PostHogLib.prototype.reloadFeatureFlags = function () {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -7,6 +7,7 @@ import { PostHogPeople } from './posthog-people'
 import { PostHogFeatureFlags } from './posthog-featureflags'
 import { PostHogPersistence, PEOPLE_DISTINCT_ID_KEY, ALIAS_ID_KEY } from './posthog-persistence'
 import { SessionRecording } from './extensions/sessionrecording'
+import { decide } from './decide'
 import { Toolbar } from './extensions/toolbar'
 import { optIn, optOut, hasOptedIn, hasOptedOut, clearOptInOut, addOptOutCheckPostHogLib } from './gdpr-utils'
 import { cookieStore, localStore } from './storage'
@@ -143,6 +144,8 @@ var create_mplib = function (token, config, name) {
 
     instance.sessionRecording = new SessionRecording(instance)
     instance.sessionRecording.startRecordingIfEnabled()
+
+    decide.init(instance)
 
     // if any instance on the page has debug = true, we set the
     // global debug to be true

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -137,37 +137,6 @@ var create_mplib = function (token, config, name) {
     instance['people'] = new PostHogPeople()
     instance['people']._init(instance)
 
-    instance.featureFlags = new PostHogFeatureFlags(instance)
-    // This key is deprecated
-    instance.feature_flags = instance.featureFlags
-
-    instance.toolbar = new Toolbar(instance)
-
-    instance.sessionRecording = new SessionRecording(instance)
-    instance.sessionRecording.startRecordingIfEnabled()
-
-    if (!instance.get_config('advanced_disable_decide')) {
-        instance.decide = new Decide(instance)
-        instance.decide.call()
-
-        instance['__autocapture_enabled'] = instance.get_config('autocapture')
-        if (instance.get_config('autocapture')) {
-            var num_buckets = 100
-            var num_enabled_buckets = 100
-            if (!autocapture.enabledForProject(instance.get_config('token'), num_buckets, num_enabled_buckets)) {
-                instance['__autocapture_enabled'] = false
-                console.log('Not in active bucket: disabling Automatic Event Collection.')
-            } else if (!autocapture.isBrowserSupported()) {
-                instance['__autocapture_enabled'] = false
-                console.log('Disabling Automatic Event Collection because this browser is not supported')
-            } else {
-                autocapture.init(instance)
-            }
-        }
-    } else {
-        instance['__autocapture_enabled'] = false
-    }
-
     // if any instance on the page has debug = true, we set the
     // global debug to be true
     Config.DEBUG = Config.DEBUG || instance.get_config('debug')
@@ -179,6 +148,38 @@ var create_mplib = function (token, config, name) {
         // flush on identify, so it's better to do all these operations first
         instance._execute_array.call(instance['people'], target['people'])
         instance._execute_array(target)
+    }
+
+    if (instance.get_config('advanced_disable_decide')) {
+        // When /decide endpoint is disabled, nonone of the features below are available.
+        return instance
+    }
+
+    instance.featureFlags = new PostHogFeatureFlags(instance)
+    // This key is deprecated
+    instance.feature_flags = instance.featureFlags
+
+    instance.toolbar = new Toolbar(instance)
+
+    instance.sessionRecording = new SessionRecording(instance)
+    instance.sessionRecording.startRecordingIfEnabled()
+
+    instance.decide = new Decide(instance)
+    instance.decide.call()
+
+    instance['__autocapture_enabled'] = instance.get_config('autocapture')
+    if (instance.get_config('autocapture')) {
+        var num_buckets = 100
+        var num_enabled_buckets = 100
+        if (!autocapture.enabledForProject(instance.get_config('token'), num_buckets, num_enabled_buckets)) {
+            instance['__autocapture_enabled'] = false
+            console.log('Not in active bucket: disabling Automatic Event Collection.')
+        } else if (!autocapture.isBrowserSupported()) {
+            instance['__autocapture_enabled'] = false
+            console.log('Disabling Automatic Event Collection because this browser is not supported')
+        } else {
+            autocapture.init(instance)
+        }
     }
 
     return instance

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -149,8 +149,7 @@ var create_mplib = function (token, config, name) {
     if (!instance.get_config('advanced_disable_decide')) {
         // As a reminder, if the /decide endpoint is disabled, feature flags, toolbar, session recording, autocapture,
         // and compression will not be available.
-        const decide = new Decide(instance)
-        decide.call()
+        new Decide(instance).call()
     }
 
     instance['__autocapture_enabled'] = instance.get_config('autocapture')

--- a/testcafe/e2e.spec.js
+++ b/testcafe/e2e.spec.js
@@ -15,7 +15,7 @@ fixture('posthog.js capture')
             })
         })
 
-        console.debug('Requests to posthog:', JSON.stringify(captureLogger.requests, null, 2))
+        // console.debug('Requests to posthog:', JSON.stringify(captureLogger.requests, null, 2))
     })
 
 test('Custom events work and are accessible via /api/event', async (t) => {
@@ -37,7 +37,7 @@ test('Custom events work and are accessible via /api/event', async (t) => {
     await t.expect(results.filter(({ event }) => event === '$autocapture').length).eql(1)
 })
 
-test('Autocaptured events work and are accessible via /api/event', async (t) => {
+test.skip('Autocaptured events work and are accessible via /api/event', async (t) => {
     await initPosthog()
     await t
         .click('[data-cy-link-mask-text]')
@@ -72,7 +72,7 @@ test('Autocaptured events work and are accessible via /api/event', async (t) => 
         .eql(['attr__id', 'attr__class', 'attr__data-sensitive', 'attr__data-cy-button-sensitive-attributes'])
 })
 
-test('Config options change autocapture behavior accordingly', async (t) => {
+test.skip('Config options change autocapture behavior accordingly', async (t) => {
     await initPosthog({ mask_all_text: true, mask_all_element_attributes: true })
     await t
         .click('[data-cy-link-mask-text]')

--- a/testcafe/e2e.spec.js
+++ b/testcafe/e2e.spec.js
@@ -21,6 +21,7 @@ fixture('posthog.js capture')
 test('Custom events work and are accessible via /api/event', async (t) => {
     await initPosthog()
     await t
+        .wait(1000)
         .click('[data-cy-custom-event-button]')
         .wait(5000)
         .expect(captureLogger.count(() => true))
@@ -37,12 +38,13 @@ test('Custom events work and are accessible via /api/event', async (t) => {
     await t.expect(results.filter(({ event }) => event === '$autocapture').length).eql(1)
 })
 
-test.skip('Autocaptured events work and are accessible via /api/event', async (t) => {
+test('Autocaptured events work and are accessible via /api/event', async (t) => {
     await initPosthog()
     await t
+        .wait(1000)
         .click('[data-cy-link-mask-text]')
         .click('[data-cy-button-sensitive-attributes]')
-        .wait(10000)
+        .wait(5000)
         .expect(captureLogger.count(() => true))
         .gte(2)
 
@@ -72,12 +74,13 @@ test.skip('Autocaptured events work and are accessible via /api/event', async (t
         .eql(['attr__id', 'attr__class', 'attr__data-sensitive', 'attr__data-cy-button-sensitive-attributes'])
 })
 
-test.skip('Config options change autocapture behavior accordingly', async (t) => {
+test('Config options change autocapture behavior accordingly', async (t) => {
     await initPosthog({ mask_all_text: true, mask_all_element_attributes: true })
     await t
+        .wait(1000)
         .click('[data-cy-link-mask-text]')
         .click('[data-cy-button-sensitive-attributes]')
-        .wait(10000)
+        .wait(5000)
         .expect(captureLogger.count(() => true))
         .gte(2)
 

--- a/testcafe/helpers.js
+++ b/testcafe/helpers.js
@@ -33,7 +33,7 @@ export const initPosthog = ClientFunction((configParams = {}) => {
     window.posthog.init('e2e_token_1239', configParams)
 })
 
-export async function retryUntilResults(operation, limit = 50) {
+export async function retryUntilResults(operation, target_results, limit = 50) {
     const attempt = (count, resolve, reject) => {
         if (count === limit) {
             return reject(new Error('Failed to fetch results in 10 attempts'))
@@ -41,7 +41,9 @@ export async function retryUntilResults(operation, limit = 50) {
 
         setTimeout(() => {
             operation()
-                .then((results) => (results.length > 0 ? resolve(results) : attempt(count + 1, resolve, reject)))
+                .then((results) =>
+                    results.length >= target_results ? resolve(results) : attempt(count + 1, resolve, reject)
+                )
                 .catch(reject)
         }, 300)
     }

--- a/testcafe/helpers.js
+++ b/testcafe/helpers.js
@@ -33,10 +33,10 @@ export const initPosthog = ClientFunction((configParams = {}) => {
     window.posthog.init('e2e_token_1239', configParams)
 })
 
-export async function retryUntilResults(operation, target_results, limit = 50) {
+export async function retryUntilResults(operation, target_results, limit = 100) {
     const attempt = (count, resolve, reject) => {
         if (count === limit) {
-            return reject(new Error('Failed to fetch results in 10 attempts'))
+            return reject(new Error(`Failed to fetch results in ${limit} attempts`))
         }
 
         setTimeout(() => {
@@ -45,7 +45,7 @@ export async function retryUntilResults(operation, target_results, limit = 50) {
                     results.length >= target_results ? resolve(results) : attempt(count + 1, resolve, reject)
                 )
                 .catch(reject)
-        }, 300)
+        }, 600)
     }
 
     return new Promise((...args) => attempt(0, ...args))

--- a/testcafe/helpers.js
+++ b/testcafe/helpers.js
@@ -33,7 +33,7 @@ export const initPosthog = ClientFunction((configParams = {}) => {
     window.posthog.init('e2e_token_1239', configParams)
 })
 
-export async function retryUntilResults(operation, target_results, limit = 100) {
+export async function retryUntilResults(operation, target_results, limit = 250) {
     const attempt = (count, resolve, reject) => {
         if (count === limit) {
             return reject(new Error(`Failed to fetch results in ${limit} attempts`))

--- a/testcafe/helpers.js
+++ b/testcafe/helpers.js
@@ -33,7 +33,7 @@ export const initPosthog = ClientFunction((configParams = {}) => {
     window.posthog.init('e2e_token_1239', configParams)
 })
 
-export async function retryUntilResults(operation, target_results, limit = 250) {
+export async function retryUntilResults(operation, target_results, limit = 100) {
     const attempt = (count, resolve, reject) => {
         if (count === limit) {
             return reject(new Error(`Failed to fetch results in ${limit} attempts`))


### PR DESCRIPTION
## Changes

This PR enables running session recording even if autocapture is disabled. This is motivated by a couple of requests from different users who wish to use session recording without autocapture.
- To enable this, we refactor the `/decide` endpoint logic out of the `autocapture` module.

## Checklist
- [X] Tests for new code (if applicable)
- [X] TypeScript definitions (module.d.ts) updated and in sync with library exports. **Not applicable**
