### PR TITLE
Update to rrweb 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "posthog-js": "link:.",
         "prettier": "^2.0.5",
         "rollup": "^2.18.2",
-        "rrweb": "^1.0.3",
+        "rrweb": "^1.0.6",
         "sinon": "9.0.2",
         "testcafe": "^1.10.1",
         "testcafe-browser-provider-browserstack": "^1.13.2-alpha.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10578,21 +10578,21 @@ rrweb-snapshot@^1.1.7:
   resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.7.tgz#92a3b47b1112a1b566c2fae2edb02fa48a6f6653"
   integrity sha512-+f2kCCvIQ1hbEeCWnV7mPVPDEdWEExqwcYqMd/r1nfK52QE7qU52jefUOyTe85Vy67rZGqWnfK/B25e/OTSgYg==
 
-rrweb-snapshot@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.8.tgz#57c3a8003a6ebbe4a2e2f5be29e30a47a8b1eb03"
-  integrity sha512-wi8T9IVobEwlns7U2m8cbPfoihsNAMpTI+UBe4KUjclU2N+vtowD2U1Rq8PleiFTDvcseHvkQDmEIZoZLXFzwg==
+rrweb-snapshot@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.9.tgz#f8d0f560291a37dab00dc5ac6d9368f76208256f"
+  integrity sha512-kpoWi2gx1AmX2PZU8XNKMvIvh5WPSz9lKfyHs9GYvczYE2H7VNrmPf7+rDin8Y+HcJ9Tu7x9id4JOCD2PsSPQA==
 
-rrweb@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-1.0.3.tgz#6f8b72eb6467240903eba1bcf83b636bfb1265b6"
-  integrity sha512-DcV0vHqXActQl0fOXuZO+nXe0hMfJAVrAGikq7Se5kLqU6zty/6QZbNGHBq5djW8fDeLRikRy8uymVJYeDEBTw==
+rrweb@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-1.0.6.tgz#381027a4331c610739145dc4142364be680504ba"
+  integrity sha512-uiRpPMNEd1oMqNYRelKBz28WBLXQEirx9u+nlTIaxk65fbTEUyKBr81GhcUSjeZAsTpkUtIAHacS0Gjz35x/Rw==
   dependencies:
     "@types/css-font-loading-module" "0.0.4"
     "@xstate/fsm" "^1.4.0"
     fflate "^0.4.4"
     mitt "^1.1.3"
-    rrweb-snapshot "^1.1.8"
+    rrweb-snapshot "^1.1.9"
 
 rsvp@^4.8.4:
   version "4.8.5"


### PR DESCRIPTION
## Changes

rrweb 1.0.6 has a few fixes. Notably: https://github.com/rrweb-io/rrweb/pull/696

This change ensures elements in incremental updates that have `ph-no-capture` as a classname will be replaced by a black box. Before, these elements were just removed if they were added to the dom after the first load.

Should resolve: https://github.com/PostHog/posthog/issues/2258

