### PR TITLE
fix(console-logs): handle undefined and null log

### DIFF
--- a/src/__tests__/extensions/sessionrecording-utils.js
+++ b/src/__tests__/extensions/sessionrecording-utils.js
@@ -209,5 +209,27 @@ describe(`SessionRecording utility functions`, () => {
                 },
             })
         })
+
+        it(`should handle and not touch null or undefined elements`, () => {
+            expect(
+                truncateLargeConsoleLogs({
+                    type: PLUGIN_EVENT_TYPE,
+                    data: {
+                        plugin: CONSOLE_LOG_PLUGIN_NAME,
+                        payload: {
+                            payload: [undefined, null],
+                        },
+                    },
+                })
+            ).toEqual({
+                type: PLUGIN_EVENT_TYPE,
+                data: {
+                    plugin: CONSOLE_LOG_PLUGIN_NAME,
+                    payload: {
+                        payload: [undefined, null],
+                    },
+                },
+            })
+        })
     })
 })

--- a/src/extensions/sessionrecording-utils.js
+++ b/src/extensions/sessionrecording-utils.js
@@ -61,7 +61,10 @@ export function truncateLargeConsoleLogs(event) {
         }
         const updatedPayload = []
         for (let i = 0; i < event.data.payload.payload.length; i++) {
-            if (event.data.payload.payload[i].length > MAX_STRING_SIZE) {
+            if (
+                event.data.payload.payload[i] && // Value can be null
+                event.data.payload.payload[i].length > MAX_STRING_SIZE
+            ) {
                 updatedPayload.push(event.data.payload.payload[i].slice(0, MAX_STRING_SIZE) + '...[truncated]')
             } else {
                 updatedPayload.push(event.data.payload.payload[i])

--- a/src/extensions/sessionrecording.js
+++ b/src/extensions/sessionrecording.js
@@ -139,9 +139,7 @@ export class SessionRecording {
 
         this.stopRrweb = this.rrwebRecord({
             emit: (event) => {
-                event = truncateLargeConsoleLogs(
-                    filterDataURLsFromLargeDataObjects(event)
-                )
+                event = truncateLargeConsoleLogs(filterDataURLsFromLargeDataObjects(event))
 
                 this._updateWindowAndSessionIds(event)
 


### PR DESCRIPTION
## Changes

We used to throw an exception if the user logged `console.log(undefined)` when the console log feature is enabled. We were expecting the payload object from rr-web to always be a string, but in this one case, it's not.

This PR handles this case, but ideally we would get this fixed upstream. Logged an issue here: https://github.com/rrweb-io/rrweb/issues/877

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
