### PR TITLE
fix(properties): dont modify input properties

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -466,6 +466,13 @@ describe('_calculate_event_properties()', () => {
             distinct_id: 'abc',
         })
     })
+
+    it("doesn't modify properties passed into it", () => {
+        const properties = { prop1: 'val1', prop2: 'val2' }
+        given.lib._calculate_event_properties(given.event_name, properties, given.start_timestamp, given.options)
+
+        expect(Object.keys(properties)).toEqual(['prop1', 'prop2'])
+    })
 })
 
 describe('_handle_unload()', () => {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -640,7 +640,7 @@ PostHogLib.prototype._invokeCaptureHooks = function (eventName, eventData) {
 
 PostHogLib.prototype._calculate_event_properties = function (event_name, event_properties, start_timestamp) {
     // set defaults
-    let properties = _.deepCircularCopy(event_properties) || {}
+    let properties = { ...event_properties } || {}
     properties['token'] = this.get_config('token')
 
     if (event_name === '$snapshot') {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -640,7 +640,7 @@ PostHogLib.prototype._invokeCaptureHooks = function (eventName, eventData) {
 
 PostHogLib.prototype._calculate_event_properties = function (event_name, event_properties, start_timestamp) {
     // set defaults
-    let properties = event_properties || {}
+    let properties = { ...event_properties } || {}
     properties['token'] = this.get_config('token')
 
     if (event_name === '$snapshot') {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -640,7 +640,7 @@ PostHogLib.prototype._invokeCaptureHooks = function (eventName, eventData) {
 
 PostHogLib.prototype._calculate_event_properties = function (event_name, event_properties, start_timestamp) {
     // set defaults
-    let properties = { ...event_properties } || {}
+    let properties = _.deepCircularCopy(event_properties) || {}
     properties['token'] = this.get_config('token')
 
     if (event_name === '$snapshot') {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -640,7 +640,7 @@ PostHogLib.prototype._invokeCaptureHooks = function (eventName, eventData) {
 
 PostHogLib.prototype._calculate_event_properties = function (event_name, event_properties, start_timestamp) {
     // set defaults
-    let properties = { ...event_properties } || {}
+    let properties = { ...event_properties }
     properties['token'] = this.get_config('token')
 
     if (event_name === '$snapshot') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -878,7 +878,6 @@ _['info']['device'] = _.info.device
 _['info']['browser'] = _.info.browser
 _['info']['browserVersion'] = _.info.browserVersion
 _['info']['properties'] = _.info.properties
-_['deepCircularCopy'] = deepCircularCopy
 
 export { win as window, _, userAgent, console, document }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -878,6 +878,7 @@ _['info']['device'] = _.info.device
 _['info']['browser'] = _.info.browser
 _['info']['browserVersion'] = _.info.browserVersion
 _['info']['properties'] = _.info.properties
+_['deepCircularCopy'] = deepCircularCopy
 
 export { win as window, _, userAgent, console, document }
 


### PR DESCRIPTION
## Changes

We were adding fields like `$token` and `$window_id` to properties input by users. This isn't great, and led to unexpected errors for users

```
var eventData = {foo: "bar"};
posthog.capture('event_test', eventData);
console.log(eventData); // this has $token and stuff
```

ref: https://posthogusers.slack.com/archives/C01GLBKHKQT/p1647013231963579?thread_ts=1646957568.583359&cid=C01GLBKHKQT
...

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
