### PR TITLE
Fix this.get_config undefined error

### DIFF
--- a/src/retry-queue.js
+++ b/src/retry-queue.js
@@ -65,7 +65,9 @@ export class RetryQueue extends RequestQueueScaffold {
             try {
                 window.navigator.sendBeacon(url, encodePostData(data, { ...options, sendBeacon: true }))
             } catch (e) {
-                if (this.get_config('debug')) {
+                // Note sendBeacon automatically retries, and after the first retry it will loose reference to contextual `this`.
+                // This means in some cases `this.getConfig` will be undefined.
+                if (this.get_config?.('debug')) {
                     console.error(e)
                 }
             }


### PR DESCRIPTION
Fixes #342

When sendBeacon fails and is retrying (the browser automatically does this), and then the reference to contextual this is lost.

This error can occur a lot, especially on progressive web apps (we've seen it 16 times in the last 24 hours).

## Changes

Fail gracefully if this.get_config is undefined.

## Checklist
- [  ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ x ] Accounted for the impact of any changes across different browsers
- [ x ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
