### PR TITLE
chore: add test for $identify events count optimization

### DIFF
--- a/functional_tests/identify.test.ts
+++ b/functional_tests/identify.test.ts
@@ -1,6 +1,7 @@
 import { PostHog, init_as_module } from '../src/posthog-core'
 import 'regenerator-runtime/runtime'
 import { waitFor } from '@testing-library/dom'
+import { v4 } from 'uuid'
 
 // configure an msw request server that persists requests to a store that we can
 // inspect within tests
@@ -8,11 +9,147 @@ import { setupServer } from 'msw/node'
 import { rest } from 'msw'
 import { assert } from 'console'
 
+test('identify sends a identify event', async () => {
+    const posthog = await createPosthogInstance()
+
+    const anonymousId = posthog.get_distinct_id()
+
+    posthog.identify('test-id')
+
+    await waitFor(() =>
+        expect(capturedRequests['/e/']).toContainEqual(
+            expect.objectContaining({
+                event: '$identify',
+                properties: expect.objectContaining({
+                    distinct_id: 'test-id',
+                    $anon_distinct_id: anonymousId,
+                    token: posthog.config.token,
+                }),
+            })
+        )
+    )
+})
+
+test('identify sends an engage request if identify called twice with the same distinct id and with $set/$set_once', async () => {
+    // The intention here is to reduce the number of unncecessary $identify
+    // requests to process.
+    const posthog = await createPosthogInstance()
+
+    const anonymousId = posthog.get_distinct_id()
+
+    // The first time we identify, it calls the /e/ endpoint with an $identify
+    posthog.identify('test-id', { email: 'first@email.com' }, { location: 'first' })
+
+    await waitFor(() =>
+        expect(capturedRequests['/e/']).toContainEqual(
+            expect.objectContaining({
+                event: '$identify',
+                $set: { email: 'first@email.com' },
+                $set_once: { location: 'first' },
+                properties: expect.objectContaining({
+                    distinct_id: 'test-id',
+                    $anon_distinct_id: anonymousId,
+                    token: posthog.config.token,
+                }),
+            })
+        )
+    )
+
+    // The second time we identify, it calls the /engage/ endpoint with the $set
+    // / $set_once properties, in two separate requests.
+    posthog.identify('test-id', { email: 'test@email.com' }, { location: 'second' })
+
+    await waitFor(() =>
+        expect(capturedRequests['/engage/']).toContainEqual(
+            expect.objectContaining({
+                $distinct_id: 'test-id',
+                $set: {
+                    $browser: 'Safari',
+                    $browser_version: null,
+                    $referrer: '$direct',
+                    $referring_domain: '$direct',
+                    email: 'test@email.com',
+                },
+                $token: posthog.config.token,
+            })
+        )
+    )
+
+    await waitFor(() =>
+        expect(capturedRequests['/engage/']).toContainEqual(
+            expect.objectContaining({
+                $distinct_id: 'test-id',
+                $set_once: { location: 'second' },
+                $token: posthog.config.token,
+            })
+        )
+    )
+})
+
+test('identify sends an engage request if identify called twice with a different distinct_id', async () => {
+    // This is due to $identify only being called for anonymous users.
+    const posthog = await createPosthogInstance()
+
+    const anonymousId = posthog.get_distinct_id()
+
+    // The first time we identify, it calls the /e/ endpoint with an $identify
+    posthog.identify('test-id', { email: 'first@email.com' }, { location: 'first' })
+
+    await waitFor(() =>
+        expect(capturedRequests['/e/']).toContainEqual(
+            expect.objectContaining({
+                event: '$identify',
+                $set: { email: 'first@email.com' },
+                $set_once: { location: 'first' },
+                properties: expect.objectContaining({
+                    distinct_id: 'test-id',
+                    $anon_distinct_id: anonymousId,
+                    token: posthog.config.token,
+                }),
+            })
+        )
+    )
+
+    // The second time we identify, it calls the /engage/ endpoint with the $set
+    // / $set_once properties, in two separate requests.
+    posthog.identify('another-test-id', { email: 'test@email.com' }, { location: 'second' })
+
+    await waitFor(() =>
+        expect(capturedRequests['/engage/']).toContainEqual(
+            expect.objectContaining({
+                $distinct_id: 'another-test-id',
+                $set: {
+                    $browser: 'Safari',
+                    $browser_version: null,
+                    $referrer: '$direct',
+                    $referring_domain: '$direct',
+                    email: 'test@email.com',
+                },
+                $token: posthog.config.token,
+            })
+        )
+    )
+
+    await waitFor(() =>
+        expect(capturedRequests['/engage/']).toContainEqual(
+            expect.objectContaining({
+                $distinct_id: 'another-test-id',
+                $set_once: { location: 'second' },
+                $token: posthog.config.token,
+            })
+        )
+    )
+})
+
 // An MSW server that handles requests to https://app.posthog.com/e/ and stores
 // the request bodies in a store that we can inspect within tests.
