### PR TITLE
fix: fewer moving parts more like safe text

### DIFF
--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -326,7 +326,7 @@ export function loadScript(scriptUrlToLoad: string, callback: (event: Event) => 
  */
 export function getDirectAndNestedSpanText(target: Element): string {
     let text = getSafeText(target)
-    text = concatenateStringsWithSpace([text, getNestedSpanText(target)])
+    text = `${text} ${getNestedSpanText(target)}`.trim()
     return shouldCaptureValue(text) ? text : ''
 }
 
@@ -338,31 +338,21 @@ export function getDirectAndNestedSpanText(target: Element): string {
  */
 export function getNestedSpanText(target: Element): string {
     let text = ''
-    if (target && target.nodeType === 1 && target.children?.length > 0) {
-        for (const child of target.children) {
-            if (child && child.nodeType === 1 && child.tagName?.toLowerCase() === 'span') {
+    if (target && target.nodeType === 1 && target.childNodes && target.childNodes.length) {
+        _each(target.childNodes, function (child) {
+            if (child && child.tagName?.toLowerCase() === 'span') {
                 try {
                     const spanText = getSafeText(child)
-                    if (shouldCaptureValue(spanText)) {
-                        text = concatenateStringsWithSpace([text, spanText])
-                    }
-                    if (child.children.length > 0) {
-                        text = concatenateStringsWithSpace([text, getNestedSpanText(child)])
+                    text = `${text} ${spanText}`.trim()
+
+                    if (child.childNodes && child.childNodes.length) {
+                        text = `${text} ${getNestedSpanText(child)}`.trim()
                     }
                 } catch (e) {
                     console.error(e)
                 }
             }
-        }
+        })
     }
     return text
-}
-
-/*
- * Take a list of strings and join them with spaces, filtering out empty strings
- * @param {strings} [] - strings to join
- * @returns {string} - joined strings
- */
-export function concatenateStringsWithSpace(strings: string[]): string {
-    return strings.filter((s) => s).join(' ')
 }

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -338,7 +338,7 @@ export function getDirectAndNestedSpanText(target: Element): string {
  */
 export function getNestedSpanText(target: Element): string {
     let text = ''
-    if (target && target.nodeType === 1 && target.childNodes && target.childNodes.length) {
+    if (target && target.childNodes && target.childNodes.length) {
         _each(target.childNodes, function (child) {
             if (child && child.tagName?.toLowerCase() === 'span') {
                 try {

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -78,7 +78,7 @@ const autocapture = {
             tag_name: tag_name,
         }
         if (autocaptureCompatibleElements.indexOf(tag_name) > -1 && !maskText) {
-            if (elem.tagName.toLowerCase() === 'a' || elem.tagName.toLowerCase() === 'button') {
+            if (tag_name.toLowerCase() === 'a' || tag_name.toLowerCase() === 'button') {
                 props['$el_text'] = getDirectAndNestedSpanText(elem)
             } else {
                 props['$el_text'] = getSafeText(elem)


### PR DESCRIPTION
## Changes

I'm waiting for another build to finish and my brain was chewing at this...

I thought I'd try making it more like `getSafeText` and remove as many moving parts as I could think of

It's very much a "poke it with a stick and see what happens change"