### PR TITLE
feat: add a session length maximum time limit

### DIFF
--- a/src/__tests__/sessionid.js
+++ b/src/__tests__/sessionid.js
@@ -39,7 +39,7 @@ describe('Session ID manager', () => {
                 sessionId: 'newUUID',
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [given.timestamp, given.timestamp, 'newUUID'],
+                [SESSION_ID]: [given.timestamp, 'newUUID', given.timestamp],
             })
             expect(sessionStore.set).toHaveBeenCalledWith('ph_persistance-name_window_id', 'newUUID')
         })
@@ -51,7 +51,7 @@ describe('Session ID manager', () => {
                 sessionId: 'newUUID',
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [given.timestamp, given.timestamp, 'newUUID'],
+                [SESSION_ID]: [given.timestamp, 'newUUID', given.timestamp],
             })
             expect(sessionStore.set).toHaveBeenCalledWith('ph_persistance-name_window_id', 'newUUID')
         })
@@ -60,7 +60,7 @@ describe('Session ID manager', () => {
     describe('stored session data', () => {
         given('timestampOfSessionStart', () => given.now - 3600)
 
-        given('storedSessionIdData', () => [given.timestampOfSessionStart, given.now, 'oldSessionID'])
+        given('storedSessionIdData', () => [given.now, 'oldSessionID', given.timestampOfSessionStart])
         beforeEach(() => {
             sessionStore.parse.mockReturnValue('oldWindowID')
         })
@@ -71,7 +71,7 @@ describe('Session ID manager', () => {
                 sessionId: 'oldSessionID',
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [given.timestampOfSessionStart, given.timestamp, 'oldSessionID'],
+                [SESSION_ID]: [given.timestamp, 'oldSessionID', given.timestampOfSessionStart],
             })
         })
 
@@ -80,7 +80,7 @@ describe('Session ID manager', () => {
             const oldTimestamp = given.now - thirtyMinutesAndOneSecond
             const sessionStart = oldTimestamp - 1000
 
-            given('storedSessionIdData', () => [sessionStart, oldTimestamp, 'oldSessionID'])
+            given('storedSessionIdData', () => [oldTimestamp, 'oldSessionID', sessionStart])
             given('readOnly', () => true)
 
             expect(given.subject).toEqual({
@@ -88,7 +88,7 @@ describe('Session ID manager', () => {
                 sessionId: 'oldSessionID',
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [sessionStart, oldTimestamp, 'oldSessionID'],
+                [SESSION_ID]: [oldTimestamp, 'oldSessionID', sessionStart],
             })
         })
 
@@ -99,21 +99,21 @@ describe('Session ID manager', () => {
                 sessionId: 'oldSessionID',
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [given.timestampOfSessionStart, given.timestamp, 'oldSessionID'],
+                [SESSION_ID]: [given.timestamp, 'oldSessionID', given.timestampOfSessionStart],
             })
             expect(sessionStore.set).toHaveBeenCalledWith('ph_persistance-name_window_id', 'newUUID')
         })
 
         it('generates a new session id and window id, and saves it when >30m since last event', () => {
             const oldTimestamp = 1602107460000
-            given('storedSessionIdData', () => [given.timestampOfSessionStart, oldTimestamp, 'oldSessionID'])
+            given('storedSessionIdData', () => [oldTimestamp, 'oldSessionID', given.timestampOfSessionStart])
 
             expect(given.subject).toEqual({
                 windowId: 'newUUID',
                 sessionId: 'newUUID',
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [given.timestamp, given.timestamp, 'newUUID'],
+                [SESSION_ID]: [given.timestamp, 'newUUID', given.timestamp],
             })
             expect(sessionStore.set).toHaveBeenCalledWith('ph_persistance-name_window_id', 'newUUID')
         })
@@ -121,7 +121,7 @@ describe('Session ID manager', () => {
         it('generates a new session id and window id, and saves it when >24 hours since start timestamp', () => {
             const oldTimestamp = 1602107460000
             const twentyFourHours = 3600 * 24
-            given('storedSessionIdData', () => [given.timestampOfSessionStart, oldTimestamp, 'oldSessionID'])
+            given('storedSessionIdData', () => [oldTimestamp, 'oldSessionID', given.timestampOfSessionStart])
             given('timestamp', () => given.timestampOfSessionStart + twentyFourHours)
 
             expect(given.subject).toEqual({
@@ -130,7 +130,7 @@ describe('Session ID manager', () => {
             })
 
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [given.timestamp, given.timestamp, 'newUUID'],
+                [SESSION_ID]: [given.timestamp, 'newUUID', given.timestamp],
             })
             expect(sessionStore.set).toHaveBeenCalledWith('ph_persistance-name_window_id', 'newUUID')
         })
@@ -138,7 +138,7 @@ describe('Session ID manager', () => {
         it('generates a new session id and window id, and saves it when >24 hours since start timestamp even when readonly is true', () => {
             const oldTimestamp = 1602107460000
             const twentyFourHoursAndOneSecond = (3600 * 24 + 1) * 1000
-            given('storedSessionIdData', () => [given.timestampOfSessionStart, oldTimestamp, 'oldSessionID'])
+            given('storedSessionIdData', () => [oldTimestamp, 'oldSessionID', given.timestampOfSessionStart])
             given('timestamp', () => given.timestampOfSessionStart + twentyFourHoursAndOneSecond)
             given('readOnly', () => true)
 
@@ -148,21 +148,21 @@ describe('Session ID manager', () => {
             })
 
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [given.timestamp, given.timestamp, 'newUUID'],
+                [SESSION_ID]: [given.timestamp, 'newUUID', given.timestamp],
             })
             expect(sessionStore.set).toHaveBeenCalledWith('ph_persistance-name_window_id', 'newUUID')
         })
 
         it('uses the current time if no timestamp is provided', () => {
             const oldTimestamp = 1601107460000
-            given('storedSessionIdData', () => [given.timestampOfSessionStart, oldTimestamp, 'oldSessionID'])
+            given('storedSessionIdData', () => [oldTimestamp, 'oldSessionID', given.timestampOfSessionStart])
             given('timestamp', () => undefined)
             expect(given.subject).toEqual({
                 windowId: 'newUUID',
                 sessionId: 'newUUID',
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [given.now, given.now, 'newUUID'],
+                [SESSION_ID]: [given.now, 'newUUID', given.now],
             })
         })
 
@@ -173,7 +173,7 @@ describe('Session ID manager', () => {
                 sessionId: 'oldSessionID',
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [given.timestamp, given.timestamp, 'oldSessionID'],
+                [SESSION_ID]: [given.timestamp, 'oldSessionID', given.timestamp],
             })
         })
     })
