### PR TITLE
feat: page view ids

### DIFF
--- a/src/__tests__/page-view-id.js
+++ b/src/__tests__/page-view-id.js
@@ -11,14 +11,16 @@ describe('PageView ID manager', () => {
     })
 
     it('generates a page view id and resets page view id', () => {
-        expect(given.pageViewIdManager._pageViewId).toEqual(null)
-        // call without reset generates
         expect(given.pageViewIdManager.getPageViewId()).toEqual('firstUUID')
 
-        given.pageViewIdManager.resetPageViewId()
+        // First pageview should NOT rotate the UUID
+        given.pageViewIdManager.onPageview()
+        expect(given.pageViewIdManager.getPageViewId()).toEqual('firstUUID')
+
+        given.pageViewIdManager.onPageview()
         expect(given.pageViewIdManager.getPageViewId()).toEqual('secondUUID')
 
-        given.pageViewIdManager.resetPageViewId()
+        given.pageViewIdManager.onPageview()
         expect(given.pageViewIdManager.getPageViewId()).toEqual('subsequentUUIDs')
     })
 })

--- a/src/__tests__/page-view-id.js
+++ b/src/__tests__/page-view-id.js
@@ -1,6 +1,3 @@
-import { SessionIdManager } from '../sessionid'
-import { SESSION_ID } from '../posthog-persistence'
-import { sessionStore } from '../storage'
 import { _UUID } from '../utils'
 import { PageViewIdManager } from '../page-view-id'
 

--- a/src/__tests__/page-view-id.js
+++ b/src/__tests__/page-view-id.js
@@ -1,0 +1,27 @@
+import { SessionIdManager } from '../sessionid'
+import { SESSION_ID } from '../posthog-persistence'
+import { sessionStore } from '../storage'
+import { _UUID } from '../utils'
+import { PageViewIdManager } from '../page-view-id'
+
+jest.mock('../utils')
+
+describe('PageView ID manager', () => {
+    given('pageViewIdManager', () => new PageViewIdManager())
+
+    beforeEach(() => {
+        _UUID.mockReturnValue('subsequentUUIDs').mockReturnValueOnce('firstUUID').mockReturnValueOnce('secondUUID')
+    })
+
+    it('generates a page view id and resets page view id', () => {
+        expect(given.pageViewIdManager._pageViewId).toEqual(null)
+        // call without reset generates
+        expect(given.pageViewIdManager.getPageViewId()).toEqual('firstUUID')
+
+        given.pageViewIdManager.resetPageViewId()
+        expect(given.pageViewIdManager.getPageViewId()).toEqual('secondUUID')
+
+        given.pageViewIdManager.resetPageViewId()
+        expect(given.pageViewIdManager.getPageViewId()).toEqual('subsequentUUIDs')
+    })
+})

