### PR TITLE
chore: manual version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.66.0 - 2023-06-06
+
+Manual addition of version 1.66.0 because CI failed to automatically bump the version
+
+- feat: send event UUIDs (#672)
+
 ## 1.65.0 - 2023-06-06
 
 - feat: backoff with jitter (#678)


### PR DESCRIPTION
## Changes

The CD job to release a new version failed here https://github.com/PostHog/posthog-js/actions/runs/5190926293/attempts/1

We released too many versions too quickly so https://github.com/PostHog/posthog-js/pull/672 tried to update as 1.65 even though that had just been released
