### PR TITLE
feat: Allow modifying of rrweb events pre-sending

### DIFF
--- a/playground/session-recordings/index.html
+++ b/playground/session-recordings/index.html
@@ -1,67 +1,109 @@
 <html>
-<head>
-    <title>PostHog JS Snippet test</title>
-</head>
-<body>
-    <button data-cy-button>Some button</button>
+    <head>
+        <title>PostHog JS Snippet test</title>
+    </head>
+    <body>
+        <button data-cy-button>Some button</button>
 
-    <br />
+        <br />
 
-    <input data-cy-input placeholder="Input" />
+        <input data-cy-input placeholder="Input" />
 
-    <br />
+        <br />
 
-    <button data-cy-custom-event-button onclick="posthog.capture('custom-event', { foo: 2 })">
-        Send custom event
-    </button>
-
-    <br />
-
-    <button data-cy-feature-flag-button onclick="console.log(posthog.isFeatureEnabled('some-feature'))">
-        Test a feature flag
-    </button>
-
-    <br />
-
-    <div data-cy-captures>
-    </div>
-
-
-    <a data-cy-link-mask-text>
-        Sensitive text!
-    </a>
-
-    <!-- TODO: Remove the ="true" once we have fixed the bug with autocapture to ensure E2E that it works -->
-    <button data-cy-button-sensitive-attributes="true" class='sensitive' id='sensitive' data-sensitive='sensitive'>
-        Sensitive attributes!
-    </button>
-
-    <div>
-
-        <div>SessionID: 
-        <span id="current-session-id"></span>
-        </div>
-        <div>WindowID: 
-        <span id="current-window-id"></span>
-        </div>
-
-        <button data-cy-custom-event-button onclick="window.open(window.location)">
-            Open new window
+        <button data-cy-custom-event-button onclick="posthog.capture('custom-event', { foo: 2 })">
+            Send custom event
         </button>
-    </div>
 
-    <script>
-        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    </script>
+        <br />
 
-    <script>
+        <button data-cy-feature-flag-button onclick="console.log(posthog.isFeatureEnabled('some-feature'))">
+            Test a feature flag
+        </button>
 
-        posthog.init('mykey', { api_host: location.origin })
+        <br />
 
-        setTimeout(() => {
-            document.getElementById("current-session-id").innerHTML = posthog.sessionRecording.sessionId
-            document.getElementById("current-window-id").innerHTML = posthog.sessionRecording.windowId
-        }, 100)
-    </script>
-</body>
+        <div data-cy-captures></div>
+
+        <a data-cy-link-mask-text> Sensitive text! </a>
+
+        <!-- TODO: Remove the ="true" once we have fixed the bug with autocapture to ensure E2E that it works -->
+        <button data-cy-button-sensitive-attributes="true" class="sensitive" id="sensitive" data-sensitive="sensitive">
+            Sensitive attributes!
+        </button>
+
+        <div>
+            <div>
+                SessionID:
+                <span id="current-session-id"></span>
+            </div>
+            <div>
+                WindowID:
+                <span id="current-window-id"></span>
+            </div>
+
+            <button data-cy-custom-event-button onclick="window.open(window.location)">Open new window</button>
+        </div>
+
+        <script>
+            !(function (t, e) {
+                var o, n, p, r
+                e.__SV ||
+                    ((window.posthog = e),
+                    (e._i = []),
+                    (e.init = function (i, s, a) {
+                        function g(t, e) {
+                            var o = e.split('.')
+                            2 == o.length && ((t = t[o[0]]), (e = o[1])),
+                                (t[e] = function () {
+                                    t.push([e].concat(Array.prototype.slice.call(arguments, 0)))
+                                })
+                        }
+                        ;((p = t.createElement('script')).type = 'text/javascript'),
+                            (p.async = !0),
+                            (p.src = s.api_host + '/static/array.js'),
+                            (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r)
+                        var u = e
+                        for (
+                            void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
+                                u.people = u.people || [],
+                                u.toString = function (t) {
+                                    var e = 'posthog'
+                                    return 'posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e
+                                },
+                                u.people.toString = function () {
+                                    return u.toString(1) + '.people (stub)'
+                                },
+                                o =
+                                    'capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags'.split(
+                                        ' '
+                                    ),
+                                n = 0;
+                            n < o.length;
+                            n++
+                        )
+                            g(u, o[n])
+                        e._i.push([i, s, a])
+                    }),
+                    (e.__SV = 1))
+            })(document, window.posthog || [])
+        </script>
+
+        <script>
+            posthog.init('mykey', {
+                api_host: location.origin,
+                session_recording: {
+                    processRecordingSnapshot: (event) => {
+                        console.log('EVENT', event)
+                        return event
+                    },
+                },
+            })
+
+            setTimeout(() => {
+                document.getElementById('current-session-id').innerHTML = posthog.sessionRecording.sessionId
+                document.getElementById('current-window-id').innerHTML = posthog.sessionRecording.windowId
+            }, 100)
+        </script>
+    </body>
 </html>

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -180,6 +180,11 @@ export class SessionRecording {
 
                 this._updateWindowAndSessionIds(event)
 
+                // Allow users to inject custom processing of the recording event, for example masking or modifiying URLs
+                if (userSessionRecordingOptions.processRecordingSnapshot) {
+                    event = userSessionRecordingOptions.processRecordingSnapshot(event)
+                }
+
                 const properties = {
                     $snapshot_data: event,
                     $session_id: this.sessionId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import { MaskInputOptions, SlimDOMOptions } from 'rrweb-snapshot'
 import { PostHog } from './posthog-core'
 import { CaptureMetrics } from './capture-metrics'
 import { RetryQueue } from './retry-queue'
+import { eventWithTime } from 'rrweb/typings/types'
 
 export type Property = any
 export type Properties = Record<string, Property>
@@ -103,6 +104,8 @@ export interface SessionRecordingOptions {
     slimDOMOptions?: SlimDOMOptions | 'all' | true
     collectFonts?: boolean
     inlineStylesheet?: boolean
+    /** ADVANCED: Allows users to pre-process rrweb events for custom redactions or modifications */
+    processRecordingSnapshot?: (snapshot: eventWithTime) => eventWithTime
 }
 
 export enum Compression {


### PR DESCRIPTION
## Changes

User had a specific issue where their users would play back recordings from an internal page which is not accesible by posthog, whereas a different public version would be. What they wanted was to be able to modify the urls so that playback would always load from the public one.

I don't know if this is a good idea but this would be the client-side variant...

This would allow the user to do something like (ignoring how bad this would be performance-wise)

```js
posthog.init('mykey', {
    session_recording: {
        processRecordingSnapshot: (event) => {
            let processed = JSON.stringify(event)
            processed = processed.replace("http://10.1.0.1", "http://my-public-dns.example.com")
           
            return JSON.parse(processed)
        },
    },
})
```

## Concerns 
* This approach would be exposing the internals of event processing which could easily lead to bad user error...
* Whilst it solves the problem it is quite hands-on and error prone. Do we instead want to try and solve this at playback?

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
