### PR TITLE
feat(toolbar): posthog.loadToolbar({ temporaryToken: 'key' })

### DIFF
--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -419,7 +419,7 @@ describe('Autocapture system', () => {
                     return 'distinctid'
                 },
                 toolbar: {
-                    maybeLoadEditor: jest.fn(),
+                    maybeLoadToolbar: jest.fn(),
                 },
             }
             autocapture.init(lib)
@@ -472,7 +472,7 @@ describe('Autocapture system', () => {
                     return 'distinctid'
                 },
                 toolbar: {
-                    maybeLoadEditor: jest.fn(),
+                    maybeLoadToolbar: jest.fn(),
                 },
             }
             autocapture.init(lib)

--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -86,7 +86,7 @@ describe('Payload Compression', () => {
                 getGroups: () => ({}),
 
                 toolbar: {
-                    maybeLoadEditor: jest.fn(),
+                    maybeLoadToolbar: jest.fn(),
                     afterDecideResponse: jest.fn(),
                 },
                 sessionRecording: {

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -15,7 +15,7 @@ describe('Decide', () => {
             .fn()
             .mockImplementation((url, params, options, callback) => callback({ config: given.decideResponse })),
         toolbar: {
-            maybeLoadEditor: jest.fn(),
+            maybeLoadToolbar: jest.fn(),
             afterDecideResponse: jest.fn(),
         },
         sessionRecording: {

--- a/src/__tests__/extensions/toolbar.js
+++ b/src/__tests__/extensions/toolbar.js
@@ -89,7 +89,7 @@ describe('Toolbar', () => {
             }))
 
             given.subject()
-            expect(given.toolbar.loadToolbar).toHaveBeenCalledWith(given.toolbarParams)
+            expect(given.toolbar.loadToolbar).toHaveBeenCalledWith({ ...given.toolbarParams, source: 'url' })
             expect(given.localStorage.setItem).toHaveBeenCalledWith(
                 '_postHogToolbarParams',
                 JSON.stringify(given.hashState)
@@ -100,7 +100,7 @@ describe('Toolbar', () => {
             given('storedEditorParams', () => JSON.stringify(toolbarParams))
 
             given.subject()
-            expect(given.toolbar.loadToolbar).toHaveBeenCalledWith(given.toolbarParams)
+            expect(given.toolbar.loadToolbar).toHaveBeenCalledWith({ ...given.toolbarParams, source: 'url' })
             expect(given.localStorage.setItem).toHaveBeenCalledWith(
                 '_postHogToolbarParams',
                 JSON.stringify(given.hashState)
@@ -133,7 +133,7 @@ describe('Toolbar', () => {
             }))
 
             given.subject()
-            expect(given.toolbar.loadToolbar).toHaveBeenCalledWith(given.toolbarParams)
+            expect(given.toolbar.loadToolbar).toHaveBeenCalledWith({ ...given.toolbarParams, source: 'url' })
             expect(given.localStorage.setItem).toHaveBeenCalledWith(
                 '_postHogToolbarParams',
                 JSON.stringify(given.toolbarParams)
@@ -145,7 +145,11 @@ describe('Toolbar', () => {
 
             given.toolbar.maybeLoadToolbar(given.location, given.localStorage, given.history)
 
-            expect(given.toolbar.loadToolbar).toHaveBeenCalledWith({ ...given.toolbarParams, apiURL: 'blabla' })
+            expect(given.toolbar.loadToolbar).toHaveBeenCalledWith({
+                ...given.toolbarParams,
+                apiURL: 'blabla',
+                source: 'url',
+            })
         })
     })
 

--- a/src/__tests__/extensions/toolbar.js
+++ b/src/__tests__/extensions/toolbar.js
@@ -90,10 +90,6 @@ describe('Toolbar', () => {
 
             given.subject()
             expect(given.toolbar.loadToolbar).toHaveBeenCalledWith({ ...given.toolbarParams, source: 'url' })
-            expect(given.localStorage.setItem).toHaveBeenCalledWith(
-                '_postHogToolbarParams',
-                JSON.stringify(given.hashState)
-            )
         })
 
         it('should initialize the toolbar when there are editor params in the session', () => {
@@ -101,10 +97,6 @@ describe('Toolbar', () => {
 
             given.subject()
             expect(given.toolbar.loadToolbar).toHaveBeenCalledWith({ ...given.toolbarParams, source: 'url' })
-            expect(given.localStorage.setItem).toHaveBeenCalledWith(
-                '_postHogToolbarParams',
-                JSON.stringify(given.hashState)
-            )
         })
 
         it('should NOT initialize the toolbar when the activation query param does not exist', () => {
@@ -163,6 +155,11 @@ describe('Toolbar', () => {
             apiURL: 'http://localhost:8000',
             jsURL: 'http://localhost:8000',
         }))
+
+        it('should persist for next time', () => {
+            expect(given.subject()).toBe(true)
+            expect(window.localStorage.getItem('_postHogToolbarParams')).toEqual(JSON.stringify(given.toolbarParams))
+        })
 
         it('should load if not previously loaded', () => {
             expect(given.subject()).toBe(true)

--- a/src/__tests__/extensions/toolbar.js
+++ b/src/__tests__/extensions/toolbar.js
@@ -146,6 +146,7 @@ describe('Toolbar', () => {
 
         given('toolbarParams', () => ({
             accessToken: 'accessToken',
+            token: 'public_token',
             expiresAt: 'expiresAt',
             apiKey: 'apiKey',
             apiURL: 'http://localhost:8000',
@@ -154,7 +155,7 @@ describe('Toolbar', () => {
 
         it('should persist for next time', () => {
             expect(given.subject()).toBe(true)
-            expect(window.localStorage.getItem('_postHogToolbarParams')).toEqual(JSON.stringify(given.toolbarParams))
+            expect(JSON.parse(window.localStorage.getItem('_postHogToolbarParams'))).toEqual(given.toolbarParams)
         })
 
         it('should load if not previously loaded', () => {
@@ -178,7 +179,12 @@ describe('Toolbar', () => {
         it('should load if not previously loaded', () => {
             expect(given.subject()).toBe(true)
             expect(window.ph_load_toolbar).toHaveBeenCalledWith(
-                { ...given.toolbarParams, jsURL: 'http://api.example.com', apiURL: 'http://api.example.com' },
+                {
+                    ...given.toolbarParams,
+                    jsURL: 'http://api.example.com',
+                    apiURL: 'http://api.example.com',
+                    token: 'test_token',
+                },
                 given.lib
             )
         })

--- a/src/__tests__/extensions/toolbar.js
+++ b/src/__tests__/extensions/toolbar.js
@@ -126,10 +126,6 @@ describe('Toolbar', () => {
 
             given.subject()
             expect(given.toolbar.loadToolbar).toHaveBeenCalledWith({ ...given.toolbarParams, source: 'url' })
-            expect(given.localStorage.setItem).toHaveBeenCalledWith(
-                '_postHogToolbarParams',
-                JSON.stringify(given.toolbarParams)
-            )
         })
 
         it('should use the apiURL in the hash if available', () => {

--- a/src/extensions/cloud.ts
+++ b/src/extensions/cloud.ts
@@ -1,0 +1,1 @@
+export const POSTHOG_MANAGED_HOSTS = ['https://app.posthog.com', 'https://eu.posthog.com']

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -61,9 +61,6 @@ export class Toolbar {
                 toolbarParams.source = 'url'
 
                 if (toolbarParams && Object.keys(toolbarParams).length > 0) {
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                    const { source: _discard, ...rest } = toolbarParams
-                    localStorage.setItem('_postHogToolbarParams', JSON.stringify(rest))
                     if (state['desiredHash']) {
                         // hash that was in the url before the redirect
                         location.hash = state['desiredHash']
@@ -104,11 +101,16 @@ export class Toolbar {
         }
         // only load the toolbar once, even if there are multiple instances of PostHogLib
         ;(window as any)['_postHogToolbarLoaded'] = true
+
+        // eslint-disable @typescript-eslint/no-unused-vars
+        const { source: _discard, ...paramsToPersist } = params || {}
+        window.localStorage.setItem('_postHogToolbarParams', JSON.stringify(paramsToPersist))
+
         const host = params?.['jsURL'] || params?.['apiURL'] || this.instance.get_config('api_host')
-        const toolbarScript = 'toolbar.js'
-        const toolbarUrl = `${host}${host.endsWith('/') ? '' : '/'}static/${toolbarScript}?_ts=${new Date().getTime()}`
+        const toolbarUrl = `${host}${host.endsWith('/') ? '' : '/'}static/toolbar.js?_ts=${new Date().getTime()}`
         const disableToolbarMetrics =
             this.instance.get_config('api_host') !== 'https://app.posthog.com' &&
+            this.instance.get_config('api_host') !== 'https://eu.posthog.com' &&
             this.instance.get_config('advanced_disable_toolbar_metrics')
         const toolbarParams = {
             apiURL: host, // defaults to api_host from the instance config if nothing else set

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -102,8 +102,7 @@ export class Toolbar {
         // only load the toolbar once, even if there are multiple instances of PostHogLib
         ;(window as any)['_postHogToolbarLoaded'] = true
 
-        // eslint-disable @typescript-eslint/no-unused-vars
-        const { source: _discard, ...paramsToPersist } = params || {}
+        const { source: _discard, ...paramsToPersist } = params || {} // eslint-disable-line
         window.localStorage.setItem('_postHogToolbarParams', JSON.stringify(paramsToPersist))
 
         const host = params?.['jsURL'] || params?.['apiURL'] || this.instance.get_config('api_host')

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -53,14 +53,17 @@ export class Toolbar {
             const stateHash = _getHashParam(location.hash, '__posthog') || _getHashParam(location.hash, 'state')
             const state = stateHash ? JSON.parse(decodeURIComponent(stateHash)) : null
             const parseFromUrl = state && state['action'] === 'ph_authorize'
-            let toolbarParams
+            let toolbarParams: ToolbarParams
 
             if (parseFromUrl) {
                 // happens if they are initializing the toolbar using an old snippet
                 toolbarParams = state
+                toolbarParams.source = 'url'
 
                 if (toolbarParams && Object.keys(toolbarParams).length > 0) {
-                    localStorage.setItem('_postHogToolbarParams', JSON.stringify(toolbarParams))
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const { source: _discard, ...rest } = toolbarParams
+                    localStorage.setItem('_postHogToolbarParams', JSON.stringify(rest))
                     if (state['desiredHash']) {
                         // hash that was in the url before the redirect
                         location.hash = state['desiredHash']
@@ -73,6 +76,7 @@ export class Toolbar {
             } else {
                 // get credentials from localStorage from a previous initialzation
                 toolbarParams = JSON.parse(localStorage.getItem('_postHogToolbarParams') || '{}')
+                toolbarParams.source = 'localstorage'
 
                 // delete "add-action" or other intent from toolbarParams, otherwise we'll have the same intent
                 // every time we open the page (e.g. you just visiting your own site an hour later)

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -2,6 +2,7 @@ import { loadScript } from '../autocapture-utils'
 import { _getHashParam, _register_event } from '../utils'
 import { PostHog } from '../posthog-core'
 import { DecideResponse, ToolbarParams } from '../types'
+import { POSTHOG_MANAGED_HOSTS } from './cloud'
 
 export class Toolbar {
     instance: PostHog
@@ -105,8 +106,7 @@ export class Toolbar {
         const host = params?.['jsURL'] || params?.['apiURL'] || this.instance.get_config('api_host')
         const toolbarUrl = `${host}${host.endsWith('/') ? '' : '/'}static/toolbar.js?_ts=${new Date().getTime()}`
         const disableToolbarMetrics =
-            this.instance.get_config('api_host') !== 'https://app.posthog.com' &&
-            this.instance.get_config('api_host') !== 'https://eu.posthog.com' &&
+            !POSTHOG_MANAGED_HOSTS.includes(this.instance.get_config('api_host')) &&
             this.instance.get_config('advanced_disable_toolbar_metrics')
 
         const toolbarParams = {

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -102,21 +102,24 @@ export class Toolbar {
         // only load the toolbar once, even if there are multiple instances of PostHogLib
         ;(window as any)['_postHogToolbarLoaded'] = true
 
-        const { source: _discard, ...paramsToPersist } = params || {} // eslint-disable-line
-        window.localStorage.setItem('_postHogToolbarParams', JSON.stringify(paramsToPersist))
-
         const host = params?.['jsURL'] || params?.['apiURL'] || this.instance.get_config('api_host')
         const toolbarUrl = `${host}${host.endsWith('/') ? '' : '/'}static/toolbar.js?_ts=${new Date().getTime()}`
         const disableToolbarMetrics =
             this.instance.get_config('api_host') !== 'https://app.posthog.com' &&
             this.instance.get_config('api_host') !== 'https://eu.posthog.com' &&
             this.instance.get_config('advanced_disable_toolbar_metrics')
+
         const toolbarParams = {
             apiURL: host, // defaults to api_host from the instance config if nothing else set
             jsURL: host, // defaults to api_host from the instance config if nothing else set
+            token: this.instance.get_config('token'),
             ...params,
             ...(disableToolbarMetrics ? { instrument: false } : {}),
         }
+
+        const { source: _discard, ...paramsToPersist } = toolbarParams // eslint-disable-line
+        window.localStorage.setItem('_postHogToolbarParams', JSON.stringify(paramsToPersist))
+
         loadScript(toolbarUrl, () => {
             ;((window as any)['ph_load_toolbar'] || (window as any)['ph_load_editor'])(toolbarParams, this.instance)
         })

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -38,6 +38,7 @@ import {
     CaptureOptions,
     CaptureResult,
     Compression,
+    ToolbarParams,
     GDPROptions,
     isFeatureEnabledOptions,
     JSC,
@@ -189,7 +190,7 @@ const create_mplib = function (token: string, config?: Partial<PostHogConfig>, n
     }
 
     instance._init(token, config, name)
-    instance.toolbar.maybeLoadEditor()
+    instance.toolbar.maybeLoadToolbar()
 
     instance.sessionRecording = new SessionRecording(instance)
     instance.sessionRecording.startRecordingIfEnabled()
@@ -1335,6 +1336,15 @@ export class PostHog {
      */
     sessionRecordingStarted(): boolean {
         return !!this.sessionRecording?.started()
+    }
+
+    /**
+     * returns a boolean indicating whether session recording
+     * @param toolbarParams
+     */
+
+    loadToolbar(params: ToolbarParams): boolean {
+        return this.toolbar.loadToolbar(params)
     }
 
     /**

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1339,7 +1339,7 @@ export class PostHog {
     }
 
     /**
-     * returns a boolean indicating whether session recording
+     * returns a boolean indicating whether the toolbar loaded
      * @param toolbarParams
      */
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,11 +211,25 @@ export interface PersistentStore {
 export type Breaker = {}
 export type EventHandler = (event: Event) => boolean | void
 
+export type ToolbarUserIntent = 'add-action' | 'edit-action'
+export type ToolbarSource = 'url' | 'localstorage'
+export type ToolbarVersion = 'toolbar'
+
+/* sync with posthog */
 export interface ToolbarParams {
-    jsURL?: string
     apiURL?: string
-    toolbarVersion?: 'toolbar'
-    // other fields that come from the API are just passed on
+    jsURL?: string
+    token?: string /** public posthog-js token */
+    temporaryToken?: string /** private temporary user token */
+    actionId?: number
+    userIntent?: ToolbarUserIntent
+    source?: ToolbarSource
+    toolbarVersion?: ToolbarVersion
+    instrument?: boolean
+    distinctId?: string
+    userEmail?: string
+    dataAttributes?: string[]
+    featureFlags?: Record<string, string | boolean>
 }
 
 export interface PostData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,8 +158,9 @@ export interface DecideResponse {
         endpoint?: string
         consoleLogRecordingEnabled?: boolean
     }
-    editorParams: EditorParams
-    toolbarVersion: 'toolbar' /** deprecated, moved to editorParams */
+    toolbarParams: ToolbarParams
+    editorParams?: ToolbarParams /** @deprecated, renamed to toolbarParams, still present on older API responses */
+    toolbarVersion: 'toolbar' /** @deprecated, moved to toolbarParams */
     isAuthenticated: boolean
     siteApps: { id: number; url: string }[]
 }
@@ -210,10 +211,11 @@ export interface PersistentStore {
 export type Breaker = {}
 export type EventHandler = (event: Event) => boolean | void
 
-export interface EditorParams {
+export interface ToolbarParams {
     jsURL?: string
     apiURL?: string
     toolbarVersion?: 'toolbar'
+    // other fields that come from the API are just passed on
 }
 
 export interface PostData {


### PR DESCRIPTION
## Changes

Implements

```ts
window.posthog.loadToolbar({ temporaryToken: 'key' })
```

With the aim to
1. provide an alternative to the `#__posthog={state}` url hash method to load the toolbar
2. provide users a way to capture the hash themselves in their single page app, and pass it on to posthog

Other params to `temporaryToken`, if provided, are passed on to the toolbar as well. Ideally they are not needed.

This PR also renames some old `Editor` identifiers into `Toolbar`, to better reflect our product. In a backwards compatible way 🤞.

There will be a follow up PR to the main repo with the some other improvements.


## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
