### PR TITLE
refactor(tests): error on console.error/warn

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,11 @@
             "json"
         ],
         "setupFilesAfterEnv": [
-            "given2/setup"
+            "given2/setup",
+            "./src/__tests__/setup.js"
+        ],
+        "modulePathIgnorePatterns": [
+            "src/__tests__/setup.js"
         ],
         "clearMocks": true,
         "testEnvironment": "jsdom"

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -87,9 +87,12 @@ describe('Decide', () => {
 
         it('Make sure receivedFeatureFlags is not called if the decide response fails', () => {
             given('decideResponse', () => ({ status: 0 }))
+            console.error = jest.fn()
+
             given.subject()
 
             expect(given.posthog.featureFlags.receivedFeatureFlags).not.toHaveBeenCalled()
+            expect(console.error).toHaveBeenCalledWith('Failed to fetch feature flags from PostHog.')
         })
     })
 })

--- a/src/__tests__/gdpr-utils.js
+++ b/src/__tests__/gdpr-utils.js
@@ -578,11 +578,15 @@ describe(`GDPR utils`, () => {
             it(`should call the wrapped method if config is undefined`, () => {
                 TOKENS.forEach((token) => {
                     setupMocks(() => undefined, false)
+                    console.error = jest.fn()
 
                     gdpr.optIn(token, { persistenceType })
                     postHogLib.capture(captureEventName, captureProperties)
 
                     expect(capture.calledOnceWith(captureEventName, captureProperties)).toBe(true)
+                    expect(console.error).toHaveBeenCalledWith(
+                        "Unexpected error when checking capturing opt-out status: TypeError: Cannot read properties of undefined (reading 'token')"
+                    )
                 })
             })
 

--- a/src/__tests__/gdpr-utils.js
+++ b/src/__tests__/gdpr-utils.js
@@ -584,9 +584,8 @@ describe(`GDPR utils`, () => {
                     postHogLib.capture(captureEventName, captureProperties)
 
                     expect(capture.calledOnceWith(captureEventName, captureProperties)).toBe(true)
-                    expect(console.error).toHaveBeenCalledWith(
-                        "Unexpected error when checking capturing opt-out status: TypeError: Cannot read properties of undefined (reading 'token')"
-                    )
+                    // :KLUDGE: Exact error message may vary between runtimes
+                    expect(console.error).toHaveBeenCalled()
                 })
             })
 

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -134,10 +134,13 @@ describe('identify()', () => {
         given('identity', () => null)
 
         it('does not update user', () => {
+            console.error = jest.fn()
+
             given.subject()
 
             expect(given.overrides.capture).not.toHaveBeenCalled()
             expect(given.overrides.register).not.toHaveBeenCalled()
+            expect(console.error).toHaveBeenCalledWith('Unique user id has not been set in posthog.identify')
         })
     })
 
