### PR TITLE
Allow APM performance on all $pageview events

### DIFF
--- a/cypress/integration/capture.spec.js
+++ b/cypress/integration/capture.spec.js
@@ -210,7 +210,7 @@ describe('Event capture', () => {
 
                 expect(captures.event).to.equal('$pageview')
 
-                const performance = captures.properties.performance
+                const performance = captures.properties.$performance
 
                 /**
                  * The performance propery holds three items.

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -253,6 +253,104 @@ describe('capture()', () => {
         const event = given.subject()
         expect(event.properties.key.length).toBe(50000)
     })
+
+    describe('capturing window performance', () => {
+        given('eventName', () => '$pageview')
+
+        given('config', () => ({
+            _capture_performance: true,
+        }))
+
+        given('performanceEntries', () => ({
+            navigation: ['a', 'b', 'c'],
+            resource: ['d', 'e', 'f'],
+            paint: ['g', 'h', 'i'],
+        }))
+
+        // e.g. IE does not implement performance paint timing
+        // https://developer.mozilla.org/en-US/docs/Web/API/PerformancePaintTiming
+        // even though it implements getEntriesByType
+        given('paintTimingsImplementedByBrowser', () => true)
+
+        beforeEach(() => {
+            /*
+                window.performance is not a complete implementation in jsdom
+                see github issue https://github.com/jsdom/jsdom/issues/3309
+                while it is not completely implemented we can follow the Jest instructions
+                here: https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+             */
+
+            Object.defineProperty(window, 'performance', {
+                writable: true,
+                value: {
+                    getEntriesByType: jest.fn().mockImplementation((type) => {
+                        if (!given.paintTimingsImplementedByBrowser && type === 'paint') {
+                            throw new Error('IE does not implement this')
+                        } else {
+                            return given.performanceEntries[type]
+                        }
+                    }),
+                },
+            })
+        })
+
+        it('does not capture performance when disabled', () => {
+            given('config', () => ({
+                _capture_performance: false,
+            }))
+
+            given.subject()
+
+            expect(window.performance.getEntriesByType).not.toHaveBeenCalled()
+        })
+
+        it('captures pageview with performance when enabled', () => {
+            const captured_event = given.subject()
+
+            expect(captured_event.properties).toHaveProperty('$performance', given.performanceEntries)
+
+            expect(window.performance.getEntriesByType).toHaveBeenCalledTimes(3)
+            expect(window.performance.getEntriesByType).toHaveBeenNthCalledWith(1, 'navigation')
+            expect(window.performance.getEntriesByType).toHaveBeenNthCalledWith(2, 'paint')
+            expect(window.performance.getEntriesByType).toHaveBeenNthCalledWith(3, 'resource')
+        })
+
+        it('safely attempts to capture pageview with performance when enabled but not available in browser', () => {
+            delete window.performance
+
+            const captured_event = given.subject()
+
+            expect(captured_event.properties).toHaveProperty('$performance', {
+                navigation: [],
+                paint: [],
+                resource: [],
+            })
+        })
+
+        it('safely attempts to capture pageview with performance when enabled but getEntriesByType is not available in browser', () => {
+            delete window.performance.getEntriesByType
+
+            const captured_event = given.subject()
+
+            expect(captured_event.properties).toHaveProperty('$performance', {
+                navigation: [],
+                paint: [],
+                resource: [],
+            })
+        })
+
+        it('safely attempts to capture performance if a type of entry is not available in a browser', () => {
+            given('paintTimingsImplementedByBrowser', () => false)
+
+            const captured_event = given.subject()
+
+            expect(captured_event.properties).toHaveProperty('$performance', {
+                navigation: given.performanceEntries.navigation,
+                resource: given.performanceEntries.resource,
+                paint: [],
+            })
+        })
+    })
 })
 
 describe('_calculate_event_properties()', () => {
@@ -696,114 +794,6 @@ describe('_loaded()', () => {
             given.subject()
 
             expect(given.overrides.capture).toHaveBeenCalledWith('$pageview', {}, { send_instantly: true })
-        })
-
-        describe('capturing window performance', () => {
-            given('config', () => ({
-                capture_pageview: true,
-                _capture_performance: true,
-            }))
-
-            given('performanceEntries', () => ({
-                navigation: ['a', 'b', 'c'],
-                resource: ['d', 'e', 'f'],
-                paint: ['g', 'h', 'i'],
-            }))
-
-            given('paintTimingsImplemented', () => true)
-
-            beforeEach(() => {
-                /*
-                    window.performance is not a complete implementation in jsdom
-                    see github issue https://github.com/jsdom/jsdom/issues/3309
-                    while it is not completely implemented we can follow the Jest instructions
-                    here: https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
-                 */
-
-                Object.defineProperty(window, 'performance', {
-                    writable: true,
-                    value: {
-                        getEntriesByType: jest.fn().mockImplementation((type) => {
-                            if (!given.paintTimingsImplemented && type === 'paint') {
-                                throw new Error('IE does not implement this')
-                            } else {
-                                return given.performanceEntries[type]
-                            }
-                        }),
-                    },
-                })
-            })
-
-            it('does not capture performance when disabled', () => {
-                given('config', () => ({
-                    capture_pageview: true,
-                    _capture_performance: false,
-                }))
-
-                given.subject()
-
-                expect(window.performance.getEntriesByType).not.toHaveBeenCalled()
-            })
-
-            it('captures pageview with performance when enabled', () => {
-                given.subject()
-
-                expect(given.overrides.capture).toHaveBeenCalledWith(
-                    '$pageview',
-                    { performance: given.performanceEntries },
-                    { send_instantly: true }
-                )
-
-                expect(window.performance.getEntriesByType).toHaveBeenCalledTimes(3)
-                expect(window.performance.getEntriesByType).toHaveBeenNthCalledWith(1, 'navigation')
-                expect(window.performance.getEntriesByType).toHaveBeenNthCalledWith(2, 'paint')
-                expect(window.performance.getEntriesByType).toHaveBeenNthCalledWith(3, 'resource')
-            })
-
-            it('safely attempts to capture pageview with performance when enabled but not available in browser', () => {
-                delete window.performance
-
-                given.subject()
-
-                expect(given.overrides.capture).toHaveBeenCalledWith(
-                    '$pageview',
-                    { performance: { navigation: [], paint: [], resource: [] } },
-                    { send_instantly: true }
-                )
-            })
-
-            it('safely attempts to capture pageview with performance when enabled but getEntriesByType is not available in browser', () => {
-                delete window.performance.getEntriesByType
-
-                given.subject()
-
-                expect(given.overrides.capture).toHaveBeenCalledWith(
-                    '$pageview',
-                    { performance: { navigation: [], paint: [], resource: [] } },
-                    { send_instantly: true }
-                )
-            })
-
-            it('safely attempts to capture performance if a type of entry is not available in a browser', () => {
-                // e.g. IE does not implement performance paint timing
-                // https://developer.mozilla.org/en-US/docs/Web/API/PerformancePaintTiming
-                // even though it implements getEntriesByType
-                given('paintTimingsImplemented', () => false)
-
-                given.subject()
-
-                expect(given.overrides.capture).toHaveBeenCalledWith(
-                    '$pageview',
-                    {
-                        performance: {
-                            navigation: given.performanceEntries.navigation,
-                            resource: given.performanceEntries.resource,
-                            paint: [],
-                        },
-                    },
-                    { send_instantly: true }
-                )
-            })
         })
     })
 

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -300,15 +300,7 @@ PostHogLib.prototype._loaded = function () {
     // this happens after so a user can call identify in
     // the loaded callback
     if (this.get_config('capture_pageview')) {
-        const props = {}
-        if (this.get_config('_capture_performance')) {
-            props.performance = {
-                navigation: getPerformanceEntriesByType('navigation'),
-                paint: getPerformanceEntriesByType('paint'),
-                resource: getPerformanceEntriesByType('resource'),
-            }
-        }
-        this.capture('$pageview', props, { send_instantly: true })
+        this.capture('$pageview', {}, { send_instantly: true })
     }
 
     // Call decide to get what features are enabled and other settings.
@@ -683,6 +675,14 @@ PostHogLib.prototype._calculate_event_properties = function (event_name, event_p
 
     // update properties with pageview info and super-properties
     properties = _.extend({}, _.info.properties(), this['persistence'].properties(), properties)
+
+    if (event_name === '$pageview' && this.get_config('_capture_performance')) {
+        properties['$performance'] = {
+            navigation: getPerformanceEntriesByType('navigation'),
+            paint: getPerformanceEntriesByType('paint'),
+            resource: getPerformanceEntriesByType('resource'),
+        }
+    }
 
     var property_blacklist = this.get_config('property_blacklist')
     if (_.isArray(property_blacklist)) {


### PR DESCRIPTION
## Changes

* Changes the alpha/beta performance feature to work for synthetic `$pageview` events
* moves to using a `$performance` key instead of `performance`
* moves unit tests from the `_loaded` describe block to the `capture()` describe block

Follows on from #347 

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
