### PR TITLE
Retry Queue

### DIFF
--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -480,6 +480,57 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@rollup/plugin-commonjs@^17.0.0":
+  version "17.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-17.1.0.tgz#757ec88737dffa8aa913eb392fade2e45aef2a2d"
+  integrity sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    commondir "^1.0.1"
+    estree-walker "^2.0.1"
+    glob "^7.1.6"
+    is-reference "^1.2.1"
+    magic-string "^0.25.7"
+    resolve "^1.17.0"
+
+"@rollup/plugin-inject@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-inject/-/plugin-inject-4.0.2.tgz#55b21bb244a07675f7fdde577db929c82fc17395"
+  integrity sha512-TSLMA8waJ7Dmgmoc8JfPnwUwVZgLjjIAM6MqeIFqPO2ODK36JqE0Cf2F54UTgCUuW8da93Mvoj75a6KAVWgylw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.4"
+    estree-walker "^1.0.1"
+    magic-string "^0.25.5"
+
+"@rollup/plugin-node-resolve@^11.0.1":
+  version "11.2.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz#82aa59397a29cd4e13248b106e6a4a1880362a60"
+  integrity sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
+"@rollup/plugin-replace@^2.3.4":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz#a2d539314fbc77c244858faa523012825068510a"
+  integrity sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    magic-string "^0.25.7"
+
+"@rollup/pluginutils@^3.0.4", "@rollup/pluginutils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
@@ -562,6 +613,16 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/estree@*":
+  version "0.0.47"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
+  integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
+
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.4.tgz#4ff9f641a7c6d1a3508ff88bc3141b152772e753"
@@ -630,6 +691,13 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
@@ -943,6 +1011,11 @@ buffer-from@1.x, buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+builtin-modules@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
+  integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -1085,6 +1158,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -1117,6 +1195,13 @@ core-util-is@1.0.2:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1128,7 +1213,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -1332,6 +1417,16 @@ estraverse@^4.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
+estree-walker@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
+  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+
+estree-walker@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -1501,6 +1596,15 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-cache-dir@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
+  integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
+
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -1540,6 +1644,15 @@ from@~0:
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
   integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
 
+fs-extra@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1549,6 +1662,11 @@ fsevents@^2.1.2:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
   integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
+
+fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -1613,10 +1731,27 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.6:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
 graceful-fs@^4.2.4:
   version "4.2.4"
@@ -1796,6 +1931,13 @@ is-core-module@^2.1.0:
   dependencies:
     has "^1.0.3"
 
+is-core-module@^2.2.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.4.0.tgz#8e9fc8e15027b011418026e98f0e6f4d86305cc1"
+  integrity sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==
+  dependencies:
+    has "^1.0.3"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -1855,6 +1997,11 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -1878,6 +2025,13 @@ is-potential-custom-element-name@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
   integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
+
+is-reference@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
+  integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -2429,6 +2583,13 @@ json5@2.x, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -2527,7 +2688,14 @@ lz-string@^1.4.4:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
-make-dir@^3.0.0:
+magic-string@^0.25.5, magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
+make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -2892,6 +3060,11 @@ picomatch@^2.0.4, picomatch@^2.0.5:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
+picomatch@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
+  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
+
 pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
@@ -2899,7 +3072,7 @@ pirates@^4.0.1:
   dependencies:
     node-modules-regexp "^1.0.0"
 
-pkg-dir@^4.2.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -3124,12 +3297,27 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
+resolve@1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+  dependencies:
+    path-parse "^1.0.6"
+
 resolve@^1.10.0, resolve@^1.18.1:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
   dependencies:
     is-core-module "^2.1.0"
+    path-parse "^1.0.6"
+
+resolve@^1.17.0, resolve@^1.19.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  dependencies:
+    is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
 ret@~0.1.10:
@@ -3143,6 +3331,24 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rollup-plugin-typescript2@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.29.0.tgz#b7ad83f5241dbc5bdf1e98d9c3fca005ffe39e1a"
+  integrity sha512-YytahBSZCIjn/elFugEGQR5qTsVhxhUwGZIsA9TmrSsC88qroGo65O5HZP/TTArH2dm0vUmYWhKchhwi2wL9bw==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    find-cache-dir "^3.3.1"
+    fs-extra "8.1.0"
+    resolve "1.17.0"
+    tslib "2.0.1"
+
+rollup@^2.35.1:
+  version "2.47.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.47.0.tgz#9d958aeb2c0f6a383cacc0401dff02b6e252664d"
+  integrity sha512-rqBjgq9hQfW0vRmz+0S062ORRNJXvwRpzxhFXORvar/maZqY6za3rgQ/p1Glg+j1hnc1GtYyQCPiAei95uTElg==
+  optionalDependencies:
+    fsevents "~2.3.1"
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -3345,6 +3551,11 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -3625,6 +3836,11 @@ tsc-watch@^4.2.9:
     string-argv "^0.1.1"
     strip-ansi "^6.0.0"
 
