### PR TITLE
Do not crash when calling capture() after skipping init(), fixes #281

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -432,3 +432,9 @@ describe('init()', () => {
         expect(given.lib['compression']).toBe(undefined)
     })
 })
+
+describe('skipped init()', () => {
+    it('capture() does not throw', () => {
+        expect(() => given.lib.capture('$pageview')).not.toThrow()
+    })
+})

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -141,6 +141,7 @@ describe('capture()', () => {
     )
 
     given('overrides', () => ({
+        __loaded: true,
         get_config: (key) => given.config?.[key],
         config: {
             _onCapture: jest.fn(),

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -531,6 +531,12 @@ PostHogLib.prototype.push = function (item) {
  * @param {String} [options.transport] Transport method for network request ('XHR' or 'sendBeacon').
  */
 PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, properties, options) {
+    // While developing, a developer might purposefully _not_ call init(),
+    // in this case, we could like capture to be a noop
+    if (!this['__loaded']) {
+        return
+    }
+
     this._captureMetrics.incr('capture')
     if (event_name === '$snapshot') {
         this._captureMetrics.incr('snapshot')

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -532,7 +532,7 @@ PostHogLib.prototype.push = function (item) {
  */
 PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, properties, options) {
     // While developing, a developer might purposefully _not_ call init(),
-    // in this case, we could like capture to be a noop
+    // in this case, we would like capture to be a noop.
     if (!this['__loaded']) {
         return
     }


### PR DESCRIPTION
## Bug
When developing on localhost - the [docs](https://posthog.com/docs/integrate/client/js) suggest to skip `posthog.init()` entirely.  However, when you do - any calls to posthog.capture throw.  More details here https://github.com/PostHog/posthog-js/issues/281

## Root Cause
Since `init_as_module` seems to purposefully skips library initialization (and therefore not set `__loaded` or `_captureMetrics` or several other critical members of the PostHogLib class).  Calling instance methods (like capture) on an uninitialized library causes it to throw.

## Changes
Simply checking `posthog.__loaded` can allow any of these methods to noop safely.

## Next Steps
There were several other instance methods that would likely throw if used (I just have no encountered them in my app so far).  At the very least, identify likely does as well.

## Checklist
- [X] Tests for new code (if applicable)
- [X] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
