### PR TITLE
Fix featureflags not working when /decide is down

### DIFF
--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -54,6 +54,7 @@ describe('Decide', () => {
                             groups: { organization: '5' },
                         })
                     ),
+                    verbose: true,
                 },
                 { method: 'POST' },
                 expect.any(Function)

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -111,5 +111,24 @@ describe('Decide', () => {
                 },
             })
         })
+
+        it('Make sure feature flags continue working if decide request fails', () => {
+            given('decideResponse', () => ({ featureFlags: ['beta-feature', 'alpha-feature-2'] }))
+            given.subject()
+
+            expect(given.posthog.persistence.register).toHaveBeenLastCalledWith({
+                $active_feature_flags: ['beta-feature', 'alpha-feature-2'],
+                $enabled_feature_flags: { 'beta-feature': true, 'alpha-feature-2': true },
+            })
+
+            given('decideResponse', () => ({ status: 0 }))
+            given.subject()
+
+            expect(given.posthog.persistence.unregister).not.toHaveBeenCalled()
+            expect(given.posthog.persistence.register).toHaveBeenLastCalledWith({
+                $active_feature_flags: ['beta-feature', 'alpha-feature-2'],
+                $enabled_feature_flags: { 'beta-feature': true, 'alpha-feature-2': true },
+            })
+        })
     })
 })

--- a/src/decide.js
+++ b/src/decide.js
@@ -28,6 +28,7 @@ export class Decide {
 
     parseDecideResponse(response) {
         if (response?.status === 0) {
+            console.error('Failed to fetch feature flags from PostHog.')
             return
         }
         if (!(document && document.body)) {

--- a/src/decide.js
+++ b/src/decide.js
@@ -20,13 +20,16 @@ export class Decide {
         const encoded_data = _.base64Encode(json_data)
         this.instance._send_request(
             `${this.instance.get_config('api_host')}/decide/?v=2`,
-            { data: encoded_data },
+            { data: encoded_data, verbose: true },
             { method: 'POST' },
             (response) => this.parseDecideResponse(response)
         )
     }
 
     parseDecideResponse(response) {
+        if (response?.status === 0) {
+            return
+        }
         if (!(document && document.body)) {
             console.log('document not ready yet, trying again in 500 milliseconds...')
             setTimeout(() => {


### PR DESCRIPTION
## Changes

Don't override feature flags when /decide errors, just use the ones still in persistence.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
