### PR TITLE
fix(web performance): calculate duration when it isn't present on navigation timing

### DIFF
--- a/src/__tests__/apm.js
+++ b/src/__tests__/apm.js
@@ -2,6 +2,12 @@ import { deduplicateKeys, optimisePerformanceData, pageLoadFrom } from '../apm'
 import veryLargePerfJson from './very-large-performance-data.json'
 import optimisedVeryLargePerfJson from './optimised-very-large-performance-data.json'
 
+const removePerformanceItem = (optimisedNavigationData, name) => {
+    const durationIndex = optimisedNavigationData[0].indexOf(name)
+    optimisedNavigationData[0].splice(durationIndex, 1)
+    optimisedNavigationData[1][0].splice(durationIndex, 1)
+}
+
 describe('when capturing performance data', () => {
     it('reduces the size of very large payloads of navigation objects', () => {
         const processedPerformanceJson = optimisePerformanceData(veryLargePerfJson.navigation)
@@ -26,17 +32,17 @@ describe('when capturing performance data', () => {
 
     it('can read duration even when the duration property is not available', () => {
         const optimisedNavigationData = optimisePerformanceData(veryLargePerfJson.navigation)
-        const durationIndex = optimisedNavigationData[0].indexOf('duration')
-        optimisedNavigationData[0].splice(durationIndex, 1)
-        optimisedNavigationData[1][0].splice(durationIndex, 1)
+        removePerformanceItem(optimisedNavigationData, 'duration')
+
         const pageLoad = pageLoadFrom({ navigation: optimisedNavigationData })
         expect(pageLoad).toBe(938.3)
     })
 
     it('can safely read absent page load duration from optimised data', () => {
         const optimisedNavigationData = optimisePerformanceData(veryLargePerfJson.navigation)
-        optimisedNavigationData[0].splice(optimisedNavigationData[0].indexOf('duration'), 1)
-        optimisedNavigationData[0].splice(optimisedNavigationData[0].indexOf('loadEventEnd'), 1)
+        removePerformanceItem(optimisedNavigationData, 'duration')
+        removePerformanceItem(optimisedNavigationData, 'loadEventEnd')
+
         const pageLoad = pageLoadFrom({ navigation: optimisedNavigationData })
         expect(pageLoad).toBe(undefined)
     })

--- a/src/__tests__/apm.js
+++ b/src/__tests__/apm.js
@@ -24,10 +24,20 @@ describe('when capturing performance data', () => {
         expect(pageLoad).toBe(938.3)
     })
 
+    it('can read duration even when the duration property is not available', () => {
+        const optimisedNavigationData = optimisePerformanceData(veryLargePerfJson.navigation)
+        const durationIndex = optimisedNavigationData[0].indexOf('duration')
+        optimisedNavigationData[0].splice(durationIndex, 1)
+        optimisedNavigationData[1][0].splice(durationIndex, 1)
+        const pageLoad = pageLoadFrom({ navigation: optimisedNavigationData })
+        expect(pageLoad).toBe(938.3)
+    })
+
     it('can safely read absent page load duration from optimised data', () => {
-        const navigation = optimisePerformanceData(veryLargePerfJson.navigation)
-        navigation[0].splice(2) //remove duration
-        const pageLoad = pageLoadFrom({ navigation: navigation })
+        const optimisedNavigationData = optimisePerformanceData(veryLargePerfJson.navigation)
+        optimisedNavigationData[0].splice(optimisedNavigationData[0].indexOf('duration'), 1)
+        optimisedNavigationData[0].splice(optimisedNavigationData[0].indexOf('loadEventEnd'), 1)
+        const pageLoad = pageLoadFrom({ navigation: optimisedNavigationData })
         expect(pageLoad).toBe(undefined)
     })
 

--- a/src/apm.js
+++ b/src/apm.js
@@ -73,10 +73,31 @@ export function deduplicateKeys(performanceEntries) {
     return [keys, performanceEntries.map((obj) => keys.map((key) => obj[key]))]
 }
 
+/*
+The duration property is on the PerformanceNavigationTiming object.
+
+It is a timestamp that is the difference between the PerformanceNavigationTiming.loadEventEnd
+and PerformanceEntry.startTime properties.
+https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming
+
+Even in browsers that implement it, it is not always available to us
+ */
 export function pageLoadFrom(performanceData) {
-    const keyIndex =
-        performanceData.navigation && performanceData.navigation[0] && performanceData.navigation[0].indexOf('duration')
-    return performanceData.navigation[1] && performanceData.navigation[1][0][keyIndex]
+    const keys = performanceData.navigation && performanceData.navigation[0]
+    const values = performanceData.navigation[1] && performanceData.navigation[1][0]
+
+    const durationIndex = keys && keys.indexOf('duration')
+    if (durationIndex > -1) {
+        return values[durationIndex]
+    } else {
+        const endKeyIndex = keys && keys.indexOf('loadEventEnd')
+        const startKeyIndex = keys && keys.indexOf('startTime') // start key is not present if start is 0
+        if (endKeyIndex > -1) {
+            const end = values && values[endKeyIndex]
+            const start = (values && values[startKeyIndex]) || 0
+            return end - start
+        }
+    }
 }
 
 export function getPerformanceData() {

--- a/src/apm.js
+++ b/src/apm.js
@@ -84,7 +84,7 @@ Even in browsers that implement it, it is not always available to us
  */
 export function pageLoadFrom(performanceData) {
     const keys = performanceData.navigation && performanceData.navigation[0]
-    const values = performanceData.navigation[1] && performanceData.navigation[1][0]
+    const values = performanceData.navigation && performanceData.navigation[1] && performanceData.navigation[1][0]
 
     const durationIndex = keys && keys.indexOf('duration')
     if (durationIndex > -1) {


### PR DESCRIPTION
When investigating [this customer request to use web performance monitoring](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1645608150705189) I saw that even though the spec has a duration property on PerformanceNavigationTiming. We don't always have it available to report page load

This calculates page load if duration isn't present 

## Changes

...

## Checklist
- [X] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