-const capturedRequests: string[] = []
+const capturedRequests: { '/e/': any[]; '/engage/': any[] } = {
+    '/e/': [],
+    '/engage/': [],
+}
+
 const server = setupServer(
-    rest.post('http://localhost/e/', (req, res, ctx) => {
+    rest.post('http://localhost/e/', (req: any, res: any, ctx: any) => {
         const body = req.body
         // type guard that body is a string
         if (typeof body !== 'string') {
@@ -24,36 +161,50 @@ const server = setupServer(
         // first. We then need to get the data param from this and base64 decode
         // it.
         const data = JSON.parse(Buffer.from(decodeURIComponent(body.split('=')[1]), 'base64').toString())
-        capturedRequests.push(data)
+        capturedRequests['/e/'] = [...(capturedRequests['/e/'] || []), data]
+        return res(ctx.status(200))
+    }),
+    rest.post('http://localhost/engage/', (req: any, res: any, ctx: any) => {
+        // NOTE: this is a slight duplication of the /e/ handler, but it's
+        // possible that the details are slightly different so I'm leaving it
+        // as is for now.
+        const body = req.body
+        // type guard that body is a string
+        if (typeof body !== 'string') {
+            assert(false, 'body is not a string')
+            return
+        }
+        // we assume the body is JSON and parse it we store the parsed body in
+        // the store The request body is url encoded, so we need to decode it
+        // first. We then need to get the data param from this and base64 decode
+        // it.
+        const data = JSON.parse(Buffer.from(decodeURIComponent(body.split('=')[1]), 'base64').toString())
+        capturedRequests['/engage/'] = [...(capturedRequests['/engage/'] || []), data]
         return res(ctx.status(200))
     })
 )
-server.listen()
+
+// Start the server before all the tests run, and close it afterwards.
+beforeAll(() => server.listen())
+afterAll(() => server.close())
 
 // The library depends on having the module initialized before it can be used.
 // It sets a global variable that is set and used to initialize subsequent libaries.
 beforeAll(() => init_as_module())
 
-test('identify sends a identify event', async () => {
-    let posthog = new PostHog()
-    posthog = await new Promise((resolve) =>
+const createPosthogInstance = async () => {
+    // We need to create a new instance of the library for each test, to ensure
+    // that they are isolated from each other. The way the library is currently
+    // written, we first create an instance, then call init on it which then
+    // creates another instance.
+    const posthog = new PostHog()
+    return await new Promise<PostHog>((resolve) =>
         posthog.init(
-            'testtoken',
+            // Use a random UUID for the token, such that we don't have to worry
+            // about collisions between test cases.
+            v4(),
             { request_batching: false, api_host: 'http://localhost', loaded: (p) => resolve(p) },
             'test'
         )
     )
-
-    const anonymousId = posthog.get_distinct_id()
-
-    posthog.identify('test-id')
-
-    await waitFor(() =>
-        expect(capturedRequests).toContainEqual(
-            expect.objectContaining({
-                event: '$identify',
-                properties: expect.objectContaining({ distinct_id: 'test-id', $anon_distinct_id: anonymousId }),
-            })
-        )
-    )
-})
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "@testing-library/dom": "^9.3.0",
         "@types/jest": "^29.5.1",
         "@types/react-dom": "^18.0.10",
+        "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.30.7",
         "@typescript-eslint/parser": "^5.30.7",
         "babel-eslint": "10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,6 +3749,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/uuid@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.1.tgz#98586dc36aee8dacc98cc396dbca8d0429647aa6"
+  integrity sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"


### PR DESCRIPTION
This is a test around something that we'll likely remove (in https://github.com/PostHog/posthog-js/pull/584), but wanted to
make sure I understood it before removing it.

## Changes

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
