### PR TITLE
Deprecate client-side feature flag overrides

### DIFF
--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -107,42 +107,6 @@ describe('Decide', () => {
                     'alpha-feature-2': true,
                     'multivariate-flag': 'variant-1',
                 },
-                $override_feature_flags: {},
-            })
-        })
-
-        it('consumes overridden feature flags in decide v2 response', () => {
-            given('decideResponse', () => ({
-                featureFlags: {
-                    'alpha-feature-2': true,
-                    'multivariate-flag': 'variant-3',
-                    'random-feature': true,
-                },
-                originalFeatureFlags: {
-                    'beta-feature': true,
-                    'alpha-feature-2': true,
-                    'multivariate-flag': 'variant-1',
-                },
-                overrideFeatureFlags: {
-                    'beta-feature': false,
-                    'random-feature': true,
-                    'multivariate-flag': 'variant-3',
-                },
-            }))
-            given.subject()
-
-            expect(given.posthog.persistence.register).toHaveBeenLastCalledWith({
-                $active_feature_flags: ['beta-feature', 'alpha-feature-2', 'multivariate-flag'],
-                $enabled_feature_flags: {
-                    'beta-feature': true,
-                    'alpha-feature-2': true,
-                    'multivariate-flag': 'variant-1',
-                },
-                $override_feature_flags: {
-                    'beta-feature': false,
-                    'random-feature': true,
-                    'multivariate-flag': 'variant-3',
-                },
             })
         })
     })

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -91,7 +91,6 @@ describe('Decide', () => {
         })
 
         it('enables multivariate feature flags from decide v2 response', () => {
-            given('config', () => ({ api_host: 'https://test.com' }))
             given('decideResponse', () => ({
                 featureFlags: {
                     'beta-feature': true,
@@ -107,6 +106,42 @@ describe('Decide', () => {
                     'beta-feature': true,
                     'alpha-feature-2': true,
                     'multivariate-flag': 'variant-1',
+                },
+                $override_feature_flags: {},
+            })
+        })
+
+        it('consumes overridden feature flags in decide v2 response', () => {
+            given('decideResponse', () => ({
+                featureFlags: {
+                    'alpha-feature-2': true,
+                    'multivariate-flag': 'variant-3',
+                    'random-feature': true,
+                },
+                originalFeatureFlags: {
+                    'beta-feature': true,
+                    'alpha-feature-2': true,
+                    'multivariate-flag': 'variant-1',
+                },
+                overrideFeatureFlags: {
+                    'beta-feature': false,
+                    'random-feature': true,
+                    'multivariate-flag': 'variant-3',
+                },
+            }))
+            given.subject()
+
+            expect(given.posthog.persistence.register).toHaveBeenLastCalledWith({
+                $active_feature_flags: ['beta-feature', 'alpha-feature-2', 'multivariate-flag'],
+                $enabled_feature_flags: {
+                    'beta-feature': true,
+                    'alpha-feature-2': true,
+                    'multivariate-flag': 'variant-1',
+                },
+                $override_feature_flags: {
+                    'beta-feature': false,
+                    'random-feature': true,
+                    'multivariate-flag': 'variant-3',
                 },
             })
         })

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -13,76 +13,37 @@ describe('featureflags', () => {
         jest.spyOn(given.instance, 'capture').mockReturnValue()
     })
 
-    describe('without override', () => {
-        given('properties', () => ({
-            $override_feature_flags: false,
-            $active_feature_flags: ['beta-feature', 'alpha-feature-2', 'multivariate-flag'],
-            $enabled_feature_flags: {
-                'beta-feature': true,
-                'alpha-feature-2': true,
-                'multivariate-flag': 'variant-1',
-            },
-        }))
+    given('properties', () => ({
+        $active_feature_flags: ['beta-feature', 'alpha-feature-2', 'multivariate-flag'],
+        $enabled_feature_flags: {
+            'beta-feature': true,
+            'alpha-feature-2': true,
+            'multivariate-flag': 'variant-1',
+        },
+    }))
 
-        it('should return the right feature flag and call capture', () => {
-            expect(given.featureFlags.getFlags()).toEqual(['beta-feature', 'alpha-feature-2', 'multivariate-flag'])
-            expect(given.featureFlags.getFlagVariants()).toEqual({
-                'alpha-feature-2': true,
-                'beta-feature': true,
-                'multivariate-flag': 'variant-1',
-            })
-            expect(given.featureFlags.isFeatureEnabled('beta-feature')).toEqual(true)
-            expect(given.featureFlags.isFeatureEnabled('random')).toEqual(false)
-            expect(given.featureFlags.isFeatureEnabled('multivariate-flag')).toEqual(true)
-
-            expect(given.instance.capture).toHaveBeenCalledTimes(3)
-
-            // It should not call `capture` on subsequent calls
-            expect(given.featureFlags.isFeatureEnabled('beta-feature')).toEqual(true)
-            expect(given.instance.capture).toHaveBeenCalledTimes(3)
+    it('should return the right feature flag and call capture', () => {
+        expect(given.featureFlags.getFlags()).toEqual(['beta-feature', 'alpha-feature-2', 'multivariate-flag'])
+        expect(given.featureFlags.getFlagVariants()).toEqual({
+            'alpha-feature-2': true,
+            'beta-feature': true,
+            'multivariate-flag': 'variant-1',
         })
+        expect(given.featureFlags.isFeatureEnabled('beta-feature')).toEqual(true)
+        expect(given.featureFlags.isFeatureEnabled('random')).toEqual(false)
+        expect(given.featureFlags.isFeatureEnabled('multivariate-flag')).toEqual(true)
 
-        it('should propertly merge overridden feature flags', () => {})
+        expect(given.instance.capture).toHaveBeenCalledTimes(3)
 
-        it('should return the right feature flag and not call capture', () => {
-            expect(given.featureFlags.isFeatureEnabled('beta-feature', { send_event: false })).toEqual(true)
-            expect(given.instance.capture).not.toHaveBeenCalled()
-        })
+        // It should not call `capture` on subsequent calls
+        expect(given.featureFlags.isFeatureEnabled('beta-feature')).toEqual(true)
+        expect(given.instance.capture).toHaveBeenCalledTimes(3)
     })
 
-    describe('with override', () => {
-        given('properties', () => ({
-            $active_feature_flags: ['beta-feature', 'alpha-feature-2', 'multivariate-flag'],
-            $enabled_feature_flags: {
-                'beta-feature': true,
-                'alpha-feature-2': true,
-                'multivariate-flag': 'variant-1',
-            },
-            $override_feature_flags: {
-                'beta-feature': false,
-                'random-feature': true,
-                'multivariate-flag': 'variant-3',
-            },
-        }))
+    it('should propertly merge overridden feature flags', () => {})
 
-        it('should return the right feature flag and call capture', () => {
-            expect(given.featureFlags.getFlags()).toEqual(['alpha-feature-2', 'multivariate-flag', 'random-feature'])
-            expect(given.featureFlags.getFlagVariants()).toEqual({
-                'alpha-feature-2': true,
-                'multivariate-flag': 'variant-3',
-                'random-feature': true,
-            })
-            expect(given.featureFlags.isFeatureEnabled('alpha-feature-2')).toEqual(true)
-            expect(given.featureFlags.isFeatureEnabled('beta-feature')).toEqual(false)
-            expect(given.featureFlags.isFeatureEnabled('random')).toEqual(false)
-            expect(given.featureFlags.isFeatureEnabled('random-feature')).toEqual(true)
-            expect(given.featureFlags.isFeatureEnabled('multivariate-flag')).toEqual(true)
-
-            expect(given.instance.capture).toHaveBeenCalledTimes(5)
-
-            // It should not call `capture` on subsequent calls
-            expect(given.featureFlags.isFeatureEnabled('random-feature')).toEqual(true)
-            expect(given.instance.capture).toHaveBeenCalledTimes(5)
-        })
+    it('should return the right feature flag and not call capture', () => {
+        expect(given.featureFlags.isFeatureEnabled('beta-feature', { send_event: false })).toEqual(true)
+        expect(given.instance.capture).not.toHaveBeenCalled()
     })
 })

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -40,8 +40,6 @@ describe('featureflags', () => {
         expect(given.instance.capture).toHaveBeenCalledTimes(3)
     })
 
-    it('should propertly merge overridden feature flags', () => {})
-
     it('should return the right feature flag and not call capture', () => {
         expect(given.featureFlags.isFeatureEnabled('beta-feature', { send_event: false })).toEqual(true)
         expect(given.instance.capture).not.toHaveBeenCalled()

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -793,17 +793,6 @@ declare namespace posthog {
         static onFeatureFlags(
             callback: (flags: string[], variants: Record<string, boolean | string>) => void
         ): false | undefined
-
-        /*
-         * Override feature flags.
-         *
-         * ### Usage:
-         *
-         *     posthog.override({ 'flag-to-enable': true, 'to-disable': false, 'with-variant': 'variant1' })
-         *
-         * @param {Object} [flags] Flags to merge on top of the user's flags
-         */
-        static override(flags: Record<string, boolean | string> | false): void
     }
 
     export class feature_flags extends featureFlags {}

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -793,6 +793,17 @@ declare namespace posthog {
         static onFeatureFlags(
             callback: (flags: string[], variants: Record<string, boolean | string>) => void
         ): false | undefined
+
+        /*
+         * Override feature flags.
+         *
+         * ### Usage:
+         *
+         *     posthog.override({ 'flag-to-enable': true, 'to-disable': false, 'with-variant': 'variant1' })
+         *
+         * @param {Object} [flags] Flags to merge on top of the user's flags
+         */
+        static override(flags: Record<string, boolean | string> | false): void
     }
 
     export class feature_flags extends featureFlags {}

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -749,7 +749,7 @@ PostHogLib.prototype.isFeatureEnabled = function (key, options = {}) {
 }
 
 PostHogLib.prototype.reloadFeatureFlags = function () {
-    return this.feature_flags.reloadFeatureFlags()
+    return this.featureFlags.reloadFeatureFlags()
 }
 
 /*
@@ -764,12 +764,10 @@ PostHogLib.prototype.reloadFeatureFlags = function () {
  *                              It'll return a list of feature flags enabled for the user.
  */
 PostHogLib.prototype.onFeatureFlags = function (callback) {
-    this.persistence.addFeatureFlagsHandler(callback)
-    const flags = this.feature_flags.getFlags()
-    const flagVariants = this.feature_flags.getFlagVariants()
-    if (flags) {
-        callback(flags, flagVariants)
-    }
+    this.featureFlags.addFeatureFlagsHandler(callback)
+    const flags = this.featureFlags.getFlags()
+    const flagVariants = this.featureFlags.getFlagVariants()
+    callback(flags, flagVariants)
 }
 
 /**

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -16,7 +16,7 @@ export const parseFeatureFlagDecideResponse = (response, persistence) => {
                     $active_feature_flags: flags,
                     $enabled_feature_flags,
                 })
-        } else {
+        } else if (flags) {
             // using the v2 api
             persistence &&
                 persistence.register({

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -59,9 +59,10 @@ export class PostHogFeatureFlags {
             this.instance.get_config('api_host') + '/decide/?v=2',
             { data: encoded_data },
             { method: 'POST' },
-            this.instance._prepare_callback((response) =>
+            this.instance._prepare_callback((response) => {
                 parseFeatureFlagDecideResponse(response, this.instance.persistence)
-            )
+                this.receivedFeatureFlags()
+            })
         )
     }
 

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -133,13 +133,18 @@ export class PostHogFeatureFlags {
     }
 
     /*
-     * Override feature flags for debugging.
+     * Override feature flags for debugging. Overridden flags are merged on top of enabled flags.
      *
      * ### Usage:
      *
-     *     posthog.feature_flags.override(['beta-feature']) or posthog.feature_flags.override(false)
+     *     posthog.feature_flags.override({
+     *         'beta-feature': true,       // enable
+     *         'with-variant': 'variant1', // set variant
+     *         'flag-to-disable': false    // disable
+     *     })
+     *     posthog.feature_flags.override(false)
      *
-     * @param {Object|String} prop Flags to override with.
+     * @param {Object|Boolean} prop Flags to override with.
      */
     override(flags) {
         if (flags === false) return this.instance.persistence.unregister('$override_feature_flags')

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -16,12 +16,12 @@ export const parseFeatureFlagDecideResponse = (response, persistence) => {
                     $active_feature_flags: flags,
                     $enabled_feature_flags,
                 })
-        } else if (flags) {
+        } else {
             // using the v2 api
             persistence &&
                 persistence.register({
-                    $active_feature_flags: Object.keys(flags),
-                    $enabled_feature_flags: flags,
+                    $active_feature_flags: Object.keys(flags || {}),
+                    $enabled_feature_flags: flags || {},
                 })
         }
     } else {

--- a/src/posthog-persistence.js
+++ b/src/posthog-persistence.js
@@ -51,7 +51,6 @@ var PostHogPersistence = function (config) {
 
     this['props'] = {}
     this.campaign_params_saved = false
-    this['featureFlagEventHandlers'] = []
 
     if (config['persistence_name']) {
         this.name = 'ph_' + config['persistence_name']
@@ -76,15 +75,6 @@ var PostHogPersistence = function (config) {
     this.load()
     this.update_config(config)
     this.save()
-}
-
-PostHogPersistence.prototype.addFeatureFlagsHandler = function (handler) {
-    this.featureFlagEventHandlers.push(handler)
-    return true
-}
-
-PostHogPersistence.prototype.receivedFeatureFlags = function (flags, variants) {
-    this.featureFlagEventHandlers.forEach((handler) => handler(flags, variants))
 }
 
 PostHogPersistence.prototype.properties = function () {
@@ -141,9 +131,6 @@ PostHogPersistence.prototype.register_once = function (props, default_value, day
             default_value = 'None'
         }
         this.expire_days = typeof days === 'undefined' ? this.default_expiry : days
-        if (props && props.$active_feature_flags && props.$enabled_feature_flags) {
-            this.receivedFeatureFlags(props.$active_feature_flags, props.$enabled_feature_flags)
-        }
 
         _.each(
             props,
@@ -169,9 +156,6 @@ PostHogPersistence.prototype.register_once = function (props, default_value, day
 PostHogPersistence.prototype.register = function (props, days) {
     if (_.isObject(props)) {
         this.expire_days = typeof days === 'undefined' ? this.default_expiry : days
-        if (props && props.$active_feature_flags && props.$enabled_feature_flags) {
-            this.receivedFeatureFlags(props.$active_feature_flags, props.$enabled_feature_flags)
-        }
 
         _.extend(this['props'], props)
 
@@ -186,10 +170,6 @@ PostHogPersistence.prototype.unregister = function (prop) {
     if (prop in this['props']) {
         delete this['props'][prop]
         this.save()
-
-        if (prop === '$active_feature_flags' || prop === '$enabled_feature_flags') {
-            this.receivedFeatureFlags([], {})
-        }
     }
 }
 

--- a/src/posthog-persistence.js
+++ b/src/posthog-persistence.js
@@ -83,8 +83,8 @@ PostHogPersistence.prototype.addFeatureFlagsHandler = function (handler) {
     return true
 }
 
-PostHogPersistence.prototype.receivedFeatureFlags = function (flags) {
-    this.featureFlagEventHandlers.forEach((handler) => handler(flags))
+PostHogPersistence.prototype.receivedFeatureFlags = function (flags, variants) {
+    this.featureFlagEventHandlers.forEach((handler) => handler(flags, variants))
 }
 
 PostHogPersistence.prototype.properties = function () {
@@ -141,8 +141,8 @@ PostHogPersistence.prototype.register_once = function (props, default_value, day
             default_value = 'None'
         }
         this.expire_days = typeof days === 'undefined' ? this.default_expiry : days
-        if (props && props.$active_feature_flags) {
-            this.receivedFeatureFlags(props.$active_feature_flags)
+        if (props && props.$active_feature_flags && props.$enabled_feature_flags) {
+            this.receivedFeatureFlags(props.$active_feature_flags, props.$enabled_feature_flags)
         }
 
         _.each(
@@ -169,8 +169,8 @@ PostHogPersistence.prototype.register_once = function (props, default_value, day
 PostHogPersistence.prototype.register = function (props, days) {
     if (_.isObject(props)) {
         this.expire_days = typeof days === 'undefined' ? this.default_expiry : days
-        if (props && props.$active_feature_flags) {
-            this.receivedFeatureFlags(props.$active_feature_flags)
+        if (props && props.$active_feature_flags && props.$enabled_feature_flags) {
+            this.receivedFeatureFlags(props.$active_feature_flags, props.$enabled_feature_flags)
         }
 
         _.extend(this['props'], props)
@@ -187,8 +187,8 @@ PostHogPersistence.prototype.unregister = function (prop) {
         delete this['props'][prop]
         this.save()
 
-        if (prop === '$active_feature_flags') {
-            this.receivedFeatureFlags([])
+        if (prop === '$active_feature_flags' || prop === '$enabled_feature_flags') {
+            this.receivedFeatureFlags([], {})
         }
     }
 }


### PR DESCRIPTION
## Changes

- Fix a bug now that we have variants in flags.
- Deprecate client-side overrides for feature flags (move from storing overrides on `person` to `user` model)
- Move a bit of feature flag logic from `persistence.js` to `featureflags.js`

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
