### PR TITLE
Split feature flags into `$feature/*` properties

### DIFF
--- a/src/__tests__/posthog-persistence.js
+++ b/src/__tests__/posthog-persistence.js
@@ -27,4 +27,13 @@ describe('persistence', () => {
         expect(given.lib.props['$referring_domain']).toBe('www.facebook.com')
         expect(given.lib.props['$referrer']).toBe('https://www.facebook.com')
     })
+
+    it('extracts enabled feature flags', () => {
+        given.lib.register({ $enabled_feature_flags: { flag: 'variant', other: true } })
+        expect(given.lib.props['$enabled_feature_flags']).toEqual({ flag: 'variant', other: true })
+        expect(given.lib.properties()).toEqual({
+            '$feature/flag': 'variant',
+            '$feature/other': true,
+        })
+    })
 })

--- a/src/__tests__/posthog-persistence.js
+++ b/src/__tests__/posthog-persistence.js
@@ -1,10 +1,10 @@
 import { PostHogPersistence } from '../posthog-persistence'
 
-let i = 0
+given('lib', () => new PostHogPersistence({ name: 'bla', persistence: 'cookie' }))
 
 describe('persistence', () => {
-    beforeEach(() => {
-        given('lib', () => new PostHogPersistence({ name: 'bla', persistence: 'cookie', token: `${i++}` }))
+    afterEach(() => {
+        given.lib.clear()
     })
 
     it('should set referrer', () => {

--- a/src/__tests__/posthog-persistence.js
+++ b/src/__tests__/posthog-persistence.js
@@ -1,8 +1,12 @@
 import { PostHogPersistence } from '../posthog-persistence'
 
-given('lib', () => new PostHogPersistence({ name: 'bla', persistence: 'cookie' }))
+let i = 0
 
 describe('persistence', () => {
+    beforeEach(() => {
+        given('lib', () => new PostHogPersistence({ name: 'bla', persistence: 'cookie', token: `${i++}` }))
+    })
+
     it('should set referrer', () => {
         // Initial visit
         given.lib.update_referrer_info('https://www.google.com')

--- a/src/posthog-persistence.js
+++ b/src/posthog-persistence.js
@@ -20,6 +20,7 @@ import { cookieStore, localStore, memoryStore } from './storage'
 /** @const */ var EVENT_TIMERS_KEY = '__timers'
 /** @const */ var SESSION_RECORDING_ENABLED = '$session_recording_enabled'
 /** @const */ var SESSION_ID = '$sesid'
+/** @const */ var ENABLED_FEATURE_FLAGS = '$enabled_feature_flags'
 /** @const */ var RESERVED_PROPERTIES = [
     SET_QUEUE_KEY,
     SET_ONCE_QUEUE_KEY,
@@ -34,6 +35,7 @@ import { cookieStore, localStore, memoryStore } from './storage'
     EVENT_TIMERS_KEY,
     SESSION_RECORDING_ENABLED,
     SESSION_ID,
+    ENABLED_FEATURE_FLAGS,
 ]
 
 /**
@@ -81,7 +83,12 @@ PostHogPersistence.prototype.properties = function () {
     var p = {}
     // Filter out reserved properties
     _.each(this['props'], function (v, k) {
-        if (!_.include(RESERVED_PROPERTIES, k)) {
+        if (k === ENABLED_FEATURE_FLAGS && typeof v === 'object') {
+            var keys = Object.keys(v)
+            for (var i = 0; i < keys.length; i++) {
+                p[`$feature/${keys[i]}`] = v[keys[i]]
+            }
+        } else if (!_.include(RESERVED_PROPERTIES, k)) {
             p[k] = v
         }
     })


### PR DESCRIPTION
## Changes

Now that we have multivariate feature flags, we have to store the selected variant in the event's properties to be able to filter for and break down by active variants.

How should that look like?

This is what we had before:

```js
event.properties = {
    $active_feature_flags: ['beta-feature', 'alpha-feature-2', 'multivariate-flag'],
}
```

The obvious choice would be to store them in an object in the properties, such as:

```js
event.properties = {
    $active_feature_flags: ['beta-feature', 'alpha-feature-2', 'multivariate-flag'],
    $enabled_feature_flags: {
        'beta-feature': true,
        'alpha-feature-2': true,
        'multivariate-flag': 'variant-1',
    }
}
```

... but we can't filter for nested properties. Hence it should be one of those options:

```js
event.properties = {
    // keeping for backwards compatibility
    $active_feature_flags: ['beta-feature', 'alpha-feature-2', 'multivariate-flag'],

    // option 1
    'beta-feature': true,
    'alpha-feature-2': true,
    'multivariate-flag': 'variant-1',
     
    // option 2
    '$flag/beta-feature': true,
    '$flag/alpha-feature-2': true,
    '$flag/multivariate-flag': 'variant-1',

    // option 3
    '$feature/beta-feature': true,
    '$feature/alpha-feature-2': true,
    '$feature/multivariate-flag': 'variant-1',

    // option 4
    '$feature_flag/beta-feature': true,
    '$feature_flag/alpha-feature-2': true,
    '$feature_flag/multivariate-flag': 'variant-1',
}
```

My vote goes to option 3, which is implemented in this PR. I chose this version because option 1 might inadvertently conflict with some existing properties, option 4 is too long, and option 2 makes me pause longer than option 3 when I see it.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
