### PR TITLE
fix: reinstate getNestedSpanText, but with no recursion

### DIFF
--- a/src/__tests__/autocapture-utils.js
+++ b/src/__tests__/autocapture-utils.js
@@ -408,14 +408,14 @@ describe(`Autocapture utility functions`, () => {
             const child1 = document.createElement(`span`)
             child1.innerHTML = `test`
             parent.appendChild(child1)
-            // expect(getNestedSpanText(parent)).toBe('test')
+            expect(getNestedSpanText(parent)).toBe('test')
             const child2 = document.createElement(`span`)
             child2.innerHTML = `test2`
             parent.appendChild(child2)
-            // expect(getNestedSpanText(parent)).toBe('test test2')
-            expect(getNestedSpanText(parent)).toBe('')
+            expect(getNestedSpanText(parent)).toBe('test test2')
         })
         it(`should return the text from nested child spans`, () => {
+            // for debugging, this currently does not go multiple levels deep
             const parent = document.createElement(`button`)
             const child1 = document.createElement(`span`)
             child1.innerHTML = `test`
@@ -424,7 +424,7 @@ describe(`Autocapture utility functions`, () => {
             child2.innerHTML = `test2`
             child1.appendChild(child2)
             // expect(getNestedSpanText(parent)).toBe('test test2')
-            expect(getNestedSpanText(parent)).toBe('')
+            expect(getNestedSpanText(parent)).toBe('test')
         })
     })
 })

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -337,23 +337,21 @@ export function getDirectAndNestedSpanText(target: Element): string {
  * @returns {string} text content of span tags
  */
 export function getNestedSpanText(target: Element): string {
-    // for temporary debugging, we are just returning an empty string from this function
-    // let text = ''
-    // if (target && target.children?.length > 0) {
-    //     for (const child of target.children) {
-    //         if (child && child.nodeType === 1 && child.tagName.toLowerCase() === 'span') {
-    //             const spanText = getSafeText(child)
-    //             if (shouldCaptureValue(spanText)) {
-    //                 text = concatenateStringsWithSpace([text, spanText])
-    //             }
-    //             if (child.children.length > 0) {
-    //                 text = concatenateStringsWithSpace([text, getNestedSpanText(child)])
-    //             }
-    //         }
-    //     }
-    // }
-    // return texs
-    return target ? '' : ''
+    let text = ''
+    if (target && target.children?.length > 0) {
+        for (const child of target.children) {
+            if (child && child.nodeType === 1 && child.tagName?.toLowerCase() === 'span') {
+                const spanText = getSafeText(child)
+                if (shouldCaptureValue(spanText)) {
+                    text = concatenateStringsWithSpace([text, spanText])
+                }
+                // if (child.children.length > 0) {
+                //     text = concatenateStringsWithSpace([text, getNestedSpanText(child)])
+                // }
+            }
+        }
+    }
+    return text
 }
 
 /*


### PR DESCRIPTION
## Changes

Simply returning an empty string from `getNestedSpanText()` stopped the sentry errors. The next most suspicious thing is the recursion, and also a couple missing `?` checks. I've reinstated most of the `getNestedSpanText` function but left out the recursion, so it'll only go one level deep. I've also added some `?` to make sure we're not failing unexpectedly in some places. 

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
