### PR TITLE
Send APM data so that we don't need a plugin

### DIFF
--- a/cypress/integration/capture.spec.js
+++ b/cypress/integration/capture.spec.js
@@ -210,10 +210,8 @@ describe('Event capture', () => {
 
                 expect(captures.event).to.equal('$pageview')
 
-                const performance = captures.properties.$performance
-
                 /**
-                 * The performance propery holds three items.
+                 * The performance propery holds two items.
                  * The result of asking window.performance for entries by type of navigation, resource, and paint
                  * We cannot guarantee what is available in resource and paint when it runs
                  *
@@ -222,24 +220,33 @@ describe('Event capture', () => {
                  * Each of resource and paint will be a list with zero or more `PerformanceEntry` objects
                  *
                  * https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType
+                 *
+                 * These are stringified so that the PostHog UI doesn't try to process them in the EventsTable
+                 *
+                 * The second item is the time of the pageLoaded event
                  */
 
-                expect(performance).to.have.property('navigation')
-                expect(performance.navigation).to.be.instanceof(Array).and.to.have.length(1)
-                expect(performance.navigation[0]).to.have.property('domContentLoadedEventEnd')
-                expect(performance.navigation[0].domContentLoadedEventEnd).to.be.greaterThan(0)
+                const pageLoad = captures.properties.$performance_pageLoaded
+                expect(pageLoad).to.be.a('number')
 
-                expect(performance).to.have.property('resource')
-                expect(performance.resource).to.be.instanceof(Array).and.to.have.length.greaterThan(0)
-                expect(performance.resource[0]).to.have.property('entryType', 'resource')
-                expect(performance.resource[0]).to.have.property('connectEnd')
+                const rawPerformance = JSON.parse(captures.properties.$performance_raw)
 
-                expect(performance).to.have.property('paint')
-                expect(performance.paint).to.be.instanceof(Array)
-                if (performance.paint.length > 0) {
+                expect(rawPerformance).to.have.property('navigation')
+                expect(rawPerformance.navigation).to.be.instanceof(Array).and.to.have.length(1)
+                expect(rawPerformance.navigation[0]).to.have.property('domContentLoadedEventEnd')
+                expect(rawPerformance.navigation[0].domContentLoadedEventEnd).to.be.greaterThan(0)
+
+                expect(rawPerformance).to.have.property('resource')
+                expect(rawPerformance.resource).to.be.instanceof(Array).and.to.have.length.greaterThan(0)
+                expect(rawPerformance.resource[0]).to.have.property('entryType', 'resource')
+                expect(rawPerformance.resource[0]).to.have.property('connectEnd')
+
+                expect(rawPerformance).to.have.property('paint')
+                expect(rawPerformance.paint).to.be.instanceof(Array)
+                if (rawPerformance.paint.length > 0) {
                     // we can't guarantee we run early enough to capture paint results
                     // so, we check if they are present before asserting on them
-                    performance.paint.forEach((paintResult) => {
+                    rawPerformance.paint.forEach((paintResult) => {
                         expect(paintResult).to.have.property('startTime')
                         expect(paintResult.startTime).to.be.greaterThan(0)
                     })

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -677,10 +677,14 @@ PostHogLib.prototype._calculate_event_properties = function (event_name, event_p
     properties = _.extend({}, _.info.properties(), this['persistence'].properties(), properties)
 
     if (event_name === '$pageview' && this.get_config('_capture_performance')) {
-        properties['$performance'] = {
+        const performanceEntries = {
             navigation: getPerformanceEntriesByType('navigation'),
             paint: getPerformanceEntriesByType('paint'),
             resource: getPerformanceEntriesByType('resource'),
+        }
+        properties['$performance_raw'] = JSON.stringify(performanceEntries)
+        if (performanceEntries.navigation.length > 0 && performanceEntries.navigation[0].duration >= 0) {
+            properties['$performance_pageLoaded'] = performanceEntries.navigation[0].duration
         }
     }
 


### PR DESCRIPTION
## Changes

Follows on from #350 

The PostHog UI will only use the pageload duration and uses the entire performance object. So they are now sent directly removing the need for https://github.com/PostHog/posthog_apm_plugin

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
