### PR TITLE
fix: PosthogProvider doesn't need to have the client be optional

### DIFF
--- a/playground/nextjs/pages/iframe.tsx
+++ b/playground/nextjs/pages/iframe.tsx
@@ -30,7 +30,7 @@ export default function Home() {
                         src={`http://${otherHost}:3000/`}
                         style={{ width: '100%', height: '500px' }}
                         onLoad={() => {
-                            posthog?.capture('iframe loaded')
+                            posthog.capture('iframe loaded')
                         }}
                     />
                 )}

--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -30,7 +30,7 @@ export default function Home() {
                 <p>The current time is {time}</p>
 
                 <div className="buttons">
-                    <button onClick={() => posthog?.capture('Clicked button')}>Capture event</button>
+                    <button onClick={() => posthog.capture('Clicked button')}>Capture event</button>
                     <button data-attr="autocapture-button">Autocapture buttons</button>
                     <button className="ph-no-capture">Ignore certain elements</button>
                 </div>

--- a/react/src/components/PostHogFeature.tsx
+++ b/react/src/components/PostHogFeature.tsx
@@ -32,12 +32,12 @@ export function PostHogFeature({
     return <>{fallback}</>
 }
 
-function trackClicks(flag: string, posthog?: PostHog) {
-    posthog?.capture('$feature_interaction', { feature_flag: flag, $set: { [`$feature_interaction/${flag}`]: true } })
+function trackClicks(flag: string, posthog: PostHog) {
+    posthog.capture('$feature_interaction', { feature_flag: flag, $set: { [`$feature_interaction/${flag}`]: true } })
 }
 
-function trackVisibility(flag: string, posthog?: PostHog) {
-    posthog?.capture('$feature_view', { feature_flag: flag })
+function trackVisibility(flag: string, posthog: PostHog) {
+    posthog.capture('$feature_view', { feature_flag: flag })
 }
 
 function VisibilityAndClickTracker({

--- a/react/src/context/PostHogContext.ts
+++ b/react/src/context/PostHogContext.ts
@@ -3,4 +3,4 @@ import { createContext } from 'react'
 
 export type PostHog = typeof posthogJs
 
-export const PostHogContext = createContext<{ client?: PostHog }>({ client: undefined })
+export const PostHogContext = createContext<{ client: PostHog }>({ client: posthogJs })

--- a/react/src/hooks/useActiveFeatureFlags.ts
+++ b/react/src/hooks/useActiveFeatureFlags.ts
@@ -9,9 +9,6 @@ export function useActiveFeatureFlags(): string[] | undefined {
     // to a hydration error when using nextjs
 
     useEffect(() => {
-        if (!client) {
-            return
-        }
         return client.onFeatureFlags((flags) => {
             setFeatureFlags(flags)
         })

--- a/react/src/hooks/useFeatureFlagEnabled.ts
+++ b/react/src/hooks/useFeatureFlagEnabled.ts
@@ -9,9 +9,6 @@ export function useFeatureFlagEnabled(flag: string): boolean | undefined {
     // to a hydration error when using nextjs
 
     useEffect(() => {
-        if (!client) {
-            return
-        }
         return client.onFeatureFlags(() => {
             setFeatureEnabled(client.isFeatureEnabled(flag))
         })

--- a/react/src/hooks/useFeatureFlagPayload.ts
+++ b/react/src/hooks/useFeatureFlagPayload.ts
@@ -10,9 +10,6 @@ export function useFeatureFlagPayload(flag: string): JsonType | undefined {
     // to a hydration error when using nextjs
 
     useEffect(() => {
-        if (!client) {
-            return
-        }
         return client.onFeatureFlags(() => {
             setFeatureFlagPayload(client.getFeatureFlagPayload(flag))
         })

--- a/react/src/hooks/useFeatureFlagVariantKey.ts
+++ b/react/src/hooks/useFeatureFlagVariantKey.ts
@@ -9,9 +9,6 @@ export function useFeatureFlagVariantKey(flag: string): string | boolean | undef
     // to a hydration error when using nextjs
 
     useEffect(() => {
-        if (!client) {
-            return
-        }
         return client.onFeatureFlags(() => {
             setFeatureFlagVariantKey(client.getFeatureFlag(flag))
         })

--- a/react/src/hooks/usePostHog.ts
+++ b/react/src/hooks/usePostHog.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import { PostHog, PostHogContext } from '../context'
 
-export const usePostHog = (): PostHog | undefined => {
+export const usePostHog = (): PostHog => {
     const { client } = useContext(PostHogContext)
     return client
 }


### PR DESCRIPTION
## Changes

PostHogProvider was originally configured with a useEffect to setup the client. This meant the first load would be undefined when it doesn't need to be.

Swapped it to useMemo instead.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
