### PR TITLE
Add missing `disable_session_recording` property in Config interface

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -507,6 +507,7 @@ declare namespace posthog {
         debug?: boolean
         cookie_expiration?: number
         upgrade?: boolean
+        disable_session_recording?: boolean
         disable_persistence?: boolean
         disable_cookie?: boolean
         secure_cookie?: boolean


### PR DESCRIPTION
## Changes

Add missing `disable_session_recording` property (documented at https://posthog.com/docs/libraries/js#config) to `posthog.Config` interface.

## Checklist
- [ ] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
