### PR TITLE
feat: Added support for cross origin iframe recording

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "@rollup/plugin-node-resolve": "^13.3.0",
         "@rollup/plugin-terser": "^0.4.0",
         "@rollup/plugin-typescript": "^8.3.3",
+        "@rrweb/types": "^2.0.0-alpha.8",
         "@sentry/types": "7.37.2",
         "@testing-library/dom": "^9.3.0",
         "@types/jest": "^29.5.1",

--- a/playground/nextjs/pages/_app.tsx
+++ b/playground/nextjs/pages/_app.tsx
@@ -10,6 +10,9 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || '', {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
+        session_recording: {
+            recordCrossOriginIframes: true,
+        },
     })
     ;(window as any).posthog = posthog
 }

--- a/playground/nextjs/pages/iframe.tsx
+++ b/playground/nextjs/pages/iframe.tsx
@@ -1,0 +1,40 @@
+import Head from 'next/head'
+import { usePostHog } from 'posthog-js/react'
+import { useEffect, useState } from 'react'
+
+export default function Home() {
+    const posthog = usePostHog()
+
+    const [otherHost, setOtherHost] = useState('')
+
+    useEffect(() => {
+        setOtherHost(window.location.origin.includes('other-localhost') ? 'localhost' : 'other-localhost')
+    })
+
+    return (
+        <>
+            <Head>
+                <title>PostHog</title>
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+            </Head>
+            <main>
+                <h1>Iframes</h1>
+
+                <h2>Cross origin iframe</h2>
+                <p>
+                    This loads the same page but from <b>other-localhost</b> which you need to add to your hosts file.
+                </p>
+
+                {otherHost && (
+                    <iframe
+                        src={`http://${otherHost}:3000/`}
+                        style={{ width: '100%', height: '500px' }}
+                        onLoad={() => {
+                            posthog?.capture('iframe loaded')
+                        }}
+                    />
+                )}
+            </main>
+        </>
+    )
+}

--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -1,9 +1,23 @@
 import Head from 'next/head'
 import { useFeatureFlagEnabled, usePostHog } from 'posthog-js/react'
+import { useEffect, useState } from 'react'
 
 export default function Home() {
     const posthog = usePostHog()
     const result = useFeatureFlagEnabled('test')
+
+    const [time, setTime] = useState('')
+
+    useEffect(() => {
+        const t = setInterval(() => {
+            setTime(new Date().toISOString().split('T')[1].split('.')[0])
+        }, 1000)
+
+        return () => {
+            clearInterval(t)
+        }
+    }, [])
+
     return (
         <>
             <Head>
@@ -12,6 +26,8 @@ export default function Home() {
             </Head>
             <main>
                 <h1>PostHog React</h1>
+
+                <p>The current time is {time}</p>
 
                 <div className="buttons">
                     <button onClick={() => posthog?.capture('Clicked button')}>Capture event</button>

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -241,6 +241,7 @@ describe('SessionRecording', () => {
                 collectFonts: false,
                 plugins: [],
                 inlineStylesheet: true,
+                recordCrossOriginIframes: false,
             })
         })
 

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -12,8 +12,9 @@ import {
 } from './sessionrecording-utils'
 import { PostHog } from '../posthog-core'
 import { DecideResponse, Properties } from '../types'
-import type { record } from 'rrweb/typings'
-import type { eventWithTime, listenerHandler, pluginEvent, recordOptions } from 'rrweb/typings/types'
+import type { record } from 'rrweb2/typings'
+import type { recordOptions } from 'rrweb2/typings/types'
+import type { eventWithTime, listenerHandler, pluginEvent } from '@rrweb/types'
 import Config from '../config'
 import { logger, loadScript } from '../utils'
 
@@ -37,6 +38,8 @@ enum IncrementalSource {
     Log = 11,
     Drag = 12,
     StyleDeclaration = 13,
+    Selection = 14,
+    AdoptedStyleSheet = 15,
 }
 
 const ACTIVE_SOURCES = [
@@ -263,6 +266,7 @@ export class SessionRecording {
             slimDOMOptions: {},
             collectFonts: false,
             inlineStylesheet: true,
+            recordCrossOriginIframes: false,
         }
         // We switched from loading all of rrweb to just the record part, but
         // keep backwards compatibility if someone hasn't upgraded PostHog

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,7 @@ export interface SessionRecordingOptions {
     collectFonts?: boolean
     inlineStylesheet?: boolean
     recorderVersion?: 'v1' | 'v2'
+    recordCrossOriginIframes?: boolean
 }
 
 export enum Compression {


### PR DESCRIPTION
## Changes

Enables support for cross origin iframe recording as an opt in

* Required v2 recorder
* Need to create a doc explaining the security implications of this

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
