### PR TITLE
ci: Point out and close stale issues/PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,27 @@
+name: 'Handle stale PRs'
+on:
+    schedule:
+        - cron: '30 9 * * 1-5'
+
+jobs:
+    stale:
+        # Only unleash the stale bot on PostHog/posthog, as there's no POSTHOG_BOT_GITHUB_TOKEN token on forks
+        if: ${{ github.repository == 'PostHog/posthog-js' }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/stale@v6
+              with:
+                  days-before-issue-stale: 730
+                  days-before-issue-close: 14
+                  stale-issue-message: "This issue hasn't seen activity in two years! If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in two weeks."
+                  close-issue-message: "This issue was closed due to lack of activity. Feel free to reopen if it's still relevant."
+                  stale-issue-label: stale
+                  remove-issue-stale-when-updated: true
+                  days-before-pr-stale: 7
+                  days-before-pr-close: 7
+                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in another week."
+                  close-pr-message: "This PR was closed due to lack of activity. Feel free to reopen if it's still relevant."
+                  stale-pr-label: stale
+                  remove-pr-stale-when-updated: true
+                  operations-per-run: 250
+                  repo-token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

Almost all PRs currently open in this repo are over 2 weeks old. In effect, they're braindead. For instance #496 was created almost four months ago, reviewed by a few people, even approved – and then abandoned until a couple weeks ago another customer pointed out the issue that #496 was supposed to solve.

It's not anyone's fault, we just need to be more _disciplined_ about the pull request process on an organizational level.
So this adds tracking of stale issues and PRs, same as already present in https://github.com/PostHog/posthog, which should prevent things from falling through the cracks (or at least make the falling very explicit).