### PR TITLE
Always reload feature flags on getEarlyAccessFeatures

### DIFF
--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -332,7 +332,13 @@ export class PostHogFeatureFlags {
         this._fireFeatureFlagsCallbacks()
     }
 
-    getEarlyAccessFeatures(callback: EarlyAccessFeatureCallback, force_reload = false): void {
+    getEarlyAccessFeatures(callback: EarlyAccessFeatureCallback, force_reload = true): void {
+        if (force_reload) {
+            this.resetPersonPropertiesForFlags()
+            this.resetGroupPropertiesForFlags()
+            this.reloadFeatureFlags()
+        }
+
         const existing_early_access_features = this.instance.get_property(PERSISTENCE_EARLY_ACCESS_FEATURES)
 
         if (!existing_early_access_features || force_reload) {


### PR DESCRIPTION
## Changes

There's an issue if person properties are updated in the early access scene, this client lib will still have a cached copy of the person property. Need to force a reload anytime the getEarlyAccessFeatures is called.

The solution offered here may still not be sufficient and will undo any caching that is meant to exist.

Alternatives:
- chain callbacks: decide with no cached props -> get early access flags after decide returns

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
