### PR TITLE
fix(persistence): set SameSite=None explicitly

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -63,7 +63,7 @@ export const cookieStore: PersistentStore = {
             }
 
             const new_cookie_val =
-                name + '=' + encodeURIComponent(JSON.stringify(value)) + expires + '; path=/' + cdomain + secure
+                name + '=' + encodeURIComponent(JSON.stringify(value)) + expires + '; SameSite=None; path=/' + cdomain + secure
             document.cookie = new_cookie_val
             return new_cookie_val
         } catch (err) {


### PR DESCRIPTION
Recent browser versions default to `Lax`, which means the cookie will
only be sent when being sent to the origin via e.g. a link. We want to
always send the cookie contents.

## Changes

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
