### PR TITLE
feat(feature-flags): error callback

### DIFF
--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -15,6 +15,7 @@ describe('Decide', () => {
         _prepare_callback: jest.fn().mockImplementation((callback) => callback),
         get_distinct_id: jest.fn().mockImplementation(() => 'distinctid'),
         _send_request: given._send_request,
+        receivedDecideError: jest.fn(),
         toolbar: {
             maybeLoadEditor: jest.fn(),
             afterDecideResponse: jest.fn(),
@@ -24,7 +25,6 @@ describe('Decide', () => {
         },
         featureFlags: {
             receivedFeatureFlags: jest.fn(),
-            receivedFeatureFlagsError: jest.fn(),
         },
         getGroups: () => ({ organization: '5' }),
     }))
@@ -82,7 +82,7 @@ describe('Decide', () => {
             given.subject()
 
             expect(given.posthog._send_request).toHaveBeenCalled()
-            expect(given.posthog.featureFlags.receivedFeatureFlagsError).toHaveBeenCalled()
+            expect(given.posthog.receivedDecideError).toHaveBeenCalled()
         })
     })
 

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -99,40 +99,6 @@ describe('featureflags', () => {
         called = false
     })
 
-    describe('onFeatureFlagsError', () => {
-        it('onFeatureFlagsError should not be called immediately if feature flags not loaded', () => {
-            var called = false
-            given.featureFlags.onFeatureFlagsError(() => (called = true))
-            expect(called).toEqual(false)
-        })
-
-        it('onFeatureFlagsError callback should be called immediately if feature flags were loaded', () => {
-            given.featureFlags.instance.decideEndpointErrored = true
-            var called = false
-            given.featureFlags.onFeatureFlagsError(() => (called = true))
-            expect(called).toEqual(true)
-            called = false
-        })
-
-        describe('errors', () => {
-            given('_send_request', () =>
-                jest.fn().mockImplementation((_, __, ___, ____, errorCallback) => errorCallback(Error('message')))
-            )
-            given('config', () => ({
-                token: 'random fake token',
-            }))
-
-            it('onFeatureFlagsError should be called if reloading feature flags errors', () => {
-                var called = false
-                given.featureFlags.onFeatureFlagsError(() => (called = true))
-                expect(called).toEqual(false)
-                given.featureFlags.reloadFeatureFlags()
-                jest.runAllTimers()
-                expect(called).toEqual(true)
-            })
-        })
-    })
-
     describe('reloadFeatureFlags', () => {
         given('decideResponse', () => ({
             featureFlags: {

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -29,7 +29,7 @@ describe('featureflags', () => {
         get_property: (key) => given.instance.persistence.props[key],
         capture: () => {},
         decideEndpointWasHit: given.decideEndpointWasHit,
-        _send_request: given._send_request,
+        _send_request: jest.fn().mockImplementation((...args) => given._send_request(...args)),
     }))
 
     given('featureFlags', () => new PostHogFeatureFlags(given.instance))
@@ -118,6 +118,9 @@ describe('featureflags', () => {
             given('_send_request', () =>
                 jest.fn().mockImplementation((_, __, ___, ____, errorCallback) => errorCallback(Error('message')))
             )
+            given('config', () => ({
+                token: 'random fake token',
+            }))
 
             it('onFeatureFlagsError should be called if reloading feature flags errors', () => {
                 var called = false

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -4,6 +4,9 @@ jest.spyOn(global, 'setTimeout')
 
 describe('featureflags', () => {
     given('decideEndpointWasHit', () => false)
+    given('_send_request', () =>
+        jest.fn().mockImplementation((url, data, headers, callback) => callback(given.decideResponse))
+    )
     given('instance', () => ({
         get_config: jest.fn().mockImplementation((key) => given.config[key]),
         get_distinct_id: () => 'blah id',
@@ -26,7 +29,7 @@ describe('featureflags', () => {
         get_property: (key) => given.instance.persistence.props[key],
         capture: () => {},
         decideEndpointWasHit: given.decideEndpointWasHit,
-        _send_request: jest.fn().mockImplementation((url, data, headers, callback) => callback(given.decideResponse)),
+        _send_request: given._send_request,
     }))
 
     given('featureFlags', () => new PostHogFeatureFlags(given.instance))
@@ -94,6 +97,37 @@ describe('featureflags', () => {
         expect(called).toEqual(true)
 
         called = false
+    })
+
+    describe('onFeatureFlagsError', () => {
+        it('onFeatureFlagsError should not be called immediately if feature flags not loaded', () => {
+            var called = false
+            given.featureFlags.onFeatureFlagsError(() => (called = true))
+            expect(called).toEqual(false)
+        })
+
+        it('onFeatureFlagsError callback should be called immediately if feature flags were loaded', () => {
+            given.featureFlags.instance.decideEndpointErrored = true
+            var called = false
+            given.featureFlags.onFeatureFlagsError(() => (called = true))
+            expect(called).toEqual(true)
+            called = false
+        })
+
+        describe('errors', () => {
+            given('_send_request', () =>
+                jest.fn().mockImplementation((_, __, ___, ____, errorCallback) => errorCallback(Error('message')))
+            )
+
+            it('onFeatureFlagsError should be called if reloading feature flags errors', () => {
+                var called = false
+                given.featureFlags.onFeatureFlagsError(() => (called = true))
+                expect(called).toEqual(false)
+                given.featureFlags.reloadFeatureFlags()
+                jest.runAllTimers()
+                expect(called).toEqual(true)
+            })
+        })
     })
 
     describe('reloadFeatureFlags', () => {

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -4,9 +4,6 @@ jest.spyOn(global, 'setTimeout')
 
 describe('featureflags', () => {
     given('decideEndpointWasHit', () => false)
-    given('_send_request', () =>
-        jest.fn().mockImplementation((url, data, headers, callback) => callback(given.decideResponse))
-    )
     given('instance', () => ({
         get_config: jest.fn().mockImplementation((key) => given.config[key]),
         get_distinct_id: () => 'blah id',
@@ -29,7 +26,7 @@ describe('featureflags', () => {
         get_property: (key) => given.instance.persistence.props[key],
         capture: () => {},
         decideEndpointWasHit: given.decideEndpointWasHit,
-        _send_request: jest.fn().mockImplementation((...args) => given._send_request(...args)),
+        _send_request: jest.fn().mockImplementation((url, data, headers, callback) => callback(given.decideResponse)),
     }))
 
     given('featureFlags', () => new PostHogFeatureFlags(given.instance))

--- a/src/decide.js
+++ b/src/decide.js
@@ -33,6 +33,7 @@ export class Decide {
             return
         }
         this.instance.decideEndpointWasHit = true
+        this.instance.decideError = null
         if (!document?.body) {
             console.log('document not ready yet, trying again in 500 milliseconds...')
             setTimeout(() => this.parseDecideResponse(response), 500)

--- a/src/decide.js
+++ b/src/decide.js
@@ -44,7 +44,6 @@ export class Decide {
         this.instance.toolbar.afterDecideResponse(response)
         this.instance.sessionRecording.afterDecideResponse(response)
         autocapture.afterDecideResponse(response, this.instance)
-
         this.instance.featureFlags.receivedFeatureFlags(response)
 
         if (response['supportedCompression']) {

--- a/src/decide.js
+++ b/src/decide.js
@@ -5,7 +5,6 @@ export class Decide {
     constructor(instance) {
         this.instance = instance
         this.instance.decideEndpointWasHit = false
-        this.instance.decideEndpointErrored = false
     }
 
     call() {
@@ -34,7 +33,6 @@ export class Decide {
             return
         }
         this.instance.decideEndpointWasHit = true
-        this.instance.decideEndpointErrored = false
         if (!document?.body) {
             console.log('document not ready yet, trying again in 500 milliseconds...')
             setTimeout(() => this.parseDecideResponse(response), 500)

--- a/src/decide.js
+++ b/src/decide.js
@@ -63,6 +63,6 @@ export class Decide {
             setTimeout(() => this.parseDecideError(error), 500)
             return
         }
-        this.instance.featureFlags.receivedFeatureFlagsError(error)
+        this.instance.receivedDecideError(error)
     }
 }

--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -517,6 +517,17 @@ declare class posthog {
      */
     static reloadFeatureFlags(): void
 
+    /*
+     * Register an event listener that runs when we had an error loading /decide, probably due to ad blockers.
+     *
+     * ### Usage:
+     *
+     *     posthog.onDecideError(function(error) { // do something })
+     *
+     * @param {Function} [callback] The callback function will be called if the `/decide` endpoint fails to load.
+     */
+    static onDecideError(callback: (error: any) => void): void
+
     /**
      * Integrate Sentry with PostHog. This will add a direct link to the person in Sentry, and an $exception event in PostHog
      *

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -447,8 +447,12 @@ PostHogLib.prototype._send_request = function (url, data, options, callback, err
                 retriesPerformedSoFar: 0,
                 retryQueue: this._retryQueue,
                 onXHRError: (req) => {
-                    debugger
-                    errorCallback?.(req)
+                    if (errorCallback) {
+                        const error = Error('XHRError')
+                        error.status = 0
+                        error.req = req
+                        errorCallback(error)
+                    }
                     this.get_config('on_xhr_error')?.(req)
                 },
             })

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -173,6 +173,8 @@ var create_mplib = function (token, config, name) {
         }
     }
 
+    instance.decideErrorHandlers = []
+
     // if any instance on the page has debug = true, we set the
     // global debug to be true
     Config.DEBUG = Config.DEBUG || instance.get_config('debug')
@@ -815,8 +817,8 @@ PostHogLib.prototype.onFeatureFlags = function (callback) {
  *
  * @param {Function} [callback] The callback function will be called if feature flags fail to load.
  */
-PostHogLib.prototype.onFeatureFlagsError = function (error) {
-    this.featureFlags.onFeatureFlagsError(error)
+PostHogLib.prototype.onDecideError = function (error) {
+    this.decideErrorHandlers.forEach((handler) => handler(error))
 }
 
 /**

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -38,8 +38,6 @@ export class PostHogFeatureFlags {
         this._override_warning = false
         this.flagCallReported = {}
         this.featureFlagEventHandlers = []
-        this.featureFlagErrorHandlers = []
-        this.featureFlagError = null
 
         this.reloadFeatureFlagsQueued = false
         this.reloadFeatureFlagsInAction = false
@@ -141,7 +139,7 @@ export class PostHogFeatureFlags {
                 this.setReloadingPaused(false)
                 this._startReloadTimer()
             }),
-            (error) => this.receivedFeatureFlagsError(error)
+            (error) => this.instance.receivedDecideError(error)
         )
     }
 
@@ -196,11 +194,6 @@ export class PostHogFeatureFlags {
         const flags = this.getFlags()
         const variants = this.getFlagVariants()
         this.featureFlagEventHandlers.forEach((handler) => handler(flags, variants))
-    }
-
-    receivedFeatureFlagsError(error) {
-        this.featureFlagError = error
-        this.featureFlagErrorHandlers.forEach((handler) => handler(error))
     }
 
     /*

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -241,21 +241,4 @@ export class PostHogFeatureFlags {
             callback(flags, flagVariants)
         }
     }
-    /*
-     * Register an event listener that runs when feature flags can not be loaded.
-     * If we already tried to load, the listener is called immediately in addition to being called on future errors.
-     *
-     * ### Usage:
-     *
-     *     posthog.onFeatureFlagsError(function(error) { // do something })
-     *
-     * @param {Function} [callback] The callback function will be called once the feature flags fail to load.
-     */
-
-    onFeatureFlagsError(callback) {
-        this.featureFlagErrorHandlers.push(callback)
-        if (this.instance.decideEndpointErrored) {
-            callback(this.featureFlagError)
-        }
-    }
 }

--- a/src/posthog-featureflags.js
+++ b/src/posthog-featureflags.js
@@ -190,7 +190,6 @@ export class PostHogFeatureFlags {
 
     receivedFeatureFlags(response) {
         parseFeatureFlagDecideResponse(response, this.instance.persistence)
-        this.featureFlagError = null
         const flags = this.getFlags()
         const variants = this.getFlagVariants()
         this.featureFlagEventHandlers.forEach((handler) => handler(flags, variants))

--- a/src/send-request.js
+++ b/src/send-request.js
@@ -117,11 +117,7 @@ export const xhr = ({
                 }
 
                 if (callback) {
-                    if (options.verbose) {
-                        callback({ status: 0, error: error })
-                    } else {
-                        callback(0)
-                    }
+                    callback({ status: 0 })
                 }
             }
         }


### PR DESCRIPTION
## Changes

1. [Fixes feature flags sending `[]`](https://github.com/PostHog/posthog-js/pull/420/files#diff-ddd24b8ce37c6ae2630e5b9f5a3a492bc0f16beabfa27858c3e19ed43a97d67c) when `/decide` errors
2. Implements `posthog.onDecideError(error => console.log(error))` to alert users when `/decide` fails, e.g. via ad blockers.

Requested by a customer.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
