### PR TITLE
feat: allow url allowlists by event name

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -731,8 +731,8 @@ export class PostHog {
         }
 
         const eventcaptureConfig = this.get_config('event_capture_config')
-        if (event_name in (eventcaptureConfig?.url_allowlists || {})) {
-            const allowlist = eventcaptureConfig.url_allowlists?.[event_name]
+        if (!!eventcaptureConfig?.url_allowlists && event_name in (eventcaptureConfig?.url_allowlists || {})) {
+            const allowlist = eventcaptureConfig.url_allowlists[event_name]
             const url = window.location.href
             if (allowlist && !allowlist.some((regex) => url.match(regex))) {
                 return

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,16 @@ export type CaptureCallback = (response: any, data: any) => void
 export type AutocaptureCompatibleElement = 'a' | 'button' | 'form' | 'input' | 'select' | 'textarea' | 'label'
 export type DomAutocaptureEvents = 'click' | 'change' | 'submit'
 
+export interface EventCaptureConfig {
+    /**
+     * An object mapping events to URLs to allow capture on, can be strings to match
+     * or regexes e.g. ['https://example.com', 'test.com/.*']
+     *
+     * Events that are not in this object will be allowed on all URLs
+     */
+    url_allowlists?: Record<string, (string | RegExp)[]>
+}
+
 /**
  * If an array is passed for an allowlist, autocapture events will only be sent for elements matching
  * at least one of the elements in the array. Multiple allowlists can be used
@@ -65,6 +75,7 @@ export interface PostHogConfig {
     img: boolean
     capture_pageview: boolean
     capture_pageleave: boolean
+    event_capture_config: EventCaptureConfig
     debug: boolean
     cookie_expiration: number
     upgrade: boolean


### PR DESCRIPTION
## Changes

[In ZenDesk a customer asks](https://posthoghelp.zendesk.com/agent/tickets/1501) if you can restrict `$pageview` by URL

We have URL allowlists for `$autocapture` but not other events

Adds an `EventCaptureConfig` that allows setting `url_allowlists` by event name

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
