### PR TITLE
Fix for posthog.onFeatureFlags not being called

### DIFF
--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -92,6 +92,9 @@ describe('Payload Compression', () => {
                 sessionRecording: {
                     afterDecideResponse: jest.fn(),
                 },
+                featureFlags: {
+                    receivedFeatureFlags: jest.fn(),
+                },
             }
         })
 

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -21,8 +21,10 @@ describe('Decide', () => {
         sessionRecording: {
             afterDecideResponse: jest.fn(),
         },
+        featureFlags: {
+            receivedFeatureFlags: jest.fn(),
+        },
         getGroups: () => ({ organization: '5' }),
-        persistence: { register: jest.fn(), unregister: jest.fn() },
     }))
 
     given('decideResponse', () => ({ enable_collect_everything: true }))
@@ -71,6 +73,7 @@ describe('Decide', () => {
 
             expect(given.posthog.sessionRecording.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
             expect(given.posthog.toolbar.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
+            expect(given.posthog.featureFlags.receivedFeatureFlags).toHaveBeenCalledWith(given.decideResponse)
             expect(autocapture.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse, given.posthog)
         })
 
@@ -82,54 +85,11 @@ describe('Decide', () => {
             expect(given.posthog.compression['lz64']).toBe(true)
         })
 
-        it('enables feature flags from decide response (v1 backwards compatibility)', () => {
-            // checks that nothing fails when asking for ?v=2 and getting a ?v=1 response
-            given('decideResponse', () => ({ featureFlags: ['beta-feature', 'alpha-feature-2'] }))
-            given.subject()
-
-            expect(given.posthog.persistence.register).toHaveBeenLastCalledWith({
-                $active_feature_flags: ['beta-feature', 'alpha-feature-2'],
-                $enabled_feature_flags: { 'beta-feature': true, 'alpha-feature-2': true },
-            })
-        })
-
-        it('enables multivariate feature flags from decide v2 response', () => {
-            given('decideResponse', () => ({
-                featureFlags: {
-                    'beta-feature': true,
-                    'alpha-feature-2': true,
-                    'multivariate-flag': 'variant-1',
-                },
-            }))
-            given.subject()
-
-            expect(given.posthog.persistence.register).toHaveBeenLastCalledWith({
-                $active_feature_flags: ['beta-feature', 'alpha-feature-2', 'multivariate-flag'],
-                $enabled_feature_flags: {
-                    'beta-feature': true,
-                    'alpha-feature-2': true,
-                    'multivariate-flag': 'variant-1',
-                },
-            })
-        })
-
-        it('Make sure feature flags continue working if decide request fails', () => {
-            given('decideResponse', () => ({ featureFlags: ['beta-feature', 'alpha-feature-2'] }))
-            given.subject()
-
-            expect(given.posthog.persistence.register).toHaveBeenLastCalledWith({
-                $active_feature_flags: ['beta-feature', 'alpha-feature-2'],
-                $enabled_feature_flags: { 'beta-feature': true, 'alpha-feature-2': true },
-            })
-
+        it('Make sure receivedFeatureFlags is not called if the decide response fails', () => {
             given('decideResponse', () => ({ status: 0 }))
             given.subject()
 
-            expect(given.posthog.persistence.unregister).not.toHaveBeenCalled()
-            expect(given.posthog.persistence.register).toHaveBeenLastCalledWith({
-                $active_feature_flags: ['beta-feature', 'alpha-feature-2'],
-                $enabled_feature_flags: { 'beta-feature': true, 'alpha-feature-2': true },
-            })
+            expect(given.posthog.featureFlags.receivedFeatureFlags).not.toHaveBeenCalled()
         })
     })
 })

--- a/src/decide.js
+++ b/src/decide.js
@@ -1,6 +1,5 @@
 import { autocapture } from './autocapture'
 import { _ } from './utils'
-import { parseFeatureFlagDecideResponse } from './posthog-featureflags'
 
 export class Decide {
     constructor(instance) {
@@ -45,7 +44,7 @@ export class Decide {
         this.instance.sessionRecording.afterDecideResponse(response)
         autocapture.afterDecideResponse(response, this.instance)
 
-        parseFeatureFlagDecideResponse(response, this.instance.persistence)
+        this.instance.featureFlags.receivedFeatureFlags(response)
 
         if (response['supportedCompression']) {
             const compression = {}

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -123,8 +123,7 @@ export class PostHogFeatureFlags {
             { data: encoded_data },
             { method: 'POST' },
             this.instance._prepare_callback((response) => {
-                parseFeatureFlagDecideResponse(response, this.instance.persistence)
-                this.receivedFeatureFlags()
+                this.receivedFeatureFlags(response)
 
                 // :TRICKY: Reload - start another request if queued!
                 this.setReloadingPaused(false)
@@ -178,7 +177,8 @@ export class PostHogFeatureFlags {
         this.featureFlagEventHandlers.push(handler)
     }
 
-    receivedFeatureFlags() {
+    receivedFeatureFlags(response) {
+        parseFeatureFlagDecideResponse(response, this.instance.persistence)
         const flags = this.getFlags()
         const variants = this.getFlagVariants()
         this.featureFlagEventHandlers.forEach((handler) => handler(flags, variants))


### PR DESCRIPTION
## Changes
Fixes a bug where the callback on `posthog.onFeatureFlags` was not being called.

Looks like this is a new bug, but I'm pretty sure before this bug, we weren't calling `receivedFeatureFlags` from the normal decide response. As a result, we would pretty much always call `posthog.onFeatureFlags` before the decide response using the cached values. After the decide response, the feature flag updated, but `posthog.onFeatureFlags` wasn't called with the updated values until the next refresh. 

Might explain some of the funny behavior around FFs that we've been seeing.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
