### PR TITLE
fix: try/catch the bit that fails in getNestedSpanText so we don't just eject the element

### DIFF
--- a/src/__tests__/autocapture-utils.js
+++ b/src/__tests__/autocapture-utils.js
@@ -394,7 +394,7 @@ describe(`Autocapture utility functions`, () => {
             const child = document.createElement(`span`)
             child.innerHTML = `test 1`
             parent.appendChild(child)
-            // expect(getDirectAndNestedSpanText(parent)).toBe('test test 1')
+            expect(getDirectAndNestedSpanText(parent)).toBe('test test 1')
         })
     })
 
@@ -415,7 +415,6 @@ describe(`Autocapture utility functions`, () => {
             expect(getNestedSpanText(parent)).toBe('test test2')
         })
         it(`should return the text from nested child spans`, () => {
-            // for debugging, this currently does not go multiple levels deep
             const parent = document.createElement(`button`)
             const child1 = document.createElement(`span`)
             child1.innerHTML = `test`

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -341,12 +341,16 @@ export function getNestedSpanText(target: Element): string {
     if (target && target.nodeType === 1 && target.children?.length > 0) {
         for (const child of target.children) {
             if (child && child.nodeType === 1 && child.tagName?.toLowerCase() === 'span') {
-                const spanText = getSafeText(child)
-                if (shouldCaptureValue(spanText)) {
-                    text = concatenateStringsWithSpace([text, spanText])
-                }
-                if (child.children.length > 0) {
-                    text = concatenateStringsWithSpace([text, getNestedSpanText(child)])
+                try {
+                    const spanText = getSafeText(child)
+                    if (shouldCaptureValue(spanText)) {
+                        text = concatenateStringsWithSpace([text, spanText])
+                    }
+                    if (child.children.length > 0) {
+                        text = concatenateStringsWithSpace([text, getNestedSpanText(child)])
+                    }
+                } catch (e) {
+                    console.error(e)
                 }
             }
         }


### PR DESCRIPTION
## Changes

Still [receiving errors](https://posthog.sentry.io/issues/?project=4504038670008320&project=6423401&project=1899813&project=4503944059682816&project=6331159&query=is:unresolved+el_text&statsPeriod=14d) on getNestedSpanText and I'm fully out of ideas. If we just try/catch it will it preserve the element instead of ejecting it?
...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
