### PR TITLE
Filter out _ngcontent attributes in autocapture

### DIFF
--- a/src/__tests__/autocapture-utils.js
+++ b/src/__tests__/autocapture-utils.js
@@ -7,6 +7,7 @@ import {
     isSensitiveElement,
     shouldCaptureValue,
     loadScript,
+    isAngularContentAttr,
 } from '../autocapture-utils'
 
 describe(`Autocapture utility functions`, () => {
@@ -354,6 +355,19 @@ describe(`Autocapture utility functions`, () => {
             expect(new_script.type).toBe('text/javascript')
             expect(new_script.src).toBe('https://fake_url/')
             expect(new_script.onload).toBe(callback)
+        })
+    })
+
+    describe('isAngularContentAttr', () => {
+        it('should detect attribute names that match _ngcontent*', () => {
+            expect(isAngularContentAttr('_ngcontent')).toBe(true)
+            expect(isAngularContentAttr('_ngcontent-c1')).toBe(true)
+            expect(isAngularContentAttr('_ngcontent-dpm-c448')).toBe(true)
+        })
+        it('should not detect attribute names that dont start with _ngcontent', () => {
+            expect(isAngularContentAttr('_ng-attr')).toBe(false)
+            expect(isAngularContentAttr('style')).toBe(false)
+            expect(isAngularContentAttr('class-name')).toBe(false)
         })
     })
 })

--- a/src/__tests__/autocapture-utils.js
+++ b/src/__tests__/autocapture-utils.js
@@ -369,5 +369,9 @@ describe(`Autocapture utility functions`, () => {
             expect(isAngularContentAttr('style')).toBe(false)
             expect(isAngularContentAttr('class-name')).toBe(false)
         })
