### PR TITLE
Add gclid to campaign params

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -629,7 +629,7 @@ _.register_event = (function () {
 
 _.info = {
     campaignParams: function () {
-        var campaign_keywords = 'utm_source utm_medium utm_campaign utm_content utm_term'.split(' '),
+        var campaign_keywords = 'utm_source utm_medium utm_campaign utm_content utm_term gclid'.split(' '),
             kw = '',
             params = {}
         _.each(campaign_keywords, function (kwkey) {


### PR DESCRIPTION
## Changes

This adds "gclid" in addition to "utm_*" as a parameter that's captured from the URL and stored as a property on the user. 

We need this to track conversion from google ad clicks.


## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
