### PR TITLE
feat(apps): add opt_in_web_app_injection

### DIFF
--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -96,7 +96,8 @@ describe('Decide', () => {
             expect(console.error).toHaveBeenCalledWith('Failed to fetch feature flags from PostHog.')
         })
 
-        it('runs injected code', () => {
+        it('runs injected code if opted in', () => {
+            given('config', () => ({ api_host: 'https://test.com', opt_in_web_app_injection: true }))
             const source = 'injected source'
             window.injectedSource = null
             window.eval = (source) => {
@@ -106,6 +107,19 @@ describe('Decide', () => {
             given('decideResponse', () => ({ inject: [{ source }] }))
             given.subject()
             expect(window.injectedSource).toBe(source)
+        })
+
+        it('does not run injected code if not opted in', () => {
+            given('config', () => ({ api_host: 'https://test.com', opt_in_web_app_injection: false }))
+            const source = 'injected source'
+            window.injectedSource = null
+            window.eval = (source) => {
+                // can't run window.eval() in jest, so mocking it instead
+                window.injectedSource = source
+            }
+            given('decideResponse', () => ({ inject: [{ source }] }))
+            given.subject()
+            expect(window.injectedSource).toBe(null)
         })
     })
 })

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -61,7 +61,7 @@ export class Decide {
             this.instance['compression'] = {}
         }
 
-        if (response['inject']) {
+        if (response['inject'] && this.instance.get_config('opt_in_web_app_injection')) {
             for (const { id, source, config } of response['inject']) {
                 try {
                     const apiHost = this.instance.get_config('api_host')

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -122,6 +122,7 @@ const defaultConfig = (): PostHogConfig => ({
     opt_out_persistence_by_default: false,
     opt_out_capturing_persistence_type: 'localStorage',
     opt_out_capturing_cookie_prefix: null,
+    opt_in_web_app_injection: false,
     property_blacklist: [],
     respect_dnt: false,
     sanitize_properties: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export interface PostHogConfig {
     opt_out_persistence_by_default: boolean
     opt_out_capturing_persistence_type: 'localStorage' | 'cookie'
     opt_out_capturing_cookie_prefix: string | null
+    opt_in_web_app_injection: boolean
     respect_dnt: boolean
     property_blacklist: string[]
     xhr_headers: { [header_name: string]: string }


### PR DESCRIPTION
## Changes

Must explicitly set `opt_in_web_app_injection` to true in order to get injected web apps working.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
