### PR TITLE
feat: Add feature preview (un)enrollment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.52.0-alpha.2",
+    "version": "1.52.0-alpha.3",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.51.5",
+    "version": "1.52.0-alpha.0",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.52.0-alpha.4",
+    "version": "1.53.0-alpha.0",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.52.0-alpha.0",
+    "version": "1.52.0-alpha.1",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.52.0-alpha.3",
+    "version": "1.52.0-alpha.4",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.52.0-alpha.1",
+    "version": "1.52.0-alpha.2",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -66,7 +66,7 @@ describe('Payload Compression', () => {
                 debug: true,
                 _prepare_callback: sandbox.spy((callback) => callback),
                 _send_request: sandbox.spy((url, params, options, callback) => {
-                    if (url === 'https://test.com/decide/?v=3') {
+                    if (url === 'https://test.com/decide/?v=4') {
                         callback({ config: { enable_collect_everything: true }, supportedCompression: ['lz64'] })
                     } else {
                         throw new Error('Should not get here')

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -48,7 +48,7 @@ describe('Decide', () => {
             given.subject()
 
             expect(given.posthog._send_request).toHaveBeenCalledWith(
-                'https://test.com/decide/?v=3',
+                'https://test.com/decide/?v=4',
                 {
                     data: _base64Encode(
                         JSON.stringify({

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -350,6 +350,7 @@ describe('parseFeatureFlagDecideResponse', () => {
                 'beta-feature': 300,
                 'alpha-feature-2': 'fake-payload',
             },
+            $feature_previews: [],
         })
     })
 

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -24,7 +24,7 @@ export class Decide {
 
         const encoded_data = _base64Encode(json_data)
         this.instance._send_request(
-            `${this.instance.get_config('api_host')}/decide/?v=3`,
+            `${this.instance.get_config('api_host')}/decide/?v=4`,
             { data: encoded_data, verbose: true },
             { method: 'POST' },
             (response) => this.parseDecideResponse(response as DecideResponse)

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -51,6 +51,7 @@ import {
     XHROptions,
     AutocaptureConfig,
     JsonType,
+    FeaturePreview,
 } from './types'
 import { SentryIntegration } from './extensions/sentry-integration'
 import { createSegmentIntegration } from './extensions/segment-integration'
@@ -1058,8 +1059,14 @@ export class PostHog {
         this.featureFlags.reloadFeatureFlags()
     }
 
+    /** EXPERIMENTAL: Opt the user in or out of a feature preview. */
     updateFeaturePreviewEnrollment(key: string, isEnrolled: boolean): void {
         this.featureFlags.updateFeaturePreviewEnrollment(key, isEnrolled)
+    }
+
+    /** EXPERIMENTAL: Get the list of feature previews. To check enrollment status, use `isFeatureEnabled`. */
+    getFeaturePreviews(): FeaturePreview[] {
+        return this.featureFlags.getFeaturePreviews()
     }
 
     /*

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1058,6 +1058,10 @@ export class PostHog {
         this.featureFlags.reloadFeatureFlags()
     }
 
+    updateFeaturePreviewEnrollment(key: string, isEnrolled: boolean): void {
+        this.featureFlags.updateFeaturePreviewEnrollment(key, isEnrolled)
+    }
+
     /*
      * Register an event listener that runs when feature flags become available or when they change.
      * If there are flags, the listener is called immediately in addition to being called on future changes.

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -223,6 +223,16 @@ export class PostHogFeatureFlags {
         return !!this.getFeatureFlag(key, options)
     }
 
+    updateFeaturePreviewEnrollment(key: string, isEnrolled: boolean): void {
+        this.instance.capture('$feature_enrollment_update', {
+            $feature_flag: key,
+            $feature_enrollment: isEnrolled,
+            $set: {
+                [`$feature_enrollment/${key}`]: isEnrolled,
+            },
+        })
+    }
+
     addFeatureFlagsHandler(handler: FeatureFlagsCallback): void {
         this.featureFlagEventHandlers.push(handler)
     }

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -240,6 +240,7 @@ export class PostHogFeatureFlags {
             [PERSISTENCE_ACTIVE_FEATURE_FLAGS]: Object.keys(newFlags),
             [PERSISTENCE_ENABLED_FEATURE_FLAGS]: newFlags,
         })
+        this._fireFeatureFlagsCallbacks()
     }
 
     getFeaturePreviews(): FeaturePreview[] {
@@ -259,8 +260,7 @@ export class PostHogFeatureFlags {
         const currentFlags = this.getFlagVariants()
         const currentFlagPayloads = this.getFlagPayloads()
         parseFeatureFlagDecideResponse(response, this.instance.persistence, currentFlags, currentFlagPayloads)
-        const { flags, flagVariants } = this._prepareFeatureFlagsForCallbacks()
-        this.featureFlagEventHandlers.forEach((handler) => handler(flags, flagVariants))
+        this._fireFeatureFlagsCallbacks()
     }
 
     /*
@@ -327,5 +327,10 @@ export class PostHogFeatureFlags {
             flags: truthyFlags,
             flagVariants: truthyFlagVariants,
         }
+    }
+
+    _fireFeatureFlagsCallbacks(): void {
+        const { flags, flagVariants } = this._prepareFeatureFlagsForCallbacks()
+        this.featureFlagEventHandlers.forEach((handler) => handler(flags, flagVariants))
     }
 }

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -165,7 +165,7 @@ export class PostHogFeatureFlags {
 
         const encoded_data = _base64Encode(json_data)
         this.instance._send_request(
-            this.instance.get_config('api_host') + '/decide/?v=3',
+            this.instance.get_config('api_host') + '/decide/?v=4',
             { data: encoded_data },
             { method: 'POST' },
             this.instance._prepare_callback((response) => {

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -235,6 +235,11 @@ export class PostHogFeatureFlags {
                 [`$feature_enrollment/${key}`]: isEnrolled,
             },
         })
+        const newFlags = { ...this.getFlagVariants(), [key]: isEnrolled }
+        this.instance.persistence.register({
+            [PERSISTENCE_ACTIVE_FEATURE_FLAGS]: Object.keys(newFlags),
+            [PERSISTENCE_ENABLED_FEATURE_FLAGS]: newFlags,
+        })
     }
 
     getFeaturePreviews(): FeaturePreview[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,7 +190,7 @@ export interface XHRParams extends QueuedRequestData {
 export interface FeaturePreview {
     name: string
     description: string
-    status: 'concept' | 'alpha' | 'closed-beta' | 'open-beta'
+    status: 'concept' | 'alpha' | 'beta'
     imageUrl: string | null
     documentationUrl: string | null
     flagKey: string | null

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,6 +186,16 @@ export interface XHRParams extends QueuedRequestData {
     timeout?: number
 }
 
+/** A feature that isn't publicly available yet. */
+export interface FeaturePreview {
+    name: string
+    description: string
+    status: 'concept' | 'alpha' | 'closed-beta' | 'open-beta'
+    imageUrl: string | null
+    documentationUrl: string | null
+    flagKey: string | null
+}
+
 export interface DecideResponse {
     status: number
     supportedCompression: Compression[]
@@ -195,6 +205,8 @@ export interface DecideResponse {
     custom_properties: AutoCaptureCustomProperty[] // TODO: delete, not sent
     featureFlags: Record<string, string | boolean>
     featureFlagPayloads: Record<string, JsonType>
+    /** Only included in v4 of the endpoint. */
+    featurePreviews?: FeaturePreview[]
     errorsWhileComputingFlags: boolean
     autocapture_opt_out?: boolean
     capturePerformance?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,7 +191,7 @@ export interface FeaturePreview {
     // Sync this with the backend's FeaturePreviewSerializer!
     name: string
     description: string
-    status: 'concept' | 'alpha' | 'beta'
+    stage: 'concept' | 'alpha' | 'beta'
     imageUrl: string | null
     documentationUrl: string | null
     flagKey: string | null

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,8 +186,9 @@ export interface XHRParams extends QueuedRequestData {
     timeout?: number
 }
 
-/** A feature that isn't publicly available yet. */
+/** A feature that isn't publicly available yet.*/
 export interface FeaturePreview {
+    // Sync this with the backend's FeaturePreviewSerializer!
     name: string
     description: string
     status: 'concept' | 'alpha' | 'beta'


### PR DESCRIPTION
## Changes

This adds support for v4 of the decide endpoint, which brings one new feature: https://github.com/PostHog/posthog/pull/14952's feature previews.

Two new methods allow building opt-in lists of beta features: `posthog.getFeaturePreviews()` and `posthog.updateFeaturePreviewEnrollment()`.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
