### PR TITLE
chore(feature-flag): only return truthy values for onFeatureFlag

### DIFF
--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -22,6 +22,7 @@ describe('featureflags', () => {
                     'beta-feature': true,
                     'alpha-feature-2': true,
                     'multivariate-flag': 'variant-1',
+                    'disabled-flag': false,
                 },
                 $override_feature_flags: false,
             },
@@ -43,11 +44,17 @@ describe('featureflags', () => {
     })
 
     it('should return the right feature flag and call capture', () => {
-        expect(given.featureFlags.getFlags()).toEqual(['beta-feature', 'alpha-feature-2', 'multivariate-flag'])
+        expect(given.featureFlags.getFlags()).toEqual([
+            'beta-feature',
+            'alpha-feature-2',
+            'multivariate-flag',
+            'disabled-flag',
+        ])
         expect(given.featureFlags.getFlagVariants()).toEqual({
             'alpha-feature-2': true,
             'beta-feature': true,
             'multivariate-flag': 'variant-1',
+            'disabled-flag': false,
         })
         expect(given.featureFlags.isFeatureEnabled('beta-feature')).toEqual(true)
         expect(given.featureFlags.isFeatureEnabled('random')).toEqual(false)
@@ -109,6 +116,23 @@ describe('featureflags', () => {
         expect(called).toEqual(true)
 
         called = false
+    })
+
+    it('onFeatureFlags should not return flags that are off', () => {
+        given.featureFlags.instance.decideEndpointWasHit = true
+        let _flags = []
+        let _variants = {}
+        given.featureFlags.onFeatureFlags((flags, variants) => {
+            _flags = flags
+            _variants = variants
+        })
+
+        expect(_flags).toEqual(['beta-feature', 'alpha-feature-2', 'multivariate-flag'])
+        expect(_variants).toEqual({
+            'beta-feature': true,
+            'alpha-feature-2': true,
+            'multivariate-flag': 'variant-1',
+        })
     })
 
     describe('reloadFeatureFlags', () => {
@@ -213,6 +237,7 @@ describe('featureflags', () => {
                 'multivariate-flag': 'variant-1',
                 'x-flag': 'x-value',
                 'feature-1': false,
+                'disabled-flag': false,
             })
         })
     })

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -107,7 +107,7 @@ describe('featureflags', () => {
             featureFlags: {
                 first: 'variant-1',
                 second: true,
-                third: false
+                third: false,
             },
         }))
 
@@ -126,7 +126,7 @@ describe('featureflags', () => {
                 _variants = variants
             })
             expect(called).toEqual(false)
-    
+
             given.featureFlags.setAnonymousDistinctId('rando_id')
             given.featureFlags.reloadFeatureFlags()
 
@@ -134,21 +134,20 @@ describe('featureflags', () => {
             expect(called).toEqual(true)
             expect(_flags).toEqual(['first', 'second'])
             expect(_variants).toEqual({
-                'first': 'variant-1',
-                'second': true
+                first: 'variant-1',
+                second: true,
             })
-
         })
-    
+
         it('onFeatureFlags callback should be called immediately if feature flags were loaded', () => {
             given.featureFlags.instance.decideEndpointWasHit = true
             var called = false
             given.featureFlags.onFeatureFlags(() => (called = true))
             expect(called).toEqual(true)
-    
+
             called = false
         })
