### PR TITLE
fix(recordings): unique window id on duplication

### DIFF
--- a/playground/session-recordings/index.html
+++ b/playground/session-recordings/index.html
@@ -1,0 +1,67 @@
+<html>
+<head>
+    <title>PostHog JS Snippet test</title>
+</head>
+<body>
+    <button data-cy-button>Some button</button>
+
+    <br />
+
+    <input data-cy-input placeholder="Input" />
+
+    <br />
+
+    <button data-cy-custom-event-button onclick="posthog.capture('custom-event', { foo: 2 })">
+        Send custom event
+    </button>
+
+    <br />
+
+    <button data-cy-feature-flag-button onclick="console.log(posthog.isFeatureEnabled('some-feature'))">
+        Test a feature flag
+    </button>
+
+    <br />
+
+    <div data-cy-captures>
+    </div>
+
+
+    <a data-cy-link-mask-text>
+        Sensitive text!
+    </a>
+
+    <!-- TODO: Remove the ="true" once we have fixed the bug with autocapture to ensure E2E that it works -->
+    <button data-cy-button-sensitive-attributes="true" class='sensitive' id='sensitive' data-sensitive='sensitive'>
+        Sensitive attributes!
+    </button>
+
+    <div>
+
+        <div>SessionID: 
+        <span id="current-session-id"></span>
+        </div>
+        <div>WindowID: 
+        <span id="current-window-id"></span>
+        </div>
+
+        <button data-cy-custom-event-button onclick="window.open(window.location)">
+            Open new window
+        </button>
+    </div>
+
+    <script>
+        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    </script>
+
+    <script>
+
+        posthog.init('mykey', { api_host: location.origin })
+
+        setTimeout(() => {
+            document.getElementById("current-session-id").innerHTML = posthog.sessionRecording.sessionId
+            document.getElementById("current-window-id").innerHTML = posthog.sessionRecording.windowId
+        }, 100)
+    </script>
+</body>
+</html>

--- a/playground/session-recordings/server.js
+++ b/playground/session-recordings/server.js
@@ -1,0 +1,32 @@
+const path = require("path")
+const express = require('express')
+const app = express()
+const port = 3001
+
+app.use('/static', express.static(__dirname + '/../../dist'))
+
+app.get('/', function (req, res) {
+    res.sendFile(__dirname + '/index.html')
+})
+
+app.get('/static/recorder.js', function (req, res) {
+    let filePath = path.join(__dirname, '/../../node_modules/rrweb/dist/rrweb.min.js')
+    res.sendFile(filePath)
+})
+
+app.listen(port, () => {
+    console.log(`Example app listening on port ${port}`)
+})
+
+app.post('/decide', function (req, res) {
+    res.json({
+        config: { enable_collect_everything: false },
+        editorParams: {},
+        featureFlags: ['session-recording-player'],
+        isAuthenticated: false,
+        sessionRecording: {
+            endpoint: '/ses/',
+        },
+        supportedCompression: ['gzip', 'lz64'],
+    })
+})

--- a/src/__tests__/sessionid.js
+++ b/src/__tests__/sessionid.js
@@ -223,22 +223,38 @@ describe('Session ID manager', () => {
         })
     })
 
