### PR TITLE
fix(toolbar): Load toolbar only in body for turbolink

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,18 @@ Testing on IE11 requires a bit more setup.
 
 ## Developing together with another repo
 
-### Using Yarn link
-
-Use [`yarn link`](https://classic.yarnpkg.com/en/docs/cli/link/). Run `yarn link` in `posthog-js`, and then `yarn link posthog-js` in `posthog`. Once you're done, remember to `yarn unlink posthog-js` in `posthog`, and `yarn unlink` in `posthog-js`.
-
-An alternative is to update dependency in package.json to e.g. `"posthog-js": "link:../posthog-js"`, `yarn` and run `yarn build && yarn build-module`
-
 #### Developing with main PostHog repo
 
 The `posthog-js` snippet for a website loads static js from the main `PostHog/posthog` repo. Which means, when testing the snippet with a website, there's a bit of extra setup required:
 
 1. Run `PostHog/posthog` locally
-2. Link the `posthog-js` dependency to your local version (see above)
+2. Link the `posthog-js` dependency to your local version (see below)
 3. Run `yarn serve` in `posthog-js`. (This ensures `dist/array.js` is being generated)
 4. In your locally running `PostHog/posthog` build, run `yarn copy-scripts`. (This copies the scripts generated in step 3 to the static assets folder for `PostHog/posthog`)
 
 Further, it's a good idea to modify `start-http` script to add development mode: `webpack serve --mode development`, which doesn't minify the resulting js (which you can then read in your browser).
 
-### Using Yalc (Alternative to yarn link)
+### Using Yalc to link local packages
 
 Run `npm install -g yalc`
 

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -303,10 +303,7 @@ export function isAngularStyleAttr(attributeName: string): boolean {
     return false
 }
 
-export function loadScript(
-    scriptUrlToLoad: string,
-    callback: (event: Event) => void,
-): void {
+export function loadScript(scriptUrlToLoad: string, callback: (event: Event) => void): void {
     const scriptTag = document.createElement('script')
     scriptTag.type = 'text/javascript'
     scriptTag.src = scriptUrlToLoad

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -306,15 +306,14 @@ export function isAngularStyleAttr(attributeName: string): boolean {
 export function loadScript(
     scriptUrlToLoad: string,
     callback: (event: Event) => void,
-    restrictToHTMLBody?: boolean
 ): void {
     const scriptTag = document.createElement('script')
     scriptTag.type = 'text/javascript'
     scriptTag.src = scriptUrlToLoad
     scriptTag.onload = callback
 
-    const scripts = document.getElementsByTagName('script')
-    if (scripts.length > 0 && !restrictToHTMLBody) {
+    const scripts = document.querySelectorAll('body > script')
+    if (scripts.length > 0) {
         scripts[0].parentNode?.insertBefore(scriptTag, scripts[0])
     } else {
         document.body.appendChild(scriptTag)

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -303,14 +303,14 @@ export function isAngularStyleAttr(attributeName: string): boolean {
     return false
 }
 
-export function loadScript(scriptUrlToLoad: string, callback: (event: Event) => void): void {
+export function loadScript(scriptUrlToLoad: string, callback: (event: Event) => void, restrictToHTMLBody?: boolean): void {
     const scriptTag = document.createElement('script')
     scriptTag.type = 'text/javascript'
     scriptTag.src = scriptUrlToLoad
     scriptTag.onload = callback
 
     const scripts = document.getElementsByTagName('script')
-    if (scripts.length > 0) {
+    if (scripts.length > 0 && !restrictToHTMLBody) {
         scripts[0].parentNode?.insertBefore(scriptTag, scripts[0])
     } else {
         document.body.appendChild(scriptTag)

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -303,7 +303,11 @@ export function isAngularStyleAttr(attributeName: string): boolean {
     return false
 }
 
-export function loadScript(scriptUrlToLoad: string, callback: (event: Event) => void, restrictToHTMLBody?: boolean): void {
+export function loadScript(
+    scriptUrlToLoad: string,
+    callback: (event: Event) => void,
+    restrictToHTMLBody?: boolean
+): void {
     const scriptTag = document.createElement('script')
     scriptTag.type = 'text/javascript'
     scriptTag.src = scriptUrlToLoad

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -120,12 +120,9 @@ export class Toolbar {
         const { source: _discard, ...paramsToPersist } = toolbarParams // eslint-disable-line
         window.localStorage.setItem('_postHogToolbarParams', JSON.stringify(paramsToPersist))
 
-        loadScript(
-            toolbarUrl,
-            () => {
-                ;((window as any)['ph_load_toolbar'] || (window as any)['ph_load_editor'])(toolbarParams, this.instance)
-            }
-        )
+        loadScript(toolbarUrl, () => {
+            ;((window as any)['ph_load_toolbar'] || (window as any)['ph_load_editor'])(toolbarParams, this.instance)
+        })
         // Turbolinks doesn't fire an onload event but does replace the entire body, including the toolbar.
         // Thus, we ensure the toolbar is only loaded inside the body, and then reloaded on turbolinks:load.
         _register_event(window, 'turbolinks:load', () => {

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -122,8 +122,9 @@ export class Toolbar {
 
         loadScript(toolbarUrl, () => {
             ;((window as any)['ph_load_toolbar'] || (window as any)['ph_load_editor'])(toolbarParams, this.instance)
-        })
-        // Turbolinks doesn't fire an onload event but does replace the entire page, including the toolbar
+        }, true)
+        // Turbolinks doesn't fire an onload event but does replace the entire body, including the toolbar.
+        // Thus, we ensure the toolbar is only loaded inside the body, and then reloaded on turbolinks:load.
         _register_event(window, 'turbolinks:load', () => {
             ;(window as any)['_postHogToolbarLoaded'] = false
             this.loadToolbar(toolbarParams)

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -120,9 +120,13 @@ export class Toolbar {
         const { source: _discard, ...paramsToPersist } = toolbarParams // eslint-disable-line
         window.localStorage.setItem('_postHogToolbarParams', JSON.stringify(paramsToPersist))
 
-        loadScript(toolbarUrl, () => {
-            ;((window as any)['ph_load_toolbar'] || (window as any)['ph_load_editor'])(toolbarParams, this.instance)
-        }, true)
+        loadScript(
+            toolbarUrl,
+            () => {
+                ;((window as any)['ph_load_toolbar'] || (window as any)['ph_load_editor'])(toolbarParams, this.instance)
+            },
+            true
+        )
         // Turbolinks doesn't fire an onload event but does replace the entire body, including the toolbar.
         // Thus, we ensure the toolbar is only loaded inside the body, and then reloaded on turbolinks:load.
         _register_event(window, 'turbolinks:load', () => {

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -124,8 +124,7 @@ export class Toolbar {
             toolbarUrl,
             () => {
                 ;((window as any)['ph_load_toolbar'] || (window as any)['ph_load_editor'])(toolbarParams, this.instance)
-            },
-            true
+            }
         )
         // Turbolinks doesn't fire an onload event but does replace the entire body, including the toolbar.
         // Thus, we ensure the toolbar is only loaded inside the body, and then reloaded on turbolinks:load.


### PR DESCRIPTION
## Changes

Restricts toolbar loading only to the body

Removes out of date (thanks to pnpm) local dev instructions.

Fixes https://github.com/PostHog/posthog/issues/13477

---

Ran locally, see the toolbar load in body, works without issues.

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
