### PR TITLE
fix: override feature flags not persisted

### DIFF
--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -161,9 +161,9 @@ export class PostHogFeatureFlags {
             for (let i = 0; i < flags.length; i++) {
                 flagsObj[flags[i]] = true
             }
-            this.instance.persistence.register('$override_feature_flags', flagsObj)
+            this.instance.persistence.register({ '$override_feature_flags': flagsObj })
         } else {
-            this.instance.persistence.register('$override_feature_flags', flags)
+            this.instance.persistence.register({ '$override_feature_flags': flags })
         }
     }
 }


### PR DESCRIPTION
## Changes

Fixes the incorrect call to the `override`-function of the persistence object
which expects to receive an `object` instead of `name`, value`-combination.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
