### PR TITLE
Fix overridden request retry data

### DIFF
--- a/src/send-request.js
+++ b/src/send-request.js
@@ -55,7 +55,7 @@ export const xhr = ({ url, data, headers, options, captureMetrics, callback, ret
             captureMetrics.incr(`xhr-response-${req.status}`)
             captureMetrics.decr('_send_request_inflight')
 
-            const data = captureMetrics.finishRequest(requestId)
+            const metricsData = captureMetrics.finishRequest(requestId)
 
             // XMLHttpRequest.DONE == 4, except in safari 4
             if (req.status === 200) {
@@ -86,7 +86,7 @@ export const xhr = ({ url, data, headers, options, captureMetrics, callback, ret
                 }
 
                 captureMetrics.markRequestFailed({
-                    ...data,
+                    ...metricsData,
                     type: 'non_200',
                     status: req.status,
                     statusText: req.statusText,


### PR DESCRIPTION
## Changes

Fixes https://github.com/PostHog/posthog-js/issues/240

`data` was being overridden in the callback and retries were all sending `undefined` payloads

Let's get this in before the release


## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
