### PR TITLE
fix: more leniency for envs with 'window' undefined

### DIFF
--- a/src/retry-queue.ts
+++ b/src/retry-queue.ts
@@ -19,7 +19,7 @@ export class RetryQueue extends RequestQueueScaffold {
         this.areWeOnline = true
         this.onXHRError = onXHRError
 
-        if ('onLine' in window.navigator) {
+        if (typeof window !== 'undefined' && 'onLine' in window.navigator) {
             this.areWeOnline = window.navigator.onLine
             window.addEventListener('online', () => {
                 this._handleWeAreNowOnline()

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -89,7 +89,7 @@ export const localStore: PersistentStore = {
         }
 
         let supported = true
-        if (window) {
+        if (typeof window !== 'undefined') {
             try {
                 const key = '__mplssupport__',
                     val = 'xyz'
@@ -236,7 +236,7 @@ export const sessionStore: PersistentStore = {
             return sessionStorageSupported
         }
         sessionStorageSupported = true
-        if (window) {
+        if (typeof window !== 'undefined') {
             try {
                 const key = '__support__',
                     val = 'xyz'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -513,7 +513,7 @@ export const _UUID = (function () {
     }
 
     return function () {
-        const se = (window.screen.height * window.screen.width).toString(16)
+        const se = typeof window !== 'undefined' ? (window.screen.height * window.screen.width).toString(16) : '0'
         return T() + '-' + R() + '-' + UA() + '-' + se + '-' + T()
     }
 })()
@@ -869,20 +869,20 @@ export const _info = {
         return _extend(
             _strip_empty_properties({
                 $os: _info.os(),
-                $browser: _info.browser(userAgent, navigator.vendor, (window as any).opera),
+                $browser: _info.browser(userAgent, navigator.vendor, (win as any).opera),
                 $device: _info.device(userAgent),
                 $device_type: _info.deviceType(userAgent),
             }),
             {
-                $current_url: window.location.href,
-                $host: window.location.host,
-                $pathname: window.location.pathname,
-                $browser_version: _info.browserVersion(userAgent, navigator.vendor, (window as any).opera),
+                $current_url: win?.location.href,
+                $host: win?.location.host,
+                $pathname: win?.location.pathname,
+                $browser_version: _info.browserVersion(userAgent, navigator.vendor, (win as any).opera),
                 $browser_language: _info.browserLanguage(),
-                $screen_height: window.screen.height,
-                $screen_width: window.screen.width,
-                $viewport_height: window.innerHeight,
-                $viewport_width: window.innerWidth,
+                $screen_height: win?.screen.height,
+                $screen_width: win?.screen.width,
+                $viewport_height: win?.innerHeight,
+                $viewport_width: win?.innerWidth,
                 $lib: 'web',
                 $lib_version: Config.LIB_VERSION,
                 $insert_id: Math.random().toString(36).substring(2, 10) + Math.random().toString(36).substring(2, 10),
@@ -895,10 +895,10 @@ export const _info = {
         return _extend(
             _strip_empty_properties({
                 $os: _info.os(),
-                $browser: _info.browser(userAgent, navigator.vendor, (window as any).opera),
+                $browser: _info.browser(userAgent, navigator.vendor, (win as any).opera),
             }),
             {
-                $browser_version: _info.browserVersion(userAgent, navigator.vendor, (window as any).opera),
+                $browser_version: _info.browserVersion(userAgent, navigator.vendor, (win as any).opera),
             }
         )
     },


### PR DESCRIPTION
Hey folks, thank you for all your hard work on PostHog, it makes my life much easier in my projects! 🥰 Thank you for taking the time to help me with this contribution!

## Background

PostHog currently [does advertise](https://posthog.com/docs/integrate/browser-extension) that it can help people to build browser extensions. This is certainly true and works for two out of three "parts" of a [browser extension](https://medium.com/@jonnykalambay/anatomy-of-a-chrome-extension-54b9dd019825) -- content script and popup script.

Things break down unfortunately if someone tried to use it in the last part -- the background script. No docs state otherwise, so I know I'm in the unsupported land. But I hope the support can be extended to background scripts as they are an essential part of the more complex extensions. 

Extension's background scripts are "service workers" (not to be confused with "web workers", see [here](https://stackoverflow.com/a/52256049/3375765) for a TLDR about the difference). They don't have access to some APIs that generally are available to web pages. In particular, they don't have a `window` defined.

So I thought I'd take a stab to see if I can at least make the "core" workflows work by making the `window`-related code more lenient to environments without one. 

## User-facing changes
Based on my testing, this PR is sufficient to make the following work in a "service worker":
- creation of a `PostHog` instance via `posthog.init()`
- event property registration via `PostHog.register()`
- user identification via `PostHog.idenify()`
- publishing events via `PostHog.capture()`
- fetch feature flats via `PostHog.isFeatureEnabled()`

## Changes

Although I don't know all the reasons for it, it is clear that `posthog-js` does make *some* an effort to work in environments without a `window` (example [one](https://github.com/PostHog/posthog-js/blob/ac546fd4ed674e8771f4c28329ac6c91b3e14483/src/utils.ts#L13), [two](https://github.com/PostHog/posthog-js/blob/ac546fd4ed674e8771f4c28329ac6c91b3e14483/src/storage.ts#L92)). But the effort is incomplete - in some places the safety checks are missing while in others they are written in a way that crashes in an environment where there is actually no `window`.

For example, `if (window) { ... }` actually throws an error in this scenario and the "safe" check is `if (typeof window === 'undefined')` (which existing `posthog-js` code does in some places, but not in all).

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
