### PR TITLE
feat: augment autocapture using data attributes

### DIFF
--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -117,31 +117,28 @@ describe('Autocapture system', () => {
             div = document.createElement('div')
             div.className = 'class1 class2 class3          ' // Lots of spaces might mess things up
             div.innerHTML = 'my <span>sweet <i>inner</i></span> text'
-            div.setAttribute('data-ph-augment-autocapture-one-on-the-div', 'one')
-            div.setAttribute('data-ph-augment-autocapture-two-on-the-div', 'two')
-            div.setAttribute('data-ph-augment-autocapture-falsey-on-the-div', '0')
-            div.setAttribute('data-ph-augment-autocapture-false-on-the-div', false)
+            div.setAttribute('data-ph-capture-attribute-one-on-the-div', 'one')
+            div.setAttribute('data-ph-capture-attribute-two-on-the-div', 'two')
+            div.setAttribute('data-ph-capture-attribute-falsey-on-the-div', '0')
+            div.setAttribute('data-ph-capture-attribute-false-on-the-div', false)
 
             input = document.createElement('input')
-            input.setAttribute('data-ph-augment-autocapture-on-the-input', 'is on the input')
+            input.setAttribute('data-ph-capture-attribute-on-the-input', 'is on the input')
             input.value = 'test val'
 
             sensitiveInput = document.createElement('input')
             sensitiveInput.value = 'test val'
-            sensitiveInput.setAttribute(
-                'data-ph-augment-autocapture-on-the-sensitive-input',
-                'is on the sensitive-input'
-            )
+            sensitiveInput.setAttribute('data-ph-capture-attribute-on-the-sensitive-input', 'is on the sensitive-input')
             sensitiveInput.className = 'ph-sensitive'
 
             hidden = document.createElement('div')
             hidden.setAttribute('type', 'hidden')
-            hidden.setAttribute('data-ph-augment-autocapture-on-the-hidden', 'is on the hidden')
+            hidden.setAttribute('data-ph-capture-attribute-on-the-hidden', 'is on the hidden')
             hidden.value = 'hidden val'
 
             password = document.createElement('div')
             password.setAttribute('type', 'password')
-            password.setAttribute('data-ph-augment-autocapture-on-the-password', 'is on the password')
+            password.setAttribute('data-ph-capture-attribute-on-the-password', 'is on the password')
             password.value = 'password val'
 
             const divSibling = document.createElement('div')
@@ -562,9 +559,9 @@ describe('Autocapture system', () => {
             autocapture.init(lib)
 
             const elTarget = document.createElement('img')
-            elTarget.setAttribute('data-ph-augment-autocapture-target-augment', 'the target')
+            elTarget.setAttribute('data-ph-capture-attribute-target-augment', 'the target')
             const elParent = document.createElement('span')
-            elParent.setAttribute('data-ph-augment-autocapture-parent-augment', 'the parent')
+            elParent.setAttribute('data-ph-capture-attribute-parent-augment', 'the parent')
             elParent.appendChild(elTarget)
             const elGrandparent = document.createElement('a')
             elGrandparent.setAttribute('href', 'http://test.com')

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -173,7 +173,7 @@ describe('Autocapture system', () => {
 
         it('should collect augment from input with class "ph-sensitive"', () => {
             const props = autocapture._getAugmentPropertiesFromElement(sensitiveInput)
-            expect(props['on-the-sensitive-input']).toBe('is on the sensitive-input')
+            expect(props['on-the-sensitive-input']).toBeUndefined()
         })
 
         it('should collect augment from the hidden element value', () => {

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -43,13 +43,18 @@ const autocapture = {
     },
 
     _getAugmentPropertiesFromElement: function (elem: Element): Properties {
+        const shouldCaptureEl = shouldCaptureElement(elem)
+        if (!shouldCaptureEl) {
+            return {}
+        }
+
         const props: Properties = {}
 
         _each(elem.attributes, function (attr: Attr) {
             if (attr.name.startsWith('data-ph-augment-autocapture')) {
                 const propertyKey = attr.name.replace('data-ph-augment-autocapture-', '')
                 const propertyValue = attr.value
-                if (propertyKey && propertyValue) {
+                if (propertyKey && propertyValue && shouldCaptureValue(propertyValue)) {
                     props[propertyKey] = propertyValue
                 }
             }
@@ -205,10 +210,8 @@ const autocapture = {
                     )
                 )
 
-                if (shouldCaptureEl) {
-                    const augmentProperties = this._getAugmentPropertiesFromElement(el)
-                    _extend(autocaptureAugmentProperties, augmentProperties)
-                }
+                const augmentProperties = this._getAugmentPropertiesFromElement(el)
+                _extend(autocaptureAugmentProperties, augmentProperties)
             })
 
             if (!instance.get_config('mask_all_text')) {

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -42,6 +42,21 @@ const autocapture = {
         }
     },
 
+    _getAugmentPropertiesFromElement: function (elem: Element): Properties {
+        const props: Properties = {}
+
+        _each(elem.attributes, function (attr: Attr) {
+            if (attr.name.startsWith('data-ph-augment-autocapture')) {
+                const propertyKey = attr.name.replace('data-ph-augment-autocapture-', '')
+                const propertyValue = attr.value
+                if (propertyKey && propertyValue) {
+                    props[propertyKey] = propertyValue
+                }
+            }
+        })
+        return props
+    },
+
     _getPropertiesFromElement: function (elem: Element, maskInputs: boolean, maskText: boolean): Properties {
         const tag_name = elem.tagName.toLowerCase()
         const props: Properties = {
@@ -163,6 +178,7 @@ const autocapture = {
             }
 
             const elementsJson: Properties[] = []
+            const autocaptureAugmentProperties: Properties = {}
             let href,
                 explicitNoCapture = false
             _each(targetElementList, (el) => {
@@ -188,6 +204,11 @@ const autocapture = {
                         instance.get_config('mask_all_text')
                     )
                 )
+
+                if (shouldCaptureEl) {
+                    const augmentProperties = this._getAugmentPropertiesFromElement(el)
+                    _extend(autocaptureAugmentProperties, augmentProperties)
+                }
             })
 
             if (!instance.get_config('mask_all_text')) {
@@ -207,7 +228,8 @@ const autocapture = {
                 {
                     $elements: elementsJson,
                 },
-                this._getCustomProperties(targetElementList)
+                this._getCustomProperties(targetElementList),
+                autocaptureAugmentProperties
             )
 
             instance.capture(eventName, props)

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -51,8 +51,8 @@ const autocapture = {
         const props: Properties = {}
 
         _each(elem.attributes, function (attr: Attr) {
-            if (attr.name.startsWith('data-ph-augment-autocapture')) {
-                const propertyKey = attr.name.replace('data-ph-augment-autocapture-', '')
+            if (attr.name.startsWith('data-ph-capture-attribute')) {
+                const propertyKey = attr.name.replace('data-ph-capture-attribute-', '')
                 const propertyValue = attr.value
                 if (propertyKey && propertyValue && shouldCaptureValue(propertyValue)) {
                     props[propertyKey] = propertyValue


### PR DESCRIPTION
## Changes

When instrumenting the notification button I wanted to know how many unread notifications were visible that (maybe) caused someone to click on the buton.

But to do that I would have had to add a custom event. 

---

Now you can add a data attribute in the format `data-ph-augment-autocapture-property-name` 

So for `<div data-ph-augment-autocapture-property-name="234"></div>` the autocapture event includes  in its properties {property-name: 234}

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
