### PR TITLE
Send initial pageview immediately

### DIFF
--- a/cypress/integration/capture.spec.js
+++ b/cypress/integration/capture.spec.js
@@ -211,7 +211,6 @@ describe('Event capture', () => {
                     'Content-Type': 'application/x-www-form-urlencoded',
                 })
                 cy.get('@capture').should(({ request }) => {
-                    console.log(request.body)
                     const data = decodeURIComponent(request.body.match(/data=(.*)/)[1])
                     const captures = JSON.parse(Buffer.from(data, 'base64'))
 

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -52,16 +52,6 @@ declare class posthog {
     ): posthog.CaptureResult
 
     /**
-     * Capture a page view event, which is currently ignored by the server.
-     * This function is called by default on page load unless the
-     * capture_pageview configuration variable is false.
-     *
-     * @param {String} [page] The url of the page to record. If you don't include this, it defaults to the current url.
-     * @api private
-     */
-    static capture_pageview(page?: string): void
-
-    /**
      * Register a set of super properties, which are included with all
      * events. This will overwrite previous super property values.
      *

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -280,7 +280,7 @@ PostHogLib.prototype._loaded = function () {
     // this happens after so a user can call identify in
     // the loaded callback
     if (this.get_config('capture_pageview')) {
-        this.capture_pageview()
+        this.capture('$pageview', {}, {})
     }
 }
 
@@ -649,21 +649,6 @@ PostHogLib.prototype._calculate_event_properties = function (event_name, event_p
     }
 
     return properties
-}
-
-/**
- * Capture a page view event.
- * This function is called by default on page load unless the
- * capture_pageview configuration variable is false.
- *
- * @param {String} [page] The url of the page to record. If you don't include this, it defaults to the current url.
- * @api private
- */
-PostHogLib.prototype.capture_pageview = function (page) {
-    if (_.isUndefined(page)) {
-        page = document.location.href
-    }
-    this.capture('$pageview')
 }
 
 /**
@@ -1502,7 +1487,6 @@ PostHogLib.prototype.decodeLZ64 = LZString.decompressFromBase64
 PostHogLib.prototype['init'] = PostHogLib.prototype.init
 PostHogLib.prototype['reset'] = PostHogLib.prototype.reset
 PostHogLib.prototype['capture'] = PostHogLib.prototype.capture
-PostHogLib.prototype['capture_pageview'] = PostHogLib.prototype.capture_pageview
 PostHogLib.prototype['register'] = PostHogLib.prototype.register
 PostHogLib.prototype['register_once'] = PostHogLib.prototype.register_once
 PostHogLib.prototype['unregister'] = PostHogLib.prototype.unregister

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -280,7 +280,7 @@ PostHogLib.prototype._loaded = function () {
     // this happens after so a user can call identify in
     // the loaded callback
     if (this.get_config('capture_pageview')) {
-        this.capture('$pageview', {}, {})
+        this.capture('$pageview', {}, { send_instantly: true })
     }
 }
 
@@ -589,7 +589,7 @@ PostHogLib.prototype.capture = addOptOutCheckPostHogLib(function (event_name, pr
 
     const has_unique_traits = options !== __NOOPTIONS
 
-    if (this.get_config('request_batching') && (!has_unique_traits || options._batchKey)) {
+    if (this.get_config('request_batching') && (!has_unique_traits || options._batchKey) && !options.send_instantly) {
         data['timestamp'] = new Date()
         this._requestQueue.enqueue(url, data, options)
     } else {


### PR DESCRIPTION
## Changes

This will increase the chance that we capture the initial pageview event if a user navigates away quickly.

Also in the spirit of reducing bundle size I removed the `capture_pageview` function. It was undocumented and likely not used.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
