### PR TITLE
fix(cd): use package manager field

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,8 +77,6 @@ jobs:
 
             - name: Install pnpm
               uses: pnpm/action-setup@v2
-              with:
-                  version: 8.x.x
 
             - name: Set up Node.js
               uses: actions/setup-node@v3


### PR DESCRIPTION
## Changes

See https://github.com/PostHog/posthog/pull/16173. This PR removes the pnpm version param from pnpm/action-setup, as it should use the [packageManager field in package.json](https://github.com/pnpm/action-setup#version).

## Checklist
- [x] ~Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))~
- [x] ~Accounted for the impact of any changes across different browsers~
