### PR TITLE
Add resetSessionId function

### DIFF
--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -22,7 +22,7 @@ describe('SessionRecording', () => {
         capture: jest.fn(),
         persistence: { register: jest.fn() },
         _captureMetrics: { incr: jest.fn() },
-        _sessionIdManager: {
+        sessionManager: {
             getSessionAndWindowId: jest.fn().mockImplementation(() => given.incomingSessionAndWindowId),
         },
         _addCaptureHook: jest.fn(),
@@ -249,7 +249,7 @@ describe('SessionRecording', () => {
                 const mockDate = new Date(1602107460000)
                 jest.spyOn(global, 'Date').mockImplementation(() => mockDate)
                 _emit({ event: 123, type: INCREMENTAL_SNAPSHOT_EVENT_TYPE })
-                expect(given.posthog._sessionIdManager.getSessionAndWindowId).toHaveBeenCalledWith(1602107460000, {
+                expect(given.posthog.sessionManager.getSessionAndWindowId).toHaveBeenCalledWith(1602107460000, {
                     event: 123,
                     type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
                 })
@@ -262,7 +262,7 @@ describe('SessionRecording', () => {
                     data: { source: MUTATION_SOURCE_TYPE },
                     timestamp: 1602107460000,
                 })
-                expect(given.posthog._sessionIdManager.getSessionAndWindowId).toHaveBeenCalledWith(1602107460000, {
+                expect(given.posthog.sessionManager.getSessionAndWindowId).toHaveBeenCalledWith(1602107460000, {
                     event: 123,
                     type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
                     data: { source: MUTATION_SOURCE_TYPE },

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -270,7 +270,7 @@ describe('_calculate_event_properties()', () => {
         persistence: {
             properties: () => ({ distinct_id: 'abc', persistent: 'prop' }),
         },
-        _sessionIdManager: {
+        sessionManager: {
             getSessionAndWindowId: jest.fn().mockReturnValue({
                 windowId: 'windowId',
                 sessionId: 'sessionId',
@@ -319,7 +319,7 @@ describe('_calculate_event_properties()', () => {
             event: 'prop',
             distinct_id: 'abc',
         })
-        expect(given.overrides._sessionIdManager.getSessionAndWindowId).not.toHaveBeenCalled()
+        expect(given.overrides.sessionManager.getSessionAndWindowId).not.toHaveBeenCalled()
     })
 
     it('calls sanitize_properties', () => {

--- a/src/__tests__/sessionid.js
+++ b/src/__tests__/sessionid.js
@@ -142,4 +142,19 @@ describe('Session ID manager', () => {
             expect(given.persistence.register).toHaveBeenCalledWith({ [SESSION_ID]: [1603107460000, 'newSessionId'] })
         })
     })
+
+    describe('reset session id', () => {
+        it('clears the existing session id', () => {
+            given.sessionIdManager.resetSessionId()
+            expect(given.persistence.register).toHaveBeenCalledWith({ [SESSION_ID]: [null, null] })
+        })
+        it('a new session id is generated when called', () => {
+            given('storedSessionIdData', () => [null, null])
+            expect(given.sessionIdManager._getSessionId()).toEqual([null, null])
+            expect(given.subject).toMatchObject({
+                windowId: 'newUUID',
+                sessionId: 'newUUID',
+            })
+        })
+    })
 })

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -86,7 +86,7 @@ export class SessionRecording {
     }
 
     _updateWindowAndSessionIds(event) {
-        const { windowId, sessionId } = this.instance._sessionIdManager.getSessionAndWindowId(
+        const { windowId, sessionId } = this.instance.sessionManager.getSessionAndWindowId(
             event.timestamp || new Date().getTime(),
             event
         )

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -766,6 +766,20 @@ declare namespace posthog {
         static toString(): string
     }
 
+    export class sessionManager {
+        /*
+         * Allows you to manually reset the current session id. By default, the session id is reset after 30 minutes
+         * of inactivity, but with this function, you can reset it earlier. This will also result in a new session recording.
+         *
+         *
+         * ### Usage:
+         *
+         *     posthog.sessionManager.resetSessionId()
+         *
+         */
+        static resetSessionId(): void
+    }
+
     export class featureFlags {
         static getFlags(): string[]
         static getFlagVariants(): Record<string, boolean | string>

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -251,7 +251,7 @@ PostHogLib.prototype._init = function (token, config, name) {
     this.__request_queue = []
 
     this['persistence'] = new PostHogPersistence(this['config'])
-    this['_sessionIdManager'] = new SessionIdManager(this['config'], this['persistence'])
+    this['sessionManager'] = new SessionIdManager(this['config'], this['persistence'])
 
     this._gdpr_init()
 
@@ -654,8 +654,8 @@ PostHogLib.prototype._calculate_event_properties = function (event_name, event_p
         properties['$duration'] = parseFloat((duration_in_ms / 1000).toFixed(3))
     }
 
-    if (this._sessionIdManager) {
-        const { sessionId, windowId } = this._sessionIdManager.getSessionAndWindowId()
+    if (this.sessionManager) {
+        const { sessionId, windowId } = this.sessionManager.getSessionAndWindowId()
         properties['$session_id'] = sessionId
         properties['$window_id'] = windowId
     }

--- a/src/sessionid.js
+++ b/src/sessionid.js
@@ -56,6 +56,12 @@ export class SessionIdManager {
         return this.persistence['props'][SESSION_ID] || [0, null]
     }
 
+    // Resets the session id by setting it to null. On the subsequent call to getSessionAndWindowId,
+    // new ids will be generated.
+    resetSessionId() {
+        this._setSessionId(null, null)
+    }
+
     getSessionAndWindowId(timestamp = null, recordingEvent = false) {
         // Some recording events are triggered by non-user events (e.g. "X minutes ago" text updating on the screen).
         // We don't want to update the session and window ids in these cases. These events are designated by event


### PR DESCRIPTION
## Changes

Adds a function `posthog.sessionManager.resetSessionId()` that allows a user to manually reset the `sessionId`. This allows users to split sessions and recordings when they want instead of having to wait for the 30 min timeout.

Been requested a few times, and most recently here: https://posthogusers.slack.com/archives/C01FKPGG5U6/p1640015446465500

## Checklist
- [x] Tests for new code (if applicable)
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
