### PR TITLE
feat: allow decide response to configure errors to drop by pattern

### DIFF
--- a/src/__tests__/extensions/exceptions/exception-observer.test.ts
+++ b/src/__tests__/extensions/exceptions/exception-observer.test.ts
@@ -13,7 +13,7 @@ describe('Exception Observer', () => {
 
     beforeEach(() => {
         mockPostHogInstance = {
-            config: jest.fn((key: string) => mockConfig[key as keyof PostHogConfig]),
+            get_config: jest.fn((key: string) => mockConfig[key as keyof PostHogConfig]),
             get_distinct_id: jest.fn(() => 'mock-distinct-id'),
             capture: mockCapture,
         }
@@ -69,7 +69,7 @@ describe('Exception Observer', () => {
         it('drops errors matching rules', () => {
             exceptionObserver.afterDecideResponse({
                 autocaptureExceptions: {
-                    errors_to_drop: ['drop me', '.*drop me (too|as well)'],
+                    errors_to_ignore: ['drop me', '.*drop me (too|as well)'],
                 },
             } as DecideResponse)
 
@@ -108,7 +108,7 @@ describe('Exception Observer', () => {
         it('rules respect anchors', () => {
             exceptionObserver.afterDecideResponse({
                 autocaptureExceptions: {
-                    errors_to_drop: ['^drop me$', '.*drop me (too|as well)'],
+                    errors_to_ignore: ['^drop me$', '.*drop me (too|as well)'],
                 },
             } as DecideResponse)
 

--- a/src/__tests__/extensions/exceptions/exception-observer.test.ts
+++ b/src/__tests__/extensions/exceptions/exception-observer.test.ts
@@ -6,13 +6,16 @@ import { ExceptionObserver } from '../../../extensions/exceptions/exception-auto
 describe('Exception Observer', () => {
     let exceptionObserver: ExceptionObserver
     let mockPostHogInstance: any
+    const mockCapture = jest.fn()
     const mockConfig: Partial<PostHogConfig> = {
         api_host: 'https://app.posthog.com',
     }
 
     beforeEach(() => {
         mockPostHogInstance = {
-            get_config: jest.fn((key: string) => mockConfig[key as keyof PostHogConfig]),
+            config: jest.fn((key: string) => mockConfig[key as keyof PostHogConfig]),
+            get_distinct_id: jest.fn(() => 'mock-distinct-id'),
+            capture: mockCapture,
         }
         exceptionObserver = new ExceptionObserver(mockPostHogInstance as PostHog)
     })
@@ -59,6 +62,64 @@ describe('Exception Observer', () => {
             expect(exceptionObserver.isCapturing()).toBe(false)
             exceptionObserver.startCapturing()
             expect(exceptionObserver.isCapturing()).toBe(false)
+        })
+    })
+
+    describe('with drop rules', () => {
+        it('drops errors matching rules', () => {
+            exceptionObserver.afterDecideResponse({
+                autocaptureExceptions: {
+                    errors_to_drop: ['drop me', '.*drop me (too|as well)'],
+                },
+            } as DecideResponse)
+
+            exceptionObserver.captureException(['drop me', undefined, undefined, undefined, new Error('drop me')])
+            expect(mockCapture).not.toHaveBeenCalled()
+
+            exceptionObserver.captureException([
+                'drop me as well',
+                undefined,
+                undefined,
+                undefined,
+                new Error('drop me as well'),
+            ])
+            expect(mockCapture).not.toHaveBeenCalled()
+
+            exceptionObserver.captureException([
+                'drop me too',
+                undefined,
+                undefined,
+                undefined,
+                new Error('drop me too'),
+            ])
+            expect(mockCapture).not.toHaveBeenCalled()
+
+            // matches because first rule has no position anchors
+            exceptionObserver.captureException([
+                'drop me - nah not really',
+                undefined,
+                undefined,
+                undefined,
+                new Error('drop me - nah not really'),
+            ])
+            expect(mockCapture).not.toHaveBeenCalled()
+        })
+
+        it('rules respect anchors', () => {
+            exceptionObserver.afterDecideResponse({
+                autocaptureExceptions: {
+                    errors_to_drop: ['^drop me$', '.*drop me (too|as well)'],
+                },
+            } as DecideResponse)
+
+            exceptionObserver.captureException([
+                'drop me - nah not really',
+                undefined,
+                undefined,
+                undefined,
+                new Error('drop me - nah not really'),
+            ])
+            expect(mockCapture).toHaveBeenCalled()
         })
     })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,7 +210,7 @@ export interface DecideResponse {
         | boolean
         | {
               endpoint?: string
-              errors_to_drop: string[]
+              errors_to_ignore: string[]
           }
     sessionRecording?: {
         endpoint?: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,7 +206,12 @@ export interface DecideResponse {
     autocapture_opt_out?: boolean
     capturePerformance?: boolean
     // this is currently in development and may have breaking changes without a major version bump
-    autocaptureExceptions?: boolean
+    autocaptureExceptions?:
+        | boolean
+        | {
+              endpoint?: string
+              errors_to_drop: string[]
+          }
     sessionRecording?: {
         endpoint?: string
         consoleLogRecordingEnabled?: boolean


### PR DESCRIPTION
## Changes

The first thing I needed to do on testing exception capture was configure errors I wanted to ignore.

This allows decide to return an array of strings that will be tested against exceptions. It drops autocaptured or manually captured exceptions so that someone can configure exceptions to drop without a code change.

backend PR inbound

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
