### PR TITLE
Change UTM tags from first touch to last touch

### DIFF
--- a/src/posthog-persistence.js
+++ b/src/posthog-persistence.js
@@ -182,7 +182,7 @@ PostHogPersistence.prototype.unregister = function (prop) {
 
 PostHogPersistence.prototype.update_campaign_params = function () {
     if (!this.campaign_params_saved) {
-        this.register_once(_.info.campaignParams())
+        this.register(_.info.campaignParams())
         this.campaign_params_saved = true
     }
 }


### PR DESCRIPTION
## Changes

Since https://github.com/PostHog/plugin-server/pull/214 we set UTM tags as `initial_utm_...` on the person, so you can get real first touch. It makes sense to now change posthog-js to send utm_ properties as last touch, so you can filter on both depending on what you need.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
