### PR TITLE
feat: remove broken capture using img support

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -115,7 +115,6 @@ const defaultConfig = (): PostHogConfig => ({
     save_referrer: true,
     test: false,
     verbose: false,
-    img: false,
     capture_pageview: true,
     capture_pageleave: true, // We'll only capture pageleave events if capture_pageview is also true
     debug: false,
@@ -648,11 +647,7 @@ export class PostHog {
             ip: this.get_config('ip'),
         })
 
-        if (_isObject(data) && this.get_config('img')) {
-            const img = document.createElement('img')
-            img.src = url
-            document.body.appendChild(img)
-        } else if (useSendBeacon) {
+        if (useSendBeacon) {
             // beacon documentation https://w3c.github.io/beacon/
             // beacons format the message and use the type property
             // also no need to try catch as sendBeacon does not report errors

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,6 @@ export interface PostHogConfig {
     save_referrer: boolean
     test: boolean
     verbose: boolean
-    img: boolean
     capture_pageview: boolean
     capture_pageleave: boolean
     debug: boolean


### PR DESCRIPTION
## Changes

You can configure posthog-js to send capture requests by adding img tags to the DOM

It doesn't work... we've wanted to remove it for forever (see #155)

Technically removing this is a breaking change but since this doesn't really work. We should be safe to remove it

