### PR TITLE
suggestion: Improvements to react flag autocapture

### DIFF
--- a/react/src/components/PostHogFeature.tsx
+++ b/react/src/components/PostHogFeature.tsx
@@ -1,5 +1,5 @@
 import { useFeatureFlagPayload, useFeatureFlagVariantKey, usePostHog } from '../hooks'
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { PostHog } from '../context'
 
 export type PostHogFeatureProps = {
@@ -55,6 +55,13 @@ function VisibilityAndClickTracker({
     const visibilityTrackedRef = useRef(false)
     const clickTrackedRef = useRef(false)
 
+    const cachedOnClick = useCallback(() => {
+        if (!clickTrackedRef.current) {
+            trackClicks(flag, posthog)
+            clickTrackedRef.current = true
+        }
+    }, [flag, posthog])
+
     useEffect(() => {
         if (ref.current === null) return
 
@@ -74,16 +81,7 @@ function VisibilityAndClickTracker({
     }, [flag, options, posthog, ref])
 
     return (
-        <div
-            ref={ref}
-            {...props}
-            onClick={() => {
-                if (!clickTrackedRef.current) {
-                    trackClicks(flag, posthog)
-                    clickTrackedRef.current = true
-                }
-            }}
-        >
+        <div ref={ref} {...props} onClick={cachedOnClick}>
             {children}
         </div>
     )

--- a/react/src/components/PostHogFeature.tsx
+++ b/react/src/components/PostHogFeature.tsx
@@ -2,7 +2,7 @@ import { useFeatureFlagPayload, useFeatureFlagVariantKey, usePostHog } from '../
 import React, { useCallback, useEffect, useRef } from 'react'
 import { PostHog } from '../context'
 
-export type PostHogFeatureProps = {
+export type PostHogFeatureProps = React.HTMLProps<HTMLDivElement> & {
     flag: string
     children: React.ReactNode | ((payload: any) => React.ReactNode)
     fallback: React.ReactNode


### PR DESCRIPTION
## Changes

First pass:
* removes the double-div
* makes sure that all tracking doesn't trigger a re-render
* Passes props through so that they can modify the div if desired
* @neilkakkar  Haven't actually tested this live yet but I think it works

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
