### PR TITLE
fix: Don't enable web perf by default for localhost

### DIFF
--- a/playground/nextjs/pages/_app.tsx
+++ b/playground/nextjs/pages/_app.tsx
@@ -11,6 +11,7 @@ if (typeof window !== 'undefined') {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || '', {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
     })
+    ;(window as any).posthog = posthog
 }
 
 export default function App({ Component, pageProps }: AppProps) {

--- a/src/extensions/web-performance.ts
+++ b/src/extensions/web-performance.ts
@@ -1,4 +1,4 @@
-import { isLocalhost, logger } from 'utils'
+import { isLocalhost, logger } from '../utils'
 import { PostHog } from '../posthog-core'
 import { DecideResponse } from '../types'
 

--- a/src/extensions/web-performance.ts
+++ b/src/extensions/web-performance.ts
@@ -1,3 +1,4 @@
+import { isLocalhost, logger } from 'utils'
 import { PostHog } from '../posthog-core'
 import { DecideResponse } from '../types'
 
@@ -80,6 +81,9 @@ export class WebPerformanceObserver {
     remoteEnabled: boolean | undefined
     observer: PerformanceObserver | undefined
 
+    // Util to help developers working on this feature manually override
+    _forceAllowLocalhost = false
+
     constructor(instance: PostHog) {
         this.instance = instance
     }
@@ -96,6 +100,12 @@ export class WebPerformanceObserver {
         if (this.observer) {
             return
         }
+
+        if (isLocalhost() && !this._forceAllowLocalhost) {
+            logger.log('PostHog Peformance observer not started because we are on localhost.')
+            return
+        }
+
         try {
             this.observer = new PerformanceObserver((list) => {
                 list.getEntries().forEach((entry) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,7 @@ const win: Window & typeof globalThis = typeof window !== 'undefined' ? window :
 const navigator = win.navigator || { userAgent: '' }
 const document = win.document || {}
 const userAgent = navigator.userAgent
+const localDomains = ['localhost', '127.0.0.1']
 
 const nativeForEach = ArrayProto.forEach,
     nativeIndexOf = ArrayProto.indexOf,
@@ -658,6 +659,10 @@ export const _register_event = (function () {
 
     return register_event
 })()
+
+export const isLocalhost = (): boolean => {
+    return localDomains.includes(location.hostname)
+}
 
 export const _info = {
     campaignParams: function (customParams?: string[]): Record<string, any> {


### PR DESCRIPTION
## Changes

Localhost is a noisy environment for perf events due to the nature of web dev frameworks. So we turn it off!

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
