### PR TITLE
feat: callback when session id changes

### DIFF
--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -526,17 +526,8 @@ describe('SessionRecording', () => {
             })
         })
 
-        describe('with a real session id manager', () => {
-            let mockSessionIdChangedFn
+        describe('the session id manager', () => {
             const startingDate = new Date()
-
-            beforeEach(() => {
-                mockSessionIdChangedFn = jest.fn()
-                given.config.on_session_id_changed_fn = mockSessionIdChangedFn
-                given('sessionManager', () => new SessionIdManager(given.config, new PostHogPersistence(given.config)))
-                given.sessionRecording.startRecordingIfEnabled()
-                given.sessionRecording.startCaptureAndTrySendingQueuedSnapshots()
-            })
 
             const emitAtDateTime = (date, source = 1) =>
                 _emit({
@@ -548,183 +539,269 @@ describe('SessionRecording', () => {
                     },
                 })
 
-            it('takes a full snapshot for the first _emit', () => {
-                emitAtDateTime(startingDate)
-                expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
-                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(1)
-            })
+            describe('onSessionId Callbacks', () => {
+                let mockCallback
+                let unsubscribeCallback
 
-            it('does not take a full snapshot for the second _emit', () => {
-                emitAtDateTime(startingDate)
-                emitAtDateTime(
-                    new Date(
-                        startingDate.getFullYear(),
-                        startingDate.getMonth(),
-                        startingDate.getDate(),
-                        startingDate.getHours(),
-                        startingDate.getMinutes() + 1
+                beforeEach(() => {
+                    given(
+                        'sessionManager',
+                        () => new SessionIdManager(given.config, new PostHogPersistence(given.config))
                     )
-                )
-                expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
-            })
 
-            it('does not change session id for a second _emit', () => {
-                const startingSessionId = given.sessionManager._getSessionId()[1]
+                    mockCallback = jest.fn()
+                    unsubscribeCallback = given.sessionManager.onSessionId(mockCallback)
 
-                emitAtDateTime(startingDate)
-                emitAtDateTime(
-                    new Date(
-                        startingDate.getFullYear(),
-                        startingDate.getMonth(),
-                        startingDate.getDate(),
-                        startingDate.getHours(),
-                        startingDate.getMinutes() + 1
-                    )
-                )
+                    expect(mockCallback).not.toHaveBeenCalled()
 
-                expect(given.sessionManager._getSessionId()[1]).toEqual(startingSessionId)
-                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(1)
-            })
+                    given.sessionRecording.startRecordingIfEnabled()
+                    given.sessionRecording.startCaptureAndTrySendingQueuedSnapshots()
 
-            it('does not take a full snapshot for the third _emit', () => {
-                emitAtDateTime(startingDate)
-
-                emitAtDateTime(
-                    new Date(
-                        startingDate.getFullYear(),
-                        startingDate.getMonth(),
-                        startingDate.getDate(),
-                        startingDate.getHours(),
-                        startingDate.getMinutes() + 1
-                    )
-                )
-
-                emitAtDateTime(
-                    new Date(
-                        startingDate.getFullYear(),
-                        startingDate.getMonth(),
-                        startingDate.getDate(),
-                        startingDate.getHours(),
-                        startingDate.getMinutes() + 2
-                    )
-                )
-                expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
-            })
-
-            it('sends a full snapshot if the session is rotated because session has been inactive for 30 minutess', () => {
-                const startingSessionId = given.sessionManager._getSessionId()[1]
-                emitAtDateTime(startingDate)
-                emitAtDateTime(
-                    new Date(
-                        startingDate.getFullYear(),
-                        startingDate.getMonth(),
-                        startingDate.getDate(),
-                        startingDate.getHours(),
-                        startingDate.getMinutes() + 1
-                    )
-                )
-
-                const inactivityThresholdLater = new Date(
-                    startingDate.getFullYear(),
-                    startingDate.getMonth(),
-                    startingDate.getDate(),
-                    startingDate.getHours(),
-                    startingDate.getMinutes() + 32
-                )
-                emitAtDateTime(inactivityThresholdLater)
-
-                expect(given.sessionManager._getSessionId()[1]).not.toEqual(startingSessionId)
-                expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(2)
-                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(2)
-            })
-
-            it('sends a full snapshot if the session is rotated because max time has passed', () => {
-                const startingSessionId = given.sessionManager._getSessionId()[1]
-                emitAtDateTime(startingDate)
-                emitAtDateTime(
-                    new Date(
-                        startingDate.getFullYear(),
-                        startingDate.getMonth(),
-                        startingDate.getDate(),
-                        startingDate.getHours(),
-                        startingDate.getMinutes() + 1
-                    )
-                )
-
-                const moreThanADayLater = new Date(
-                    startingDate.getFullYear(),
-                    startingDate.getMonth(),
-                    startingDate.getDate() + 1,
-                    startingDate.getHours() + 1
-                )
-                emitAtDateTime(moreThanADayLater)
-
-                expect(given.sessionManager._getSessionId()[1]).not.toEqual(startingSessionId)
-                expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(2)
-                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(2)
-            })
-        })
-
-        describe('idle timeouts', () => {
-            it("enters idle state if the activity is non-user generated and there's no activity for 5 seconds", () => {
-                given.sessionRecording.startRecordingIfEnabled()
-                const lastActivityTimestamp = given.sessionRecording.lastActivityTimestamp
-                expect(lastActivityTimestamp).toBeGreaterThan(0)
-
-                expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(0)
-
-                _emit({
-                    event: 123,
-                    type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
-                    data: {
-                        source: 1,
-                    },
-                    timestamp: lastActivityTimestamp + 100,
+                    expect(mockCallback).toHaveBeenCalledTimes(1)
                 })
-                expect(given.sessionRecording.isIdle).toEqual(false)
-                expect(given.sessionRecording.lastActivityTimestamp).toEqual(lastActivityTimestamp + 100)
 
-                expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
-                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(2)
+                it('calls the callback when the session id changes', () => {
+                    const startingSessionId = given.sessionManager._getSessionId()[1]
+                    emitAtDateTime(startingDate)
+                    emitAtDateTime(
+                        new Date(
+                            startingDate.getFullYear(),
+                            startingDate.getMonth(),
+                            startingDate.getDate(),
+                            startingDate.getHours(),
+                            startingDate.getMinutes() + 1
+                        )
+                    )
 
-                _emit({
-                    event: 123,
-                    type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
-                    data: {
-                        source: 0,
-                    },
-                    timestamp: lastActivityTimestamp + 200,
+                    const inactivityThresholdLater = new Date(
+                        startingDate.getFullYear(),
+                        startingDate.getMonth(),
+                        startingDate.getDate(),
+                        startingDate.getHours(),
+                        startingDate.getMinutes() + 32
+                    )
+                    emitAtDateTime(inactivityThresholdLater)
+
+                    expect(given.sessionManager._getSessionId()[1]).not.toEqual(startingSessionId)
+
+                    expect(mockCallback).toHaveBeenCalledTimes(2)
+                    // last call received the new session id
+                    expect(mockCallback.mock.calls[1][0]).toEqual(given.sessionManager._getSessionId()[1])
                 })
-                expect(given.sessionRecording.isIdle).toEqual(false)
-                expect(given.sessionRecording.lastActivityTimestamp).toEqual(lastActivityTimestamp + 100)
 
-                _emit({
-                    event: 123,
-                    type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
-                    data: {
-                        source: 0,
-                    },
-                    timestamp: lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 1000,
-                })
-                expect(given.sessionRecording.isIdle).toEqual(true)
-                expect(given.sessionRecording.lastActivityTimestamp).toEqual(lastActivityTimestamp + 100)
-                expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
-                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(3)
+                it('does not calls the callback when the session id changes after unsubscribe', () => {
+                    unsubscribeCallback()
 
-                _emit({
-                    event: 123,
-                    type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
-                    data: {
-                        source: 1,
-                    },
-                    timestamp: lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 2000,
+                    const startingSessionId = given.sessionManager._getSessionId()[1]
+                    emitAtDateTime(startingDate)
+                    emitAtDateTime(
+                        new Date(
+                            startingDate.getFullYear(),
+                            startingDate.getMonth(),
+                            startingDate.getDate(),
+                            startingDate.getHours(),
+                            startingDate.getMinutes() + 1
+                        )
+                    )
+
+                    const inactivityThresholdLater = new Date(
+                        startingDate.getFullYear(),
+                        startingDate.getMonth(),
+                        startingDate.getDate(),
+                        startingDate.getHours(),
+                        startingDate.getMinutes() + 32
+                    )
+                    emitAtDateTime(inactivityThresholdLater)
+
+                    expect(given.sessionManager._getSessionId()[1]).not.toEqual(startingSessionId)
+
+                    expect(mockCallback).toHaveBeenCalledTimes(1)
+                    // the only call received the original session id
+                    expect(mockCallback.mock.calls[0][0]).toEqual(startingSessionId)
                 })
-                expect(given.sessionRecording.isIdle).toEqual(false)
-                expect(given.sessionRecording.lastActivityTimestamp).toEqual(
-                    lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 2000
-                )
-                expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(2)
-                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(4)
+            })
+
+            describe('with a real session id manager', () => {
+                beforeEach(() => {
+                    given(
+                        'sessionManager',
+                        () => new SessionIdManager(given.config, new PostHogPersistence(given.config))
+                    )
+                    given.sessionRecording.startRecordingIfEnabled()
+                    given.sessionRecording.startCaptureAndTrySendingQueuedSnapshots()
+                })
+
+                it('takes a full snapshot for the first _emit', () => {
+                    emitAtDateTime(startingDate)
+                    expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
+                })
+
+                it('does not take a full snapshot for the second _emit', () => {
+                    emitAtDateTime(startingDate)
+                    emitAtDateTime(
+                        new Date(
+                            startingDate.getFullYear(),
+                            startingDate.getMonth(),
+                            startingDate.getDate(),
+                            startingDate.getHours(),
+                            startingDate.getMinutes() + 1
+                        )
+                    )
+                    expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
+                })
+
+                it('does not change session id for a second _emit', () => {
+                    const startingSessionId = given.sessionManager._getSessionId()[1]
+
+                    emitAtDateTime(startingDate)
+                    emitAtDateTime(
+                        new Date(
+                            startingDate.getFullYear(),
+                            startingDate.getMonth(),
+                            startingDate.getDate(),
+                            startingDate.getHours(),
+                            startingDate.getMinutes() + 1
+                        )
+                    )
+
+                    expect(given.sessionManager._getSessionId()[1]).toEqual(startingSessionId)
+                })
+
+                it('does not take a full snapshot for the third _emit', () => {
+                    emitAtDateTime(startingDate)
+
+                    emitAtDateTime(
+                        new Date(
+                            startingDate.getFullYear(),
+                            startingDate.getMonth(),
+                            startingDate.getDate(),
+                            startingDate.getHours(),
+                            startingDate.getMinutes() + 1
+                        )
+                    )
+
+                    emitAtDateTime(
+                        new Date(
+                            startingDate.getFullYear(),
+                            startingDate.getMonth(),
+                            startingDate.getDate(),
+                            startingDate.getHours(),
+                            startingDate.getMinutes() + 2
+                        )
+                    )
+                    expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
+                })
+
+                it('sends a full snapshot if the session is rotated because session has been inactive for 30 minutes', () => {
+                    const startingSessionId = given.sessionManager._getSessionId()[1]
+                    emitAtDateTime(startingDate)
+                    emitAtDateTime(
+                        new Date(
+                            startingDate.getFullYear(),
+                            startingDate.getMonth(),
+                            startingDate.getDate(),
+                            startingDate.getHours(),
+                            startingDate.getMinutes() + 1
+                        )
+                    )
+
+                    const inactivityThresholdLater = new Date(
+                        startingDate.getFullYear(),
+                        startingDate.getMonth(),
+                        startingDate.getDate(),
+                        startingDate.getHours(),
+                        startingDate.getMinutes() + 32
+                    )
+                    emitAtDateTime(inactivityThresholdLater)
+
+                    expect(given.sessionManager._getSessionId()[1]).not.toEqual(startingSessionId)
+                    expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(2)
+                })
+
+                it('sends a full snapshot if the session is rotated because max time has passed', () => {
+                    const startingSessionId = given.sessionManager._getSessionId()[1]
+                    emitAtDateTime(startingDate)
+                    emitAtDateTime(
+                        new Date(
+                            startingDate.getFullYear(),
+                            startingDate.getMonth(),
+                            startingDate.getDate(),
+                            startingDate.getHours(),
+                            startingDate.getMinutes() + 1
+                        )
+                    )
+
+                    const moreThanADayLater = new Date(
+                        startingDate.getFullYear(),
+                        startingDate.getMonth(),
+                        startingDate.getDate() + 1,
+                        startingDate.getHours() + 1
+                    )
+                    emitAtDateTime(moreThanADayLater)
+
+                    expect(given.sessionManager._getSessionId()[1]).not.toEqual(startingSessionId)
+                    expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(2)
+                })
+            })
+
+            describe('idle timeouts', () => {
+                it("enters idle state if the activity is non-user generated and there's no activity for 5 seconds", () => {
+                    given.sessionRecording.startRecordingIfEnabled()
+                    const lastActivityTimestamp = given.sessionRecording.lastActivityTimestamp
+                    expect(lastActivityTimestamp).toBeGreaterThan(0)
+
+                    expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(0)
+
+                    _emit({
+                        event: 123,
+                        type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
+                        data: {
+                            source: 1,
+                        },
+                        timestamp: lastActivityTimestamp + 100,
+                    })
+                    expect(given.sessionRecording.isIdle).toEqual(false)
+                    expect(given.sessionRecording.lastActivityTimestamp).toEqual(lastActivityTimestamp + 100)
+
+                    expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
+
+                    _emit({
+                        event: 123,
+                        type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
+                        data: {
+                            source: 0,
+                        },
+                        timestamp: lastActivityTimestamp + 200,
+                    })
+                    expect(given.sessionRecording.isIdle).toEqual(false)
+                    expect(given.sessionRecording.lastActivityTimestamp).toEqual(lastActivityTimestamp + 100)
+
+                    _emit({
+                        event: 123,
+                        type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
+                        data: {
+                            source: 0,
+                        },
+                        timestamp: lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 1000,
+                    })
+                    expect(given.sessionRecording.isIdle).toEqual(true)
+                    expect(given.sessionRecording.lastActivityTimestamp).toEqual(lastActivityTimestamp + 100)
+                    expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
+
+                    _emit({
+                        event: 123,
+                        type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
+                        data: {
+                            source: 1,
+                        },
+                        timestamp: lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 2000,
+                    })
+                    expect(given.sessionRecording.isIdle).toEqual(false)
+                    expect(given.sessionRecording.lastActivityTimestamp).toEqual(
+                        lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 2000
+                    )
+                    expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(2)
+                })
             })
         })
     })

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -527,9 +527,12 @@ describe('SessionRecording', () => {
         })
 
         describe('with a real session id manager', () => {
+            let mockSessionIdChangedFn
             const startingDate = new Date()
 
             beforeEach(() => {
+                mockSessionIdChangedFn = jest.fn()
+                given.config.on_session_id_changed_fn = mockSessionIdChangedFn
                 given('sessionManager', () => new SessionIdManager(given.config, new PostHogPersistence(given.config)))
                 given.sessionRecording.startRecordingIfEnabled()
                 given.sessionRecording.startCaptureAndTrySendingQueuedSnapshots()
@@ -548,6 +551,7 @@ describe('SessionRecording', () => {
             it('takes a full snapshot for the first _emit', () => {
                 emitAtDateTime(startingDate)
                 expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
+                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(1)
             })
 
             it('does not take a full snapshot for the second _emit', () => {
@@ -579,6 +583,7 @@ describe('SessionRecording', () => {
                 )
 
                 expect(given.sessionManager._getSessionId()[1]).toEqual(startingSessionId)
+                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(1)
             })
 
             it('does not take a full snapshot for the third _emit', () => {
@@ -630,6 +635,7 @@ describe('SessionRecording', () => {
 
                 expect(given.sessionManager._getSessionId()[1]).not.toEqual(startingSessionId)
                 expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(2)
+                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(2)
             })
 
             it('sends a full snapshot if the session is rotated because max time has passed', () => {
@@ -655,6 +661,7 @@ describe('SessionRecording', () => {
 
                 expect(given.sessionManager._getSessionId()[1]).not.toEqual(startingSessionId)
                 expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(2)
+                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(2)
             })
         })
 
@@ -678,6 +685,7 @@ describe('SessionRecording', () => {
                 expect(given.sessionRecording.lastActivityTimestamp).toEqual(lastActivityTimestamp + 100)
 
                 expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
+                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(2)
 
                 _emit({
                     event: 123,
@@ -701,6 +709,7 @@ describe('SessionRecording', () => {
                 expect(given.sessionRecording.isIdle).toEqual(true)
                 expect(given.sessionRecording.lastActivityTimestamp).toEqual(lastActivityTimestamp + 100)
                 expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
+                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(3)
 
                 _emit({
                     event: 123,
@@ -715,6 +724,7 @@ describe('SessionRecording', () => {
                     lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 2000
                 )
                 expect(window.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(2)
+                expect(mockSessionIdChangedFn).toHaveBeenCalledTimes(4)
             })
         })
     })

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -159,6 +159,7 @@ const defaultConfig = (): PostHogConfig => ({
     bootstrap: {},
     disable_compression: false,
     session_idle_timeout_seconds: 30 * 60, // 30 minutes
+    on_session_id_changed_fn: __NOOP,
 })
 
 /**

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -58,7 +58,6 @@ import { createSegmentIntegration } from './extensions/segment-integration'
 import { PageViewIdManager } from './page-view-id'
 import { ExceptionObserver } from './extensions/exceptions/exception-autocapture'
 import { PostHogSurveys, SurveyCallback } from './posthog-surveys'
-import __ from 'cypress/types/lodash/fp/__'
 
 /*
 SIMPLE STYLE GUIDE:

--- a/src/sessionid.ts
+++ b/src/sessionid.ts
@@ -69,6 +69,8 @@ export class SessionIdManager {
     }
 
     onSessionId(callback: SessionIdChangedCallback): () => void {
+        // KLUDGE: when running in tests the handlers array was always undefined
+        // it's yucky but safe to set it here so that it's always definitely available
         if (this._sessionIdChangedHandlers === undefined) {
             this._sessionIdChangedHandlers = []
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,11 @@ export interface PostHogConfig {
     properties_string_max_length: number
     session_recording: SessionRecordingOptions
     session_idle_timeout_seconds: number
+    /**
+     * Provide a function to be called when the session_id or window_ id changes
+     * used for example to send the session_id to a backend
+     **/
+    on_session_id_changed_fn: (sessionId: string | null | undefined, windowId: string | null | undefined) => void | null
     mask_all_element_attributes: boolean
     mask_all_text: boolean
     advanced_disable_decide: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,11 +92,6 @@ export interface PostHogConfig {
     properties_string_max_length: number
     session_recording: SessionRecordingOptions
     session_idle_timeout_seconds: number
-    /**
-     * Provide a function to be called when the session_id or window_ id changes
-     * used for example to send the session_id to a backend
-     **/
-    on_session_id_changed_fn: (sessionId: string | null | undefined, windowId: string | null | undefined) => void | null
     mask_all_element_attributes: boolean
     mask_all_text: boolean
     advanced_disable_decide: boolean
@@ -153,6 +148,8 @@ export interface SessionRecordingOptions {
     recorderVersion?: 'v1' | 'v2'
     recordCrossOriginIframes?: boolean
 }
+
+export type SessionIdChangedCallback = (sessionId: string, windowId: string | null | undefined) => void
 
 export enum Compression {
     GZipJS = 'gzip-js',


### PR DESCRIPTION
## Changes

See zendesk ticket https://posthoghelp.zendesk.com/agent/tickets/4038 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/6696)

If someone wants to filter for session recordings using backend events. They can't, because we can only filter for events that have a $session_id property.

We don't care how the event got that property.

Adds an optional callback to config that is called with session id and window id whenever either changes. Some can use this to synchronise the session id to their backend and allow it to enrich events with the session id

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
