### PR TITLE
fix: performance observer is not always available

### DIFF
--- a/src/__tests__/extensions/web-performance.test.ts
+++ b/src/__tests__/extensions/web-performance.test.ts
@@ -45,6 +45,28 @@ describe('WebPerformance', () => {
         performance.now = jest.fn(() => Date.now())
     })
 
+    describe('when the browser does not support performance observer', () => {
+        beforeAll(() => {
+            const OriginalPerformanceObserver = window.PerformanceObserver
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            window.PerformanceObserver = undefined
+
+            afterAll(() => {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                window.PerformanceObserver = OriginalPerformanceObserver
+            })
+        })
+
+        it('should not start the observer', () => {
+            const webPerformance = new WebPerformanceObserver(mockPostHogInstance as PostHog)
+            webPerformance.startObserving()
+            expect(webPerformance.isObserving()).toBe(false)
+        })
+    })
+
     describe('_capturePerformanceEvent', () => {
         it('should capture and save a standard perf event', () => {
             webPerformance._capturePerformanceEvent(

--- a/src/__tests__/extensions/web-performance.test.ts
+++ b/src/__tests__/extensions/web-performance.test.ts
@@ -46,9 +46,9 @@ describe('WebPerformance', () => {
     })
 
     describe('when the browser does not support performance observer', () => {
-        beforeAll(() => {
-            const OriginalPerformanceObserver = window.PerformanceObserver
+        const OriginalPerformanceObserver = window.PerformanceObserver
 
+        beforeAll(() => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
             window.PerformanceObserver = undefined

--- a/src/__tests__/extensions/web-performance.test.ts
+++ b/src/__tests__/extensions/web-performance.test.ts
@@ -52,12 +52,12 @@ describe('WebPerformance', () => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
             window.PerformanceObserver = undefined
+        })
 
-            afterAll(() => {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                window.PerformanceObserver = OriginalPerformanceObserver
-            })
+        afterAll(() => {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            window.PerformanceObserver = OriginalPerformanceObserver
         })
 
         it('should not start the observer', () => {

--- a/src/extensions/web-performance.ts
+++ b/src/extensions/web-performance.ts
@@ -101,6 +101,11 @@ export class WebPerformanceObserver {
             return
         }
 
+        if (window?.PerformanceObserver?.supportedEntryTypes === undefined) {
+            logger.log('PostHog Peformance observer not started because PerformanceObserver is not supported.')
+            return
+        }
+
         if (isLocalhost() && !this._forceAllowLocalhost) {
             logger.log('PostHog Peformance observer not started because we are on localhost.')
             return

--- a/src/extensions/web-performance.ts
+++ b/src/extensions/web-performance.ts
@@ -102,7 +102,9 @@ export class WebPerformanceObserver {
         }
 
         if (window?.PerformanceObserver?.supportedEntryTypes === undefined) {
-            logger.log('PostHog Peformance observer not started because PerformanceObserver is not supported.')
+            logger.log(
+                'PostHog Peformance observer not started because PerformanceObserver is not supported by this browser.'
+            )
             return
         }
 


### PR DESCRIPTION
## Changes

see https://caniuse.com/mdn-api_performanceobserver
and private slack thread https://posthog.slack.com/archives/C0522G09STW/p1685541615179339

performance observer is not always available (e.g. Safari <= 11) and even when it is `supportedEntryTypes` is not always available (e.g. Safari <= 12)

So, let's check it is available before trying to use it