### PR TITLE
feat(apps): load web apps from external scripts, no eval

### DIFF
--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -98,28 +98,21 @@ describe('Decide', () => {
 
         it('runs injected code if opted in', () => {
             given('config', () => ({ api_host: 'https://test.com', opt_in_web_app_injection: true }))
-            const source = 'injected source'
-            window.injectedSource = null
-            window.eval = (source) => {
-                // can't run window.eval() in jest, so mocking it instead
-                window.injectedSource = source
-            }
-            given('decideResponse', () => ({ inject: [{ source }] }))
+            given('decideResponse', () => ({ inject: [{ id: 1, url: '/web_js/1/tokentoken/' }] }))
             given.subject()
-            expect(window.injectedSource).toBe(source)
+            const element = window.document.body.children[0]
+            expect(element.src).toBe('https://test.com/web_js/1/tokentoken/')
         })
 
         it('does not run injected code if not opted in', () => {
             given('config', () => ({ api_host: 'https://test.com', opt_in_web_app_injection: false }))
-            const source = 'injected source'
-            window.injectedSource = null
-            window.eval = (source) => {
-                // can't run window.eval() in jest, so mocking it instead
-                window.injectedSource = source
-            }
-            given('decideResponse', () => ({ inject: [{ source }] }))
-            given.subject()
-            expect(window.injectedSource).toBe(null)
+            given('decideResponse', () => ({ inject: [{ id: 1, url: '/web_js/1/tokentoken/' }] }))
+            expect(() => {
+                given.subject()
+            }).toThrow(
+                // throwing only in tests, just an error in production
+                'Unexpected console.error: PostHog app injection was requested, but is disabled. Enable the "opt_in_web_app_injection" config to proceed.'
+            )
         })
     })
 })

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -66,7 +66,10 @@ export class Decide {
                 const apiHost = this.instance.get_config('api_host')
                 for (const { id, url } of response['inject']) {
                     const script = document.createElement('script')
-                    script.src = [apiHost, url].join('').split('//').join('/')
+                    script.src = [
+                        apiHost,
+                        apiHost[apiHost.length - 1] === '/' && url[0] === '/' ? url.substring(1) : url,
+                    ].join('')
                     script.onerror = (e) => {
                         console.error(`Error while initializing PostHog app with config id ${id}`, e)
                     }

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -61,14 +61,22 @@ export class Decide {
             this.instance['compression'] = {}
         }
 
-        if (response['inject'] && this.instance.get_config('opt_in_web_app_injection')) {
-            for (const { id, source, config } of response['inject']) {
-                try {
-                    const apiHost = this.instance.get_config('api_host')
-                    window.eval(source)?.(apiHost)?.inject?.({ config, posthog: this.instance })
-                } catch (e) {
-                    console.error(`[POSTHOG-JS] Error while initializing PostHog app with config id ${id}`, e)
+        if (response['inject']) {
+            if (this.instance.get_config('opt_in_web_app_injection')) {
+                const apiHost = this.instance.get_config('api_host')
+                for (const { id, url } of response['inject']) {
+                    const script = document.createElement('script')
+                    script.src = [apiHost, url].join('').split('//').join('/')
+                    script.onerror = (e) => {
+                        console.error(`Error while initializing PostHog app with config id ${id}`, e)
+                    }
+                    ;(window as any)[`__$$ph_web_js_${id}`] = this.instance
+                    document.body.appendChild(script)
                 }
+            } else {
+                console.error(
+                    'PostHog app injection was requested, but is disabled. Enable the "opt_in_web_app_injection" config to proceed.'
+                )
             }
         }
     }

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -76,7 +76,7 @@ export class Decide {
                     ;(window as any)[`__$$ph_web_js_${id}`] = this.instance
                     document.body.appendChild(script)
                 }
-            } else {
+            } else if (response['inject'].length > 0) {
                 console.error(
                     'PostHog app injection was requested, but is disabled. Enable the "opt_in_web_app_injection" config to proceed.'
                 )

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,7 +161,7 @@ export interface DecideResponse {
     editorParams: EditorParams
     toolbarVersion: 'toolbar' /** deprecated, moved to editorParams */
     isAuthenticated: boolean
-    inject: { id: number; source: string; config?: Record<string, any> }[]
+    inject: { id: number; url: string }[]
 }
 
 export type FeatureFlagsCallback = (flags: string[], variants: Record<string, string | boolean>) => void


### PR DESCRIPTION
## Changes

Seeing `window.eval` in the posthog-js codebase triggers all sorts of warnings. Let's avoid it.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
