### PR TITLE
feat: Custom campaign param support

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,23 +1,23 @@
 name: TypeScript
 
 on:
-  - pull_request
+    - pull_request
 
 jobs:
-  build:
-    name: Check definitions
-    runs-on: ubuntu-latest
-    steps:
-      # Check out the repository
-      - uses: actions/checkout@v1
+    build:
+        name: Check definitions
+        runs-on: ubuntu-latest
+        steps:
+            # Check out the repository
+            - uses: actions/checkout@v1
 
-      # Install Node.js
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14
+            # Install Node.js
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 14
 
-      # Install your dependencies
-      - run: yarn install
+            # Install your dependencies
+            - run: yarn install
 
-      # Run test
-      - run: tsc -b
+            # Run test
+            - run: yarn tsc -b

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -70,7 +70,7 @@ describe('capture()', () => {
         given('config', () => ({
             property_blacklist: [],
             _onCapture: jest.fn(),
-            store_utm_params: true,
+            store_google: true,
             save_referrer: true,
         }))
 

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -70,7 +70,7 @@ describe('capture()', () => {
         given('config', () => ({
             property_blacklist: [],
             _onCapture: jest.fn(),
-            store_google: true,
+            store_utm_params: true,
             save_referrer: true,
         }))
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -110,7 +110,7 @@ const defaultConfig = (): PostHogConfig => ({
     cookie_name: '',
     loaded: __NOOP,
     store_google: true,
-    custom_utm_params: [],
+    custom_campaign_params: [],
     save_referrer: true,
     test: false,
     verbose: false,

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -110,7 +110,6 @@ const defaultConfig = (): PostHogConfig => ({
     cookie_name: '',
     loaded: __NOOP,
     store_google: true,
-    store_utm_params: true,
     custom_utm_params: [],
     save_referrer: true,
     test: false,
@@ -834,8 +833,7 @@ export class PostHog {
         // update persistence
         this.sessionPersistence.update_search_keyword()
 
-        // Deprecated config option. Only proceed if both are true
-        if (this.get_config('store_utm_params') && this.get_config('store_google')) {
+        if (this.get_config('store_google')) {
             this.sessionPersistence.update_campaign_params()
         }
         if (this.get_config('save_referrer')) {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -110,6 +110,8 @@ const defaultConfig = (): PostHogConfig => ({
     cookie_name: '',
     loaded: __NOOP,
     store_google: true,
+    store_utm_params: true,
+    custom_utm_params: [],
     save_referrer: true,
     test: false,
     verbose: false,
@@ -832,7 +834,8 @@ export class PostHog {
         // update persistence
         this.sessionPersistence.update_search_keyword()
 
-        if (this.get_config('store_google')) {
+        // Deprecated config option. Only proceed if both are true
+        if (this.get_config('store_utm_params') && this.get_config('store_google')) {
             this.sessionPersistence.update_campaign_params()
         }
         if (this.get_config('save_referrer')) {

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -47,6 +47,7 @@ export class PostHogPersistence {
     props: Properties
     storage: PersistentStore
     campaign_params_saved: boolean
+    custom_camaign_params: string[]
     name: string
     disabled: boolean | undefined
     secure: boolean | undefined
@@ -66,6 +67,7 @@ export class PostHogPersistence {
 
         this.props = {}
         this.campaign_params_saved = false
+        this.custom_camaign_params = config['custom_utm_params'] || []
 
         if (config['persistence_name']) {
             this.name = 'ph_' + config['persistence_name']
@@ -221,7 +223,7 @@ export class PostHogPersistence {
 
     update_campaign_params(): void {
         if (!this.campaign_params_saved) {
-            this.register(_info.campaignParams())
+            this.register(_info.campaignParams(this.custom_camaign_params))
             this.campaign_params_saved = true
         }
     }

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -47,7 +47,7 @@ export class PostHogPersistence {
     props: Properties
     storage: PersistentStore
     campaign_params_saved: boolean
-    custom_camaign_params: string[]
+    custom_campaign_params: string[]
     name: string
     disabled: boolean | undefined
     secure: boolean | undefined
@@ -67,7 +67,7 @@ export class PostHogPersistence {
 
         this.props = {}
         this.campaign_params_saved = false
-        this.custom_camaign_params = config['custom_utm_params'] || []
+        this.custom_campaign_params = config['custom_campaign_params'] || []
 
         if (config['persistence_name']) {
             this.name = 'ph_' + config['persistence_name']
@@ -223,7 +223,7 @@ export class PostHogPersistence {
 
     update_campaign_params(): void {
         if (!this.campaign_params_saved) {
-            this.register(_info.campaignParams(this.custom_camaign_params))
+            this.register(_info.campaignParams(this.custom_campaign_params))
             this.campaign_params_saved = true
         }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,7 @@ export interface PostHogConfig {
     cookie_name: string
     loaded: (posthog_instance: PostHog) => void
     store_google: boolean
-    custom_utm_params: string[]
+    custom_campaign_params: string[]
     save_referrer: boolean
     test: boolean
     verbose: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,13 @@ export interface PostHogConfig {
     persistence_name: string
     cookie_name: string
     loaded: (posthog_instance: PostHog) => void
+    /**
+     * @deprecated
+     * use store_utm_params instead
+     */
     store_google: boolean
+    store_utm_params: boolean
+    custom_utm_params: string[]
     save_referrer: boolean
     test: boolean
     verbose: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,12 +58,7 @@ export interface PostHogConfig {
     persistence_name: string
     cookie_name: string
     loaded: (posthog_instance: PostHog) => void
-    /**
-     * @deprecated
-     * use store_utm_params instead
-     */
     store_google: boolean
-    store_utm_params: boolean
     custom_utm_params: string[]
     save_referrer: boolean
     test: boolean

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -661,9 +661,16 @@ export const _register_event = (function () {
 
 export const _info = {
     campaignParams: function (customParams?: string[]): Record<string, any> {
-        const campaign_keywords = 'utm_source utm_medium utm_campaign utm_content utm_term gclid fbclid msclkid'
-            .split(' ')
-            .concat(customParams || [])
+        const campaign_keywords = [
+            'utm_source',
+            'utm_medium',
+            'utm_campaign',
+            'utm_content',
+            'utm_term',
+            'gclid',
+            'fbclid',
+            'msclkid',
+        ].concat(customParams || [])
 
         const params: Record<string, any> = {}
         _each(campaign_keywords, function (kwkey) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -660,10 +660,11 @@ export const _register_event = (function () {
 })()
 
 export const _info = {
-    campaignParams: function (): Record<string, any> {
-        const campaign_keywords = 'utm_source utm_medium utm_campaign utm_content utm_term gclid fbclid msclkid'.split(
-            ' '
-        )
+    campaignParams: function (customParams?: string[]): Record<string, any> {
+        const campaign_keywords = 'utm_source utm_medium utm_campaign utm_content utm_term gclid fbclid msclkid'
+            .split(' ')
+            .concat(customParams || [])
+
         const params: Record<string, any> = {}
         _each(campaign_keywords, function (kwkey) {
             const kw = _getQueryParam(document.URL, kwkey)


### PR DESCRIPTION
## Changes

* Adds support for `custom_utm_params` so that people can specify which params they care about in addition to the standard ones

Related docs change https://github.com/PostHog/posthog.com/pull/5703

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
