### PR TITLE
Fix for enabling a disabled session recording

### DIFF
--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -5,7 +5,7 @@ import {
     MUTATION_SOURCE_TYPE,
     SessionRecording,
 } from '../../extensions/sessionrecording'
-import { SESSION_RECORDING_ENABLED } from '../../posthog-persistence'
+import { SESSION_RECORDING_ENABLED_SERVER_SIDE } from '../../posthog-persistence'
 
 jest.mock('../../autocapture-utils')
 jest.mock('../../config', () => ({ LIB_VERSION: 'v0.0.1' }))
@@ -17,7 +17,7 @@ describe('SessionRecording', () => {
     given('incomingSessionAndWindowId', () => ({ sessionId: 'sessionId', windowId: 'windowId' }))
 
     given('posthog', () => ({
-        get_property: () => given.$session_recording_enabled,
+        get_property: () => given.$session_recording_enabled_server_side,
         get_config: jest.fn().mockImplementation((key) => given.config[key]),
         capture: jest.fn(),
         persistence: { register: jest.fn() },
@@ -38,6 +38,8 @@ describe('SessionRecording', () => {
             someUnregisteredProp: 'abc',
         },
     }))
+    given('$session_recording_enabled_server_side', () => true)
+    given('disabled', () => false)
 
     beforeEach(() => {
         window.rrweb = {
@@ -45,54 +47,98 @@ describe('SessionRecording', () => {
         }
     })
 
-    describe('afterDecideResponse()', () => {
-        given('subject', () => () => given.sessionRecording.afterDecideResponse(given.response))
-
-        beforeEach(() => {
-            jest.spyOn(given.sessionRecording, 'submitRecordings')
+    describe('isRecordingEnabled', () => {
+        given('subject', () => () => given.sessionRecording.isRecordingEnabled())
+        it('is enabled id both the server and client config says enabled', () => {
+            given.subject()
+            expect(given.subject()).toBe(true)
         })
 
-        it('starts session recording, saves setting when enabled', () => {
-            given('response', () => ({ sessionRecording: true }))
+        it('is disabled if the server is disabled', () => {
+            given('$session_recording_enabled_server_side', () => false)
+            given.subject()
+            expect(given.subject()).toBe(false)
+        })
+
+        it('is disabled if the client config is disabled', () => {
+            given('disabled', () => true)
+            given.subject()
+            expect(given.subject()).toBe(false)
+        })
+    })
+
+    describe('startRecordingIfEnabled', () => {
+        given('subject', () => () => given.sessionRecording.startRecordingIfEnabled())
+
+        beforeEach(() => {
+            jest.spyOn(given.sessionRecording, 'startCaptureAndTrySendingQueuedSnapshots')
+            jest.spyOn(given.sessionRecording, 'stopRecording')
+        })
+
+        it('call startCaptureAndTrySendingQueuedSnapshots if its enabled', () => {
+            given.subject()
+            expect(given.sessionRecording.startCaptureAndTrySendingQueuedSnapshots).toHaveBeenCalled()
+        })
+
+        it('call stopRecording if its not enabled', () => {
+            given('disabled', () => true)
+            given.subject()
+            expect(given.sessionRecording.stopRecording).toHaveBeenCalled()
+        })
+    })
+
+    describe('afterDecideResponse()', () => {
+        given('subject', () => () => given.sessionRecording.afterDecideResponse(given.response))
+        given('response', () => ({ sessionRecording: { endpoint: '/s/' } }))
+        given('$session_recording_enabled_server_side', () => true)
+        given('disabled', () => false)
+
+        beforeEach(() => {
+            jest.spyOn(given.sessionRecording, 'startRecordingIfEnabled')
+
+            loadScript.mockImplementation((path, callback) => callback())
+        })
+
+        it('emit is not set to true until decide is called', () => {
+            given.sessionRecording.startRecordingIfEnabled()
+            expect(loadScript).toHaveBeenCalled()
+            expect(given.sessionRecording.emit).toBe(false)
 
             given.subject()
+            expect(given.sessionRecording.emit).toBe(true)
+        })
 
-            expect(given.sessionRecording.submitRecordings).toHaveBeenCalled()
-            expect(given.posthog.persistence.register).toHaveBeenCalledWith({ [SESSION_RECORDING_ENABLED]: true })
+        it('stores true in persistence if recording is enabled from the server', () => {
+            given.subject()
+            expect(given.posthog.persistence.register).toHaveBeenCalledWith({
+                [SESSION_RECORDING_ENABLED_SERVER_SIDE]: true,
+            })
+        })
+
+        it('stores false in persistence if recording is not enabled from the server', () => {
+            given('response', () => ({}))
+            given.subject()
+            expect(given.posthog.persistence.register).toHaveBeenCalledWith({
+                [SESSION_RECORDING_ENABLED_SERVER_SIDE]: false,
+            })
         })
 
         it('starts session recording, saves setting and endpoint when enabled', () => {
             given('response', () => ({ sessionRecording: { endpoint: '/ses/' } }))
 
             given.subject()
-
-            expect(given.sessionRecording.submitRecordings).toHaveBeenCalled()
-            expect(given.posthog.persistence.register).toHaveBeenCalledWith({ [SESSION_RECORDING_ENABLED]: true })
+            expect(given.sessionRecording.startRecordingIfEnabled).toHaveBeenCalled()
+            expect(loadScript).toHaveBeenCalled()
+            expect(given.posthog.persistence.register).toHaveBeenCalledWith({
+                [SESSION_RECORDING_ENABLED_SERVER_SIDE]: true,
+            })
             expect(given.sessionRecording.endpoint).toEqual('/ses/')
-        })
-
-        it('does not start recording if not allowed', () => {
-            given('response', () => ({}))
-
-            given.subject()
-
-            expect(given.sessionRecording.submitRecordings).not.toHaveBeenCalled()
-            expect(given.posthog.persistence.register).toHaveBeenCalledWith({ [SESSION_RECORDING_ENABLED]: false })
-        })
-
-        it('does not start session recording if enabled via server but not client', () => {
-            given('response', () => ({ sessionRecording: { endpoint: '/ses/' } }))
-            given('disabled', () => true)
-            given.subject()
-
-            expect(given.sessionRecording.submitRecordings).not.toHaveBeenCalled()
-            expect(given.posthog.persistence.register).toHaveBeenCalledWith({ [SESSION_RECORDING_ENABLED]: false })
         })
     })
 
     describe('recording', () => {
         given('disabled', () => false)
-        given('$session_recording_enabled', () => true)
+        given('$session_recording_enabled_server_side', () => true)
 
         beforeEach(() => {
             const mockFullSnapshot = jest.fn()
@@ -131,7 +177,7 @@ describe('SessionRecording', () => {
             _emit({ event: 1 })
             expect(given.posthog.capture).not.toHaveBeenCalled()
 
-            given.sessionRecording.submitRecordings()
+            given.sessionRecording.afterDecideResponse({ endpoint: '/s/' })
             _emit({ event: 2 })
 
             expect(given.posthog.capture).toHaveBeenCalledTimes(2)
@@ -177,13 +223,13 @@ describe('SessionRecording', () => {
             expect(loadScript).toHaveBeenCalledWith('https://test.com/static/recorder.js?v=v0.0.1', expect.anything())
         })
 
-        it('loads script after `submitRecordings` if not previously loaded', () => {
-            given('$session_recording_enabled', () => false)
+        it('loads script after `startCaptureAndTrySendingQueuedSnapshots` if not previously loaded', () => {
+            given('$session_recording_enabled_server_side', () => false)
 
             given.sessionRecording.startRecordingIfEnabled()
             expect(loadScript).not.toHaveBeenCalled()
 
-            given.sessionRecording.submitRecordings()
+            given.sessionRecording.startCaptureAndTrySendingQueuedSnapshots()
 
             expect(loadScript).toHaveBeenCalled()
         })
@@ -192,12 +238,27 @@ describe('SessionRecording', () => {
             given('disabled', () => true)
 
             given.sessionRecording.startRecordingIfEnabled()
-            given.sessionRecording.submitRecordings()
+            given.sessionRecording.startCaptureAndTrySendingQueuedSnapshots()
 
             expect(loadScript).not.toHaveBeenCalled()
         })
 
         it('session recording can be turned on and off', () => {
+            expect(given.sessionRecording.stopRrweb).toEqual(null)
+
+            given.sessionRecording.startRecordingIfEnabled()
+
+            expect(given.sessionRecording.started()).toEqual(true)
+            expect(given.sessionRecording.captureStarted).toEqual(true)
+            expect(given.sessionRecording.stopRrweb).not.toEqual(null)
+
+            given.sessionRecording.stopRecording()
+
+            expect(given.sessionRecording.stopRrweb).toEqual(null)
+            expect(given.sessionRecording.captureStarted).toEqual(false)
+        })
+
+        it('session recording can be turned on after being turned off', () => {
             expect(given.sessionRecording.stopRrweb).toEqual(null)
 
             given.sessionRecording.startRecordingIfEnabled()
@@ -218,7 +279,7 @@ describe('SessionRecording', () => {
                 given.sessionRecording.windowId = 'old-window-id'
 
                 given.sessionRecording.startRecordingIfEnabled()
-                given.sessionRecording.submitRecordings()
+                given.sessionRecording.startCaptureAndTrySendingQueuedSnapshots()
             })
 
             it('sends a full snapshot if there is a new session/window id and the event is not type FullSnapshot or Meta', () => {

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -49,7 +49,7 @@ describe('SessionRecording', () => {
 
     describe('isRecordingEnabled', () => {
         given('subject', () => () => given.sessionRecording.isRecordingEnabled())
-        it('is enabled id both the server and client config says enabled', () => {
+        it('is enabled if both the server and client config says enabled', () => {
             given.subject()
             expect(given.subject()).toBe(true)
         })

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -90,8 +90,6 @@ describe('SessionRecording', () => {
     describe('afterDecideResponse()', () => {
         given('subject', () => () => given.sessionRecording.afterDecideResponse(given.response))
         given('response', () => ({ sessionRecording: { endpoint: '/s/' } }))
-        given('$session_recording_enabled_server_side', () => true)
-        given('disabled', () => false)
 
         beforeEach(() => {
             jest.spyOn(given.sessionRecording, 'startRecordingIfEnabled')
@@ -137,9 +135,6 @@ describe('SessionRecording', () => {
     })
 
     describe('recording', () => {
-        given('disabled', () => false)
-        given('$session_recording_enabled_server_side', () => true)
-
         beforeEach(() => {
             const mockFullSnapshot = jest.fn()
             window.rrweb = {

--- a/src/posthog-persistence.js
+++ b/src/posthog-persistence.js
@@ -18,7 +18,7 @@ import { cookieStore, localStore, localPlusCookieStore, memoryStore } from './st
 /** @const */ var ALIAS_ID_KEY = '__alias'
 /** @const */ var CAMPAIGN_IDS_KEY = '__cmpns'
 /** @const */ var EVENT_TIMERS_KEY = '__timers'
-/** @const */ var SESSION_RECORDING_ENABLED = '$session_recording_enabled'
+/** @const */ var SESSION_RECORDING_ENABLED_SERVER_SIDE = '$session_recording_enabled_server_side'
 /** @const */ var SESSION_ID = '$sesid'
 /** @const */ var ENABLED_FEATURE_FLAGS = '$enabled_feature_flags'
 /** @const */ var RESERVED_PROPERTIES = [
@@ -33,7 +33,7 @@ import { cookieStore, localStore, localPlusCookieStore, memoryStore } from './st
     ALIAS_ID_KEY,
     CAMPAIGN_IDS_KEY,
     EVENT_TIMERS_KEY,
-    SESSION_RECORDING_ENABLED,
+    SESSION_RECORDING_ENABLED_SERVER_SIDE,
     SESSION_ID,
     ENABLED_FEATURE_FLAGS,
 ]
@@ -291,6 +291,6 @@ export {
     ALIAS_ID_KEY,
     CAMPAIGN_IDS_KEY,
     EVENT_TIMERS_KEY,
-    SESSION_RECORDING_ENABLED,
+    SESSION_RECORDING_ENABLED_SERVER_SIDE,
     SESSION_ID,
 }


### PR DESCRIPTION
## Changes

Fixes an issue where if a user has session recording disabled client side when the decide response happened, the disabled state was stored in local storage. It was then impossible to re-enable it client side (because the cached value and the re-enabled value both had to be true). This meant our recommended way of turning on/off recording via feature flags to enable/disable recordings for a subset of users was broken.

The fix was to only cache the server side response in local storage and still respect the client side config during run-time.

In fixing this, I also tried to merge the paths for the two ways that recordings can be started (via the `decide` response and via `startRecordingIfEnabled`)

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
