### PR TITLE
fix: dont set initial referrer

### DIFF
--- a/src/__tests__/posthog-persistence.js
+++ b/src/__tests__/posthog-persistence.js
@@ -15,23 +15,16 @@ describe('persistence', () => {
     it('should set referrer', () => {
         // Initial visit
         given.lib.update_referrer_info('https://www.google.com')
-
-        expect(given.lib.props['$initial_referring_domain']).toBe('www.google.com')
         expect(given.lib.props['$referring_domain']).toBe('www.google.com')
         expect(given.lib.props['$referrer']).toBe('https://www.google.com')
 
         //subsequent visit
         given.lib.update_referrer_info('https://www.facebook.com')
-        // first touch
-        expect(given.lib.props['$initial_referring_domain']).toBe('www.google.com')
-
-        // last touch
         expect(given.lib.props['$referring_domain']).toBe('www.facebook.com')
         expect(given.lib.props['$referrer']).toBe('https://www.facebook.com')
 
         // page visit that doesn't have direct referrer
         given.lib.update_referrer_info('')
-        expect(given.lib.props['$initial_referring_domain']).toBe('www.google.com')
         // last touch should still be set to facebook
         expect(given.lib.props['$referring_domain']).toBe('www.facebook.com')
         expect(given.lib.props['$referrer']).toBe('https://www.facebook.com')

--- a/src/posthog-persistence.js
+++ b/src/posthog-persistence.js
@@ -194,16 +194,6 @@ PostHogPersistence.prototype.update_search_keyword = function (referrer) {
 
 // EXPORTED METHOD, we test this directly.
 PostHogPersistence.prototype.update_referrer_info = function (referrer) {
-    // If referrer doesn't exist, we want to note the fact that it was type-in traffic.
-    // Register once, so first touch
-    this.register_once(
-        {
-            $initial_referrer: referrer || '$direct',
-            $initial_referring_domain: _.info.referringDomain(referrer) || '$direct',
-        },
-        ''
-    )
-    // Register the current referrer but override if it's different, hence register
     this.register({
         $referrer: referrer || this['props']['$referrer'] || '$direct',
         $referring_domain: _.info.referringDomain(referrer) || this['props']['$referring_domain'] || '$direct',
@@ -212,8 +202,8 @@ PostHogPersistence.prototype.update_referrer_info = function (referrer) {
 
 PostHogPersistence.prototype.get_referrer_info = function () {
     return _.strip_empty_properties({
-        $initial_referrer: this['props']['$initial_referrer'],
-        $initial_referring_domain: this['props']['$initial_referring_domain'],
+        $referrer: this['props']['$referrer'],
+        $referring_domain: this['props']['$referring_domain'],
     })
 }
 


### PR DESCRIPTION
## Changes

closes https://github.com/PostHog/posthog-js/issues/419
Looks like there's a bunch of logic around referrer compared to the url handling, so just did the small update to remove setting initial_ref* values (see the issue for more details on why).

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
