### PR TITLE
ci: add prettier and eslint linting stage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on:
+    pull_request:
+    push:
+        branches:
+            - master
+
+jobs:
+    build:
+        name: Lint
+        runs-on: ubuntu-latest
+        steps:
+            # Check out the repository
+            - uses: actions/checkout@v1
+
+            # Install Node.js
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 14
+                  cache: 'yarn'
+
+            # Install your dependencies
+            - run: yarn install
+
+            - run: |
+                  yarn prettier --check
+                  yarn eslint

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "build:prepare-types:rename-4": "cd lib/rrweb/typings && sed 's/rrweb-snapshot/..\\/..\\/rrweb-snapshot/g' utils.d.ts > x && mv x utils.d.ts",
         "build:prepare-types:rename-5": "cd lib/src/extensions && sed 's/rrweb\\/typings/..\\/..\\/rrweb\\/typings/g' sessionrecording.d.ts > x && mv x sessionrecording.d.ts",
         "build:prepare-types:rename-6": "cd lib/src && sed 's/rrweb-snapshot/..\\/rrweb-snapshot/g' types.d.ts > x && mv x types.d.ts",
-        "prettier": "prettier --write src/**/* functional_tests/",
+        "prettier": "prettier --write src/ functional_tests/",
         "prepublishOnly": "yarn lint && yarn test && yarn build && yarn test-react",
         "test": "jest src",
         "test-react": "cd react; yarn test",


### PR DESCRIPTION
I don't think we had this before. Assuming you have husky installed or
skip pre-commit hooks, this should never be failing.

## Changes

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
