### PR TITLE
Fix invalid cookie

### DIFF
--- a/src/posthog-persistence.js
+++ b/src/posthog-persistence.js
@@ -41,6 +41,14 @@ import { cookieStore, localStore, memoryStore } from './storage'
  * @constructor
  */
 var PostHogPersistence = function (config) {
+    // clean chars that aren't accepted by the http spec for cookie values
+    // https://datatracker.ietf.org/doc/html/rfc2616#section-2.2
+    let token = ''
+
+    if (config['token']) {
+        token = config['token'].replace(/\+/g, 'PL').replace(/\//g, 'SL').replace(/=/g, 'EQ')
+    }
+
     this['props'] = {}
     this.campaign_params_saved = false
     this['featureFlagEventHandlers'] = []
@@ -48,7 +56,7 @@ var PostHogPersistence = function (config) {
     if (config['persistence_name']) {
         this.name = 'ph_' + config['persistence_name']
     } else {
-        this.name = 'ph_' + config['token'] + '_posthog'
+        this.name = 'ph_' + token + '_posthog'
     }
 
     var storage_type = config['persistence']


### PR DESCRIPTION
## Changes

https://github.com/PostHog/posthog/pull/4832 addresses #249 for the future. This addresses it "retroactively".

I spent a bit of time looking into converting the base64 token to base36 but it's not super straightforward as [`BigInt` isn't supported in some browsers we target](https://caniuse.com/?search=bigint). And ultimately, we don't actually need it. Replacing the 3 chars that may appear in b64 strings is quite enough. 


## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
