### PR TITLE
feat(feature-flags): Enable bootstrapping the library

### DIFF
--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -95,6 +95,7 @@ describe('Payload Compression', () => {
                 featureFlags: {
                     receivedFeatureFlags: jest.fn(),
                 },
+                _hasBootstrappedFeatureFlags: jest.fn(),
             }
         })
 

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -24,6 +24,7 @@ describe('Decide', () => {
         featureFlags: {
             receivedFeatureFlags: jest.fn(),
         },
+        _hasBootstrappedFeatureFlags: jest.fn(),
         getGroups: () => ({ organization: '5' }),
     }))
 

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -609,7 +609,6 @@ describe('__compress_and_send_json_request', () => {
 })
 
 describe('bootstrapping feature flags', () => {
-
     given('subject', () => () => given.lib._init('posthog', given.config, 'testhog'))
 
     given('overrides', () => ({
@@ -625,9 +624,9 @@ describe('bootstrapping feature flags', () => {
         given('config', () => ({
             bootstrap: {
                 distinctID: 'abcd',
-            }
+            },
         }))
-    
+
         given.subject()
         expect(given.lib.get_distinct_id()).toBe('abcd')
         expect(given.lib.get_property('$device_id')).toBe('abcd')
@@ -644,15 +643,15 @@ describe('bootstrapping feature flags', () => {
         )
     })
 
-    it("treats identified distinctIDs appropriately", () => {
+    it('treats identified distinctIDs appropriately', () => {
         given('config', () => ({
             bootstrap: {
                 distinctID: 'abcd',
                 isIdentifiedID: true,
             },
-            get_device_id: (uuid) => 'og-device-id',
+            get_device_id: () => 'og-device-id',
         }))
-    
+
         given.subject()
         expect(given.lib.get_distinct_id()).toBe('abcd')
         expect(given.lib.get_property('$device_id')).toBe('og-device-id')
@@ -664,24 +663,24 @@ describe('bootstrapping feature flags', () => {
     it('sets the right feature flags', () => {
         given('config', () => ({
             bootstrap: {
-                featureFlags: { 'multivariant': 'variant-1', 'enabled': true, 'disabled': false, 'undef': undefined }
-            }
+                featureFlags: { multivariant: 'variant-1', enabled: true, disabled: false, undef: undefined },
+            },
         }))
-    
+
         given.subject()
         expect(given.lib.get_distinct_id()).not.toBe('abcd')
         expect(given.lib.get_distinct_id()).not.toEqual(undefined)
         expect(given.lib.getFeatureFlag('multivariant')).toBe('variant-1')
         expect(given.lib.getFeatureFlag('disabled')).toBe(undefined)
         expect(given.lib.getFeatureFlag('undef')).toBe(undefined)
-        expect(given.lib.featureFlags.getFlagVariants()).toEqual({'multivariant': 'variant-1', 'enabled': true})
+        expect(given.lib.featureFlags.getFlagVariants()).toEqual({ multivariant: 'variant-1', enabled: true })
     })
 
     it('does nothing when empty', () => {
         given('config', () => ({
-            bootstrap: {}
+            bootstrap: {},
         }))
-    
+
         given.subject()
         expect(given.lib.get_distinct_id()).not.toBe('abcd')
         expect(given.lib.get_distinct_id()).not.toEqual(undefined)
@@ -696,8 +695,8 @@ describe('bootstrapping feature flags', () => {
 
         given('config', () => ({
             bootstrap: {
-                featureFlags: { 'multivariant': 'variant-1' }
-            }
+                featureFlags: { multivariant: 'variant-1' },
+            },
         }))
 
         given.subject()
@@ -710,8 +709,8 @@ describe('bootstrapping feature flags', () => {
 
         given('config', () => ({
             bootstrap: {
-                featureFlags: {}
-            }
+                featureFlags: {},
+            },
         }))
 
         given.subject()
@@ -724,15 +723,14 @@ describe('bootstrapping feature flags', () => {
 
         given('config', () => ({
             bootstrap: {
-                featureFlags: undefined
-            }
+                featureFlags: undefined,
+            },
         }))
 
         given.subject()
         given.lib.featureFlags.onFeatureFlags(() => (called = true))
         expect(called).toEqual(false)
     })
-
 })
 
 describe('init()', () => {

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -630,6 +630,35 @@ describe('bootstrapping feature flags', () => {
     
         given.subject()
         expect(given.lib.get_distinct_id()).toBe('abcd')
+        expect(given.lib.get_property('$device_id')).toBe('abcd')
+
+        given.lib.identify('efgh')
+
+        expect(given.overrides.capture).toHaveBeenCalledWith(
+            '$identify',
+            {
+                distinct_id: 'efgh',
+                $anon_distinct_id: 'abcd',
+            },
+            { $set: {}, $set_once: {} }
+        )
+    })
+
+    it("treats identified distinctIDs appropriately", () => {
+        given('config', () => ({
+            bootstrap: {
+                distinctID: 'abcd',
+                isIdentifiedID: true,
+            },
+            get_device_id: (uuid) => 'og-device-id',
+        }))
+    
+        given.subject()
+        expect(given.lib.get_distinct_id()).toBe('abcd')
+        expect(given.lib.get_property('$device_id')).toBe('og-device-id')
+
+        given.lib.identify('efgh')
+        expect(given.overrides.capture).not.toHaveBeenCalled()
     })
 
     it('sets the right feature flags', () => {

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -662,6 +662,48 @@ describe('bootstrapping feature flags', () => {
         expect(given.lib.featureFlags.getFlagVariants()).toEqual({})
     })
 
+    it('onFeatureFlags should be called immediately if feature flags are bootstrapped', () => {
+        let called = false
+
+        given('config', () => ({
+            bootstrap: {
+                featureFlags: { 'multivariant': 'variant-1' }
+            }
+        }))
+
+        given.subject()
+        given.lib.featureFlags.onFeatureFlags(() => (called = true))
+        expect(called).toEqual(true)
+    })
+
+    it('onFeatureFlags should not be called immediately if feature flags bootstrap is empty', () => {
+        let called = false
+
+        given('config', () => ({
+            bootstrap: {
+                featureFlags: {}
+            }
+        }))
+
+        given.subject()
+        given.lib.featureFlags.onFeatureFlags(() => (called = true))
+        expect(called).toEqual(false)
+    })
+
+    it('onFeatureFlags should not be called immediately if feature flags bootstrap is undefined', () => {
+        let called = false
+
+        given('config', () => ({
+            bootstrap: {
+                featureFlags: undefined
+            }
+        }))
+
+        given.subject()
+        given.lib.featureFlags.onFeatureFlags(() => (called = true))
+        expect(called).toEqual(false)
+    })
+
 })
 
 describe('init()', () => {

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -8,7 +8,8 @@ export class Decide {
 
     constructor(instance: PostHog) {
         this.instance = instance
-        this.instance.decideEndpointWasHit = false
+        // don't need to wait for `decide` to return if flags were provided on initialisation
+        this.instance.decideEndpointWasHit = this.instance._hasBootstrappedFeatureFlags()
     }
 
     call(): void {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -357,14 +357,7 @@ export class PostHog {
             .filter(flag => !!config.bootstrap?.featureFlags?.[flag])
             .reduce( (res: Record<string, string | boolean>, key) => (res[key] = config.bootstrap?.featureFlags?.[key] || false, res), {} );
             
-            console.log('current decide value: ', this.decideEndpointWasHit)
             this.featureFlags.receivedFeatureFlags({ featureFlags: activeFlags })
-            console.log('current decide value after calling received: ', this.decideEndpointWasHit)
-            // this.register({
-            //     $active_feature_flags: Object.keys(activeFlags || {}),
-            //     $enabled_feature_flags: activeFlags || {},
-            // })
-            // this.decideEndpointWasHit = activeFlags && Object.keys(activeFlags).length > 0
         }
 
         if (!this.get_distinct_id()) {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -158,7 +158,7 @@ const defaultConfig = (): PostHogConfig => ({
     _capture_performance: false,
     name: 'posthog',
     callback_fn: 'posthog._jsc',
-    bootstrap: {}
+    bootstrap: {},
 })
 
 /**
@@ -356,9 +356,14 @@ export class PostHog {
 
         if (this._hasBootstrappedFeatureFlags()) {
             const activeFlags = Object.keys(config.bootstrap?.featureFlags || {})
-            .filter(flag => !!config.bootstrap?.featureFlags?.[flag])
-            .reduce( (res: Record<string, string | boolean>, key) => (res[key] = config.bootstrap?.featureFlags?.[key] || false, res), {} );
-            
+                .filter((flag) => !!config.bootstrap?.featureFlags?.[flag])
+                .reduce(
+                    (res: Record<string, string | boolean>, key) => (
+                        (res[key] = config.bootstrap?.featureFlags?.[key] || false), res
+                    ),
+                    {}
+                )
+
             this.featureFlags.receivedFeatureFlags({ featureFlags: activeFlags })
         }
 
@@ -630,7 +635,10 @@ export class PostHog {
     }
 
     _hasBootstrappedFeatureFlags(): boolean {
-        return (this.config.bootstrap?.featureFlags && Object.keys(this.config.bootstrap?.featureFlags).length > 0) || false
+        return (
+            (this.config.bootstrap?.featureFlags && Object.keys(this.config.bootstrap?.featureFlags).length > 0) ||
+            false
+        )
     }
 
     /**

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -352,15 +352,19 @@ export class PostHog {
             })
         }
 
-        if (!!config.bootstrap?.featureFlags) {
-            const activeFlags = Object.keys(config.bootstrap.featureFlags)
-                .filter(flag => !!config.bootstrap.featureFlags[flag])
-                .reduce( (res: Record<string, string | boolean>, key) => (res[key] = config.bootstrap.featureFlags[key], res), {} );
+        if (this._hasBootstrappedFeatureFlags()) {
+            const activeFlags = Object.keys(config.bootstrap?.featureFlags || {})
+            .filter(flag => !!config.bootstrap?.featureFlags?.[flag])
+            .reduce( (res: Record<string, string | boolean>, key) => (res[key] = config.bootstrap?.featureFlags?.[key] || false, res), {} );
             
-            this.register({
-                $active_feature_flags: Object.keys(activeFlags || {}),
-                $enabled_feature_flags: activeFlags || {},
-            })
+            console.log('current decide value: ', this.decideEndpointWasHit)
+            this.featureFlags.receivedFeatureFlags({ featureFlags: activeFlags })
+            console.log('current decide value after calling received: ', this.decideEndpointWasHit)
+            // this.register({
+            //     $active_feature_flags: Object.keys(activeFlags || {}),
+            //     $enabled_feature_flags: activeFlags || {},
+            // })
+            // this.decideEndpointWasHit = activeFlags && Object.keys(activeFlags).length > 0
         }
 
         if (!this.get_distinct_id()) {
@@ -628,6 +632,10 @@ export class PostHog {
         execute(alias_calls, this)
         execute(other_calls, this)
         execute(capturing_calls, this)
+    }
+
+    _hasBootstrappedFeatureFlags(): boolean {
+        return (this.config.bootstrap?.featureFlags && Object.keys(this.config.bootstrap?.featureFlags).length > 0) || false
     }
 
     /**

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -346,9 +346,11 @@ export class PostHog {
         this._gdpr_init()
 
         if (config.bootstrap?.distinctID !== undefined) {
+            const uuid = this.get_config('get_device_id')(_UUID())
+            const deviceID = config.bootstrap?.isIdentifiedID ? uuid : config.bootstrap.distinctID
             this.register({
                 distinct_id: config.bootstrap.distinctID,
-                $device_id: config.bootstrap.distinctID
+                $device_id: deviceID,
             })
         }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -352,8 +352,6 @@ export class PostHog {
             })
         }
 
-        console.log('initing', config.bootstrap, this.persistence['props'])
-
         if (!!config.bootstrap?.featureFlags) {
             const activeFlags = Object.keys(config.bootstrap.featureFlags)
                 .filter(flag => !!config.bootstrap.featureFlags[flag])
@@ -365,13 +363,7 @@ export class PostHog {
             })
         }
 
-        console.log('initing', config.bootstrap, this.persistence['props'])
-
-        console.log('found distinctID', this.persistence['props']['distinct_id'], this.get_distinct_id(), this.get_property('distinct_id'))
-
-
         if (!this.get_distinct_id()) {
-            console.log('NOT found distinctID', this.get_distinct_id())
             // There is no need to set the distinct id
             // or the device id if something was already stored
             // in the persitence

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -203,7 +203,6 @@ export class PostHogFeatureFlags {
         parseFeatureFlagDecideResponse(response, this.instance.persistence)
         const flags = this.getFlags()
         const variants = this.getFlagVariants()
-        console.log('handlers: ', this.featureFlagEventHandlers)
         this.featureFlagEventHandlers.forEach((handler) => handler(flags, variants))
     }
 
@@ -246,7 +245,6 @@ export class PostHogFeatureFlags {
      */
     onFeatureFlags(callback: FeatureFlagsCallback): void {
         this.addFeatureFlagsHandler(callback)
-        console.log('called on Feature Flags', this.instance.decideEndpointWasHit)
         if (this.instance.decideEndpointWasHit) {
             const flags = this.getFlags()
             const flagVariants = this.getFlagVariants()

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -3,7 +3,7 @@ import { PostHog } from './posthog-core'
 import { DecideResponse, FeatureFlagsCallback, RequestCallback } from './types'
 import { PostHogPersistence } from './posthog-persistence'
 
-export const parseFeatureFlagDecideResponse = (response: DecideResponse, persistence: PostHogPersistence) => {
+export const parseFeatureFlagDecideResponse = (response: Partial<DecideResponse>, persistence: PostHogPersistence) => {
     const flags = response['featureFlags']
     if (flags) {
         // using the v1 api
@@ -198,10 +198,12 @@ export class PostHogFeatureFlags {
         this.featureFlagEventHandlers.push(handler)
     }
 
-    receivedFeatureFlags(response: DecideResponse): void {
+    receivedFeatureFlags(response: Partial<DecideResponse>): void {
+        this.instance.decideEndpointWasHit = true
         parseFeatureFlagDecideResponse(response, this.instance.persistence)
         const flags = this.getFlags()
         const variants = this.getFlagVariants()
+        console.log('handlers: ', this.featureFlagEventHandlers)
         this.featureFlagEventHandlers.forEach((handler) => handler(flags, variants))
     }
 
@@ -244,6 +246,7 @@ export class PostHogFeatureFlags {
      */
     onFeatureFlags(callback: FeatureFlagsCallback): void {
         this.addFeatureFlagsHandler(callback)
+        console.log('called on Feature Flags', this.instance.decideEndpointWasHit)
         if (this.instance.decideEndpointWasHit) {
             const flags = this.getFlags()
             const flagVariants = this.getFlagVariants()

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export interface PostHogConfig {
     _capture_performance: boolean
     bootstrap: {
         distinctID?: string
+        isIdentifiedID?: boolean
         featureFlags?: Record<string, boolean | string>
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,10 @@ export interface PostHogConfig {
     _onCapture: (eventName: string, eventData: CaptureResult) => void
     _capture_metrics: boolean
     _capture_performance: boolean
+    bootstrap: {
+        distinctID?: string
+        featureFlags?: Record<string, boolean | string>
+    }
 }
 
 export interface OptInOutCapturingOptions {


### PR DESCRIPTION
## Changes

Allows for initialising the library with a distinctID, and/or feature flags as well. This id is treated as an anonymous ID, unless you explicitly say that it's not.

This allows for immediate flag availability on load, and makes possible to do things like: redirect pages based on feature flags (which wouldn't have been possible earlier, since the flags take some time to load)

@mariusandra , @Twixes  , have a look here for how I expect this to be used: https://github.com/PostHog/posthog/pull/11704 -> just a PoC, to help review this PR, if you want interface changes, etc. etc.

...

---

Tested by running locally with the PoC PR, see everything works as expected.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
