### PR TITLE
feat(rrweb): implement rrweb2 dynamic loading on decide

### DIFF
--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -122,7 +122,7 @@ describe('SessionRecording', () => {
         })
 
         it('uses client side setting v1 over server side', () => {
-                        given('$session_recording_recorder_version_server_side', () => 'v2')
+            given('$session_recording_recorder_version_server_side', () => 'v2')
             given('recorder_version_client_side', () => 'v1')
             expect(given.subject()).toBe('v1')
         })
@@ -301,7 +301,10 @@ describe('SessionRecording', () => {
             given('$session_recording_recorder_version_server_side', () => 'v2')
             given.sessionRecording.startRecordingIfEnabled()
 
-            expect(loadScript).toHaveBeenCalledWith('https://test.com/static/recorder-v2.js?v=v0.0.1', expect.anything())
+            expect(loadScript).toHaveBeenCalledWith(
+                'https://test.com/static/recorder-v2.js?v=v0.0.1',
+                expect.anything()
+            )
         })
 
         it('do not load recording script again', () => {
@@ -317,7 +320,10 @@ describe('SessionRecording', () => {
             given('$session_recording_recorder_version_server_side', () => 'v2')
             given.sessionRecording.startRecordingIfEnabled()
 
-            expect(loadScript).toHaveBeenCalledWith('https://test.com/static/recorder-v2.js?v=v0.0.1', expect.anything())
+            expect(loadScript).toHaveBeenCalledWith(
+                'https://test.com/static/recorder-v2.js?v=v0.0.1',
+                expect.anything()
+            )
         })
 
         it('loads script after `startCaptureAndTrySendingQueuedSnapshots` if not previously loaded', () => {

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -467,7 +467,7 @@ describe('bootstrapping feature flags', () => {
 })
 
 describe('init()', () => {
-    let windowSpy = jest.spyOn(window, 'window', 'get')
+    jest.spyOn(window, 'window', 'get')
     given('subject', () => () => given.lib._init('posthog', given.config, 'testhog'))
 
     given('overrides', () => ({

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -508,28 +508,40 @@ describe('init()', () => {
         expect(given.overrides._send_request.mock.calls.length).toBe(0) // No outgoing requests
     })
 
-    it('does not set __loaded_recorder flag to true if recording script has not been included', () => {
+    it('does not set __loaded_recorder_version flag if recording script has not been included', () => {
         given('overrides', () => ({
-            __loaded_recorder: false,
+            __loaded_recorder_version: undefined,
         }))
         delete window.rrweb
         window.rrweb = { record: undefined }
         delete window.rrwebRecord
         window.rrwebRecord = undefined
         given.subject()
-        expect(given.lib.__loaded_recorder).toEqual(false)
+        expect(given.lib.__loaded_recorder_version).toEqual(undefined)
     })
 
-    it('set __loaded_recorder flag to true if recording script has been included', () => {
+    it('set __loaded_recorder_version flag to v1 if recording script has been included', () => {
         given('overrides', () => ({
-            __loaded_recorder: false,
+            __loaded_recorder_version: undefined,
         }))
         delete window.rrweb
-        window.rrweb = { record: 'anything' }
+        window.rrweb = { record: 'anything', version: "1.1.3" }
         delete window.rrwebRecord
         window.rrwebRecord = 'is possible'
         given.subject()
-        expect(given.lib.__loaded_recorder).toEqual(true)
+        expect(given.lib.__loaded_recorder_version).toMatch(new RegExp(`^1\.?`)) // start with 1.?.?
+    })
+
+    it('set __loaded_recorder_version flag to v1 if recording script has been included', () => {
+        given('overrides', () => ({
+            __loaded_recorder_version: undefined,
+        }))
+        delete window.rrweb
+        window.rrweb = { record: 'anything', version: "2.0.0-alpha.5" }
+        delete window.rrwebRecord
+        window.rrwebRecord = 'is possible'
+        given.subject()
+        expect(given.lib.__loaded_recorder_version).toMatch(new RegExp(`^2\.?`)) // start with 2.?.?
     })
 
     it('does not load autocapture, feature flags, toolbar, session recording or compression', () => {

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -525,7 +525,7 @@ describe('init()', () => {
             __loaded_recorder_version: undefined,
         }))
         delete window.rrweb
-        window.rrweb = { record: 'anything', version: "1.1.3" }
+        window.rrweb = { record: 'anything', version: '1.1.3' }
         delete window.rrwebRecord
         window.rrwebRecord = 'is possible'
         given.subject()
@@ -537,7 +537,7 @@ describe('init()', () => {
             __loaded_recorder_version: undefined,
         }))
         delete window.rrweb
-        window.rrweb = { record: 'anything', version: "2.0.0-alpha.5" }
+        window.rrweb = { record: 'anything', version: '2.0.0-alpha.5' }
         delete window.rrwebRecord
         window.rrwebRecord = 'is possible'
         given.subject()

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -1,6 +1,7 @@
 import {
     CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE,
     SESSION_RECORDING_ENABLED_SERVER_SIDE,
+    SESSION_RECORDING_RECORDER_VERSION_SERVER_SIDE,
 } from '../posthog-persistence'
 import {
     filterDataURLsFromLargeDataObjects,
@@ -76,12 +77,19 @@ export class SessionRecording {
         return enabled_client_side ?? enabled_server_side
     }
 
+    getRecordingVersion() {
+        const recordingVersion_server_side = this.instance.get_property(SESSION_RECORDING_RECORDER_VERSION_SERVER_SIDE)
+        const recordingVersion_client_side = this.instance.get_config('session_recording')?.recorderVersion
+        return recordingVersion_client_side || recordingVersion_server_side || 'v1'
+    }
+
     afterDecideResponse(response: DecideResponse) {
         this.receivedDecide = true
         if (this.instance.persistence) {
             this.instance.persistence.register({
                 [SESSION_RECORDING_ENABLED_SERVER_SIDE]: !!response['sessionRecording'],
                 [CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE]: response.sessionRecording?.consoleLogRecordingEnabled,
+                [SESSION_RECORDING_RECORDER_VERSION_SERVER_SIDE]: response.sessionRecording?.recorderVersion,
             })
         }
         if (response.sessionRecording?.endpoint) {
@@ -115,16 +123,14 @@ export class SessionRecording {
         if (typeof Object.assign === 'undefined') {
             return
         }
+        // Nested if block ensures we do not switch recorder versions midway through a recording.
         if (!this.captureStarted && !this.instance.get_config('disable_session_recording')) {
-            const userSessionRecordingOptions = this.instance.get_config('session_recording')
-            // Always use the client side setting if given, otherwise use the server side setting
-            this.recorderVersion = userSessionRecordingOptions?.recorderVersion || this.recorderVersion
-            const recorderJS = this.recorderVersion === 'v2' ? 'recorder-v2.js' : 'recorder.js'
-
+            const recorderJS = this.getRecordingVersion() === 'v2' ? 'recorder-v2.js' : 'recorder.js'
             this.captureStarted = true
-            // If recorder.js is already loaded (if array.full.js snippet is used or posthog-js/dist/recorder is imported), don't load script.
-            // Otherwise, remotely import recorder.js from cdn since it hasn't been loaded
-            if (!this.instance.__loaded_recorder) {
+            // If recorder.js is already loaded (if array.full.js snippet is used or posthog-js/dist/recorder is
+            // imported) or matches the requested recorder version, don't load script. Otherwise, remotely import
+            // recorder.js from cdn since it hasn't been loaded.
+            if (this.instance.__loaded_recorder_version !== this.getRecordingVersion()) {
                 loadScript(
                     this.instance.get_config('api_host') + `/static/${recorderJS}?v=${Config.LIB_VERSION}`,
                     this._onScriptLoaded.bind(this)

--- a/src/loader-recorder-v2.ts
+++ b/src/loader-recorder-v2.ts
@@ -12,7 +12,7 @@ import { getRecordConsolePlugin } from 'rrweb2/es/rrweb/packages/rrweb/src/plugi
 
 const win: Window & typeof globalThis = typeof window !== 'undefined' ? window : ({} as typeof window)
 
-;(win as any).rrweb = { record: rrwebRecord, version: version }
+;(win as any).rrweb = { record: rrwebRecord, version }
 ;(win as any).rrwebConsoleRecord = { getRecordConsolePlugin }
 
 export default rrwebRecord

--- a/src/loader-recorder.ts
+++ b/src/loader-recorder.ts
@@ -1,4 +1,4 @@
-import { version } from 'rrweb2/package.json'
+import { version } from 'rrweb/package.json'
 
 // Same as loader-globals.ts except includes rrweb scripts.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -243,7 +243,7 @@ const create_mplib = function (token: string, config?: Partial<PostHogConfig>, n
  */
 export class PostHog {
     __loaded: boolean
-    __loaded_recorder: boolean // flag that checks if recorder.js is loaded already
+    __loaded_recorder_version: "v1" | "v2" | undefined // flag that keeps track of which version of recorder is loaded
     config: PostHogConfig
 
     persistence: PostHogPersistence
@@ -280,7 +280,7 @@ export class PostHog {
         this.__captureHooks = []
         this.__request_queue = []
         this.__loaded = false
-        this.__loaded_recorder = false
+        this.__loaded_recorder_version = undefined
         this.__autocapture = undefined
         this._jsc = function () {} as JSC
         this.people = new PostHogPeople(this)
@@ -358,7 +358,9 @@ export class PostHog {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         if (window?.rrweb?.record || window?.rrwebRecord) {
-            this.__loaded_recorder = true
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            this.__loaded_recorder_version = window?.rrweb?.version
         }
 
         this._captureMetrics = new CaptureMetrics(this.get_config('_capture_metrics'))

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -243,7 +243,7 @@ const create_mplib = function (token: string, config?: Partial<PostHogConfig>, n
  */
 export class PostHog {
     __loaded: boolean
-    __loaded_recorder_version: "v1" | "v2" | undefined // flag that keeps track of which version of recorder is loaded
+    __loaded_recorder_version: 'v1' | 'v2' | undefined // flag that keeps track of which version of recorder is loaded
     config: PostHogConfig
 
     persistence: PostHogPersistence

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -21,6 +21,7 @@ export const CAMPAIGN_IDS_KEY = '__cmpns'
 export const EVENT_TIMERS_KEY = '__timers'
 export const SESSION_RECORDING_ENABLED_SERVER_SIDE = '$session_recording_enabled_server_side'
 export const CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE = '$console_log_recording_enabled_server_side'
+export const SESSION_RECORDING_RECORDER_VERSION_SERVER_SIDE = '$session_recording_recorder_version_server_side' // follows rrweb versioning
 export const SESSION_ID = '$sesid'
 export const ENABLED_FEATURE_FLAGS = '$enabled_feature_flags'
 const USER_STATE = '$user_state'


### PR DESCRIPTION
## Changes

- [x] Add `recordingVersion` config to persistence
- [x] Add logic for determining recording version to use
- [x] Fixed version in loader-recorder bundling scripts

This should be merged in before https://github.com/PostHog/posthog/pull/14333


## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Linked posthog-js to local posthog and tested correct version is loaded

https://user-images.githubusercontent.com/13460330/220994940-2267d598-ee46-4042-8f8d-ebfb9c94178d.mov

