### PR TITLE
fix: Remove flag param from useActiveFeatureFlags

### DIFF
--- a/react/src/hooks/useActiveFeatureFlags.ts
+++ b/react/src/hooks/useActiveFeatureFlags.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { usePostHog } from './usePostHog'
 
-export function useActiveFeatureFlags(flag: string): string[] | undefined {
+export function useActiveFeatureFlags(): string[] | undefined {
     const client = usePostHog()
 
     const [featureFlags, setFeatureFlags] = useState<string[] | undefined>()
@@ -15,7 +15,7 @@ export function useActiveFeatureFlags(flag: string): string[] | undefined {
         return client.onFeatureFlags((flags) => {
             setFeatureFlags(flags)
         })
-    }, [client, flag])
+    }, [client])
 
     return featureFlags
 }


### PR DESCRIPTION
## Changes

Closes: #596

I'm pretty sure this is what we want. This `flag` param has no effect on the returned array and causes type errors in clients.

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
