### PR TITLE
chore(dep): update rrweb to 1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "@sentry/types": "^6.11.0",
         "fflate": "^0.4.1",
-        "rrweb-snapshot": "^1.1.7"
+        "rrweb-snapshot": "^1.1.14"
     },
     "devDependencies": {
         "@babel/core": "7.12.10",
@@ -60,7 +60,7 @@
         "posthog-js": "link:.",
         "prettier": "^2.0.5",
         "rollup": "^2.18.2",
-        "rrweb": "^1.1.2",
+        "rrweb": "^1.1.3",
         "sinon": "9.0.2",
         "testcafe": "^1.17.1",
         "testcafe-browser-provider-browserstack": "^1.13.2-alpha.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11112,27 +11112,22 @@ rollup@^2.18.2:
   optionalDependencies:
     fsevents "~2.1.2"
 
-rrweb-snapshot@^1.1.13:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.13.tgz#fc15adb7eb6354c859c8d594f57b09e1f5bccdd8"
-  integrity sha512-lv4vBSJ5orBcRoJnjLvtly6cSsctC+TNm5orVzYRL9SH3LmtSpQ+wI4bw7eh4AcyKoUf0x4pe1Bn632GggmKWQ==
+rrweb-snapshot@^1.1.14:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.14.tgz#9d4d9be54a28a893373428ee4393ec7e5bd83fcc"
+  integrity sha512-eP5pirNjP5+GewQfcOQY4uBiDnpqxNRc65yKPW0eSoU1XamDfc4M8oqpXGMyUyvLyxFDB0q0+DChuxxiU2FXBQ==
 
-rrweb-snapshot@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.7.tgz#92a3b47b1112a1b566c2fae2edb02fa48a6f6653"
-  integrity sha512-+f2kCCvIQ1hbEeCWnV7mPVPDEdWEExqwcYqMd/r1nfK52QE7qU52jefUOyTe85Vy67rZGqWnfK/B25e/OTSgYg==
-
-rrweb@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-1.1.2.tgz#65279c8528dcfff7158bb31ed21323d3f26a741f"
-  integrity sha512-D1r3MdfYshY7rA8lN3R0cXqeY6fTtgHlkLQM4lxkU+TdKi023/hNQz6tvDJbXGX3HWGa4mRAmQs3S2uGho6Nsw==
+rrweb@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-1.1.3.tgz#4fbb3d473d71c79b6c30a54e585e5a01c8ac08bb"
+  integrity sha512-F2qp8LteJLyycsv+lCVJqtVpery63L3U+/ogqMA0da8R7Jx57o6gT+HpjrzdeeGMIBZR7kKNaKyJwDupTTu5KA==
   dependencies:
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"
     fflate "^0.4.4"
     mitt "^1.1.3"
-    rrweb-snapshot "^1.1.13"
+    rrweb-snapshot "^1.1.14"
 
 rsvp@^4.8.4:
   version "4.8.5"


### PR DESCRIPTION
## Changes

RR-web fixed [this issue](https://github.com/rrweb-io/rrweb/issues/790) which has been causing big issues for us (creating giant recordings and crashing browsers)

Updating to get the fix.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
