### PR TITLE
feat: capture server timings

### DIFF
--- a/src/extensions/web-performance.ts
+++ b/src/extensions/web-performance.ts
@@ -170,5 +170,40 @@ export class WebPerformanceObserver {
             _noTruncate: true,
             _batchKey: 'performanceEvent',
         })
+
+        if (exposesServerTiming(event)) {
+            for (const timing of event.serverTiming) {
+                this.instance.capture(
+                    '$performance_event',
+                    {
+                        [PERFORMANCE_EVENTS_MAPPING['timeOrigin']]: timeOrigin,
+                        [PERFORMANCE_EVENTS_MAPPING['timestamp']]: Math.floor(timeOrigin + event.startTime),
+                        [PERFORMANCE_EVENTS_MAPPING['name']]: timing.name,
+                        [PERFORMANCE_EVENTS_MAPPING['duration']]: timing.duration,
+                        // the spec has a closed list of possible types
+                        // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/entryType
+                        // but we need to know this was a server timing so that we know to
+                        // match it to the appropriate navigation or resource timing
+                        // that matching will have to be on timestamp and $current_url
+                        [PERFORMANCE_EVENTS_MAPPING['entryType']]: 'serverTiming',
+                    },
+                    {
+                        transport: 'XHR',
+                        method: 'POST',
+                        endpoint: PERFORMANCE_INGESTION_ENDPOINT,
+                        _noTruncate: true,
+                        _batchKey: 'performanceEvent',
+                    }
+                )
+            }
+        }
     }
 }
+
+/**
+ *  Check if this PerformanceEntry is either a PerformanceResourceTiming or a PerformanceNavigationTiming
+ *  NB PerformanceNavigationTiming extends PerformanceResourceTiming
+ *  Here we don't care which interface it implements as both expose `serverTimings`
+ */
+const exposesServerTiming = (event: PerformanceEntry): event is PerformanceResourceTiming =>
+    event.entryType === 'navigation' || event.entryType === 'resource'


### PR DESCRIPTION
## Changes

In https://github.com/PostHog/posthog/pull/13511 we added a `Server-Timing` header to PostHog responses.

This lets us capture those server timings as `$performance_events`. They can then be surfaced as additional information alongside Navigation and Resource events.

Here you can see the timings appearing alongside other events. 

![Screenshot 2022-12-30 at 13 12 18](https://user-images.githubusercontent.com/984817/210073894-bd5ddccc-9bab-47d1-88d2-f7fe7e819df1.png)

It looks to be "good enough for rock and roll"™️ to rely on timestamp to correlate these for now

In future we should probably add a correlation ID to the parent and children events so we can be more concrete