### PR TITLE
Do not load toolbar when disabled

### DIFF
--- a/src/__tests__/extensions/toolbar.js
+++ b/src/__tests__/extensions/toolbar.js
@@ -139,7 +139,10 @@ describe('Toolbar', () => {
     })
 
     describe('load and close editor', () => {
-        given('subject', () => () => given.toolbar._loadEditor(given.editorParams))
+        given('localStorage', () => ({
+            getItem: jest.fn(() => true), // toolbar enabled
+        }))
+        given('subject', () => () => given.toolbar._loadEditor(given.editorParams, given.localStorage))
 
         given('editorParams', () => ({
             accessToken: 'accessToken',
@@ -163,19 +166,27 @@ describe('Toolbar', () => {
         given('localStorage', () => ({
             setItem: jest.fn(),
             removeItem: jest.fn(),
+            getItem: jest.fn(() => null),
         }))
 
         it('should enable the toolbar based on the /decide response', () => {
             given('decideResponse', () => ({ isAuthenticated: true, editorParams: { toolbarVersion: 'toolbar' } }))
             given.toolbar.afterDecideResponse(given.decideResponse, given.localStorage)
-            expect(given.localStorage.setItem).not.toHaveBeenCalled()
-            expect(given.localStorage.removeItem).toHaveBeenCalledWith('toolbar_disabled')
+            expect(given.localStorage.setItem).toHaveBeenCalledWith('toolbar_enabled_by_user', '1')
         })
 
         it('should disable the toolbar based on the /decide response', () => {
             given('decideResponse', () => ({}))
             given.toolbar.afterDecideResponse(given.decideResponse, given.localStorage)
-            expect(given.localStorage.setItem).toHaveBeenCalledWith('toolbar_disabled', '1')
+            expect(given.localStorage.setItem).not.toHaveBeenCalled()
+            expect(given.localStorage.removeItem).toHaveBeenCalledWith('toolbar_enabled_by_user')
+        })
+
+        it('should disable the toolbar based on the /decide response', () => {
+            given('editorParams', () => ({ toolbarVersion: 'toolbar' }))
+
+            const toolbarLoaded = given.toolbar._loadEditor(given.editorParams, given.localStorage)
+            expect(toolbarLoaded).toEqual(false)
         })
     })
 })

--- a/src/__tests__/extensions/toolbar.js
+++ b/src/__tests__/extensions/toolbar.js
@@ -158,4 +158,24 @@ describe('Toolbar', () => {
             expect(given.subject()).toBe(false)
         })
     })
+
+    describe('afterDecideResponse', () => {
+        given('localStorage', () => ({
+            setItem: jest.fn(),
+            removeItem: jest.fn(),
+        }))
+
+        it('should enable the toolbar based on the /decide response', () => {
+            given('decideResponse', () => ({ isAuthenticated: true, editorParams: { toolbarVersion: 'toolbar' } }))
+            given.toolbar.afterDecideResponse(given.decideResponse, given.localStorage)
+            expect(given.localStorage.setItem).not.toHaveBeenCalled()
+            expect(given.localStorage.removeItem).toHaveBeenCalledWith('toolbar_disabled')
+        })
+
+        it('should disable the toolbar based on the /decide response', () => {
+            given('decideResponse', () => ({}))
+            given.toolbar.afterDecideResponse(given.decideResponse, given.localStorage)
+            expect(given.localStorage.setItem).toHaveBeenCalledWith('toolbar_disabled', '1')
+        })
+    })
 })

--- a/src/extensions/toolbar.js
+++ b/src/extensions/toolbar.js
@@ -19,9 +19,9 @@ export class Toolbar {
                 ...editorParams,
                 apiURL: this.instance.get_config('api_host'),
             })
-            localStorage.removeItem('toolbar_disabled')
+            localStorage.setItem('toolbar_enabled_by_user', '1')
         } else {
-            localStorage.setItem('toolbar_disabled', '1')
+            localStorage.removeItem('toolbar_enabled_by_user')
         }
     }
 
@@ -75,8 +75,8 @@ export class Toolbar {
         }
     }
 
-    _loadEditor(editorParams) {
-        if (localStorage.getItem('toolbar_disabled') || window['_postHogToolbarLoaded']) {
+    _loadEditor(editorParams, localStorage = window.localStorage) {
+        if (!localStorage.getItem('toolbar_enabled_by_user') || window['_postHogToolbarLoaded']) {
             return false
         }
         // only load the codeless event editor once, even if there are multiple instances of PostHogLib


### PR DESCRIPTION
## Changes

Currently, if a user disables the toolbar, we'll still load it in some cases. 

Needs https://github.com/PostHog/posthog/pull/5526 to work but safe to merge either way

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
