### PR TITLE
fix: debug nested span text (part 2)

### DIFF
--- a/src/__tests__/autocapture-utils.js
+++ b/src/__tests__/autocapture-utils.js
@@ -408,11 +408,13 @@ describe(`Autocapture utility functions`, () => {
             const child1 = document.createElement(`span`)
             child1.innerHTML = `test`
             parent.appendChild(child1)
-            expect(getNestedSpanText(parent)).toBe('test')
+            // expect(getNestedSpanText(parent)).toBe('test')
+            expect(getNestedSpanText(parent)).toBe('')
             const child2 = document.createElement(`span`)
             child2.innerHTML = `test2`
             parent.appendChild(child2)
-            expect(getNestedSpanText(parent)).toBe('test test2')
+            // expect(getNestedSpanText(parent)).toBe('test test2')
+            expect(getNestedSpanText(parent)).toBe('')
         })
         it(`should return the text from nested child spans`, () => {
             // for debugging, this currently does not go multiple levels deep
@@ -424,7 +426,7 @@ describe(`Autocapture utility functions`, () => {
             child2.innerHTML = `test2`
             child1.appendChild(child2)
             // expect(getNestedSpanText(parent)).toBe('test test2')
-            expect(getNestedSpanText(parent)).toBe('test')
+            expect(getNestedSpanText(parent)).toBe('')
         })
     })
 })

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -345,9 +345,9 @@ export function getNestedSpanText(target: Element): string {
                 if (shouldCaptureValue(spanText)) {
                     text = concatenateStringsWithSpace([text, spanText])
                 }
-                // if (child.children.length > 0) {
-                //     text = concatenateStringsWithSpace([text, getNestedSpanText(child)])
-                // }
+                if (child.children.length > 0) {
+                    text = concatenateStringsWithSpace([text, getNestedSpanText(child)])
+                }
             }
         }
     }
@@ -360,5 +360,6 @@ export function getNestedSpanText(target: Element): string {
  * @returns {string} - joined strings
  */
 export function concatenateStringsWithSpace(strings: string[]): string {
-    return strings.filter((s) => s).join(' ')
+    // return strings.filter((s) => s).join(' ')
+    return strings ? '' : ''
 }

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -361,5 +361,5 @@ export function getNestedSpanText(target: Element): string {
  */
 export function concatenateStringsWithSpace(strings: string[]): string {
     // return strings.filter((s) => s).join(' ')
-    return strings ? '' : ''
+    return strings[0]
 }


### PR DESCRIPTION
## Changes

#576 restarted the sentry errors, so it's not the recursion that is the problem but something else with the function. Next suspect is the concatenation function? Maybe if it throws it somehow ejects the element? (I know this doesn't make sense because if it throws it should throw completely but none of this makes sense so 🤷‍♀️ )

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
