### PR TITLE
feat: capture clicked elements on rageclicks

### DIFF
--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -376,6 +376,8 @@ describe('Autocapture system', () => {
                     switch (key) {
                         case 'mask_all_element_attributes':
                             return false
+                        case 'rageclick':
+                            return true
                     }
                 }),
             }
@@ -450,6 +452,34 @@ describe('Autocapture system', () => {
             expect(eventType1).toBe('my property value')
             expect(eventType2).toBe('my property value')
             lib.capture.resetHistory()
+        })
+
+        it('should capture rageclick', () => {
+            autocapture.init(lib)
+
+            const elTarget = document.createElement('img')
+            const elParent = document.createElement('span')
+            elParent.appendChild(elTarget)
+            const elGrandparent = document.createElement('a')
+            elGrandparent.setAttribute('href', 'http://test.com')
+            elGrandparent.appendChild(elParent)
+            const fakeEvent = {
+                target: elTarget,
+                type: 'click',
+                clientX: 5,
+                clientY: 5,
+            }
+            Object.setPrototypeOf(fakeEvent, MouseEvent.prototype)
+            autocapture._captureEvent(fakeEvent, lib)
+            autocapture._captureEvent(fakeEvent, lib)
+            autocapture._captureEvent(fakeEvent, lib)
+
+            expect(lib.capture.args.map((args) => args[0])).toEqual([
+                '$autocapture',
+                '$autocapture',
+                '$rageclick',
+                '$autocapture',
+            ])
         })
 
         it('should not capture events when get_config returns false, when an element matching any of the event selectors is clicked', () => {

--- a/src/__tests__/extensions/rageclick.js
+++ b/src/__tests__/extensions/rageclick.js
@@ -2,44 +2,82 @@ import RageClick from '../../extensions/rageclick'
 
 describe('RageClick()', () => {
     given('instance', () => new RageClick(given.enabled))
-    given('capture', () => jest.fn())
     given('enabled', () => true)
 
-    const click = (x, y, t) => given.instance.click(x, y, t, given.capture)
+    const isRageClick = (x, y, t) => given.instance.isRageClick(x, y, t)
 
-    it('captures some rage clicking', () => {
-        click(0, 0, 10)
-        click(10, 10, 20)
-        click(5, 5, 40)
-        click(5, 5, 80)
-        click(5, 5, 100)
+    it('identifies some rage clicking', () => {
+        const detection = [
+            isRageClick(0, 0, 10),
+            isRageClick(10, 10, 20),
+            isRageClick(5, 5, 40), // triggers rage click
+            isRageClick(5, 5, 50), // does not re-trigger
+        ]
 
-        expect(given.capture).toHaveBeenCalledWith()
+        expect(detection).toEqual([false, false, true, false])
+    })
+
+    it('identifies some rage clicking when time delta has passed', () => {
+        const detection = [
+            isRageClick(0, 0, 10),
+            isRageClick(10, 10, 20),
+            isRageClick(5, 5, 40), // triggers rage click
+            // these next three don't trigger
+            // because you need to move past threshold before triggering again
+            isRageClick(5, 5, 80),
+            isRageClick(5, 5, 100),
+            isRageClick(5, 5, 110),
+            // moving past the time threshold resets the counter
+            isRageClick(5, 5, 1120),
+            isRageClick(5, 5, 1121),
+            isRageClick(5, 5, 1122), // triggers rage click
+        ]
+
+        expect(detection).toEqual([false, false, true, false, false, false, false, false, true])
+    })
+
+    it('identifies some rage clicking when pixel delta has passed', () => {
+        const detection = [
+            isRageClick(0, 0, 10),
+            isRageClick(10, 10, 20),
+            isRageClick(5, 5, 40), // triggers rage click
+            // these next three don't trigger
+            // because you need to move past threshold before triggering again
+            isRageClick(5, 5, 80),
+            isRageClick(5, 5, 100),
+            isRageClick(5, 5, 110),
+            // moving past the pixel threshold resets the counter
+            isRageClick(36, 5, 120),
+            isRageClick(36, 5, 130),
+            isRageClick(36, 5, 140), // triggers rage click
+        ]
+
+        expect(detection).toEqual([false, false, true, false, false, false, false, false, true])
     })
 
     it('does not capture rage clicks if not enabled', () => {
         given('enabled', () => false)
 
-        click(0, 0, 10)
-        click(10, 10, 20)
-        click(5, 5, 40)
+        isRageClick(5, 5, 10)
+        isRageClick(5, 5, 20)
+        const rageClickDetected = isRageClick(5, 5, 40)
 
-        expect(given.capture).not.toHaveBeenCalled()
+        expect(rageClickDetected).toBeFalsy()
     })
 
     it('does not capture clicks too far apart (time)', () => {
-        click(0, 0, 10)
-        click(10, 10, 20)
-        click(5, 5, 4000)
+        isRageClick(5, 5, 10)
+        isRageClick(5, 5, 20)
+        const rageClickDetected = isRageClick(5, 5, 4000)
 
-        expect(given.capture).not.toHaveBeenCalled()
+        expect(rageClickDetected).toBeFalsy()
     })
 
     it('does not capture clicks too far apart (space)', () => {
-        click(0, 0, 10)
-        click(10, 10, 20)
-        click(50, 10, 40)
+        isRageClick(0, 0, 10)
+        isRageClick(10, 10, 20)
+        const rageClickDetected = isRageClick(50, 10, 40)
 
-        expect(given.capture).not.toHaveBeenCalled()
+        expect(rageClickDetected).toBeFalsy()
     })
 })

--- a/src/__tests__/extensions/rageclick.js
+++ b/src/__tests__/extensions/rageclick.js
@@ -14,7 +14,7 @@ describe('RageClick()', () => {
         click(5, 5, 80)
         click(5, 5, 100)
 
-        expect(given.capture).toHaveBeenCalledWith('$rageclick')
+        expect(given.capture).toHaveBeenCalledWith()
     })
 
     it('does not capture rage clicks if not enabled', () => {

--- a/src/__tests__/extensions/rageclick.js
+++ b/src/__tests__/extensions/rageclick.js
@@ -1,11 +1,11 @@
 import RageClick from '../../extensions/rageclick'
 
 describe('RageClick()', () => {
-    given('instance', () => new RageClick({ capture: given.capture }, given.enabled))
+    given('instance', () => new RageClick(given.enabled))
     given('capture', () => jest.fn())
     given('enabled', () => true)
 
-    const click = (x, y, t) => given.instance.click(x, y, t)
+    const click = (x, y, t) => given.instance.click(x, y, t, given.capture)
 
     it('captures some rage clicking', () => {
         click(0, 0, 10)

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -144,8 +144,11 @@ const autocapture = {
         }
 
         if (eventName === '$autocapture' && e.type === 'click' && e instanceof MouseEvent) {
-            this.rageclicks?.click(e.clientX, e.clientY, new Date().getTime(), (name: string) => {
-                this._captureEvent(e, instance, name)
+            this.rageclicks?.click(e.clientX, e.clientY, new Date().getTime(), () => {
+                // if `this.rageClicks` decides to capture the event,
+                // then it will call into _captureEvent here
+                // which will capture the event elements chain onto the rageclick event
+                this._captureEvent(e, instance, '$rageclick')
             })
         }
 

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -135,7 +135,7 @@ const autocapture = {
         }
     },
 
-    _captureEvent: function (e: Event, instance: PostHog): boolean | void {
+    _captureEvent: function (e: Event, instance: PostHog, eventName = '$autocapture'): boolean | void {
         /*** Don't mess with this code without running IE8 tests on it ***/
         let target = this._getEventTarget(e)
         if (isTextNode(target)) {
@@ -143,8 +143,10 @@ const autocapture = {
             target = (target.parentNode || null) as Element | null
         }
 
-        if (e.type === 'click' && e instanceof MouseEvent) {
-            this.rageclicks?.click(e.clientX, e.clientY, new Date().getTime())
+        if (eventName === '$autocapture' && e.type === 'click' && e instanceof MouseEvent) {
+            this.rageclicks?.click(e.clientX, e.clientY, new Date().getTime(), (name: string) => {
+                this._captureEvent(e, instance, name)
+            })
         }
 
         if (target && shouldCaptureDomEvent(target, e, this.config)) {
@@ -208,7 +210,7 @@ const autocapture = {
                 this._getCustomProperties(targetElementList)
             )
 
-            instance.capture('$autocapture', props)
+            instance.capture(eventName, props)
             return true
         }
     },
@@ -243,7 +245,7 @@ const autocapture = {
             this.config.url_allowlist = this.config.url_allowlist.map((url) => new RegExp(url))
         }
 
-        this.rageclicks = new RageClick(instance)
+        this.rageclicks = new RageClick(instance.get_config('rageclick'))
     },
 
     afterDecideResponse: function (response: DecideResponse, instance: PostHog): void {

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -144,12 +144,9 @@ const autocapture = {
         }
 
         if (eventName === '$autocapture' && e.type === 'click' && e instanceof MouseEvent) {
-            this.rageclicks?.click(e.clientX, e.clientY, new Date().getTime(), () => {
-                // if `this.rageClicks` decides to capture the event,
-                // then it will call into _captureEvent here
-                // which will capture the event elements chain onto the rageclick event
+            if (this.rageclicks?.isRageClick(e.clientX, e.clientY, new Date().getTime())) {
                 this._captureEvent(e, instance, '$rageclick')
-            })
+            }
         }
 
         if (target && shouldCaptureDomEvent(target, e, this.config)) {

--- a/src/extensions/rageclick.ts
+++ b/src/extensions/rageclick.ts
@@ -15,7 +15,7 @@ export default class RageClick {
         this.enabled = enabled
     }
 
-    click(x: number, y: number, timestamp: number, capture: (s: string) => void) {
+    click(x: number, y: number, timestamp: number, captureRageClickEvent: () => void) {
         if (!this.enabled) {
             return
         }
@@ -29,7 +29,7 @@ export default class RageClick {
             this.clicks.push({ x, y, timestamp })
 
             if (this.clicks.length === RAGE_CLICK_CLICK_COUNT) {
-                capture('$rageclick')
+                captureRageClickEvent()
             }
         } else {
             this.clicks = [{ x, y, timestamp }]

--- a/src/extensions/rageclick.ts
+++ b/src/extensions/rageclick.ts
@@ -15,9 +15,9 @@ export default class RageClick {
         this.enabled = enabled
     }
 
-    click(x: number, y: number, timestamp: number, captureRageClickEvent: () => void) {
+    isRageClick(x: number, y: number, timestamp: number): boolean {
         if (!this.enabled) {
-            return
+            return false
         }
 
         const lastClick = this.clicks[this.clicks.length - 1]
@@ -29,10 +29,12 @@ export default class RageClick {
             this.clicks.push({ x, y, timestamp })
 
             if (this.clicks.length === RAGE_CLICK_CLICK_COUNT) {
-                captureRageClickEvent()
+                return true
             }
         } else {
             this.clicks = [{ x, y, timestamp }]
         }
+
+        return false
     }
 }

--- a/src/extensions/rageclick.ts
+++ b/src/extensions/rageclick.ts
@@ -1,24 +1,21 @@
 // Naive rage click implementation: If mouse has not moved than RAGE_CLICK_THRESHOLD_PX
 // over RAGE_CLICK_CLICK_COUNT clicks with max RAGE_CLICK_TIMEOUT_MS between clicks, it's
 // counted as a rage click
-import { PostHog } from '../posthog-core'
 
 const RAGE_CLICK_THRESHOLD_PX = 30
 const RAGE_CLICK_TIMEOUT_MS = 1000
 const RAGE_CLICK_CLICK_COUNT = 3
 
 export default class RageClick {
-    instance: PostHog
     clicks: { x: number; y: number; timestamp: number }[]
     enabled: boolean
 
-    constructor(instance: PostHog, enabled = instance.get_config('rageclick')) {
+    constructor(enabled: boolean) {
         this.clicks = []
-        this.instance = instance
         this.enabled = enabled
     }
 
-    click(x: number, y: number, timestamp: number) {
+    click(x: number, y: number, timestamp: number, capture: (s: string) => void) {
         if (!this.enabled) {
             return
         }
@@ -32,7 +29,7 @@ export default class RageClick {
             this.clicks.push({ x, y, timestamp })
 
             if (this.clicks.length === RAGE_CLICK_CLICK_COUNT) {
-                this.instance.capture('$rageclick')
+                capture('$rageclick')
             }
         } else {
             this.clicks = [{ x, y, timestamp }]


### PR DESCRIPTION
## Changes

A customer asked if they could look at rageclicks by element. But we don't capture information about the rageclicked elements

Adds elements to rageclicks by injecting the autocapture capture method into the RageClick class instead of using the generic capture method

<img width="884" alt="Screenshot 2023-01-18 at 14 01 26" src="https://user-images.githubusercontent.com/984817/213192069-4ca1fe38-f332-4f3e-9c77-7503a4f3f315.png">

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
