### PR TITLE
fix: correctly persist user state across page loads

### DIFF
--- a/src/__tests__/posthog-persistence.js
+++ b/src/__tests__/posthog-persistence.js
@@ -55,6 +55,25 @@ describe('persistence', () => {
         expect(document.cookie).toEqual('')
     })
 
+    it('should save user state', () => {
+        let lib = new PostHogPersistence({ name: 'bla', persistence: 'cookie' })
+        lib.set_user_state('identified')
+        expect(document.cookie).toEqual('ph__posthog=%7B%22%24user_state%22%3A%22identified%22%7D')
+    })
+
+    it('can load user state', () => {
+        let lib = new PostHogPersistence({ name: 'bla', persistence: 'cookie' })
+        lib.set_user_state('identified')
+        expect(lib.get_user_state()).toEqual('identified')
+    })
+
+    it('has user state as a reserved property key', () => {
+        let lib = new PostHogPersistence({ name: 'bla', persistence: 'cookie' })
+        lib.register({ distinct_id: 'testy', test_prop: 'test_value' })
+        lib.set_user_state('identified')
+        expect(lib.properties()).toEqual({ distinct_id: 'testy', test_prop: 'test_value' })
+    })
+
     it(`should register once LS`, () => {
         let lib = new PostHogPersistence({ name: 'test', persistence: 'localStorage+cookie' })
         lib.register_once({ distinct_id: 'hi', test_prop: 'test_val' })

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -23,6 +23,8 @@ export const SESSION_RECORDING_ENABLED_SERVER_SIDE = '$session_recording_enabled
 export const CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE = '$console_log_recording_enabled_server_side'
 export const SESSION_ID = '$sesid'
 export const ENABLED_FEATURE_FLAGS = '$enabled_feature_flags'
+const USER_STATE = '$user_state'
+
 export const RESERVED_PROPERTIES = [
     SET_QUEUE_KEY,
     SET_ONCE_QUEUE_KEY,
@@ -38,6 +40,7 @@ export const RESERVED_PROPERTIES = [
     SESSION_RECORDING_ENABLED_SERVER_SIDE,
     SESSION_ID,
     ENABLED_FEATURE_FLAGS,
+    USER_STATE,
 ]
 
 /**
@@ -308,11 +311,11 @@ export class PostHogPersistence {
     }
 
     get_user_state(): 'anonymous' | 'identified' | undefined {
-        return this.user_state
+        return this.props[USER_STATE]
     }
 
     set_user_state(state: 'anonymous' | 'identified'): void {
-        this.user_state = state
+        this.props[USER_STATE] = state
         this.save()
     }
 }


### PR DESCRIPTION
## Changes

In #524 I misunderstood how persistence works and all of our tests are in the same page load so didn't see the issue.

On a call with a customer we had some overlapping issues but also saw that when there is a page load between reset and identify we're not holding the correct state. So checking for it is never going to work.

This would be obscured/fixed by #530 which defaults to anonymous unless identified. But I want to get this fix in separately.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
