### PR TITLE
chore: added types for PostHog provider `options`

### DIFF
--- a/react/src/context/PostHogProvider.tsx
+++ b/react/src/context/PostHogProvider.tsx
@@ -1,4 +1,4 @@
-import posthogJs from 'posthog-js'
+import posthogJs, { PostHogConfig } from 'posthog-js'
 
 import * as React from 'react'
 
@@ -14,7 +14,7 @@ export function PostHogProvider({
     children?: React.ReactNode
     client?: PostHog | undefined
     apiKey?: string | undefined
-    options?: any | undefined
+    options?: Partial<PostHogConfig> | undefined
 }) {
     const [posthog, setPosthog] = useState<PostHog | undefined>(client)
 
@@ -41,7 +41,7 @@ export function PostHogProvider({
             posthogJs.init(apiKey, options)
             setPosthog(posthogJs)
         }
-    }, [client, apiKey, options])
+    }, [posthog, client, apiKey, options])
 
     return <PostHogContext.Provider value={{ client: posthog }}>{children}</PostHogContext.Provider>
 }


### PR DESCRIPTION
## Changes

Adds the types for the PostHog provider `options` parameter

Also adds `posthog` to the useEffect as otherwise vscode was complaining

Fixes the issue mentioned in https://github.com/PostHog/posthog.com/pull/5489
> options also as not typed currently (type: any). Is it possible to add typesafety to this parameter?

## How did I test this

Ran this locally with the playground and checked that I could see the type signature
