### PR TITLE
fix: Add facebook crawlers to blocked user agents

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -517,7 +517,7 @@ _.UUID = (function () {
 // This is to block various web spiders from executing our JS and
 // sending false captureing data
 _.isBlockedUA = function (ua) {
-    if (/(google web preview|baiduspider|yandexbot|bingbot|googlebot|yahoo! slurp|ahrefsbot)/i.test(ua)) {
+    if (/(google web preview|baiduspider|yandexbot|bingbot|googlebot|yahoo! slurp|ahrefsbot|facebookexternalhit|facebookcatalog)/i.test(ua)) {
         return true
     }
     return false


### PR DESCRIPTION
## Changes

Don't count facebook crawlers as traffic.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
