### PR TITLE
fix: localStorage access denied error being thrown

### DIFF
--- a/src/extensions/toolbar.js
+++ b/src/extensions/toolbar.js
@@ -36,7 +36,6 @@ export class Toolbar {
                     window.localStorage.setItem('test', 'test')
                     window.localStorage.removeItem('test')
                 } catch (error) {
-                    console.log('Error occurred with message:', error.message, error)
                     return false
                 }
 


### PR DESCRIPTION
## Changes
The function `maybeLoadError` has `window.localStorage` as a default value
accessing `localStorage` can throw an error when the code is running in
a restricted area were accessing `localStorage` is denied

Now if `localStorage` is not accessible it will return `false` so the
Toolar won't get loaded in these circumstances

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
