### PR TITLE
feat: Made session timeout configurable

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -959,8 +959,8 @@ describe('session_id', () => {
             checkAndGetSessionAndWindowId: jest.fn().mockReturnValue({
                 windowId: 'windowId',
                 sessionId: 'sessionId',
+                sessionStartTimestamp: new Date().getTime() - 30000,
             }),
-            _sessionStartTimestamp: new Date().getTime() - 30000,
         },
     }))
     it('returns the session_id', () => {

--- a/src/__tests__/sessionid.js
+++ b/src/__tests__/sessionid.js
@@ -256,4 +256,31 @@ describe('Session ID manager', () => {
             expect(sessionStore.set).toHaveBeenCalledWith('ph_persistance-name_primary_window_exists', true)
         })
     })
+
+    describe('custom session_idle_timeout_seconds', () => {
+        const mockSessionManager = (timeout) =>
+            new SessionIdManager(
+                {
+                    session_idle_timeout_seconds: timeout,
+                },
+                given.persistence
+            )
+
+        beforeEach(() => {
+            console.warn = jest.fn()
+        })
+
+        it('uses the custom session_idle_timeout_seconds if within bounds', () => {
+            expect(mockSessionManager(61)._sessionTimeoutMs).toEqual(61 * 1000)
+            expect(console.warn).toBeCalledTimes(0)
+            expect(mockSessionManager(59)._sessionTimeoutMs).toEqual(60 * 1000)
+            expect(console.warn).toBeCalledTimes(1)
+            expect(mockSessionManager(30 * 60 - 1)._sessionTimeoutMs).toEqual((30 * 60 - 1) * 1000)
+            expect(console.warn).toBeCalledTimes(1)
+            expect(mockSessionManager(30 * 60 + 1)._sessionTimeoutMs).toEqual(30 * 60 * 1000)
+            expect(console.warn).toBeCalledTimes(2)
+            expect(mockSessionManager('foobar')._sessionTimeoutMs).toEqual(30 * 60 * 1000)
+            expect(console.warn).toBeCalledTimes(3)
+        })
+    })
 })

