### PR TITLE
fix: remove legacy logic preventing  if device_id != distinct_id

### DIFF
--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -866,10 +866,7 @@ PostHogLib.prototype.identify = function (new_distinct_id, userPropertiesToSet, 
 
     // send an $identify event any time the distinct_id is changing and the old ID is an anoymous ID
     // - logic on the server will determine whether or not to do anything with it.
-    if (
-        new_distinct_id !== previous_distinct_id &&
-        (!this.get_property('$device_id') || previous_distinct_id === this.get_property('$device_id'))
-    ) {
+    if (new_distinct_id !== previous_distinct_id) {
         this.capture(
             '$identify',
             {


### PR DESCRIPTION
We added this client-side logic to prevent identifying identified users to identified users, but the problem is that this breaks when `posthog.reset()` is called (without `reset_device_id=true`). That's because we keep the device ID but generate a new distinct id, tricking this logic into believing we have already identified this user.

This is safe to remove because this handling now exists on the server side.

Also note this was added **on top** of the more sane check that id1 != id2

