### PR TITLE
fix: spans inside buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `posthog-js` snippet for a website loads static js from the main `PostHog/po
 
 1. Run `PostHog/posthog` locally
 2. Link the `posthog-js` dependency to your local version (see below)
-3. Run `yarn serve` in `posthog-js`. (This ensures `dist/array.js` is being generated)
+3. Run `yarn start` in `posthog-js`. (This ensures `dist/array.js` is being generated)
 4. In your locally running `PostHog/posthog` build, run `yarn copy-scripts`. (This copies the scripts generated in step 3 to the static assets folder for `PostHog/posthog`)
 
 Further, it's a good idea to modify `start-http` script to add development mode: `webpack serve --mode development`, which doesn't minify the resulting js (which you can then read in your browser).
@@ -56,7 +56,7 @@ Run `npm install -g yalc`
 -   In the posthog-js repo
     -   Run `yalc publish`
 -   In the posthog repo
-    -   Run `yalc add posthog-js && pnpm i && pnpm-copy-scripts`
+    -   Run `yalc add posthog-js && pnpm i && pnpm copy-scripts`
 
 #### When making changes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.50.1",
+    "version": "1.50.2",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.50.2",
+    "version": "1.50.1",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/src/__tests__/autocapture-utils.js
+++ b/src/__tests__/autocapture-utils.js
@@ -9,6 +9,7 @@ import {
     loadScript,
     isAngularStyleAttr,
     getNestedSpanText,
+    getDirectAndNestedSpanText,
 } from '../autocapture-utils'
 
 describe(`Autocapture utility functions`, () => {
@@ -378,6 +379,22 @@ describe(`Autocapture utility functions`, () => {
         it('should be safe for non-string attribute names', () => {
             expect(isAngularStyleAttr(1)).toBe(false)
             expect(isAngularStyleAttr(null)).toBe(false)
+        })
+    })
+
+    describe(`getDirectAndNestedSpanText`, () => {
+        it(`should return direct text on the element with no children`, () => {
+            const el = document.createElement(`button`)
+            el.innerHTML = `test`
+            expect(getDirectAndNestedSpanText(el)).toBe('test')
+        })
+        it(`should return the direct text on the el and text from child spans`, () => {
+            const parent = document.createElement(`button`)
+            parent.innerHTML = `test`
+            const child = document.createElement(`span`)
+            child.innerHTML = `test 1`
+            parent.appendChild(child)
+            expect(getDirectAndNestedSpanText(parent)).toBe('test test 1')
         })
     })
 

--- a/src/__tests__/autocapture-utils.js
+++ b/src/__tests__/autocapture-utils.js
@@ -8,6 +8,7 @@ import {
     shouldCaptureValue,
     loadScript,
     isAngularStyleAttr,
+    getNestedSpanText,
 } from '../autocapture-utils'
 
 describe(`Autocapture utility functions`, () => {
@@ -377,6 +378,34 @@ describe(`Autocapture utility functions`, () => {
         it('should be safe for non-string attribute names', () => {
             expect(isAngularStyleAttr(1)).toBe(false)
             expect(isAngularStyleAttr(null)).toBe(false)
+        })
+    })
+
+    describe(`getNestedSpanText`, () => {
+        it(`should return an empty string if there are no children or text`, () => {
+            const el = document.createElement(`button`)
+            expect(getNestedSpanText(el)).toBe('')
+        })
+        it(`should return the text from sibling child spans`, () => {
+            const parent = document.createElement(`button`)
+            const child1 = document.createElement(`span`)
+            child1.innerHTML = `test`
+            parent.appendChild(child1)
+            expect(getNestedSpanText(parent)).toBe('test')
+            const child2 = document.createElement(`span`)
+            child2.innerHTML = `test2`
+            parent.appendChild(child2)
+            expect(getNestedSpanText(parent)).toBe('test test2')
+        })
+        it(`should return the text from nested child spans`, () => {
+            const parent = document.createElement(`button`)
+            const child1 = document.createElement(`span`)
+            child1.innerHTML = `test`
+            parent.appendChild(child1)
+            const child2 = document.createElement(`span`)
+            child2.innerHTML = `test2`
+            child1.appendChild(child2)
+            expect(getNestedSpanText(parent)).toBe('test test2')
         })
     })
 })

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -316,3 +316,31 @@ export function loadScript(scriptUrlToLoad: string, callback: (event: Event) => 
         document.body.appendChild(scriptTag)
     }
 }
+
+/*
+ * Iterate through children of a target element looking for span tags
+ * and return the text content of the span tags, separated by spaces
+ * @param {Element} target - element to check
+ * @returns {string} text content of span tags
+ */
+export function getNestedSpanText(target: Element): string {
+    let text = ''
+    if (target.children.length > 0) {
+        const children = target.children
+        for (const child of children) {
+            if (child && child.nodeType === 1 && child.tagName.toLowerCase() === 'span') {
+                const spanText = getSafeText(child)
+                if (shouldCaptureValue(spanText)) {
+                    text = `${
+                        // if there is already text on the element, add a space
+                        text !== '' ? ' ' : ''
+                    }${spanText}`
+                }
+                if (child.children.length > 0) {
+                    text = `${text}${getNestedSpanText(child)}`
+                }
+            }
+        }
+    }
+    return text
+}

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -319,6 +319,19 @@ export function loadScript(scriptUrlToLoad: string, callback: (event: Event) => 
 
 /*
  * Iterate through children of a target element looking for span tags
+ * and return the text content of the span tags, separated by spaces,
+ * along with the direct text content of the target element
+ * @param {Element} target - element to check
+ * @returns {string} text content of the target element and its child span tags
+ */
+export function getDirectAndNestedSpanText(target: Element): string {
+    let text = getSafeText(target)
+    text = concatenateStringsWithSpace(text, getNestedSpanText(target))
+    return shouldCaptureValue(text) ? text : ''
+}
+
+/*
+ * Iterate through children of a target element looking for span tags
  * and return the text content of the span tags, separated by spaces
  * @param {Element} target - element to check
  * @returns {string} text content of span tags
@@ -329,15 +342,21 @@ export function getNestedSpanText(target: Element): string {
         if (child && child.nodeType === 1 && child.tagName.toLowerCase() === 'span') {
             const spanText = getSafeText(child)
             if (shouldCaptureValue(spanText)) {
-                text += `${
-                    // if there is already text on the element, add a space
-                    text !== '' ? ' ' : ''
-                }${spanText}`
+                text = concatenateStringsWithSpace(text, spanText)
             }
             if (child.children.length > 0) {
-                text += `${text && ' '}${getNestedSpanText(child)}`
+                text = concatenateStringsWithSpace(text, getNestedSpanText(child))
             }
         }
     }
     return text
+}
+
+/*
+ * Take a list of strings and join them with spaces, filtering out empty strings
+ * @param {strings} [] - strings to join
+ * @returns {string} - joined strings
+ */
+export function concatenateStringsWithSpace(...strings: string[]): string {
+    return strings.filter((string) => string).join(' ')
 }

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -326,7 +326,7 @@ export function loadScript(scriptUrlToLoad: string, callback: (event: Event) => 
  */
 export function getDirectAndNestedSpanText(target: Element): string {
     let text = getSafeText(target)
-    text = concatenateStringsWithSpace(text, getNestedSpanText(target))
+    text = concatenateStringsWithSpace([text, getNestedSpanText(target)])
     return shouldCaptureValue(text) ? text : ''
 }
 
@@ -342,10 +342,10 @@ export function getNestedSpanText(target: Element): string {
         if (child && child.nodeType === 1 && child.tagName.toLowerCase() === 'span') {
             const spanText = getSafeText(child)
             if (shouldCaptureValue(spanText)) {
-                text = concatenateStringsWithSpace(text, spanText)
+                text = concatenateStringsWithSpace([text, spanText])
             }
             if (child.children.length > 0) {
-                text = concatenateStringsWithSpace(text, getNestedSpanText(child))
+                text = concatenateStringsWithSpace([text, getNestedSpanText(child)])
             }
         }
     }
@@ -357,6 +357,6 @@ export function getNestedSpanText(target: Element): string {
  * @param {strings} [] - strings to join
  * @returns {string} - joined strings
  */
-export function concatenateStringsWithSpace(...strings: string[]): string {
+export function concatenateStringsWithSpace(strings: string[]): string {
     return strings.filter((string) => string).join(' ')
 }

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -325,20 +325,17 @@ export function loadScript(scriptUrlToLoad: string, callback: (event: Event) => 
  */
 export function getNestedSpanText(target: Element): string {
     let text = ''
-    if (target.children.length > 0) {
-        const children = target.children
-        for (const child of children) {
-            if (child && child.nodeType === 1 && child.tagName.toLowerCase() === 'span') {
-                const spanText = getSafeText(child)
-                if (shouldCaptureValue(spanText)) {
-                    text += `${
-                        // if there is already text on the element, add a space
-                        text !== '' ? ' ' : ''
-                    }${spanText}`
-                }
-                if (child.children.length > 0) {
-                    text += `${text && ' '}${getNestedSpanText(child)}`
-                }
+    for (const child of target?.children || []) {
+        if (child && child.nodeType === 1 && child.tagName.toLowerCase() === 'span') {
+            const spanText = getSafeText(child)
+            if (shouldCaptureValue(spanText)) {
+                text += `${
+                    // if there is already text on the element, add a space
+                    text !== '' ? ' ' : ''
+                }${spanText}`
+            }
+            if (child.children.length > 0) {
+                text += `${text && ' '}${getNestedSpanText(child)}`
             }
         }
     }

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -331,13 +331,13 @@ export function getNestedSpanText(target: Element): string {
             if (child && child.nodeType === 1 && child.tagName.toLowerCase() === 'span') {
                 const spanText = getSafeText(child)
                 if (shouldCaptureValue(spanText)) {
-                    text = `${
+                    text += `${
                         // if there is already text on the element, add a space
                         text !== '' ? ' ' : ''
                     }${spanText}`
                 }
                 if (child.children.length > 0) {
-                    text = `${text}${getNestedSpanText(child)}`
+                    text += `${text && ' '}${getNestedSpanText(child)}`
                 }
             }
         }

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -338,14 +338,16 @@ export function getDirectAndNestedSpanText(target: Element): string {
  */
 export function getNestedSpanText(target: Element): string {
     let text = ''
-    for (const child of target?.children || []) {
-        if (child && child.nodeType === 1 && child.tagName.toLowerCase() === 'span') {
-            const spanText = getSafeText(child)
-            if (shouldCaptureValue(spanText)) {
-                text = concatenateStringsWithSpace([text, spanText])
-            }
-            if (child.children.length > 0) {
-                text = concatenateStringsWithSpace([text, getNestedSpanText(child)])
+    if (target.children?.length > 0) {
+        for (const child of target?.children) {
+            if (child && child.nodeType === 1 && child.tagName.toLowerCase() === 'span') {
+                const spanText = getSafeText(child)
+                if (shouldCaptureValue(spanText)) {
+                    text = concatenateStringsWithSpace([text, spanText])
+                }
+                if (child.children.length > 0) {
+                    text = concatenateStringsWithSpace([text, getNestedSpanText(child)])
+                }
             }
         }
     }
@@ -358,5 +360,5 @@ export function getNestedSpanText(target: Element): string {
  * @returns {string} - joined strings
  */
 export function concatenateStringsWithSpace(strings: string[]): string {
-    return strings.filter((string) => string).join(' ')
+    return strings.filter((s) => s).join(' ')
 }

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -339,7 +339,7 @@ export function getDirectAndNestedSpanText(target: Element): string {
 export function getNestedSpanText(target: Element): string {
     let text = ''
     if (target.children?.length > 0) {
-        for (const child of target?.children) {
+        for (const child of target.children) {
             if (child && child.nodeType === 1 && child.tagName.toLowerCase() === 'span') {
                 const spanText = getSafeText(child)
                 if (shouldCaptureValue(spanText)) {

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -22,6 +22,7 @@ import {
     autocaptureCompatibleElements,
     isAngularStyleAttr,
     isDocumentFragment,
+    getNestedSpanText,
 } from './autocapture-utils'
 import RageClick from './extensions/rageclick'
 import { AutocaptureConfig, AutoCaptureCustomProperty, DecideResponse, Properties } from './types'
@@ -216,6 +217,15 @@ const autocapture = {
 
             if (!instance.get_config('mask_all_text')) {
                 elementsJson[0]['$el_text'] = getSafeText(target)
+                // if the element is a button or anchor tag, and if there is no direct text on it,
+                // get the span text from any children and include it as the text
+                // property on the parent element
+                if (
+                    !elementsJson[0]['$el_text'] &&
+                    (target.tagName.toLowerCase() === 'a' || target.tagName.toLowerCase() === 'button')
+                ) {
+                    elementsJson[0]['$el_text'] = getNestedSpanText(target)
+                }
             }
 
             if (href) {

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -22,7 +22,7 @@ import {
     autocaptureCompatibleElements,
     isAngularStyleAttr,
     isDocumentFragment,
-    getNestedSpanText,
+    getDirectAndNestedSpanText,
 } from './autocapture-utils'
 import RageClick from './extensions/rageclick'
 import { AutocaptureConfig, AutoCaptureCustomProperty, DecideResponse, Properties } from './types'
@@ -69,7 +69,11 @@ const autocapture = {
             tag_name: tag_name,
         }
         if (autocaptureCompatibleElements.indexOf(tag_name) > -1 && !maskText) {
-            props['$el_text'] = getSafeText(elem)
+            if (elem.tagName.toLowerCase() === 'a' || elem.tagName.toLowerCase() === 'button') {
+                props['$el_text'] = getDirectAndNestedSpanText(elem)
+            } else {
+                props['$el_text'] = getSafeText(elem)
+            }
         }
 
         const classes = getClassName(elem)
@@ -216,14 +220,12 @@ const autocapture = {
             })
 
             if (!instance.get_config('mask_all_text')) {
-                elementsJson[0]['$el_text'] = getSafeText(target)
                 // if the element is a button or anchor tag get the span text from any
                 // children and include it as/with the text property on the parent element
                 if (target.tagName.toLowerCase() === 'a' || target.tagName.toLowerCase() === 'button') {
-                    const additionalText = getNestedSpanText(target)
-                    elementsJson[0]['$el_text'] += `${
-                        elementsJson[0]['$el_text'] && additionalText && ' '
-                    }${additionalText}`
+                    elementsJson[0]['$el_text'] = getDirectAndNestedSpanText(target)
+                } else {
+                    elementsJson[0]['$el_text'] = getSafeText(target)
                 }
             }
 

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -217,14 +217,13 @@ const autocapture = {
 
             if (!instance.get_config('mask_all_text')) {
                 elementsJson[0]['$el_text'] = getSafeText(target)
-                // if the element is a button or anchor tag, and if there is no direct text on it,
-                // get the span text from any children and include it as the text
-                // property on the parent element
-                if (
-                    !elementsJson[0]['$el_text'] &&
-                    (target.tagName.toLowerCase() === 'a' || target.tagName.toLowerCase() === 'button')
-                ) {
-                    elementsJson[0]['$el_text'] = getNestedSpanText(target)
+                // if the element is a button or anchor tag get the span text from any
+                // children and include it as/with the text property on the parent element
+                if (target.tagName.toLowerCase() === 'a' || target.tagName.toLowerCase() === 'button') {
+                    const additionalText = getNestedSpanText(target)
+                    elementsJson[0]['$el_text'] += `${
+                        elementsJson[0]['$el_text'] && additionalText && ' '
+                    }${additionalText}`
                 }
             }
 


### PR DESCRIPTION
## Changes

Fixes https://github.com/PostHog/posthog/issues/14387

If an anchor or button element had its text nested inside a `<span>` (eg `<button href="#"><span>Some Text</span></button>` then autocapture would not assign that text to the button when the button click was captured. So if in the example there, someone clicked on the button element but not directly on the span (because padding or something) then it would capture the button click, but someone's action for `autocapture text contains Some Text` would _not_ get triggered.

With this change we now iterate through any children inside `a` and `button` elements, looking for `span`s, pull the text out of those spans, and assign them to the button text property.

❓ I'm not sure how impactful this change will be... I believe that this would be the expected behavior for autocapture, but it's possible that it could mess up some peoples' metrics.... How should we go about deciding how to release this?

...

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
