### PR TITLE
feat(apps): inject javascript from decide

### DIFF
--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -94,5 +94,17 @@ describe('Decide', () => {
             expect(given.posthog.featureFlags.receivedFeatureFlags).not.toHaveBeenCalled()
             expect(console.error).toHaveBeenCalledWith('Failed to fetch feature flags from PostHog.')
         })
+
+        it('runs injected code', () => {
+            const source = 'injected source'
+            window.injectedSource = null
+            window.eval = (source) => {
+                // can't run window.eval() in jest, so mocking it instead
+                window.injectedSource = source
+            }
+            given('decideResponse', () => ({ inject: [{ source }] }))
+            given.subject()
+            expect(window.injectedSource).toBe(source)
+        })
     })
 })

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -63,9 +63,10 @@ export class Decide {
         if (response['inject']) {
             for (const { source, payload, id } of response['inject']) {
                 try {
-                    window.eval(source)?.()?.inject?.(payload)
+                    const apiHost = this.instance.get_config('api_host')
+                    window.eval(source)?.(apiHost)?.inject?.(payload)
                 } catch (e) {
-                    console.error(`[POSTHOG-JS] Error while initializing PostHog app with ID ${id}`, e)
+                    console.error(`[POSTHOG-JS] Error while initializing PostHog app with config id ${id}`, e)
                 }
             }
         }

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -61,10 +61,10 @@ export class Decide {
         }
 
         if (response['inject']) {
-            for (const { source, payload, id } of response['inject']) {
+            for (const { id, source, config } of response['inject']) {
                 try {
                     const apiHost = this.instance.get_config('api_host')
-                    window.eval(source)?.(apiHost)?.inject?.(payload)
+                    window.eval(source)?.(apiHost)?.inject?.(config, this.instance)
                 } catch (e) {
                     console.error(`[POSTHOG-JS] Error while initializing PostHog app with config id ${id}`, e)
                 }

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -59,5 +59,15 @@ export class Decide {
         } else {
             this.instance['compression'] = {}
         }
+
+        if (response['inject']) {
+            for (const { source, payload, id } of response['inject']) {
+                try {
+                    window.eval(source)?.()?.inject?.(payload)
+                } catch (e) {
+                    console.error(`[POSTHOG-JS] Error while initializing PostHog app with ID ${id}`, e)
+                }
+            }
+        }
     }
 }

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -64,7 +64,7 @@ export class Decide {
             for (const { id, source, config } of response['inject']) {
                 try {
                     const apiHost = this.instance.get_config('api_host')
-                    window.eval(source)?.(apiHost)?.inject?.(config, this.instance)
+                    window.eval(source)?.(apiHost)?.inject?.({ config, posthog: this.instance })
                 } catch (e) {
                     console.error(`[POSTHOG-JS] Error while initializing PostHog app with config id ${id}`, e)
                 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,7 +154,7 @@ export interface DecideResponse {
     editorParams: EditorParams
     toolbarVersion: 'toolbar' /** deprecated, moved to editorParams */
     isAuthenticated: boolean
-    inject: { id: number; source: string; payload?: Record<string, any> }[]
+    inject: { id: number; source: string; config?: Record<string, any> }[]
 }
 
 export type FeatureFlagsCallback = (flags: string[], variants: Record<string, string | boolean>) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,7 @@ export interface DecideResponse {
     editorParams: EditorParams
     toolbarVersion: 'toolbar' /** deprecated, moved to editorParams */
     isAuthenticated: boolean
+    inject: { id: number; source: string; payload?: Record<string, any> }[]
 }
 
 export type FeatureFlagsCallback = (flags: string[], variants: Record<string, string | boolean>) => void


### PR DESCRIPTION
## Changes

When the `/decide` endpoints contains code in the format:

```js
{
    inject: [{ 
        id: 9,
        source: 'export function inject({ config, posthog }) { console.log("hello"); }', 
        config: { key: 'value' } ,
    }]
}
```

then posthog-js will execute it.

This is needed to get https://github.com/PostHog/posthog/pull/12003 working.

What do we send and when is still up for debate in that linked issue, though getting this in will greatly help local dev and testing for apps at the hackathon here in Rome.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
