### PR TITLE
Fix in-progress check for utils/deepCircularCopy

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -5,7 +5,7 @@
  * currently not supported in the browser lib).
  */
 
-import { _ } from '../utils'
+import { _, COPY_IN_PROGRESS_ATTRIBUTE } from '../utils'
 
 describe(`utils.js`, () => {
     it('should have $host and $pathname in properties', () => {
@@ -61,6 +61,16 @@ describe('_.copyAndTruncateStrings', () => {
         })
 
         expect(given.subject).toEqual({ key: 'vaaaa', values: ['fooob', undefined], __deepCircularCopyInProgress__: 1 })
+    })
+
+    it('should check copy-in-progress correctly', () => {
+        given('target', () => {
+            const base = Object.create({ [COPY_IN_PROGRESS_ATTRIBUTE]: undefined })
+            const object = Object.create(base)
+            return object
+        })
+
+        expect(given.subject).toEqual({})
     })
 })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -303,7 +303,7 @@ const COPY_IN_PROGRESS_ATTRIBUTE =
 function deepCircularCopy(value, customizer) {
     if (value !== Object(value)) return customizer ? customizer(value) : value // primitive value
 
-    if (COPY_IN_PROGRESS_ATTRIBUTE in value) return undefined
+    if (value[COPY_IN_PROGRESS_ATTRIBUTE]) return undefined
 
     value[COPY_IN_PROGRESS_ATTRIBUTE] = true
     let result

--- a/src/utils.js
+++ b/src/utils.js
@@ -870,3 +870,6 @@ _['info']['browserVersion'] = _.info.browserVersion
 _['info']['properties'] = _.info.properties
 
 export { win as window, _, userAgent, console, document }
+
+// Exports For Test ONLY
+export { COPY_IN_PROGRESS_ATTRIBUTE }


### PR DESCRIPTION
## Changes

Lately we are working on IE11 support and found this weird problem.

TL;DR
After applying babel polyfill for `Symbol`, if you try to create a `Symbol`, whatever it creates is written to the prototype chain, which leads to...

```javascript
var a = Symbol("__I_am_a_symbol__");
var b = {};

console.log(a in b); // true
console.log(a[b]); // undefined
```

As a result, it brakes the in-progress check in `deepCircularCopy`:
https://github.com/PostHog/posthog-js/blob/d939de99893b1f2c2d9287d7d516bdb021908430/src/utils.js#L306

...and causes error in
https://github.com/PostHog/posthog-js/blob/d939de99893b1f2c2d9287d7d516bdb021908430/src/posthog-core.js#L577

...because `data` is `undefined`.

This PR takes the edge case into consideration, and basically does not change the origin logic.

## Checklist
- [x] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
