### PR TITLE
Reduce code paths that could encode post data as the string undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-react": "^7.21.5",
         "eslint-plugin-react-hooks": "^4.2.0",
+        "fast-check": "^2.17.0",
         "given2": "^2.1.7",
         "husky": "^4.2.5",
         "jest": "^26.1.0",

--- a/src/__tests__/__snapshots__/send-request.js.snap
+++ b/src/__tests__/__snapshots__/send-request.js.snap
@@ -30,18 +30,6 @@ Array [
 ]
 `;
 
-exports[`encodePostData() handles sendBeacon when blob is also true 1`] = `
-Array [
-  "Blob",
-  Array [
-    "data=content",
-  ],
-  Object {
-    "type": "application/x-www-form-urlencoded",
-  },
-]
-`;
-
 exports[`encodePostData() handles sendBeacon when data is a typed array and blob is also true 1`] = `
 Array [
   "Blob",

--- a/src/__tests__/__snapshots__/send-request.js.snap
+++ b/src/__tests__/__snapshots__/send-request.js.snap
@@ -41,3 +41,27 @@ Array [
   },
 ]
 `;
+
+exports[`encodePostData() handles sendBeacon when data is a typed array and blob is also true 1`] = `
+Array [
+  "Blob",
+  Array [
+    ArrayBuffer [],
+  ],
+  Object {
+    "type": "text/plain",
+  },
+]
+`;
+
+exports[`encodePostData() handles sendBeacon when data is not a typed array and blob is also true 1`] = `
+Array [
+  "Blob",
+  Array [
+    "data=content",
+  ],
+  Object {
+    "type": "application/x-www-form-urlencoded",
+  },
+]
+`;

--- a/src/__tests__/__snapshots__/send-request.js.snap
+++ b/src/__tests__/__snapshots__/send-request.js.snap
@@ -29,3 +29,15 @@ Array [
   },
 ]
 `;
+
+exports[`encodePostData() handles sendBeacon when blob is also true 1`] = `
+Array [
+  "Blob",
+  Array [
+    "data=content",
+  ],
+  Object {
+    "type": "application/x-www-form-urlencoded",
+  },
+]
+`;

--- a/src/__tests__/send-request.js
+++ b/src/__tests__/send-request.js
@@ -104,4 +104,10 @@ describe('encodePostData()', () => {
 
         expect(given.subject).toMatchSnapshot()
     })
+
+    it('handles sendBeacon when blob is also true', () => {
+        given('options', () => ({ method: 'POST', sendBeacon: true, blob: true }))
+
+        expect(given.subject).toMatchSnapshot()
+    })
 })

