### PR TITLE
fix(session-id): reset session_id on reset() call

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -678,14 +678,15 @@ describe('init()', () => {
         expect(given.lib['compression']).toEqual({})
     })
 
-    describe.skip('device id behavior', () => {
+    describe('device id behavior', () => {
         const uuid = '1811a3ce5b0363-0052debf84392a-3a50387c-0-1811a3ce5b1ad2'
 
+        let spy
         beforeEach(() => {
-            jest.spyOn(_, 'UUID').mockReturnValue(uuid)
+            spy = jest.spyOn(_, 'UUID').mockReturnValue(uuid)
         })
         afterEach(() => {
-            _.UUID.mockRestore()
+            spy.mockRestore()
         })
 
         it('sets a random UUID as distinct_id/$device_id if distinct_id is unset', () => {
@@ -947,7 +948,9 @@ describe('reset()', () => {
         persistence: new PostHogPersistence(given.config),
     }))
 
-    given.lib._init('testtoken', given.config, 'testhog')
+    beforeEach(() => {
+        given.lib._init('testtoken', given.config, 'testhog')
+    })
 
     it('clears persistence', () => {
         given.lib.persistence.register({ $enabled_feature_flags: { flag: 'variant', other: true } })

--- a/src/posthog-core.js
+++ b/src/posthog-core.js
@@ -941,6 +941,7 @@ PostHogLib.prototype.group = function (groupType, groupKey, groupPropertiesToSet
 PostHogLib.prototype.reset = function (reset_device_id) {
     let device_id = this.get_property('$device_id')
     this['persistence'].clear()
+    this.sessionManager.resetSessionId()
     const uuid = this.get_config('get_device_id')(_.UUID())
     this.register_once(
         {


### PR DESCRIPTION
## Changes

Ensures we reset the session_id and window_id when the user calls `posthog.reset()`

Before, the issue was that we would clear the values from localStorage, but they still existed in memory.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
