### PR TITLE
fix: debug return empty string on getNestedSpanText

### DIFF
--- a/src/__tests__/autocapture-utils.js
+++ b/src/__tests__/autocapture-utils.js
@@ -394,7 +394,7 @@ describe(`Autocapture utility functions`, () => {
             const child = document.createElement(`span`)
             child.innerHTML = `test 1`
             parent.appendChild(child)
-            expect(getDirectAndNestedSpanText(parent)).toBe('test test 1')
+            // expect(getDirectAndNestedSpanText(parent)).toBe('test test 1')
         })
     })
 
@@ -408,11 +408,12 @@ describe(`Autocapture utility functions`, () => {
             const child1 = document.createElement(`span`)
             child1.innerHTML = `test`
             parent.appendChild(child1)
-            expect(getNestedSpanText(parent)).toBe('test')
+            // expect(getNestedSpanText(parent)).toBe('test')
             const child2 = document.createElement(`span`)
             child2.innerHTML = `test2`
             parent.appendChild(child2)
-            expect(getNestedSpanText(parent)).toBe('test test2')
+            // expect(getNestedSpanText(parent)).toBe('test test2')
+            expect(getNestedSpanText(parent)).toBe('')
         })
         it(`should return the text from nested child spans`, () => {
             const parent = document.createElement(`button`)
@@ -422,7 +423,8 @@ describe(`Autocapture utility functions`, () => {
             const child2 = document.createElement(`span`)
             child2.innerHTML = `test2`
             child1.appendChild(child2)
-            expect(getNestedSpanText(parent)).toBe('test test2')
+            // expect(getNestedSpanText(parent)).toBe('test test2')
+            expect(getNestedSpanText(parent)).toBe('')
         })
     })
 })

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -337,21 +337,23 @@ export function getDirectAndNestedSpanText(target: Element): string {
  * @returns {string} text content of span tags
  */
 export function getNestedSpanText(target: Element): string {
-    let text = ''
-    if (target && target.children?.length > 0) {
-        for (const child of target.children) {
-            if (child && child.nodeType === 1 && child.tagName.toLowerCase() === 'span') {
-                const spanText = getSafeText(child)
-                if (shouldCaptureValue(spanText)) {
-                    text = concatenateStringsWithSpace([text, spanText])
-                }
-                if (child.children.length > 0) {
-                    text = concatenateStringsWithSpace([text, getNestedSpanText(child)])
-                }
-            }
-        }
-    }
-    return text
+    // for temporary debugging, we are just returning an empty string from this function
+    // let text = ''
+    // if (target && target.children?.length > 0) {
+    //     for (const child of target.children) {
+    //         if (child && child.nodeType === 1 && child.tagName.toLowerCase() === 'span') {
+    //             const spanText = getSafeText(child)
+    //             if (shouldCaptureValue(spanText)) {
+    //                 text = concatenateStringsWithSpace([text, spanText])
+    //             }
+    //             if (child.children.length > 0) {
+    //                 text = concatenateStringsWithSpace([text, getNestedSpanText(child)])
+    //             }
+    //         }
+    //     }
+    // }
+    // return texs
+    return ''
 }
 
 /*

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -353,7 +353,7 @@ export function getNestedSpanText(target: Element): string {
     //     }
     // }
     // return texs
-    return ''
+    return target ? '' : ''
 }
 
 /*


### PR DESCRIPTION
## Changes

We have no idea why we're getting errors when augmenting `a` and `button` elements with text from children. So we're gonna try just returning an empty string for the nested span text to see if that stops the errors, which will help us identify the source of the problem.

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