@@ -175,12 +178,15 @@ describe('capture()', () => {
         given.lib.capture(given.eventName, given.eventProperties, given.options, given.callback)
     )
 
+    given('config', () => ({
+        property_blacklist: [],
+        _onCapture: jest.fn(),
+    }))
+
     given('overrides', () => ({
         __loaded: true,
         get_config: (key) => given.config?.[key],
-        config: {
-            _onCapture: jest.fn(),
-        },
+        config: given.config,
         persistence: {
             remove_event_timer: jest.fn(),
             update_search_keyword: jest.fn(),
@@ -214,27 +220,33 @@ describe('capture()', () => {
 
     it('errors with undefined event name', () => {
         given('eventName', () => undefined)
+        console.error = jest.fn()
 
         const hook = jest.fn()
         given.lib._addCaptureHook(hook)
 
         expect(() => given.subject()).not.toThrow()
         expect(hook).not.toHaveBeenCalled()
+        expect(console.error).toHaveBeenCalledWith('No event name provided to posthog.capture')
     })
 
     it('errors with object event name', () => {
         given('eventName', () => ({ event: 'object as name' }))
+        console.error = jest.fn()
 
         const hook = jest.fn()
         given.lib._addCaptureHook(hook)
 
         expect(() => given.subject()).not.toThrow()
         expect(hook).not.toHaveBeenCalled()
+        expect(console.error).toHaveBeenCalledWith('No event name provided to posthog.capture')
     })
 
     it('truncates long properties', () => {
         given('config', () => ({
             properties_string_max_length: 1000,
+            property_blacklist: [],
+            _onCapture: jest.fn(),
         }))
         given('eventProperties', () => ({
             key: 'value'.repeat(10000),
@@ -246,6 +258,8 @@ describe('capture()', () => {
     it('keeps long properties if null', () => {
         given('config', () => ({
             properties_string_max_length: null,
+            property_blacklist: [],
+            _onCapture: jest.fn(),
         }))
         given('eventProperties', () => ({
             key: 'value'.repeat(10000),
@@ -258,7 +272,9 @@ describe('capture()', () => {
         given('eventName', () => '$pageview')
 
         given('config', () => ({
+            property_blacklist: [],
             _capture_performance: true,
+            _onCapture: jest.fn(),
         }))
 
         given('performanceEntries', () => ({
@@ -303,7 +319,9 @@ describe('capture()', () => {
 
         it('does not capture performance when disabled', () => {
             given('config', () => ({
+                property_blacklist: [],
                 _capture_performance: false,
+                _onCapture: jest.fn(),
             }))
 
             given.subject()
@@ -417,6 +435,7 @@ describe('_calculate_event_properties()', () => {
         property_blacklist: given.property_blacklist,
         sanitize_properties: given.sanitize_properties,
     }))
+    given('property_blacklist', () => [])
 
     beforeEach(() => {
         jest.spyOn(_.info, 'properties').mockReturnValue({ $lib: 'web' })
@@ -775,11 +794,9 @@ describe('_loaded()', () => {
         },
         _start_queue_if_opted_in: jest.fn(),
     }))
-    given('config', () => ({}))
+    given('config', () => ({ loaded: jest.fn() }))
 
-    it('calls loafed config option', () => {
-        given('config', () => ({ loaded: jest.fn() }))
-
+    it('calls loaded config option', () => {
         given.subject()
 
         expect(given.config.loaded).toHaveBeenCalledWith(given.lib)
@@ -791,8 +808,11 @@ describe('_loaded()', () => {
                 throw Error()
             },
         }))
+        console.error = jest.fn()
 
         given.subject()
+
+        expect(console.error).toHaveBeenCalledWith('`loaded` function failed', expect.anything())
     })
 
     describe('/decide', () => {
@@ -810,6 +830,7 @@ describe('_loaded()', () => {
         it('does not call decide if disabled', () => {
             given('config', () => ({
                 advanced_disable_decide: true,
+                loaded: jest.fn(),
             }))
 
             given.subject()
@@ -822,6 +843,7 @@ describe('_loaded()', () => {
         it('captures not capture pageview if disabled', () => {
             given('config', () => ({
                 capture_pageview: false,
+                loaded: jest.fn(),
             }))
 
             given.subject()
@@ -832,6 +854,7 @@ describe('_loaded()', () => {
         it('captures pageview if enabled', () => {
             given('config', () => ({
                 capture_pageview: true,
+                loaded: jest.fn(),
             }))
 
             given.subject()

--- a/src/__tests__/posthog-people.js
+++ b/src/__tests__/posthog-people.js
@@ -1,24 +1,28 @@
 import { PostHogLib } from '../posthog-core'
 import { PostHogPeople } from '../posthog-people'
 
-given('people', () => new PostHogPeople())
+given('people', () =>
+    Object.assign(new PostHogPeople(), {
+        _send_request: jest.fn(),
+    })
+)
+given('lib', () => Object.assign(new PostHogLib(), given.overrides))
+
+given('overrides', () => ({
+    get_config: () => ({}),
+    get_property: () => 'something',
+    persistence: {
+        get_referrer_info: jest.fn().mockReturnValue(''),
+        update_referrer_info: jest.fn(),
+    },
+}))
 
 describe('posthog.people', () => {
     beforeEach(() => {
-        const ph = new PostHogLib()
-        ph.init('some token')
-        given.people._init(ph)
-
-        ph.get_config = jest.fn(() => false)
-        ph.get_property = jest.fn(() => 'something')
-
-        given.people._send_request = jest.fn()
+        given.people._init(given.lib)
     })
 
     it('should process set correctly', () => {
-        given.people._posthog['persistence'] = {
-            get_referrer_info: jest.fn(() => ''),
-        }
         given.people.set({ set_me: 'set me' })
         expect(given.people._send_request).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -32,6 +36,7 @@ describe('posthog.people', () => {
 
     it('should process set_once correctly', () => {
         given.people.set_once({ set_me_once: 'set once' })
+
         expect(given.people._send_request).toHaveBeenCalledWith({ $set_once: { set_me_once: 'set once' } }, undefined)
     })
 })

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -1,0 +1,8 @@
+beforeEach(() => {
+    console.error = (message) => {
+        throw new Error(`Unexpected console.error: ${message}`)
+    }
+    console.warn = (message) => {
+        throw new Error(`Unexpected console.warn: ${message}`)
+    }
+})


### PR DESCRIPTION
## Changes

Noticed that running the test suite has gotten really noisy due to excessive amount of console.errors. This cleans up these tests and ensures we always keep a clean console.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
