### PR TITLE
fix(apps): grab the correct global var

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -73,7 +73,7 @@ export class Decide {
                     script.onerror = (e) => {
                         console.error(`Error while initializing PostHog app with config id ${id}`, e)
                     }
-                    ;(window as any)[`__$$ph_web_js_${id}`] = this.instance
+                    ;(window as any)[`__$$ph_site_app_${id}`] = this.instance
                     document.body.appendChild(script)
                 }
             } else if (response['siteApps'].length > 0) {


### PR DESCRIPTION
## Changes

This one `web_js` didn't get renamed.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
