### PR TITLE
feat: Added buffer for perf events

### DIFF
--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -1,5 +1,4 @@
-// Creates a buffer which has a max size, a flush interval, and a flush callback.
-
+// Creates a buffer which has a max size, a flush interval, and a flush callback. Useful for batching things.
 export interface EventBuffer<T> {
     push: (data: T) => void
     flush: () => void

--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -1,0 +1,41 @@
+// Creates a buffer which has a max size, a flush interval, and a flush callback.
+
+export interface EventBuffer<T> {
+    push: (data: T) => void
+    flush: () => void
+}
+
+export function createEventBuffer<T>(options: {
+    maxDepth: number
+    flushInterval: number
+    callback: (data: T[]) => void
+}): EventBuffer<T> {
+    const { maxDepth, flushInterval, callback } = options
+    let buffer: any[] = []
+    let timeout: ReturnType<typeof setTimeout> | undefined
+
+    const flush = () => {
+        if (buffer.length > 0) {
+            callback(buffer)
+            buffer = []
+        }
+        if (timeout) {
+            clearTimeout(timeout)
+            timeout = undefined
+        }
+    }
+
+    const push = (data: any) => {
+        buffer.push(data)
+        if (buffer.length >= maxDepth) {
+            flush()
+        } else if (!timeout) {
+            timeout = setTimeout(flush, flushInterval)
+        }
+    }
+
+    return {
+        push,
+        flush,
+    }
+}


### PR DESCRIPTION
## Changes
Needs https://github.com/PostHog/posthog/pull/15045

Needs the relevant backend changes first but the idea here is to try and reduce the number of raw events that we are ingesting, especially for perf events that can typically have 100s of things fire all at once on a page load for example.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