+tslib@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -3671,10 +3887,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.1.2:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.1.3:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -3685,6 +3901,11 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^2.0.1"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unset-value@^1.0.0:
   version "1.0.0"

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -295,6 +295,9 @@ describe('_handle_unload()', () => {
         _requestQueue: {
             unload: jest.fn(),
         },
+        _retryQueue: {
+            unload: jest.fn(),
+        },
     }))
 
     given('config', () => ({

--- a/src/__tests__/retry-queue.js
+++ b/src/__tests__/retry-queue.js
@@ -1,0 +1,180 @@
+import { CaptureMetrics } from '../capture-metrics'
+import { RetryQueue } from '../retry-queue'
+
+const EPOCH = 1_600_000_000
+const defaultRequestOptions = {
+    method: 'POST',
+    transport: 'XHR',
+}
+
+describe('RetryQueue', () => {
+    given('queue', () => new RetryQueue(given.captureMetrics))
+    given('captureMetrics', () => new CaptureMetrics(true, jest.fn(), jest.fn()))
+
+    const xhrMockClass = () => ({
+        open: jest.fn(),
+        send: jest.fn(),
+        setRequestHeader: jest.fn(),
+        status: 418,
+    })
+
+    window.XMLHttpRequest = jest.fn().mockImplementation(xhrMockClass)
+    window.navigator.sendBeacon = jest.fn()
+
+    function enqueueRequests() {
+        given.queue.enqueue({
+            url: '/e',
+            data: { event: 'foo', timestamp: EPOCH - 3000 },
+            options: defaultRequestOptions,
+            requestId: 1,
+        })
+        given.queue.enqueue({
+            url: '/e',
+            data: { event: 'bar', timestamp: EPOCH - 2000 },
+            options: defaultRequestOptions,
+            requestId: 2,
+        })
+        given.queue.enqueue({
+            url: '/e',
+            data: { event: 'baz', timestamp: EPOCH - 1000 },
+            options: defaultRequestOptions,
+            requestId: 3,
+        })
+        given.queue.enqueue({
+            url: '/e',
+            data: { event: 'fizz', timestamp: EPOCH },
+            options: defaultRequestOptions,
+            requestId: 4,
+        })
+    }
+
+    beforeEach(() => {
+        jest.useFakeTimers()
+
+        jest.spyOn(given.queue, 'getTime').mockReturnValue(EPOCH)
+    })
+
+    it('processes retry requests', () => {
+        enqueueRequests()
+
+        expect(given.queue._event_queue.length).toEqual(4)
+        expect(given.queue._requestRetriesMap).toEqual(
+            new Map([
+                [1, 0],
+                [2, 0],
+                [3, 0],
+                [4, 0],
+            ])
+        )
+
+        given.queue.poll()
+
+        expect(window.XMLHttpRequest).toHaveBeenCalledTimes(0)
+
+        jest.runOnlyPendingTimers()
+
+        expect(window.XMLHttpRequest).toHaveBeenCalledTimes(4)
+
+        expect(given.queue._event_queue.length).toEqual(0)
+
+        enqueueRequests()
+
+        expect(given.queue._event_queue.length).toEqual(4)
+        expect(given.queue._requestRetriesMap).toEqual(
+            new Map([
+                [1, 1],
+                [2, 1],
+                [3, 1],
+                [4, 1],
+            ])
+        )
+        expect(given.queue._event_queue).toEqual([
+            {
+                url: '/e',
+                data: { event: 'foo', timestamp: EPOCH - 3000 },
+                options: defaultRequestOptions,
+                requestId: 1,
+            },
+            {
+                url: '/e',
+                data: { event: 'bar', timestamp: EPOCH - 2000 },
+                options: defaultRequestOptions,
+                requestId: 2,
+            },
+            {
+                url: '/e',
+                data: { event: 'baz', timestamp: EPOCH - 1000 },
+                options: defaultRequestOptions,
+                requestId: 3,
+            },
+            {
+                url: '/e',
+                data: { event: 'fizz', timestamp: EPOCH },
+                options: defaultRequestOptions,
+                requestId: 4,
+            },
+        ])
+    })
+
+    it('tries to send requests via beacon on unload ', () => {
+        enqueueRequests()
+
+        given.queue.poll()
+        given.queue.unload()
+
+        expect(given.queue._event_queue.length).toEqual(0)
+        expect(window.navigator.sendBeacon).toHaveBeenCalledTimes(4)
+    })
+
+    it('clears polling flag after 4 empty iterations', () => {
+        enqueueRequests()
+
+        for (let i = 0; i < 5; i++) {
+            given.queue.poll()
+            jest.runOnlyPendingTimers()
+
+            expect(given.queue.isPolling).toEqual(true)
+        }
+
+        given.queue.poll()
+        jest.runOnlyPendingTimers()
+
+        expect(given.queue.isPolling).toEqual(false)
+    })
+
+    it('stops retrying after 3 attempts', () => {
+        given.queue.poll()
+
+        // Add requests to queue and retry twice
+        for (let i = 0; i < 2; ++i) {
+            enqueueRequests()
+            expect(given.queue._event_queue.length).toEqual(4)
+            jest.runOnlyPendingTimers()
+        }
+
+        // Enqueue requests a third time
+        enqueueRequests()
+
+        expect(given.queue._event_queue.length).toEqual(4)
+        expect(given.queue._requestRetriesMap).toEqual(
+            new Map([
+                [1, 2],
+                [2, 2],
+                [3, 2],
+                [4, 2],
+            ])
+        )
+
+        // Retry a third time
+        jest.runOnlyPendingTimers()
+
+        // Try to enqueue the same requests again
+        enqueueRequests()
+
+        // Requests are not added to the queue
+        expect(given.queue._event_queue.length).toEqual(0)
+
+        // Requests are cleared from retries map
+        expect(given.queue._requestRetriesMap).toEqual(new Map())
+    })
+})

--- a/src/__tests__/retry-queue.js
+++ b/src/__tests__/retry-queue.js
@@ -11,10 +11,6 @@ describe('RetryQueue', () => {
     given('queue', () => new RetryQueue(given.captureMetrics))
     given('captureMetrics', () => new CaptureMetrics(true, jest.fn(), jest.fn()))
 
-    window.addEventListener = jest.fn().mockImplementationOnce((event, callback) => {
-        callback()
-    })
-
     const xhrMockClass = () => ({
         open: jest.fn(),
         send: jest.fn(),
@@ -116,7 +112,7 @@ describe('RetryQueue', () => {
         ])
     })
 
-    it('tries to send requests via beacon on unload ', () => {
+    it('tries to send requests via beacon on unload', () => {
         enqueueRequests()
 
         given.queue.poll()

--- a/src/__tests__/retry-queue.js
+++ b/src/__tests__/retry-queue.js
@@ -8,7 +8,7 @@ const defaultRequestOptions = {
 }
 
 describe('RetryQueue', () => {
-    given('queue', () => new RetryQueue(given.captureMetrics))
+    given('retryQueue', () => new RetryQueue(given.captureMetrics))
     given('captureMetrics', () => new CaptureMetrics(true, jest.fn(), jest.fn()))
 
     const xhrMockClass = () => ({
@@ -21,175 +21,186 @@ describe('RetryQueue', () => {
     window.XMLHttpRequest = jest.fn().mockImplementation(xhrMockClass)
     window.navigator.sendBeacon = jest.fn()
 
+    function fastForwardTimeAndRunTimer() {
+        jest.spyOn(global.Date, 'now').mockImplementationOnce(() => new Date().getTime() + 3500)
+
+        jest.runOnlyPendingTimers()
+    }
+
     function enqueueRequests() {
-        given.queue.enqueue({
+        given.retryQueue.enqueue({
             url: '/e',
             data: { event: 'foo', timestamp: EPOCH - 3000 },
             options: defaultRequestOptions,
-            requestId: 1,
         })
-        given.queue.enqueue({
+        given.retryQueue.enqueue({
             url: '/e',
             data: { event: 'bar', timestamp: EPOCH - 2000 },
             options: defaultRequestOptions,
-            requestId: 2,
         })
-        given.queue.enqueue({
+        given.retryQueue.enqueue({
             url: '/e',
             data: { event: 'baz', timestamp: EPOCH - 1000 },
             options: defaultRequestOptions,
-            requestId: 3,
         })
-        given.queue.enqueue({
+        given.retryQueue.enqueue({
             url: '/e',
             data: { event: 'fizz', timestamp: EPOCH },
             options: defaultRequestOptions,
-            requestId: 4,
         })
     }
 
     beforeEach(() => {
         jest.useFakeTimers()
-        jest.spyOn(given.queue, 'getTime').mockReturnValue(EPOCH)
+        jest.spyOn(given.retryQueue, 'getTime').mockReturnValue(EPOCH)
     })
 
     it('processes retry requests', () => {
         enqueueRequests()
 
-        expect(given.queue._counterToQueueMap[1].length).toEqual(4)
-        expect(given.queue._requestRetriesMap).toEqual({
-            1: 0,
-            2: 0,
-            3: 0,
-            4: 0,
-        })
+        expect(given.retryQueue.queue.length).toEqual(4)
 
-        given.queue.poll()
+        expect(given.retryQueue.queue).toEqual([
+            {
+                requestData: {
+                    url: '/e',
+                    data: { event: 'foo', timestamp: EPOCH - 3000 },
+                    options: defaultRequestOptions,
+                },
+                retryAt: expect.any(Date),
+            },
+            {
+                requestData: {
+                    url: '/e',
+                    data: { event: 'bar', timestamp: EPOCH - 2000 },
+                    options: defaultRequestOptions,
+                },
+                retryAt: expect.any(Date),
+            },
+            {
+                requestData: {
+                    url: '/e',
+                    data: { event: 'baz', timestamp: EPOCH - 1000 },
+                    options: defaultRequestOptions,
+                },
+                retryAt: expect.any(Date),
+            },
+            {
+                requestData: {
+                    url: '/e',
+                    data: { event: 'fizz', timestamp: EPOCH },
+                    options: defaultRequestOptions,
+                },
+                retryAt: expect.any(Date),
+            },
+        ])
 
         expect(window.XMLHttpRequest).toHaveBeenCalledTimes(0)
 
-        jest.runOnlyPendingTimers()
+        fastForwardTimeAndRunTimer()
+
+        // clears queue
+        expect(given.retryQueue.queue.length).toEqual(0)
 
         expect(window.XMLHttpRequest).toHaveBeenCalledTimes(4)
-
-        expect(given.queue._counterToQueueMap[1]).toEqual(undefined)
-
-        enqueueRequests()
-
-        expect(given.queue._counterToQueueMap[2].length).toEqual(4)
-        expect(given.queue._requestRetriesMap).toEqual({
-            1: 1,
-            2: 1,
-            3: 1,
-            4: 1,
-        })
-
-        expect(given.queue._counterToQueueMap[2]).toEqual([
-            {
-                url: '/e',
-                data: { event: 'foo', timestamp: EPOCH - 3000 },
-                options: defaultRequestOptions,
-                requestId: 1,
-            },
-            {
-                url: '/e',
-                data: { event: 'bar', timestamp: EPOCH - 2000 },
-                options: defaultRequestOptions,
-                requestId: 2,
-            },
-            {
-                url: '/e',
-                data: { event: 'baz', timestamp: EPOCH - 1000 },
-                options: defaultRequestOptions,
-                requestId: 3,
-            },
-            {
-                url: '/e',
-                data: { event: 'fizz', timestamp: EPOCH },
-                options: defaultRequestOptions,
-                requestId: 4,
-            },
-        ])
     })
 
     it('tries to send requests via beacon on unload', () => {
         enqueueRequests()
 
-        given.queue.poll()
-        given.queue.unload()
+        given.retryQueue.poll()
+        given.retryQueue.unload()
 
-        expect(given.queue._event_queue.length).toEqual(0)
+        expect(given.retryQueue.queue.length).toEqual(0)
         expect(window.navigator.sendBeacon).toHaveBeenCalledTimes(4)
     })
 
     it('enqueues requests when offline and flushes immediately when online again', () => {
+        given.retryQueue.areWeOnline = false
+        expect(given.retryQueue.areWeOnline).toEqual(false)
+
         enqueueRequests()
 
-        given.queue._areWeOnline = false
-        expect(given.queue._areWeOnline).toEqual(false)
+        fastForwardTimeAndRunTimer()
 
-        given.queue.poll()
-        jest.runOnlyPendingTimers()
+        // requests aren't attempted when we're offline
+        expect(window.XMLHttpRequest).toHaveBeenCalledTimes(0)
+
+        // queue stays the same
+        expect(given.retryQueue.queue.length).toEqual(4)
+
+        given.retryQueue._handleWeAreNowOnline()
+
+        expect(given.retryQueue.areWeOnline).toEqual(true)
+        expect(given.retryQueue.queue.length).toEqual(0)
 
         expect(window.XMLHttpRequest).toHaveBeenCalledTimes(4)
-        expect(given.queue._offlineBacklog.length).toEqual(4)
-
-        given.queue._handleWeAreNowOnline()
-
-        expect(given.queue._areWeOnline).toEqual(true)
-        expect(given.queue._offlineBacklog.length).toEqual(0)
-
-        expect(window.XMLHttpRequest).toHaveBeenCalledTimes(8)
     })
 
     it('retries using an exponential backoff mechanism', () => {
-        enqueueRequests()
+        const fixedDate = new Date('2021-05-31T00:00:00')
+        jest.spyOn(global.Date, 'now').mockImplementation(() => fixedDate.getTime())
 
-        expect(given.queue._counterToQueueMap[1].length).toEqual(4)
-        expect(given.queue._requestRetriesMap).toEqual({
-            1: 0,
-            2: 0,
-            3: 0,
-            4: 0,
+        given.retryQueue.enqueue({
+            url: '/e',
+            data: { event: '1retry', timestamp: EPOCH },
+            options: defaultRequestOptions,
+            retriesPerformedSoFar: 1,
         })
 
-        jest.runOnlyPendingTimers()
-        enqueueRequests()
-
-        expect(given.queue._counterToQueueMap[1]).toEqual(undefined)
-        expect(given.queue._counterToQueueMap[2].length).toEqual(4)
-        expect(given.queue._requestRetriesMap).toEqual({
-            1: 1,
-            2: 1,
-            3: 1,
-            4: 1,
+        given.retryQueue.enqueue({
+            url: '/e',
+            data: { event: '5retries', timestamp: EPOCH },
+            options: defaultRequestOptions,
+            retriesPerformedSoFar: 5,
         })
 
-        jest.runOnlyPendingTimers()
-        enqueueRequests()
-
-        expect(given.queue._counterToQueueMap[2]).toEqual(undefined)
-        expect(given.queue._counterToQueueMap[4].length).toEqual(4)
-        expect(given.queue._requestRetriesMap).toEqual({
-            1: 2,
-            2: 2,
-            3: 2,
-            4: 2,
+        given.retryQueue.enqueue({
+            url: '/e',
+            data: { event: '9retries', timestamp: EPOCH },
+            options: defaultRequestOptions,
+            retriesPerformedSoFar: 9,
         })
 
-        for (let i = 0; i < 2; ++i) {
-            jest.runOnlyPendingTimers()
-        }
+        expect(given.retryQueue.queue).toEqual([
+            {
+                requestData: {
+                    url: '/e',
+                    data: { event: '1retry', timestamp: EPOCH },
+                    options: defaultRequestOptions,
+                    retriesPerformedSoFar: 1,
+                },
+                retryAt: new Date(fixedDate.getTime() + 6000), // 3000 * 2^1
+            },
+            {
+                requestData: {
+                    url: '/e',
+                    data: { event: '5retries', timestamp: EPOCH },
+                    options: defaultRequestOptions,
+                    retriesPerformedSoFar: 5,
+                },
+                retryAt: new Date(fixedDate.getTime() + 96000), // 3000 * 2^5
+            },
+            {
+                requestData: {
+                    url: '/e',
+                    data: { event: '9retries', timestamp: EPOCH },
+                    options: defaultRequestOptions,
+                    retriesPerformedSoFar: 9,
+                },
+                retryAt: new Date(fixedDate.getTime() + 1536000), // 3000 * 2^9
+            },
+        ])
+    })
 
-        enqueueRequests()
-
-        expect(given.queue._counterToQueueMap[4]).toEqual(undefined)
-        expect(given.queue._counterToQueueMap[8].length).toEqual(4)
-        expect(given.queue._requestRetriesMap).toEqual({
-            1: 3,
-            2: 3,
-            3: 3,
-            4: 3,
+    it('does not enqueue a request after 10 retries', () => {
+        given.retryQueue.enqueue({
+            url: '/e',
+            data: { event: 'maxretries', timestamp: EPOCH },
+            options: defaultRequestOptions,
+            retriesPerformedSoFar: 10,
         })
+
+        expect(given.retryQueue.queue.length).toEqual(0)
     })
 })

--- a/src/base-request-queue.js
+++ b/src/base-request-queue.js
@@ -1,0 +1,33 @@
+export class RequestQueueScaffold {
+    constructor(pollInterval = 3000) {
+        this.isPolling = true // flag to continue to recursively poll or not
+        this._event_queue = []
+        this._empty_queue_count = 0 // to track empty polls
+        this._poller = function () {} // to become interval for reference to clear later
+        this._pollInterval = pollInterval
+    }
+
+    setPollInterval(interval) {
+        this._pollInterval = interval
+        // Reset interval if running already
+        if (this.isPolling && this.poll) {
+            this.poll()
+        }
+    }
+
+    enqueue() {
+        return
+    }
+
+    poll() {
+        return
+    }
+
+    unload() {
+        return
+    }
+
+    getTime() {
+        return new Date().getTime()
+    }
+}

--- a/src/base-request-queue.js
+++ b/src/base-request-queue.js
@@ -10,7 +10,7 @@ export class RequestQueueScaffold {
     setPollInterval(interval) {
         this._pollInterval = interval
         // Reset interval if running already
-        if (this.isPolling && this.poll) {
+        if (this.isPolling) {
             this.poll()
         }
     }

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -408,7 +408,6 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
         window.navigator.sendBeacon(url, encodePostData(data, { ...options, sendBeacon: true }))
     } else if (USE_XHR) {
         try {
-            const retryRequestId = Math.floor(Math.random() * 10 ** 9)
             xhr({
                 url: url,
                 data: data,
@@ -416,7 +415,7 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
                 options: options,
                 captureMetrics: this._captureMetrics,
                 callback,
-                retryRequestId,
+                retriesPerformedSoFar: 0,
                 retryQueue: this._retryQueue,
             })
         } catch (e) {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -408,7 +408,7 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
         window.navigator.sendBeacon(url, encodePostData(data, { ...options, sendBeacon: true }))
     } else if (USE_XHR) {
         try {
-            const retryRequestId = Math.floor(Math.random() * 1000000)
+            const retryRequestId = Math.floor(Math.random() * 10 ** 9)
             xhr({
                 url: url,
                 data: data,

--- a/src/request-queue.js
+++ b/src/request-queue.js
@@ -1,22 +1,11 @@
+import { RequestQueueScaffold } from './base-request-queue'
 import { _ } from './utils'
 
-export class RequestQueue {
+export class RequestQueue extends RequestQueueScaffold {
     constructor(captureMetrics, handlePollRequest, pollInterval = 3000) {
-        this.captureMetrics = captureMetrics
+        super(pollInterval)
         this.handlePollRequest = handlePollRequest
-        this.isPolling = true // flag to continue to recursively poll or not
-        this._event_queue = []
-        this._empty_queue_count = 0 // to track empty polls
-        this._poller = function () {} // to become interval for reference to clear later
-        this._pollInterval = pollInterval
-    }
-
-    setPollInterval(interval) {
-        this._pollInterval = interval
-        // Reset interval if running already
-        if (this.isPolling) {
-            this.poll()
-        }
+        this.captureMetrics = captureMetrics
     }
 
     enqueue(url, data, options) {
@@ -49,6 +38,7 @@ export class RequestQueue {
                     this.captureMetrics.incr(`batch-handle-${url.slice(url.length - 2)}`, data.length)
                 }
                 this._event_queue.length = 0 // flush the _event_queue
+                this._empty_queue_count = 0
             } else {
                 this._empty_queue_count++
             }
@@ -114,9 +104,5 @@ export class RequestQueue {
             requests[key].data.push(data)
         })
         return requests
-    }
-
-    getTime() {
-        return new Date().getTime()
     }
 }

--- a/src/retry-queue.js
+++ b/src/retry-queue.js
@@ -54,17 +54,7 @@ export class RetryQueue extends RequestQueueScaffold {
                     this._offlineBacklog = [...this._offlineBacklog, ...currentQueue]
                 } else {
                     for (let i = 0; i < currentQueue.length; ++i) {
-                        const { url, data, options, headers, callback, requestId } = currentQueue[i]
-                        xhr({
-                            url,
-                            data: data || {},
-                            options: options || {},
-                            headers: headers || {},
-                            requestId,
-                            callback,
-                            captureMetrics: this.captureMetrics,
-                            retryQueue: this,
-                        })
+                        this._executeXhrRequest(currentQueue[i])
                     }
                 }
 
@@ -87,18 +77,21 @@ export class RetryQueue extends RequestQueueScaffold {
 
     _flushOfflineBacklog() {
         for (let i = 0; i < this._offlineBacklog.length; ++i) {
-            const { url, data, options, headers, callback, requestId } = this._offlineBacklog[i]
-            xhr({
-                url,
-                data: data || {},
-                options: options || {},
-                headers: headers || {},
-                requestId,
-                callback,
-                captureMetrics: this.captureMetrics,
-                retryQueue: this,
-            })
+            this._executeXhrRequest(this._offlineBacklog[i])
         }
         this._offlineBacklog.length = 0
+    }
+
+    _executeXhrRequest({ url, data, options, headers, callback, requestId }) {
+        xhr({
+            url,
+            data: data || {},
+            options: options || {},
+            headers: headers || {},
+            requestId,
+            callback,
+            captureMetrics: this.captureMetrics,
+            retryQueue: this,
+        })
     }
 }

--- a/src/retry-queue.js
+++ b/src/retry-queue.js
@@ -5,6 +5,7 @@ export class RetryQueue extends RequestQueueScaffold {
     constructor(captureMetrics) {
         super()
         this.captureMetrics = captureMetrics
+        this.isPolling = false
         this._requestRetriesMap = {} // <RequestId, number>
         this._counterToQueueMap = {}
         this._pollerCounter = 1
@@ -40,7 +41,10 @@ export class RetryQueue extends RequestQueueScaffold {
             this._counterToQueueMap[nextRetry] = []
         }
         this._counterToQueueMap[nextRetry].push(requestData)
-        this.poll()
+        if (!this.isPolling) {
+            this.isPolling = true
+            this.poll()
+        }
     }
 
     poll() {

--- a/src/retry-queue.js
+++ b/src/retry-queue.js
@@ -1,0 +1,71 @@
+import { RequestQueueScaffold } from './base-request-queue'
+import { encodePostData, xhr } from './send-request'
+
+export class RetryQueue extends RequestQueueScaffold {
+    constructor(captureMetrics) {
+        super()
+        this._requestRetriesMap = new Map() // <RequestId, number>
+        this.captureMetrics = captureMetrics
+    }
+
+    enqueue(requestData) {
+        const { requestId } = requestData
+        if (!this._requestRetriesMap.has(requestId)) {
+            this._requestRetriesMap.set(requestId, 0)
+        } else {
+            const retriesPerformedSoFar = this._requestRetriesMap.get(requestId)
+            if (retriesPerformedSoFar === 2) {
+                this._requestRetriesMap.delete(requestId)
+                return
+            }
+            this._requestRetriesMap.set(requestId, retriesPerformedSoFar + 1)
+        }
+        this._event_queue.push(requestData)
+    }
+
+    poll() {
+        clearTimeout(this._poller)
+        this._poller = setTimeout(() => {
+            if (this._event_queue.length > 0) {
+                // Clone and flush before doing the requests as they may push to the queue
+                const currentEventQueue = this._event_queue.slice(0, this._event_queue.length) // clone queue
+                this._event_queue.length = 0 // flush queue
+                for (let i = 0; i < currentEventQueue.length; ++i) {
+                    const { url, data, options, headers, callback, requestId } = currentEventQueue[i]
+
+                    xhr({
+                        url,
+                        data,
+                        options,
+                        requestId,
+                        headers,
+                        callback,
+                        captureMetrics: this.captureMetrics,
+                        retryQueue: this,
+                    })
+                }
+                this._empty_queue_count = 0
+            } else {
+                this._empty_queue_count++
+            }
+
+            if (this._empty_queue_count > 4) {
+                this.isPolling = false
+                this._empty_queue_count = 0
+            }
+            if (this.isPolling) {
+                this.poll()
+            }
+        }, this._pollInterval)
+    }
+
+    unload() {
+        clearTimeout(this._poller)
+        for (let i = 0; i < this._event_queue.length; ++i) {
+            let { url, data, options } = this._event_queue[i]
+            window.navigator.sendBeacon(url, encodePostData(data, { ...options, sendBeacon: true }))
+        }
+
+        this._event_queue.length = 0
+    }
+}

--- a/src/retry-queue.js
+++ b/src/retry-queue.js
@@ -25,7 +25,9 @@ export class RetryQueue extends RequestQueueScaffold {
         if (retriesPerformedSoFar >= 10) {
             return
         }
-        const retryAt = new Date(Date.now() + 3000 * 2 ** retriesPerformedSoFar)
+        const msToNextRetry = 3000 * 2 ** retriesPerformedSoFar
+        const retryAt = new Date(Date.now() + msToNextRetry)
+        console.warn(`Enqueued failed request for retry in ${msToNextRetry}`)
         this.queue.push({ retryAt, requestData })
         if (!this.isPolling) {
             this.isPolling = true

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -24,7 +24,7 @@ export const encodePostData = (data, options) => {
     return body_data
 }
 
-export const xhr = (url, data, headers, options, captureMetrics, callback) => {
+export const xhr = ({ url, data, headers, options, captureMetrics, callback, retryRequestId, retryQueue }) => {
     const req = new XMLHttpRequest()
     req.open(options.method, url, true)
 
@@ -72,6 +72,11 @@ export const xhr = (url, data, headers, options, captureMetrics, callback) => {
             } else {
                 const error = 'Bad HTTP status: ' + req.status + ' ' + req.statusText
                 console.error(error)
+
+                // don't retry certain errors
+                if ([401, 403, 404].indexOf(req.status) < 0) {
+                    retryQueue.enqueue({ url, data, options, headers, retryRequestId, callback })
+                }
 
                 captureMetrics.markRequestFailed({
                     ...data,

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -24,7 +24,7 @@ export const encodePostData = (data, options) => {
     return body_data
 }
 
-export const xhr = ({ url, data, headers, options, captureMetrics, callback, retryRequestId, retryQueue }) => {
+export const xhr = ({ url, data, headers, options, captureMetrics, callback, retriesPerformedSoFar, retryQueue }) => {
     const req = new XMLHttpRequest()
     req.open(options.method, url, true)
 
@@ -75,7 +75,14 @@ export const xhr = ({ url, data, headers, options, captureMetrics, callback, ret
 
                 // don't retry certain errors
                 if ([401, 403, 404].indexOf(req.status) < 0) {
-                    retryQueue.enqueue({ url, data, options, headers, retryRequestId, callback })
+                    retryQueue.enqueue({
+                        url,
+                        data,
+                        options,
+                        headers,
+                        retriesPerformedSoFar: (retriesPerformedSoFar || 0) + 1,
+                        callback,
+                    })
                 }
 
                 captureMetrics.markRequestFailed({


### PR DESCRIPTION
## Changes

Here's a first pass at a retry queue.

There are a few open questions:

- Do we want any config options for this? Polling interval, ability to disable?
- Are there certain status codes we don't want to retry? I've made it so that it doesn't retry 401s, 403s, and 404s, but that's an arbitrary choice to serve more as an example here - don't feel strongly about it.
- I saw that the request queue would stop polling after 4 empty runs, but it didn't reset on a non-empty run in between - do we want to keep this behavior? Given that we're looking for idling here I went ahead and made it so that we need 4 **consecutive** empty runs to stop polling.

EDIT:

So here's some context:

Given exponential backoff, I thought having intervals set for each request would become a bit messy with timers all over the place. Plugins (where I'm now implementing exponential backoff queues) that have a nice job queues API :wink: , but such is not the case here.

So what I've done is kept the poller running at a regular interval, as well as kept a list of requests to be retried at interval _n_. The poller will then only execute the requests specified for that interval. The _n_ value for each request is calculated based on the number of retries that request has already seen, following this formula: 

```
currentPollerCount - 1 + 2 ^ retriesPerformedSoFar
```

This means if the poller has just started, here's a table of retries (assuming a 3000ms polling interval):
| Retries performed already | Interval when retry will happen | Seconds until retry |
| :----: | :----: | :----:| 
| 0 | 1  | 0  |
| 1 | 2  | 3  |
| 2 | 4  | 9  |
| 3 | 8  | 21  |
| 4 | 16  | 45  |
| 5 | 32  | 93  |
| 6 | 64  | 189  |
| 7 | 128  | 381  |
| 8 | 256  | 765  |
| 9 | 512  | 1533  |
| 10 | 1024  | 3069  |

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
