### PR TITLE
Do not load toobar only if autocapture enabled

### DIFF
--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -897,12 +897,6 @@ describe('Autocapture system', () => {
 
             jest.spyOn(autocapture, '_addDomEventHandlers')
         })
-
-        it('should check whether to load the editor', () => {
-            given.subject()
-
-            expect(given.lib.toolbar.maybeLoadEditor).toHaveBeenCalled()
-        })
     })
 
     describe('afterDecideResponse()', () => {

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -231,7 +231,6 @@ var autocapture = {
 
     _customProperties: {},
     init: function (instance) {
-        instance.toolbar.maybeLoadEditor()
         this.rageclicks = new RageClick(instance)
     },
 

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -142,6 +142,7 @@ var create_mplib = function (token, config, name) {
     instance.feature_flags = instance.featureFlags
 
     instance.toolbar = new Toolbar(instance)
+    instance.toolbar.maybeLoadEditor()
 
     instance.sessionRecording = new SessionRecording(instance)
     instance.sessionRecording.startRecordingIfEnabled()


### PR DESCRIPTION
## Changes

Previously the toolbar would load only when autocapture was enabled. While most of what you can do on the toolbar is currently related to just autocapture, it won't be so for long. Plus this caused confusion with a customer who passed `autocapture: false` since the toolbar just wouldn't open.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
