### PR TITLE
feat: default endpoint for session recordings is /s/

### DIFF
--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -266,7 +266,7 @@ describe('SessionRecording', () => {
                 {
                     method: 'POST',
                     transport: 'XHR',
-                    endpoint: '/e/',
+                    endpoint: '/s/',
                     _noTruncate: true,
                     _batchKey: 'sessionRecording',
                     _metrics: expect.anything(),
@@ -282,7 +282,7 @@ describe('SessionRecording', () => {
                 {
                     method: 'POST',
                     transport: 'XHR',
-                    endpoint: '/e/',
+                    endpoint: '/s/',
                     _noTruncate: true,
                     _batchKey: 'sessionRecording',
                     _metrics: expect.anything(),

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -27,11 +27,11 @@ import Config from '../config'
 import { logger, loadScript } from '../utils'
 import type { DataURLOptions, MaskInputFn, MaskInputOptions, MaskTextFn, SlimDOMOptions } from 'rrweb-snapshot'
 
-const BASE_ENDPOINT = '/e/'
+const BASE_ENDPOINT = '/s/'
 
 export const RECORDING_IDLE_ACTIVITY_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 
-// NOTE: Importing this type is problematic as we can't safely bundle it to a TS definition so instead we redefine.
+// NOTE: Importing this type is problematic as we can't safely bundle it to a TS definition so, instead we redefine.
 // import type { record } from 'rrweb2/typings'
 // import type { recordOptions } from 'rrweb/typings/types'
 


### PR DESCRIPTION
## Changes

It's been /s/ for _years_ let's make it official

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
