### PR TITLE
fix: register/unregister crash when undefined

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -652,6 +652,18 @@ describe('skipped init()', () => {
     it('capture() does not throw', () => {
         expect(() => given.lib.capture('$pageview')).not.toThrow()
     })
+    it('register() does not throw', () => {
+        expect(() => given.lib.register({})).not.toThrow()
+    })
+    it('register_once() does not throw', () => {
+        expect(() => given.lib.register_once({})).not.toThrow()
+    })
+    it('unregister() does not throw', () => {
+        expect(() => given.lib.unregister('property')).not.toThrow()
+    })
+    it('identify() does not throw', () => {
+        expect(() => given.lib.identify('user')).not.toThrow()
+    })
 })
 
 describe('group()', () => {


### PR DESCRIPTION
## Changes

This is a follow up to #282 which started implementing the ability to skip the init in dev. This adds in support for register/unregister/register_once/identify which currently throw errors if called when posthog init is skipped.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
