### PR TITLE
Capture viewport size

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -838,6 +838,8 @@ _.info = {
                 $browser_version: _.info.browserVersion(userAgent, navigator.vendor, window.opera),
                 $screen_height: window.screen.height,
                 $screen_width: window.screen.width,
+                $viewport_height: window.innerHeight,
+                $viewport_width: window.innerWidth,
                 $lib: 'web',
                 $lib_version: Config.LIB_VERSION,
                 $insert_id: Math.random().toString(36).substring(2, 10) + Math.random().toString(36).substring(2, 10),


### PR DESCRIPTION
## Changes
Start capturing the actual viewport size by sending `window.innerHeight` and `window.innerWidth` as props.

Closes https://github.com/PostHog/posthog-js/issues/245#issue-919890687

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
