### PR TITLE
Fix sessionRecording bug

### DIFF
--- a/src/request-queue.js
+++ b/src/request-queue.js
@@ -87,8 +87,8 @@ export class RequestQueue {
         clearTimeout(this._poller)
         const requests = this._event_queue.length > 0 ? this.formatQueue() : {}
         this._event_queue.length = 0
-        for (let url in requests) {
-            const { data, options } = requests[url]
+        for (let key in requests) {
+            const { url, data, options } = requests[key]
             this.handlePollRequest(url, data, { ...options, transport: 'sendbeacon' })
         }
     }


### PR DESCRIPTION
## Changes

Fixes #183 

What a rollercoaster! The `url` is just one of many possible values for the key in the request object, the other possible options being: `batchKey`, which, ofcourse, we set to `sessionRecording` for session recording! ( https://github.com/PostHog/posthog-js/blob/master/src/extensions/sessionrecording.js#L122 )

The annoying bit was figuring out that it was this specific part of the request queue that was mangling things up.

...

## Checklist
- [x] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
