### PR TITLE
feat: allow disable compression in config

### DIFF
--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -86,6 +86,22 @@ describe('Decide', () => {
             expect(given.posthog.compression['lz64']).toBe(true)
         })
 
+        it('enables compression from decide response when only one received', () => {
+            given('decideResponse', () => ({ supportedCompression: ['lz64'] }))
+            given.subject()
+
+            expect(given.posthog.compression).not.toHaveProperty('gzip')
+            expect(given.posthog.compression['lz64']).toBe(true)
+        })
+
+        it('does not enable compression from decide response if compression is disabled', () => {
+            given('config', () => ({ disable_compression: true }))
+            given('decideResponse', () => ({ supportedCompression: ['gzip', 'lz64'] }))
+            given.subject()
+
+            expect(given.posthog.compression).toEqual({})
+        })
+
         it('Make sure receivedFeatureFlags is not called if the decide response fails', () => {
             given('decideResponse', () => ({ status: 0 }))
             console.error = jest.fn()

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -51,14 +51,13 @@ export class Decide {
 
         this.instance.featureFlags.receivedFeatureFlags(response)
 
-        if (response['supportedCompression']) {
+        this.instance['compression'] = {}
+        if (response['supportedCompression'] && !this.instance.get_config('disable_compression')) {
             const compression: Partial<Record<Compression, boolean>> = {}
             for (const method of response['supportedCompression']) {
                 compression[method] = true
             }
             this.instance['compression'] = compression
-        } else {
-            this.instance['compression'] = {}
         }
 
         if (response['siteApps']) {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -161,6 +161,7 @@ const defaultConfig = (): PostHogConfig => ({
     name: 'posthog',
     callback_fn: 'posthog._jsc',
     bootstrap: {},
+    disable_compression: false,
 })
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,8 @@ export interface PostHogConfig {
     _onCapture: (eventName: string, eventData: CaptureResult) => void
     _capture_metrics: boolean
     _capture_performance: boolean
+    // Should only be used for testing. Could negatively impact performance.
+    disable_compression: boolean
     bootstrap: {
         distinctID?: string
         isIdentifiedID?: boolean


### PR DESCRIPTION
## Changes

When debugging a user's issue https://posthoghelp.zendesk.com/agent/tickets/768 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/5138) it is very hard to see why we receive 400 bad request from sending events.

This allows the user to disable compression so we can track events right up to the wire

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
