### PR TITLE
feat: event_allowlist and url_allowlist for autocapture

### DIFF
--- a/cypress/e2e/capture.cy.js
+++ b/cypress/e2e/capture.cy.js
@@ -113,6 +113,64 @@ describe('Event capture', () => {
             cy.phCaptures().should('include', '$pageview')
             cy.phCaptures().should('include', 'custom-event')
         })
+
+        it('collect button elements', () => {
+            given('options', () => ({
+                autocapture: {
+                    element_allowlist: ['button'],
+                },
+            }))
+            start()
+
+            cy.get('[data-cy-custom-event-button]').click()
+            cy.phCaptures().should('have.length', 3)
+            cy.phCaptures().should('include', '$pageview')
+            cy.phCaptures().should('include', '$autocapture')
+            cy.phCaptures().should('include', 'custom-event')
+        })
+
+        it('dont collect on button elements', () => {
+            given('options', () => ({
+                autocapture: {
+                    element_allowlist: ['a'],
+                },
+            }))
+            start()
+
+            cy.get('[data-cy-custom-event-button]').click()
+            cy.phCaptures().should('have.length', 2)
+            cy.phCaptures().should('include', '$pageview')
+            cy.phCaptures().should('include', 'custom-event')
+        })
+
+        it('collect with data attribute', () => {
+            given('options', () => ({
+                autocapture: {
+                    css_attribute_allowlist: ['[data-cy-custom-event-button]'],
+                },
+            }))
+            start()
+
+            cy.get('[data-cy-custom-event-button]').click()
+            cy.phCaptures().should('have.length', 3)
+            cy.phCaptures().should('include', '$pageview')
+            cy.phCaptures().should('include', '$autocapture')
+            cy.phCaptures().should('include', 'custom-event')
+        })
+
+        it('dont collect with data attribute', () => {
+            given('options', () => ({
+                autocapture: {
+                    css_selector_allowlist: ['[nope]'],
+                },
+            }))
+            start()
+
+            cy.get('[data-cy-custom-event-button]').click()
+            cy.phCaptures().should('have.length', 2)
+            cy.phCaptures().should('include', '$pageview')
+            cy.phCaptures().should('include', 'custom-event')
+        })
     })
 
     it('captures $feature_flag_called', () => {

--- a/cypress/e2e/capture.cy.js
+++ b/cypress/e2e/capture.cy.js
@@ -9,7 +9,6 @@ describe('Event capture', () => {
     given('options', () => ({}))
     given('sessionRecording', () => false)
     given('supportedCompression', () => ['gzip', 'lz64'])
-    given('url', () => './playground/cypress')
 
     // :TRICKY: Use a custom start command over beforeEach to deal with given2 not being ready yet.
     const start = ({ waitForDecide = true } = {}) => {
@@ -28,7 +27,7 @@ describe('Event capture', () => {
             },
         }).as('decide')
 
-        cy.visit(given.url, {
+        cy.visit('./playground/cypress', {
             onBeforeLoad(win) {
                 cy.stub(win.console, 'error').as('consoleError')
             },

--- a/cypress/e2e/capture.cy.js
+++ b/cypress/e2e/capture.cy.js
@@ -59,7 +59,7 @@ describe('Event capture', () => {
         it('dont capture click when configured not to', () => {
             given('options', () => ({
                 autocapture: {
-                    event_allowlist: ['change'],
+                    dom_event_allowlist: ['change'],
                 },
             }))
             start()
@@ -73,7 +73,7 @@ describe('Event capture', () => {
         it('capture clicks when configured to', () => {
             given('options', () => ({
                 autocapture: {
-                    event_allowlist: ['click'],
+                    dom_event_allowlist: ['click'],
                 },
             }))
             start()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.37.0",
+    "version": "1.36.1",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.36.1",
+    "version": "1.37.0",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -956,7 +956,7 @@ describe('Autocapture system', () => {
     })
 
     describe('shouldCaptureDomEvent autocapture config', () => {
-        it('should only autocapture capture urls which match the url regex allowlist', () => {
+        it('only capture urls which match the url regex allowlist', () => {
             var main_el = document.createElement('some-element')
             var button = document.createElement('a')
             button.innerHTML = 'bla'
@@ -980,9 +980,9 @@ describe('Autocapture system', () => {
             expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(false)
         })
 
-        it('should only autocapture capture event types which match the allowlist', () => {
+        it('only capture event types which match the allowlist', () => {
             var main_el = document.createElement('some-element')
-            var button = document.createElement('a')
+            var button = document.createElement('button')
             button.innerHTML = 'bla'
             main_el.appendChild(button)
             const e = {
@@ -997,6 +997,27 @@ describe('Autocapture system', () => {
 
             const autocapture_config_change = {
                 event_allowlist: ['change'],
+            }
+            expect(shouldCaptureDomEvent(button, e, autocapture_config_change)).toBe(false)
+        })
+
+        it('only capture elements which match the allowlist', () => {
+            var main_el = document.createElement('some-element')
+            var button = document.createElement('button')
+            button.innerHTML = 'bla'
+            main_el.appendChild(button)
+            const e = {
+                target: main_el,
+                composedPath: () => [button, main_el],
+                type: 'click',
+            }
+            const autocapture_config = {
+                elements_allowlist: ['button'],
+            }
+            expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(true)
+
+            const autocapture_config_change = {
+                elements_allowlist: ['a'],
             }
             expect(shouldCaptureDomEvent(button, e, autocapture_config_change)).toBe(false)
         })

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -991,12 +991,12 @@ describe('Autocapture system', () => {
                 type: 'click',
             }
             const autocapture_config = {
-                event_allowlist: ['click'],
+                dom_event_allowlist: ['click'],
             }
             expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(true)
 
             const autocapture_config_change = {
-                event_allowlist: ['change'],
+                dom_event_allowlist: ['change'],
             }
             expect(shouldCaptureDomEvent(button, e, autocapture_config_change)).toBe(false)
         })

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -1012,12 +1012,12 @@ describe('Autocapture system', () => {
                 type: 'click',
             }
             const autocapture_config = {
-                elements_allowlist: ['button'],
+                element_allowlist: ['button'],
             }
             expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(true)
 
             const autocapture_config_change = {
-                elements_allowlist: ['a'],
+                element_allowlist: ['a'],
             }
             expect(shouldCaptureDomEvent(button, e, autocapture_config_change)).toBe(false)
         })
@@ -1034,12 +1034,12 @@ describe('Autocapture system', () => {
                 type: 'click',
             }
             const autocapture_config = {
-                css_allowlist: ['[data-track=yes]'],
+                css_selector_allowlist: ['[data-track="yes"]'],
             }
             expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(true)
 
             const autocapture_config_change = {
-                elements_allowlist: ['[data-track=no]'],
+                css_selector_allowlist: ['[data-track="no"]'],
             }
             expect(shouldCaptureDomEvent(button, e, autocapture_config_change)).toBe(false)
         })

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -1021,5 +1021,27 @@ describe('Autocapture system', () => {
             }
             expect(shouldCaptureDomEvent(button, e, autocapture_config_change)).toBe(false)
         })
+
+        it('only capture elements which match the css allowlist', () => {
+            var main_el = document.createElement('some-element')
+            var button = document.createElement('button')
+            button.setAttribute('data-track', 'yes')
+            button.innerHTML = 'bla'
+            main_el.appendChild(button)
+            const e = {
+                target: main_el,
+                composedPath: () => [button, main_el],
+                type: 'click',
+            }
+            const autocapture_config = {
+                css_allowlist: ['[data-track=yes]'],
+            }
+            expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(true)
+
+            const autocapture_config_change = {
+                elements_allowlist: ['[data-track=no]'],
+            }
+            expect(shouldCaptureDomEvent(button, e, autocapture_config_change)).toBe(false)
+        })
     })
 })

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -797,7 +797,7 @@ describe('init()', () => {
         jest.spyOn(given.lib.persistence, 'register').mockImplementation()
 
         // Autocapture
-        expect(given.lib.__autocapture_enabled).toEqual(undefined)
+        expect(given.lib.__autocapture).toEqual(undefined)
         expect(autocapture.init).not.toHaveBeenCalled()
         expect(autocapture.afterDecideResponse).not.toHaveBeenCalled()
 

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -92,7 +92,7 @@ export function isDocumentFragment(el: Element | ParentNode | undefined | null):
     return !!el && el.nodeType === 11 // Node.DOCUMENT_FRAGMENT_NODE - use integer constant for browser portability
 }
 
-export const usefulElements = ['a', 'button', 'form', 'input', 'select', 'textarea', 'label']
+export const autocaptureCompatibleElements = ['a', 'button', 'form', 'input', 'select', 'textarea', 'label']
 /*
  * Check whether a DOM event should be "captured" or if it may contain sentitive data
  * using a variety of heuristics.
@@ -118,8 +118,8 @@ export function shouldCaptureDomEvent(
         }
     }
 
-    if (autocaptureConfig?.event_allowlist) {
-        const allowlist = autocaptureConfig.event_allowlist
+    if (autocaptureConfig?.dom_event_allowlist) {
+        const allowlist = autocaptureConfig.dom_event_allowlist
         if (allowlist && !allowlist.some((eventType) => event.type === eventType)) {
             return false
         }
@@ -152,7 +152,7 @@ export function shouldCaptureDomEvent(
         }
         parentNode = (curEl.parentNode as Element) || false
         if (!parentNode) break
-        if (usefulElements.indexOf(parentNode.tagName.toLowerCase()) > -1) {
+        if (autocaptureCompatibleElements.indexOf(parentNode.tagName.toLowerCase()) > -1) {
             parentIsUsefulElement = true
         } else {
             const compStyles = window.getComputedStyle(parentNode)
@@ -185,7 +185,7 @@ export function shouldCaptureDomEvent(
             if (parentIsUsefulElement) return event.type === 'click'
             return (
                 event.type === 'click' &&
-                (usefulElements.indexOf(tag) > -1 || el.getAttribute('contenteditable') === 'true')
+                (autocaptureCompatibleElements.indexOf(tag) > -1 || el.getAttribute('contenteditable') === 'true')
             )
     }
 }

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -126,7 +126,6 @@ export function shouldCaptureDomEvent(
     }
 
     if (autocaptureConfig?.element_allowlist) {
-        console.log('debug', el, event, autocaptureConfig)
         const allowlist = autocaptureConfig.element_allowlist
         if (allowlist && !allowlist.some((elementType) => el.tagName.toLowerCase() === elementType)) {
             return false

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -125,9 +125,17 @@ export function shouldCaptureDomEvent(
         }
     }
 
-    if (autocaptureConfig?.elements_allowlist) {
-        const allowlist = autocaptureConfig.elements_allowlist
+    if (autocaptureConfig?.element_allowlist) {
+        console.log('debug', el, event, autocaptureConfig)
+        const allowlist = autocaptureConfig.element_allowlist
         if (allowlist && !allowlist.some((elementType) => el.tagName.toLowerCase() === elementType)) {
+            return false
+        }
+    }
+
+    if (autocaptureConfig?.css_selector_allowlist) {
+        const allowlist = autocaptureConfig.css_selector_allowlist
+        if (allowlist && !allowlist.some((selector) => el.matches(selector))) {
             return false
         }
     }

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -3,6 +3,7 @@
  * @param {Element} el - element to get the className of
  * @returns {string} the element's class
  */
+import { AutocaptureConfig } from 'types'
 import { _each, _includes, _isUndefined, _trim } from './utils'
 
 export function getClassName(el: Element): string {
@@ -97,11 +98,31 @@ export const usefulElements = ['a', 'button', 'form', 'input', 'select', 'textar
  * using a variety of heuristics.
  * @param {Element} el - element to check
  * @param {Event} event - event to check
+ * @param {Object} autocaptureConfig - autocapture config
  * @returns {boolean} whether the event should be captured
  */
-export function shouldCaptureDomEvent(el: Element, event: Event): boolean {
+export function shouldCaptureDomEvent(
+    el: Element,
+    event: Event,
+    autocaptureConfig: AutocaptureConfig | undefined = undefined
+): boolean {
     if (!el || isTag(el, 'html') || !isElementNode(el)) {
         return false
+    }
+
+    if (autocaptureConfig?.url_allowlist) {
+        const url = window.location.href
+        const allowlist = autocaptureConfig.url_allowlist
+        if (allowlist && !allowlist.some((regex) => url.match(regex))) {
+            return false
+        }
+    }
+
+    if (autocaptureConfig?.event_allowlist) {
+        const allowlist = autocaptureConfig.event_allowlist
+        if (allowlist && !allowlist.some((eventType) => event.type === eventType)) {
+            return false
+        }
     }
 
     let parentIsUsefulElement = false

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -125,6 +125,13 @@ export function shouldCaptureDomEvent(
         }
     }
 
+    if (autocaptureConfig?.elements_allowlist) {
+        const allowlist = autocaptureConfig.elements_allowlist
+        if (allowlist && !allowlist.some((elementType) => el.tagName.toLowerCase() === elementType)) {
+            return false
+        }
+    }
+
     let parentIsUsefulElement = false
     const targetElementList: Element[] = [el] // TODO: remove this var, it's never queried
     let parentNode: Element | boolean = true

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -19,7 +19,7 @@ import {
     shouldCaptureDomEvent,
     shouldCaptureElement,
     shouldCaptureValue,
-    usefulElements,
+    autocaptureCompatibleElements,
     isAngularStyleAttr,
     isDocumentFragment,
 } from './autocapture-utils'
@@ -47,7 +47,7 @@ const autocapture = {
         const props: Properties = {
             tag_name: tag_name,
         }
-        if (usefulElements.indexOf(tag_name) > -1 && !maskText) {
+        if (autocaptureCompatibleElements.indexOf(tag_name) > -1 && !maskText) {
             props['$el_text'] = getSafeText(elem)
         }
 

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -238,6 +238,11 @@ const autocapture = {
             this.config = instance.__autocapture
         }
 
+        // precompile the regex
+        if (this.config?.url_allowlist) {
+            this.config.url_allowlist = this.config.url_allowlist.map((url) => new RegExp(url))
+        }
+
         this.rageclicks = new RageClick(instance)
     },
 

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -24,8 +24,9 @@ import {
     isDocumentFragment,
 } from './autocapture-utils'
 import RageClick from './extensions/rageclick'
-import { AutoCaptureCustomProperty, DecideResponse, Properties } from './types'
+import { AutocaptureConfig, AutoCaptureCustomProperty, DecideResponse, Properties } from './types'
 import { PostHog } from './posthog-core'
+import { bool } from 'prop-types'
 
 const autocapture = {
     _initializedTokens: [] as string[],
@@ -147,7 +148,7 @@ const autocapture = {
             this.rageclicks?.click(e.clientX, e.clientY, new Date().getTime())
         }
 
-        if (target && shouldCaptureDomEvent(target, e)) {
+        if (target && shouldCaptureDomEvent(target, e, this.config)) {
             const targetElementList = [target]
             let curEl = target
             while (curEl.parentNode && !isTag(curEl, 'body')) {
@@ -231,8 +232,12 @@ const autocapture = {
 
     _customProperties: [] as AutoCaptureCustomProperty[],
     rageclicks: null as RageClick | null,
+    config: undefined as AutocaptureConfig | undefined,
 
     init: function (instance: PostHog): void {
+        if (typeof instance.__autocapture !== 'boolean') {
+            this.config = instance.__autocapture
+        }
         this.rageclicks = new RageClick(instance)
     },
 
@@ -257,7 +262,7 @@ const autocapture = {
             }
             this._addDomEventHandlers(instance)
         } else {
-            instance['__autocapture_enabled'] = false
+            instance['__autocapture'] = false
         }
     },
 

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -238,11 +238,6 @@ const autocapture = {
             this.config = instance.__autocapture
         }
 
-        // precompile the regex
-        if (this.config?.url_allowlist) {
-            this.config.url_allowlist = this.config.url_allowlist.map((url) => new RegExp(url))
-        }
-
         this.rageclicks = new RageClick(instance)
     },
 

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -26,7 +26,6 @@ import {
 import RageClick from './extensions/rageclick'
 import { AutocaptureConfig, AutoCaptureCustomProperty, DecideResponse, Properties } from './types'
 import { PostHog } from './posthog-core'
-import { bool } from 'prop-types'
 
 const autocapture = {
     _initializedTokens: [] as string[],

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -237,6 +237,12 @@ const autocapture = {
         if (typeof instance.__autocapture !== 'boolean') {
             this.config = instance.__autocapture
         }
+
+        // precompile the regex
+        if (this.config?.url_allowlist) {
+            this.config.url_allowlist = this.config.url_allowlist.map((url) => new RegExp(url))
+        }
+
         this.rageclicks = new RageClick(instance)
     },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,8 @@ export type AutocaptureEvents = 'click' | 'change' | 'submit'
 export interface AutocaptureConfig {
     url_allowlist?: RegExp[]
     event_allowlist?: AutocaptureEvents[]
-    elements_allowlist?: UsefulElements[]
+    element_allowlist?: UsefulElements[]
+    css_selector_allowlist?: string[]
 }
 
 export interface PostHogConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,6 @@ export interface CaptureResult {
 }
 export type CaptureCallback = (response: any, data: any) => void
 
-export type UsefulElements = 'a' | 'button' | 'form' | 'input' | 'select' | 'textarea' | 'label'
 export type AutocaptureEvents = 'click' | 'change' | 'submit'
 
 export interface AutocaptureConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export type UsefulElements = 'a' | 'button' | 'form' | 'input' | 'select' | 'tex
 export type AutocaptureEvents = 'click' | 'change' | 'submit'
 
 export interface AutocaptureConfig {
-    url_allowlist?: RegExp[]
+    url_allowlist?: string[] | RegExp[]
     event_allowlist?: AutocaptureEvents[]
     element_allowlist?: UsefulElements[]
     css_selector_allowlist?: string[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,13 +13,21 @@ export interface CaptureResult {
 }
 export type CaptureCallback = (response: any, data: any) => void
 
+export type UsefulElements = 'a' | 'button' | 'form' | 'input' | 'select' | 'textarea' | 'label'
+export type AutocaptureEvents = 'click' | 'change' | 'submit'
+
+export interface AutocaptureConfig {
+    url_allowlist?: RegExp[]
+    event_allowlist?: AutocaptureEvents[]
+}
+
 export interface PostHogConfig {
     api_host: string
     api_method: string
     api_transport: string
     ui_host: string | null
     token: string
-    autocapture: boolean
+    autocapture: boolean | AutocaptureConfig
     rageclick: boolean
     cross_subdomain_cookie: boolean
     persistence: 'localStorage' | 'cookie' | 'memory' | 'localStorage+cookie'

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,10 +16,32 @@ export type CaptureCallback = (response: any, data: any) => void
 export type AutocaptureCompatibleElement = 'a' | 'button' | 'form' | 'input' | 'select' | 'textarea' | 'label'
 export type DomAutocaptureEvents = 'click' | 'change' | 'submit'
 
+/**
+ * If an array is passed for an allowlist, autocapture events will only be sent for elements matching
+ * at least one of the elements in the array. Multiple allowlists can be used
+ */
 export interface AutocaptureConfig {
+    /**
+     * List of URLs to allow autocapture on, can be strings to match
+     * or regexes e.g. ['https://example.com', 'test.com/.*']
+     */
     url_allowlist?: (string | RegExp)[]
+
+    /**
+     * List of DOM events to allow autocapture on  e.g. ['click', 'change', 'submit']
+     */
     dom_event_allowlist?: DomAutocaptureEvents[]
+
+    /**
+     * List of DOM elements to allow autocapture on
+     * e.g. ['a', 'button', 'form', 'input', 'select', 'textarea', 'label']
+     */
     element_allowlist?: AutocaptureCompatibleElement[]
+
+    /**
+     * List of CSS selectors to allow autocapture on
+     * e.g. ['[ph-capture]']
+     */
     css_selector_allowlist?: string[]
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,11 +13,13 @@ export interface CaptureResult {
 }
 export type CaptureCallback = (response: any, data: any) => void
 
+export type UsefulElements = 'a' | 'button' | 'form' | 'input' | 'select' | 'textarea' | 'label'
 export type AutocaptureEvents = 'click' | 'change' | 'submit'
 
 export interface AutocaptureConfig {
     url_allowlist?: RegExp[]
     event_allowlist?: AutocaptureEvents[]
+    elements_allowlist?: UsefulElements[]
 }
 
 export interface PostHogConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,13 +13,13 @@ export interface CaptureResult {
 }
 export type CaptureCallback = (response: any, data: any) => void
 
-export type UsefulElements = 'a' | 'button' | 'form' | 'input' | 'select' | 'textarea' | 'label'
-export type AutocaptureEvents = 'click' | 'change' | 'submit'
+export type AutocaptureCompatibleElement = 'a' | 'button' | 'form' | 'input' | 'select' | 'textarea' | 'label'
+export type DomAutocaptureEvents = 'click' | 'change' | 'submit'
 
 export interface AutocaptureConfig {
-    url_allowlist?: string[] | RegExp[]
-    event_allowlist?: AutocaptureEvents[]
-    element_allowlist?: UsefulElements[]
+    url_allowlist?: (string | RegExp)[]
+    dom_event_allowlist?: DomAutocaptureEvents[]
+    element_allowlist?: AutocaptureCompatibleElement[]
     css_selector_allowlist?: string[]
 }
 


### PR DESCRIPTION
## Changes

add the ability to configure autocapture events with an allowlist of regex urls and/or an allow list of events

as requested in: https://github.com/PostHog/product-internal/pull/382

e.g. 
```
autocapture: {
	event_allowlist: ['click'],
	url_allowlist: ['*/docs/*],
        element_allowlist: ['button']
        css_selector_allowlist: ['[track-this="yes"]']
}
```

TODOs:
- [x] Check how this would impact session recordings
- [ ] Update docs
- [ ] Decide what to do about page views when using the autocapture config
  - Keeping page views as separate for now

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
