### PR TITLE
chore: add ie11 target to babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-    "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+    "presets": ["@babel/preset-env", "@babel/preset-typescript"],
+    "targets": {
+      "ie": "11"
+    }
 }


### PR DESCRIPTION
I was making a change
[here](https://github.com/PostHog/posthog-js/pull/586) to fix a race
condition bug by ensuring we called loaded after we'd registered the
segment plugin, but I used a Promise which is not supported in IE11.

The testcafe test failed for IE11 :partyface: but I would prefer if
these errors are picked up early in the build process.

I've added the browser targets to the babelrc file, which should
hopefully ensure that babel will try to transpile any code that is not
supported by the browsers we support.

I would also love to add something to our typescript config such that
this would have been highlighted in editor, but I'm not sure how to do
that.

Also note that we could probably do with adding the other browser
versions, but I'm not exactly sure how this all works and I'm assuming
that targetting ie11 will cover the other browsers.

## Changes

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