+        it('should be safe for non-string attribute names', () => {
+            expect(isAngularContentAttr(1)).toBe(false)
+            expect(isAngularContentAttr(null)).toBe(false)
+        })
     })
 })

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -21,7 +21,7 @@ describe('Autocapture system', () => {
     })
 
     describe('_getPropertiesFromElement', () => {
-        let div, div2, input, sensitiveInput, hidden, password
+        let div, div2, input, sensitiveInput, hidden, password, angularDiv
         beforeEach(() => {
             div = document.createElement('div')
             div.className = 'class1 class2 class3          ' // Lots of spaces might mess things up
@@ -41,6 +41,9 @@ describe('Autocapture system', () => {
             password = document.createElement('div')
             password.setAttribute('type', 'password')
             password.value = 'password val'
+
+            angularDiv = document.createElement('div')
+            angularDiv.setAttribute('_ngcontent-dpm-c448', '')
 
             const divSibling = document.createElement('div')
             const divSibling2 = document.createElement('span')
@@ -94,6 +97,11 @@ describe('Autocapture system', () => {
         it('should contain nth-child', () => {
             const props = autocapture._getPropertiesFromElement(password)
             expect(props['nth_child']).toBe(7)
+        })
+
+        it('should filter out Angular content attributes', () => {
+            const props = autocapture._getPropertiesFromElement(angularDiv)
+            expect(props['_ngcontent-dpm-c448']).toBeUndefined()
         })
     })
 

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -21,7 +21,7 @@ describe('Autocapture system', () => {
     })
 
     describe('_getPropertiesFromElement', () => {
-        let div, div2, input, sensitiveInput, hidden, password, angularDiv
+        let div, div2, input, sensitiveInput, hidden, password
         beforeEach(() => {
             div = document.createElement('div')
             div.className = 'class1 class2 class3          ' // Lots of spaces might mess things up
@@ -41,9 +41,6 @@ describe('Autocapture system', () => {
             password = document.createElement('div')
             password.setAttribute('type', 'password')
             password.value = 'password val'
-
-            angularDiv = document.createElement('div')
-            angularDiv.setAttribute('_ngcontent-dpm-c448', '')
 
             const divSibling = document.createElement('div')
             const divSibling2 = document.createElement('span')
@@ -100,6 +97,8 @@ describe('Autocapture system', () => {
         })
 
         it('should filter out Angular content attributes', () => {
+            const angularDiv = document.createElement('div')
+            angularDiv.setAttribute('_ngcontent-dpm-c448', '')
             const props = autocapture._getPropertiesFromElement(angularDiv)
             expect(props['_ngcontent-dpm-c448']).toBeUndefined()
         })

--- a/src/autocapture-utils.js
+++ b/src/autocapture-utils.js
@@ -246,7 +246,7 @@ export function shouldCaptureValue(value) {
  * @returns {boolean} whether the element is an angular tag
  */
 export function isAngularContentAttr(attributeName) {
-    return attributeName.startsWith('_ngcontent')
+    return attributeName.substring(0, 10) === '_ngcontent'
 }
 
 export function loadScript(scriptUrlToLoad, callback) {

--- a/src/autocapture-utils.js
+++ b/src/autocapture-utils.js
@@ -238,6 +238,17 @@ export function shouldCaptureValue(value) {
     return true
 }
 
+/*
+ * Check whether an attribute name is an Angular content attr
+ * These update on each build and lead to noise in the element chain
+ * https://stackoverflow.com/questions/45082129/what-does-ngcontent-c-mean-in-angular
+ * @param {string} attributeName - string value to check
+ * @returns {boolean} whether the element is an angular tag
+ */
+export function isAngularContentAttr(attributeName) {
+    return attributeName.startsWith('_ngcontent')
+}
+
 export function loadScript(scriptUrlToLoad, callback) {
     var scriptTag = document.createElement('script')
     scriptTag.type = 'text/javascript'

--- a/src/autocapture-utils.js
+++ b/src/autocapture-utils.js
@@ -246,7 +246,10 @@ export function shouldCaptureValue(value) {
  * @returns {boolean} whether the element is an angular tag
  */
 export function isAngularContentAttr(attributeName) {
-    return attributeName.substring(0, 10) === '_ngcontent'
+    if (typeof attributeName === 'string') {
+        return attributeName.substring(0, 10) === '_ngcontent'
+    }
+    return false
 }
 
 export function loadScript(scriptUrlToLoad, callback) {

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -10,6 +10,7 @@ import {
     shouldCaptureElement,
     shouldCaptureValue,
     usefulElements,
+    isAngularContentAttr,
 } from './autocapture-utils'
 import RageClick from './extensions/rageclick'
 
@@ -46,7 +47,7 @@ var autocapture = {
             // Only capture attributes we know are safe
             if (isSensitiveElement(elem) && ['name', 'id', 'class'].indexOf(attr.name) === -1) return
 
-            if (!maskInputs && shouldCaptureValue(attr.value)) {
+            if (!maskInputs && shouldCaptureValue(attr.value) && !isAngularContentAttr(attr.name)) {
                 props['attr__' + attr.name] = attr.value
             }
         })

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -161,9 +161,9 @@ export class PostHogFeatureFlags {
             for (let i = 0; i < flags.length; i++) {
                 flagsObj[flags[i]] = true
             }
-            this.instance.persistence.register({ '$override_feature_flags': flagsObj })
+            this.instance.persistence.register({ $override_feature_flags: flagsObj })
         } else {
-            this.instance.persistence.register({ '$override_feature_flags': flags })
+            this.instance.persistence.register({ $override_feature_flags: flags })
         }
     }
 }


### PR DESCRIPTION
## Changes

This change filters out attributes like `_ngcontent-dpm-c448` or `_ngcontent-c1` in autocapture. These attributes are auto generated by Angular and change on each build, so with them included, there isn't consistency on the event chains between builds, and as a result, our heatmap feature breaks.

Related issue: https://github.com/PostHog/posthog/issues/6135

## Checklist
- [x] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
