### PR TITLE
feat: Added session storage as a persistence type

### DIFF
--- a/src/gdpr-utils.ts
+++ b/src/gdpr-utils.ts
@@ -12,7 +12,7 @@
  */
 
 import { _each, _includes, _isNumber, _isString, window } from './utils'
-import { cookieStore, localStore, localPlusCookieStore } from './storage'
+import { cookieStore, localStore, localPlusCookieStore, sessionStore } from './storage'
 import { GDPROptions, PersistentStore } from './types'
 import { PostHog } from './posthog-core'
 
@@ -112,11 +112,14 @@ export function clearOptInOut(token: string, options: GDPROptions) {
  */
 function _getStorage(options: GDPROptions): PersistentStore {
     options = options || {}
-    if (options.persistenceType === 'localStorage') {
-        return localStore
-    }
-    if (options.persistenceType === 'localStorage+cookie') {
-        return localPlusCookieStore
+
+    switch (options.persistenceType) {
+        case 'localStorage': 
+            return localStore
+        case 'sessionStorage': 
+            return sessionStore
+        case 'localStorage+cookie':
+            return localPlusCookieStore
     }
     return cookieStore
 }

--- a/src/gdpr-utils.ts
+++ b/src/gdpr-utils.ts
@@ -113,14 +113,13 @@ export function clearOptInOut(token: string, options: GDPROptions) {
 function _getStorage(options: GDPROptions): PersistentStore {
     options = options || {}
 
-    if (options.persistenceType === 'localStorage') {
-        return localStore
-    }
-    if (options.persistenceType === 'localStorage+cookie') {
-        return localPlusCookieStore
-    }
-    if (options.persistenceType === 'sessionStorage') {
-        return sessionStore;
+    switch (options.persistenceType) {
+        case 'localStorage':
+            return localStore
+        case 'sessionStorage':
+            return sessionStore
+        case 'localStorage+cookie':
+            return localPlusCookieStore
     }
     return cookieStore
 }

--- a/src/gdpr-utils.ts
+++ b/src/gdpr-utils.ts
@@ -113,13 +113,14 @@ export function clearOptInOut(token: string, options: GDPROptions) {
 function _getStorage(options: GDPROptions): PersistentStore {
     options = options || {}
 
-    switch (options.persistenceType) {
-        case 'localStorage': 
-            return localStore
-        case 'sessionStorage': 
-            return sessionStore
-        case 'localStorage+cookie':
-            return localPlusCookieStore
+    if (options.persistenceType === 'localStorage') {
+        return localStore
+    }
+    if (options.persistenceType === 'localStorage+cookie') {
+        return localPlusCookieStore
+    }
+    if (options.persistenceType === 'sessionStorage') {
+        return sessionStore;
     }
     return cookieStore
 }

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -1,7 +1,7 @@
 /* eslint camelcase: "off" */
 
 import { _each, _extend, _include, _info, _isObject, _isUndefined, _strip_empty_properties, logger } from './utils'
-import { cookieStore, localStore, localPlusCookieStore, memoryStore } from './storage'
+import { cookieStore, localStore, localPlusCookieStore, memoryStore, sessionStore } from './storage'
 import { PersistentStore, PostHogConfig, Properties } from './types'
 
 /*
@@ -86,6 +86,8 @@ export class PostHogPersistence {
         }
         if (storage_type === 'localstorage' && localStore.is_supported()) {
             this.storage = localStore
+        } else if (storage_type === 'sessionstorage' && sessionStore.is_supported()){
+            this.storage = sessionStore
         } else if (storage_type === 'localstorage+cookie' && localPlusCookieStore.is_supported()) {
             this.storage = localPlusCookieStore
         } else if (storage_type === 'memory') {

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -86,7 +86,7 @@ export class PostHogPersistence {
         }
         if (storage_type === 'localstorage' && localStore.is_supported()) {
             this.storage = localStore
-        } else if (storage_type === 'sessionstorage' && sessionStore.is_supported()){
+        } else if (storage_type === 'sessionstorage' && sessionStore.is_supported()) {
             this.storage = sessionStore
         } else if (storage_type === 'localstorage+cookie' && localPlusCookieStore.is_supported()) {
             this.storage = localPlusCookieStore

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,7 @@ export interface PostHogConfig {
     autocapture: boolean | AutocaptureConfig
     rageclick: boolean
     cross_subdomain_cookie: boolean
-    persistence: 'localStorage' | 'cookie' | 'memory' | 'localStorage+cookie'
+    persistence: 'localStorage' | 'cookie' | 'memory' | 'localStorage+cookie' | 'sessionStorage'
     persistence_name: string
     cookie_name: string
     loaded: (posthog_instance: PostHog) => void


### PR DESCRIPTION
## Changes

Added the sessionStorage as a persistence type.

I'm using the already declared store "sessionStore" so I haven't really added much functionality, just made it possible to choose it as a persistence type

We wanted to remove the opt-in/ out status when the user leaves the webpage and I think there might be others who want to do the same.

## TODO
- [x] Update posthog.com docs. PR for updated docs is [Here](https://github.com/PostHog/posthog.com/pull/5607)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
