### PR TITLE
allow disabling toolbar tracking for self-hosted users

### DIFF
--- a/src/extensions/toolbar.js
+++ b/src/extensions/toolbar.js
@@ -7,6 +7,9 @@ export class Toolbar {
     }
 
     afterDecideResponse(response) {
+        const disableToolbarMetrics =
+            this.instance.get_config('api_host') !== 'https://app.posthog.com' &&
+            this.instance.get_config('advanced_disable_toolbar_metrics')
         const editorParams =
             response['editorParams'] ||
             (response['toolbarVersion'] ? { toolbarVersion: response['toolbarVersion'] } : {})
@@ -18,6 +21,7 @@ export class Toolbar {
             this._loadEditor({
                 ...editorParams,
                 apiURL: this.instance.get_config('api_host'),
+                instrument: !!editorParams['instrument'] && !disableToolbarMetrics,
             })
             this.instance.set_config({ debug: true })
         }

--- a/src/extensions/toolbar.js
+++ b/src/extensions/toolbar.js
@@ -7,9 +7,6 @@ export class Toolbar {
     }
 
     afterDecideResponse(response) {
-        const disableToolbarMetrics =
-            this.instance.get_config('api_host') !== 'https://app.posthog.com' &&
-            this.instance.get_config('advanced_disable_toolbar_metrics')
         const editorParams =
             response['editorParams'] ||
             (response['toolbarVersion'] ? { toolbarVersion: response['toolbarVersion'] } : {})
@@ -21,7 +18,6 @@ export class Toolbar {
             this._loadEditor({
                 ...editorParams,
                 apiURL: this.instance.get_config('api_host'),
-                ...(disableToolbarMetrics ? { instrument: false } : {}),
             })
             this.instance.set_config({ debug: true })
         }
@@ -98,6 +94,10 @@ export class Toolbar {
             const toolbarScript = 'toolbar.js'
             const editorUrl =
                 host + (host.endsWith('/') ? '' : '/') + 'static/' + toolbarScript + '?_ts=' + new Date().getTime()
+            const disableToolbarMetrics =
+                this.instance.get_config('api_host') !== 'https://app.posthog.com' &&
+                this.instance.get_config('advanced_disable_toolbar_metrics')
+            editorParams = { ...editorParams, ...(disableToolbarMetrics ? { instrument: false } : {}) }
             loadScript(editorUrl, () => {
                 window['ph_load_editor'](editorParams, this.instance)
             })

--- a/src/extensions/toolbar.js
+++ b/src/extensions/toolbar.js
@@ -21,7 +21,7 @@ export class Toolbar {
             this._loadEditor({
                 ...editorParams,
                 apiURL: this.instance.get_config('api_host'),
-                instrument: !!editorParams['instrument'] && !disableToolbarMetrics,
+                ...(disableToolbarMetrics ? { instrument: false } : {}),
             })
             this.instance.set_config({ debug: true })
         }

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -294,6 +294,12 @@ declare class posthog {
      *      // autocapture, feature flags, compression and session recording will be disabled when set to `true`
      *      advanced_disable_decide: false
      *
+     *
+     *      // disable capturing of metrics about toolbar usage
+     *      // only available to self-hosted users, changing this
+     *      // setting will not do  anything if you use PostHog Cloud
+     *      advanced_disable_toolbar_metrics: false
+     *
      *     }
      *
      *
@@ -605,6 +611,7 @@ declare namespace posthog {
         mask_all_element_attributes?: boolean
         mask_all_text?: boolean
         advanced_disable_decide?: boolean
+        advanced_disable_toolbar_metrics?: boolean
     }
 
     interface OptInOutCapturingOptions {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -101,6 +101,7 @@ const defaultConfig = () => ({
     mask_all_element_attributes: false,
     mask_all_text: false,
     advanced_disable_decide: false,
+    advanced_disable_toolbar_metrics: false,
     on_xhr_error: (req) => {
         const error = 'Bad HTTP status: ' + req.status + ' ' + req.statusText
         console.error(error)


### PR DESCRIPTION
## Changes

The instrumentation we have for the toolbar causes issues for self-hosted users due to CSP policies. They should be able to disable this.

The best solution would be a setting in the UI for project settings, but moving fast here to help out a user.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
