### PR TITLE
feat: allow moving to UUID v7 by config in posthog-js

### DIFF
--- a/cypress/e2e/capture.cy.js
+++ b/cypress/e2e/capture.cy.js
@@ -29,11 +29,7 @@ describe('Event capture', () => {
             },
         }).as('decide')
 
-        cy.visit('./playground/cypress-full', {
-            onBeforeLoad(win) {
-                cy.stub(win.console, 'error').as('consoleError')
-            },
-        })
+        cy.visit('./playground/cypress-full')
         cy.posthogInit(given.options)
         if (waitForDecide) {
             cy.wait('@decide')

--- a/cypress/e2e/identify.cy.js
+++ b/cypress/e2e/identify.cy.js
@@ -1,67 +1,102 @@
 /// <reference types="cypress" />
 
+function setup(initOptions) {
+    cy.visit('./playground/cypress-full')
+    cy.posthogInit({ ...initOptions })
+    // reset and clear device ID so that we can test the uuid format
+    // without worrying about the previous test's device ID
+    cy.posthog().invoke('reset', true)
+    cy.wait('@decide')
+}
+
 describe('identify()', () => {
-    beforeEach(() => {
-        cy.visit('./playground/cypress-full')
-        cy.posthogInit({})
+    describe('with v7 uuid config', () => {
+        beforeEach(() => {
+            setup({ uuid_version: 'v7' })
+        })
 
-        cy.wait('@decide')
+        it('uses the v7 uuid format when configured', () => {
+            cy.posthog().invoke('capture', '$pageview')
+            cy.phCaptures({ full: true }).then((events) => {
+                let deviceIds = new Set(events.map((e) => e.properties['$device_id']))
+                expect(deviceIds.size).to.eql(1)
+                const [deviceId] = deviceIds
+                expect(deviceId.length).to.be.lessThan(52)
+            })
+        })
     })
 
-    it('opt_out_capturing() does not fail after identify()', () => {
-        cy.posthog().invoke('identify', 'some-id')
-        cy.posthog().invoke('opt_out_capturing')
-    })
+    describe('with default config', () => {
+        beforeEach(() => {
+            setup()
+        })
 
-    it('merges people as expected when reset is called', () => {
-        cy.posthog().invoke('capture', 'an-anonymous-event')
-        cy.posthog().invoke('identify', 'first-identify') // test identify merges with previous events after init
-        cy.posthog().invoke('capture', 'an-identified-event')
-        cy.posthog().invoke('identify', 'second-identify-should-not-be-merged') // test identify is not sent after previous identify
-        cy.posthog().invoke('capture', 'another-identified-event') // but does change the distinct id
-        cy.posthog().invoke('reset')
-        cy.posthog().invoke('capture', 'an-anonymous-event')
-        cy.posthog().invoke('identify', 'third-identify')
-        cy.posthog().invoke('capture', 'an-identified-event')
+        it('uses the OG uuid format by default', () => {
+            cy.posthog().invoke('capture', 'an-anonymous-event')
+            cy.phCaptures({ full: true }).then((events) => {
+                cy.log(events)
+                let deviceIds = new Set(events.map((e) => e.properties['$device_id']))
+                expect(deviceIds.size).to.eql(1)
+                const [deviceId] = deviceIds
+                expect(deviceId.length).to.be.gte(52)
+            })
+        })
 
-        cy.phCaptures({ full: true }).then((events) => {
-            const eventsSeen = events.map((e) => e.event)
+        it('opt_out_capturing() does not fail after identify()', () => {
+            cy.posthog().invoke('identify', 'some-id')
+            cy.posthog().invoke('opt_out_capturing')
+        })
 
-            expect(eventsSeen.filter((e) => e === '$identify').length).to.eq(2)
+        it('merges people as expected when reset is called', () => {
+            cy.posthog().invoke('capture', 'an-anonymous-event')
+            cy.posthog().invoke('identify', 'first-identify') // test identify merges with previous events after init
+            cy.posthog().invoke('capture', 'an-identified-event')
+            cy.posthog().invoke('identify', 'second-identify-should-not-be-merged') // test identify is not sent after previous identify
+            cy.posthog().invoke('capture', 'another-identified-event') // but does change the distinct id
+            cy.posthog().invoke('reset')
+            cy.posthog().invoke('capture', 'an-anonymous-event')
+            cy.posthog().invoke('identify', 'third-identify')
+            cy.posthog().invoke('capture', 'an-identified-event')
 
-            expect(eventsSeen).to.deep.eq([
-                '$pageview',
-                'an-anonymous-event',
-                '$identify',
-                'an-identified-event',
-                'another-identified-event',
-                'an-anonymous-event',
-                '$identify',
-                'an-identified-event',
-            ])
+            cy.phCaptures({ full: true }).then((events) => {
+                const eventsSeen = events.map((e) => e.event)
 
-            expect(new Set(events.map((e) => e.properties['$device_id'])).size).to.eql(1)
+                expect(eventsSeen.filter((e) => e === '$identify').length).to.eq(2)
 
-            // the first two events share a distinct id
-            expect(events[0].properties.distinct_id).to.eql(events[1].properties.distinct_id)
-            // then first identify is called and sends that distinct id as its anon to merge
-            expect(events[2].properties.distinct_id).to.eql('first-identify')
-            expect(events[2].properties['$anon_distinct_id']).to.eql(events[0].properties.distinct_id)
-            // and an event is sent with that distinct id
-            expect(events[3].properties.distinct_id).to.eql('first-identify')
-            // then second identify is called and is ignored but does change the distinct id
-            expect(events[4].event).to.eql('another-identified-event')
-            expect(events[4].properties.distinct_id).to.eql('second-identify-should-not-be-merged')
-            // then reset is called and the next event has a new distinct id
-            expect(events[5].event).to.eql('an-anonymous-event')
-            expect(events[5].properties.distinct_id)
-                .not.to.eql('first-identify')
-                .and.not.to.eql('second-identify-should-not-be-merged')
-            // then an identify merges that distinct id with the new distinct id
-            expect(events[6].properties.distinct_id).to.eql('third-identify')
-            expect(events[6].properties['$anon_distinct_id']).to.eql(events[5].properties.distinct_id)
-            // then a final identified event includes that identified distinct id
-            expect(events[7].properties.distinct_id).to.eql('third-identify')
+                expect(eventsSeen).to.deep.eq([
+                    '$pageview',
+                    'an-anonymous-event',
+                    '$identify',
+                    'an-identified-event',
+                    'another-identified-event',
+                    'an-anonymous-event',
+                    '$identify',
+                    'an-identified-event',
+                ])
+
+                expect(new Set(events.map((e) => e.properties['$device_id'])).size).to.eql(1)
+
+                // the first two events share a distinct id
+                expect(events[0].properties.distinct_id).to.eql(events[1].properties.distinct_id)
+                // then first identify is called and sends that distinct id as its anon to merge
+                expect(events[2].properties.distinct_id).to.eql('first-identify')
+                expect(events[2].properties['$anon_distinct_id']).to.eql(events[0].properties.distinct_id)
+                // and an event is sent with that distinct id
+                expect(events[3].properties.distinct_id).to.eql('first-identify')
+                // then second identify is called and is ignored but does change the distinct id
+                expect(events[4].event).to.eql('another-identified-event')
+                expect(events[4].properties.distinct_id).to.eql('second-identify-should-not-be-merged')
+                // then reset is called and the next event has a new distinct id
+                expect(events[5].event).to.eql('an-anonymous-event')
+                expect(events[5].properties.distinct_id)
+                    .not.to.eql('first-identify')
+                    .and.not.to.eql('second-identify-should-not-be-merged')
+                // then an identify merges that distinct id with the new distinct id
+                expect(events[6].properties.distinct_id).to.eql('third-identify')
+                expect(events[6].properties['$anon_distinct_id']).to.eql(events[5].properties.distinct_id)
+                // then a final identified event includes that identified distinct id
+                expect(events[7].properties.distinct_id).to.eql('third-identify')
+            })
         })
     })
 })

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -20,6 +20,14 @@ import 'given2/setup'
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
+// Add console errors into cypress logs.
+Cypress.on('window:before:load', (win) => {
+    cy.spy(win.console, 'error')
+    cy.spy(win.console, 'warn')
+    cy.spy(win.console, 'log')
+    cy.spy(win.console, 'debug')
+})
+
 beforeEach(() => {
     cy.server()
 

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -1,4 +1,4 @@
-import { loadScript } from '../../utils'
+import { _UUID, loadScript } from '../../utils'
 import {
     SessionRecording,
     RECORDING_IDLE_ACTIVITY_TIMEOUT_MS,
@@ -67,6 +67,7 @@ describe('SessionRecording', () => {
     given('$session_recording_recorder_version_server_side', () => undefined)
     given('disabled', () => false)
     given('__loaded_recorder_version', () => undefined)
+    given('uuidFn', () => _UUID('v7'))
 
     beforeEach(() => {
         window.rrwebRecord = jest.fn()
@@ -546,7 +547,7 @@ describe('SessionRecording', () => {
                 beforeEach(() => {
                     given(
                         'sessionManager',
-                        () => new SessionIdManager(given.config, new PostHogPersistence(given.config))
+                        () => new SessionIdManager(given.config, new PostHogPersistence(given.config), given.uuidFn)
                     )
 
                     mockCallback = jest.fn()
@@ -625,7 +626,7 @@ describe('SessionRecording', () => {
                 beforeEach(() => {
                     given(
                         'sessionManager',
-                        () => new SessionIdManager(given.config, new PostHogPersistence(given.config))
+                        () => new SessionIdManager(given.config, new PostHogPersistence(given.config), given.uuidFn)
                     )
                     given.sessionRecording.startRecordingIfEnabled()
                     given.sessionRecording.startCaptureAndTrySendingQueuedSnapshots()

--- a/src/__tests__/page-view-id.js
+++ b/src/__tests__/page-view-id.js
@@ -4,10 +4,14 @@ import { PageViewIdManager } from '../page-view-id'
 jest.mock('../utils')
 
 describe('PageView ID manager', () => {
-    given('pageViewIdManager', () => new PageViewIdManager())
+    given('uuidFn', () => jest.fn())
+    given('pageViewIdManager', () => new PageViewIdManager(given.uuidFn))
 
     beforeEach(() => {
-        _UUID.mockReturnValue('subsequentUUIDs').mockReturnValueOnce('firstUUID').mockReturnValueOnce('secondUUID')
+        given.uuidFn
+            .mockReturnValue('subsequentUUIDs')
+            .mockReturnValueOnce('firstUUID')
+            .mockReturnValueOnce('secondUUID')
     })
 
     it('generates a page view id and resets page view id', () => {

--- a/src/__tests__/page-view-id.js
+++ b/src/__tests__/page-view-id.js
@@ -1,4 +1,3 @@
-import { _UUID } from '../utils'
 import { PageViewIdManager } from '../page-view-id'
 
 jest.mock('../utils')

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -3,7 +3,7 @@ import { PostHogPersistence } from '../posthog-persistence'
 import { CaptureMetrics } from '../capture-metrics'
 import { Decide } from '../decide'
 import { autocapture } from '../autocapture'
-import { _info, document } from '../utils'
+import { _info } from '../utils'
 
 import { truth } from './helpers/truth'
 

--- a/src/__tests__/segment.ts
+++ b/src/__tests__/segment.ts
@@ -21,7 +21,7 @@ describe(`Module-based loader in Node env`, () => {
     beforeEach(() => {
         jest.spyOn(posthog, '_send_request').mockReturnValue()
         jest.spyOn(console, 'log').mockReturnValue()
-        posthogName = _UUID()
+        posthogName = _UUID('v7')
 
         // Create something that looks like the Segment Analytics 2.0 API. We
         // could use the actual client, but it's a little more tricky and we'd

--- a/src/__tests__/sessionid.js
+++ b/src/__tests__/sessionid.js
@@ -1,7 +1,6 @@
 import { SessionIdManager } from '../sessionid'
 import { SESSION_ID } from '../posthog-persistence'
 import { sessionStore } from '../storage'
-import { _UUID } from '../utils'
 
 jest.mock('../utils')
 jest.mock('../storage')

--- a/src/__tests__/sessionid.js
+++ b/src/__tests__/sessionid.js
@@ -7,8 +7,9 @@ jest.mock('../utils')
 jest.mock('../storage')
 
 describe('Session ID manager', () => {
+    given('uuidFn', () => () => 'newUUID')
     given('subject', () => given.sessionIdManager.checkAndGetSessionAndWindowId(given.readOnly, given.timestamp))
-    given('sessionIdManager', () => new SessionIdManager(given.config, given.persistence))
+    given('sessionIdManager', () => new SessionIdManager(given.config, given.persistence, given.uuidFn))
 
     given('persistence', () => ({
         props: { [SESSION_ID]: given.storedSessionIdData },
@@ -26,7 +27,6 @@ describe('Session ID manager', () => {
     given('now', () => given.timestamp + 1000)
 
     beforeEach(() => {
-        _UUID.mockReturnValue('newUUID')
         sessionStore.is_supported.mockReturnValue(true)
         const mockDate = new Date(given.now)
         jest.spyOn(global, 'Date').mockImplementation(() => mockDate)
@@ -263,7 +263,8 @@ describe('Session ID manager', () => {
                 {
                     session_idle_timeout_seconds: timeout,
                 },
-                given.persistence
+                given.persistence,
+                given.uuidFn
             )
 
         beforeEach(() => {

--- a/src/__tests__/test-uuid.js
+++ b/src/__tests__/test-uuid.js
@@ -1,26 +1,30 @@
 import { _UUID } from '../utils'
 
 describe('uuid', () => {
+    let originalUUIDFn = _UUID('og')
+    let v7UUIDFn = _UUID('v7')
+    let defaultUUIDFn = _UUID()
+
     it('should be a uuid when requested', () => {
-        expect(_UUID('v7')).toHaveLength(36)
+        expect(v7UUIDFn()).toHaveLength(36)
     })
 
     it('generates many unique v7 UUIDs in a reasonable time', () => {
-        const ids = Array.from({ length: 500_000 }, () => _UUID('v7'))
+        const ids = Array.from({ length: 500_000 }, () => v7UUIDFn())
         expect(new Set(ids).size).toBe(ids.length)
     })
 
     it('generates many unique OG UUIDs in a reasonable time', () => {
-        const ids = Array.from({ length: 500_000 }, () => _UUID())
+        const ids = Array.from({ length: 500_000 }, () => originalUUIDFn())
         expect(new Set(ids).size).toBe(ids.length)
     })
 
     it('by default should be the format we have used forever', () => {
-        expect(_UUID().length).toBeGreaterThanOrEqual(52)
+        expect(defaultUUIDFn().length).toBeGreaterThanOrEqual(52)
     })
 
     it('using window.performance for UUID still generates differing time parts of OG UUID', () => {
-        const uuids = Array.from({ length: 1000 }, () => _UUID())
+        const uuids = Array.from({ length: 1000 }, () => defaultUUIDFn())
 
         for (const uuid of uuids) {
             // both the first and last value are based on time, but we want them to be different

--- a/src/page-view-id.ts
+++ b/src/page-view-id.ts
@@ -1,5 +1,3 @@
-import { _UUID } from './utils'
-
 export class PageViewIdManager {
     _pageViewId: string | undefined
 

--- a/src/page-view-id.ts
+++ b/src/page-view-id.ts
@@ -5,18 +5,20 @@ export class PageViewIdManager {
 
     _seenFirstPageView = false
 
+    constructor(private uuidFn: () => string) {}
+
     onPageview(): void {
         // As the first $pageview event may come after a different event,
         // we only reset the ID _after_ the second $pageview event.
         if (this._seenFirstPageView) {
-            this._pageViewId = _UUID()
+            this._pageViewId = this.uuidFn()
         }
         this._seenFirstPageView = true
     }
 
     getPageViewId(): string {
         if (!this._pageViewId) {
-            this._pageViewId = _UUID()
+            this._pageViewId = this.uuidFn()
         }
 
         return this._pageViewId

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -160,6 +160,7 @@ const defaultConfig = (): PostHogConfig => ({
     bootstrap: {},
     disable_compression: false,
     session_idle_timeout_seconds: 30 * 60, // 30 minutes
+    uuid_version: 'og',
 })
 
 /**
@@ -285,6 +286,9 @@ export class PostHog {
 
     SentryIntegration: typeof SentryIntegration
     segmentIntegration: () => any
+    // keep the default as the original version of the function
+    // config _might_ override this in init below
+    private uuidFn: (version?: 'v7') => string = _UUID('og')
 
     constructor() {
         this.config = defaultConfig()
@@ -301,7 +305,7 @@ export class PostHog {
         this.people = new PostHogPeople(this)
         this.featureFlags = new PostHogFeatureFlags(this)
         this.toolbar = new Toolbar(this)
-        this.pageViewIdManager = new PageViewIdManager()
+        this.pageViewIdManager = new PageViewIdManager(this.uuidFn)
         this.surveys = new PostHogSurveys(this)
 
         // these are created in _init() after we have the config
@@ -399,6 +403,11 @@ export class PostHog {
             })
         )
 
+        // in preparation for switching from a custom UUID format
+        // to UUID v7 this lets us inject the desired default version
+        // into the _UUID function
+        this.uuidFn = _UUID(this.config.uuid_version || 'og')
+
         this._jsc = function () {} as JSC
 
         // Check if recorder.js is already loaded
@@ -417,7 +426,7 @@ export class PostHog {
         this.__request_queue = []
 
         this.persistence = new PostHogPersistence(this.config)
-        this.sessionManager = new SessionIdManager(this.config, this.persistence)
+        this.sessionManager = new SessionIdManager(this.config, this.persistence, this.uuidFn)
         this.sessionPersistence =
             this.config.persistence === 'sessionStorage'
                 ? this.persistence
@@ -443,7 +452,7 @@ export class PostHog {
         }
 
         if (config.bootstrap?.distinctID !== undefined) {
-            const uuid = this.get_config('get_device_id')(_UUID())
+            const uuid = this.get_config('get_device_id')(this.uuidFn())
             const deviceID = config.bootstrap?.isIdentifiedID ? uuid : config.bootstrap.distinctID
             this.persistence.set_user_state(config.bootstrap?.isIdentifiedID ? 'identified' : 'anonymous')
             this.register({
@@ -477,7 +486,7 @@ export class PostHog {
             // There is no need to set the distinct id
             // or the device id if something was already stored
             // in the persitence
-            const uuid = this.get_config('get_device_id')(_UUID())
+            const uuid = this.get_config('get_device_id')(this.uuidFn())
             this.register_once(
                 {
                     distinct_id: uuid,
@@ -848,7 +857,7 @@ export class PostHog {
         }
 
         let data: CaptureResult = {
-            uuid: _UUID('v7'),
+            uuid: this.uuidFn('v7'),
             event: event_name,
             properties: this._calculate_event_properties(event_name, properties || {}),
         }
@@ -1384,7 +1393,7 @@ export class PostHog {
         this.sessionPersistence.clear()
         this.persistence.set_user_state('anonymous')
         this.sessionManager.resetSessionId()
-        const uuid = this.get_config('get_device_id')(_UUID())
+        const uuid = this.get_config('get_device_id')(this.uuidFn())
         this.register_once(
             {
                 distinct_id: uuid,

--- a/src/sessionid.ts
+++ b/src/sessionid.ts
@@ -19,7 +19,7 @@ export class SessionIdManager {
     private _sessionTimeoutMs: number
     private _sessionIdChangedHandlers: SessionIdChangedCallback[] = []
 
-    constructor(config: Partial<PostHogConfig>, persistence: PostHogPersistence) {
+    constructor(config: Partial<PostHogConfig>, persistence: PostHogPersistence, private uuidFn: () => string) {
         this.config = config
         this.persistence = persistence
         this._windowId = undefined
@@ -200,12 +200,12 @@ export class SessionIdManager {
             (!readOnly && Math.abs(timestamp - lastTimestamp) > this._sessionTimeoutMs) ||
             sessionPastMaximumLength
         ) {
-            sessionId = _UUID()
-            windowId = _UUID()
+            sessionId = this.uuidFn()
+            windowId = this.uuidFn()
             startTimestamp = timestamp
             valuesChanged = true
         } else if (!windowId) {
-            windowId = _UUID()
+            windowId = this.uuidFn()
             valuesChanged = true
         }
 

--- a/src/sessionid.ts
+++ b/src/sessionid.ts
@@ -1,6 +1,5 @@
 import { PostHogPersistence, SESSION_ID } from './posthog-persistence'
 import { sessionStore } from './storage'
-import { _UUID } from './utils'
 import { PostHogConfig, SessionIdChangedCallback } from './types'
 
 const MAX_SESSION_IDLE_TIMEOUT = 30 * 60 // 30 mins

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,8 @@ export interface AutocaptureConfig {
     css_selector_allowlist?: string[]
 }
 
+export type UUIDVersion = 'og' | 'v7'
+
 export interface PostHogConfig {
     api_host: string
     api_method: string
@@ -111,6 +113,10 @@ export interface PostHogConfig {
         featureFlagPayloads?: Record<string, JsonType>
     }
     segment?: any
+    // we are replacing the OG uuid generation code, with newer faster UUIDv7
+    // this is a temporary flag to allow us to test the new UUID generation code
+    // this flag *will be deleted* in a future version of PostHog-js
+    uuid_version?: UUIDVersion
 }
 
 export interface OptInOutCapturingOptions {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -532,11 +532,10 @@ export const _UUID = function (defaultVersion?: UUIDVersion) {
     }
 
     return function (version?: UUIDVersion) {
-        console.warn('generating UUIDs with version: ' + version || defaultVersion || 'og', { version, defaultVersion })
         if (version === 'v7' || defaultVersion === 'v7') {
             return uuidv7()
         }
-        console.warn('generating an OG  UUID')
+
         const se = typeof window !== 'undefined' ? (window.screen.height * window.screen.width).toString(16) : '0'
         return T() + '-' + R() + '-' + UA() + '-' + se + '-' + T()
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import Config from './config'
-import { Breaker, EventHandler, Properties } from './types'
+import { Breaker, EventHandler, Properties, UUIDVersion } from './types'
 import { uuidv7 } from './uuidv7'
 
 /*
@@ -462,7 +462,7 @@ export const _utf8Encode = function (string: string): string {
     return utftext
 }
 
-export const _UUID = (function () {
+export const _UUID = function (defaultVersion?: UUIDVersion) {
     // Time/ticks information
     const T = function () {
         const d = new Date().valueOf()
@@ -531,15 +531,16 @@ export const _UUID = (function () {
         return ret.toString(16)
     }
 
-    return function (version?: 'v7') {
-        if (version === 'v7') {
+    return function (version?: UUIDVersion) {
+        console.warn('generating UUIDs with version: ' + version || defaultVersion || 'og', { version, defaultVersion })
+        if (version === 'v7' || defaultVersion === 'v7') {
             return uuidv7()
         }
-
+        console.warn('generating an OG  UUID')
         const se = typeof window !== 'undefined' ? (window.screen.height * window.screen.width).toString(16) : '0'
         return T() + '-' + R() + '-' + UA() + '-' + se + '-' + T()
     }
-})()
+}
 
 // _.isBlockedUA()
 // This is to block various web spiders from executing our JS and


### PR DESCRIPTION
## Changes

The OG UUID generation code in posthog-js is really slow (in comparison to the newer uuid v7 code)

This adds a flag to let us switch to using the UUID v7 everywhere. And still be able to switch back without a deploy cycle.

This is only to allow us to test in prod ourselves before affecting other customers

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
