### PR TITLE
fix: properties with "length" value

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -151,6 +151,11 @@ describe('capture()', () => {
             expect.objectContaining({ $set: { email: 'john@example.com' }, $set_once: { howOftenAmISet: 'once!' } })
         )
     })
+
+    it('correctly handles the "length" property', () => {
+        const captureResult = given.lib.capture('event-name', { foo: 'bar', length: 0 })
+        expect(captureResult.properties).toEqual(expect.objectContaining({ foo: 'bar', length: 0 }))
+    })
 })
 
 describe('_calculate_event_properties()', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,20 +102,21 @@ export function _each(obj: any, iterator: (value: any, key: any) => void | Break
     if (obj === null || obj === undefined) {
         return
     }
-    if (nativeForEach && Array.isArray(obj) && obj.forEach === nativeForEach) {
-        obj.forEach(iterator, thisArg)
-    } else if ('length' in obj && obj.length === +obj.length) {
-        for (let i = 0, l = obj.length; i < l; i++) {
-            if (i in obj && iterator.call(thisArg, obj[i], i) === breaker) {
-                return
-            }
-        }
-    } else {
-        for (const key in obj) {
-            if (hasOwnProperty.call(obj, key)) {
-                if (iterator.call(thisArg, obj[key], key) === breaker) {
+    if (Array.isArray(obj)) {
+        if (nativeForEach && Array.isArray(obj) && obj.forEach === nativeForEach) {
+            obj.forEach(iterator, thisArg)
+        } else {
+            for (let i = 0, l = obj.length; i < l; i++) {
+                if (i in obj && iterator.call(thisArg, obj[i], i) === breaker) {
                     return
                 }
+            }
+        }
+    }
+    for (const key in obj) {
+        if (hasOwnProperty.call(obj, key)) {
+            if (iterator.call(thisArg, obj[key], key) === breaker) {
+                return
             }
         }
     }


### PR DESCRIPTION
## Changes

Fixes https://github.com/PostHog/posthog-js/issues/632

We were using "length" to check for an array and iterate. This meant objects with the value "length" failed

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
