### PR TITLE
feat: allow record canvas

### DIFF
--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -50,7 +50,6 @@ describe('SessionRecording', () => {
         autocapture: false, // Assert that session recording works even if `autocapture = false`
         session_recording: {
             maskAllInputs: false,
-            recordCanvas: true,
             someUnregisteredProp: 'abc',
             recorderVersion: given.recorder_version_client_side,
         },
@@ -236,6 +235,7 @@ describe('SessionRecording', () => {
                 slimDOMOptions: {},
                 collectFonts: false,
                 plugins: [],
+                recordCanvas: false,
                 inlineStylesheet: true,
             })
         })

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -177,6 +177,7 @@ export class SessionRecording {
             slimDOMOptions: {},
             collectFonts: false,
             inlineStylesheet: true,
+            recordCanvas: false,
         }
         // We switched from loading all of rrweb to just the record part, but
         // keep backwards compatibility if someone hasn't upgraded PostHog

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,6 +138,7 @@ export interface SessionRecordingOptions {
     collectFonts?: boolean
     inlineStylesheet?: boolean
     recorderVersion?: 'v1' | 'v2'
+    recordCanvas?: boolean
 }
 
 export enum Compression {


### PR DESCRIPTION
## Changes

Exposes the rrweb option to record canvas elements. False by default.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
