### PR TITLE
Changelog for 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.10.0 - 2021-05-07
+
+- Refactor /decide endpoint & allow recording without autocapture (#212)
+- Fix in-progress check for utils/deepCircularCopy (#216)
+- Update types, add missing reloadFeatureFlags (#219)
+- Add missing disable_session_recording property in Config interface (#221)
+
 ## 1.9.7 - 2021-04-09
 
 - Config Additions: session_recording, mask_all_element_attributes, mask_all_text (#209)


### PR DESCRIPTION
## Changes

- Adds what was missed due to the level 8 error that made us not use the bump labels

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
