### PR TITLE
Add an allow list to skip truncating strings when capturing events

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -72,6 +72,15 @@ describe('_.copyAndTruncateStrings', () => {
 
         expect(given.subject).toEqual({})
     })
+
+    it('does not truncate the apm raw performance property', () => {
+        const original = {
+            $performance_raw: 'longer_than_the_maximum',
+        }
+        given('target', () => original)
+
+        expect(given.subject).toEqual(original)
+    })
 })
 
 describe('_.info', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -336,7 +336,7 @@ const LONG_STRINGS_ALLOW_LIST = ['$performance_raw']
 
 _.copyAndTruncateStrings = (object, maxStringLength) =>
     deepCircularCopy(object, (value, key) => {
-        if (key && LONG_STRINGS_ALLOW_LIST.includes(key)) {
+        if (key && LONG_STRINGS_ALLOW_LIST.indexOf(key) > -1) {
             return value
         }
         if (typeof value === 'string' && maxStringLength !== null) {


### PR DESCRIPTION
## Changes

Adds a (static) allow list to allow some properties to be skipped when truncating string properties during event capture

See #354 

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
