### PR TITLE
fix: use django cache for toolbar js

### DIFF
--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -105,7 +105,6 @@ export class Toolbar {
 
         // the toolbar does not use the `jsURL` as that route is cached for 24 hours.
         // By design array.js, recorder.js, and toolbar.js are served from Django with no or limited caching, not from our CDN
-        // instead we request it from the `apiURL` (i.e. Django)
         // that respects the query params for caching
         const host = params?.['apiURL'] || this.instance.get_config('api_host')
         const timestampToNearestThirtySeconds = Math.floor(Date.now() / 30000) * 30000

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -103,7 +103,8 @@ export class Toolbar {
         // only load the toolbar once, even if there are multiple instances of PostHogLib
         ;(window as any)['_postHogToolbarLoaded'] = true
 
-        // the toolbar does not use the `jsURL` as that route is cached for 24 hours
+        // the toolbar does not use the `jsURL` as that route is cached for 24 hours.
+        // By design array.js, recorder.js, and toolbar.js are served from Django with no or limited caching, not from our CDN
         // instead we request it from the `apiURL` (i.e. Django)
         // that respects the query params for caching
         const host = params?.['apiURL'] || this.instance.get_config('api_host')

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -105,7 +105,7 @@ export class Toolbar {
 
         // the toolbar does not use the `jsURL` as that route is cached for 24 hours.
         // By design array.js, recorder.js, and toolbar.js are served from Django with no or limited caching, not from our CDN
-        // that respects the query params for caching
+        // Django respects the query params for caching, returning a 304 if appropriate
         const host = params?.['apiURL'] || this.instance.get_config('api_host')
         const timestampToNearestThirtySeconds = Math.floor(Date.now() / 30000) * 30000
         const toolbarUrl = `${host}${

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -103,8 +103,14 @@ export class Toolbar {
         // only load the toolbar once, even if there are multiple instances of PostHogLib
         ;(window as any)['_postHogToolbarLoaded'] = true
 
-        const host = params?.['jsURL'] || params?.['apiURL'] || this.instance.get_config('api_host')
-        const toolbarUrl = `${host}${host.endsWith('/') ? '' : '/'}static/toolbar.js?_ts=${new Date().getTime()}`
+        // the toolbar does not use the `jsURL` as that route is cached for 24 hours
+        // instead we request it from the `apiURL` (i.e. Django)
+        // that respects the query params for caching
+        const host = params?.['apiURL'] || this.instance.get_config('api_host')
+        const timestampToNearestThirtySeconds = Math.floor(Date.now() / 30000) * 30000
+        const toolbarUrl = `${host}${
+            host.endsWith('/') ? '' : '/'
+        }static/toolbar.js?_ts=${timestampToNearestThirtySeconds}`
         const disableToolbarMetrics =
             !POSTHOG_MANAGED_HOSTS.includes(this.instance.get_config('api_host')) &&
             this.instance.get_config('advanced_disable_toolbar_metrics')


### PR DESCRIPTION
## Changes

In #464 (probably) we started serving `toolbar.js` from `app-static-prod` cdn. That CDN ignores queryparams and caches by filename for 24 hours.

When we released https://github.com/PostHog/posthog/pull/13620 this meant that the toolbar was effectively broken as the API had changed but the served JS had not.

This has two changes:

* first, don't use the `jsURL` for the toolbar.js
* second, only change the query param once every 30 seconds to reduce load on django

## toolbar being served from CDN always shows hit from cloudfront

![Screenshot 2023-01-11 at 13 54 00](https://user-images.githubusercontent.com/984817/211824710-49f91a39-601b-491a-9eca-10c496c1d9b0.png)
![Screenshot 2023-01-11 at 13 54 08](https://user-images.githubusercontent.com/984817/211824704-2eec3e0f-cfcc-4333-b9e6-50c7361ef77e.png)

## toolbar served from Django

sends 304 on query param repeat visit

![Screenshot 2023-01-11 at 13 53 09](https://user-images.githubusercontent.com/984817/211824774-6dc27277-f61a-4554-8ca4-f918dfdc85bb.png)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
