### PR TITLE
feat(sentry-integration): Add `ui_host` option for reverse-proxying

### DIFF
--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -33,10 +33,11 @@ export class SentryIntegration implements Integration {
             addGlobalEventProcessor((event: Event) => {
                 if (event.level !== 'error' || !_posthog.__loaded) return event
                 if (!event.tags) event.tags = {}
-                event.tags['PostHog Person URL'] = _posthog.config.api_host + '/person/' + _posthog.get_distinct_id()
+                const host = _posthog.config.ui_host || _posthog.config.api_host
+                event.tags['PostHog Person URL'] = host + '/person/' + _posthog.get_distinct_id()
                 if (_posthog.sessionRecordingStarted()) {
                     event.tags['PostHog Recording URL'] =
-                        _posthog.config.api_host +
+                    host +
                         '/recordings/#sessionRecordingId=' +
                         _posthog.sessionManager.checkAndGetSessionAndWindowId(true).sessionId
                 }

--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -37,7 +37,7 @@ export class SentryIntegration implements Integration {
                 event.tags['PostHog Person URL'] = host + '/person/' + _posthog.get_distinct_id()
                 if (_posthog.sessionRecordingStarted()) {
                     event.tags['PostHog Recording URL'] =
-                    host +
+                        host +
                         '/recordings/#sessionRecordingId=' +
                         _posthog.sessionManager.checkAndGetSessionAndWindowId(true).sessionId
                 }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -97,6 +97,7 @@ const defaultConfig = (): PostHogConfig => ({
     api_host: 'https://app.posthog.com',
     api_method: 'POST',
     api_transport: 'XHR',
+    ui_host: null,
     token: '',
     autocapture: true,
     rageclick: false,
@@ -1174,11 +1175,16 @@ export class PostHog {
      * The default config is:
      *
      *     {
-     *       // Posthog host
+     *       // PostHog API host
      *       api_host: 'https://app.posthog.com',
      *
      *       // HTTP method for capturing requests
      *       api_method: 'POST'
+     * 
+     *       // PostHog web app host, currently only used by the Sentry integration.
+     *       // This will only be different from api_host when using a reverse-proxied API host – in that case
+     *       // the original web app host needs to be passed here so that links to the web app are still convenient.
+     *       ui_host: 'https://app.posthog.com',
      *
      *       // Automatically capture clicks, form submissions and change events
      *       autocapture: true

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1180,7 +1180,7 @@ export class PostHog {
      *
      *       // HTTP method for capturing requests
      *       api_method: 'POST'
-     * 
+     *
      *       // PostHog web app host, currently only used by the Sentry integration.
      *       // This will only be different from api_host when using a reverse-proxied API host – in that case
      *       // the original web app host needs to be passed here so that links to the web app are still convenient.

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface PostHogConfig {
     api_host: string
     api_method: string
     api_transport: string
+    ui_host: string | null
     token: string
     autocapture: boolean
     rageclick: boolean


### PR DESCRIPTION
## Changes

This new `ui_host` option allows setups with reverse-proxied PostHog Cloud to still have a good Sentry experience. Customer issue: ZEN-980.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
