### PR TITLE
feat: send library version outside of compressed body as a debug signal

### DIFF
--- a/cypress/integration/capture.spec.js
+++ b/cypress/integration/capture.spec.js
@@ -3,7 +3,7 @@ import { version } from '../../package.json'
 
 import { getBase64EncodedPayload, getGzipEncodedPayload, getLZStringEncodedPayload } from '../support/compression'
 
-const urlWithVersion = new RegExp(`&v=${version}`)
+const urlWithVersion = new RegExp(`&ver=${version}`)
 
 describe('Event capture', () => {
     given('options', () => ({}))

--- a/cypress/integration/capture.spec.js
+++ b/cypress/integration/capture.spec.js
@@ -1,6 +1,9 @@
 /// <reference types="cypress" />
+import { version } from '../../package.json'
 
 import { getBase64EncodedPayload, getGzipEncodedPayload, getLZStringEncodedPayload } from '../support/compression'
+
+const urlWithVersion = new RegExp(`&v=${version}`)
 
 describe('Event capture', () => {
     given('options', () => ({}))
@@ -202,10 +205,13 @@ describe('Event capture', () => {
             start()
 
             // Pageview will be sent immediately
-            cy.wait('@capture').its('request.headers').should('deep.equal', {
-                'Content-Type': 'application/x-www-form-urlencoded',
-            })
-            cy.get('@capture').should(({ request }) => {
+            cy.wait('@capture').should(({ request, url }) => {
+                expect(request.headers).to.eql({
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                })
+
+                expect(url).to.match(urlWithVersion)
+
                 const captures = getBase64EncodedPayload(request)
 
                 expect(captures.event).to.equal('$pageview')
@@ -240,10 +246,12 @@ describe('Event capture', () => {
             start()
 
             // Pageview will be sent immediately
-            cy.wait('@capture').its('request.headers').should('deep.equal', {
-                'Content-Type': 'application/x-www-form-urlencoded',
-            })
-            cy.get('@capture').should(({ request }) => {
+            cy.wait('@capture').should(({ request, url }) => {
+                expect(request.headers).to.eql({
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                })
+
+                expect(url).to.match(urlWithVersion)
                 const captures = getBase64EncodedPayload(request)
 
                 expect(captures['event']).to.equal('$pageview')
@@ -255,10 +263,12 @@ describe('Event capture', () => {
             cy.phCaptures().should('include', '$autocapture')
             cy.phCaptures().should('include', 'custom-event')
 
-            cy.wait('@capture').its('request.headers').should('deep.equal', {
-                'Content-Type': 'application/x-www-form-urlencoded',
-            })
-            cy.get('@capture').should(({ request }) => {
+            cy.wait('@capture').should(({ request, url }) => {
+                expect(request.headers).to.eql({
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                })
+
+                expect(url).to.match(urlWithVersion)
                 const captures = getLZStringEncodedPayload(request)
 
                 expect(captures.map(({ event }) => event)).to.deep.equal([
@@ -276,10 +286,12 @@ describe('Event capture', () => {
             it('contains the correct payload after an event', () => {
                 start()
                 // Pageview will be sent immediately
-                cy.wait('@capture').its('request.headers').should('deep.equal', {
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                })
-                cy.get('@capture').should(({ request }) => {
+                cy.wait('@capture').should(({ request, url }) => {
+                    expect(request.headers).to.eql({
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    })
+
+                    expect(url).to.match(urlWithVersion)
                     const data = decodeURIComponent(request.body.match(/data=(.*)/)[1])
                     const captures = JSON.parse(Buffer.from(data, 'base64'))
 

--- a/src/__tests__/send-request.js
+++ b/src/__tests__/send-request.js
@@ -64,7 +64,7 @@ describe('adding query params to posthog API calls', () => {
     }))
 
     it('adds library and version', () => {
-        expect(new URL(given.subject()).search).toContain('&v=1.23.45')
+        expect(new URL(given.subject()).search).toContain('&ver=1.23.45')
     })
 
     it('adds i as 1 when IP in config', () => {
@@ -76,6 +76,17 @@ describe('adding query params to posthog API calls', () => {
     })
     it('adds timestamp', () => {
         expect(new URL(given.subject()).search).toMatch(/_=\d+/)
+    })
+
+    it('does not add a query parameter if it already exists in the URL', () => {
+        given('posthogURL', () => 'https://test.com/')
+        const whenItShouldAddParam = given.subject()
+        expect(whenItShouldAddParam).toContain('ver=1.23.45')
+
+        given('posthogURL', () => 'https://test.com/decide/?ver=2')
+        const whenItShouldNotAddParam = given.subject()
+        expect(whenItShouldNotAddParam).not.toContain('ver=1.23.45')
+        expect(whenItShouldNotAddParam).toContain('ver=2')
     })
 })
 

--- a/src/__tests__/send-request.js
+++ b/src/__tests__/send-request.js
@@ -63,7 +63,7 @@ describe('adding query params to posthog API calls', () => {
         ip: true,
     }))
 
-    it('adds library and version', () => {
+    it('adds library version', () => {
         expect(new URL(given.subject()).search).toContain('&ver=1.23.45')
     })
 

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -14,7 +14,7 @@ import { cookieStore, localStore } from './storage'
 import { RequestQueue } from './request-queue'
 import { CaptureMetrics } from './capture-metrics'
 import { compressData, decideCompression } from './compression'
-import { encodePostData, xhr } from './send-request'
+import { addParamsToURL, encodePostData, xhr } from './send-request'
 import { RetryQueue } from './retry-queue'
 import { SessionIdManager } from './sessionid'
 import { getPerformanceData } from './apm'
@@ -412,12 +412,9 @@ PostHogLib.prototype._send_request = function (url, data, options, callback) {
     }
 
     const useSendBeacon = window.navigator.sendBeacon && options.transport.toLowerCase() === 'sendbeacon'
-    var args = options.urlQueryArgs || {}
-    args['ip'] = this.get_config('ip') ? 1 : 0
-    args['_'] = new Date().getTime().toString()
-
-    const argSeparator = url.indexOf('?') > -1 ? '&' : '?'
-    url += argSeparator + _.HTTPBuildQuery(args)
+    url = addParamsToURL(url, options.urlQueryArgs, {
+        ip: this.get_config('ip'),
+    })
 
     if (_.isObject(data) && this.get_config('img')) {
         var img = document.createElement('img')

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -1,4 +1,15 @@
 import { _, logger } from './utils'
+import Config from './config'
+
+export const addParamsToURL = (url, urlQueryArgs, parameterOptions) => {
+    const args = urlQueryArgs || {}
+    args['ip'] = parameterOptions['ip'] ? 1 : 0
+    args['_'] = new Date().getTime().toString()
+    args['v'] = Config.LIB_VERSION
+
+    const argSeparator = url.indexOf('?') > -1 ? '&' : '?'
+    return url + argSeparator + _.HTTPBuildQuery(args)
+}
 
 export const encodePostData = (data, options) => {
     if (options.blob && data.buffer) {
@@ -51,6 +62,7 @@ export const xhr = ({
     _.each(headers, function (headerValue, headerName) {
         req.setRequestHeader(headerName, headerValue)
     })
+
     if (options.method === 'POST' && !options.blob) {
         req.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded')
     }

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -5,7 +5,18 @@ export const addParamsToURL = (url, urlQueryArgs, parameterOptions) => {
     const args = urlQueryArgs || {}
     args['ip'] = parameterOptions['ip'] ? 1 : 0
     args['_'] = new Date().getTime().toString()
-    args['v'] = Config.LIB_VERSION
+    args['ver'] = Config.LIB_VERSION
+
+    const halves = url.split('?')
+    if (halves.length > 1) {
+        const params = halves[1].split('&')
+        for (const p of params) {
+            const key = p.split('=')[0]
+            if (args[key]) {
+                delete args[key]
+            }
+        }
+    }
 
     const argSeparator = url.indexOf('?') > -1 ? '&' : '?'
     return url + argSeparator + _.HTTPBuildQuery(args)


### PR DESCRIPTION
## Changes

reverts #375 which reverted #351

----

We add the library version to event properties. This is really useful when debugging problems.

When decompression of the request body fails we get an error report in Sentry. But we can't add the library version to the Sentry report because it is inside the compressed content.

This change adds the lib version to an HTTP query parameter so that it would always be available in Sentry. We could (optionally) follow up by having the backend add that library version as a tag to Sentry so we get richer behaviour in the Sentry UI

----

This originally added parameter `v` clashed with an existing parameter on the decide calls.

All of the network calls on the tests are mocked, so the tests on decide didn't catch this. And other tests on other areas might not too...

----

So, this renames the parameter to one that is still vague, but less likely to clash `ver`

_and_ when constructing the URL doesn't duplicate _or_ replace query params

So sending `https:/example.io/?other=things&ver=keep-me` results in `https:/example.io/?other-things&ver=keep-me` but sending `https:/example.io/?other=things` results in  `https:/example.io/?other=things&ver=1.23.45`

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
