### PR TITLE
chore: try the compressed-size-action GH action

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -1,0 +1,14 @@
+name: Bundled Size
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          build-script: "build-rollup"
+          compression: "none"


### PR DESCRIPTION
## Changes

Adds an action to report bundled size onto PRs

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
