### PR TITLE
fix: support copying non-extensible objects

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -5,7 +5,7 @@
  * currently not supported in the browser lib).
  */
 
-import { _copyAndTruncateStrings, _info, COPY_IN_PROGRESS_ATTRIBUTE } from '../utils'
+import { _copyAndTruncateStrings, _info } from '../utils'
 
 describe(`utils.js`, () => {
     it('should have $host and $pathname in properties', () => {
@@ -54,23 +54,13 @@ describe('_.copyAndTruncateStrings', () => {
 
     it('handles recursive objects', () => {
         given('target', () => {
-            const object = { key: 'vaaaaalue', values: ['fooobar'], __deepCircularCopyInProgress__: 1 }
+            const object = { key: 'vaaaaalue', values: ['fooobar'] }
             object.values.push(object)
             object.ref = object
             return object
         })
 
-        expect(given.subject).toEqual({ key: 'vaaaa', values: ['fooob', undefined], __deepCircularCopyInProgress__: 1 })
-    })
-
-    it('should check copy-in-progress correctly', () => {
-        given('target', () => {
-            const base = Object.create({ [COPY_IN_PROGRESS_ATTRIBUTE]: undefined })
-            const object = Object.create(base)
-            return object
-        })
-
-        expect(given.subject).toEqual({})
+        expect(given.subject).toEqual({ key: 'vaaaa', values: ['fooob', undefined] })
     })
 
     it('does not truncate the apm raw performance property', () => {
@@ -80,6 +70,13 @@ describe('_.copyAndTruncateStrings', () => {
         given('target', () => original)
 
         expect(given.subject).toEqual(original)
+    })
+
+    it('handles frozen objects', () => {
+        const original = Object.freeze({ key: 'vaaaaalue' })
+        given('target', () => original)
+
+        expect(given.subject).toEqual({ key: 'vaaaa' })
     })
 })
 


### PR DESCRIPTION
## Changes

I encountered an issue when sending an object from our state management store, which freezes objects in development, to `posthog.capture`. When the input value is copied before it's sent a property is added to keep track of recursive objects. For frozen objects this cause a TypeError with the message that the object is not extensible. Since the copy function is interrupted the special property is also not removed from the input value.

This fixes the issue by using an array to store the values that have been seen before instead of a special property. I added it inside the function so that the values don't leak and created a new function that has access to it.

Fixes #393

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
