### PR TITLE
chore: update sentry types

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "react/dist/*"
     ],
     "dependencies": {
-        "@sentry/types": "^7.2.0",
+        "@sentry/types": "7.22.0",
         "fflate": "^0.4.1",
         "rrweb-snapshot": "^1.1.14"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3368,10 +3368,10 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@sentry/types@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.2.0.tgz#0c20073956bb46bdea3288683aeba2d5c350deb8"
-  integrity sha512-e6w62C2AmE5ULr9w/BuVaKTRpKUMGWyw4PhcBlSdDRoS47QgURGgDFIvr3VlaDwkUfCbASwSv49fDhKRX3aoew==
+"@sentry/types@7.22.0":
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.22.0.tgz#58e4ce77b523048e0f31e2ea4b597946d76f6079"
+  integrity sha512-LhCL+wb1Jch+OesB2CIt6xpfO1Ab6CRvoNYRRzVumWPLns1T3ZJkarYfhbLaOEIb38EIbPgREdxn2AJT560U4Q==
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.7.2":
   version "1.8.1"
@@ -8702,6 +8702,7 @@ posix-character-classes@^0.1.0:
 
 "posthog-js@link:.":
   version "0.0.0"
+  uid ""
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Changes

We want to upgrade Sentry in https://github.com/PostHog/posthog/pull/13061 but that requires that the types here are updated first.

