### PR TITLE
feat(capture): Track `navigator.language` as `$language`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -872,7 +872,7 @@ export const _info = {
                 $host: window.location.host,
                 $pathname: window.location.pathname,
                 $browser_version: _info.browserVersion(userAgent, navigator.vendor, (window as any).opera),
-                $language: navigator.language,
+                $locale: navigator.language,
                 $screen_height: window.screen.height,
                 $screen_width: window.screen.width,
                 $viewport_height: window.innerHeight,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -872,6 +872,7 @@ export const _info = {
                 $host: window.location.host,
                 $pathname: window.location.pathname,
                 $browser_version: _info.browserVersion(userAgent, navigator.vendor, (window as any).opera),
+                $language: navigator.language,
                 $screen_height: window.screen.height,
                 $screen_width: window.screen.width,
                 $viewport_height: window.innerHeight,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -796,6 +796,13 @@ export const _info = {
         return parseFloat(matches[matches.length - 2])
     },
 
+    browserLanguage: function (): string {
+        return (
+            navigator.language || // Any modern browser
+            (navigator as Record<string, any>).userLanguage // IE11
+        )
+    },
+
     os: function (): string {
         const a = userAgent
         if (/Windows/i.test(a)) {
@@ -872,7 +879,7 @@ export const _info = {
                 $host: window.location.host,
                 $pathname: window.location.pathname,
                 $browser_version: _info.browserVersion(userAgent, navigator.vendor, (window as any).opera),
-                $locale: navigator.language,
+                $browser_language: _info.browserLanguage(),
                 $screen_height: window.screen.height,
                 $screen_width: window.screen.width,
                 $viewport_height: window.innerHeight,


### PR DESCRIPTION
## Changes

Adds `$language` as per https://github.com/PostHog/posthog/pull/11722#discussion_r994771992.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
	- This is available in all browsers~~, except IE where `navigator.language` is undefined~~ including IE (though the value is  not as reliable there)