### PR TITLE
fix: Typescript import issue with rrweb

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,19 +8,9 @@
     "scripts": {
         "start": "yarn build-rollup -w",
         "build": "yarn build-rollup && yarn build-react",
-        "build-rollup": "yarn build:prepare-types && rollup -c",
+        "build-rollup": "rm -rf lib && tsc -b && rollup -c",
         "build-react": "cd react; yarn; yarn build;",
         "lint": "eslint src",
-        "build:prepare-types": "yarn build:prepare-types:tsc && yarn build:prepare-types:copy && yarn build:prepare-types:fix && yarn build:prepare-types:rename-1 && yarn build:prepare-types:rename-2 && yarn build:prepare-types:rename-3 && yarn build:prepare-types:rename-4 && yarn build:prepare-types:rename-5 && yarn build:prepare-types:rename-6",
-        "build:prepare-types:tsc": "rm -rf lib && tsc -b",
-        "build:prepare-types:copy": "rm -rf lib/rrweb && rm -rf lib/rrweb-snapshot && cp -a node_modules/rrweb lib/rrweb; cp -a node_modules/rrweb-snapshot/typings lib/rrweb-snapshot",
-        "build:prepare-types:fix": "cd lib/rrweb/typings/replay && cat index.d.ts |grep -v 'styles/style.css' > x && mv x index.d.ts",
-        "build:prepare-types:rename-1": "cd lib/rrweb/typings/record && sed 's/rrweb-snapshot/..\\/..\\/..\\/rrweb-snapshot/g' iframe-manager.d.ts > x && mv x iframe-manager.d.ts",
-        "build:prepare-types:rename-2": "cd lib/rrweb/typings/replay && sed 's/rrweb-snapshot/..\\/..\\/..\\/rrweb-snapshot/g' virtual-styles.d.ts > x && mv x virtual-styles.d.ts",
-        "build:prepare-types:rename-3": "cd lib/rrweb/typings && sed 's/rrweb-snapshot/..\\/..\\/rrweb-snapshot/g' types.d.ts > x && mv x types.d.ts",
-        "build:prepare-types:rename-4": "cd lib/rrweb/typings && sed 's/rrweb-snapshot/..\\/..\\/rrweb-snapshot/g' utils.d.ts > x && mv x utils.d.ts",
-        "build:prepare-types:rename-5": "cd lib/src/extensions && sed 's/rrweb\\/typings/..\\/..\\/rrweb\\/typings/g' sessionrecording.d.ts > x && mv x sessionrecording.d.ts",
-        "build:prepare-types:rename-6": "cd lib/src && sed 's/rrweb-snapshot/..\\/rrweb-snapshot/g' types.d.ts > x && mv x types.d.ts",
         "prettier": "prettier --write src/ functional_tests/",
         "prepublishOnly": "yarn lint && yarn test && yarn build && yarn test-react",
         "test": "jest src",
@@ -39,8 +29,7 @@
         "react/package.json"
     ],
     "dependencies": {
-        "fflate": "^0.4.1",
-        "rrweb-snapshot": "^1.1.14"
+        "fflate": "^0.4.1"
     },
     "devDependencies": {
         "@babel/core": "7.18.9",
@@ -83,8 +72,9 @@
         "rollup": "^2.77.0",
         "rollup-plugin-dts": "^4.2.2",
         "rollup-plugin-visualizer": "^5.9.0",
-        "rrweb": "^1.1.3",
-        "rrweb2": "npm:rrweb@2.0.0-alpha.8",
+        "rrweb-v1": "npm:rrweb@1.1.3",
+        "rrweb": "2.0.0-alpha.8",
+        "rrweb-snapshot": "2.0.0-alpha.8",
         "sinon": "9.0.2",
         "testcafe": "^1.19.0",
         "testcafe-browser-provider-browserstack": "^1.14.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -3735,11 +3735,6 @@ rollup@^2.35.1:
   optionalDependencies:
     fsevents "~2.3.1"
 
-rrweb-snapshot@^1.1.14:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.14.tgz#9d4d9be54a28a893373428ee4393ec7e5bd83fcc"
-  integrity sha512-eP5pirNjP5+GewQfcOQY4uBiDnpqxNRc65yKPW0eSoU1XamDfc4M8oqpXGMyUyvLyxFDB0q0+DChuxxiU2FXBQ==
-
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -90,6 +90,10 @@ export default [
     {
         input: './lib/src/loader-module.d.ts',
         output: [{ file: pkg.types, format: 'es' }],
-        plugins: [dts()],
+        plugins: [
+            dts({
+                respectExternal: true,
+            }),
+        ],
     },
 ]

--- a/src/extensions/sessionrecording-utils.ts
+++ b/src/extensions/sessionrecording-utils.ts
@@ -1,4 +1,4 @@
-import type { pluginEvent } from 'rrweb/typings/types'
+import type { pluginEvent } from '@rrweb/types'
 
 export const replacementImageURI =
     'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNOCAwSDE2TDAgMTZWOEw4IDBaIiBmaWxsPSIjMkQyRDJEIi8+CjxwYXRoIGQ9Ik0xNiA4VjE2SDhMMTYgOFoiIGZpbGw9IiMyRDJEMkQiLz4KPC9zdmc+Cg=='

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -12,15 +12,66 @@ import {
 } from './sessionrecording-utils'
 import { PostHog } from '../posthog-core'
 import { DecideResponse, Properties } from '../types'
-import type { record } from 'rrweb2/typings'
-import type { recordOptions } from 'rrweb2/typings/types'
-import type { eventWithTime, listenerHandler, pluginEvent } from '@rrweb/types'
+import type {
+    KeepIframeSrcFn,
+    RecordPlugin,
+    SamplingStrategy,
+    blockClass,
+    eventWithTime,
+    hooksParam,
+    listenerHandler,
+    maskTextClass,
+    pluginEvent,
+} from '@rrweb/types'
 import Config from '../config'
 import { logger, loadScript } from '../utils'
+import type { DataURLOptions, MaskInputFn, MaskInputOptions, MaskTextFn, SlimDOMOptions } from 'rrweb-snapshot'
 
 const BASE_ENDPOINT = '/e/'
 
 export const RECORDING_IDLE_ACTIVITY_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
+
+// NOTE: Importing this type is problematic as we can't safely bundle it to a TS definition so instead we redefine.
+// import type { record } from 'rrweb2/typings'
+// import type { recordOptions } from 'rrweb/typings/types'
+
+export type rrwebRecord = {
+    (options: recordOptions<eventWithTime>): listenerHandler
+    addCustomEvent: (tag: string, payload: any) => void
+    takeFullSnapshot: () => void
+}
+
+export declare type recordOptions<T> = {
+    emit?: (e: T, isCheckout?: boolean) => void
+    checkoutEveryNth?: number
+    checkoutEveryNms?: number
+    blockClass?: blockClass
+    blockSelector?: string
+    ignoreClass?: string
+    maskTextClass?: maskTextClass
+    maskTextSelector?: string
+    maskAllInputs?: boolean
+    maskInputOptions?: MaskInputOptions
+    maskInputFn?: MaskInputFn
+    maskTextFn?: MaskTextFn
+    slimDOMOptions?: SlimDOMOptions | 'all' | true
+    ignoreCSSAttributes?: Set<string>
+    inlineStylesheet?: boolean
+    hooks?: hooksParam
+    // packFn?: PackFn
+    sampling?: SamplingStrategy
+    dataURLOptions?: DataURLOptions
+    recordCanvas?: boolean
+    recordCrossOriginIframes?: boolean
+    recordAfter?: 'DOMContentLoaded' | 'load'
+    userTriggeredOnInput?: boolean
+    collectFonts?: boolean
+    inlineImages?: boolean
+    plugins?: RecordPlugin[]
+    mousemoveWait?: number
+    keepIframeSrcFn?: KeepIframeSrcFn
+    // errorHandler?: ErrorHandler
+}
 
 // Copied from rrweb typings to avoid import
 enum IncrementalSource {
@@ -63,7 +114,7 @@ export class SessionRecording {
     windowId: string | null
     sessionId: string | null
     receivedDecide: boolean
-    rrwebRecord: typeof record | undefined
+    rrwebRecord: rrwebRecord | undefined
     recorderVersion?: string
     lastActivityTimestamp: number = Date.now()
     isIdle = false

--- a/src/loader-recorder-v2.ts
+++ b/src/loader-recorder-v2.ts
@@ -1,12 +1,12 @@
-import { version } from 'rrweb2/package.json'
+import { version } from 'rrweb/package.json'
 
 // Same as loader-globals.ts except includes rrweb2 scripts.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import rrwebRecord from 'rrweb2/es/rrweb/packages/rrweb/src/record'
+import rrwebRecord from 'rrweb/es/rrweb/packages/rrweb/src/record'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import { getRecordConsolePlugin } from 'rrweb2/es/rrweb/packages/rrweb/src/plugins/console/record'
+import { getRecordConsolePlugin } from 'rrweb/es/rrweb/packages/rrweb/src/plugins/console/record'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 

--- a/src/loader-recorder.ts
+++ b/src/loader-recorder.ts
@@ -1,12 +1,12 @@
-import { version } from 'rrweb/package.json'
+import { version } from 'rrweb-v1/package.json'
 
 // Same as loader-globals.ts except includes rrweb scripts.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import rrwebRecord from 'rrweb/es/rrweb/packages/rrweb/src/record'
+import rrwebRecord from 'rrweb-v1/es/rrweb/packages/rrweb/src/record'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import { getRecordConsolePlugin } from 'rrweb/es/rrweb/packages/rrweb/src/plugins/console/record'
+import { getRecordConsolePlugin } from 'rrweb-v1/es/rrweb/packages/rrweb/src/plugins/console/record'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10279,12 +10279,24 @@ rrweb-snapshot@^1.1.14:
   resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.14.tgz#9d4d9be54a28a893373428ee4393ec7e5bd83fcc"
   integrity sha512-eP5pirNjP5+GewQfcOQY4uBiDnpqxNRc65yKPW0eSoU1XamDfc4M8oqpXGMyUyvLyxFDB0q0+DChuxxiU2FXBQ==
 
-rrweb-snapshot@^2.0.0-alpha.8:
+rrweb-snapshot@^2.0.0-alpha.8, "rrweb-snapshot@npm:rrweb-snapshot@2.0.0-alpha.8":
   version "2.0.0-alpha.8"
   resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.8.tgz#5f93f8ab7d78b3de26f6a64e993ff68edd54e0cf"
   integrity sha512-3Rb7c+mnDEADQ8N9qn9SDH5PzCyHlZ1cwZC932qRyt9O8kJWLM11JLYqqEyQCa2FZVQbzH2iAaCgnyM7A32p7A==
 
-"rrweb2@npm:rrweb@2.0.0-alpha.8":
+"rrweb-v1@npm:rrweb@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-1.1.3.tgz#4fbb3d473d71c79b6c30a54e585e5a01c8ac08bb"
+  integrity sha512-F2qp8LteJLyycsv+lCVJqtVpery63L3U+/ogqMA0da8R7Jx57o6gT+HpjrzdeeGMIBZR7kKNaKyJwDupTTu5KA==
+  dependencies:
+    "@types/css-font-loading-module" "0.0.7"
+    "@xstate/fsm" "^1.4.0"
+    base64-arraybuffer "^1.0.1"
+    fflate "^0.4.4"
+    mitt "^1.1.3"
+    rrweb-snapshot "^1.1.14"
+
+rrweb@2.0.0-alpha.8:
   version "2.0.0-alpha.8"
   resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-2.0.0-alpha.8.tgz#5cd21510fa011dcb21284a43f3f3d467e2985590"
   integrity sha512-JtJCeUjZ91/qJ6gvLmZw/1Bxuddt06pD887shIYzGhKuOgjtvkUdhBtB5uXrV7Bvi3WELYGZr1stqBugWa9MXg==
@@ -10297,18 +10309,6 @@ rrweb-snapshot@^2.0.0-alpha.8:
     mitt "^3.0.0"
     rrdom "^2.0.0-alpha.8"
     rrweb-snapshot "^2.0.0-alpha.8"
-
-rrweb@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-1.1.3.tgz#4fbb3d473d71c79b6c30a54e585e5a01c8ac08bb"
-  integrity sha512-F2qp8LteJLyycsv+lCVJqtVpery63L3U+/ogqMA0da8R7Jx57o6gT+HpjrzdeeGMIBZR7kKNaKyJwDupTTu5KA==
-  dependencies:
-    "@types/css-font-loading-module" "0.0.7"
-    "@xstate/fsm" "^1.4.0"
-    base64-arraybuffer "^1.0.1"
-    fflate "^0.4.4"
-    mitt "^1.1.3"
-    rrweb-snapshot "^1.1.14"
 
 rsvp@^4.8.4:
   version "4.8.5"


### PR DESCRIPTION
## Changes

We had some hacky code to ensure we import rrweb types and only types. Got rid of the hacky code by copying a few imports directly and enforcing the dts of rollup to include those types in the bundle

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
