### PR TITLE
revert: "feat: send library version outside of compressed body as a debug signal"

### DIFF
--- a/cypress/integration/capture.spec.js
+++ b/cypress/integration/capture.spec.js
@@ -1,9 +1,6 @@
 /// <reference types="cypress" />
-import { version } from '../../package.json'
 
 import { getBase64EncodedPayload, getGzipEncodedPayload, getLZStringEncodedPayload } from '../support/compression'
-
-const urlWithVersion = new RegExp(`&v=${version}`)
 
 describe('Event capture', () => {
     given('options', () => ({}))
@@ -205,13 +202,10 @@ describe('Event capture', () => {
             start()
 
             // Pageview will be sent immediately
-            cy.wait('@capture').should(({ request, url }) => {
-                expect(request.headers).to.eql({
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                })
-
-                expect(url).to.match(urlWithVersion)
-
+            cy.wait('@capture').its('request.headers').should('deep.equal', {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            })
+            cy.get('@capture').should(({ request }) => {
                 const captures = getBase64EncodedPayload(request)
 
                 expect(captures.event).to.equal('$pageview')
@@ -246,12 +240,10 @@ describe('Event capture', () => {
             start()
 
             // Pageview will be sent immediately
-            cy.wait('@capture').should(({ request, url }) => {
-                expect(request.headers).to.eql({
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                })
-
-                expect(url).to.match(urlWithVersion)
+            cy.wait('@capture').its('request.headers').should('deep.equal', {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            })
+            cy.get('@capture').should(({ request }) => {
                 const captures = getBase64EncodedPayload(request)
 
                 expect(captures['event']).to.equal('$pageview')
@@ -263,12 +255,10 @@ describe('Event capture', () => {
             cy.phCaptures().should('include', '$autocapture')
             cy.phCaptures().should('include', 'custom-event')
 
-            cy.wait('@capture').should(({ request, url }) => {
-                expect(request.headers).to.eql({
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                })
-
-                expect(url).to.match(urlWithVersion)
+            cy.wait('@capture').its('request.headers').should('deep.equal', {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            })
+            cy.get('@capture').should(({ request }) => {
                 const captures = getLZStringEncodedPayload(request)
 
                 expect(captures.map(({ event }) => event)).to.deep.equal([
@@ -286,12 +276,10 @@ describe('Event capture', () => {
             it('contains the correct payload after an event', () => {
                 start()
                 // Pageview will be sent immediately
-                cy.wait('@capture').should(({ request, url }) => {
-                    expect(request.headers).to.eql({
-                        'Content-Type': 'application/x-www-form-urlencoded',
-                    })
-
-                    expect(url).to.match(urlWithVersion)
+                cy.wait('@capture').its('request.headers').should('deep.equal', {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                })
+                cy.get('@capture').should(({ request }) => {
                     const data = decodeURIComponent(request.body.match(/data=(.*)/)[1])
                     const captures = JSON.parse(Buffer.from(data, 'base64'))
 

--- a/src/__tests__/send-request.js
+++ b/src/__tests__/send-request.js
@@ -1,12 +1,10 @@
-import { addParamsToURL, encodePostData, xhr } from '../send-request'
+import { encodePostData, xhr } from '../send-request'
 import { assert, boolean, property, uint8Array, VerbosityLevel } from 'fast-check'
 
-jest.mock('../config', () => ({ DEBUG: false, LIB_VERSION: '1.23.45' }))
-
-describe('xhr', () => {
+describe('when xhr requests fail', () => {
     given('mockXHR', () => ({
         open: jest.fn(),
-        setRequestHeader: jest.fn,
+        setRequestHeader: jest.fn(),
         onreadystatechange: jest.fn(),
         send: jest.fn(),
         readyState: 4,
@@ -39,43 +37,17 @@ describe('xhr', () => {
         window.XMLHttpRequest = jest.fn(() => given.mockXHR)
     })
 
-    describe('when xhr requests fail', () => {
-        it('does not error if the configured onXHRError is not a function', () => {
-            given('onXHRError', () => 'not a function')
-            expect(() => given.subject()).not.toThrow()
-        })
-
-        it('calls the injected XHR error handler', () => {
-            //cannot use an auto-mock from jest as the code checks if onXHRError is a Function
-            let requestFromError
-            given('onXHRError', () => (req) => (requestFromError = req))
-            given.subject()
-            expect(requestFromError).toHaveProperty('status', 502)
-        })
-    })
-})
-
-describe('adding query params to posthog API calls', () => {
-    given('subject', () => () => addParamsToURL(given.posthogURL, given.urlQueryArgs, given.parameterOptions))
-    given('posthogURL', () => 'https://any.posthog-instance.com')
-    given('urlQueryArgs', () => ({}))
-    given('parameterOptions', () => ({
-        ip: true,
-    }))
-
-    it('adds library and version', () => {
-        expect(new URL(given.subject()).search).toContain('&v=1.23.45')
+    it('does not error if the configured onXHRError is not a function', () => {
+        given('onXHRError', () => 'not a function')
+        expect(() => given.subject()).not.toThrow()
     })
 
-    it('adds i as 1 when IP in config', () => {
-        expect(new URL(given.subject()).search).toContain('ip=1')
-    })
-    it('adds i as 0 when IP not in config', () => {
-        given('parameterOptions', () => ({}))
-        expect(new URL(given.subject()).search).toContain('ip=0')
-    })
-    it('adds timestamp', () => {
-        expect(new URL(given.subject()).search).toMatch(/_=\d+/)
+    it('calls the injected XHR error handler', () => {
+        //cannot use an auto-mock from jest as the code checks if onXHRError is a Function
+        let requestFromError
+        given('onXHRError', () => (req) => (requestFromError = req))
+        given.subject()
+        expect(requestFromError).toHaveProperty('status', 502)
     })
 })
 

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -14,7 +14,7 @@ import { cookieStore, localStore } from './storage'
 import { RequestQueue } from './request-queue'
 import { CaptureMetrics } from './capture-metrics'
 import { compressData, decideCompression } from './compression'
-import { addParamsToURL, encodePostData, xhr } from './send-request'
+import { encodePostData, xhr } from './send-request'
 import { RetryQueue } from './retry-queue'
 import { SessionIdManager } from './sessionid'
 import { getPerformanceData } from './apm'
@@ -412,9 +412,12 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
     }
 
     const useSendBeacon = window.navigator.sendBeacon && options.transport.toLowerCase() === 'sendbeacon'
-    url = addParamsToURL(url, options.urlQueryArgs, {
-        ip: this.get_config('ip'),
-    })
+    var args = options.urlQueryArgs || {}
+    args['ip'] = this.get_config('ip') ? 1 : 0
+    args['_'] = new Date().getTime().toString()
+
+    const argSeparator = url.indexOf('?') > -1 ? '&' : '?'
+    url += argSeparator + _.HTTPBuildQuery(args)
 
     if (_.isObject(data) && this.get_config('img')) {
         var img = document.createElement('img')

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -1,15 +1,4 @@
 import { _, logger } from './utils'
-import Config from './config'
-
-export const addParamsToURL = (url, urlQueryArgs, parameterOptions) => {
-    const args = urlQueryArgs || {}
-    args['ip'] = parameterOptions['ip'] ? 1 : 0
-    args['_'] = new Date().getTime().toString()
-    args['v'] = Config.LIB_VERSION
-
-    const argSeparator = url.indexOf('?') > -1 ? '&' : '?'
-    return url + argSeparator + _.HTTPBuildQuery(args)
-}
 
 export const encodePostData = (data, options) => {
     if (options.blob && data.buffer) {
@@ -62,7 +51,6 @@ export const xhr = ({
     _.each(headers, function (headerValue, headerName) {
         req.setRequestHeader(headerName, headerValue)
     })
-
     if (options.method === 'POST' && !options.blob) {
         req.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded')
     }


### PR DESCRIPTION
Reverts PostHog/posthog-js#351

This is breaking the `/decide` request because it adds a second `v=...` query param, so the request looks like `http://localhost:8000/decide/?v=2&ip=1&_=1647974321278&v=1.19.1`