### PR TITLE
feat: Added OS version to the OS details

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -110,6 +110,57 @@ describe('_.info', () => {
         }
     })
 
+    it('osVersion', () => {
+        const osVersions = {
+            // Windows Phone
+            'Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 635; BOOST) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537':
+                { os_name: 'Windows Phone', os_version: '' },
+            'Mozilla/5.0 (Windows NT 6.3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36': {
+                os_name: 'Windows',
+                os_version: '6.3',
+            },
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) CriOS/44.0.2403.67 Mobile/12D508 Safari/600.1.4':
+                {
+                    os_name: 'iOS',
+                    os_version: '8.2.0',
+                },
+            'Mozilla/5.0 (iPad; CPU OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H143 Safari/600.1.4':
+                {
+                    os_name: 'iOS',
+                    os_version: '8.4.0',
+                },
+            'Mozilla/5.0 (Linux; Android 4.4.2; Lenovo A7600-F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Safari/537.36':
+                {
+                    os_name: 'Android',
+                    os_version: '4.4.2',
+                },
+            'Mozilla/5.0 (BlackBerry; U; BlackBerry 9300; es) AppleWebKit/534.8+ (KHTML, like Gecko) Version/6.0.0.480 Mobile Safari/534.8+':
+                {
+                    os_name: 'BlackBerry',
+                    os_version: '',
+                },
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36':
+                {
+                    os_name: 'Mac OS X',
+                    os_version: '10.9.5',
+                },
+            'Opera/9.80 (Linux armv7l; InettvBrowser/2.2 (00014A;SonyDTV140;0001;0001) KDL40W600B; CC/MEX) Presto/2.12.407 Version/12.50':
+                {
+                    os_name: 'Linux',
+                    os_version: '',
+                },
+            'Mozilla/5.0 (X11; CrOS armv7l 6680.81.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36':
+                {
+                    os_name: 'Chrome OS',
+                    os_version: '',
+                },
+        }
+
+        for (const [userAgent, osInfo] of Object.entries(osVersions)) {
+            expect(given.subject.os(userAgent)).toEqual(osInfo)
+        }
+    })
+
     it('properties', () => {
         const properties = given.subject.properties()
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -861,14 +861,34 @@ export const _info = {
             if (/Phone/.test(a) || /WPDesktop/.test(a)) {
                 return 'Windows Phone'
             }
+            const match = /Windows NT ([0-9.]+)/i.exec(a)
+            if (match && match[1]) {
+                const version = match[1]
+                return `Windows NT ${version}`
+            }
             return 'Windows'
         } else if (/(iPhone|iPad|iPod)/.test(a)) {
+            const match = /OS (\d+)_(\d+)_?(\d+)?/i.exec(a)
+            if (match && match[1]) {
+                const versionParts = [match[1], match[2], match[3] || '0']
+                return `iOS ${versionParts.join('.')}`
+            }
             return 'iOS'
         } else if (/Android/.test(a)) {
+            const match = /Android (\d+)\.(\d+)\.?(\d+)?/i.exec(a)
+            if (match && match[1]) {
+                const versionParts = [match[1], match[2], match[3] || '0']
+                return `Android ${versionParts.join('.')}`
+            }
             return 'Android'
         } else if (/(BlackBerry|PlayBook|BB10)/i.test(a)) {
             return 'BlackBerry'
         } else if (/Mac/i.test(a)) {
+            const match = /Mac OS X (\d+)[_.](\d+)[_.]?(\d+)?/i.exec(a)
+            if (match && match[1]) {
+                const versionParts = [match[1], match[2], match[3] || '0']
+                return `Mac OS X ${versionParts.join('.')}`
+            }
             return 'Mac OS X'
         } else if (/Linux/.test(a)) {
             return 'Linux'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -855,47 +855,47 @@ export const _info = {
         )
     },
 
-    os: function (): string {
+    os: function (): { os_name: string; os_version: string } {
         const a = userAgent
         if (/Windows/i.test(a)) {
             if (/Phone/.test(a) || /WPDesktop/.test(a)) {
-                return 'Windows Phone'
+                return { os_name: 'Windows Phone', os_version: '' }
             }
             const match = /Windows NT ([0-9.]+)/i.exec(a)
             if (match && match[1]) {
                 const version = match[1]
-                return `Windows NT ${version}`
+                return { os_name: 'Windows', os_version: version }
             }
-            return 'Windows'
+            return { os_name: 'Windows', os_version: '' }
         } else if (/(iPhone|iPad|iPod)/.test(a)) {
             const match = /OS (\d+)_(\d+)_?(\d+)?/i.exec(a)
             if (match && match[1]) {
                 const versionParts = [match[1], match[2], match[3] || '0']
-                return `iOS ${versionParts.join('.')}`
+                return { os_name: 'iOS', os_version: versionParts.join('.') }
             }
-            return 'iOS'
+            return { os_name: 'iOS', os_version: '' }
         } else if (/Android/.test(a)) {
             const match = /Android (\d+)\.(\d+)\.?(\d+)?/i.exec(a)
             if (match && match[1]) {
                 const versionParts = [match[1], match[2], match[3] || '0']
-                return `Android ${versionParts.join('.')}`
+                return { os_name: 'Android', os_version: versionParts.join('.') }
             }
-            return 'Android'
+            return { os_name: 'Android', os_version: '' }
         } else if (/(BlackBerry|PlayBook|BB10)/i.test(a)) {
-            return 'BlackBerry'
+            return { os_name: 'BlackBerry', os_version: '' }
         } else if (/Mac/i.test(a)) {
             const match = /Mac OS X (\d+)[_.](\d+)[_.]?(\d+)?/i.exec(a)
             if (match && match[1]) {
                 const versionParts = [match[1], match[2], match[3] || '0']
-                return `Mac OS X ${versionParts.join('.')}`
+                return { os_name: 'Mac OS X', os_version: versionParts.join('.') }
             }
-            return 'Mac OS X'
+            return { os_name: 'Mac OS X', os_version: '' }
         } else if (/Linux/.test(a)) {
-            return 'Linux'
+            return { os_name: 'Linux', os_version: '' }
         } else if (/CrOS/.test(a)) {
-            return 'Chrome OS'
+            return { os_name: 'Chrome OS', os_version: '' }
         } else {
-            return ''
+            return { os_name: '', os_version: '' }
         }
     },
 
@@ -944,9 +944,11 @@ export const _info = {
     },
 
     properties: function (): Properties {
+        const { os_name, os_version } = _info.os()
         return _extend(
             _strip_empty_properties({
-                $os: _info.os(),
+                $os: os_name,
+                $os_version: os_version,
                 $browser: _info.browser(userAgent, navigator.vendor, (win as any).opera),
                 $device: _info.device(userAgent),
                 $device_type: _info.deviceType(userAgent),
@@ -970,9 +972,11 @@ export const _info = {
     },
 
     people_properties: function (): Properties {
+        const { os_name, os_version } = _info.os()
         return _extend(
             _strip_empty_properties({
-                $os: _info.os(),
+                $os: os_name,
+                $os_version: os_version,
                 $browser: _info.browser(userAgent, navigator.vendor, (win as any).opera),
             }),
             {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -855,44 +855,43 @@ export const _info = {
         )
     },
 
-    os: function (): { os_name: string; os_version: string } {
-        const a = userAgent
-        if (/Windows/i.test(a)) {
-            if (/Phone/.test(a) || /WPDesktop/.test(a)) {
+    os: function (user_agent: string): { os_name: string; os_version: string } {
+        if (/Windows/i.test(user_agent)) {
+            if (/Phone/.test(user_agent) || /WPDesktop/.test(user_agent)) {
                 return { os_name: 'Windows Phone', os_version: '' }
             }
-            const match = /Windows NT ([0-9.]+)/i.exec(a)
+            const match = /Windows NT ([0-9.]+)/i.exec(user_agent)
             if (match && match[1]) {
                 const version = match[1]
                 return { os_name: 'Windows', os_version: version }
             }
             return { os_name: 'Windows', os_version: '' }
-        } else if (/(iPhone|iPad|iPod)/.test(a)) {
-            const match = /OS (\d+)_(\d+)_?(\d+)?/i.exec(a)
+        } else if (/(iPhone|iPad|iPod)/.test(user_agent)) {
+            const match = /OS (\d+)_(\d+)_?(\d+)?/i.exec(user_agent)
             if (match && match[1]) {
                 const versionParts = [match[1], match[2], match[3] || '0']
                 return { os_name: 'iOS', os_version: versionParts.join('.') }
             }
             return { os_name: 'iOS', os_version: '' }
-        } else if (/Android/.test(a)) {
-            const match = /Android (\d+)\.(\d+)\.?(\d+)?/i.exec(a)
+        } else if (/Android/.test(user_agent)) {
+            const match = /Android (\d+)\.(\d+)\.?(\d+)?/i.exec(user_agent)
             if (match && match[1]) {
                 const versionParts = [match[1], match[2], match[3] || '0']
                 return { os_name: 'Android', os_version: versionParts.join('.') }
             }
             return { os_name: 'Android', os_version: '' }
-        } else if (/(BlackBerry|PlayBook|BB10)/i.test(a)) {
+        } else if (/(BlackBerry|PlayBook|BB10)/i.test(user_agent)) {
             return { os_name: 'BlackBerry', os_version: '' }
-        } else if (/Mac/i.test(a)) {
-            const match = /Mac OS X (\d+)[_.](\d+)[_.]?(\d+)?/i.exec(a)
+        } else if (/Mac/i.test(user_agent)) {
+            const match = /Mac OS X (\d+)[_.](\d+)[_.]?(\d+)?/i.exec(user_agent)
             if (match && match[1]) {
                 const versionParts = [match[1], match[2], match[3] || '0']
                 return { os_name: 'Mac OS X', os_version: versionParts.join('.') }
             }
             return { os_name: 'Mac OS X', os_version: '' }
-        } else if (/Linux/.test(a)) {
+        } else if (/Linux/.test(user_agent)) {
             return { os_name: 'Linux', os_version: '' }
-        } else if (/CrOS/.test(a)) {
+        } else if (/CrOS/.test(user_agent)) {
             return { os_name: 'Chrome OS', os_version: '' }
         } else {
             return { os_name: '', os_version: '' }
@@ -944,7 +943,7 @@ export const _info = {
     },
 
     properties: function (): Properties {
-        const { os_name, os_version } = _info.os()
+        const { os_name, os_version } = _info.os(userAgent)
         return _extend(
             _strip_empty_properties({
                 $os: os_name,
@@ -972,7 +971,7 @@ export const _info = {
     },
 
     people_properties: function (): Properties {
-        const { os_name, os_version } = _info.os()
+        const { os_name, os_version } = _info.os(userAgent)
         return _extend(
             _strip_empty_properties({
                 $os: os_name,


### PR DESCRIPTION
## Changes
Added new regexs for matching with the OS versions from the user agent. Currently implemented the version details for the following OSes:
- Windows
- Mac
- IOS
- Android

If needed, I can add for the other OSes too.

fixes https://github.com/PostHog/posthog/issues/6268

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
