### PR TITLE
Fix deps containing types not being installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,17 @@
         "dist/*",
         "react/dist/*"
     ],
+    "dependencies": {
+        "@sentry/types": "^6.2.2",
+        "fflate": "^0.4.1",
+        "rrweb-snapshot": "^1.1.7"
+    },
     "devDependencies": {
         "@babel/core": "7.12.10",
         "@babel/preset-env": "7.12.11",
         "@rollup/plugin-babel": "^5.2.1",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^8.1.0",
-        "@sentry/types": "^6.2.2",
         "@typescript-eslint/eslint-plugin": "^3.5.0",
         "@typescript-eslint/parser": "^3.5.0",
         "babel-eslint": "10.1.0",
@@ -56,7 +60,6 @@
         "prettier": "^2.0.5",
         "rollup": "^2.18.2",
         "rrweb": "^0.9.9",
-        "rrweb-snapshot": "^1.1.7",
         "sinon": "9.0.2",
         "testcafe": "^1.10.1",
         "testcafe-browser-provider-browserstack": "^1.13.2-alpha.1",
@@ -88,8 +91,5 @@
             "given2/setup"
         ],
         "clearMocks": true
-    },
-    "dependencies": {
-        "fflate": "^0.4.1"
     }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -531,6 +531,11 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@sentry/types@^6.2.2":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.11.0.tgz#5122685478d32ddacd3a891cbcf550012df85f7c"
+  integrity sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
@@ -3085,9 +3090,8 @@ posix-character-classes@^0.1.0:
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
 "posthog-js@link:..":
-  version "1.10.2"
-  dependencies:
-    fflate "^0.4.1"
+  version "0.0.0"
+  uid ""
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -3350,6 +3354,11 @@ rollup@^2.35.1:
   integrity sha512-Ztz4NurU2LbS3Jn5rlhnYv35z6pkjBUmYKr94fOBIKINKRO6kug9NTFHArT7jqwMP2kqEZ39jJuEtkk91NBltQ==
   optionalDependencies:
     fsevents "~2.3.1"
+
+rrweb-snapshot@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.7.tgz#92a3b47b1112a1b566c2fae2edb02fa48a6f6653"
+  integrity sha512-+f2kCCvIQ1hbEeCWnV7mPVPDEdWEExqwcYqMd/r1nfK52QE7qU52jefUOyTe85Vy67rZGqWnfK/B25e/OTSgYg==
 
 rsvp@^4.8.4:
   version "4.8.5"


### PR DESCRIPTION
## Changes

Resolves #252 by putting deps containing necessary types in prod `dependencies`. This should not increase bundle size served to users of our users, since nothing but types is actually imported.
