### PR TITLE
fix: UUIDs should not take literally forever to generate

### DIFF
--- a/src/__tests__/test-uuid.js
+++ b/src/__tests__/test-uuid.js
@@ -5,8 +5,13 @@ describe('uuid', () => {
         expect(_UUID('v7')).toHaveLength(36)
     })
 
-    it('generates many unique ids in a reasonable time', () => {
+    it('generates many unique v7 UUIDs in a reasonable time', () => {
         const ids = Array.from({ length: 500_000 }, () => _UUID('v7'))
+        expect(new Set(ids).size).toBe(ids.length)
+    })
+
+    it('generates many unique OG UUIDs in a reasonable time', () => {
+        const ids = Array.from({ length: 500_000 }, () => _UUID())
         expect(new Set(ids).size).toBe(ids.length)
     })
 
@@ -15,7 +20,7 @@ describe('uuid', () => {
     })
 
     it('generates different UUIDs when window.performance is available', () => {
-        const uuids = Array.from({ length: 500 }, () => _UUID())
+        const uuids = Array.from({ length: 1000 }, () => _UUID())
 
         expect(new Set(uuids).size).toBe(uuids.length)
 

--- a/src/__tests__/test-uuid.js
+++ b/src/__tests__/test-uuid.js
@@ -13,4 +13,18 @@ describe('uuid', () => {
     it('by default should be the format we have used forever', () => {
         expect(_UUID().length).toBeGreaterThanOrEqual(52)
     })
+
+    it('generates different UUIDs when window.performance is available', () => {
+        const uuids = Array.from({ length: 500 }, () => _UUID())
+
+        expect(new Set(uuids).size).toBe(uuids.length)
+
+        for (const uuid of uuids) {
+            // both the first and last value are based on time, but we want them to be different
+            const parts = uuid.split('-')
+            const first = parts[0]
+            const last = parts[parts.length - 1]
+            expect(first).not.toBe(last)
+        }
+    })
 })

--- a/src/__tests__/test-uuid.js
+++ b/src/__tests__/test-uuid.js
@@ -19,10 +19,8 @@ describe('uuid', () => {
         expect(_UUID().length).toBeGreaterThanOrEqual(52)
     })
 
-    it('generates different UUIDs when window.performance is available', () => {
+    it('using window.performance for UUID still generates differing time parts of OG UUID', () => {
         const uuids = Array.from({ length: 1000 }, () => _UUID())
-
-        expect(new Set(uuids).size).toBe(uuids.length)
 
         for (const uuid of uuids) {
             // both the first and last value are based on time, but we want them to be different

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -467,6 +467,8 @@ export const _UUID = (function () {
     const T = function () {
         const d = new Date().valueOf()
         let ticks = 0
+        // performance.now is pretty widely supported
+        // https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
         if (win.performance && win.performance.now) {
             // if the environment has a frozen time (e.g. in tests)
             // then the busy loop below will never complete.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -472,9 +472,10 @@ export const _UUID = (function () {
             // then the busy loop below will never complete.
             // where performance is supported we can use that to
             // avoid the busy loop (saving a full millisecond)
-            // and avoiding getting stuck in a never ending loop
-            // when time is frozen
-            ticks = win.performance.now()
+            // and avoiding getting stuck in a never ending loop when time is frozen
+            // it returns milliseconds as a float whereas the busy loop counts ticks
+            // there should be 10000 ticks in a millisecond, so we multiply by 10,000
+            ticks = win.performance.now() * 10_000
         } else {
             // this while loop figures how many browser ticks go by
             // before 1*new Date() returns a new number, ie the amount

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -464,19 +464,27 @@ export const _utf8Encode = function (string: string): string {
 
 export const _UUID = (function () {
     // Time/ticks information
-    // 1*new Date() is a cross browser version of Date.now()
     const T = function () {
         const d = new Date().valueOf()
-        let i = 0
-
-        // this while loop figures how many browser ticks go by
-        // before 1*new Date() returns a new number, ie the amount
-        // of ticks that go by per millisecond
-        while (d == new Date().valueOf()) {
-            i++
+        let ticks = 0
+        if (win.performance && win.performance.now) {
+            // if the environment has a frozen time (e.g. in tests)
+            // then the busy loop below will never complete.
+            // where performance is supported we can use that to
+            // avoid the busy loop (saving a full millisecond)
+            // and avoiding getting stuck in a never ending loop
+            // when time is frozen
+            ticks = win.performance.now()
+        } else {
+            // this while loop figures how many browser ticks go by
+            // before 1*new Date() returns a new number, ie the amount
+            // of ticks that go by per millisecond
+            while (d == new Date().valueOf()) {
+                ticks++
+            }
         }
 
-        return d.toString(16) + i.toString(16)
+        return d.toString(16) + Math.floor(ticks).toString(16)
     }
 
     // Math.Random entropy


### PR DESCRIPTION
## Changes

In https://github.com/PostHog/posthog/pull/16430 I added a call to the posthog library when api.ts makes a fetch call. In that PR the runs of the visual regression tests would only finish after timing out. 

Visiting storybook manually e.g. https://61260360a8e859003a7c138b-myokuqhoaz.chromatic.com/?path=/story/exporter-exporter--insight would freeze the browser.

`PostHog-js` UUID generation includes a busy loop that tries to measure the number of ticks in a millisecond. The busy loop depends on `new Date()` being a value that changes. But in some tests that won't be true. 

This shifts to using `window.performance.now` this is a high-resolution clock so safe to use for the time-based entropy needed for this UUID generation. And since we read it once, if someone does mock values in their tests this won't block forever.

This has the added benefit that UUIDs no longer take at least a millisecond to generate. For context, a test that generates and compares 500 UUIDs takes around 1500ms with the old code and around 40 ms with the new code (not that PostHog-js needs to generate 500 UUIDs very often 🤣 

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
