### PR TITLE
Expose rrweb options to mask text in session recording

### DIFF
--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -230,6 +230,8 @@ describe('SessionRecording', () => {
                 blockClass: 'ph-no-capture',
                 blockSelector: undefined,
                 ignoreClass: 'ph-ignore-input',
+                maskTextClass: 'ph-mask',
+                maskTextSelector: undefined,
                 maskInputOptions: {},
                 maskInputFn: undefined,
                 slimDOMOptions: {},

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -184,6 +184,8 @@ export class SessionRecording {
             blockClass: 'ph-no-capture',
             blockSelector: undefined,
             ignoreClass: 'ph-ignore-input',
+            maskTextClass: 'ph-mask',
+            maskTextSelector: undefined,
             maskAllInputs: true,
             maskInputOptions: {},
             maskInputFn: undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,8 @@ export interface SessionRecordingOptions {
     blockClass?: string | RegExp
     blockSelector?: string | null
     ignoreClass?: string
+    maskTextClass?: string | RegExp
+    maskTextSelector?: string | null
     maskAllInputs?: boolean
     maskInputOptions?: MaskInputOptions
     maskInputFn?: ((text: string) => string) | null


### PR DESCRIPTION
## Changes
PostHog currently supports blocking elements in session recording by using the `ph-no-capture` CSS class. For most cases this is fine, however in some cases it makes more sense to mask the text (eg. `******`) instead of just rendering blank elements in the recording.

This is particularly useful for applications that display financial data. It can be helpful to see the magnitude of the figure but not the exact value of the figure.

This change simply forwards the rrweb text masking options through as an option for users and sets the default text masking class to `ph-mask`.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
