### PR TITLE
feat: Allow overriding device id generation

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -308,6 +308,9 @@ declare class posthog {
      *      // setting will not do  anything if you use PostHog Cloud
      *      advanced_disable_toolbar_metrics: false
      *
+     *      // Anonymous users get a random UUID as their device by default.
+     *      // This option allows overriding that option.
+     *      get_device_id: (uuid) => uuid
      *     }
      *
      *
@@ -620,6 +623,7 @@ declare namespace posthog {
         mask_all_text?: boolean
         advanced_disable_decide?: boolean
         advanced_disable_toolbar_metrics?: boolean
+        get_device_id?: (uuid: string) => string
         _capture_performance?: boolean
     }
 

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -1137,6 +1137,10 @@ PostHogLib.prototype.alias = function (alias, original) {
  *
  *      // prevent autocapture from capturing textContent on all elements
  *      mask_all_text: false
+ *
+ *      // Anonymous users get a random UUID as their device by default.
+ *      // This option allows overriding that option.
+ *      get_device_id: (uuid) => uuid
  *     }
  *
  *

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -109,6 +109,7 @@ const defaultConfig = () => ({
         const error = 'Bad HTTP status: ' + req.status + ' ' + req.statusText
         console.error(error)
     },
+    get_device_id: (uuid) => uuid,
     // Used for internal testing
     _onCapture: () => {},
     _capture_metrics: false,
@@ -131,7 +132,7 @@ export const PostHogLib = function () {}
  */
 var create_mplib = function (token, config, name) {
     var instance,
-        target = name === PRIMARY_INSTANCE_NAME ? posthog_master : posthog_master[name]
+        target = name === PRIMARY_INSTANCE_NAME || !posthog_master ? posthog_master : posthog_master[name]
 
     if (target && init_type === INIT_MODULE) {
         instance = target
@@ -259,11 +260,11 @@ PostHogLib.prototype._init = function (token, config, name) {
 
     this._gdpr_init()
 
-    var uuid = _.UUID()
     if (!this.get_distinct_id()) {
         // There is no need to set the distinct id
         // or the device id if something was already stored
         // in the persitence
+        const uuid = this.get_config('get_device_id')(_.UUID())
         this.register_once(
             {
                 distinct_id: uuid,
@@ -937,7 +938,7 @@ PostHogLib.prototype.group = function (groupType, groupKey, groupPropertiesToSet
 PostHogLib.prototype.reset = function (reset_device_id) {
     let device_id = this.get_property('$device_id')
     this['persistence'].clear()
-    var uuid = _.UUID()
+    const uuid = this.get_config('get_device_id')(_.UUID())
     this.register_once(
         {
             distinct_id: uuid,


### PR DESCRIPTION
This is useful for cross-domain tracking of anonymous users.