### PR TITLE
feat: capture page title with pageview

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -956,7 +956,11 @@ describe('_loaded()', () => {
 
             given.subject()
 
-            expect(given.overrides.capture).toHaveBeenCalledWith('$pageview', {}, { send_instantly: true })
+            expect(given.overrides.capture).toHaveBeenCalledWith(
+                '$pageview',
+                { title: 'test' },
+                { send_instantly: true }
+            )
         })
     })
 

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -3,7 +3,8 @@ import { PostHogPersistence } from '../posthog-persistence'
 import { CaptureMetrics } from '../capture-metrics'
 import { Decide } from '../decide'
 import { autocapture } from '../autocapture'
-import { _info } from '../utils'
+import { _info, document } from '../utils'
+
 import { truth } from './helpers/truth'
 
 jest.mock('../gdpr-utils', () => ({
@@ -11,6 +12,10 @@ jest.mock('../gdpr-utils', () => ({
     addOptOutCheck: (fn) => fn,
 }))
 jest.mock('../decide')
+jest.mock('../utils', () => ({
+    ...jest.requireActual('../utils'),
+    document: { title: 'test' },
+}))
 
 given('lib', () => Object.assign(new PostHog(), given.overrides))
 
@@ -272,6 +277,12 @@ describe('_calculate_event_properties()', () => {
         given.lib._calculate_event_properties(given.event_name, properties, given.start_timestamp, given.options)
 
         expect(Object.keys(properties)).toEqual(['prop1', 'prop2'])
+    })
+
+    it('adds page title to $pageview', () => {
+        given('event_name', () => '$pageview')
+
+        expect(given.subject).toEqual(expect.objectContaining({ title: 'test' }))
     })
 })
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1,21 +1,21 @@
 import Config from './config'
 import {
-    logger,
+    _copyAndTruncateStrings,
+    _each,
+    _eachArray,
+    _extend,
+    _info,
+    _isArray,
+    _isBlockedUA,
+    _isObject,
+    _isUndefined,
+    _register_event,
+    _safewrap_class,
+    _UUID,
     document,
+    logger,
     userAgent,
     window,
-    _isUndefined,
-    _extend,
-    _each,
-    _isObject,
-    _isBlockedUA,
-    _copyAndTruncateStrings,
-    _isArray,
-    _safewrap_class,
-    _register_event,
-    _UUID,
-    _info,
-    _eachArray,
 } from './utils'
 import { autocapture } from './autocapture'
 import { PostHogPeople } from './posthog-people'
@@ -34,23 +34,23 @@ import { addParamsToURL, encodePostData, xhr } from './send-request'
 import { RetryQueue } from './retry-queue'
 import { SessionIdManager } from './sessionid'
 import {
+    AutocaptureConfig,
     CaptureOptions,
     CaptureResult,
     Compression,
-    ToolbarParams,
+    EarlyAccessFeatureCallback,
     GDPROptions,
     isFeatureEnabledOptions,
     JSC,
+    JsonType,
     OptInOutCapturingOptions,
     PostHogConfig,
     Properties,
     Property,
     RequestCallback,
     SnippetArrayItem,
+    ToolbarParams,
     XHROptions,
-    AutocaptureConfig,
-    JsonType,
-    EarlyAccessFeatureCallback,
 } from './types'
 import { SentryIntegration } from './extensions/sentry-integration'
 import { createSegmentIntegration } from './extensions/segment-integration'
@@ -516,7 +516,7 @@ export class PostHog {
         // this happens after so a user can call identify in
         // the loaded callback
         if (this.get_config('capture_pageview')) {
-            this.capture('$pageview', {}, { send_instantly: true })
+            this.capture('$pageview', { title: document.title }, { send_instantly: true })
         }
 
         // Call decide to get what features are enabled and other settings.
@@ -921,6 +921,10 @@ export class PostHog {
                 this.pageViewIdManager.onPageview()
             }
             properties = _extend(properties, { $pageview_id: this.pageViewIdManager.getPageViewId() })
+        }
+
+        if (event_name === '$pageview') {
+            properties['title'] = document.title
         }
 
         if (event_name === '$performance_event') {


### PR DESCRIPTION
## Changes

A friend asked me a question about how $pageview worked which made me realise that capturing page title could be useful when analysing page views.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
