### PR TITLE
Fix OS tagging for Macs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -810,7 +810,7 @@ export const _info = {
         } else if (/(BlackBerry|PlayBook|BB10)/i.test(a)) {
             return 'BlackBerry'
         } else if (/Mac/i.test(a)) {
-            return 'Mac OS X'
+            return 'Mac OS'
         } else if (/Linux/.test(a)) {
             return 'Linux'
         } else if (/CrOS/.test(a)) {


### PR DESCRIPTION
## Changes

This changes the user agent parser to return `Mac OS` instead of `Mac OS X` which sounds more correct and also aligns with the output of the PostHog User Agent populator.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
