### PR TITLE
feat(identify): disable anon_distinct_id sending

### DIFF
--- a/src/module.d.ts
+++ b/src/module.d.ts
@@ -623,6 +623,7 @@ declare namespace posthog {
         mask_all_text?: boolean
         advanced_disable_decide?: boolean
         advanced_disable_toolbar_metrics?: boolean
+        send_anon_distinct_id?: boolean
         get_device_id?: (uuid: string) => string
         _capture_performance?: boolean
     }

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -51,7 +51,7 @@ const USE_XHR = window.XMLHttpRequest && 'withCredentials' in new XMLHttpRequest
 // should only be true for Opera<12
 let ENQUEUE_REQUESTS = !USE_XHR && userAgent.indexOf('MSIE') === -1 && userAgent.indexOf('Mozilla') === -1
 
-const defaultConfig = () => ({
+export const defaultConfig = () => ({
     api_host: 'https://app.posthog.com',
     api_method: 'POST',
     api_transport: 'XHR',
@@ -105,6 +105,7 @@ const defaultConfig = () => ({
     mask_all_text: false,
     advanced_disable_decide: false,
     advanced_disable_toolbar_metrics: false,
+    send_anon_distinct_id: true,
     on_xhr_error: (req) => {
         const error = 'Bad HTTP status: ' + req.status + ' ' + req.statusText
         console.error(error)
@@ -873,10 +874,12 @@ PostHogLib.prototype.identify = function (new_distinct_id, userPropertiesToSet, 
     ) {
         this.capture(
             '$identify',
-            {
-                distinct_id: new_distinct_id,
-                $anon_distinct_id: previous_distinct_id,
-            },
+            this.get_config('send_anon_distinct_id')
+                ? {
+                      distinct_id: new_distinct_id,
+                      $anon_distinct_id: previous_distinct_id,
+                  }
+                : { distinct_id: new_distinct_id },
             { $set: userPropertiesToSet || {} },
             { $set_once: userPropertiesToSetOnce || {} }
         )


### PR DESCRIPTION
## Changes

This came from a customer request, where they `identify` a user as soon as they logged in. Even though no anonymous events are sent before the `identify` event, the `$anon_distinct_id` prop is still sent, and thus a new ID is associated with the user every time. That's just noise when looking at persons.

This PR adds a config `send_anon_distinct_id` (default: `true`), which can be disabled to not send `$anon_distinct_id` on identify. 

I considered instead detecting if any events are sent by the anonymous id, and if not, automatically not sending it, but paused when I tried to start untangling how the distinct id is created and set. Afraid of making mistakes, I put this no-nonsense PR up instead.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
