### PR TITLE
fix(web-performance): clear resource timings after reading

### DIFF
--- a/src/apm.js
+++ b/src/apm.js
@@ -106,6 +106,7 @@ export function getPerformanceData() {
         paint: getPerformanceEntriesByType('paint'),
         resource: getPerformanceEntriesByType('resource'),
     }
+    window?.performance?.clearResourceTimings()
 
     const properties = {}
 

--- a/src/apm.js
+++ b/src/apm.js
@@ -106,7 +106,10 @@ export function getPerformanceData() {
         paint: getPerformanceEntriesByType('paint'),
         resource: getPerformanceEntriesByType('resource'),
     }
-    window?.performance?.clearResourceTimings()
+
+    if (typeof window !== undefined && window.performance && window.performance.clearResourceTimings) {
+        window.performance.clearResourceTimings()
+    }
 
     const properties = {}
 


### PR DESCRIPTION
## Changes

The web performance page sometimes shows resource loads after a large gap. In one case after a greater than 40 minute gap.

<img width="1199" alt="Screenshot 2022-03-26 at 07 37 16" src="https://user-images.githubusercontent.com/984817/160229781-e2a1262b-4a0f-4ab4-bcc5-5431e411df07.png">

It is likely this is someone returning to a page after a large gap and navigating within the SPA.

The web performance code (incorrectly) assumes that the browser performance resource entries are always fresh and relevant. 

This change clears resource timings after reading them to avoid this

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [-] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
