### PR TITLE
fix(ua): Add additional user-agents to ignore list

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -523,7 +523,7 @@ export const _UUID = (function () {
 // sending false capturing data
 export const _isBlockedUA = function (ua: string): boolean {
     if (
-        /(google web preview|baiduspider|yandexbot|bingbot|googlebot|yahoo! slurp|ahrefsbot|facebookexternalhit|facebookcatalog)/i.test(
+        /(google web preview|baiduspider|yandexbot|bingbot|googlebot|yahoo! slurp|ahrefsbot|facebookexternalhit|facebookcatalog|applebot|semrushbot|duckduckbot|twitterbot|rogerbot|linkedinbot|mj12bot|sitebulb|bot.htm|bot.php)/i.test(
             ua
         )
     ) {


### PR DESCRIPTION
## Changes
Adds some new excludes of common user-agents from spiders/crawlers. I also added `bot.htm` and `bot.php` as lots of sites crawlers to have them at the end (or even `bot.html` which is encompassed by `bot.htm`).
...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