--- a/src/__tests__/send-request.js
+++ b/src/__tests__/send-request.js
@@ -1,4 +1,4 @@
-import { encodePostData } from '../send-request'
+import { encodePostData, xhr } from '../send-request'
 import { assert, boolean, property, uint8Array, VerbosityLevel } from 'fast-check'
 
 describe('when xhr requests fail', () => {

--- a/src/__tests__/send-request.js
+++ b/src/__tests__/send-request.js
@@ -67,7 +67,7 @@ describe('using property based testing to identify edge cases in encodePostData'
             property(uint8Array(), boolean(), boolean(), (data, blob, sendBeacon) => {
                 const encodedData = encodePostData(data, { blob, sendBeacon, method: 'POST' })
                 // returns blob or string - ignore when it is not a string response
-                return (encodedData.indexOf && encodedData.indexOf('undefined') < 0) || true
+                return encodedData.indexOf && encodedData.indexOf('undefined') < 0
             }),
             { numRuns: 1000, verbose: VerbosityLevel.VeryVerbose }
         )

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -1,17 +1,16 @@
 import { _, console } from './utils'
 
 export const encodePostData = (data, options) => {
-    if (options.blob) {
-        if (data.buffer) {
-            return new Blob([data.buffer], { type: 'text/plain' })
-        } else {
-            const body = encodePostData(data, { method: 'POST' })
-            return new Blob([body], { type: 'application/x-www-form-urlencoded' })
-        }
-    } else if (options.sendBeacon) {
+    if (options.blob && data.buffer) {
+        return new Blob([data.buffer], { type: 'text/plain' })
+    }
+
+    if (options.sendBeacon || options.blob) {
         const body = encodePostData(data, { method: 'POST' })
         return new Blob([body], { type: 'application/x-www-form-urlencoded' })
-    } else if (options.method !== 'POST') {
+    }
+
+    if (options.method !== 'POST') {
         return null
     }
 

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -16,8 +16,8 @@ export const encodePostData = (data, options) => {
     }
 
     let body_data
-    const isTypedArray = (d) => ArrayBuffer.isView(d) && Object.prototype.toString.call(d) !== '[object DataView]'
-    if (Array.isArray(data) || isTypedArray(data)) {
+    const isUint8Array = (d) => Object.prototype.toString.call(d) === '[object Uint8Array]'
+    if (Array.isArray(data) || isUint8Array(data)) {
         body_data = 'data=' + encodeURIComponent(data)
     } else {
         body_data = 'data=' + encodeURIComponent(data['data'])

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -1,11 +1,11 @@
 import { _, console } from './utils'
 
 export const encodePostData = (data, options) => {
-    if (options.blob) {
-        return new Blob([data.buffer], { type: 'text/plain' })
-    } else if (options.sendBeacon) {
+    if (options.sendBeacon) {
         const body = encodePostData(data, { method: 'POST' })
         return new Blob([body], { type: 'application/x-www-form-urlencoded' })
+    } else if (options.blob) {
+        return new Blob([data.buffer], { type: 'text/plain' })
     } else if (options.method !== 'POST') {
         return null
     }

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -1,17 +1,23 @@
 import { _, console } from './utils'
 
 export const encodePostData = (data, options) => {
-    if (options.sendBeacon) {
+    if (options.blob) {
+        if (data.buffer) {
+            return new Blob([data.buffer], { type: 'text/plain' })
+        } else {
+            const body = encodePostData(data, { method: 'POST' })
+            return new Blob([body], { type: 'application/x-www-form-urlencoded' })
+        }
+    } else if (options.sendBeacon) {
         const body = encodePostData(data, { method: 'POST' })
         return new Blob([body], { type: 'application/x-www-form-urlencoded' })
-    } else if (options.blob) {
-        return new Blob([data.buffer], { type: 'text/plain' })
     } else if (options.method !== 'POST') {
         return null
     }
 
     let body_data
-    if (Array.isArray(data)) {
+    const isTypedArray = (d) => ArrayBuffer.isView(d) && Object.prototype.toString.call(d) !== '[object DataView]'
+    if (Array.isArray(data) || isTypedArray(data)) {
         body_data = 'data=' + encodeURIComponent(data)
     } else {
         body_data = 'data=' + encodeURIComponent(data['data'])

--- a/yarn.lock
+++ b/yarn.lock
@@ -6113,6 +6113,13 @@ falafel@^2.1.0:
     isarray "^2.0.1"
     object-keys "^1.0.6"
 
+fast-check@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-2.17.0.tgz#9b9637684332be386219a5f73a4799874da7461c"
+  integrity sha512-fNNKkxNEJP+27QMcEzF6nbpOYoSZIS0p+TyB+xh/jXqRBxRhLkiZSREly4ruyV8uJi7nwH1YWAhi7OOK5TubRw==
+  dependencies:
+    pure-rand "^5.0.0"
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -10088,6 +10095,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+pure-rand@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-5.0.0.tgz#87f5bdabeadbd8904e316913a5c0b8caac517b37"
+  integrity sha512-lD2/y78q+7HqBx2SaT6OT4UcwtvXNRfEpzYEzl0EQ+9gZq2Qi3fa0HDnYPeqQwhlHJFBUhT7AO3mLU3+8bynHA==
 
 purgecss@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
[Property based testing](https://medium.com/criteo-engineering/introduction-to-property-based-testing-f5236229d237) is a mechanism of sending many different combinations of arguments into some software and asserting on the general result of that. 

Often when property based testing libraries find possible failures. They search for simpler examples of the failure to make them easy to understand. E.g. A library will try to identify not that failures are caused by "very long strings" but instead that they're caused by "strings longer than 6400 characters"

Imagine someone has implemented an algorithm which should always generate a number below 100

```
const fancyAlgorithm = (n) => n > 7 ? 99 : 101
```

It is easy to see in this simple example that the implementation doesn't meet the spec. But it isn't always easy to see that in real code.

using [fast check](https://github.com/dubzzz/fast-check) we could test that the code has the property "regardless of the number given as input it generates a number less than 100"

```
import * as fc from 'fast-check'

fc.assert(
  fc.property(
    //generate number for input
    fc.integer(),
    // express the property
    (n) => fancyAlgorithm(n) < 100
  )
)
```
In this output below we can see FastCheck tried a negative number, identified a failure, and then tried zero to see if that still failed. When it did it reported zero as a counter example to the rule it had been given

![image](https://user-images.githubusercontent.com/984817/135609618-da6e5808-b829-4a0a-ba5f-ef6a5678a002.png)

In PostHog/posthog#4816 we see many instances of the API receiving an event or screen recording payload where the body is the literal value "undefined"

It is not easy to identify what is causing this

This PR uses property based testing to identify routes through the `encodePostData` method which could cause that output

Fast check allows the test below

```
describe('using property based testing to identify edge cases in encodePostData', () => {
    it('can use many combinations of typed arrays and options to detect if the method generates undefined', () => {
        assert(
            property(
                // the fast check framework runs the same test many times
                // these methods generate different values to use as input
                uint8Array(),
                boolean(),
                boolean(),
                // the test framework tries to be clever about generating values
                // or combinations that are more likely to cause a fail
                // e.g. very long strings or unusual string encodings for string inputs
                (data, blob, sendBeacon) => {
                // this method receives the generated parameters
                // uses them
                // and then returns true or false
                // false means that combination of parameters don't work as expected
                    const encodedData = encodePostData(data, { blob, sendBeacon, method: 'POST' })
                    // returns blob or string - ignore when it is not a string response
                    return (encodedData.indexOf && encodedData.indexOf('undefined') < 0) || true
                }
            ),
            { numRuns: 1000 } // default is 100 combinations
        )
    })
})
```

that property based test identifed a combination that generated the body `data=undefined`

```
    // this was identified as a combination that generated `data=undefined`, and the code could be fixed to stop that
    it('does not return undefined when blob and send beacon are false and the input is an empty uint8array', () => {
        const encodedData = encodePostData(new Uint8Array([]), { method: 'POST' })
        expect(typeof encodedData).toBe('string')
        expect(encodedData).toBe('data=')
    })
```

if both `options.blob` and `options.sendBeacon` were false ) _and_ the input was a `TypedArray` then the undesirable input was generated.

Within the code was the check `Array.isArray` which fails for a `TypedArray` (thanks, JavaScript) and as a result the code would treat the input as an object and try to read a data property.

That can now be made impossible

NB that doesn't mean that the running application does travel that code path but that the code path was present and could have been travelled