### PR TITLE
fix(options): Add capture_pageleave option

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -541,10 +541,12 @@ describe('_handle_unload()', () => {
 
     given('config', () => ({
         capture_pageview: given.capturePageviews,
+        capture_pageleave: given.capturePageleave,
         request_batching: given.batching,
     }))
 
     given('capturePageviews', () => true)
+    given('capturePageleave', () => true)
     given('batching', () => true)
 
     it('captures $pageleave', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -114,6 +114,7 @@ const defaultConfig = (): PostHogConfig => ({
     verbose: false,
     img: false,
     capture_pageview: true,
+    capture_pageleave: true, // We'll only capture pageleave events if capture_pageview is also true
     debug: false,
     cookie_expiration: 365,
     upgrade: false,
@@ -500,13 +501,13 @@ export class PostHog {
 
     _handle_unload(): void {
         if (!this.get_config('request_batching')) {
-            if (this.get_config('capture_pageview')) {
+            if (this.get_config('capture_pageview') && this.get_config('capture_pageleave')) {
                 this.capture('$pageleave', null, { transport: 'sendBeacon' })
             }
             return
         }
 
-        if (this.get_config('capture_pageview')) {
+        if (this.get_config('capture_pageview') && this.get_config('capture_pageleave')) {
             this.capture('$pageleave')
         }
         if (this.get_config('_capture_metrics')) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export interface PostHogConfig {
     verbose: boolean
     img: boolean
     capture_pageview: boolean
+    capture_pageleave: boolean
     debug: boolean
     cookie_expiration: number
     upgrade: boolean


### PR DESCRIPTION
## Changes

Some users want to capture pageviews but not pageleave.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