@@ -202,9 +202,9 @@ describe('Session ID manager', () => {
         it('stores and retrieves a session id and timestamp', () => {
             given.sessionIdManager._setSessionId('newSessionId', 1603107460000, 1603107460000)
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [1603107460000, 1603107460000, 'newSessionId'],
+                [SESSION_ID]: [1603107460000, 'newSessionId', 1603107460000],
             })
-            expect(given.sessionIdManager._getSessionId()).toEqual([1603107460000, 1603107460000, 'newSessionId'])
+            expect(given.sessionIdManager._getSessionId()).toEqual([1603107460000, 'newSessionId', 1603107460000])
         })
     })
 

--- a/src/__tests__/sessionid.js
+++ b/src/__tests__/sessionid.js
@@ -13,9 +13,9 @@ describe('Session ID manager', () => {
     given('persistence', () => ({
         props: { [SESSION_ID]: given.storedSessionIdData },
         register: jest.fn(),
-        disabled: given.disable_persistence,
+        disabled: given.disablePersistence,
     }))
-    given('disable_persistence', () => false)
+    given('disablePersistence', () => false)
 
     given('config', () => ({
         persistence_name: 'persistance-name',
@@ -58,9 +58,9 @@ describe('Session ID manager', () => {
     })
 
     describe('stored session data', () => {
-        given('timestamp_of_session_start', () => given.now - 3600)
+        given('timestampOfSessionStart', () => given.now - 3600)
 
-        given('storedSessionIdData', () => [given.timestamp_of_session_start, given.now, 'oldSessionID'])
+        given('storedSessionIdData', () => [given.timestampOfSessionStart, given.now, 'oldSessionID'])
         beforeEach(() => {
             sessionStore.parse.mockReturnValue('oldWindowID')
         })
@@ -71,16 +71,16 @@ describe('Session ID manager', () => {
                 sessionId: 'oldSessionID',
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [given.timestamp_of_session_start, given.timestamp, 'oldSessionID'],
+                [SESSION_ID]: [given.timestampOfSessionStart, given.timestamp, 'oldSessionID'],
             })
         })
 
         it('reuses old ids and does not update the session timestamp if  > 30m pass and readOnly is true', () => {
             let thirtyMinutesAndOneSecond = 60 * 60 * 30 + 1
-            const old_timestamp = given.now - thirtyMinutesAndOneSecond
-            const sessionStart = old_timestamp - 1000
+            const oldTimestamp = given.now - thirtyMinutesAndOneSecond
+            const sessionStart = oldTimestamp - 1000
 
-            given('storedSessionIdData', () => [sessionStart, old_timestamp, 'oldSessionID'])
+            given('storedSessionIdData', () => [sessionStart, oldTimestamp, 'oldSessionID'])
             given('readOnly', () => true)
 
             expect(given.subject).toEqual({
@@ -88,7 +88,7 @@ describe('Session ID manager', () => {
                 sessionId: 'oldSessionID',
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [sessionStart, old_timestamp, 'oldSessionID'],
+                [SESSION_ID]: [sessionStart, oldTimestamp, 'oldSessionID'],
             })
         })
 
@@ -99,14 +99,14 @@ describe('Session ID manager', () => {
                 sessionId: 'oldSessionID',
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
-                [SESSION_ID]: [given.timestamp_of_session_start, given.timestamp, 'oldSessionID'],
+                [SESSION_ID]: [given.timestampOfSessionStart, given.timestamp, 'oldSessionID'],
             })
             expect(sessionStore.set).toHaveBeenCalledWith('ph_persistance-name_window_id', 'newUUID')
         })
 
         it('generates a new session id and window id, and saves it when >30m since last event', () => {
-            const old_timestamp = 1602107460000
-            given('storedSessionIdData', () => [given.timestamp_of_session_start, old_timestamp, 'oldSessionID'])
+            const oldTimestamp = 1602107460000
+            given('storedSessionIdData', () => [given.timestampOfSessionStart, oldTimestamp, 'oldSessionID'])
 
             expect(given.subject).toEqual({
                 windowId: 'newUUID',
@@ -119,10 +119,10 @@ describe('Session ID manager', () => {
         })
 
         it('generates a new session id and window id, and saves it when >24 hours since start timestamp', () => {
-            const old_timestamp = 1602107460000
+            const oldTimestamp = 1602107460000
             const twentyFourHours = 3600 * 24
-            given('storedSessionIdData', () => [given.timestamp_of_session_start, old_timestamp, 'oldSessionID'])
-            given('timestamp', () => given.timestamp_of_session_start + twentyFourHours)
+            given('storedSessionIdData', () => [given.timestampOfSessionStart, oldTimestamp, 'oldSessionID'])
+            given('timestamp', () => given.timestampOfSessionStart + twentyFourHours)
 
             expect(given.subject).toEqual({
                 windowId: 'newUUID',
@@ -136,10 +136,10 @@ describe('Session ID manager', () => {
         })
 
         it('generates a new session id and window id, and saves it when >24 hours since start timestamp even when readonly is true', () => {
-            const old_timestamp = 1602107460000
+            const oldTimestamp = 1602107460000
             const twentyFourHoursAndOneSecond = (3600 * 24 + 1) * 1000
-            given('storedSessionIdData', () => [given.timestamp_of_session_start, old_timestamp, 'oldSessionID'])
-            given('timestamp', () => given.timestamp_of_session_start + twentyFourHoursAndOneSecond)
+            given('storedSessionIdData', () => [given.timestampOfSessionStart, oldTimestamp, 'oldSessionID'])
+            given('timestamp', () => given.timestampOfSessionStart + twentyFourHoursAndOneSecond)
             given('readOnly', () => true)
 
             expect(given.subject).toEqual({
@@ -154,8 +154,8 @@ describe('Session ID manager', () => {
         })
 
         it('uses the current time if no timestamp is provided', () => {
-            const old_timestamp = 1601107460000
-            given('storedSessionIdData', () => [given.timestamp_of_session_start, old_timestamp, 'oldSessionID'])
+            const oldTimestamp = 1601107460000
+            given('storedSessionIdData', () => [given.timestampOfSessionStart, oldTimestamp, 'oldSessionID'])
             given('timestamp', () => undefined)
             expect(given.subject).toEqual({
                 windowId: 'newUUID',
@@ -174,7 +174,7 @@ describe('Session ID manager', () => {
             expect(sessionStore.set).toHaveBeenCalledWith('ph_persistance-name_window_id', 'newWindowId')
         })
         it('stores and retrieves a window_id if persistance is disabled and storage is not used', () => {
-            given('disable_persistence', () => true)
+            given('disablePersistence', () => true)
             given.sessionIdManager._setWindowId('newWindowId')
             expect(given.sessionIdManager._getWindowId()).toEqual('newWindowId')
             expect(sessionStore.set).not.toHaveBeenCalled()

--- a/src/__tests__/sessionid.js
+++ b/src/__tests__/sessionid.js
@@ -165,6 +165,17 @@ describe('Session ID manager', () => {
                 [SESSION_ID]: [given.now, given.now, 'newUUID'],
             })
         })
+
+        it('populates the session start timestamp for a browser with no start time stored', () => {
+            given('storedSessionIdData', () => [given.timestamp, 'oldSessionID'])
+            expect(given.subject).toEqual({
+                windowId: 'oldWindowID',
+                sessionId: 'oldSessionID',
+            })
+            expect(given.persistence.register).toHaveBeenCalledWith({
+                [SESSION_ID]: [given.timestamp, given.timestamp, 'oldSessionID'],
+            })
+        })
     })
 
     describe('window id storage', () => {
@@ -190,10 +201,10 @@ describe('Session ID manager', () => {
     describe('session id storage', () => {
         it('stores and retrieves a session id and timestamp', () => {
             given.sessionIdManager._setSessionId('newSessionId', 1603107460000, 1603107460000)
-            expect(given.sessionIdManager._getSessionId()).toEqual([1603107460000, 1603107460000, 'newSessionId'])
             expect(given.persistence.register).toHaveBeenCalledWith({
                 [SESSION_ID]: [1603107460000, 1603107460000, 'newSessionId'],
             })
+            expect(given.sessionIdManager._getSessionId()).toEqual([1603107460000, 1603107460000, 'newSessionId'])
         })
     })
 

--- a/src/sessionid.js
+++ b/src/sessionid.js
@@ -51,23 +51,23 @@ export class SessionIdManager {
             this._sessionActivityTimestamp = sessionActivityTimestamp
             this._sessionId = sessionId
             this.persistence.register({
-                [SESSION_ID]: [sessionStartTimestamp, sessionActivityTimestamp, sessionId],
+                [SESSION_ID]: [sessionActivityTimestamp, sessionId, sessionStartTimestamp],
             })
         }
     }
 
     _getSessionId() {
         if (this._sessionId && this._sessionActivityTimestamp && this._sessionStartTimestamp) {
-            return [this._sessionStartTimestamp, this._sessionActivityTimestamp, this._sessionId]
+            return [this._sessionActivityTimestamp, this._sessionId, this._sessionStartTimestamp]
         }
         const sessionId = this.persistence['props'][SESSION_ID]
 
         if (Array.isArray(sessionId) && sessionId.length === 2) {
             // Storage does not yet have a session start time. Add the last activity timestamp as the start time
-            sessionId.unshift(sessionId[0])
+            sessionId.push(sessionId[0])
         }
 
-        return sessionId || [0, 0, null]
+        return sessionId || [0, null, 0]
     }
 
     // Resets the session id by setting it to null. On the subsequent call to checkAndGetSessionAndWindowId,
@@ -95,7 +95,7 @@ export class SessionIdManager {
     checkAndGetSessionAndWindowId(readOnly = false, timestamp = null) {
         timestamp = timestamp || new Date().getTime()
 
-        let [startTimestamp, lastTimestamp, sessionId] = this._getSessionId()
+        let [lastTimestamp, sessionId, startTimestamp] = this._getSessionId()
         let windowId = this._getWindowId()
 
         const sessionPastMaximumLength =

--- a/src/sessionid.js
+++ b/src/sessionid.js
@@ -60,7 +60,14 @@ export class SessionIdManager {
         if (this._sessionId && this._sessionActivityTimestamp && this._sessionStartTimestamp) {
             return [this._sessionStartTimestamp, this._sessionActivityTimestamp, this._sessionId]
         }
-        return this.persistence['props'][SESSION_ID] || [0, 0, null]
+        const sessionId = this.persistence['props'][SESSION_ID]
+
+        if (Array.isArray(sessionId) && sessionId.length === 2) {
+            // Storage does not yet have a session start time. Add the last activity timestamp as the start time
+            sessionId.unshift(sessionId[0])
+        }
+
+        return sessionId || [0, 0, null]
     }
 
     // Resets the session id by setting it to null. On the subsequent call to checkAndGetSessionAndWindowId,

--- a/src/sessionid.js
+++ b/src/sessionid.js
@@ -3,6 +3,7 @@ import { sessionStore } from './storage'
 import { _ } from './utils'
 
 const SESSION_CHANGE_THRESHOLD = 30 * 60 * 1000 // 30 mins
+const SESSION_LENGTH_LIMIT = 24 * 3600 * 1000 // 24 hours
 
 export class SessionIdManager {
     constructor(config, persistence) {
@@ -40,25 +41,32 @@ export class SessionIdManager {
 
     // Note: 'this.persistence.register' can be disabled in the config.
     // In that case, this works by storing sessionId and the timestamp in memory.
-    _setSessionId(sessionId, timestamp) {
-        if (sessionId !== this._sessionId || timestamp !== this._timestamp) {
-            this._timestamp = timestamp
+    _setSessionId(sessionId, sessionActivityTimestamp, sessionStartTimestamp) {
+        if (
+            sessionId !== this._sessionId ||
+            sessionActivityTimestamp !== this._sessionActivityTimestamp ||
+            sessionStartTimestamp !== this._sessionStartTimestamp
+        ) {
+            this._sessionStartTimestamp = sessionStartTimestamp
+            this._sessionActivityTimestamp = sessionActivityTimestamp
             this._sessionId = sessionId
-            this.persistence.register({ [SESSION_ID]: [timestamp, sessionId] })
+            this.persistence.register({
+                [SESSION_ID]: [sessionStartTimestamp, sessionActivityTimestamp, sessionId],
+            })
         }
     }
 
     _getSessionId() {
-        if (this._sessionId && this._timestamp) {
-            return [this._timestamp, this._sessionId]
+        if (this._sessionId && this._sessionActivityTimestamp && this._sessionStartTimestamp) {
+            return [this._sessionStartTimestamp, this._sessionActivityTimestamp, this._sessionId]
         }
-        return this.persistence['props'][SESSION_ID] || [0, null]
+        return this.persistence['props'][SESSION_ID] || [0, 0, null]
     }
 
     // Resets the session id by setting it to null. On the subsequent call to checkAndGetSessionAndWindowId,
     // new ids will be generated.
     resetSessionId() {
-        this._setSessionId(null, null)
+        this._setSessionId(null, null, null)
     }
 
     /*
@@ -80,20 +88,29 @@ export class SessionIdManager {
     checkAndGetSessionAndWindowId(readOnly = false, timestamp = null) {
         timestamp = timestamp || new Date().getTime()
 
-        let [lastTimestamp, sessionId] = this._getSessionId()
+        let [startTimestamp, lastTimestamp, sessionId] = this._getSessionId()
         let windowId = this._getWindowId()
 
-        if (!sessionId || (!readOnly && Math.abs(timestamp - lastTimestamp) > SESSION_CHANGE_THRESHOLD)) {
+        const sessionPastMaximumLength =
+            startTimestamp && startTimestamp > 0 && Math.abs(timestamp - startTimestamp) > SESSION_LENGTH_LIMIT
+
+        if (
+            !sessionId ||
+            (!readOnly && Math.abs(timestamp - lastTimestamp) > SESSION_CHANGE_THRESHOLD) ||
+            sessionPastMaximumLength
+        ) {
             sessionId = _.UUID()
             windowId = _.UUID()
+            startTimestamp = timestamp
         } else if (!windowId) {
             windowId = _.UUID()
         }
 
-        const newTimestamp = lastTimestamp === 0 || !readOnly ? timestamp : lastTimestamp
+        const newTimestamp = lastTimestamp === 0 || !readOnly || sessionPastMaximumLength ? timestamp : lastTimestamp
+        const sessionStartTimestamp = startTimestamp === 0 ? new Date().getTime() : startTimestamp
 
         this._setWindowId(windowId)
-        this._setSessionId(sessionId, newTimestamp)
+        this._setSessionId(sessionId, newTimestamp, sessionStartTimestamp)
 
         return {
             sessionId: sessionId,


### PR DESCRIPTION
## Changes

Enforces a maximum age for session ids. Regardless of activity in the session.

Takes advantage of the existing mechanism to rotate session id after `SESSION_CHANGE_THRESHOLD` milliseconds of inactivity. 

Alongside that "last session activity timestamp" stores a "session start timestamp"

And checks a `SESSION_LENGTH_LIMIT` from that new "session start timestamp". Rolling the session and window id if that limit has passed

Those values are stored as an array: [`sessionActivityTimestamp`, `sessionId`]. The new value is added to the end of the array:  [`sessionActivityTimestamp`, `sessionId`, `sessionStartTimestamp`]. 

This allows existing sessions to add a session start timestamp the next time the session is read. Without losing data if the version of posthog-js has to be rolled back

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
