### PR TITLE
feat(rageclicks): turn on rageclicks by default

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -100,7 +100,7 @@ const defaultConfig = (): PostHogConfig => ({
     ui_host: null,
     token: '',
     autocapture: true,
-    rageclick: false,
+    rageclick: true,
     cross_subdomain_cookie: document?.location?.hostname?.indexOf('herokuapp.com') === -1,
     persistence: 'cookie',
     persistence_name: '',
@@ -1199,8 +1199,8 @@ export class PostHog {
      *       // Automatically capture clicks, form submissions and change events
      *       autocapture: true
      *
-     *       // Capture rage clicks (beta) - useful for session recording
-     *       rageclick: false
+     *       // Capture rage clicks
+     *       rageclick: true
      *
      *       // transport for sending requests ('XHR' or 'sendBeacon')
      *       // NB: sendBeacon should only be used for scenarios such as


### PR DESCRIPTION
## Changes

Turns on `$rageclick` by default. This was a feature that was turned off in most prod instances by default back when session recordings was in beta.

@corywatilo https://squeak.cloud/question/347

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
