### PR TITLE
feat: Add get_session_id and get_session_replay_url functions

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -947,3 +947,32 @@ describe('_loaded()', () => {
         expect(given.overrides.featureFlags.resetRequestQueue).toHaveBeenCalled()
     })
 })
+
+describe('session_id', () => {
+    given('overrides', () => ({
+        sessionManager: {
+            checkAndGetSessionAndWindowId: jest.fn().mockReturnValue({
+                windowId: 'windowId',
+                sessionId: 'sessionId',
+            }),
+            _sessionStartTimestamp: new Date().getTime() - 30000,
+        },
+    }))
+    it('returns the session_id', () => {
+        expect(given.lib.get_session_id()).toEqual('sessionId')
+    })
+
+    it('returns the replay URL', () => {
+        expect(given.lib.get_session_replay_url()).toEqual('https://app.posthog.com/replay/sessionId')
+    })
+
+    it('returns the replay URL including timestamp', () => {
+        expect(given.lib.get_session_replay_url({ withTimestamp: true })).toEqual(
+            'https://app.posthog.com/replay/sessionId?t=20' // default lookback is 10 seconds
+        )
+
+        expect(given.lib.get_session_replay_url({ withTimestamp: true, timestampLookBack: 0 })).toEqual(
+            'https://app.posthog.com/replay/sessionId?t=30'
+        )
+    })
+})

--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -58,8 +58,7 @@ export class SentryIntegration implements _SentryIntegration {
                 const host = _posthog.config.ui_host || _posthog.config.api_host
                 event.tags['PostHog Person URL'] = host + '/person/' + _posthog.get_distinct_id()
                 if (_posthog.sessionRecordingStarted()) {
-                    event.tags['PostHog Recording URL'] =
-                        host + '/recordings/' + _posthog.sessionManager.checkAndGetSessionAndWindowId(true).sessionId
+                    event.tags['PostHog Recording URL'] = _posthog.get_session_replay_url({ withTimestamp: true })
                 }
                 const exceptions = event.exception?.values || []
                 const data: Properties = {


### PR DESCRIPTION
## Changes

We have a use case for this ourselves where we built a [custom code for getting the replay url](https://github.com/PostHog/posthog/blob/master/frontend/src/lib/components/Support/supportLogic.ts#L14) but this is something people often want themselves so now we offer it.

* Adds a simple getter method for the session_id as well as for the replay URL

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
