### PR TITLE
fix: Catch fullsnapshot error

### DIFF
--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -165,7 +165,12 @@ export class SessionRecording {
             (this.windowId !== windowId || this.sessionId !== sessionId) &&
             [FULL_SNAPSHOT_EVENT_TYPE, META_EVENT_TYPE].indexOf(event.type) === -1
         ) {
-            this.rrwebRecord?.takeFullSnapshot()
+            try {
+                this.rrwebRecord?.takeFullSnapshot()
+            } catch (e) {
+                // Sometimes a race can occur where the recorder is not fully started yet, so we can't take a full snapshot.
+                logger.error('Error taking full snapshot.', e)
+            }
         }
         this.windowId = windowId
         this.sessionId = sessionId


### PR DESCRIPTION
## Changes

Not sure why this is happening but it seems sometimes the `emit` from rrweb triggers our logic to decide we should do a fullsnapshot which struggles because rrweb isn't "ready". I couldn't reproduce locally but given this is an optimisation of sorts, I decided to just wrap it and log it rather than erroring out and breaking the recording

[Related Sentry error](https://posthog.sentry.io/issues/4005222646/?project=1899813&referrer=slack)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
