### PR TITLE
noop reset if posthog was not initialized

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -709,6 +709,7 @@ export class PostHog {
         // While developing, a developer might purposefully _not_ call init(),
         // in this case, we would like capture to be a noop.
         if (!this.__loaded) {
+            console.warn('called posthog.capture before posthog was initialized. Did not capture')
             return
         }
 
@@ -1111,6 +1112,10 @@ export class PostHog {
      * Useful for clearing data when a user logs out.
      */
     reset(reset_device_id?: boolean): void {
+        if (!this.__loaded) {
+            console.warn('called posthog.reset before posthog was initialized. Did not reset.')
+            return
+        }
         const device_id = this.get_property('$device_id')
         this.persistence.clear()
         this.sessionManager.resetSessionId()


### PR DESCRIPTION
## Changes

Added noop for posthog.reset if capture is not initialized. Partially solves this: https://github.com/PostHog/posthog-js/issues/323

However, it might end up in reset not running when the user thought it ran.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
