### PR TITLE
chore: no-op change to allow version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,7 @@
     "main": "dist/module.js",
     "module": "dist/es.js",
     "types": "dist/module.d.ts",
-    "files": [
-        "lib/*",
-        "dist/*",
-        "react/dist/*"
-    ],
+    "files": ["lib/*", "dist/*", "react/dist/*"],
     "dependencies": {
         "fflate": "^0.4.1",
         "rrweb-snapshot": "^1.1.14"


### PR DESCRIPTION
## Changes

#541 auto version bump failed because it was a fork. This is a no-op change to bump the version.

See #548 where the formatter had too much fun with the changelog

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
