### PR TITLE
fix: Script loading before DOM is ready

### DIFF
--- a/src/__tests__/autocapture-utils.js
+++ b/src/__tests__/autocapture-utils.js
@@ -6,7 +6,6 @@ import {
     shouldCaptureElement,
     isSensitiveElement,
     shouldCaptureValue,
-    loadScript,
     isAngularStyleAttr,
     getNestedSpanText,
     getDirectAndNestedSpanText,

--- a/src/__tests__/autocapture-utils.js
+++ b/src/__tests__/autocapture-utils.js
@@ -333,33 +333,6 @@ describe(`Autocapture utility functions`, () => {
         })
     })
 
-    describe('loadScript', () => {
-        it('should insert the given script before the one already on the page', () => {
-            document.body.appendChild(document.createElement('script'))
-            const callback = (_) => _
-            loadScript('https://fake_url', callback)
-            const scripts = document.getElementsByTagName('script')
-            const new_script = scripts[0]
-
-            expect(scripts.length).toBe(2)
-            expect(new_script.type).toBe('text/javascript')
-            expect(new_script.src).toBe('https://fake_url/')
-            expect(new_script.onload).toBe(callback)
-        })
-
-        it("should add the script to the page when there aren't any preexisting scripts on the page", () => {
-            const callback = (_) => _
-            loadScript('https://fake_url', callback)
-            const scripts = document.getElementsByTagName('script')
-            const new_script = scripts[0]
-
-            expect(scripts.length).toBe(1)
-            expect(new_script.type).toBe('text/javascript')
-            expect(new_script.src).toBe('https://fake_url/')
-            expect(new_script.onload).toBe(callback)
-        })
-    })
-
     describe('isAngularStyleAttr', () => {
         it('should detect attribute names that match _ngcontent*', () => {
             expect(isAngularStyleAttr('_ngcontent')).toBe(true)

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -15,7 +15,10 @@ import {
 // Type and source defined here designate a non-user-generated recording event
 const NON_USER_GENERATED_EVENT = { type: INCREMENTAL_SNAPSHOT_EVENT_TYPE, data: { source: MUTATION_SOURCE_TYPE } }
 
-jest.mock('../../utils')
+jest.mock('../../utils', () => ({
+    ...jest.requireActual('../../utils'),
+    loadScript: jest.fn((path, callback) => callback()),
+}))
 jest.mock('../../config', () => ({ LIB_VERSION: 'v0.0.1' }))
 
 describe('SessionRecording', () => {

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -1,4 +1,4 @@
-import { loadScript } from '../../autocapture-utils'
+import { loadScript } from '../../utils'
 import { SessionRecording } from '../../extensions/sessionrecording'
 import {
     PostHogPersistence,
@@ -15,7 +15,7 @@ import {
 // Type and source defined here designate a non-user-generated recording event
 const NON_USER_GENERATED_EVENT = { type: INCREMENTAL_SNAPSHOT_EVENT_TYPE, data: { source: MUTATION_SOURCE_TYPE } }
 
-jest.mock('../../autocapture-utils')
+jest.mock('../../utils')
 jest.mock('../../config', () => ({ LIB_VERSION: 'v0.0.1' }))
 
 describe('SessionRecording', () => {

--- a/src/__tests__/extensions/toolbar.js
+++ b/src/__tests__/extensions/toolbar.js
@@ -1,7 +1,7 @@
 import { Toolbar } from '../../extensions/toolbar'
-import { loadScript } from '../../autocapture-utils'
+import { loadScript } from '../../utils'
 
-jest.mock('../../autocapture-utils')
+jest.mock('../../utils')
 
 describe('Toolbar', () => {
     given('toolbar', () => new Toolbar(given.lib))

--- a/src/__tests__/extensions/toolbar.js
+++ b/src/__tests__/extensions/toolbar.js
@@ -1,7 +1,10 @@
 import { Toolbar } from '../../extensions/toolbar'
 import { loadScript } from '../../utils'
 
-jest.mock('../../utils')
+jest.mock('../../utils', () => ({
+    ...jest.requireActual('../../utils'),
+    loadScript: jest.fn((path, callback) => callback()),
+}))
 
 describe('Toolbar', () => {
     given('toolbar', () => new Toolbar(given.lib))

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -5,7 +5,7 @@
  * currently not supported in the browser lib).
  */
 
-import { _copyAndTruncateStrings, _info } from '../utils'
+import { _copyAndTruncateStrings, _info, loadScript } from '../utils'
 
 describe(`utils.js`, () => {
     it('should have $host and $pathname in properties', () => {
@@ -115,5 +115,46 @@ describe('_.info', () => {
 
         expect(properties['$lib']).toEqual('web')
         expect(properties['$device_type']).toEqual('Desktop')
+    })
+})
+
+describe('loadScript', () => {
+    beforeEach(() => {
+        document.getElementsByTagName('html')[0].innerHTML = ''
+    })
+
+    it('should insert the given script before the one already on the page', () => {
+        document.body.appendChild(document.createElement('script'))
+        const callback = jest.fn()
+        loadScript('https://fake_url', callback)
+        const scripts = document.getElementsByTagName('script')
+        const new_script = scripts[0]
+
+        expect(scripts.length).toBe(2)
+        expect(new_script.type).toBe('text/javascript')
+        expect(new_script.src).toBe('https://fake_url/')
+        new_script.onload('test')
+        expect(callback).toHaveBeenCalledWith(undefined, 'test')
+    })
+
+    it("should add the script to the page when there aren't any preexisting scripts on the page", () => {
+        const callback = jest.fn()
+        loadScript('https://fake_url', callback)
+        const scripts = document.getElementsByTagName('script')
+        const new_script = scripts[0]
+
+        expect(scripts.length).toBe(1)
+        expect(new_script.type).toBe('text/javascript')
+        expect(new_script.src).toBe('https://fake_url/')
+    })
+
+    it('should respond with an error if one happens', () => {
+        const callback = jest.fn()
+        loadScript('https://fake_url', callback)
+        const scripts = document.getElementsByTagName('script')
+        const new_script = scripts[0]
+
+        new_script.onerror('uh-oh')
+        expect(callback).toHaveBeenCalledWith('uh-oh')
     })
 })

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -303,20 +303,6 @@ export function isAngularStyleAttr(attributeName: string): boolean {
     return false
 }
 
-export function loadScript(scriptUrlToLoad: string, callback: (event: Event) => void): void {
-    const scriptTag = document.createElement('script')
-    scriptTag.type = 'text/javascript'
-    scriptTag.src = scriptUrlToLoad
-    scriptTag.onload = callback
-
-    const scripts = document.querySelectorAll('body > script')
-    if (scripts.length > 0) {
-        scripts[0].parentNode?.insertBefore(scriptTag, scripts[0])
-    } else {
-        document.body.appendChild(scriptTag)
-    }
-}
-
 /*
  * Iterate through children of a target element looking for span tags
  * and return the text content of the span tags, separated by spaces,

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -1,5 +1,5 @@
 import { autocapture } from './autocapture'
-import { _base64Encode } from './utils'
+import { _base64Encode, loadScript } from './utils'
 import { PostHog } from './posthog-core'
 import { Compression, DecideResponse } from './types'
 
@@ -65,16 +65,18 @@ export class Decide {
             if (this.instance.get_config('opt_in_site_apps')) {
                 const apiHost = this.instance.get_config('api_host')
                 for (const { id, url } of response['siteApps']) {
-                    const script = document.createElement('script')
-                    script.src = [
+                    const scriptUrl = [
                         apiHost,
                         apiHost[apiHost.length - 1] === '/' && url[0] === '/' ? url.substring(1) : url,
                     ].join('')
-                    script.onerror = (e) => {
-                        console.error(`Error while initializing PostHog app with config id ${id}`, e)
-                    }
+
                     ;(window as any)[`__$$ph_site_app_${id}`] = this.instance
-                    document.body.appendChild(script)
+
+                    loadScript(scriptUrl, (err) => {
+                        if (err) {
+                            console.error(`Error while initializing PostHog app with config id ${id}`, err)
+                        }
+                    })
                 }
             } else if (response['siteApps'].length > 0) {
                 console.error('PostHog site apps are disabled. Enable the "opt_in_site_apps" config to proceed.')

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -15,9 +15,8 @@ import { PostHog } from '../posthog-core'
 import { DecideResponse, Properties } from '../types'
 import type { record } from 'rrweb/typings'
 import type { eventWithTime, listenerHandler, pluginEvent, recordOptions } from 'rrweb/typings/types'
-import { loadScript } from '../autocapture-utils'
 import Config from '../config'
-import { logger } from '../utils'
+import { logger, loadScript } from '../utils'
 
 const BASE_ENDPOINT = '/e/'
 
@@ -140,7 +139,13 @@ export class SessionRecording {
         if (this.instance.__loaded_recorder_version !== this.getRecordingVersion()) {
             loadScript(
                 this.instance.get_config('api_host') + `/static/${recorderJS}?v=${Config.LIB_VERSION}`,
-                this._onScriptLoaded.bind(this)
+                (err) => {
+                    if (err) {
+                        return logger.error(`Could not load ${recorderJS}`, err)
+                    }
+
+                    this._onScriptLoaded()
+                }
             )
         } else {
             this._onScriptLoaded()

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -1,5 +1,4 @@
-import { loadScript } from '../autocapture-utils'
-import { _getHashParam, _register_event } from '../utils'
+import { _getHashParam, _register_event, loadScript, logger } from '../utils'
 import { PostHog } from '../posthog-core'
 import { DecideResponse, ToolbarParams } from '../types'
 import { POSTHOG_MANAGED_HOSTS } from './cloud'
@@ -126,7 +125,11 @@ export class Toolbar {
         const { source: _discard, ...paramsToPersist } = toolbarParams // eslint-disable-line
         window.localStorage.setItem('_postHogToolbarParams', JSON.stringify(paramsToPersist))
 
-        loadScript(toolbarUrl, () => {
+        loadScript(toolbarUrl, (err) => {
+            if (err) {
+                logger.error('Failed to load toolbar', err)
+                return
+            }
             ;((window as any)['ph_load_toolbar'] || (window as any)['ph_load_editor'])(toolbarParams, this.instance)
         })
         // Turbolinks doesn't fire an onload event but does replace the entire body, including the toolbar.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -679,6 +679,26 @@ export const isLocalhost = (): boolean => {
     return localDomains.includes(location.hostname)
 }
 
+export function loadScript(scriptUrlToLoad: string, callback: (error?: string | Event, event?: Event) => void): void {
+    const scriptTag = document.createElement('script')
+    scriptTag.type = 'text/javascript'
+    scriptTag.src = scriptUrlToLoad
+    scriptTag.onload = (event) => callback(undefined, event)
+    scriptTag.onerror = (error) => callback(error)
+
+    const scripts = document.querySelectorAll('body > script')
+    if (scripts.length > 0) {
+        scripts[0].parentNode?.insertBefore(scriptTag, scripts[0])
+    } else if (document.body) {
+        // In exceptional situations this call might load before the DOM is fully ready.
+        document.body.appendChild(scriptTag)
+    } else {
+        document.addEventListener('DOMContentLoaded', () => {
+            document.body.appendChild(scriptTag)
+        })
+    }
+}
+
 export const _info = {
     campaignParams: function (customParams?: string[]): Record<string, any> {
         const campaign_keywords = [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -680,22 +680,26 @@ export const isLocalhost = (): boolean => {
 }
 
 export function loadScript(scriptUrlToLoad: string, callback: (error?: string | Event, event?: Event) => void): void {
-    const scriptTag = document.createElement('script')
-    scriptTag.type = 'text/javascript'
-    scriptTag.src = scriptUrlToLoad
-    scriptTag.onload = (event) => callback(undefined, event)
-    scriptTag.onerror = (error) => callback(error)
+    const addScript = () => {
+        const scriptTag = document.createElement('script')
+        scriptTag.type = 'text/javascript'
+        scriptTag.src = scriptUrlToLoad
+        scriptTag.onload = (event) => callback(undefined, event)
+        scriptTag.onerror = (error) => callback(error)
 
-    const scripts = document.querySelectorAll('body > script')
-    if (scripts.length > 0) {
-        scripts[0].parentNode?.insertBefore(scriptTag, scripts[0])
-    } else if (document.body) {
-        // In exceptional situations this call might load before the DOM is fully ready.
-        document.body.appendChild(scriptTag)
-    } else {
-        document.addEventListener('DOMContentLoaded', () => {
+        const scripts = document.querySelectorAll('body > script')
+        if (scripts.length > 0) {
+            scripts[0].parentNode?.insertBefore(scriptTag, scripts[0])
+        } else {
+            // In exceptional situations this call might load before the DOM is fully ready.
             document.body.appendChild(scriptTag)
-        })
+        }
+    }
+
+    if (document.body) {
+        addScript()
+    } else {
+        document.addEventListener('DOMContentLoaded', addScript)
     }
 }
 


### PR DESCRIPTION
## Changes

Found an issue where in some browsers (Brave in this case) the script can get loaded faster than the body of the page which leads to a condition where we try to append a script to a body that doesn't exist.

* Fixes this by checking for body and then wrapping with a dom load callback otherwise
* Moves the `loadScript` to utils as it was always confusing to see errors for this coming from "autocapture-utils"
* Changes decide siteapps to use the standardised `loadScript` helper

Hard to write tests for this as JSdom is limited here and it is a very weird behaviour

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
