### PR TITLE
feat(recordings): server side console log setting

### DIFF
--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -24,7 +24,10 @@ describe('SessionRecording', () => {
         checkAndGetSessionAndWindowId: jest.fn().mockImplementation(() => given.incomingSessionAndWindowId),
     }))
     given('posthog', () => ({
-        get_property: (property_key) => property_key===SESSION_RECORDING_ENABLED_SERVER_SIDE?given.$session_recording_enabled_server_side:given.$console_log_enabled_server_side,
+        get_property: (property_key) =>
+            property_key === SESSION_RECORDING_ENABLED_SERVER_SIDE
+                ? given.$session_recording_enabled_server_side
+                : given.$console_log_enabled_server_side,
         get_config: jest.fn().mockImplementation((key) => given.config[key]),
         capture: jest.fn(),
         persistence: { register: jest.fn() },
@@ -79,8 +82,8 @@ describe('SessionRecording', () => {
         it('uses client side setting when set to false', () => {
             given('$console_log_enabled_server_side', () => true)
             given('enable_recording_console_log_client_side', () => false)
-            expect(given.subject()).toBe(false)       
-         })
+            expect(given.subject()).toBe(false)
+        })
 
         it('uses client side setting when set to true', () => {
             given('$console_log_enabled_server_side', () => false)
@@ -90,7 +93,6 @@ describe('SessionRecording', () => {
 
         it('uses server side setting if client side setting is not set', () => {
             given('enable_recording_console_log_client_side', () => undefined)
-
 
             given('$console_log_enabled_server_side', () => false)
             expect(given.subject()).toBe(false)

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -1,5 +1,8 @@
 import { loadScript } from '../autocapture-utils'
-import { CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE, SESSION_RECORDING_ENABLED_SERVER_SIDE } from '../posthog-persistence'
+import {
+    CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE,
+    SESSION_RECORDING_ENABLED_SERVER_SIDE,
+} from '../posthog-persistence'
 import Config from '../config'
 import { filterDataURLsFromLargeDataObjects, truncateLargeConsoleLogs } from './sessionrecording-utils'
 import { PostHog } from '../posthog-core'

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -68,7 +68,6 @@ export class SessionRecording {
     isConsoleLogCaptureEnabled() {
         const enabled_server_side = !!this.instance.get_property(CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE)
         const enabled_client_side = this.instance.get_config('enable_recording_console_log')
-        console.log(enabled_client_side)
         return enabled_client_side ?? enabled_server_side
     }
 

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -1,5 +1,5 @@
 import { loadScript } from '../autocapture-utils'
-import { SESSION_RECORDING_ENABLED_SERVER_SIDE } from '../posthog-persistence'
+import { CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE, SESSION_RECORDING_ENABLED_SERVER_SIDE } from '../posthog-persistence'
 import Config from '../config'
 import { filterDataURLsFromLargeDataObjects, truncateLargeConsoleLogs } from './sessionrecording-utils'
 import { PostHog } from '../posthog-core'
@@ -65,11 +65,19 @@ export class SessionRecording {
         return enabled_server_side && enabled_client_side
     }
 
+    isConsoleLogCaptureEnabled() {
+        const enabled_server_side = !!this.instance.get_property(CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE)
+        const enabled_client_side = this.instance.get_config('enable_recording_console_log')
+        console.log(enabled_client_side)
+        return enabled_client_side ?? enabled_server_side
+    }
+
     afterDecideResponse(response: DecideResponse) {
         this.receivedDecide = true
         if (this.instance.persistence) {
             this.instance.persistence.register({
                 [SESSION_RECORDING_ENABLED_SERVER_SIDE]: !!response['sessionRecording'],
+                [CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE]: response.sessionRecording?.consoleLogRecordingEnabled,
             })
         }
         if (response.sessionRecording?.endpoint) {
@@ -186,7 +194,7 @@ export class SessionRecording {
                 }
             },
             plugins:
-                (window as any).rrwebConsoleRecord && this.instance.get_config('enable_recording_console_log')
+                (window as any).rrwebConsoleRecord && this.isConsoleLogCaptureEnabled()
                     ? [(window as any).rrwebConsoleRecord.getRecordConsolePlugin()]
                     : [],
             ...sessionRecordingOptions,

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -115,7 +115,7 @@ const defaultConfig = (): PostHogConfig => ({
     disable_session_recording: false,
     disable_persistence: false,
     disable_cookie: false,
-    enable_recording_console_log: false,
+    enable_recording_console_log: undefined, // When undefined, it falls back to the server-side setting
     secure_cookie: window?.location?.protocol === 'https:',
     ip: true,
     opt_out_capturing_by_default: false,

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -20,6 +20,7 @@ export const ALIAS_ID_KEY = '__alias'
 export const CAMPAIGN_IDS_KEY = '__cmpns'
 export const EVENT_TIMERS_KEY = '__timers'
 export const SESSION_RECORDING_ENABLED_SERVER_SIDE = '$session_recording_enabled_server_side'
+export const CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE = '$console_log_recording_enabled_server_side'
 export const SESSION_ID = '$sesid'
 export const ENABLED_FEATURE_FLAGS = '$enabled_feature_flags'
 export const RESERVED_PROPERTIES = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export interface PostHogConfig {
     disable_session_recording: boolean
     disable_persistence: boolean
     disable_cookie: boolean
-    enable_recording_console_log: boolean
+    enable_recording_console_log?: boolean
     secure_cookie: boolean
     ip: boolean
     opt_out_capturing_by_default: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,7 @@ export interface DecideResponse {
     featureFlags: Record<string, string | boolean>
     sessionRecording?: {
         endpoint?: string
+        consoleLogRecordingEnabled?: boolean
     }
     editorParams: EditorParams
     toolbarVersion: 'toolbar' /** deprecated, moved to editorParams */


### PR DESCRIPTION
## Changes

Allows for enabling/disabling console logs from the server.

If the client side setting is set, that's used. Otherwise, it falls back to the server side setting.

- [ ] Need to add the application side of this and test e2e

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
