### PR TITLE
feat(recordings): add inline stylesheet option

### DIFF
--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -161,6 +161,7 @@ describe('SessionRecording', () => {
                 slimDOMOptions: {},
                 collectFonts: false,
                 plugins: [],
+                inlineStylesheet: true,
             })
         })
 

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -124,6 +124,7 @@ export class SessionRecording {
             maskInputFn: null,
             slimDOMOptions: {},
             collectFonts: false,
+            inlineStylesheet: true,
         }
         // We switched from loading all of rrweb to just the record part, but
         // keep backwards compatibility if someone hasn't upgraded PostHog
@@ -139,9 +140,7 @@ export class SessionRecording {
 
         this.stopRrweb = this.rrwebRecord({
             emit: (event) => {
-                event = truncateLargeConsoleLogs(
-                    filterDataURLsFromLargeDataObjects(event)
-                )
+                event = truncateLargeConsoleLogs(filterDataURLsFromLargeDataObjects(event))
 
                 this._updateWindowAndSessionIds(event)
 

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -289,6 +289,7 @@ declare class posthog {
      *         maskInputFn: null,
      *         slimDOMOptions: {},
      *         collectFonts: false
+     *         inlineStylesheet: true
      *      }
      *
      *      // prevent autocapture from capturing any attribute names on elements
@@ -658,6 +659,7 @@ declare namespace posthog {
         maskInputFn?: (text: string) => string
         slimDOMOptions?: SlimDOMOptions | 'all' | true
         collectFonts?: boolean
+        inlineStylesheet?: boolean
     }
 
     export class persistence {

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -99,6 +99,7 @@ const defaultConfig = () => ({
         maskInputFn: null,
         slimDOMOptions: {},
         collectFonts: false,
+        inlineStylesheet: true,
     },
     mask_all_element_attributes: false,
     mask_all_text: false,


### PR DESCRIPTION
## Changes

Adds the configuration for inlining the stylesheets in recordings. By default this is on, but turning it off is really useful for customers who:
* Have large stylesheets (to keep the size of the recordings down)
* Are hitting some bugs in Chrome's MutationObserver's css serialization

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
