### PR TITLE
Only hit onFeatureFlags callback after decide

### DIFF
--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -1,10 +1,12 @@
 import { PostHogFeatureFlags } from '../posthog-featureflags'
 
 describe('featureflags', () => {
+    given('decideEndpointWasHit', () => false)
     given('instance', () => ({
         get_config: jest.fn().mockImplementation((key) => given.config[key]),
         get_property: (key) => given.properties[key],
         capture: () => {},
+        decideEndpointWasHit: given.decideEndpointWasHit,
     }))
 
     given('featureFlags', () => new PostHogFeatureFlags(given.instance))
@@ -65,5 +67,21 @@ describe('featureflags', () => {
             'alpha-feature-2': 'as-a-variant',
             'multivariate-flag': 'variant-1',
         })
+    })
+
+    it('onFeatureFlags should not be called immediately if feature flags not loaded', () => {
+        var called = false
+
+        given.featureFlags.onFeatureFlags(() => (called = true))
+        expect(called).toEqual(false)
+    })
+
+    it('onFeatureFlags callback should be called immediately if feature flags were loaded', () => {
+        given.featureFlags.instance.decideEndpointWasHit = true
+        var called = false
+        given.featureFlags.onFeatureFlags(() => (called = true))
+        expect(called).toEqual(true)
+
+        called = false
     })
 })

--- a/src/decide.js
+++ b/src/decide.js
@@ -5,6 +5,7 @@ import { parseFeatureFlagDecideResponse } from './posthog-featureflags'
 export class Decide {
     constructor(instance) {
         this.instance = instance
+        this.instance.decideEndpointWasHit = false
     }
 
     call() {
@@ -27,6 +28,7 @@ export class Decide {
     }
 
     parseDecideResponse(response) {
+        this.instance.decideEndpointWasHit = true
         if (!(document && document.body)) {
             console.log('document not ready yet, trying again in 500 milliseconds...')
             setTimeout(() => {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -794,10 +794,7 @@ PostHogLib.prototype.reloadFeatureFlags = function () {
  *                              It'll return a list of feature flags enabled for the user.
  */
 PostHogLib.prototype.onFeatureFlags = function (callback) {
-    this.featureFlags.addFeatureFlagsHandler(callback)
-    const flags = this.featureFlags.getFlags()
-    const flagVariants = this.featureFlags.getFlagVariants()
-    callback(flags, flagVariants)
+    this.featureFlags.onFeatureFlags(callback)
 }
 
 /**

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -210,4 +210,24 @@ export class PostHogFeatureFlags {
             this.instance.persistence.register({ $override_feature_flags: flags })
         }
     }
+    /*
+     * Register an event listener that runs when feature flags become available or when they change.
+     * If there are flags, the listener is called immediately in addition to being called on future changes.
+     *
+     * ### Usage:
+     *
+     *     posthog.onFeatureFlags(function(featureFlags) { // do something })
+     *
+     * @param {Function} [callback] The callback function will be called once the feature flags are ready or when they are updated.
+     *                              It'll return a list of feature flags enabled for the user.
+     */
+    onFeatureFlags(callback) {
+        this.addFeatureFlagsHandler(callback)
+        console.log(this.instance)
+        if (this.instance.decideEndpointWasHit) {
+            const flags = this.getFlags()
+            const flagVariants = this.getFlagVariants()
+            callback(flags, flagVariants)
+        }
+    }
 }

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -223,7 +223,6 @@ export class PostHogFeatureFlags {
      */
     onFeatureFlags(callback) {
         this.addFeatureFlagsHandler(callback)
-        console.log(this.instance)
         if (this.instance.decideEndpointWasHit) {
             const flags = this.getFlags()
             const flagVariants = this.getFlagVariants()


### PR DESCRIPTION
## Changes

Right now we immediately return onFeatureFlags callbacks, even if flags haven't loaded.

@mariusandra given you changed this behaviour

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
