### PR TITLE
feat: send event UUIDs

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -46,6 +46,11 @@ describe('capture()', () => {
         __captureHooks: [],
     }))
 
+    it('adds a UUID to each message', () => {
+        const captureData = given.subject()
+        expect(captureData).toHaveProperty('uuid')
+    })
+
     it('handles recursive objects', () => {
         given('eventProperties', () => {
             const props = {}

--- a/src/__tests__/test-uuid.js
+++ b/src/__tests__/test-uuid.js
@@ -1,0 +1,12 @@
+import { _UUID } from '../utils'
+
+describe('uuid', () => {
+    it('should be a uuid when requested', () => {
+        // the most thorough test case it is possible to write
+        expect(_UUID('v7')).toHaveLength(36)
+    })
+
+    it('by default should be the format we have used forever', () => {
+        expect(_UUID().length).toBeGreaterThanOrEqual(52)
+    })
+})

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -857,6 +857,7 @@ export class PostHog {
         }
 
         let data: CaptureResult = {
+            uuid: _UUID('v7'),
             event: event_name,
             properties: this._calculate_event_properties(event_name, properties || {}),
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import { RetryQueue } from './retry-queue'
 export type Property = any
 export type Properties = Record<string, Property>
 export interface CaptureResult {
+    uuid: string
     event: string
     properties: Properties
     $set?: Properties

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import Config from './config'
 import { Breaker, EventHandler, Properties } from './types'
+import { uuidv7 } from './uuidv7'
 
 /*
  * Saved references to long variable names, so that closure compiler can
@@ -519,7 +520,11 @@ export const _UUID = (function () {
         return ret.toString(16)
     }
 
-    return function () {
+    return function (version?: 'v7') {
+        if (version === 'v7') {
+            return uuidv7()
+        }
+
         const se = typeof window !== 'undefined' ? (window.screen.height * window.screen.width).toString(16) : '0'
         return T() + '-' + R() + '-' + UA() + '-' + se + '-' + T()
     }

--- a/src/uuidv7.ts
+++ b/src/uuidv7.ts
@@ -1,0 +1,226 @@
+/**
+ * uuidv7: An experimental implementation of the proposed UUID Version 7
+ *
+ * @license Apache-2.0
+ * @copyright 2021-2023 LiosK
+ * @packageDocumentation
+ *
+ * from https://github.com/LiosK/uuidv7/blob/e501462ea3d23241de13192ceae726956f9b3b7d/src/index.ts
+ */
+
+const DIGITS = '0123456789abcdef'
+
+/** Represents a UUID as a 16-byte byte array. */
+export class UUID {
+    /** @param bytes - The 16-byte byte array representation. */
+    constructor(readonly bytes: Readonly<Uint8Array>) {
+        if (bytes.length !== 16) {
+            throw new TypeError('not 128-bit length')
+        }
+    }
+
+    /**
+     * Builds a byte array from UUIDv7 field values.
+     *
+     * @param unixTsMs - A 48-bit `unix_ts_ms` field value.
+     * @param randA - A 12-bit `rand_a` field value.
+     * @param randBHi - The higher 30 bits of 62-bit `rand_b` field value.
+     * @param randBLo - The lower 32 bits of 62-bit `rand_b` field value.
+     */
+    static fromFieldsV7(unixTsMs: number, randA: number, randBHi: number, randBLo: number): UUID {
+        if (
+            !Number.isInteger(unixTsMs) ||
+            !Number.isInteger(randA) ||
+            !Number.isInteger(randBHi) ||
+            !Number.isInteger(randBLo) ||
+            unixTsMs < 0 ||
+            randA < 0 ||
+            randBHi < 0 ||
+            randBLo < 0 ||
+            unixTsMs > 0xffff_ffff_ffff ||
+            randA > 0xfff ||
+            randBHi > 0x3fff_ffff ||
+            randBLo > 0xffff_ffff
+        ) {
+            throw new RangeError('invalid field value')
+        }
+
+        const bytes = new Uint8Array(16)
+        bytes[0] = unixTsMs / 2 ** 40
+        bytes[1] = unixTsMs / 2 ** 32
+        bytes[2] = unixTsMs / 2 ** 24
+        bytes[3] = unixTsMs / 2 ** 16
+        bytes[4] = unixTsMs / 2 ** 8
+        bytes[5] = unixTsMs
+        bytes[6] = 0x70 | (randA >>> 8)
+        bytes[7] = randA
+        bytes[8] = 0x80 | (randBHi >>> 24)
+        bytes[9] = randBHi >>> 16
+        bytes[10] = randBHi >>> 8
+        bytes[11] = randBHi
+        bytes[12] = randBLo >>> 24
+        bytes[13] = randBLo >>> 16
+        bytes[14] = randBLo >>> 8
+        bytes[15] = randBLo
+        return new UUID(bytes)
+    }
+
+    /** @returns The 8-4-4-4-12 canonical hexadecimal string representation. */
+    toString(): string {
+        let text = ''
+        for (let i = 0; i < this.bytes.length; i++) {
+            text += DIGITS.charAt(this.bytes[i] >>> 4)
+            text += DIGITS.charAt(this.bytes[i] & 0xf)
+            if (i === 3 || i === 5 || i === 7 || i === 9) {
+                text += '-'
+            }
+        }
+        return text
+    }
+
+    /** Creates an object from `this`. */
+    clone(): UUID {
+        return new UUID(this.bytes.slice(0))
+    }
+
+    /** Returns true if `this` is equivalent to `other`. */
+    equals(other: UUID): boolean {
+        return this.compareTo(other) === 0
+    }
+
+    /**
+     * Returns a negative integer, zero, or positive integer if `this` is less
+     * than, equal to, or greater than `other`, respectively.
+     */
+    compareTo(other: UUID): number {
+        for (let i = 0; i < 16; i++) {
+            const diff = this.bytes[i] - other.bytes[i]
+            if (diff !== 0) {
+                return Math.sign(diff)
+            }
+        }
+        return 0
+    }
+}
+
+/** Encapsulates the monotonic counter state. */
+class V7Generator {
+    private timestamp = 0
+    private counter = 0
+    private readonly random = new DefaultRandom()
+
+    /**
+     * Generates a new UUIDv7 object from the current timestamp, or resets the
+     * generator upon significant timestamp rollback.
+     *
+     * This method returns monotonically increasing UUIDs unless the up-to-date
+     * timestamp is significantly (by ten seconds or more) smaller than the one
+     * embedded in the immediately preceding UUID. If such a significant clock
+     * rollback is detected, this method resets the generator and returns a new
+     * UUID based on the current timestamp.
+     */
+    generate(): UUID {
+        const value = this.generateOrAbort()
+        if (value !== undefined) {
+            return value
+        } else {
+            // reset state and resume
+            this.timestamp = 0
+            return this.generateOrAbort()!
+        }
+    }
+
+    /**
+     * Generates a new UUIDv7 object from the current timestamp, or returns
+     * `undefined` upon significant timestamp rollback.
+     *
+     * This method returns monotonically increasing UUIDs unless the up-to-date
+     * timestamp is significantly (by ten seconds or more) smaller than the one
+     * embedded in the immediately preceding UUID. If such a significant clock
+     * rollback is detected, this method aborts and returns `undefined`.
+     */
+    generateOrAbort(): UUID | undefined {
+        const MAX_COUNTER = 0x3ff_ffff_ffff
+        const ROLLBACK_ALLOWANCE = 10_000 // 10 seconds
+
+        const ts = Date.now()
+        if (ts > this.timestamp) {
+            this.timestamp = ts
+            this.resetCounter()
+        } else if (ts + ROLLBACK_ALLOWANCE > this.timestamp) {
+            // go on with previous timestamp if new one is not much smaller
+            this.counter++
+            if (this.counter > MAX_COUNTER) {
+                // increment timestamp at counter overflow
+                this.timestamp++
+                this.resetCounter()
+            }
+        } else {
+            // abort if clock went backwards to unbearable extent
+            return undefined
+        }
+
+        return UUID.fromFieldsV7(
+            this.timestamp,
+            Math.trunc(this.counter / 2 ** 30),
+            this.counter & (2 ** 30 - 1),
+            this.random.nextUint32()
+        )
+    }
+
+    /** Initializes the counter at a 42-bit random integer. */
+    private resetCounter(): void {
+        this.counter = this.random.nextUint32() * 0x400 + (this.random.nextUint32() & 0x3ff)
+    }
+}
+
+/** A global flag to force use of cryptographically strong RNG. */
+declare const UUIDV7_DENY_WEAK_RNG: boolean
+
+/** Stores `crypto.getRandomValues()` available in the environment. */
+let getRandomValues: <T extends Uint8Array | Uint32Array>(buffer: T) => T = (buffer) => {
+    // fall back on Math.random() unless the flag is set to true
+    if (typeof UUIDV7_DENY_WEAK_RNG !== 'undefined' && UUIDV7_DENY_WEAK_RNG) {
+        throw new Error('no cryptographically strong RNG available')
+    }
+
+    for (let i = 0; i < buffer.length; i++) {
+        buffer[i] = Math.trunc(Math.random() * 0x1_0000) * 0x1_0000 + Math.trunc(Math.random() * 0x1_0000)
+    }
+    return buffer
+}
+
+// detect Web Crypto API
+if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    getRandomValues = (buffer) => crypto.getRandomValues(buffer)
+}
+
+/**
+ * Wraps `crypto.getRandomValues()` and compatibles to enable buffering; this
+ * uses a small buffer by default to avoid unbearable throughput decline in some
+ * environments as well as the waste of time and space for unused values.
+ */
+class DefaultRandom {
+    private readonly buffer = new Uint32Array(8)
+    private cursor = Infinity
+    nextUint32(): number {
+        if (this.cursor >= this.buffer.length) {
+            getRandomValues(this.buffer)
+            this.cursor = 0
+        }
+        return this.buffer[this.cursor++]
+    }
+}
+
+let defaultGenerator: V7Generator | undefined
+
+/**
+ * Generates a UUIDv7 string.
+ *
+ * @returns The 8-4-4-4-12 canonical hexadecimal string representation
+ * ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx").
+ */
+export const uuidv7 = (): string => uuidv7obj().toString()
+
+/** Generates a UUIDv7 object. */
+const uuidv7obj = (): UUID => (defaultGenerator || (defaultGenerator = new V7Generator())).generate()


### PR DESCRIPTION
## Changes

We want each message to have its own UUID so that if it is retried and multiple instances of the event are written to ClickHouse it will be auto-de-duplicated

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
