### PR TITLE
fix: Sentry URL for recording

### DIFF
--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -37,9 +37,7 @@ export class SentryIntegration implements Integration {
                 event.tags['PostHog Person URL'] = host + '/person/' + _posthog.get_distinct_id()
                 if (_posthog.sessionRecordingStarted()) {
                     event.tags['PostHog Recording URL'] =
-                        host +
-                        '/recordings/#sessionRecordingId=' +
-                        _posthog.sessionManager.checkAndGetSessionAndWindowId(true).sessionId
+                        host + '/recordings/' + _posthog.sessionManager.checkAndGetSessionAndWindowId(true).sessionId
                 }
                 const exceptions = event.exception?.values || []
                 const data: Properties = {


### PR DESCRIPTION
## Changes

The URL from before was no longer supported. I'll try and add a catch for the old URL but we should also update it to the right one.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
