### PR TITLE
Allow session recording reload

### DIFF
--- a/playground/flags/demo.html
+++ b/playground/flags/demo.html
@@ -1,6 +1,6 @@
 <script src="../../dist/array.js"></script>
 <script>
-    posthog.init('sTMFPsFhdP1Ssg', {api_host: 'http://127.0.0.1:8000', debug: true, persistence: 'memory', loaded: function(posthog) { posthog.identify('test')}})
+    posthog.init('phc_xMRngB5qATbzxdSysEDuNu6LvonmNrErAa4HUFdx6sB', {api_host: 'http://127.0.0.1:8000', debug: true, persistence: 'memory', loaded: function(posthog) { posthog.identify('test')}})
 </script>
 <h2>Demo site</h2>
 <button>Here's a button you could click if you want to</button><br /><br />

--- a/playground/flags/demo.html
+++ b/playground/flags/demo.html
@@ -1,6 +1,6 @@
 <script src="../../dist/array.js"></script>
 <script>
-    posthog.init('phc_xMRngB5qATbzxdSysEDuNu6LvonmNrErAa4HUFdx6sB', {api_host: 'http://127.0.0.1:8000', debug: true, persistence: 'memory', loaded: function(posthog) { posthog.identify('test')}})
+    posthog.init('sTMFPsFhdP1Ssg', {api_host: 'http://127.0.0.1:8000', debug: true, persistence: 'memory', loaded: function(posthog) { posthog.identify('test')}})
 </script>
 <h2>Demo site</h2>
 <button>Here's a button you could click if you want to</button><br /><br />

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -90,6 +90,7 @@ describe('SessionRecording', () => {
             window.rrweb = {
                 record: jest.fn(({ emit }) => {
                     _emit = emit
+                    return () => {}
                 }),
             }
 
@@ -184,6 +185,20 @@ describe('SessionRecording', () => {
             given.sessionRecording.submitRecordings()
 
             expect(loadScript).not.toHaveBeenCalled()
+        })
+
+        it('toggles session recording on and off', () => {
+            expect(given.sessionRecording.stopRecording).toEqual(null)
+
+            given.sessionRecording.startRecordingIfEnabled()
+
+            expect(given.sessionRecording.captureStarted).toEqual(true)
+            expect(given.sessionRecording.stopRecording).not.toEqual(null)
+
+            given.sessionRecording.toggleSessionRecording(false)
+
+            expect(given.sessionRecording.stopRecording).toEqual(null)
+            expect(given.sessionRecording.captureStarted).toEqual(false)
         })
     })
 })

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -187,17 +187,18 @@ describe('SessionRecording', () => {
             expect(loadScript).not.toHaveBeenCalled()
         })
 
