### PR TITLE
fix: page view ids didn't work with server side config

### DIFF
--- a/src/page-view-id.ts
+++ b/src/page-view-id.ts
@@ -18,6 +18,7 @@ export class PageViewIdManager {
         if (!this._pageViewId) {
             this._pageViewId = _UUID()
         }
+
         return this._pageViewId
     }
 }

--- a/src/page-view-id.ts
+++ b/src/page-view-id.ts
@@ -1,7 +1,7 @@
 import { _UUID } from './utils'
 
 export class PageViewIdManager {
-    _pageViewId: string | undefined
+    _pageViewId: string = _UUID()
 
     _seenFirstPageView = false
 
@@ -15,10 +15,6 @@ export class PageViewIdManager {
     }
 
     getPageViewId(): string {
-        if (!this._pageViewId) {
-            this._pageViewId = _UUID()
-        }
-
         return this._pageViewId
     }
 }

--- a/src/page-view-id.ts
+++ b/src/page-view-id.ts
@@ -1,7 +1,7 @@
 import { _UUID } from './utils'
 
 export class PageViewIdManager {
-    _pageViewId: string = _UUID()
+    _pageViewId: string | undefined
 
     _seenFirstPageView = false
 
@@ -15,6 +15,9 @@ export class PageViewIdManager {
     }
 
     getPageViewId(): string {
+        if (!this._pageViewId) {
+            this._pageViewId = _UUID()
+        }
         return this._pageViewId
     }
 }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -820,7 +820,7 @@ export class PostHog {
             properties['$window_id'] = windowId
         }
 
-        if (this.get_config('capture_performance')) {
+        if (this.webPerformance?.isEnabled) {
             if (event_name === '$pageview') {
                 this.pageViewIdManager.onPageview()
             }


### PR DESCRIPTION
## Changes

Page view ids were only allocated when capture_performance was enabled on the client. But they are needed also when capture_performance is enabled via decide.

So, now they are.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
