### PR TITLE
fix: Race condition error with loading rrweb

### DIFF
--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -17,7 +17,7 @@ import type { record } from 'rrweb/typings'
 import type { eventWithTime, listenerHandler, pluginEvent, recordOptions } from 'rrweb/typings/types'
 import { loadScript } from '../autocapture-utils'
 import Config from '../config'
-import { logger } from 'utils'
+import { logger } from '../utils'
 
 const BASE_ENDPOINT = '/e/'
 

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -200,7 +200,14 @@ export class SessionRecording {
             }
         }
 
-        this.stopRrweb = this.rrwebRecord?.({
+        if (!this.rrwebRecord) {
+            console.warn(
+                'onScriptLoaded was called but rrwebRecord is not available. This indicates something has gone wrong.'
+            )
+            return
+        }
+
+        this.stopRrweb = this.rrwebRecord({
             emit: (event) => {
                 event = truncateLargeConsoleLogs(
                     filterDataURLsFromLargeDataObjects(event) as pluginEvent<{ payload: string[] }>
@@ -234,7 +241,7 @@ export class SessionRecording {
         //   Dropping the initial event is fine (it's always captured by rrweb).
         this.instance._addCaptureHook((eventName) => {
             if (eventName === '$pageview') {
-                this.rrwebRecord?.addCustomEvent('$pageview', { href: window.location.href })
+                this.rrwebRecord.addCustomEvent('$pageview', { href: window.location.href })
             }
         })
     }

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -123,19 +123,25 @@ export class SessionRecording {
         if (typeof Object.assign === 'undefined') {
             return
         }
-        // Nested if block ensures we do not switch recorder versions midway through a recording.
-        if (!this.captureStarted && !this.instance.get_config('disable_session_recording')) {
-            const recorderJS = this.getRecordingVersion() === 'v2' ? 'recorder-v2.js' : 'recorder.js'
-            this.captureStarted = true
-            // If recorder.js is already loaded (if array.full.js snippet is used or posthog-js/dist/recorder is
-            // imported) or matches the requested recorder version, don't load script. Otherwise, remotely import
-            // recorder.js from cdn since it hasn't been loaded.
-            if (this.instance.__loaded_recorder_version !== this.getRecordingVersion()) {
-                loadScript(
-                    this.instance.get_config('api_host') + `/static/${recorderJS}?v=${Config.LIB_VERSION}`,
-                    this._onScriptLoaded.bind(this)
-                )
-            }
+
+        // We do not switch recorder versions midway through a recording.
+        if (this.captureStarted || this.instance.get_config('disable_session_recording')) {
+            return
+        }
+
+        this.captureStarted = true
+
+        const recorderJS = this.getRecordingVersion() === 'v2' ? 'recorder-v2.js' : 'recorder.js'
+
+        // If recorder.js is already loaded (if array.full.js snippet is used or posthog-js/dist/recorder is
+        // imported) or matches the requested recorder version, don't load script. Otherwise, remotely import
+        // recorder.js from cdn since it hasn't been loaded.
+        if (this.instance.__loaded_recorder_version !== this.getRecordingVersion()) {
+            loadScript(
+                this.instance.get_config('api_host') + `/static/${recorderJS}?v=${Config.LIB_VERSION}`,
+                this._onScriptLoaded.bind(this)
+            )
+        } else {
             this._onScriptLoaded()
         }
     }

--- a/src/loader-recorder-v2.ts
+++ b/src/loader-recorder-v2.ts
@@ -12,7 +12,7 @@ import { getRecordConsolePlugin } from 'rrweb2/es/rrweb/packages/rrweb/src/plugi
 
 const win: Window & typeof globalThis = typeof window !== 'undefined' ? window : ({} as typeof window)
 
-;(win as any).rrweb = { record: rrwebRecord, version }
+;(win as any).rrweb = { record: rrwebRecord, version: 'v2', rrwebVersion: version }
 ;(win as any).rrwebConsoleRecord = { getRecordConsolePlugin }
 
 export default rrwebRecord

--- a/src/loader-recorder.ts
+++ b/src/loader-recorder.ts
@@ -12,7 +12,7 @@ import { getRecordConsolePlugin } from 'rrweb/es/rrweb/packages/rrweb/src/plugin
 
 const win: Window & typeof globalThis = typeof window !== 'undefined' ? window : ({} as typeof window)
 
-;(win as any).rrweb = { record: rrwebRecord, version }
+;(win as any).rrweb = { record: rrwebRecord, version: 'v1', rrwebVersion: version }
 ;(win as any).rrwebConsoleRecord = { getRecordConsolePlugin }
 
 export default rrwebRecord


### PR DESCRIPTION
## Changes

We had some different ways of loading recorder.js one of which led to a race condition that loaded it before it was available. This fixes it.

Also wraps the capture hook in a try catch to avoid any major crashes.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
