### PR TITLE
fix(identify): actually send $set_once on identify calls

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -129,6 +129,28 @@ describe('capture()', () => {
         const event = given.subject()
         expect(event.properties.key.length).toBe(50000)
     })
+
+    it('passes through $set and $set_once into the request, if the event is an $identify event', () => {
+        // NOTE: this is slightly unusual to test capture for this specific case
+        // of being called with $identify as the event name. It might be that we
+        // decide that this shouldn't be a special case of capture in this case,
+        // but I'll add the case to capture current functionality.
+        //
+        // We check that if identify is called with user $set and $set_once
+        // properties, we also want to ensure capture does the expected thing
+        // with them.
+        const captureResult = given.lib.capture(
+            '$identify',
+            { distinct_id: 'some-distinct-id' },
+            { $set: { email: 'john@example.com' }, $set_once: { howOftenAmISet: 'once!' } }
+        )
+
+        // We assume that the returned result is the object we would send to the
+        // server.
+        expect(captureResult).toEqual(
+            expect.objectContaining({ $set: { email: 'john@example.com' }, $set_once: { howOftenAmISet: 'once!' } })
+        )
+    })
 })
 
 describe('_calculate_event_properties()', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -846,8 +846,9 @@ export class PostHog {
             properties: this._calculate_event_properties(event_name, properties || {}),
         }
 
-        if (event_name === '$identify' && options.$set) {
+        if (event_name === '$identify') {
             data['$set'] = options['$set']
+            data['$set_once'] = options['$set_once']
         }
 
         data = _copyAndTruncateStrings(

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface CaptureResult {
     event: string
     properties: Properties
     $set?: Properties
+    $set_once?: Properties
     timestamp?: Date
 }
 export type CaptureCallback = (response: any, data: any) => void


### PR DESCRIPTION
We were handling $set but not $set_once. This fixes that.

Fixes #615

## Changes

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