-    
+
         it('onFeatureFlags should not return flags that are off', () => {
             given.featureFlags.instance.decideEndpointWasHit = true
             let _flags = []
@@ -157,7 +156,7 @@ describe('featureflags', () => {
                 _flags = flags
                 _variants = variants
             })
-    
+
             expect(_flags).toEqual(['beta-feature', 'alpha-feature-2', 'multivariate-flag'])
             expect(_variants).toEqual({
                 'beta-feature': true,

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -102,36 +102,68 @@ describe('featureflags', () => {
         })
     })
 
-    it('onFeatureFlags should not be called immediately if feature flags not loaded', () => {
-        var called = false
+    describe('onFeatureFlags', () => {
+        given('decideResponse', () => ({
+            featureFlags: {
+                first: 'variant-1',
+                second: true,
+                third: false
+            },
+        }))
 
-        given.featureFlags.onFeatureFlags(() => (called = true))
-        expect(called).toEqual(false)
-    })
+        given('config', () => ({
+            token: 'random fake token',
+        }))
 
-    it('onFeatureFlags callback should be called immediately if feature flags were loaded', () => {
-        given.featureFlags.instance.decideEndpointWasHit = true
-        var called = false
-        given.featureFlags.onFeatureFlags(() => (called = true))
-        expect(called).toEqual(true)
+        it('onFeatureFlags should not be called immediately if feature flags not loaded', () => {
+            var called = false
+            let _flags = []
+            let _variants = {}
 
-        called = false
-    })
+            given.featureFlags.onFeatureFlags((flags, variants) => {
+                called = true
+                _flags = flags
+                _variants = variants
+            })
+            expect(called).toEqual(false)
+    
+            given.featureFlags.setAnonymousDistinctId('rando_id')
+            given.featureFlags.reloadFeatureFlags()
 
-    it('onFeatureFlags should not return flags that are off', () => {
-        given.featureFlags.instance.decideEndpointWasHit = true
-        let _flags = []
-        let _variants = {}
-        given.featureFlags.onFeatureFlags((flags, variants) => {
-            _flags = flags
-            _variants = variants
+            jest.runAllTimers()
+            expect(called).toEqual(true)
+            expect(_flags).toEqual(['first', 'second'])
+            expect(_variants).toEqual({
+                'first': 'variant-1',
+                'second': true
+            })
+
         })
-
-        expect(_flags).toEqual(['beta-feature', 'alpha-feature-2', 'multivariate-flag'])
-        expect(_variants).toEqual({
-            'beta-feature': true,
-            'alpha-feature-2': true,
-            'multivariate-flag': 'variant-1',
+    
+        it('onFeatureFlags callback should be called immediately if feature flags were loaded', () => {
+            given.featureFlags.instance.decideEndpointWasHit = true
+            var called = false
+            given.featureFlags.onFeatureFlags(() => (called = true))
+            expect(called).toEqual(true)
+    
+            called = false
+        })
+    
+        it('onFeatureFlags should not return flags that are off', () => {
+            given.featureFlags.instance.decideEndpointWasHit = true
+            let _flags = []
+            let _variants = {}
+            given.featureFlags.onFeatureFlags((flags, variants) => {
+                _flags = flags
+                _variants = variants
+            })
+    
+            expect(_flags).toEqual(['beta-feature', 'alpha-feature-2', 'multivariate-flag'])
+            expect(_variants).toEqual({
+                'beta-feature': true,
+                'alpha-feature-2': true,
+                'multivariate-flag': 'variant-1',
+            })
         })
     })
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -997,7 +997,7 @@ export class PostHog {
      * @param {Function} [callback] The callback function will be called once the feature flags are ready or when they are updated.
      *                              It'll return a list of feature flags enabled for the user.
      */
-    onFeatureFlags(callback: (flags: string[], variants: Record<string, boolean | string>) => void): void {
+    onFeatureFlags(callback: (flags: string[], variants: Record<string, JsonType>) => void): void {
         return this.featureFlags.onFeatureFlags(callback)
     }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -997,7 +997,7 @@ export class PostHog {
      * @param {Function} [callback] The callback function will be called once the feature flags are ready or when they are updated.
      *                              It'll return a list of feature flags enabled for the user.
      */
-    onFeatureFlags(callback: (flags: string[], variants: Record<string, JsonType>) => void): void {
+    onFeatureFlags(callback: (flags: string[], variants: Record<string, string | boolean>) => void): void {
         return this.featureFlags.onFeatureFlags(callback)
     }
 

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -276,12 +276,12 @@ export class PostHogFeatureFlags {
     onFeatureFlags(callback: FeatureFlagsCallback): void {
         this.addFeatureFlagsHandler(callback)
         if (this.instance.decideEndpointWasHit) {
-            const {flags, flagVariants} = this._prepareFeatureFlagsForCallbacks()
+            const { flags, flagVariants } = this._prepareFeatureFlagsForCallbacks()
             callback(flags, flagVariants)
         }
     }
 
-    _prepareFeatureFlagsForCallbacks(): { flags: string[], flagVariants: Record<string, string | boolean> } {
+    _prepareFeatureFlagsForCallbacks(): { flags: string[]; flagVariants: Record<string, string | boolean> } {
         const flags = this.getFlags()
         const flagVariants = this.getFlagVariants()
 
@@ -296,7 +296,7 @@ export class PostHogFeatureFlags {
 
         return {
             flags: truthyFlags,
-            flagVariants: truthyFlagVariants
+            flagVariants: truthyFlagVariants,
         }
     }
 }

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -279,7 +279,16 @@ export class PostHogFeatureFlags {
         if (this.instance.decideEndpointWasHit) {
             const flags = this.getFlags()
             const flagVariants = this.getFlagVariants()
-            callback(flags, flagVariants)
+
+            // Return truthy
+            const truthyFlags = flags.filter((flag) => flagVariants[flag])
+            const truthyFlagVariants = Object.keys(flagVariants)
+                .filter((variantKey) => flagVariants[variantKey])
+                .reduce((res: Record<string, JsonType>, key) => {
+                    res[key] = flagVariants[key]
+                    return res
+                }, {})
+            callback(truthyFlags, truthyFlagVariants)
         }
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,7 +207,7 @@ export interface DecideResponse {
     siteApps: { id: number; url: string }[]
 }
 
-export type FeatureFlagsCallback = (flags: string[], variants: Record<string, string | boolean>) => void
+export type FeatureFlagsCallback = (flags: string[], variants: Record<string, JsonType>) => void
 
 // TODO: delete custom_properties after changeless typescript refactor
 export interface AutoCaptureCustomProperty {

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,7 +207,7 @@ export interface DecideResponse {
     siteApps: { id: number; url: string }[]
 }
 
-export type FeatureFlagsCallback = (flags: string[], variants: Record<string, JsonType>) => void
+export type FeatureFlagsCallback = (flags: string[], variants: Record<string, string | boolean>) => void
 
 // TODO: delete custom_properties after changeless typescript refactor
 export interface AutoCaptureCustomProperty {


### PR DESCRIPTION
## Changes

- v3 decide endpoint returns _all_ feature flags. Make sure flags that are returned on the callback function are only truthy

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
