### PR TITLE
feat(flags): Allow adding person and group property overrides for flags

### DIFF
--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -7,23 +7,25 @@ jest.spyOn(global, 'setTimeout')
 describe('featureflags', () => {
     given('decideEndpointWasHit', () => false)
     given('config', () => ({
-        'token': 'testtoken',
-        'persistence': 'memory',
+        token: 'testtoken',
+        persistence: 'memory',
     })),
-    given('instance', () => ({
-        get_config: jest.fn().mockImplementation((key) => given.config[key]),
-        get_distinct_id: () => 'blah id',
-        getGroups: () => {},
-        _prepare_callback: (callback) => callback,
-        persistence: new PostHogPersistence(given.config),
-        register: (props) => given.instance.persistence.register(props),
-        unregister: (key) => given.instance.persistence.unregister(key),
-        get_property: (key) => given.instance.persistence.props[key],
-        capture: () => {},
-        decideEndpointWasHit: given.decideEndpointWasHit,
-        _send_request: jest.fn().mockImplementation((url, data, headers, callback) => callback(given.decideResponse)),
-        reloadFeatureFlags: () => given.featureFlags.reloadFeatureFlags(),
-    }))
+        given('instance', () => ({
+            get_config: jest.fn().mockImplementation((key) => given.config[key]),
+            get_distinct_id: () => 'blah id',
+            getGroups: () => {},
+            _prepare_callback: (callback) => callback,
+            persistence: new PostHogPersistence(given.config),
+            register: (props) => given.instance.persistence.register(props),
+            unregister: (key) => given.instance.persistence.unregister(key),
+            get_property: (key) => given.instance.persistence.props[key],
+            capture: () => {},
+            decideEndpointWasHit: given.decideEndpointWasHit,
+            _send_request: jest
+                .fn()
+                .mockImplementation((url, data, headers, callback) => callback(given.decideResponse)),
+            reloadFeatureFlags: () => given.featureFlags.reloadFeatureFlags(),
+        }))
 
     given('featureFlags', () => new PostHogFeatureFlags(given.instance))
 
@@ -279,7 +281,7 @@ describe('featureflags', () => {
         })
 
         it('on providing personProperties runs reload automatically', () => {
-            given.featureFlags.personPropertiesForFlags({'a': 'b', c: 'd'})
+            given.featureFlags.personPropertiesForFlags({ a: 'b', c: 'd' })
 
             jest.runAllTimers()
 
@@ -294,7 +296,7 @@ describe('featureflags', () => {
             ).toEqual({
                 token: 'random fake token',
                 distinct_id: 'blah id',
-                person_properties: {'a': 'b', c: 'd'},
+                person_properties: { a: 'b', c: 'd' },
             })
         })
     })
@@ -313,8 +315,8 @@ describe('featureflags', () => {
         }))
 
         it('on providing personProperties updates properties successively', () => {
-            given.featureFlags.personPropertiesForFlags({'a': 'b', c: 'd'})
-            given.featureFlags.personPropertiesForFlags({'x': 'y', c: 'e'})
+            given.featureFlags.personPropertiesForFlags({ a: 'b', c: 'd' })
+            given.featureFlags.personPropertiesForFlags({ x: 'y', c: 'e' })
 
             jest.runAllTimers()
 
@@ -329,32 +331,32 @@ describe('featureflags', () => {
             ).toEqual({
                 token: 'random fake token',
                 distinct_id: 'blah id',
-                person_properties: {'a': 'b', c: 'e', x: 'y'},
+                person_properties: { a: 'b', c: 'e', x: 'y' },
             })
         })
 
         it('doesnt reload flags if explicitly asked not to', () => {
-            given.featureFlags.personPropertiesForFlags({'a': 'b', c: 'd'}, false)
+            given.featureFlags.personPropertiesForFlags({ a: 'b', c: 'd' }, false)
 
             jest.runAllTimers()
 
             // still old flags
             expect(given.featureFlags.getFlagVariants()).toEqual({
-                "alpha-feature-2": true,
-                "beta-feature": true,
-                "disabled-flag": false,
-                "multivariate-flag": "variant-1",
+                'alpha-feature-2': true,
+                'beta-feature': true,
+                'disabled-flag': false,
+                'multivariate-flag': 'variant-1',
             })
 
             expect(given.instance._send_request).not.toHaveBeenCalled()
         })
 
         it('resetPersonProperties resets all properties', () => {
-            given.featureFlags.personPropertiesForFlags({'a': 'b', c: 'd'}, false)
-            given.featureFlags.personPropertiesForFlags({'x': 'y', c: 'e'}, false)
+            given.featureFlags.personPropertiesForFlags({ a: 'b', c: 'd' }, false)
+            given.featureFlags.personPropertiesForFlags({ x: 'y', c: 'e' }, false)
             jest.runAllTimers()
 
-            expect(given.instance.persistence.props.$stored_person_properties).toEqual({'a': 'b', c: 'e', x: 'y'})
+            expect(given.instance.persistence.props.$stored_person_properties).toEqual({ a: 'b', c: 'e', x: 'y' })
 
             given.featureFlags.resetPersonPropertiesForFlags()
             given.featureFlags.reloadFeatureFlags()
@@ -370,11 +372,11 @@ describe('featureflags', () => {
         })
 
         it('on providing groupProperties updates properties successively', () => {
-            given.featureFlags.groupPropertiesForFlags({'orgs': {'a': 'b', c: 'd'}, 'projects': {'x': 'y', c: 'e'}})
+            given.featureFlags.groupPropertiesForFlags({ orgs: { a: 'b', c: 'd' }, projects: { x: 'y', c: 'e' } })
 
             expect(given.instance.persistence.props.$stored_group_properties).toEqual({
-                orgs: {'a': 'b', c: 'd'},
-                projects: {'x': 'y', c: 'e'},
+                orgs: { a: 'b', c: 'd' },
+                projects: { x: 'y', c: 'e' },
             })
 
             jest.runAllTimers()
@@ -390,32 +392,32 @@ describe('featureflags', () => {
             ).toEqual({
                 token: 'random fake token',
                 distinct_id: 'blah id',
-                group_properties: {'orgs': {'a': 'b', c: 'd'}, 'projects': {'x': 'y', c: 'e'}},
+                group_properties: { orgs: { a: 'b', c: 'd' }, projects: { x: 'y', c: 'e' } },
             })
         })
 
         it('handles groupProperties updates', () => {
-            given.featureFlags.groupPropertiesForFlags({'orgs': {'a': 'b', c: 'd'}, 'projects': {'x': 'y', c: 'e'}})
+            given.featureFlags.groupPropertiesForFlags({ orgs: { a: 'b', c: 'd' }, projects: { x: 'y', c: 'e' } })
 
             expect(given.instance.persistence.props.$stored_group_properties).toEqual({
-                orgs: {'a': 'b', c: 'd'},
-                projects: {'x': 'y', c: 'e'},
+                orgs: { a: 'b', c: 'd' },
+                projects: { x: 'y', c: 'e' },
             })
 
-            given.featureFlags.groupPropertiesForFlags({'orgs': {'w': '1'}, 'other': {'z': '2'}})
+            given.featureFlags.groupPropertiesForFlags({ orgs: { w: '1' }, other: { z: '2' } })
 
             expect(given.instance.persistence.props.$stored_group_properties).toEqual({
-                orgs: {'a': 'b', c: 'd', w: '1'},
-                projects: {'x': 'y', c: 'e'},
-                other: {'z': '2'},
+                orgs: { a: 'b', c: 'd', w: '1' },
+                projects: { x: 'y', c: 'e' },
+                other: { z: '2' },
             })
 
             given.featureFlags.resetGroupPropertiesForFlags('orgs')
 
             expect(given.instance.persistence.props.$stored_group_properties).toEqual({
                 orgs: {},
-                projects: {'x': 'y', c: 'e'},
-                other: {'z': '2'},
+                projects: { x: 'y', c: 'e' },
+                other: { z: '2' },
             })
 
             given.featureFlags.resetGroupPropertiesForFlags()
@@ -423,20 +425,19 @@ describe('featureflags', () => {
             expect(given.instance.persistence.props.$stored_group_properties).toEqual(undefined)
 
             jest.runAllTimers()
-
         })
 
         it('doesnt reload group flags if explicitly asked not to', () => {
-            given.featureFlags.groupPropertiesForFlags({'orgs': {'a': 'b', c: 'd'}}, false)
+            given.featureFlags.groupPropertiesForFlags({ orgs: { a: 'b', c: 'd' } }, false)
 
             jest.runAllTimers()
 
             // still old flags
             expect(given.featureFlags.getFlagVariants()).toEqual({
-                "alpha-feature-2": true,
-                "beta-feature": true,
-                "disabled-flag": false,
-                "multivariate-flag": "variant-1",
+                'alpha-feature-2': true,
+                'beta-feature': true,
+                'disabled-flag': false,
+                'multivariate-flag': 'variant-1',
             })
 
             expect(given.instance._send_request).not.toHaveBeenCalled()

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -281,7 +281,7 @@ describe('featureflags', () => {
         })
 
         it('on providing personProperties runs reload automatically', () => {
-            given.featureFlags.personPropertiesForFlags({ a: 'b', c: 'd' })
+            given.featureFlags.setPersonPropertiesForFlags({ a: 'b', c: 'd' })
 
             jest.runAllTimers()
 
@@ -315,8 +315,8 @@ describe('featureflags', () => {
         }))
 
         it('on providing personProperties updates properties successively', () => {
-            given.featureFlags.personPropertiesForFlags({ a: 'b', c: 'd' })
-            given.featureFlags.personPropertiesForFlags({ x: 'y', c: 'e' })
+            given.featureFlags.setPersonPropertiesForFlags({ a: 'b', c: 'd' })
+            given.featureFlags.setPersonPropertiesForFlags({ x: 'y', c: 'e' })
 
             jest.runAllTimers()
 
@@ -336,7 +336,7 @@ describe('featureflags', () => {
         })
 
         it('doesnt reload flags if explicitly asked not to', () => {
-            given.featureFlags.personPropertiesForFlags({ a: 'b', c: 'd' }, false)
+            given.featureFlags.setPersonPropertiesForFlags({ a: 'b', c: 'd' }, false)
 
             jest.runAllTimers()
 
@@ -352,13 +352,13 @@ describe('featureflags', () => {
         })
 
         it('resetPersonProperties resets all properties', () => {
-            given.featureFlags.personPropertiesForFlags({ a: 'b', c: 'd' }, false)
-            given.featureFlags.personPropertiesForFlags({ x: 'y', c: 'e' }, false)
+            given.featureFlags.setPersonPropertiesForFlags({ a: 'b', c: 'd' }, false)
+            given.featureFlags.setPersonPropertiesForFlags({ x: 'y', c: 'e' }, false)
             jest.runAllTimers()
 
             expect(given.instance.persistence.props.$stored_person_properties).toEqual({ a: 'b', c: 'e', x: 'y' })
 
-            given.featureFlags.resetPersonPropertiesForFlags()
+            given.featureFlags.resetsetPersonPropertiesForFlags()
             given.featureFlags.reloadFeatureFlags()
             jest.runAllTimers()
 
@@ -372,7 +372,7 @@ describe('featureflags', () => {
         })
 
         it('on providing groupProperties updates properties successively', () => {
-            given.featureFlags.groupPropertiesForFlags({ orgs: { a: 'b', c: 'd' }, projects: { x: 'y', c: 'e' } })
+            given.featureFlags.setGroupPropertiesForFlags({ orgs: { a: 'b', c: 'd' }, projects: { x: 'y', c: 'e' } })
 
             expect(given.instance.persistence.props.$stored_group_properties).toEqual({
                 orgs: { a: 'b', c: 'd' },
@@ -397,14 +397,14 @@ describe('featureflags', () => {
         })
 
         it('handles groupProperties updates', () => {
-            given.featureFlags.groupPropertiesForFlags({ orgs: { a: 'b', c: 'd' }, projects: { x: 'y', c: 'e' } })
+            given.featureFlags.setGroupPropertiesForFlags({ orgs: { a: 'b', c: 'd' }, projects: { x: 'y', c: 'e' } })
 
             expect(given.instance.persistence.props.$stored_group_properties).toEqual({
                 orgs: { a: 'b', c: 'd' },
                 projects: { x: 'y', c: 'e' },
             })
 
-            given.featureFlags.groupPropertiesForFlags({ orgs: { w: '1' }, other: { z: '2' } })
+            given.featureFlags.setGroupPropertiesForFlags({ orgs: { w: '1' }, other: { z: '2' } })
 
             expect(given.instance.persistence.props.$stored_group_properties).toEqual({
                 orgs: { a: 'b', c: 'd', w: '1' },
@@ -428,7 +428,7 @@ describe('featureflags', () => {
         })
 
         it('doesnt reload group flags if explicitly asked not to', () => {
-            given.featureFlags.groupPropertiesForFlags({ orgs: { a: 'b', c: 'd' } }, false)
+            given.featureFlags.setGroupPropertiesForFlags({ orgs: { a: 'b', c: 'd' } }, false)
 
             jest.runAllTimers()
 

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -358,7 +358,7 @@ describe('featureflags', () => {
 
             expect(given.instance.persistence.props.$stored_person_properties).toEqual({ a: 'b', c: 'e', x: 'y' })
 
-            given.featureFlags.resetsetPersonPropertiesForFlags()
+            given.featureFlags.resetPersonPropertiesForFlags()
             given.featureFlags.reloadFeatureFlags()
             jest.runAllTimers()
 

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -684,6 +684,36 @@ describe('group()', () => {
         expect(given.lib.getGroups()).toEqual({ organization: 'org::6', instance: 'app.posthog.com' })
     })
 
+    it('records info on groupProperties for groups', () => {
+        given.lib.group('organization', 'org::5', { name: 'PostHog' })
+        expect(given.lib.getGroups()).toEqual({ organization: 'org::5' })
+
+        expect(given.lib.persistence.props['$stored_group_properties']).toEqual({ organization: { name: 'PostHog'} })
+
+        given.lib.group('organization', 'org::6')
+        expect(given.lib.getGroups()).toEqual({ organization: 'org::6' })
+        expect(given.lib.persistence.props['$stored_group_properties']).toEqual({ organization: {} })
+
+        given.lib.group('instance', 'app.posthog.com')
+        expect(given.lib.getGroups()).toEqual({ organization: 'org::6', instance: 'app.posthog.com' })
+        expect(given.lib.persistence.props['$stored_group_properties']).toEqual({ organization: {}, instance: {} })
+
+        // now add properties to the group
+        given.lib.group('organization', 'org::7', { name: 'PostHog2' })
+        expect(given.lib.getGroups()).toEqual({ organization: 'org::7', instance: 'app.posthog.com' })
+        expect(given.lib.persistence.props['$stored_group_properties']).toEqual({ organization: { name: 'PostHog2'}, instance: {} })
+
+
+        given.lib.group('instance', 'app.posthog.com', { 'a': 'b' })
+        expect(given.lib.getGroups()).toEqual({ organization: 'org::7', instance: 'app.posthog.com' })
+        expect(given.lib.persistence.props['$stored_group_properties']).toEqual({ organization: { name: 'PostHog2'}, instance: {'a': 'b'} })
+
+
+        given.lib.resetGroupPropertiesForFlags()
+        expect(given.lib.persistence.props['$stored_group_properties']).toEqual(undefined)
+
+    })
+
     it('does not result in a capture call', () => {
         given.lib.group('organization', 'org::5')
 
@@ -691,11 +721,20 @@ describe('group()', () => {
     })
 
     it('results in a reloadFeatureFlags call if group changes', () => {
-        given.lib.group('organization', 'org::5')
+        given.lib.group('organization', 'org::5', { name: 'PostHog' })
         given.lib.group('instance', 'app.posthog.com')
         given.lib.group('organization', 'org::5')
 
         expect(given.overrides.reloadFeatureFlags).toHaveBeenCalledTimes(2)
+    })
+
+    it('results in a reloadFeatureFlags call if group properties change', () => {
+        given.lib.group('organization', 'org::5')
+        given.lib.group('instance', 'app.posthog.com')
+        given.lib.group('organization', 'org::5', { name: 'PostHog' })
+        given.lib.group('instance', 'app.posthog.com')
+
+        expect(given.overrides.reloadFeatureFlags).toHaveBeenCalledTimes(3)
     })
 
     it('captures $groupidentify event', () => {
@@ -764,16 +803,25 @@ describe('group()', () => {
     describe('reset group', () => {
         it('groups property is empty and reloads feature flags', () => {
             given.lib.group('organization', 'org::5')
-            given.lib.group('instance', 'app.posthog.com')
+            given.lib.group('instance', 'app.posthog.com', { group: 'property', foo: 5 })
 
             expect(given.lib.persistence.props['$groups']).toEqual({
                 organization: 'org::5',
                 instance: 'app.posthog.com',
             })
 
+            expect(given.lib.persistence.props['$stored_group_properties']).toEqual({
+                organization: {},
+                instance: {
+                    group: 'property',
+                    foo: 5,
+                },
+            })
+
             given.lib.resetGroups()
 
             expect(given.lib.persistence.props['$groups']).toEqual({})
+            expect(given.lib.persistence.props['$stored_group_properties']).toEqual(undefined)
 
             expect(given.overrides.reloadFeatureFlags).toHaveBeenCalledTimes(3)
         })

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -688,7 +688,7 @@ describe('group()', () => {
         given.lib.group('organization', 'org::5', { name: 'PostHog' })
         expect(given.lib.getGroups()).toEqual({ organization: 'org::5' })
 
-        expect(given.lib.persistence.props['$stored_group_properties']).toEqual({ organization: { name: 'PostHog'} })
+        expect(given.lib.persistence.props['$stored_group_properties']).toEqual({ organization: { name: 'PostHog' } })
 
         given.lib.group('organization', 'org::6')
         expect(given.lib.getGroups()).toEqual({ organization: 'org::6' })
@@ -701,17 +701,20 @@ describe('group()', () => {
         // now add properties to the group
         given.lib.group('organization', 'org::7', { name: 'PostHog2' })
         expect(given.lib.getGroups()).toEqual({ organization: 'org::7', instance: 'app.posthog.com' })
-        expect(given.lib.persistence.props['$stored_group_properties']).toEqual({ organization: { name: 'PostHog2'}, instance: {} })
+        expect(given.lib.persistence.props['$stored_group_properties']).toEqual({
+            organization: { name: 'PostHog2' },
+            instance: {},
+        })
 
-
-        given.lib.group('instance', 'app.posthog.com', { 'a': 'b' })
+        given.lib.group('instance', 'app.posthog.com', { a: 'b' })
         expect(given.lib.getGroups()).toEqual({ organization: 'org::7', instance: 'app.posthog.com' })
-        expect(given.lib.persistence.props['$stored_group_properties']).toEqual({ organization: { name: 'PostHog2'}, instance: {'a': 'b'} })
-
+        expect(given.lib.persistence.props['$stored_group_properties']).toEqual({
+            organization: { name: 'PostHog2' },
+            instance: { a: 'b' },
+        })
 
         given.lib.resetGroupPropertiesForFlags()
         expect(given.lib.persistence.props['$stored_group_properties']).toEqual(undefined)
-
     })
 
     it('does not result in a capture call', () => {

--- a/src/__tests__/posthog-people.js
+++ b/src/__tests__/posthog-people.js
@@ -21,8 +21,7 @@ given('overrides', () => ({
         update_referrer_info: jest.fn(),
     },
     persistence: {
-        props: {
-        },
+        props: {},
         register: (dict) => {
             given.overrides.persistence.props = { ...given.overrides.persistence.props, ...dict }
         },

--- a/src/__tests__/posthog-people.js
+++ b/src/__tests__/posthog-people.js
@@ -10,10 +10,25 @@ given('people', () =>
 
 given('overrides', () => ({
     get_config: () => ({}),
-    get_property: () => 'something',
+    get_property: (key) => {
+        if (key === '$stored_person_properties') {
+            return given.overrides.persistence.props.$stored_person_properties
+        }
+        return 'something'
+    },
     sessionPersistence: {
         get_referrer_info: jest.fn().mockReturnValue(''),
         update_referrer_info: jest.fn(),
+    },
+    persistence: {
+        props: {
+        },
+        register: (dict) => {
+            given.overrides.persistence.props = { ...given.overrides.persistence.props, ...dict }
+        },
+        unregister: (key) => {
+            delete given.overrides.persistence.props[key]
+        },
     },
 }))
 
@@ -28,11 +43,15 @@ describe('posthog.people', () => {
             }),
             undefined
         )
+
+        expect(given.overrides.persistence.props.$stored_person_properties).toEqual({ set_me: 'set me' })
     })
 
     it('should process set_once correctly', () => {
         given.people.set_once({ set_me_once: 'set once' })
 
         expect(given.people._send_request).toHaveBeenCalledWith({ $set_once: { set_me_once: 'set once' } }, undefined)
+
+        expect(given.overrides.persistence.props.$stored_person_properties).toEqual(undefined)
     })
 })

--- a/src/gdpr-utils.ts
+++ b/src/gdpr-utils.ts
@@ -12,7 +12,7 @@
  */
 
 import { _each, _includes, _isNumber, _isString, window } from './utils'
-import { cookieStore, localStore, localPlusCookieStore, sessionStore } from './storage'
+import { cookieStore, localStore, localPlusCookieStore } from './storage'
 import { GDPROptions, PersistentStore } from './types'
 import { PostHog } from './posthog-core'
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -21,7 +21,13 @@ import {
 import { autocapture } from './autocapture'
 import { PostHogPeople } from './posthog-people'
 import { PostHogFeatureFlags } from './posthog-featureflags'
-import { ALIAS_ID_KEY, PEOPLE_DISTINCT_ID_KEY, PostHogPersistence, STORED_GROUP_PROPERTIES_KEY, STORED_PERSON_PROPERTIES_KEY } from './posthog-persistence'
+import {
+    ALIAS_ID_KEY,
+    PEOPLE_DISTINCT_ID_KEY,
+    PostHogPersistence,
+    STORED_GROUP_PROPERTIES_KEY,
+    STORED_PERSON_PROPERTIES_KEY,
+} from './posthog-persistence'
 import { SessionRecording } from './extensions/sessionrecording'
 import { WebPerformanceObserver } from './extensions/web-performance'
 import { Decide } from './decide'
@@ -1298,7 +1304,7 @@ export class PostHog {
      * This is used when dealing with new persons / where you don't want to wait for ingestion
      * to update user properties.
      */
-    personPropertiesForFlags(properties: Properties, reloadFeatureFlags: boolean = true): void {
+    personPropertiesForFlags(properties: Properties, reloadFeatureFlags = true): void {
         this.featureFlags.personPropertiesForFlags(properties, reloadFeatureFlags)
     }
 
@@ -1314,7 +1320,7 @@ export class PostHog {
      * For example:
      *     groupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } })
      */
-    groupPropertiesForFlags(properties: { [type: string]: Properties }, reloadFeatureFlags: boolean = true): void {
+    groupPropertiesForFlags(properties: { [type: string]: Properties }, reloadFeatureFlags = true): void {
         this.featureFlags.groupPropertiesForFlags(properties, reloadFeatureFlags)
     }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -21,7 +21,7 @@ import {
 import { autocapture } from './autocapture'
 import { PostHogPeople } from './posthog-people'
 import { PostHogFeatureFlags } from './posthog-featureflags'
-import { ALIAS_ID_KEY, PEOPLE_DISTINCT_ID_KEY, PostHogPersistence } from './posthog-persistence'
+import { ALIAS_ID_KEY, PEOPLE_DISTINCT_ID_KEY, PostHogPersistence, STORED_GROUP_PROPERTIES_KEY, STORED_PERSON_PROPERTIES_KEY } from './posthog-persistence'
 import { SessionRecording } from './extensions/sessionrecording'
 import { WebPerformanceObserver } from './extensions/web-performance'
 import { Decide } from './decide'
@@ -1259,6 +1259,11 @@ export class PostHog {
 
         const existingGroups = this.getGroups()
 
+        // if group key changes, remove stored group properties
+        if (existingGroups[groupType] !== groupKey) {
+            this.resetGroupPropertiesForFlags(groupType)
+        }
+
         this.register({ $groups: { ...existingGroups, [groupType]: groupKey } })
 
         if (groupPropertiesToSet) {
@@ -1267,10 +1272,13 @@ export class PostHog {
                 $group_key: groupKey,
                 $group_set: groupPropertiesToSet,
             })
+            console.log('calling group properties for flags')
+            this.groupPropertiesForFlags({[groupType]: groupPropertiesToSet})
         }
 
-        // If groups change, reload feature flags.
-        if (existingGroups[groupType] !== groupKey) {
+        // If groups change and no properties change, reload feature flags.
+        // The property change reload case is handled in groupPropertiesForFlags.
+        if (existingGroups[groupType] !== groupKey && !groupPropertiesToSet) {
             this.reloadFeatureFlags()
         }
     }
@@ -1280,9 +1288,39 @@ export class PostHog {
      */
     resetGroups(): void {
         this.register({ $groups: {} })
+        this.resetGroupPropertiesForFlags()
 
         // If groups changed, reload feature flags.
         this.reloadFeatureFlags()
+    }
+
+    /**
+     * Set override person properties for feature flags.
+     * This is used when dealing with new persons / where you don't want to wait for ingestion
+     * to update user properties.
+     */
+    personPropertiesForFlags(properties: Properties, reloadFeatureFlags: boolean = true): void {
+        this.featureFlags.personPropertiesForFlags(properties, reloadFeatureFlags)
+    }
+
+    resetPersonPropertiesForFlags(): void {
+        this.featureFlags.resetPersonPropertiesForFlags()
+    }
+
+    /**
+     * Set override group properties for feature flags.
+     * This is used when dealing with new groups / where you don't want to wait for ingestion
+     * to update properties.
+     * Takes in an object, the key of which is the group type.
+     * For example:
+     *     groupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } })
+     */
+    groupPropertiesForFlags(properties: { [type: string]: Properties }, reloadFeatureFlags: boolean = true): void {
+        this.featureFlags.groupPropertiesForFlags(properties, reloadFeatureFlags)
+    }
+
+    resetGroupPropertiesForFlags(group_type?: string): void {
+        this.featureFlags.resetGroupPropertiesForFlags(group_type)
     }
 
     /**

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1272,11 +1272,11 @@ export class PostHog {
                 $group_key: groupKey,
                 $group_set: groupPropertiesToSet,
             })
-            this.groupPropertiesForFlags({ [groupType]: groupPropertiesToSet })
+            this.setGroupPropertiesForFlags({ [groupType]: groupPropertiesToSet })
         }
 
         // If groups change and no properties change, reload feature flags.
-        // The property change reload case is handled in groupPropertiesForFlags.
+        // The property change reload case is handled in setGroupPropertiesForFlags.
         if (existingGroups[groupType] !== groupKey && !groupPropertiesToSet) {
             this.reloadFeatureFlags()
         }
@@ -1298,8 +1298,8 @@ export class PostHog {
      * This is used when dealing with new persons / where you don't want to wait for ingestion
      * to update user properties.
      */
-    personPropertiesForFlags(properties: Properties, reloadFeatureFlags = true): void {
-        this.featureFlags.personPropertiesForFlags(properties, reloadFeatureFlags)
+    setPersonPropertiesForFlags(properties: Properties, reloadFeatureFlags = true): void {
+        this.featureFlags.setPersonPropertiesForFlags(properties, reloadFeatureFlags)
     }
 
     resetPersonPropertiesForFlags(): void {
@@ -1312,10 +1312,10 @@ export class PostHog {
      * to update properties.
      * Takes in an object, the key of which is the group type.
      * For example:
-     *     groupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } })
+     *     setGroupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } })
      */
-    groupPropertiesForFlags(properties: { [type: string]: Properties }, reloadFeatureFlags = true): void {
-        this.featureFlags.groupPropertiesForFlags(properties, reloadFeatureFlags)
+    setGroupPropertiesForFlags(properties: { [type: string]: Properties }, reloadFeatureFlags = true): void {
+        this.featureFlags.setGroupPropertiesForFlags(properties, reloadFeatureFlags)
     }
 
     resetGroupPropertiesForFlags(group_type?: string): void {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -21,11 +21,7 @@ import {
 import { autocapture } from './autocapture'
 import { PostHogPeople } from './posthog-people'
 import { PostHogFeatureFlags } from './posthog-featureflags'
-import {
-    ALIAS_ID_KEY,
-    PEOPLE_DISTINCT_ID_KEY,
-    PostHogPersistence,
-} from './posthog-persistence'
+import { ALIAS_ID_KEY, PEOPLE_DISTINCT_ID_KEY, PostHogPersistence } from './posthog-persistence'
 import { SessionRecording } from './extensions/sessionrecording'
 import { WebPerformanceObserver } from './extensions/web-performance'
 import { Decide } from './decide'

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -25,8 +25,6 @@ import {
     ALIAS_ID_KEY,
     PEOPLE_DISTINCT_ID_KEY,
     PostHogPersistence,
-    STORED_GROUP_PROPERTIES_KEY,
-    STORED_PERSON_PROPERTIES_KEY,
 } from './posthog-persistence'
 import { SessionRecording } from './extensions/sessionrecording'
 import { WebPerformanceObserver } from './extensions/web-performance'

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1272,8 +1272,7 @@ export class PostHog {
                 $group_key: groupKey,
                 $group_set: groupPropertiesToSet,
             })
-            console.log('calling group properties for flags')
-            this.groupPropertiesForFlags({[groupType]: groupPropertiesToSet})
+            this.groupPropertiesForFlags({ [groupType]: groupPropertiesToSet })
         }
 
         // If groups change and no properties change, reload feature flags.

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -1,7 +1,7 @@
 import { _base64Encode, _extend } from './utils'
 import { PostHog } from './posthog-core'
-import { DecideResponse, FeatureFlagsCallback, JsonType, RequestCallback } from './types'
-import { PostHogPersistence } from './posthog-persistence'
+import { DecideResponse, FeatureFlagsCallback, JsonType, Properties, RequestCallback } from './types'
+import { PostHogPersistence, STORED_GROUP_PROPERTIES_KEY, STORED_PERSON_PROPERTIES_KEY } from './posthog-persistence'
 
 const PERSISTENCE_ACTIVE_FEATURE_FLAGS = '$active_feature_flags'
 const PERSISTENCE_ENABLED_FEATURE_FLAGS = '$enabled_feature_flags'
@@ -152,11 +152,15 @@ export class PostHogFeatureFlags {
     _reloadFeatureFlagsRequest(): void {
         this.setReloadingPaused(true)
         const token = this.instance.get_config('token')
+        const personProperties = this.instance.get_property(STORED_PERSON_PROPERTIES_KEY)
+        const groupProperties = this.instance.get_property(STORED_GROUP_PROPERTIES_KEY)
         const json_data = JSON.stringify({
             token: token,
             distinct_id: this.instance.get_distinct_id(),
             groups: this.instance.getGroups(),
             $anon_distinct_id: this.$anon_distinct_id,
+            person_properties: personProperties,
+            group_properties: groupProperties,
         })
 
         const encoded_data = _base64Encode(json_data)
@@ -303,6 +307,77 @@ export class PostHogFeatureFlags {
         return {
             flags: truthyFlags,
             flagVariants: truthyFlagVariants,
+        }
+    }
+
+    /**
+     * Set override person properties for feature flags.
+     * This is used when dealing with new persons / where you don't want to wait for ingestion
+     * to update user properties.
+     */
+    personPropertiesForFlags(properties: Properties, reloadFeatureFlags: boolean = true): void {
+        // Get persisted person properties
+        const existingProperties = this.instance.get_property(STORED_PERSON_PROPERTIES_KEY) || {}
+
+        this.instance.register({
+            [STORED_PERSON_PROPERTIES_KEY]: {
+                ...existingProperties,
+                ...properties
+            }
+        })
+
+        if (reloadFeatureFlags) {
+            this.instance.reloadFeatureFlags()
+        }
+    }
+
+    resetPersonPropertiesForFlags(): void {
+        this.instance.unregister(STORED_PERSON_PROPERTIES_KEY)
+    }
+
+    /**
+     * Set override group properties for feature flags.
+     * This is used when dealing with new groups / where you don't want to wait for ingestion
+     * to update properties.
+     * Takes in an object, the key of which is the group type.
+     * For example:
+     *     groupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } })
+     */
+    groupPropertiesForFlags(properties: { [type: string]: Properties }, reloadFeatureFlags: boolean = true): void {
+        // Get persisted group properties
+        const existingProperties = this.instance.get_property(STORED_GROUP_PROPERTIES_KEY) || {}
+
+        if (Object.keys(existingProperties).length !== 0) {
+            Object.keys(existingProperties).forEach((groupType) => {
+                existingProperties[groupType] = {
+                ...existingProperties[groupType],
+                ...properties[groupType],
+                }
+                delete properties[groupType]
+            })
+        }
+
+        this.instance.register({
+            [STORED_GROUP_PROPERTIES_KEY]: {
+                ...existingProperties,
+                ...properties
+            }
+        })
+
+        if (reloadFeatureFlags) {
+            this.instance.reloadFeatureFlags()
+        }
+    }
+
+    resetGroupPropertiesForFlags(group_type?: string): void {
+        if (group_type) {
+            const existingProperties = this.instance.get_property(STORED_GROUP_PROPERTIES_KEY) || {}
+            this.instance.register({
+                [STORED_GROUP_PROPERTIES_KEY]: {...existingProperties, [group_type]: {}}
+            })
+
+        } else {
+            this.instance.unregister(STORED_GROUP_PROPERTIES_KEY)
         }
     }
 }

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -315,15 +315,15 @@ export class PostHogFeatureFlags {
      * This is used when dealing with new persons / where you don't want to wait for ingestion
      * to update user properties.
      */
-    personPropertiesForFlags(properties: Properties, reloadFeatureFlags: boolean = true): void {
+    personPropertiesForFlags(properties: Properties, reloadFeatureFlags = true): void {
         // Get persisted person properties
         const existingProperties = this.instance.get_property(STORED_PERSON_PROPERTIES_KEY) || {}
 
         this.instance.register({
             [STORED_PERSON_PROPERTIES_KEY]: {
                 ...existingProperties,
-                ...properties
-            }
+                ...properties,
+            },
         })
 
         if (reloadFeatureFlags) {
@@ -343,15 +343,15 @@ export class PostHogFeatureFlags {
      * For example:
      *     groupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } })
      */
-    groupPropertiesForFlags(properties: { [type: string]: Properties }, reloadFeatureFlags: boolean = true): void {
+    groupPropertiesForFlags(properties: { [type: string]: Properties }, reloadFeatureFlags = true): void {
         // Get persisted group properties
         const existingProperties = this.instance.get_property(STORED_GROUP_PROPERTIES_KEY) || {}
 
         if (Object.keys(existingProperties).length !== 0) {
             Object.keys(existingProperties).forEach((groupType) => {
                 existingProperties[groupType] = {
-                ...existingProperties[groupType],
-                ...properties[groupType],
+                    ...existingProperties[groupType],
+                    ...properties[groupType],
                 }
                 delete properties[groupType]
             })
@@ -360,8 +360,8 @@ export class PostHogFeatureFlags {
         this.instance.register({
             [STORED_GROUP_PROPERTIES_KEY]: {
                 ...existingProperties,
-                ...properties
-            }
+                ...properties,
+            },
         })
 
         if (reloadFeatureFlags) {
@@ -373,9 +373,8 @@ export class PostHogFeatureFlags {
         if (group_type) {
             const existingProperties = this.instance.get_property(STORED_GROUP_PROPERTIES_KEY) || {}
             this.instance.register({
-                [STORED_GROUP_PROPERTIES_KEY]: {...existingProperties, [group_type]: {}}
+                [STORED_GROUP_PROPERTIES_KEY]: { ...existingProperties, [group_type]: {} },
             })
-
         } else {
             this.instance.unregister(STORED_GROUP_PROPERTIES_KEY)
         }

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -315,7 +315,7 @@ export class PostHogFeatureFlags {
      * This is used when dealing with new persons / where you don't want to wait for ingestion
      * to update user properties.
      */
-    personPropertiesForFlags(properties: Properties, reloadFeatureFlags = true): void {
+    setPersonPropertiesForFlags(properties: Properties, reloadFeatureFlags = true): void {
         // Get persisted person properties
         const existingProperties = this.instance.get_property(STORED_PERSON_PROPERTIES_KEY) || {}
 
@@ -341,9 +341,9 @@ export class PostHogFeatureFlags {
      * to update properties.
      * Takes in an object, the key of which is the group type.
      * For example:
-     *     groupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } })
+     *     setGroupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } })
      */
-    groupPropertiesForFlags(properties: { [type: string]: Properties }, reloadFeatureFlags = true): void {
+    setGroupPropertiesForFlags(properties: { [type: string]: Properties }, reloadFeatureFlags = true): void {
         // Get persisted group properties
         const existingProperties = this.instance.get_property(STORED_GROUP_PROPERTIES_KEY) || {}
 

--- a/src/posthog-people.ts
+++ b/src/posthog-people.ts
@@ -43,7 +43,7 @@ class PostHogPeople {
             const data = this.set_action(prop, to)
 
             // Update current user properties
-            this._posthog.personPropertiesForFlags(data['$set'] || {})
+            this._posthog.setPersonPropertiesForFlags(data['$set'] || {})
 
             if (_isObject(prop)) {
                 callback = to as any

--- a/src/posthog-people.ts
+++ b/src/posthog-people.ts
@@ -41,6 +41,10 @@ class PostHogPeople {
          */
         this.set = addOptOutCheck(posthog, (prop: string | Properties, to?: string, callback?: RequestCallback) => {
             const data = this.set_action(prop, to)
+
+            // Update current user properties
+            this._posthog.personPropertiesForFlags(data['$set'] || {})
+
             if (_isObject(prop)) {
                 callback = to as any
             }

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -18,6 +18,9 @@ export const CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE = '$console_log_recording
 export const SESSION_RECORDING_RECORDER_VERSION_SERVER_SIDE = '$session_recording_recorder_version_server_side' // follows rrweb versioning
 export const SESSION_ID = '$sesid'
 export const ENABLED_FEATURE_FLAGS = '$enabled_feature_flags'
+export const STORED_PERSON_PROPERTIES_KEY = '$stored_person_properties'
+export const STORED_GROUP_PROPERTIES_KEY = '$stored_group_properties'
+
 const USER_STATE = '$user_state'
 
 export const RESERVED_PROPERTIES = [
@@ -29,6 +32,8 @@ export const RESERVED_PROPERTIES = [
     SESSION_ID,
     ENABLED_FEATURE_FLAGS,
     USER_STATE,
+    STORED_GROUP_PROPERTIES_KEY,
+    STORED_PERSON_PROPERTIES_KEY,
 ]
 
 const CASE_INSENSITIVE_PERSISTENCE_TYPES: readonly Lowercase<PostHogConfig['persistence']>[] = [


### PR DESCRIPTION
## Changes

When you want properties to be reflected immediately for feature flags, you can now use these functions to override server properties & not wait for ingestion to resolve flags.

Docs here: https://github.com/PostHog/posthog.com/pull/5827

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
