### PR TITLE
Avoid needless /decide calls

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -138,6 +138,32 @@ describe('identify()', () => {
             expect(given.overrides.register).not.toHaveBeenCalled()
         })
     })
+
+    describe('reloading feature flags', () => {
+        it('reloads when identity changes', () => {
+            given.subject()
+
+            expect(given.overrides.reloadFeatureFlags).toHaveBeenCalled()
+        })
+
+        it('does not reload feature flags if identity does not change', () => {
+            given('oldIdentity', () => given.identity)
+
+            given.subject()
+
+            expect(given.overrides.reloadFeatureFlags).not.toHaveBeenCalled()
+        })
+
+        it('does not reload feature flags if identity does not change but properties do', () => {
+            given('oldIdentity', () => given.identity)
+            given('userPropertiesToSet', () => ({ email: 'john@example.com' }))
+            given('userPropertiesToSetOnce', () => ({ howOftenAmISet: 'once!' }))
+
+            given.subject()
+
+            expect(given.overrides.reloadFeatureFlags).not.toHaveBeenCalled()
+        })
+    })
 })
 
 describe('capture()', () => {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -869,7 +869,11 @@ PostHogLib.prototype.identify = function (new_distinct_id, userPropertiesToSet, 
         }
     }
 
-    this.reloadFeatureFlags()
+    // Reload active feature flags if the user identity changes.
+    // Note we don't reload this on property changes as these get processed async
+    if (new_distinct_id !== previous_distinct_id) {
+        this.reloadFeatureFlags()
+    }
 }
 
 /**


### PR DESCRIPTION
Only reload feature flags if user identity actually changes.

Note the comment on user properties.

See also https://github.com/PostHog/posthog-js/issues/339

## Checklist
- [x] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
