### PR TITLE
fix: Don't delete existing flags on decide errors

### DIFF
--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -69,12 +69,6 @@ export const parseFeatureFlagDecideResponse = (
                     [PERSISTENCE_FEATURE_FLAG_PAYLOADS]: newFeatureFlagPayloads || {},
                 })
         }
-    } else {
-        if (persistence) {
-            persistence.unregister(PERSISTENCE_ACTIVE_FEATURE_FLAGS)
-            persistence.unregister(ENABLED_FEATURE_FLAGS)
-            persistence.unregister(PERSISTENCE_FEATURE_FLAG_PAYLOADS)
-        }
     }
 }
 


### PR DESCRIPTION
This seems to be off: the whole point of this library being stateful is to not bork when decide sporadically errors out.

This means flags can go stale if decide is down for a long time, _but_ you wouldn't lose all flags - which can be a much bigger hindrance.

## Changes

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
