### PR TITLE
feat(feature-flags): Enable experience continuity

### DIFF
--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -109,7 +109,7 @@ describe('featureflags', () => {
         }))
 
         it('on providing anonDistinctId', () => {
-            given.featureFlags.sendAnonymousDistinctId('rando_id')
+            given.featureFlags.setAnonymousDistinctId('rando_id')
             given.featureFlags.reloadFeatureFlags()
 
             jest.runAllTimers()
@@ -130,7 +130,7 @@ describe('featureflags', () => {
         })
 
         it('on providing anonDistinctId and calling reload multiple times', () => {
-            given.featureFlags.sendAnonymousDistinctId('rando_id')
+            given.featureFlags.setAnonymousDistinctId('rando_id')
             given.featureFlags.reloadFeatureFlags()
             given.featureFlags.reloadFeatureFlags()
 

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -168,7 +168,7 @@ describe('featureflags', () => {
 
             // check the request didn't send $anon_distinct_id the second time around
             expect(
-                JSON.parse(Buffer.from(given.instance._send_request.mock.calls[1][1].data, 'base64').toString())
+                JSON.parse(Buffer.from(given.instance._send_request.mock.calls[2][1].data, 'base64').toString())
             ).toEqual({
                 token: 'random fake token',
                 distinct_id: 'blah id',

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -36,6 +36,9 @@ describe('identify()', () => {
         _captureMetrics: {
             incr: jest.fn(),
         },
+        featureFlags: {
+            sendAnonymousDistinctId: jest.fn(),
+        },
         reloadFeatureFlags: jest.fn(),
     }))
 
@@ -63,6 +66,7 @@ describe('identify()', () => {
             { $set_once: {} }
         )
         expect(given.overrides.people.set).not.toHaveBeenCalled()
+        expect(given.overrides.featureFlags.sendAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
     })
 
     it('calls capture when identity changes and old ID is anonymous', () => {
@@ -80,6 +84,7 @@ describe('identify()', () => {
             { $set_once: {} }
         )
         expect(given.overrides.people.set).not.toHaveBeenCalled()
+        expect(given.overrides.featureFlags.sendAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
     })
 
     it("don't identify if the old id isn't anonymous", () => {
@@ -89,6 +94,7 @@ describe('identify()', () => {
 
         expect(given.overrides.capture).not.toHaveBeenCalled()
         expect(given.overrides.people.set).not.toHaveBeenCalled()
+        expect(given.overrides.featureFlags.sendAnonymousDistinctId).not.toHaveBeenCalled()
     })
 
     it('calls capture with user properties if passed', () => {
@@ -106,6 +112,7 @@ describe('identify()', () => {
             { $set: { email: 'john@example.com' } },
             { $set_once: { howOftenAmISet: 'once!' } }
         )
+        expect(given.overrides.featureFlags.sendAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
     })
 
     describe('identity did not change', () => {
@@ -116,6 +123,7 @@ describe('identify()', () => {
 
             expect(given.overrides.capture).not.toHaveBeenCalled()
             expect(given.overrides.people.set).not.toHaveBeenCalled()
+            expect(given.overrides.featureFlags.sendAnonymousDistinctId).not.toHaveBeenCalled()
         })
 
         it('calls people.set when user properties passed', () => {
@@ -125,6 +133,7 @@ describe('identify()', () => {
             given.subject()
 
             expect(given.overrides.capture).not.toHaveBeenCalled()
+            expect(given.overrides.featureFlags.sendAnonymousDistinctId).not.toHaveBeenCalled()
             expect(given.overrides.people.set).toHaveBeenCalledWith({ email: 'john@example.com' })
             expect(given.overrides.people.set_once).toHaveBeenCalledWith({ howOftenAmISet: 'once!' })
         })
@@ -148,6 +157,7 @@ describe('identify()', () => {
         it('reloads when identity changes', () => {
             given.subject()
 
+            expect(given.overrides.featureFlags.sendAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
             expect(given.overrides.reloadFeatureFlags).toHaveBeenCalled()
         })
 
@@ -156,6 +166,7 @@ describe('identify()', () => {
 
             given.subject()
 
+            expect(given.overrides.featureFlags.sendAnonymousDistinctId).not.toHaveBeenCalled()
             expect(given.overrides.reloadFeatureFlags).not.toHaveBeenCalled()
         })
 
@@ -165,7 +176,7 @@ describe('identify()', () => {
             given('userPropertiesToSetOnce', () => ({ howOftenAmISet: 'once!' }))
 
             given.subject()
-
+            expect(given.overrides.featureFlags.sendAnonymousDistinctId).not.toHaveBeenCalled()
             expect(given.overrides.reloadFeatureFlags).not.toHaveBeenCalled()
         })
     })

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -37,7 +37,7 @@ describe('identify()', () => {
             incr: jest.fn(),
         },
         featureFlags: {
-            sendAnonymousDistinctId: jest.fn(),
+            setAnonymousDistinctId: jest.fn(),
         },
         reloadFeatureFlags: jest.fn(),
     }))
@@ -66,7 +66,7 @@ describe('identify()', () => {
             { $set_once: {} }
         )
         expect(given.overrides.people.set).not.toHaveBeenCalled()
-        expect(given.overrides.featureFlags.sendAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
+        expect(given.overrides.featureFlags.setAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
     })
 
     it('calls capture when identity changes and old ID is anonymous', () => {
@@ -84,7 +84,7 @@ describe('identify()', () => {
             { $set_once: {} }
         )
         expect(given.overrides.people.set).not.toHaveBeenCalled()
-        expect(given.overrides.featureFlags.sendAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
+        expect(given.overrides.featureFlags.setAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
     })
 
     it("don't identify if the old id isn't anonymous", () => {
@@ -94,7 +94,7 @@ describe('identify()', () => {
 
         expect(given.overrides.capture).not.toHaveBeenCalled()
         expect(given.overrides.people.set).not.toHaveBeenCalled()
-        expect(given.overrides.featureFlags.sendAnonymousDistinctId).not.toHaveBeenCalled()
+        expect(given.overrides.featureFlags.setAnonymousDistinctId).not.toHaveBeenCalled()
     })
 
     it('calls capture with user properties if passed', () => {
@@ -112,7 +112,7 @@ describe('identify()', () => {
             { $set: { email: 'john@example.com' } },
             { $set_once: { howOftenAmISet: 'once!' } }
         )
-        expect(given.overrides.featureFlags.sendAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
+        expect(given.overrides.featureFlags.setAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
     })
 
     describe('identity did not change', () => {
@@ -123,7 +123,7 @@ describe('identify()', () => {
 
             expect(given.overrides.capture).not.toHaveBeenCalled()
             expect(given.overrides.people.set).not.toHaveBeenCalled()
-            expect(given.overrides.featureFlags.sendAnonymousDistinctId).not.toHaveBeenCalled()
+            expect(given.overrides.featureFlags.setAnonymousDistinctId).not.toHaveBeenCalled()
         })
 
         it('calls people.set when user properties passed', () => {
@@ -133,7 +133,7 @@ describe('identify()', () => {
             given.subject()
 
             expect(given.overrides.capture).not.toHaveBeenCalled()
-            expect(given.overrides.featureFlags.sendAnonymousDistinctId).not.toHaveBeenCalled()
+            expect(given.overrides.featureFlags.setAnonymousDistinctId).not.toHaveBeenCalled()
             expect(given.overrides.people.set).toHaveBeenCalledWith({ email: 'john@example.com' })
             expect(given.overrides.people.set_once).toHaveBeenCalledWith({ howOftenAmISet: 'once!' })
         })
@@ -157,7 +157,7 @@ describe('identify()', () => {
         it('reloads when identity changes', () => {
             given.subject()
 
-            expect(given.overrides.featureFlags.sendAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
+            expect(given.overrides.featureFlags.setAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
             expect(given.overrides.reloadFeatureFlags).toHaveBeenCalled()
         })
 
@@ -166,7 +166,7 @@ describe('identify()', () => {
 
             given.subject()
 
-            expect(given.overrides.featureFlags.sendAnonymousDistinctId).not.toHaveBeenCalled()
+            expect(given.overrides.featureFlags.setAnonymousDistinctId).not.toHaveBeenCalled()
             expect(given.overrides.reloadFeatureFlags).not.toHaveBeenCalled()
         })
 
@@ -176,7 +176,7 @@ describe('identify()', () => {
             given('userPropertiesToSetOnce', () => ({ howOftenAmISet: 'once!' }))
 
             given.subject()
-            expect(given.overrides.featureFlags.sendAnonymousDistinctId).not.toHaveBeenCalled()
+            expect(given.overrides.featureFlags.setAnonymousDistinctId).not.toHaveBeenCalled()
             expect(given.overrides.reloadFeatureFlags).not.toHaveBeenCalled()
         })
     })

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -882,7 +882,7 @@ PostHogLib.prototype.identify = function (new_distinct_id, userPropertiesToSet, 
         )
         // let the reload feature flag request know to send this previous distinct id
         // for flag consistency
-        this.featureFlags.sendAnonymousDistinctId(previous_distinct_id)
+        this.featureFlags.setAnonymousDistinctId(previous_distinct_id)
     } else {
         if (userPropertiesToSet) {
             this['people'].set(userPropertiesToSet)

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -892,6 +892,8 @@ PostHogLib.prototype.identify = function (new_distinct_id, userPropertiesToSet, 
     // Reload active feature flags if the user identity changes.
     // Note we don't reload this on property changes as these get processed async
     if (new_distinct_id !== previous_distinct_id) {
+        // let the reload feature flag request know to send the previous distinct id
+        this.featureFlags.sendAnonymousDistinctId(previous_distinct_id)
         this.reloadFeatureFlags()
     }
 }

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -880,6 +880,9 @@ PostHogLib.prototype.identify = function (new_distinct_id, userPropertiesToSet, 
             { $set: userPropertiesToSet || {} },
             { $set_once: userPropertiesToSetOnce || {} }
         )
+        // let the reload feature flag request know to send this previous distinct id
+        // for flag consistency
+        this.featureFlags.sendAnonymousDistinctId(previous_distinct_id)
     } else {
         if (userPropertiesToSet) {
             this['people'].set(userPropertiesToSet)
@@ -892,8 +895,6 @@ PostHogLib.prototype.identify = function (new_distinct_id, userPropertiesToSet, 
     // Reload active feature flags if the user identity changes.
     // Note we don't reload this on property changes as these get processed async
     if (new_distinct_id !== previous_distinct_id) {
-        // let the reload feature flag request know to send the previous distinct id
-        this.featureFlags.sendAnonymousDistinctId(previous_distinct_id)
         this.reloadFeatureFlags()
     }
 }

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -90,6 +90,10 @@ export class PostHogFeatureFlags {
         }
     }
 
+    sendAnonymousDistinctId(anon_distinct_id) {
+        this.$anon_distinct_id = anon_distinct_id
+    }
+
     setReloadingPaused(isPaused) {
         this.reloadFeatureFlagsInAction = isPaused
     }
@@ -116,7 +120,15 @@ export class PostHogFeatureFlags {
             token: token,
             distinct_id: this.instance.get_distinct_id(),
             groups: this.instance.getGroups(),
+            $anon_distinct_id: this.$anon_distinct_id,
         })
+
+        // console.log('json data: ', json_data)
+
+        // reset anon_distinct_id after a single request with it
+        // makes it through
+        this.$anon_distinct_id = undefined
+
         const encoded_data = _.base64Encode(json_data)
         this.instance._send_request(
             this.instance.get_config('api_host') + '/decide/?v=2',

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -90,7 +90,7 @@ export class PostHogFeatureFlags {
         }
     }
 
-    sendAnonymousDistinctId(anon_distinct_id) {
+    setAnonymousDistinctId(anon_distinct_id) {
         this.$anon_distinct_id = anon_distinct_id
     }
 
@@ -123,16 +123,16 @@ export class PostHogFeatureFlags {
             $anon_distinct_id: this.$anon_distinct_id,
         })
 
-        // reset anon_distinct_id after a single request with it
-        // makes it through
-        this.$anon_distinct_id = undefined
-
         const encoded_data = _.base64Encode(json_data)
         this.instance._send_request(
             this.instance.get_config('api_host') + '/decide/?v=2',
             { data: encoded_data },
             { method: 'POST' },
             this.instance._prepare_callback((response) => {
+                // reset anon_distinct_id after at least a single request with it
+                // makes it through
+                this.$anon_distinct_id = undefined
+
                 this.receivedFeatureFlags(response)
 
                 // :TRICKY: Reload - start another request if queued!

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -123,8 +123,6 @@ export class PostHogFeatureFlags {
             $anon_distinct_id: this.$anon_distinct_id,
         })
 
-        // console.log('json data: ', json_data)
-
         // reset anon_distinct_id after a single request with it
         // makes it through
         this.$anon_distinct_id = undefined

--- a/testcafe/helpers.js
+++ b/testcafe/helpers.js
@@ -45,7 +45,7 @@ export async function retryUntilResults(operation, target_results, limit = 100) 
                     results.length >= target_results ? resolve(results) : attempt(count + 1, resolve, reject)
                 )
                 .catch(reject)
-        }, 600)
+        }, 1000)
     }
 
     return new Promise((...args) => attempt(0, ...args))

--- a/testcafe/helpers.js
+++ b/testcafe/helpers.js
@@ -45,7 +45,7 @@ export async function retryUntilResults(operation, target_results, limit = 100) 
                     results.length >= target_results ? resolve(results) : attempt(count + 1, resolve, reject)
                 )
                 .catch(reject)
-        }, 1000)
+        }, 600)
     }
 
     return new Promise((...args) => attempt(0, ...args))


### PR DESCRIPTION
## Changes

Goes in after https://github.com/PostHog/posthog/pull/10196 - client side support for persistent feature flags
...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
