### PR TITLE
feat(groups): allow resetting only user's groups

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -969,6 +969,24 @@ describe('group()', () => {
             expect(given.overrides.register).not.toHaveBeenCalled()
         })
     })
+
+    describe('reset group', () => {
+        it('groups property is empty and reloads feature flags', () => {
+            given.lib.group('organization', 'org::5')
+            given.lib.group('instance', 'app.posthog.com')
+
+            expect(given.lib.persistence.props['$groups']).toEqual({
+                organization: 'org::5',
+                instance: 'app.posthog.com',
+            })
+
+            given.lib.resetGroup()
+
+            expect(given.lib.persistence.props['$groups']).toEqual({})
+
+            expect(given.overrides.reloadFeatureFlags).toHaveBeenCalledTimes(3)
+        })
+    })
 })
 
 describe('_loaded()', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1085,6 +1085,19 @@ export class PostHog {
     }
 
     /**
+     * Alpha feature: don't use unless you know what you're doing!
+     *
+     * Resets only the group properties of the user currently logged in.
+     *
+     */
+    resetGroup(): void {
+        this.register({ $groups: {} })
+
+        // If groups changed, reload feature flags.
+        this.reloadFeatureFlags()
+    }
+
+    /**
      * Clears super properties and generates a new random distinct_id for this instance.
      * Useful for clearing data when a user logs out.
      */


### PR DESCRIPTION
## Changes

Adds resetGroup() which resets only a user's `$groups` property in persistence.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
