### PR TITLE
fix: Session timeout overridden on reload

### DIFF
--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -162,6 +162,8 @@ export class SessionRecording {
         }
 
         this.captureStarted = true
+        // We want to ensure the sessionManager is reset if necessary on load of the recorder
+        this.instance.sessionManager.checkAndGetSessionAndWindowId()
 
         const recorderJS = this.getRecordingVersion() === 'v2' ? 'recorder-v2.js' : 'recorder.js'
 
@@ -215,8 +217,9 @@ export class SessionRecording {
             return
         }
 
+        // We only want to extend the session if it is an interactive event.
         const { windowId, sessionId } = this.instance.sessionManager.checkAndGetSessionAndWindowId(
-            !isUserInteraction, // readonly if it isn't a user interaction
+            !isUserInteraction,
             event.timestamp
         )
 


### PR DESCRIPTION
## Changes

We were accounting for "idle time" whilst the page is loaded but on a reload it can happen that the initial non-interactive events get tracked against the old session ID which is not what we want

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
