### PR TITLE
feat: backoff with jitter

### DIFF
--- a/src/__tests__/retry-queue.js
+++ b/src/__tests__/retry-queue.js
@@ -1,5 +1,5 @@
 import { CaptureMetrics } from '../capture-metrics'
-import { RetryQueue } from '../retry-queue'
+import { pickNextRetryDelay, RetryQueue } from '../retry-queue'
 import * as SendRequest from '../send-request'
 
 const EPOCH = 1_600_000_000
@@ -183,7 +183,7 @@ describe('RetryQueue', () => {
                     options: defaultRequestOptions,
                     retriesPerformedSoFar: 1,
                 },
-                retryAt: new Date(fixedDate.getTime() + 6000), // 3000 * 2^1
+                retryAt: expect.any(Date),
             },
             {
                 requestData: {
@@ -192,7 +192,7 @@ describe('RetryQueue', () => {
                     options: defaultRequestOptions,
                     retriesPerformedSoFar: 5,
                 },
-                retryAt: new Date(fixedDate.getTime() + 96000), // 3000 * 2^5
+                retryAt: expect.any(Date),
             },
             {
                 requestData: {
@@ -201,7 +201,7 @@ describe('RetryQueue', () => {
                     options: defaultRequestOptions,
                     retriesPerformedSoFar: 9,
                 },
-                retryAt: new Date(fixedDate.getTime() + 1536000), // 3000 * 2^9
+                retryAt: expect.any(Date),
             },
         ])
     })
@@ -215,5 +215,34 @@ describe('RetryQueue', () => {
         })
 
         expect(given.retryQueue.queue.length).toEqual(0)
+    })
+
+    describe('backoff calculation', () => {
+        const retryDelaysOne = Array.from({ length: 10 }, (_, i) => i).map((i) => {
+            return pickNextRetryDelay(i + 1)
+        })
+        const retryDelaysTwo = Array.from({ length: 10 }, (_, i) => i).map((i) => {
+            return pickNextRetryDelay(i + 1)
+        })
+        const retryDelaysThree = Array.from({ length: 10 }, (_, i) => i).map((i) => {
+            return pickNextRetryDelay(i + 1)
+        })
+
+        it('retry times are not identical each time they are generated', () => {
+            retryDelaysOne.forEach((delay, i) => {
+                expect(delay).not.toEqual(retryDelaysTwo[i])
+                expect(delay).not.toEqual(retryDelaysThree[i])
+            })
+        })
+
+        it('retry times are within bounds +/- jitter of 50%', () => {
+            retryDelaysOne
+                .concat(retryDelaysTwo)
+                .concat(retryDelaysThree)
+                .forEach((delay) => {
+                    expect(delay).toBeGreaterThanOrEqual(6000 * 0.5)
+                    expect(delay).toBeLessThanOrEqual(45 * 60 * 1000 * 1.5)
+                })
+        })
     })
 })

--- a/src/__tests__/retry-queue.js
+++ b/src/__tests__/retry-queue.js
@@ -241,7 +241,7 @@ describe('RetryQueue', () => {
                 .concat(retryDelaysThree)
                 .forEach((delay) => {
                     expect(delay).toBeGreaterThanOrEqual(6000 * 0.5)
-                    expect(delay).toBeLessThanOrEqual(45 * 60 * 1000 * 1.5)
+                    expect(delay).toBeLessThanOrEqual(30 * 60 * 1000 * 1.5)
                 })
         })
     })


### PR DESCRIPTION
## Changes

When retrying against posthog we used an (effectively) fixed amount of milliseconds backoff which could cause a [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem)

This introduces a random jitter between +/- 50% of the backoff value

See: https://github.com/PostHog/incidents-analysis/pull/33

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
