### PR TITLE
fix(decide): Make sure all stored properties are sent on first decide request

### DIFF
--- a/cypress/e2e/capture.cy.js
+++ b/cypress/e2e/capture.cy.js
@@ -448,6 +448,10 @@ describe('Event capture', () => {
                         company: 'id:5',
                         playlist: 'id:77',
                     },
+                    group_properties: {
+                        company: { id: 5, company_name: 'Awesome Inc' },
+                        playlist: { length: 8 },
+                    },
                 })
             })
         })

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -3,7 +3,6 @@ import { Decide } from '../decide'
 import { _base64Encode } from '../utils'
 import { PostHogPersistence } from '../posthog-persistence'
 
-
 describe('Decide', () => {
     given('decide', () => new Decide(given.posthog))
     given('posthog', () => ({
@@ -72,7 +71,10 @@ describe('Decide', () => {
         })
 
         it('should send all stored properties with decide request', () => {
-            given.posthog.register({'$stored_person_properties': { 'key': 'value' }, '$stored_group_properties': { 'organization': { 'orgName': 'orgValue' }}})
+            given.posthog.register({
+                $stored_person_properties: { key: 'value' },
+                $stored_group_properties: { organization: { orgName: 'orgValue' } },
+            })
             given.subject()
 
             expect(given.posthog._send_request).toHaveBeenCalledWith(
@@ -83,8 +85,8 @@ describe('Decide', () => {
                             token: 'testtoken',
                             distinct_id: 'distinctid',
                             groups: { organization: '5' },
-                            person_properties: { 'key': 'value' },
-                            group_properties: { 'organization': { 'orgName': 'orgValue' } },
+                            person_properties: { key: 'value' },
+                            group_properties: { organization: { orgName: 'orgValue' } },
                         })
                     ),
                     verbose: true,

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -1,11 +1,17 @@
 import { autocapture } from '../autocapture'
 import { Decide } from '../decide'
 import { _base64Encode } from '../utils'
+import { PostHogPersistence } from '../posthog-persistence'
+
 
 describe('Decide', () => {
     given('decide', () => new Decide(given.posthog))
     given('posthog', () => ({
         get_config: jest.fn().mockImplementation((key) => given.config[key]),
+        persistence: new PostHogPersistence(given.config),
+        register: (props) => given.posthog.persistence.register(props),
+        unregister: (key) => given.posthog.persistence.unregister(key),
+        get_property: (key) => given.posthog.persistence.props[key],
         capture: jest.fn(),
         _captureMetrics: { incr: jest.fn() },
         _addCaptureHook: jest.fn(),
@@ -30,7 +36,7 @@ describe('Decide', () => {
 
     given('decideResponse', () => ({ enable_collect_everything: true }))
 
-    given('config', () => ({ api_host: 'https://test.com' }))
+    given('config', () => ({ api_host: 'https://test.com', persistence: 'memory' }))
 
     beforeEach(() => {
         jest.spyOn(autocapture, 'afterDecideResponse').mockImplementation()
@@ -42,6 +48,7 @@ describe('Decide', () => {
         given('config', () => ({
             api_host: 'https://test.com',
             token: 'testtoken',
+            persistence: 'memory',
         }))
 
         it('should call instance._send_request on constructor', () => {
@@ -55,6 +62,29 @@ describe('Decide', () => {
                             token: 'testtoken',
                             distinct_id: 'distinctid',
                             groups: { organization: '5' },
+                        })
+                    ),
+                    verbose: true,
+                },
+                { method: 'POST' },
+                expect.any(Function)
+            )
+        })
+
+        it('should send all stored properties with decide request', () => {
+            given.posthog.register({'$stored_person_properties': { 'key': 'value' }, '$stored_group_properties': { 'organization': { 'orgName': 'orgValue' }}})
+            given.subject()
+
+            expect(given.posthog._send_request).toHaveBeenCalledWith(
+                'https://test.com/decide/?v=3',
+                {
+                    data: _base64Encode(
+                        JSON.stringify({
+                            token: 'testtoken',
+                            distinct_id: 'distinctid',
+                            groups: { organization: '5' },
+                            person_properties: { 'key': 'value' },
+                            group_properties: { 'organization': { 'orgName': 'orgValue' } },
                         })
                     ),
                     verbose: true,
@@ -97,7 +127,7 @@ describe('Decide', () => {
         })
 
         it('does not enable compression from decide response if compression is disabled', () => {
-            given('config', () => ({ disable_compression: true }))
+            given('config', () => ({ disable_compression: true, persistence: 'memory' }))
             given('decideResponse', () => ({ supportedCompression: ['gzip', 'lz64'] }))
             given.subject()
 
@@ -115,7 +145,7 @@ describe('Decide', () => {
         })
 
         it('runs site apps if opted in', () => {
-            given('config', () => ({ api_host: 'https://test.com', opt_in_site_apps: true }))
+            given('config', () => ({ api_host: 'https://test.com', opt_in_site_apps: true, persistence: 'memory' }))
             given('decideResponse', () => ({ siteApps: [{ id: 1, url: '/site_app/1/tokentoken/hash/' }] }))
             given.subject()
             const element = window.document.body.children[0]
@@ -123,7 +153,7 @@ describe('Decide', () => {
         })
 
         it('does not run site apps code if not opted in', () => {
-            given('config', () => ({ api_host: 'https://test.com', opt_in_site_apps: false }))
+            given('config', () => ({ api_host: 'https://test.com', opt_in_site_apps: false, persistence: 'memory' }))
             given('decideResponse', () => ({ siteApps: [{ id: 1, url: '/site_app/1/tokentoken/hash/' }] }))
             expect(() => {
                 given.subject()

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -23,7 +23,6 @@ export class Decide {
             groups: this.instance.getGroups(),
             person_properties: this.instance.get_property(STORED_PERSON_PROPERTIES_KEY),
             group_properties: this.instance.get_property(STORED_GROUP_PROPERTIES_KEY),
-
         })
 
         const encoded_data = _base64Encode(json_data)

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -2,6 +2,7 @@ import { autocapture } from './autocapture'
 import { _base64Encode, loadScript } from './utils'
 import { PostHog } from './posthog-core'
 import { Compression, DecideResponse } from './types'
+import { STORED_GROUP_PROPERTIES_KEY, STORED_PERSON_PROPERTIES_KEY } from './posthog-persistence'
 
 export class Decide {
     instance: PostHog
@@ -20,6 +21,9 @@ export class Decide {
             token: this.instance.get_config('token'),
             distinct_id: this.instance.get_distinct_id(),
             groups: this.instance.getGroups(),
+            person_properties: this.instance.get_property(STORED_PERSON_PROPERTIES_KEY),
+            group_properties: this.instance.get_property(STORED_GROUP_PROPERTIES_KEY),
+
         })
 
         const encoded_data = _base64Encode(json_data)


### PR DESCRIPTION
## Changes

Ensures stored properties, if any, are sent for all decide requests, not just on feature flag reload
...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
