### PR TITLE
fix: Only call capture snapshot if recording

### DIFF
--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -161,6 +161,7 @@ export class SessionRecording {
 
         // Event types FullSnapshot and Meta mean we're already in the process of sending a full snapshot
         if (
+            this.captureStarted &&
             (this.windowId !== windowId || this.sessionId !== sessionId) &&
             [FULL_SNAPSHOT_EVENT_TYPE, META_EVENT_TYPE].indexOf(event.type) === -1
         ) {


### PR DESCRIPTION
## Changes

We have a call for doing a full snapshot but with rrweb2 this throws an error if called without an active recording.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
