### PR TITLE
fix: Remove API and JS urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.57.1",
+    "version": "1.57.2-alpha.0",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.57.0",
+    "version": "1.57.1-alpha.0",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",

--- a/src/__tests__/extensions/toolbar.js
+++ b/src/__tests__/extensions/toolbar.js
@@ -78,7 +78,6 @@ describe('Toolbar', () => {
                 flag_2: 1,
             },
             userId: 12345,
-            apiURL: given.config.api_host,
             ...given.toolbarParamsOverrides,
         }))
 
@@ -92,14 +91,20 @@ describe('Toolbar', () => {
             }))
 
             given.subject()
-            expect(given.toolbar.loadToolbar).toHaveBeenCalledWith({ ...given.toolbarParams, source: 'url' })
+            expect(given.toolbar.loadToolbar).toHaveBeenCalledWith({
+                ...given.toolbarParams,
+                source: 'url',
+            })
         })
 
         it('should initialize the toolbar when there are editor params in the session', () => {
             given('storedEditorParams', () => JSON.stringify(toolbarParams))
 
             given.subject()
-            expect(given.toolbar.loadToolbar).toHaveBeenCalledWith({ ...given.toolbarParams, source: 'url' })
+            expect(given.toolbar.loadToolbar).toHaveBeenCalledWith({
+                ...given.toolbarParams,
+                source: 'url',
+            })
         })
 
         it('should NOT initialize the toolbar when the activation query param does not exist', () => {
@@ -152,18 +157,22 @@ describe('Toolbar', () => {
             token: 'public_token',
             expiresAt: 'expiresAt',
             apiKey: 'apiKey',
-            apiURL: 'http://localhost:8000',
-            jsURL: 'http://localhost:8000',
         }))
 
         it('should persist for next time', () => {
             expect(given.subject()).toBe(true)
-            expect(JSON.parse(window.localStorage.getItem('_postHogToolbarParams'))).toEqual(given.toolbarParams)
+            expect(JSON.parse(window.localStorage.getItem('_postHogToolbarParams'))).toEqual({
+                ...given.toolbarParams,
+                apiURL: 'http://api.example.com',
+            })
         })
 
         it('should load if not previously loaded', () => {
             expect(given.subject()).toBe(true)
-            expect(window.ph_load_toolbar).toHaveBeenCalledWith(given.toolbarParams, given.lib)
+            expect(window.ph_load_toolbar).toHaveBeenCalledWith(
+                { ...given.toolbarParams, apiURL: 'http://api.example.com' },
+                given.lib
+            )
         })
 
         it('should NOT load if previously loaded', () => {
@@ -184,7 +193,6 @@ describe('Toolbar', () => {
             expect(window.ph_load_toolbar).toHaveBeenCalledWith(
                 {
                     ...given.toolbarParams,
-                    jsURL: 'http://api.example.com',
                     apiURL: 'http://api.example.com',
                     token: 'test_token',
                 },

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -21,7 +21,6 @@ export class Toolbar {
         ) {
             this.loadToolbar({
                 ...toolbarParams,
-                apiURL: this.instance.get_config('api_host'),
             })
         }
     }
@@ -80,10 +79,6 @@ export class Toolbar {
                 delete toolbarParams.userIntent
             }
 
-            if (!toolbarParams.apiURL) {
-                toolbarParams.apiURL = this.instance.get_config('api_host')
-            }
-
             if (toolbarParams['token'] && this.instance.get_config('token') === toolbarParams['token']) {
                 this.loadToolbar(toolbarParams)
                 return true
@@ -102,10 +97,9 @@ export class Toolbar {
         // only load the toolbar once, even if there are multiple instances of PostHogLib
         ;(window as any)['_postHogToolbarLoaded'] = true
 
-        // the toolbar does not use the `jsURL` as that route is cached for 24 hours.
         // By design array.js, recorder.js, and toolbar.js are served from Django with no or limited caching, not from our CDN
         // Django respects the query params for caching, returning a 304 if appropriate
-        const host = params?.['apiURL'] || this.instance.get_config('api_host')
+        const host = this.instance.get_config('api_host')
         const timestampToNearestThirtySeconds = Math.floor(Date.now() / 30000) * 30000
         const toolbarUrl = `${host}${
             host.endsWith('/') ? '' : '/'
@@ -115,10 +109,9 @@ export class Toolbar {
             this.instance.get_config('advanced_disable_toolbar_metrics')
 
         const toolbarParams = {
-            apiURL: host, // defaults to api_host from the instance config if nothing else set
-            jsURL: host, // defaults to api_host from the instance config if nothing else set
             token: this.instance.get_config('token'),
             ...params,
+            apiURL: host, // defaults to api_host from the instance config if nothing else set
             ...(disableToolbarMetrics ? { instrument: false } : {}),
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -268,8 +268,6 @@ export type ToolbarVersion = 'toolbar'
 
 /* sync with posthog */
 export interface ToolbarParams {
-    apiURL?: string
-    jsURL?: string
     token?: string /** public posthog-js token */
     temporaryToken?: string /** private temporary user token */
     actionId?: number


### PR DESCRIPTION
## Changes

Remove API and JS urls, and instead pass the server just the configured API url.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