-        it('toggles session recording on and off', () => {
-            expect(given.sessionRecording.stopRecording).toEqual(null)
+        it('session recording can be turned on and off', () => {
+            expect(given.sessionRecording.stopRrweb).toEqual(null)
 
             given.sessionRecording.startRecordingIfEnabled()
 
+            expect(given.sessionRecording.started()).toEqual(true)
             expect(given.sessionRecording.captureStarted).toEqual(true)
-            expect(given.sessionRecording.stopRecording).not.toEqual(null)
+            expect(given.sessionRecording.stopRrweb).not.toEqual(null)
 
-            given.sessionRecording.toggleSessionRecording(false)
+            given.sessionRecording.stopRecording()
 
-            expect(given.sessionRecording.stopRecording).toEqual(null)
+            expect(given.sessionRecording.stopRrweb).toEqual(null)
             expect(given.sessionRecording.captureStarted).toEqual(false)
         })
     })

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -104,7 +104,6 @@ export class SessionRecording {
 
         this.stopRecording = window.rrweb.record({
             emit: (data) => {
-                console.log('snapshot')
                 const properties = {
                     $snapshot_data: data,
                     $session_id: sessionIdGenerator(this.instance.persistence, data.timestamp),

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -13,6 +13,7 @@ export class SessionRecording {
         this.snapshots = []
         this.emit = false
         this.endpoint = BASE_ENDPOINT
+        this.stopRecording = null
     }
 
     startRecordingIfEnabled() {
@@ -21,6 +22,19 @@ export class SessionRecording {
             !this.instance.get_config('disable_session_recording')
         ) {
             this._startCapture()
+        }
+    }
+
+    toggleSessionRecording(turnOn) {
+        if (turnOn) {
+            this.startRecordingIfEnabled()
+            return
+        }
+
+        if (this.captureStarted && this.stopRecording) {
+            this.stopRecording()
+            this.stopRecording = null
+            this.captureStarted = false
         }
     }
 
@@ -88,8 +102,9 @@ export class SessionRecording {
             }
         }
 
-        window.rrweb.record({
+        this.stopRecording = window.rrweb.record({
             emit: (data) => {
+                console.log('snapshot')
                 const properties = {
                     $snapshot_data: data,
                     $session_id: sessionIdGenerator(this.instance.persistence, data.timestamp),

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -13,7 +13,7 @@ export class SessionRecording {
         this.snapshots = []
         this.emit = false
         this.endpoint = BASE_ENDPOINT
-        this.stopRecording = null
+        this.stopRrweb = null
     }
 
     startRecordingIfEnabled() {
@@ -25,15 +25,14 @@ export class SessionRecording {
         }
     }
 
-    toggleSessionRecording(turnOn) {
-        if (turnOn) {
-            this.startRecordingIfEnabled()
-            return
-        }
+    started() {
+        return this.captureStarted
+    }
 
-        if (this.captureStarted && this.stopRecording) {
-            this.stopRecording()
-            this.stopRecording = null
+    stopRecording() {
+        if (this.captureStarted && this.stopRrweb) {
+            this.stopRrweb()
+            this.stopRrweb = null
             this.captureStarted = false
         }
     }
@@ -102,7 +101,7 @@ export class SessionRecording {
             }
         }
 
-        this.stopRecording = window.rrweb.record({
+        this.stopRrweb = window.rrweb.record({
             emit: (data) => {
                 const properties = {
                     $snapshot_data: data,

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -510,6 +510,35 @@ declare class posthog {
 
     /* Will log all capture requests to the Javascript console, including event properties for easy debugging */
     static debug(): void
+
+    /*
+     * Starts session recording and updates disable_session_recording to false.
+     * Used for manual session recording management. By default, session recording is enabled and
+     * starts automatically.
+     *
+     * ### Usage:
+     *
+     *     posthog.startSessionRecording()
+     */
+    static startSessionRecording(): void
+
+    /*
+     * Stops session recording and updates disable_session_recording to true.
+     *
+     * ### Usage:
+     *
+     *     posthog.stopSessionRecording()
+     */
+    static stopSessionRecording(): void
+
+    /*
+     * Check if session recording is currently running.
+     *
+     * ### Usage:
+     *
+     *     const isSessionRecordingOn = posthog.sessionRecordingStarted()
+     */
+    static sessionRecordingStarted(): boolean
 }
 
 declare namespace posthog {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1075,6 +1075,7 @@ PostHogLib.prototype.alias = function (alias, original) {
  */
 
 PostHogLib.prototype.set_config = function (config) {
+    const oldConfig = { ...this.config }
     if (_.isObject(config)) {
         _.extend(this['config'], config)
 
@@ -1093,7 +1094,22 @@ PostHogLib.prototype.set_config = function (config) {
             this['config']['debug'] = true
         }
         Config.DEBUG = Config.DEBUG || this.get_config('debug')
+
+        if (this.sessionRecording && typeof config.disable_session_recording !== 'undefined') {
+            if (oldConfig.disable_session_recording !== config.disable_session_recording) {
+                this.sessionRecording.toggleSessionRecording(!config.disable_session_recording)
+            }
+        }
     }
+}
+
+/**
+ * turns session recording on if it is off, and off if it is on.
+ * returns true if session recording is enabled after the operation, and false otherwise.
+ */
+PostHogLib.prototype.toggleSessionRecording = function () {
+    this.set_config({ disable_session_recording: !this.config.disable_session_recording })
+    return !this.config.disable_session_recording
 }
 
 /**
@@ -1488,6 +1504,7 @@ PostHogLib.prototype['decodeLZ64'] = PostHogLib.prototype.decodeLZ64
 PostHogLib.prototype['SentryIntegration'] = PostHogLib.prototype.sentry_integration
 PostHogLib.prototype['debug'] = PostHogLib.prototype.debug
 PostHogLib.prototype['LIB_VERSION'] = Config.LIB_VERSION
+PostHogLib.prototype['toggleSessionRecording'] = PostHogLib.prototype.toggleSessionRecording
 
 // PostHogPersistence Exports
 PostHogPersistence.prototype['properties'] = PostHogPersistence.prototype.properties

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1097,19 +1097,38 @@ PostHogLib.prototype.set_config = function (config) {
 
         if (this.sessionRecording && typeof config.disable_session_recording !== 'undefined') {
             if (oldConfig.disable_session_recording !== config.disable_session_recording) {
-                this.sessionRecording.toggleSessionRecording(!config.disable_session_recording)
+                if (config.disable_session_recording) {
+                    this.sessionRecording.stopRecording()
+                } else {
+                    this.sessionRecording.startRecordingIfEnabled()
+                }
             }
         }
     }
 }
 
 /**
- * turns session recording on if it is off, and off if it is on.
- * returns true if session recording is enabled after the operation, and false otherwise.
+ * turns session recording on, and updates the config option
+ * disable_session_recording to false
  */
-PostHogLib.prototype.toggleSessionRecording = function () {
-    this.set_config({ disable_session_recording: !this.config.disable_session_recording })
-    return !this.config.disable_session_recording
+PostHogLib.prototype.startSessionRecording = function () {
+    this.set_config({ disable_session_recording: false })
+}
+
+/**
+ * turns session recording off, and updates the config option
+ * disable_session_recording to true
+ */
+PostHogLib.prototype.stopSessionRecording = function () {
+    this.set_config({ disable_session_recording: true })
+}
+
+/**
+ * returns a boolean indicating whether session recording
+ * is currently running
+ */
+PostHogLib.prototype.sessionRecordingStarted = function () {
+    return this.sessionRecording.started()
 }
 
 /**
@@ -1504,7 +1523,9 @@ PostHogLib.prototype['decodeLZ64'] = PostHogLib.prototype.decodeLZ64
 PostHogLib.prototype['SentryIntegration'] = PostHogLib.prototype.sentry_integration
 PostHogLib.prototype['debug'] = PostHogLib.prototype.debug
 PostHogLib.prototype['LIB_VERSION'] = Config.LIB_VERSION
-PostHogLib.prototype['toggleSessionRecording'] = PostHogLib.prototype.toggleSessionRecording
+PostHogLib.prototype['startSessionRecording'] = PostHogLib.prototype.startSessionRecording
+PostHogLib.prototype['stopSessionRecording'] = PostHogLib.prototype.stopSessionRecording
+PostHogLib.prototype['sessionRecordingStarted'] = PostHogLib.prototype.sessionRecordingStarted
 
 // PostHogPersistence Exports
 PostHogPersistence.prototype['properties'] = PostHogPersistence.prototype.properties


### PR DESCRIPTION
## Changes

Partly addresses #220 and closes #214. 

Makes `set_config` update session recording changes appropriately, and also introduces `toggleSessionRecording`, which allows one to turn session recording on and off mid-session. This is the setup necessary for sampling sessions with feature flags (now possible), as well as allow us to provide this an an option in the PostHog UI (still to be built).

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
