### PR TITLE
fix(config): Handle config undefined

### DIFF
--- a/src/__tests__/gdpr-utils.js
+++ b/src/__tests__/gdpr-utils.js
@@ -575,6 +575,17 @@ describe(`GDPR utils`, () => {
                 })
             })
 
+            it(`should call the wrapped method if config is undefined`, () => {
+                TOKENS.forEach((token) => {
+                    setupMocks(() => undefined, false)
+
+                    gdpr.optIn(token, { persistenceType })
+                    postHogLib.capture(captureEventName, captureProperties)
+
+                    expect(capture.calledOnceWith(captureEventName, captureProperties)).toBe(true)
+                })
+            })
+
             it(`should allow use of a custom "persistence prefix" string`, () => {
                 TOKENS.forEach((token) => {
                     setupMocks(() => ({

--- a/src/gdpr-utils.js
+++ b/src/gdpr-utils.js
@@ -265,20 +265,22 @@ function _addOptOutCheck(method, getConfigValue, silenceErrors) {
         var optedOut = false
 
         try {
-            var token = getConfigValue.call(this, 'token')
-            var respectDnt = getConfigValue.call(this, 'respect_dnt')
-            var persistenceType = getConfigValue.call(this, 'opt_out_capturing_persistence_type')
-            var persistencePrefix = getConfigValue.call(this, 'opt_out_capturing_cookie_prefix')
-            var win = getConfigValue.call(this, 'window') // used to override window during browser tests
+            if (this['config']) {
+                var token = getConfigValue.call(this, 'token')
+                var respectDnt = getConfigValue.call(this, 'respect_dnt')
+                var persistenceType = getConfigValue.call(this, 'opt_out_capturing_persistence_type')
+                var persistencePrefix = getConfigValue.call(this, 'opt_out_capturing_cookie_prefix')
+                var win = getConfigValue.call(this, 'window') // used to override window during browser tests
 
-            if (token) {
-                // if there was an issue getting the token, continue method execution as normal
-                optedOut = hasOptedOut(token, {
-                    respectDnt,
-                    persistenceType,
-                    persistencePrefix,
-                    window: win,
-                })
+                if (token) {
+                    // if there was an issue getting the token, continue method execution as normal
+                    optedOut = hasOptedOut(token, {
+                        respectDnt,
+                        persistenceType,
+                        persistencePrefix,
+                        window: win,
+                    })
+                }
             }
         } catch (err) {
             if (!silenceErrors) {

--- a/src/gdpr-utils.js
+++ b/src/gdpr-utils.js
@@ -265,22 +265,20 @@ function _addOptOutCheck(method, getConfigValue, silenceErrors) {
         var optedOut = false
 
         try {
-            if (this['config']) {
-                var token = getConfigValue.call(this, 'token')
-                var respectDnt = getConfigValue.call(this, 'respect_dnt')
-                var persistenceType = getConfigValue.call(this, 'opt_out_capturing_persistence_type')
-                var persistencePrefix = getConfigValue.call(this, 'opt_out_capturing_cookie_prefix')
-                var win = getConfigValue.call(this, 'window') // used to override window during browser tests
+            var token = getConfigValue.call(this, 'token')
+            var respectDnt = getConfigValue.call(this, 'respect_dnt')
+            var persistenceType = getConfigValue.call(this, 'opt_out_capturing_persistence_type')
+            var persistencePrefix = getConfigValue.call(this, 'opt_out_capturing_cookie_prefix')
+            var win = getConfigValue.call(this, 'window') // used to override window during browser tests
 
-                if (token) {
-                    // if there was an issue getting the token, continue method execution as normal
-                    optedOut = hasOptedOut(token, {
-                        respectDnt,
-                        persistenceType,
-                        persistencePrefix,
-                        window: win,
-                    })
-                }
+            if (token) {
+                // if there was an issue getting the token, continue method execution as normal
+                optedOut = hasOptedOut(token, {
+                    respectDnt,
+                    persistenceType,
+                    persistencePrefix,
+                    window: win,
+                })
             }
         } catch (err) {
             if (!silenceErrors) {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1202,7 +1202,7 @@ PostHogLib.prototype.sessionRecordingStarted = function () {
  * returns the current config object for the library.
  */
 PostHogLib.prototype.get_config = function (prop_name) {
-    return this['config'][prop_name]
+    return this.config?.[prop_name]
 }
 
 /**


### PR DESCRIPTION
## Changes

- Config can be undefined during the optout check which [errors](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1649076377124529) out `TypeError: Cannot read properties of undefined`
- this adds a check on the config object
...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
