### PR TITLE
Restore feature flag client-side override method

### DIFF
--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -20,6 +20,7 @@ describe('featureflags', () => {
             'alpha-feature-2': true,
             'multivariate-flag': 'variant-1',
         },
+        $override_feature_flags: false,
     }))
 
     it('should return the right feature flag and call capture', () => {
@@ -43,5 +44,25 @@ describe('featureflags', () => {
     it('should return the right feature flag and not call capture', () => {
         expect(given.featureFlags.isFeatureEnabled('beta-feature', { send_event: false })).toEqual(true)
         expect(given.instance.capture).not.toHaveBeenCalled()
+    })
+
+    it('supports overrides', () => {
+        given('properties', () => ({
+            $active_feature_flags: ['beta-feature', 'alpha-feature-2', 'multivariate-flag'],
+            $enabled_feature_flags: {
+                'beta-feature': true,
+                'alpha-feature-2': true,
+                'multivariate-flag': 'variant-1',
+            },
+            $override_feature_flags: {
+                'beta-feature': false,
+                'alpha-feature-2': 'as-a-variant',
+            },
+        }))
+        expect(given.featureFlags.getFlags()).toEqual(['alpha-feature-2', 'multivariate-flag'])
+        expect(given.featureFlags.getFlagVariants()).toEqual({
+            'alpha-feature-2': 'as-a-variant',
+            'multivariate-flag': 'variant-1',
+        })
     })
 })

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -793,6 +793,19 @@ declare namespace posthog {
         static onFeatureFlags(
             callback: (flags: string[], variants: Record<string, boolean | string>) => void
         ): false | undefined
+
+        /*
+         * Override flags locally.
+         *
+         * ### Usage:
+         *
+         *     - posthog.feature_flags.override(false)
+         *     - posthog.feature_flags.override(['beta-feature'])
+         *     - posthog.feature_flags.override({'beta-feature': 'variant', 'other-feature': True})
+         *
+         * @param {Function} [callback] The callback function will be called once the feature flags are ready. It'll return a list of feature flags enabled for the user.
+         */
+        static override(flags: false | string[] | Record<string, boolean | string>): void
     }
 
     export class feature_flags extends featureFlags {}

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -96,7 +96,7 @@ export class PostHogFeatureFlags {
      *
      *     if(posthog.getFeatureFlag('my-flag') === 'some-variant') { // do something }
      *
-     * @param {Object|String} prop Key of the feature flag.
+     * @param {Object|String} key Key of the feature flag.
      * @param {Object|String} options (optional) If {send_event: false}, we won't send an $feature_flag_call event to PostHog.
      */
     getFeatureFlag(key, options = {}) {
@@ -119,7 +119,7 @@ export class PostHogFeatureFlags {
      *
      *     if(posthog.isFeatureEnabled('beta-feature')) { // do something }
      *
-     * @param {Object|String} prop Key of the feature flag.
+     * @param {Object|String} key Key of the feature flag.
      * @param {Object|String} options (optional) If {send_event: false}, we won't send an $feature_flag_call event to PostHog.
      */
     isFeatureEnabled(key, options = {}) {
@@ -149,7 +149,7 @@ export class PostHogFeatureFlags {
      *     - posthog.feature_flags.override(['beta-feature'])
      *     - posthog.feature_flags.override({'beta-feature': 'variant', 'other-feature': True})
      *
-     * @param {Object|String} prop Flags to override with.
+     * @param {Object|Array|String} flags Flags to override with.
      */
     override(flags) {
         this._override_warning = false


### PR DESCRIPTION
## Changes

Resolves https://github.com/PostHog/posthog-js/pull/271#issuecomment-915993730
TODO: add types

The only difference from before is that the `override(flags)` method now also supports the `flags = {flag: 'variant'}` syntax in addition to `['flag1', 'flag2']`. This also means that the `$override_feature_flags` event property will be passed as an object, instead of an array.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
