### PR TITLE
Filter out _nghost attributes from autocapture

### DIFF
--- a/src/__tests__/autocapture-utils.js
+++ b/src/__tests__/autocapture-utils.js
@@ -7,7 +7,7 @@ import {
     isSensitiveElement,
     shouldCaptureValue,
     loadScript,
-    isAngularContentAttr,
+    isAngularStyleAttr,
 } from '../autocapture-utils'
 
 describe(`Autocapture utility functions`, () => {
@@ -358,20 +358,25 @@ describe(`Autocapture utility functions`, () => {
         })
     })
 
-    describe('isAngularContentAttr', () => {
+    describe('isAngularStyleAttr', () => {
         it('should detect attribute names that match _ngcontent*', () => {
-            expect(isAngularContentAttr('_ngcontent')).toBe(true)
-            expect(isAngularContentAttr('_ngcontent-c1')).toBe(true)
-            expect(isAngularContentAttr('_ngcontent-dpm-c448')).toBe(true)
+            expect(isAngularStyleAttr('_ngcontent')).toBe(true)
+            expect(isAngularStyleAttr('_ngcontent-c1')).toBe(true)
+            expect(isAngularStyleAttr('_ngcontent-dpm-c448')).toBe(true)
         })
-        it('should not detect attribute names that dont start with _ngcontent', () => {
-            expect(isAngularContentAttr('_ng-attr')).toBe(false)
-            expect(isAngularContentAttr('style')).toBe(false)
-            expect(isAngularContentAttr('class-name')).toBe(false)
+        it('should detect attribute names that match _nghost*', () => {
+            expect(isAngularStyleAttr('_nghost')).toBe(true)
+            expect(isAngularStyleAttr('_nghost-c1')).toBe(true)
+            expect(isAngularStyleAttr('_nghost-dpm-c448')).toBe(true)
+        })
+        it('should not detect attribute names that dont start with _ngcontent or _nghost', () => {
+            expect(isAngularStyleAttr('_ng-attr')).toBe(false)
+            expect(isAngularStyleAttr('style')).toBe(false)
+            expect(isAngularStyleAttr('class-name')).toBe(false)
         })
         it('should be safe for non-string attribute names', () => {
-            expect(isAngularContentAttr(1)).toBe(false)
-            expect(isAngularContentAttr(null)).toBe(false)
+            expect(isAngularStyleAttr(1)).toBe(false)
+            expect(isAngularStyleAttr(null)).toBe(false)
         })
     })
 })

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -103,8 +103,10 @@ describe('Autocapture system', () => {
         it('should filter out Angular content attributes', () => {
             const angularDiv = document.createElement('div')
             angularDiv.setAttribute('_ngcontent-dpm-c448', '')
+            angularDiv.setAttribute('_nghost-dpm-c448', '')
             const props = autocapture._getPropertiesFromElement(angularDiv)
             expect(props['_ngcontent-dpm-c448']).toBeUndefined()
+            expect(props['_nghost-dpm-c448']).toBeUndefined()
         })
     })
 

--- a/src/autocapture-utils.js
+++ b/src/autocapture-utils.js
@@ -242,7 +242,7 @@ export function shouldCaptureValue(value) {
 /*
  * Check whether an attribute name is an Angular style attr (either _ngcontent or _nghost)
  * These update on each build and lead to noise in the element chain
- * https://stackoverflow.com/questions/45082129/what-does-ngcontent-c-mean-in-angular
+ * More details on the attributes here: https://angular.io/guide/view-encapsulation
  * @param {string} attributeName - string value to check
  * @returns {boolean} whether the element is an angular tag
  */

--- a/src/autocapture-utils.js
+++ b/src/autocapture-utils.js
@@ -240,15 +240,15 @@ export function shouldCaptureValue(value) {
 }
 
 /*
- * Check whether an attribute name is an Angular content attr
+ * Check whether an attribute name is an Angular style attr (either _ngcontent or _nghost)
  * These update on each build and lead to noise in the element chain
  * https://stackoverflow.com/questions/45082129/what-does-ngcontent-c-mean-in-angular
  * @param {string} attributeName - string value to check
  * @returns {boolean} whether the element is an angular tag
  */
-export function isAngularContentAttr(attributeName) {
+export function isAngularStyleAttr(attributeName) {
     if (typeof attributeName === 'string') {
-        return attributeName.substring(0, 10) === '_ngcontent'
+        return attributeName.substring(0, 10) === '_ngcontent' || attributeName.substring(0, 7) === '_nghost'
     }
     return false
 }

--- a/src/autocapture.js
+++ b/src/autocapture.js
@@ -10,7 +10,7 @@ import {
     shouldCaptureElement,
     shouldCaptureValue,
     usefulElements,
-    isAngularContentAttr,
+    isAngularStyleAttr,
 } from './autocapture-utils'
 import RageClick from './extensions/rageclick'
 
@@ -47,7 +47,7 @@ var autocapture = {
             // Only capture attributes we know are safe
             if (isSensitiveElement(elem) && ['name', 'id', 'class'].indexOf(attr.name) === -1) return
 
-            if (!maskInputs && shouldCaptureValue(attr.value) && !isAngularContentAttr(attr.name)) {
+            if (!maskInputs && shouldCaptureValue(attr.value) && !isAngularStyleAttr(attr.name)) {
                 props['attr__' + attr.name] = attr.value
             }
         })


### PR DESCRIPTION
## Changes

In [this PR](https://github.com/PostHog/posthog-js/pull/298), we added a filter for the angular style attribute `_ngcontent*`. These lead to a lot of noise in the element chain (and a potentially broken heat map) because they update on each build.

Turns out angular also uses a `_nghost*` attribute for "elements that would be a shadow DOM host in native encapsulation", and this was another source of noise. This PR filters out all attributes that match the `_nghost*` pattern too.


## Checklist
- [x] Tests for new code (if applicable)
