### PR TITLE
fix: Removed Sentry types from compiled types

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
         "react/dist/*"
     ],
     "dependencies": {
-        "@sentry/types": "7.37.2",
         "fflate": "^0.4.1",
         "rrweb-snapshot": "^1.1.14"
     },
@@ -50,6 +49,7 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.3.0",
         "@rollup/plugin-typescript": "^8.3.3",
+        "@sentry/types": "7.37.2",
         "@types/react-dom": "^18.0.10",
         "@typescript-eslint/eslint-plugin": "^5.30.7",
         "@typescript-eslint/parser": "^5.30.7",

--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -19,8 +19,8 @@
 import { Properties } from '../types'
 import { PostHog } from '../posthog-core'
 
-// NOTE - we can't import from @sentry/types because it's not a dependency of posthog-js
-// Doing so cause clashes everytime sentry package is updated. Instead we implement our own types as a minimal subset of the sentry ones
+// NOTE - we can't import from @sentry/types because it changes frequently and causes clashes
+// We only use a small subset of the types, so we can just define the integration overall and use any for the rest
 
 // import {
 //     Event as _SentryEvent,

--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -15,22 +15,46 @@
  * @param {Number} [projectId] Optional: The Sentry project id, used to send a direct link from PostHog to Sentry
  * @param {string} [prefix] Optional: Url of a self-hosted sentry instance (default: https://sentry.io/organizations/)
  */
-import { Event, EventProcessor, Hub, Integration } from '@sentry/types'
+
 import { Properties } from '../types'
 import { PostHog } from '../posthog-core'
 
-export class SentryIntegration implements Integration {
+// NOTE - we can't import from @sentry/types because it's not a dependency of posthog-js
+// Doing so cause clashes everytime sentry package is updated. Instead we implement our own types as a minimal subset of the sentry ones
+
+// import {
+//     Event as _SentryEvent,
+//     EventProcessor as _SentryEventProcessor,
+//     Hub as _SentryHub,
+//     Integration as _SentryIntegration,
+// } from '@sentry/types'
+
+// Uncomment the above and comment the below to get type checking for development
+
+type _SentryEvent = any
+type _SentryEventProcessor = any
+type _SentryHub = any
+
+interface _SentryIntegration {
+    name: string
+    setupOnce(addGlobalEventProcessor: (callback: _SentryEventProcessor) => void, getCurrentHub: () => _SentryHub): void
+}
+
+export class SentryIntegration implements _SentryIntegration {
     name: string
 
-    setupOnce: (addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub) => void
+    setupOnce: (
+        addGlobalEventProcessor: (callback: _SentryEventProcessor) => void,
+        getCurrentHub: () => _SentryHub
+    ) => void
 
     constructor(_posthog: PostHog, organization?: string, projectId?: number, prefix?: string) {
         // setupOnce gets called by Sentry when it intializes the plugin
         // 'this' is not this: PostHogLib object, but the new class that's created.
         // TODO: refactor to a real class. The types
         this.name = 'posthog-js'
-        this.setupOnce = function (addGlobalEventProcessor: (callback: EventProcessor) => void) {
-            addGlobalEventProcessor((event: Event) => {
+        this.setupOnce = function (addGlobalEventProcessor: (callback: _SentryEventProcessor) => void) {
+            addGlobalEventProcessor((event: _SentryEvent) => {
                 if (event.level !== 'error' || !_posthog.__loaded) return event
                 if (!event.tags) event.tags = {}
                 const host = _posthog.config.ui_host || _posthog.config.api_host


### PR DESCRIPTION
## Changes

We have had multiple compilation issues with people using Sentry due to different types conflicting with the exact package we have.

Given we only use a small subset of the functionality, we can remove the typings from the code and allow them to be lose, only using them when developing.

This isn't perfect as we don't know which versions end up breaking things but feels much better than the constant back and forth of updating the packages everywhere.

Example of this problem here: https://github.com/PostHog/posthog/actions/runs/4232636013/jobs/7352610629

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
