### PR TITLE
Expand allowed input types for autocapture

### DIFF
--- a/src/autocapture-utils.js
+++ b/src/autocapture-utils.js
@@ -196,8 +196,9 @@ export function shouldCaptureElement(el) {
 export function isSensitiveElement(el) {
     // don't send data from inputs or similar elements since there will always be
     // a risk of clientside javascript placing sensitive data in attributes
+    const allowedInputTypes = ['button', 'checkbox', 'submit', 'reset']
     if (
-        (isTag(el, 'input') && el.type != 'button') ||
+        (isTag(el, 'input') && !allowedInputTypes.includes(el.type)) ||
         isTag(el, 'select') ||
         isTag(el, 'textarea') ||
         el.getAttribute('contenteditable') === 'true'


### PR DESCRIPTION
## Changes

Expands the definition of _non-sensitive_ `<input>` types to include 'button', 'checkbox', 'submit', 'reset'. Previously it was only 'button'.

Related to https://github.com/PostHog/posthog-js/issues/314. A user was quite surprised to see data-attrs being removed from a checkbox.


## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
