### PR TITLE
fix(flags): Make sure flags are reloaded only once on identify calls

### DIFF
--- a/src/__tests__/posthog-core.identify.js
+++ b/src/__tests__/posthog-core.identify.js
@@ -249,7 +249,7 @@ describe('identify()', () => {
             expect(given.overrides.reloadFeatureFlags).not.toHaveBeenCalled()
         })
 
-        it('does not reload feature flags if identity does not change but properties do', () => {
+        it('reloads feature flags if identity does not change but properties do', () => {
             given('oldIdentity', () => given.identity)
             given('userPropertiesToSet', () => ({ email: 'john@example.com' }))
             given('userPropertiesToSetOnce', () => ({ howOftenAmISet: 'once!' }))
@@ -257,6 +257,20 @@ describe('identify()', () => {
             given.subject()
             expect(given.overrides.featureFlags.setAnonymousDistinctId).not.toHaveBeenCalled()
             expect(given.overrides.reloadFeatureFlags).not.toHaveBeenCalled()
+            expect(given.overrides.setPersonPropertiesForFlags).toHaveBeenCalledWith({ email: 'john@example.com' })
+        })
+
+        it('reloads feature flags if identity and properties change', () => {
+            given('userPropertiesToSet', () => ({ email: 'john@example.com' }))
+            given('userPropertiesToSetOnce', () => ({ howOftenAmISet: 'once!' }))
+
+            given.subject()
+            expect(given.overrides.featureFlags.setAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
+            expect(given.overrides.reloadFeatureFlags).toHaveBeenCalled()
+            expect(given.overrides.setPersonPropertiesForFlags).toHaveBeenCalledWith(
+                { email: 'john@example.com' },
+                false
+            )
         })
 
         it('clears flag calls reported when identity changes', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1294,7 +1294,7 @@ export class PostHog {
             this.persistence.set_user_state('identified')
 
             // Update current user properties
-            this.setPersonPropertiesForFlags(userPropertiesToSet || {})
+            this.setPersonPropertiesForFlags(userPropertiesToSet || {}, false)
 
             this.capture(
                 '$identify',


### PR DESCRIPTION
## Changes

Noticed flags are reloaded 2x on identify calls, because we call reloadFeatureFlags anyway when identity changes.
...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