-    describe('use new window id on duplication but not reload', () => {
-        it('reload - use old window id available during unload', () => {
+    describe('do_not_refresh_window_id', () => {
+        it('if do not refresh window id is true, use same window id', () => {
             // setup
-            given.sessionIdManager._setWindowId('oldWindowId')
-            // trigger unload event
-            sessionStore.set(given.sessionIdManager.last_window_id_storage_key, given.sessionIdManager._getWindowId())
-
+            sessionStore.parse.mockImplementation((storeKey) =>
+                storeKey === 'ph_persistance-name_do_not_refresh_window_id' ? true : 'oldWindowId'
+            )
             // expect
-            expect(given.sessionIdManager._getWindowId()).toEqual('oldWindowId')
+            expect(given.sessionIdManager._windowId).toEqual('oldWindowId')
+            expect(sessionStore.remove).toHaveBeenCalledTimes(1)
+            expect(sessionStore.remove).toHaveBeenCalledWith('ph_persistance-name_do_not_refresh_window_id')
         })
-        it('duplication - use new window id', () => {
+        it('if do not refresh window id is undefined, use new window id', () => {
             // setup
-            given.sessionIdManager._setWindowId(null) // no window id in memory on dupe or reload
-
+            sessionStore.parse.mockImplementation((storeKey) =>
+                storeKey === 'ph_persistance-name_do_not_refresh_window_id' ? undefined : 'oldWindowId'
+            )
             // expect
-            expect(given.sessionIdManager._getWindowId()).toEqual(null)
+            expect(given.sessionIdManager._windowId).toEqual(undefined)
+            expect(sessionStore.remove).toHaveBeenCalledTimes(2)
+            expect(sessionStore.remove).toHaveBeenNthCalledWith(1, 'ph_persistance-name_window_id')
+            expect(sessionStore.remove).toHaveBeenNthCalledWith(2, 'ph_persistance-name_do_not_refresh_window_id')
+        })
+        it('if do not refresh window id is false, use new window id', () => {
+            // setup
+            sessionStore.parse.mockImplementation((storeKey) =>
+                storeKey === 'ph_persistance-name_do_not_refresh_window_id' ? false : 'oldWindowId'
+            )
+            // expect
+            expect(given.sessionIdManager._windowId).toEqual(undefined)
+            expect(sessionStore.remove).toHaveBeenCalledTimes(2)
+            expect(sessionStore.remove).toHaveBeenNthCalledWith(1, 'ph_persistance-name_window_id')
+            expect(sessionStore.remove).toHaveBeenNthCalledWith(2, 'ph_persistance-name_do_not_refresh_window_id')
         })
     })
 })

--- a/src/__tests__/sessionid.js
+++ b/src/__tests__/sessionid.js
@@ -223,38 +223,26 @@ describe('Session ID manager', () => {
         })
     })
 
-    describe('do_not_refresh_window_id', () => {
-        it('if do not refresh window id is true, use same window id', () => {
+    describe('primary_window_exists_storage_key', () => {
+        it('if primary_window_exists key does not exist, do not cycle window id', () => {
             // setup
             sessionStore.parse.mockImplementation((storeKey) =>
-                storeKey === 'ph_persistance-name_do_not_refresh_window_id' ? true : 'oldWindowId'
+                storeKey === 'ph_persistance-name_primary_window_exists' ? undefined : 'oldWindowId'
             )
             // expect
             expect(given.sessionIdManager._windowId).toEqual('oldWindowId')
-            expect(sessionStore.remove).toHaveBeenCalledTimes(1)
-            expect(sessionStore.remove).toHaveBeenCalledWith('ph_persistance-name_do_not_refresh_window_id')
+            expect(sessionStore.remove).toHaveBeenCalledTimes(0)
+            expect(sessionStore.set).toHaveBeenCalledWith('ph_persistance-name_primary_window_exists', true)
         })
-        it('if do not refresh window id is undefined, use new window id', () => {
+        it('if primary_window_exists key exists, cycle window id', () => {
             // setup
             sessionStore.parse.mockImplementation((storeKey) =>
-                storeKey === 'ph_persistance-name_do_not_refresh_window_id' ? undefined : 'oldWindowId'
+                storeKey === 'ph_persistance-name__primary_window_exists' ? true : 'oldWindowId'
             )
             // expect
             expect(given.sessionIdManager._windowId).toEqual(undefined)
-            expect(sessionStore.remove).toHaveBeenCalledTimes(2)
-            expect(sessionStore.remove).toHaveBeenNthCalledWith(1, 'ph_persistance-name_window_id')
-            expect(sessionStore.remove).toHaveBeenNthCalledWith(2, 'ph_persistance-name_do_not_refresh_window_id')
-        })
-        it('if do not refresh window id is false, use new window id', () => {
-            // setup
-            sessionStore.parse.mockImplementation((storeKey) =>
-                storeKey === 'ph_persistance-name_do_not_refresh_window_id' ? false : 'oldWindowId'
-            )
-            // expect
-            expect(given.sessionIdManager._windowId).toEqual(undefined)
-            expect(sessionStore.remove).toHaveBeenCalledTimes(2)
-            expect(sessionStore.remove).toHaveBeenNthCalledWith(1, 'ph_persistance-name_window_id')
-            expect(sessionStore.remove).toHaveBeenNthCalledWith(2, 'ph_persistance-name_do_not_refresh_window_id')
+            expect(sessionStore.remove).toHaveBeenCalledWith('ph_persistance-name_window_id')
+            expect(sessionStore.set).toHaveBeenCalledWith('ph_persistance-name_primary_window_exists', true)
         })
     })
 })

--- a/src/__tests__/sessionid.js
+++ b/src/__tests__/sessionid.js
@@ -190,7 +190,7 @@ describe('Session ID manager', () => {
             expect(given.sessionIdManager._getWindowId()).toEqual('newWindowId')
             expect(sessionStore.set).not.toHaveBeenCalled()
         })
-        it('stores and retrieves a window_id if sessionStoage is not supported', () => {
+        it('stores and retrieves a window_id if sessionStorage is not supported', () => {
             sessionStore.is_supported.mockReturnValue(false)
             given.sessionIdManager._setWindowId('newWindowId')
             expect(given.sessionIdManager._getWindowId()).toEqual('newWindowId')
@@ -220,6 +220,25 @@ describe('Session ID manager', () => {
                 windowId: 'newUUID',
                 sessionId: 'newUUID',
             })
+        })
+    })
+
+    describe('use new window id on duplication but not reload', () => {
+        it('reload - use old window id available during unload', () => {
+            // setup
+            given.sessionIdManager._setWindowId('oldWindowId')
+            // trigger unload event
+            sessionStore.set(given.sessionIdManager.last_window_id_storage_key, given.sessionIdManager._getWindowId())
+
+            // expect
+            expect(given.sessionIdManager._getWindowId()).toEqual('oldWindowId')
+        })
+        it('duplication - use new window id', () => {
+            // setup
+            given.sessionIdManager._setWindowId(null) // no window id in memory on dupe or reload
+
+            // expect
+            expect(given.sessionIdManager._getWindowId()).toEqual(null)
         })
     })
 })

--- a/src/sessionid.ts
+++ b/src/sessionid.ts
@@ -11,7 +11,7 @@ export class SessionIdManager {
     _windowId: string | null | undefined
     _sessionId: string | null | undefined
     window_id_storage_key: string
-    last_window_id_storage_key: string // persists only across tab reload, not tab duplication
+    last_window_id_storage_key: string
     _sessionStartTimestamp: number | null
     _sessionActivityTimestamp: number | null
 

--- a/src/sessionid.ts
+++ b/src/sessionid.ts
@@ -45,6 +45,8 @@ export class SessionIdManager {
             // Cleanup any traces
             sessionStore.remove(this.do_not_refresh_window_id_key)
         }
+
+        this._listenToReloadWindow()
     }
 
     // Note: this tries to store the windowId in sessionStorage. SessionStorage is unique to the current window/tab,
@@ -169,7 +171,6 @@ export class SessionIdManager {
 
         this._setWindowId(windowId)
         this._setSessionId(sessionId, newTimestamp, sessionStartTimestamp)
-        this._listenToReloadWindow()
 
         return {
             sessionId: sessionId,

--- a/src/sessionid.ts
+++ b/src/sessionid.ts
@@ -11,7 +11,7 @@ export class SessionIdManager {
     _windowId: string | null | undefined
     _sessionId: string | null | undefined
     window_id_storage_key: string
-    do_not_refresh_window_id_key: string
+    primary_window_exists_storage_key: string
     _sessionStartTimestamp: number | null
     _sessionActivityTimestamp: number | null
 
@@ -22,28 +22,26 @@ export class SessionIdManager {
         this._sessionStartTimestamp = null
         this._sessionActivityTimestamp = null
 
-        if (config['persistence_name']) {
-            this.window_id_storage_key = 'ph_' + config['persistence_name'] + '_window_id'
-            this.do_not_refresh_window_id_key = 'ph_' + config['persistence_name'] + '_do_not_refresh_window_id'
-        } else {
-            this.window_id_storage_key = 'ph_' + config['token'] + '_window_id'
-            this.do_not_refresh_window_id_key = 'ph_' + config['token'] + '_do_not_refresh_window_id'
-        }
+        const persistenceName = config['persistence_name'] || config['token']
 
-        // doNotRefreshWindowId is only true when the DOM has been unloaded
-        // this happens on reloads and doesn't happen on tab duplication, window.open, etc.
+        this.window_id_storage_key = 'ph_' + persistenceName + '_window_id'
+        this.primary_window_exists_storage_key = 'ph_' + persistenceName + '_primary_window_exists'
+
+        // primary_window_exists is set when the DOM has been loaded and is cleared on unload
+        // if it exists here it means there was no unload which suggests this window is opened as a tab duplication, window.open, etc.
         if (!this.persistence.disabled && sessionStore.is_supported()) {
             const lastWindowId = sessionStore.parse(this.window_id_storage_key)
-            const doNotRefreshWindowId = sessionStore.parse(this.do_not_refresh_window_id_key)
-            if (lastWindowId && doNotRefreshWindowId) {
+
+            const primaryWindowExists = sessionStore.parse(this.primary_window_exists_storage_key)
+            if (lastWindowId && !primaryWindowExists) {
                 // Persist window from previous storage state
                 this._windowId = lastWindowId
             } else {
                 // Wipe any reference to previous window id
                 sessionStore.remove(this.window_id_storage_key)
             }
-            // Cleanup any traces
-            sessionStore.remove(this.do_not_refresh_window_id_key)
+            // Flag this session as having a primary window
+            sessionStore.set(this.primary_window_exists_storage_key, true)
         }
 
         this._listenToReloadWindow()
@@ -115,15 +113,15 @@ export class SessionIdManager {
     }
 
     /*
-     * Listens to window unloads and exposes doNotRefresh key in sessionStorage between unload and on load.
-     * New tabs created after a DOM unloads (reloading the same tab) will have this doNotRefresh flag in their session storage.
-     * New tabs created from scratch (new tab, tab duplication, window.open(), ...) will NOT have this doNotRefresh flag in their session storage.
-     * We conditionally check the doNotRefresh value in the constructor to decide if the window id in the last session storage should be carried over.
+     * Listens to window unloads and removes the primaryWindowExists key from sessionStorage.
+     * Reloaded or fresh tabs created after a DOM unloads (reloading the same tab) WILL NOT have this primaryWindowExists flag in session storage.
+     * Cloned sessions (new tab, tab duplication, window.open(), ...) WILL have this primaryWindowExists flag in their copied session storage.
+     * We conditionally check the primaryWindowExists value in the constructor to decide if the window id in the last session storage should be carried over.
      */
     _listenToReloadWindow(): void {
         window.addEventListener('beforeunload', () => {
             if (!this.persistence.disabled && sessionStore.is_supported()) {
-                sessionStore.set(this.do_not_refresh_window_id_key, true)
+                sessionStore.remove(this.primary_window_exists_storage_key)
             }
         })
     }


### PR DESCRIPTION
## Problem

Whenever a user duplicates a tab (right click duplicate tab, new windows, window.open(), cmd + click refresh icon, etc.) the session storage from the original tab (where we store the recording's windowId) is duplicated into the new tab. Today it is impossible to differentiate tabs created in this way, and users are running into issues where parts of the recording are lost or malformed. 

Example: https://posthogusers.slack.com/archives/C01GLBKHKQT/p1662734141817939

## Changes

It's tricky to differentiate a tab duplicate from a tab reload. In the first case, we want to use a new window id to generate a fresh set of snapshots, whereas in the second we want to persist the same window id.

In order to differentiate the two, this PR exposes a new key `do_not_refresh_window_id` in sessionStorage only on the `window.beforeunload` event. This event is only triggered on reloads when the DOM must be unloaded and reloaded in the same window. This event is NOT triggered on new windows/tabs since there is no DOM to unload in the new tab. After the new DOM has loaded, it simply checks the session storage for this `do_not_refresh_window_id`, recycling it if it's there and generating a new one if it isn't.

...

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers. Tested on safari, chrome, firefox.
