### PR TITLE
fix: remove warning of duplicate nextjs import

### DIFF
--- a/react/src/context/PostHogProvider.tsx
+++ b/react/src/context/PostHogProvider.tsx
@@ -31,13 +31,6 @@ export function PostHogProvider({
             )
         }
 
-        if (posthog) {
-            console.warn(
-                'This provider has already been initialized. You should only initialize it once at the root of your app.'
-            )
-            return
-        }
-
         if (client) {
             setPosthog(client)
         } else if (apiKey) {

--- a/react/src/context/PostHogProvider.tsx
+++ b/react/src/context/PostHogProvider.tsx
@@ -31,6 +31,10 @@ export function PostHogProvider({
             )
         }
 
+        if (posthog) {
+            return
+        }
+
         if (client) {
             setPosthog(client)
         } else if (apiKey) {


### PR DESCRIPTION
Removes warning of duplicate posthog import, as this occurs normally when using react strict mode
