### PR TITLE
chore: no compatability testing for test files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,4 +28,18 @@ module.exports = {
             version: '17.0',
         },
     },
+    overrides: [
+        {
+            files: 'src/__tests__/**/*',
+            // the same set of config as in the root
+            // but excluding the 'plugin:compat/recommended' rule
+            // we don't mind using the latest features in our tests
+            extends: [
+                'plugin:@typescript-eslint/recommended',
+                'plugin:react/recommended',
+                'plugin:react-hooks/recommended',
+                'prettier',
+            ],
+        },
+    ],
 }


### PR DESCRIPTION
## Changes

You can apply overrides to eslint config based on file patterns

That's great for us because we want to have browser compatibility checks on the code we ship in the SDK but not in the tests. 

This change turns off the browser compatibility tests for anything in ./src/__tests__ folder

## Checklist

tested by seeing linting didn't apply in that directory but did outside of it
