### PR TITLE
fix(storage): Fix cross subdomain cookies for localpluscookie

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -167,21 +167,21 @@ export const localPlusCookieStore = {
         return null
     },
 
-    set: function (name, value) {
+    set: function (name, value, days, cross_subdomain, is_secure) {
         try {
             localStore.set(name, value)
             if (value.distinct_id) {
-                cookieStore.set(name, { distinct_id: value.distinct_id })
+                cookieStore.set(name, { distinct_id: value.distinct_id }, days, cross_subdomain, is_secure)
             }
         } catch (err) {
             localStore.error(err)
         }
     },
 
-    remove: function (name) {
+    remove: function (name, cross_subdomain) {
         try {
             window.localStorage.removeItem(name)
-            cookieStore.remove(name)
+            cookieStore.remove(name, cross_subdomain)
         } catch (err) {
             localStore.error(err)
         }


### PR DESCRIPTION
## Changes

We weren't setting subdomain tracking if you used localstorage+cookie as a storage type

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
