### PR TITLE
Remove capture failed request

### DIFF
--- a/src/__tests__/capture-metrics.js
+++ b/src/__tests__/capture-metrics.js
@@ -5,12 +5,9 @@ import { _ } from '../utils'
 jest.mock('../utils')
 
 describe('CaptureMetrics()', () => {
-    given('captureMetrics', () => new CaptureMetrics(given.enabled, given.capture, given.getTime))
+    given('captureMetrics', () => new CaptureMetrics(given.enabled))
 
     given('enabled', () => true)
-    given('capture', () => jest.fn())
-
-    given('getTime', () => jest.fn())
 
     describe('incr() and decr()', () => {
         it('supports incrementing and decrementing metrics', () => {
@@ -28,65 +25,6 @@ describe('CaptureMetrics()', () => {
             given.captureMetrics.incr('key')
 
             expect(given.captureMetrics.metrics).toEqual({})
-        })
-    })
-
-    describe('tracking requests', () => {
-        beforeEach(() => {
-            let i = 0
-            _.UUID.mockImplementation(() => i++)
-        })
-
-        it('handles starting and finishing a request', () => {
-            given.getTime.mockReturnValue(5000)
-            const id = given.captureMetrics.startRequest({ size: 123 })
-
-            given.getTime.mockReturnValue(5100)
-            const payload = given.captureMetrics.finishRequest(id)
-
-            expect(id).toEqual(0)
-            expect(payload).toEqual({ size: 123, duration: 100 })
-        })
-
-        it('handles marking a request as failed', () => {
-            given.captureMetrics.markRequestFailed({ foo: 'bar' })
-
-            expect(given.capture).toHaveBeenCalledWith('$capture_failed_request', { foo: 'bar' })
-        })
-
-        it('handles marking all in-flight requests as failed', () => {
-            given.getTime.mockReturnValue(5000)
-            given.captureMetrics.startRequest({ size: 100 })
-
-            given.getTime.mockReturnValue(5100)
-            given.captureMetrics.startRequest({ size: 200 })
-
-            given.getTime.mockReturnValue(5500)
-
-            given.captureMetrics.captureInProgressRequests()
-
-            expect(given.capture).toHaveBeenCalledTimes(2)
-            expect(given.capture).toHaveBeenCalledWith('$capture_failed_request', {
-                size: 100,
-                duration: 500,
-                type: 'inflight_at_unload',
-            })
-            expect(given.capture).toHaveBeenCalledWith('$capture_failed_request', {
-                size: 200,
-                duration: 400,
-                type: 'inflight_at_unload',
-            })
-        })
-
-        it('does nothing if not enabled', () => {
-            given('enabled', () => false)
-
-            given.captureMetrics.startRequest({ size: 100 })
-            given.captureMetrics.captureInProgressRequests()
-            given.captureMetrics.markRequestFailed({ foo: 'bar' })
-            given.captureMetrics.finishRequest(null)
-
-            expect(given.capture).not.toHaveBeenCalled()
         })
     })
 })

--- a/src/__tests__/send-request.js
+++ b/src/__tests__/send-request.js
@@ -11,7 +11,6 @@ describe('when xhr requests fail', () => {
         responseText: JSON.stringify('something here'),
         status: 502,
     }))
-    given('markRequestFailed', jest.fn)
     given('onXHRError', jest.fn)
     given('xhrParams', () => ({
         url: 'https://any.posthog-instance.com',
@@ -20,10 +19,7 @@ describe('when xhr requests fail', () => {
         options: {},
         captureMetrics: {
             incr: () => {},
-            startRequest: () => {},
             decr: () => {},
-            finishRequest: () => {},
-            markRequestFailed: given.markRequestFailed,
         },
         callback: () => {},
         retriesPerformedSoFar: null,
@@ -44,12 +40,6 @@ describe('when xhr requests fail', () => {
     it('does not error if the configured onXHRError is not a function', () => {
         given('onXHRError', () => 'not a function')
         expect(() => given.subject()).not.toThrow()
-    })
-
-    it('marks the request as failed', () => {
-        given('onXHRError', () => undefined)
-        given.subject()
-        expect(given.markRequestFailed).toHaveBeenCalled()
     })
 
     it('calls the injected XHR error handler', () => {

--- a/src/capture-metrics.js
+++ b/src/capture-metrics.js
@@ -1,12 +1,9 @@
 import { _ } from './utils'
 
 export class CaptureMetrics {
-    constructor(enabled, capture, getTime = () => new Date().getTime()) {
+    constructor(enabled) {
         this.enabled = enabled
-        this.capture = capture
-        this.getTime = getTime
         this.metrics = {}
-        this.requests = {}
     }
 
     incr(key, by = 1) {
@@ -20,40 +17,6 @@ export class CaptureMetrics {
         if (this.enabled) {
             key = `phjs-${key}`
             this.metrics[key] = (this.metrics[key] || 0) - 1
-        }
-    }
-
-    startRequest(payload) {
-        if (this.enabled) {
-            const requestId = _.UUID()
-
-            this.requests[requestId] = [this.getTime(), payload]
-
-            return requestId
-        }
-    }
-
-    finishRequest(requestId) {
-        if (this.enabled && this.requests[requestId]) {
-            const [startTime, payload] = this.requests[requestId]
-            payload['duration'] = this.getTime() - startTime
-            delete this.requests[requestId]
-            return payload
-        }
-    }
-
-    markRequestFailed(payload) {
-        if (this.enabled) {
-            this.capture('$capture_failed_request', payload)
-        }
-    }
-
-    captureInProgressRequests() {
-        if (this.enabled) {
-            Object.keys(this.requests).forEach((requestId) => {
-                const payload = this.finishRequest(requestId)
-                this.markRequestFailed({ ...payload, type: 'inflight_at_unload' })
-            })
         }
     }
 }

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -244,7 +244,7 @@ PostHogLib.prototype._init = function (token, config, name) {
 
     this['_jsc'] = function () {}
 
-    this._captureMetrics = new CaptureMetrics(this.get_config('_capture_metrics'), _.bind(this.capture, this))
+    this._captureMetrics = new CaptureMetrics(this.get_config('_capture_metrics'))
 
     this._requestQueue = new RequestQueue(this._captureMetrics, _.bind(this._handle_queued_event, this))
 
@@ -378,7 +378,6 @@ PostHogLib.prototype._handle_unload = function () {
     if (this.get_config('_capture_metrics')) {
         this._requestQueue.updateUnloadMetrics()
         this.capture('$capture_metrics', this._captureMetrics.metrics)
-        this._captureMetrics.captureInProgressRequests()
     }
     this._requestQueue.unload()
     this._retryQueue.unload()

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -48,12 +48,6 @@ export const xhr = ({
     captureMetrics.incr('_send_request')
     captureMetrics.incr('_send_request_inflight')
 
-    const requestId = captureMetrics.startRequest({
-        data_size: _.isString(data) ? data.length : body.length,
-        endpoint: url.slice(url.length - 2),
-        ...options._metrics,
-    })
-
     _.each(headers, function (headerValue, headerName) {
         req.setRequestHeader(headerName, headerValue)
     })
@@ -69,8 +63,6 @@ export const xhr = ({
             captureMetrics.incr(`xhr-response`)
             captureMetrics.incr(`xhr-response-${req.status}`)
             captureMetrics.decr('_send_request_inflight')
-
-            const metricsData = captureMetrics.finishRequest(requestId)
 
             // XMLHttpRequest.DONE == 4, except in safari 4
             if (req.status === 200) {
@@ -100,13 +92,6 @@ export const xhr = ({
                         callback,
                     })
                 }
-
-                captureMetrics.markRequestFailed({
-                    ...metricsData,
-                    type: 'non_200',
-                    status: req.status,
-                    statusText: req.statusText,
-                })
 
                 if (callback) {
                     if (options.verbose) {


### PR DESCRIPTION
## Changes

In the postmortem from the 1/21 outage, a concern was raised that we could have been ddos'ing ourselves with the  `$capture_failed_request` event.

While this concern seems pretty unlikely (because only the posthog app has this feature enabled), it looks like the event is from an old session recordings investigation, and I don't think anyone uses it, so this PR removes it.

(also the count of failed capture requests is still available in the `$capture_metrics` event via the status code properties)

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
