### PR TITLE
chore: correct pnpm version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,7 +78,7 @@ jobs:
             - name: Install pnpm
               uses: pnpm/action-setup@v2
               with:
-                  version: 7.x.x
+                  version: 8.x.x
 
             - name: Set up Node.js
               uses: actions/setup-node@v3


### PR DESCRIPTION
## Changes

The main repo uses pnpm 8, so when the `cd.yml` workflow created a PR to upgrade the posthog-js version it was failing