--- a/src/page-view-id.ts
+++ b/src/page-view-id.ts
@@ -1,12 +1,9 @@
 import { _UUID } from './utils'
 
 export class PageViewIdManager {
-    _pageViewId: string
-    _seenFirstPageView = false
+    _pageViewId: string | undefined
 
-    constructor() {
-        this._pageViewId = _UUID()
-    }
+    _seenFirstPageView = false
 
     onPageview(): void {
         // As the first $pageview event may come after a different event,
@@ -18,6 +15,10 @@ export class PageViewIdManager {
     }
 
     getPageViewId(): string {
+        if (!this._pageViewId) {
+            this._pageViewId = _UUID()
+        }
+
         return this._pageViewId
     }
 }

--- a/src/page-view-id.ts
+++ b/src/page-view-id.ts
@@ -1,24 +1,19 @@
 import { _UUID } from './utils'
 
 export class PageViewIdManager {
-    _pageViewId: string | null
+    _pageViewId: string = _UUID()
+    _seenFirstPageView = false
 
-    constructor() {
-        this._pageViewId = null
-    }
-
-    _setPageViewId(pageViewId: string | null): void {
-        this._pageViewId = pageViewId
-    }
-
-    resetPageViewId(): void {
-        this._setPageViewId(_UUID())
+    onPageview(): void {
+        // As the first $pageview event may come after a different event,
+        // we only reset the ID _after_ the second $pageview event.
+        if (this._seenFirstPageView) {
+            this._pageViewId = _UUID()
+        }
+        this._seenFirstPageView = true
     }
 
     getPageViewId(): string {
-        if (this._pageViewId === null) {
-            this.resetPageViewId()
-        }
-        return <string>this._pageViewId
+        return this._pageViewId
     }
 }

--- a/src/page-view-id.ts
+++ b/src/page-view-id.ts
@@ -1,8 +1,12 @@
 import { _UUID } from './utils'
 
 export class PageViewIdManager {
-    _pageViewId: string = _UUID()
+    _pageViewId: string
     _seenFirstPageView = false
+
+    constructor() {
+        this._pageViewId = _UUID()
+    }
 
     onPageview(): void {
         // As the first $pageview event may come after a different event,

--- a/src/page-view-id.ts
+++ b/src/page-view-id.ts
@@ -1,7 +1,4 @@
-import { PostHogPersistence, SESSION_ID } from './posthog-persistence'
-import { sessionStore } from './storage'
 import { _UUID } from './utils'
-import { PostHogConfig } from './types'
 
 export class PageViewIdManager {
     _pageViewId: string | null
@@ -10,9 +7,7 @@ export class PageViewIdManager {
         this._pageViewId = null
     }
 
-    _setPageViewId(
-        pageViewId: string | null,
-    ): void {
+    _setPageViewId(pageViewId: string | null): void {
         this._pageViewId = pageViewId
     }
 

--- a/src/page-view-id.ts
+++ b/src/page-view-id.ts
@@ -1,0 +1,29 @@
+import { PostHogPersistence, SESSION_ID } from './posthog-persistence'
+import { sessionStore } from './storage'
+import { _UUID } from './utils'
+import { PostHogConfig } from './types'
+
+export class PageViewIdManager {
+    _pageViewId: string | null
+
+    constructor() {
+        this._pageViewId = null
+    }
+
+    _setPageViewId(
+        pageViewId: string | null,
+    ): void {
+        this._pageViewId = pageViewId
+    }
+
+    resetPageViewId(): void {
+        this._setPageViewId(_UUID())
+    }
+
+    getPageViewId(): string {
+        if (this._pageViewId === null) {
+            this.resetPageViewId()
+        }
+        return <string>this._pageViewId
+    }
+}

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -829,7 +829,7 @@ export class PostHog {
             if (event_name === '$pageview') {
                 this.pageViewIdManager.resetPageViewId()
             }
-            properties = _extend(properties, {'$pageview_id': this.pageViewIdManager.getPageViewId()})
+            properties = _extend(properties, { $pageview_id: this.pageViewIdManager.getPageViewId() })
         }
 
         if (event_name === '$pageview' && this.get_config('_capture_performance')) {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -825,9 +825,9 @@ export class PostHog {
         // update properties with pageview info and super-properties
         properties = _extend({}, _info.properties(), this.persistence.properties(), properties)
 
-        if (this.pageViewIdManager && this.get_config('_capture_performance')) {
+        if (this.get_config('_capture_performance')) {
             if (event_name === '$pageview') {
-                this.pageViewIdManager.resetPageViewId()
+                this.pageViewIdManager.onPageview()
             }
             properties = _extend(properties, { $pageview_id: this.pageViewIdManager.getPageViewId() })
         }


### PR DESCRIPTION
## Changes

In order to level-up web performance we want to store data differently and be able to load all performance data for a session or all performance data for a pageview

But we have no (fast) consistent way to associate an event and its pageview

This 

* adds an in-memory pageview id manager which ensure it always returns a GUID
* rotates that GUID on pageview
* attaches the GUID to the pageview and all subsequent

Tested by running locally and seeing pageview IDs rotate (nb the screenshot runs from newest at the top to oldest at the bottom)

<img width="1191" alt="Screenshot 2022-12-12 at 22 47 41" src="https://user-images.githubusercontent.com/984817/207172128-9e226c60-a82b-4804-bde9-8854df02d538.png">


