### PR TITLE
feat: identify user on first identify

### DIFF
--- a/src/__tests__/posthog-core.identify.js
+++ b/src/__tests__/posthog-core.identify.js
@@ -66,25 +66,7 @@ describe('identify()', () => {
     it('calls capture when identity changes', () => {
         given('identity', () => 'calls capture when identity changes')
         given('oldIdentity', () => 'oldIdentity')
-
-        given.subject()
-
-        expect(given.overrides.capture).toHaveBeenCalledWith(
-            '$identify',
-            {
-                distinct_id: 'calls capture when identity changes',
-                $anon_distinct_id: 'oldIdentity',
-            },
-            { $set: {}, $set_once: {} }
-        )
-        expect(given.overrides.people.set).not.toHaveBeenCalled()
-        expect(given.overrides.featureFlags.setAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
-    })
-
-    it('calls capture when user has not been explictly identified', () => {
-        given('identity', () => 'calls capture when identity changes')
-        given('oldIdentity', () => 'oldIdentity')
-        given.lib.persistence.set_user_state(undefined)
+        given.lib.persistence.set_user_state('anonymous')
 
         given.subject()
 

--- a/src/__tests__/posthog-core.identify.js
+++ b/src/__tests__/posthog-core.identify.js
@@ -81,6 +81,25 @@ describe('identify()', () => {
         expect(given.overrides.featureFlags.setAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
     })
 
+    it('calls capture when user has not been explictly identified', () => {
+        given('identity', () => 'calls capture when identity changes')
+        given('oldIdentity', () => 'oldIdentity')
+        given.lib.persistence.set_user_state(undefined)
+
+        given.subject()
+
+        expect(given.overrides.capture).toHaveBeenCalledWith(
+            '$identify',
+            {
+                distinct_id: 'calls capture when identity changes',
+                $anon_distinct_id: 'oldIdentity',
+            },
+            { $set: {}, $set_once: {} }
+        )
+        expect(given.overrides.people.set).not.toHaveBeenCalled()
+        expect(given.overrides.featureFlags.setAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
+    })
+
     it('sets user state when identifying', () => {
         given('identity', () => 'calls capture when identity changes')
         given('oldIdentity', () => 'oldIdentity')

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1075,7 +1075,7 @@ export class PostHog {
         }
 
         const deviceIdMarksForIdentify = !this.get_property('$device_id')
-        const isKnownAnonymous = this.persistence.get_user_state() === 'anonymous'
+        const isKnownAnonymous = this.persistence.get_user_state() !== 'identified'
 
         // send an $identify event any time the distinct_id is changing and the old ID is an anoymous ID
         // - logic on the server will determine whether or not to do anything with it.

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1031,6 +1031,7 @@ export class PostHog {
      * they will appear to be a new user.
      *
      * Users are marked as 'identified' when an $identify event is sent to posthog.
+     * See https://github.com/PostHog/posthog-js/issues/512 for more context.
      *
      * This means if (in a single browser "session") you call
      *

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -412,7 +412,7 @@ export class PostHog {
         if (!this.get_distinct_id()) {
             // There is no need to set the distinct id
             // or the device id if something was already stored
-            // in the persitence
+            // in the persistence
             const uuid = this.get_config('get_device_id')(_UUID())
             this.register_once(
                 {
@@ -421,8 +421,6 @@ export class PostHog {
                 },
                 ''
             )
-            // distinct id == $device_id is a proxy for anonymous user
-            this.persistence.set_user_state('anonymous')
         }
         // Set up event handler for pageleave
         // Use `onpagehide` if available, see https://calendar.perfplanet.com/2020/beaconing-in-practice/#beaconing-reliability-avoiding-abandons
@@ -1011,12 +1009,18 @@ export class PostHog {
      * then unique visitors will be identified by a UUID generated
      * the first time they visit the site.
      *
+     * Usually `identify` is called after successful login, and `reset` is called on logout.
+     *
      * If user properties are passed, they are also sent to posthog.
      *
      * ### Usage:
      *
+     *      // set the user's unique id
      *      posthog.identify('[user unique id]')
+     *      // set the user's unique id and set the user's properties
      *      posthog.identify('[user unique id]', { email: 'john@example.com' })
+     *      // set the user's unique id and set the user's properties
+     *      // and set the user's referral code _if it hasn't already been set_
      *      posthog.identify('[user unique id]', {}, { referral_code: '12345' })
      *
      * ### Notes:
@@ -1025,6 +1029,25 @@ export class PostHog {
      * unique ID for the current user. PostHog cannot translate
      * between IDs at this time, so when you change a user's ID
      * they will appear to be a new user.
+     *
+     * Users are marked as 'identified' when an $identify event is sent to posthog.
+     *
+     * This means if (in a single browser "session") you call
+     *
+     * identify('a') => capture('event 1') => identify('b') => capture('event 2')
+     *
+     * event 1 is linked to person a, and event 2 is linked to person b.
+     * person a and person b are not merged
+     *
+     * Users are marked as 'anonymous' when reset is called and in some cases on init.
+     *
+     * This means if (in a single browser "session") you call
+     *
+     * identify('a') => capture('event 1') => reset() => capture('event 2') => identify('b') => capture('event 3')
+     *
+     * person a and person b are merged, and event 1, 2, and event 3 are linked to person b.
+     *
+     * If you need more control over how users are merged, you can use the alias method.
      *
      * When used alone, posthog.identify will change the user's
      * distinct_id to the unique ID provided. When used in tandem
@@ -1037,6 +1060,11 @@ export class PostHog {
      * at the same time can cause a race condition, so it is best
      * practice to call identify on the original, anonymous ID
      * right after you've aliased it.
+     *
+     * A user can be initalised as identified by segment or posthog boostrap
+     * in that case we mark them as 'identified' and don't capture an $identify event
+     * That happens in init so we should not be able to capture any "anonymous" events
+     * before we call identify. So an $identify event is not necessary.
      *
      * @param {String} [new_distinct_id] A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.
      * @param {Object} [userPropertiesToSet] Optional: An associative array of properties to store about the user
@@ -1074,8 +1102,11 @@ export class PostHog {
             this.register({ distinct_id: new_distinct_id })
         }
 
+        // Historically, both device id being absent or distinct ID == device ID
+        // were a proxy for "anonymous" users.
+        // We now explicitly mark users as anonymous until they are identified.
         const deviceIdMarksForIdentify = !this.get_property('$device_id')
-        const isKnownAnonymous = this.persistence.get_user_state() !== 'identified'
+        const isKnownAnonymous = this.persistence.get_user_state() == 'anonymous'
 
         // send an $identify event any time the distinct_id is changing and the old ID is an anoymous ID
         // - logic on the server will determine whether or not to do anything with it.

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -54,7 +54,7 @@ export class PostHogPersistence {
     expire_days: number | undefined
     default_expiry: number | undefined
     cross_subdomain: boolean | undefined
-    user_state: 'anonymous' | 'identified' | undefined
+    user_state: 'anonymous' | 'identified'
 
     constructor(config: PostHogConfig) {
         // clean chars that aren't accepted by the http spec for cookie values
@@ -89,7 +89,7 @@ export class PostHogPersistence {
             this.storage = cookieStore
         }
 
-        this.user_state = undefined
+        this.user_state = 'anonymous'
 
         this.load()
         this.update_config(config)


### PR DESCRIPTION
## Changes

A person in posthog-js can be in one of three states: undefined, anonymous, and identified

If the person is in the state "identified" (which is always set when $identify is issued) then we don't capture a $identify when it is called

However, on first load the person is "undefined" and we don't capture $identify and so don't merge anonymous events when logging in.

We only call $identify if the person is known "anonymous".

This changes the logic so that we only _skip_ $identify if the user is in the state "identified"

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
