### PR TITLE
feat: Added idle timer to recordings

### DIFF
--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -440,6 +440,9 @@ describe('SessionRecording', () => {
                 _emit({
                     event: 123,
                     type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
+                    data: {
+                        source: 1,
+                    },
                 })
                 expect(given.posthog.sessionManager.checkAndGetSessionAndWindowId).toHaveBeenCalledWith(
                     false,
@@ -457,8 +460,15 @@ describe('SessionRecording', () => {
                 given.sessionRecording.startCaptureAndTrySendingQueuedSnapshots()
             })
 
-            const emitAtDateTime = (date) =>
-                _emit({ event: 123, type: INCREMENTAL_SNAPSHOT_EVENT_TYPE, timestamp: date.getTime() })
+            const emitAtDateTime = (date, source = 1) =>
+                _emit({
+                    event: 123,
+                    type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
+                    timestamp: date.getTime(),
+                    data: {
+                        source,
+                    },
+                })
 
             it('takes a full snapshot for the first _emit', () => {
                 emitAtDateTime(startingDate)

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -185,7 +185,7 @@ export class SessionRecording {
     }
 
     _isInteractiveEvent(event: eventWithTime) {
-        return event.type === INCREMENTAL_SNAPSHOT_EVENT_TYPE && ACTIVE_SOURCES.indexOf(event.data.source) !== -1
+        return event.type === INCREMENTAL_SNAPSHOT_EVENT_TYPE && ACTIVE_SOURCES.indexOf(event.data?.source) !== -1
     }
 
     _updateWindowAndSessionIds(event: eventWithTime) {

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -19,7 +19,7 @@ import { logger, loadScript } from '../utils'
 
 const BASE_ENDPOINT = '/e/'
 
-const IDLE_ACTIVITY_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
+export const RECORDING_IDLE_ACTIVITY_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 
 // Copied from rrweb typings to avoid import
 enum IncrementalSource {
@@ -192,11 +192,12 @@ export class SessionRecording {
         // Some recording events are triggered by non-user events (e.g. "X minutes ago" text updating on the screen).
         // We don't want to extend the session or trigger a new session in these cases. These events are designated by event
         // type -> incremental update, and source -> mutation.
+
         const isUserInteraction = this._isInteractiveEvent(event)
 
         if (!isUserInteraction && !this.isIdle) {
             // We check if the lastActivityTimestamp is old enough to go idle
-            if (event.timestamp - this.lastActivityTimestamp > IDLE_ACTIVITY_TIMEOUT_MS) {
+            if (event.timestamp - this.lastActivityTimestamp > RECORDING_IDLE_ACTIVITY_TIMEOUT_MS) {
                 this.isIdle = true
             }
         }

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -14,11 +14,42 @@ import {
 import { PostHog } from '../posthog-core'
 import { DecideResponse, Properties } from '../types'
 import type { record } from 'rrweb/typings'
-import type { eventWithTime, listenerHandler, pluginEvent, recordOptions } from 'rrweb/typings/types'
+import type { eventWithTime, listenerHandler, pluginEvent, recordOptions, EventType } from 'rrweb/typings/types'
 import Config from '../config'
 import { logger, loadScript } from '../utils'
 
 const BASE_ENDPOINT = '/e/'
+
+const IDLE_ACTIVITY_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
+
+// Copied from rrweb typings to avoid import
+enum IncrementalSource {
+    Mutation = 0,
+    MouseMove = 1,
+    MouseInteraction = 2,
+    Scroll = 3,
+    ViewportResize = 4,
+    Input = 5,
+    TouchMove = 6,
+    MediaInteraction = 7,
+    StyleSheetRule = 8,
+    CanvasMutation = 9,
+    Font = 10,
+    Log = 11,
+    Drag = 12,
+    StyleDeclaration = 13,
+}
+
+const ACTIVE_SOURCES = [
+    IncrementalSource.MouseMove,
+    IncrementalSource.MouseInteraction,
+    IncrementalSource.Scroll,
+    IncrementalSource.ViewportResize,
+    IncrementalSource.Input,
+    IncrementalSource.TouchMove,
+    IncrementalSource.MediaInteraction,
+    IncrementalSource.Drag,
+]
 
 export class SessionRecording {
     instance: PostHog
@@ -32,6 +63,8 @@ export class SessionRecording {
     receivedDecide: boolean
     rrwebRecord: typeof record | undefined
     recorderVersion?: string
+    lastActivityTimestamp?: number
+    isIdle = false
 
     constructor(instance: PostHog) {
         this.instance = instance
@@ -152,33 +185,63 @@ export class SessionRecording {
         }
     }
 
+    _isInteractiveEvent(event: eventWithTime) {
+        return event.type === INCREMENTAL_SNAPSHOT_EVENT_TYPE && ACTIVE_SOURCES.indexOf(event.data.source) !== -1
+    }
+
     _updateWindowAndSessionIds(event: eventWithTime) {
         // Some recording events are triggered by non-user events (e.g. "X minutes ago" text updating on the screen).
         // We don't want to extend the session or trigger a new session in these cases. These events are designated by event
         // type -> incremental update, and source -> mutation.
-        const isNotUserInteraction =
-            event.type === INCREMENTAL_SNAPSHOT_EVENT_TYPE && event.data?.source === MUTATION_SOURCE_TYPE
+        const isUserInteraction = this._isInteractiveEvent(event)
+
+        if (!isUserInteraction && !this.isIdle) {
+            // We check if the lastActivityTimestamp is old enough to go idle
+            if (event.timestamp - (this.lastActivityTimestamp || Date.now()) > IDLE_ACTIVITY_TIMEOUT_MS) {
+                this.isIdle = true
+            }
+        }
+
+        if (isUserInteraction) {
+            // Remove the idle state
+            this.lastActivityTimestamp = event.timestamp
+            if (this.isIdle) {
+                this.isIdle = false
+                this._tryTakeFullSnapshot()
+            }
+        }
+
+        if (this.isIdle) {
+            return
+        }
 
         const { windowId, sessionId } = this.instance.sessionManager.checkAndGetSessionAndWindowId(
-            isNotUserInteraction,
+            !isUserInteraction, // readonly if it isn't a user interaction
             event.timestamp
         )
 
-        // Event types FullSnapshot and Meta mean we're already in the process of sending a full snapshot
         if (
-            this.captureStarted &&
-            (this.windowId !== windowId || this.sessionId !== sessionId) &&
-            [FULL_SNAPSHOT_EVENT_TYPE, META_EVENT_TYPE].indexOf(event.type) === -1
+            [FULL_SNAPSHOT_EVENT_TYPE, META_EVENT_TYPE].indexOf(event.type) === -1 &&
+            (this.windowId !== windowId || this.sessionId !== sessionId)
         ) {
-            try {
-                this.rrwebRecord?.takeFullSnapshot()
-            } catch (e) {
-                // Sometimes a race can occur where the recorder is not fully started yet, so we can't take a full snapshot.
-                logger.error('Error taking full snapshot.', e)
-            }
+            this._tryTakeFullSnapshot()
         }
         this.windowId = windowId
         this.sessionId = sessionId
+    }
+
+    _tryTakeFullSnapshot(): boolean {
+        if (!this.captureStarted) {
+            return false
+        }
+        try {
+            this.rrwebRecord?.takeFullSnapshot()
+            return true
+        } catch (e) {
+            // Sometimes a race can occur where the recorder is not fully started yet, so we can't take a full snapshot.
+            logger.error('Error taking full snapshot.', e)
+            return false
+        }
     }
 
     _onScriptLoaded() {
@@ -244,6 +307,10 @@ export class SessionRecording {
                 logger.error('Could not add $pageview to rrweb session', e)
             }
         })
+
+        // We reset the last activity timestamp, resetting the idle timer
+        this.lastActivityTimestamp = Date.now()
+        this.isIdle = false
     }
 
     onRRwebEmit(event: eventWithTime) {
@@ -252,6 +319,11 @@ export class SessionRecording {
         ) as eventWithTime
 
         this._updateWindowAndSessionIds(event)
+
+        if (this.isIdle) {
+            // When in an idle state we keep recording, but don't capture the events
+            return
+        }
 
         const properties = {
             $snapshot_data: event,


### PR DESCRIPTION
## Changes

Closes https://github.com/PostHog/posthog-js/issues/625

We have some really overly long recordings full of useless data, largely due to the fact that we don't check for idle timeouts properly. This PR adds an idle timer which means:

* After N minutes we will stop capturing the recorded data
* A physical interaction is required to come out of idle time (closing a tab doesn't count)
* This should ensure the session reset timer works as expected and that we don't capture a tonne of mutations that happen in the background when the user is not interacting with the page

## TODO
- [x] Add tests for this new functionality

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
