### PR TITLE
feat: Allow masking of input by referencing the element

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "rollup": "^2.77.0",
         "rollup-plugin-dts": "^4.2.2",
         "rrweb": "^1.1.3",
-        "rrweb2": "npm:rrweb@2.0.0-alpha.6",
+        "rrweb2": "npm:rrweb@2.0.0-alpha.8",
         "sinon": "9.0.2",
         "testcafe": "^1.19.0",
         "testcafe-browser-provider-browserstack": "^1.14.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,7 +134,7 @@ export interface SessionRecordingOptions {
     ignoreClass?: string
     maskAllInputs?: boolean
     maskInputOptions?: MaskInputOptions
-    maskInputFn?: ((text: string) => string) | null
+    maskInputFn?: ((text: string, element?: HTMLElement) => string) | null
     slimDOMOptions?: SlimDOMOptions | 'all' | true
     collectFonts?: boolean
     inlineStylesheet?: boolean

--- a/yarn.lock
+++ b/yarn.lock
@@ -3377,12 +3377,12 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@rrweb/types@^2.0.0-alpha.6":
-  version "2.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/@rrweb/types/-/types-2.0.0-alpha.6.tgz#0c880272d455666c57c4180a2b6c818d642aebc7"
-  integrity sha512-c7Adw44pNkNsE9wkBPrONaLS9fq2WtWAMFks9+6SjOLaRv+d6Iu7/6RNBokESHQkvaj1fZ8nPqxT9GjfQ5TMyQ==
+"@rrweb/types@^2.0.0-alpha.8":
+  version "2.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@rrweb/types/-/types-2.0.0-alpha.8.tgz#29a6550dd833364a459af4be4ce3b233003fb78b"
+  integrity sha512-yAr6ZQrgmr7+qZU5DMGqYXnVsolC5epftmZtkOtgFD/bbvCWflNnl09M32hUjttlKCV1ohhmQGioXkCQ37IF7A==
   dependencies:
-    rrweb-snapshot "^2.0.0-alpha.6"
+    rrweb-snapshot "^2.0.0-alpha.8"
 
 "@sentry/types@7.37.2":
   version "7.37.2"
@@ -8970,6 +8970,7 @@ posix-character-classes@^0.1.0:
 
 "posthog-js@link:.":
   version "0.0.0"
+  uid ""
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -9538,36 +9539,36 @@ rollup@^2.77.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
-rrdom@^2.0.0-alpha.6:
-  version "2.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/rrdom/-/rrdom-2.0.0-alpha.6.tgz#80d2efc1afe94ab617622d256375837b19299b9b"
-  integrity sha512-b7eFnFbWQ5/t7abHgioeGPxsYUPj0sSf0yLjX+n1bKkC2zS3NBETdSK1KGMmBdLRgjxpKDh061EVKoA1AG65JQ==
+rrdom@^2.0.0-alpha.8:
+  version "2.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/rrdom/-/rrdom-2.0.0-alpha.8.tgz#d8561ca0b95cae8b8fe14ed29179ddd8fc18a60d"
+  integrity sha512-rUyeS9fSOO6uSxCdeY5bQkKQTPECIgxsOCb/WR7eA/UsVkVpdDOyCV43wxm92V2JOtqMuv+36rUpEDFW+YFjOw==
   dependencies:
-    rrweb-snapshot "^2.0.0-alpha.6"
+    rrweb-snapshot "^2.0.0-alpha.8"
 
 rrweb-snapshot@^1.1.14:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.14.tgz#9d4d9be54a28a893373428ee4393ec7e5bd83fcc"
   integrity sha512-eP5pirNjP5+GewQfcOQY4uBiDnpqxNRc65yKPW0eSoU1XamDfc4M8oqpXGMyUyvLyxFDB0q0+DChuxxiU2FXBQ==
 
-rrweb-snapshot@^2.0.0-alpha.6:
-  version "2.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.6.tgz#c7e7f902312a564d8494d916042e1d9aefe62ce7"
-  integrity sha512-mTeIZn8a6crtHigyO+cSENuKq68ayEdSZJAybkWWVjJQOvDY9EHaqhc8jWXpNkPVcc8M5T8ORc/RXsc52osYHQ==
+rrweb-snapshot@^2.0.0-alpha.8:
+  version "2.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.8.tgz#5f93f8ab7d78b3de26f6a64e993ff68edd54e0cf"
+  integrity sha512-3Rb7c+mnDEADQ8N9qn9SDH5PzCyHlZ1cwZC932qRyt9O8kJWLM11JLYqqEyQCa2FZVQbzH2iAaCgnyM7A32p7A==
 
-"rrweb2@npm:rrweb@2.0.0-alpha.6":
-  version "2.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-2.0.0-alpha.6.tgz#f38e63635747314adf144e1a96c1bbc7b2b90883"
-  integrity sha512-WbgkEB4MIEnD03SBN6lG0HYCQTIUaDo1+dw/nKXhBlqwRip3p/I+lambTv+6SuIGx4f0cdvUWHTKF++4H48DJA==
+"rrweb2@npm:rrweb@2.0.0-alpha.8":
+  version "2.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-2.0.0-alpha.8.tgz#5cd21510fa011dcb21284a43f3f3d467e2985590"
+  integrity sha512-JtJCeUjZ91/qJ6gvLmZw/1Bxuddt06pD887shIYzGhKuOgjtvkUdhBtB5uXrV7Bvi3WELYGZr1stqBugWa9MXg==
   dependencies:
-    "@rrweb/types" "^2.0.0-alpha.6"
+    "@rrweb/types" "^2.0.0-alpha.8"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"
     fflate "^0.4.4"
     mitt "^3.0.0"
-    rrdom "^2.0.0-alpha.6"
-    rrweb-snapshot "^2.0.0-alpha.6"
+    rrdom "^2.0.0-alpha.8"
+    rrweb-snapshot "^2.0.0-alpha.8"
 
 rrweb@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
## Changes

Allows better control of masking an input by having access to the element in question. (brings [this PR](https://github.com/rrweb-io/rrweb/pull/1188/files#diff-185b8ff868973ccd68a879036d1e5f5abcd83ce0a908c833015b204222676214) into support via our SDK.

Updates to rrweb alpha 8

e.g. 

```js
posthog.init("key", {
  session_recording: {
    maskAllInputs: true,
    maskInputFn: (text: string, element: HTMLElement) => {
        // If the element has the attribute "data-unmask-example", we don't mask it
        if (element.hasAttribute('data-unmask-example')) {
            return text;
        }

        return '*'.repeat(text.length);
    }
})
// will NOT mask <input type="text" data-unmask-example />
```
## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