--- a/src/__tests__/sessionid.js
+++ b/src/__tests__/sessionid.js
@@ -37,6 +37,7 @@ describe('Session ID manager', () => {
             expect(given.subject).toMatchObject({
                 windowId: 'newUUID',
                 sessionId: 'newUUID',
+                sessionStartTimestamp: given.timestamp,
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
                 [SESSION_ID]: [given.timestamp, 'newUUID', given.timestamp],
@@ -49,6 +50,7 @@ describe('Session ID manager', () => {
             expect(given.subject).toMatchObject({
                 windowId: 'newUUID',
                 sessionId: 'newUUID',
+                sessionStartTimestamp: given.timestamp,
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
                 [SESSION_ID]: [given.timestamp, 'newUUID', given.timestamp],
@@ -69,6 +71,7 @@ describe('Session ID manager', () => {
             expect(given.subject).toEqual({
                 windowId: 'oldWindowID',
                 sessionId: 'oldSessionID',
+                sessionStartTimestamp: given.timestampOfSessionStart,
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
                 [SESSION_ID]: [given.timestamp, 'oldSessionID', given.timestampOfSessionStart],
@@ -86,6 +89,7 @@ describe('Session ID manager', () => {
             expect(given.subject).toEqual({
                 windowId: 'oldWindowID',
                 sessionId: 'oldSessionID',
+                sessionStartTimestamp: sessionStart,
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
                 [SESSION_ID]: [oldTimestamp, 'oldSessionID', sessionStart],
@@ -97,6 +101,7 @@ describe('Session ID manager', () => {
             expect(given.subject).toEqual({
                 windowId: 'newUUID',
                 sessionId: 'oldSessionID',
+                sessionStartTimestamp: given.timestampOfSessionStart,
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
                 [SESSION_ID]: [given.timestamp, 'oldSessionID', given.timestampOfSessionStart],
@@ -111,6 +116,7 @@ describe('Session ID manager', () => {
             expect(given.subject).toEqual({
                 windowId: 'newUUID',
                 sessionId: 'newUUID',
+                sessionStartTimestamp: given.timestamp,
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
                 [SESSION_ID]: [given.timestamp, 'newUUID', given.timestamp],
@@ -127,6 +133,7 @@ describe('Session ID manager', () => {
             expect(given.subject).toEqual({
                 windowId: 'newUUID',
                 sessionId: 'newUUID',
+                sessionStartTimestamp: given.timestamp,
             })
 
             expect(given.persistence.register).toHaveBeenCalledWith({
@@ -145,6 +152,7 @@ describe('Session ID manager', () => {
             expect(given.subject).toEqual({
                 windowId: 'newUUID',
                 sessionId: 'newUUID',
+                sessionStartTimestamp: given.timestamp,
             })
 
             expect(given.persistence.register).toHaveBeenCalledWith({
@@ -154,12 +162,14 @@ describe('Session ID manager', () => {
         })
 
         it('uses the current time if no timestamp is provided', () => {
+            const now = new Date().getTime()
             const oldTimestamp = 1601107460000
             given('storedSessionIdData', () => [oldTimestamp, 'oldSessionID', given.timestampOfSessionStart])
             given('timestamp', () => undefined)
             expect(given.subject).toEqual({
                 windowId: 'newUUID',
                 sessionId: 'newUUID',
+                sessionStartTimestamp: now,
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
                 [SESSION_ID]: [given.now, 'newUUID', given.now],
@@ -171,6 +181,7 @@ describe('Session ID manager', () => {
             expect(given.subject).toEqual({
                 windowId: 'oldWindowID',
                 sessionId: 'oldSessionID',
+                sessionStartTimestamp: given.timestamp,
             })
             expect(given.persistence.register).toHaveBeenCalledWith({
                 [SESSION_ID]: [given.timestamp, 'oldSessionID', given.timestamp],

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -159,6 +159,7 @@ const defaultConfig = (): PostHogConfig => ({
     callback_fn: 'posthog._jsc',
     bootstrap: {},
     disable_compression: false,
+    session_timeout_seconds: 30 * 60, // 30 minutes
 })
 
 /**

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -159,7 +159,7 @@ const defaultConfig = (): PostHogConfig => ({
     callback_fn: 'posthog._jsc',
     bootstrap: {},
     disable_compression: false,
-    session_timeout_seconds: 30 * 60, // 30 minutes
+    session_idle_timeout_seconds: 30 * 60, // 30 minutes
 })
 
 /**

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1417,15 +1417,15 @@ export class PostHog {
      */
     get_session_replay_url(options?: { withTimestamp?: boolean; timestampLookBack?: number }): string {
         const host = this.config.ui_host || this.config.api_host
-        let url = host + '/replay/' + this.get_session_id()
-        if (options?.withTimestamp && this.sessionManager._sessionStartTimestamp) {
+        const { sessionId, sessionStartTimestamp } = this.sessionManager.checkAndGetSessionAndWindowId(true)
+        let url = host + '/replay/' + sessionId
+        if (options?.withTimestamp && sessionStartTimestamp) {
             const LOOK_BACK = options.timestampLookBack ?? 10
-            if (!this.sessionManager._sessionStartTimestamp) {
+            if (!sessionStartTimestamp) {
                 return url
             }
             const recordingStartTime = Math.max(
-                Math.floor((new Date().getTime() - (this.sessionManager._sessionStartTimestamp || 0)) / 1000) -
-                    LOOK_BACK,
+                Math.floor((new Date().getTime() - sessionStartTimestamp) / 1000) - LOOK_BACK,
                 0
             )
             url += `?t=${recordingStartTime}`

--- a/src/sessionid.ts
+++ b/src/sessionid.ts
@@ -27,9 +27,12 @@ export class SessionIdManager {
         this._sessionActivityTimestamp = null
 
         const persistenceName = config['persistence_name'] || config['token']
-        const desiredTimeout = config['session_idle_timeout_seconds'] || MAX_SESSION_IDLE_TIMEOUT
+        let desiredTimeout = config['session_idle_timeout_seconds'] || MAX_SESSION_IDLE_TIMEOUT
 
-        if (desiredTimeout > MAX_SESSION_IDLE_TIMEOUT) {
+        if (typeof desiredTimeout !== 'number') {
+            console.warn('[PostHog] session_idle_timeout_seconds must be a number. Defaulting to 30 minutes.')
+            desiredTimeout = MAX_SESSION_IDLE_TIMEOUT
+        } else if (desiredTimeout > MAX_SESSION_IDLE_TIMEOUT) {
             console.warn(
                 '[PostHog] session_idle_timeout_seconds cannot be  greater than 30 minutes. Using 30 minutes instead.'
             )

--- a/src/sessionid.ts
+++ b/src/sessionid.ts
@@ -64,7 +64,7 @@ export class SessionIdManager {
         this._listenToReloadWindow()
     }
 
-    _canUseSessionStorage(): boolean {
+    private _canUseSessionStorage(): boolean {
         // We only want to use sessionStorage if persistence is enabled and not memory storage
         return this.config.persistence !== 'memory' && !this.persistence.disabled && sessionStore.is_supported()
     }
@@ -73,7 +73,7 @@ export class SessionIdManager {
     // and persists page loads/reloads. So it's uniquely suited for storing the windowId. This function also respects
     // when persistence is disabled (by user config) and when sessionStorage is not supported (it *should* be supported on all browsers),
     // and in that case, it falls back to memory (which sadly, won't persist page loads)
-    _setWindowId(windowId: string): void {
+    private _setWindowId(windowId: string): void {
         if (windowId !== this._windowId) {
             this._windowId = windowId
             if (this._canUseSessionStorage()) {
@@ -82,7 +82,7 @@ export class SessionIdManager {
         }
     }
 
-    _getWindowId(): string | null {
+    private _getWindowId(): string | null {
         if (this._windowId) {
             return this._windowId
         }
@@ -95,7 +95,7 @@ export class SessionIdManager {
 
     // Note: 'this.persistence.register' can be disabled in the config.
     // In that case, this works by storing sessionId and the timestamp in memory.
-    _setSessionId(
+    private _setSessionId(
         sessionId: string | null,
         sessionActivityTimestamp: number | null,
         sessionStartTimestamp: number | null
@@ -114,7 +114,7 @@ export class SessionIdManager {
         }
     }
 
-    _getSessionId(): [number, string, number] {
+    private _getSessionId(): [number, string, number] {
         if (this._sessionId && this._sessionActivityTimestamp && this._sessionStartTimestamp) {
             return [this._sessionActivityTimestamp, this._sessionId, this._sessionStartTimestamp]
         }
@@ -140,7 +140,7 @@ export class SessionIdManager {
      * Cloned sessions (new tab, tab duplication, window.open(), ...) WILL have this primaryWindowExists flag in their copied session storage.
      * We conditionally check the primaryWindowExists value in the constructor to decide if the window id in the last session storage should be carried over.
      */
-    _listenToReloadWindow(): void {
+    private _listenToReloadWindow(): void {
         window.addEventListener('beforeunload', () => {
             if (this._canUseSessionStorage()) {
                 sessionStore.remove(this._primary_window_exists_storage_key)
@@ -193,8 +193,9 @@ export class SessionIdManager {
         this._setSessionId(sessionId, newTimestamp, sessionStartTimestamp)
 
         return {
-            sessionId: sessionId,
-            windowId: windowId,
+            sessionId,
+            windowId,
+            sessionStartTimestamp,
         }
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,7 @@ export interface PostHogConfig {
     sanitize_properties: ((properties: Properties, event_name: string) => Properties) | null
     properties_string_max_length: number
     session_recording: SessionRecordingOptions
+    session_idle_timeout_seconds: number
     mask_all_element_attributes: boolean
     mask_all_text: boolean
     advanced_disable_decide: boolean


### PR DESCRIPTION
## Changes

Some people want to have a reduced session timeout. Currently it is hardcoded to 30 mins of idleness (i.e. no events or interactive recording events). This PR allows it to be configured to as low as 1 minute whilst keeping the 30 minute max. 

I think the 30 minute max is necessary as it there are some assumptions around processing that we don't want to break here.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
