### PR TITLE
fix(flags): Don't return undefined for flags when decide is not hit b…

### DIFF
--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -209,7 +209,7 @@ export class PostHogFeatureFlags {
      * @param {Object|String} options (optional) If {send_event: false}, we won't send an $feature_flag_call event to PostHog.
      */
     getFeatureFlag(key: string, options: { send_event?: boolean } = {}): boolean | string | undefined {
-        if (!this.instance.decideEndpointWasHit) {
+        if (!this.instance.decideEndpointWasHit && !(this.getFlags() && this.getFlags().length > 0)) {
             console.warn('getFeatureFlag for key "' + key + '" failed. Feature flags didn\'t load in time.')
             return undefined
         }
@@ -248,7 +248,7 @@ export class PostHogFeatureFlags {
      * @param {Object|String} options (optional) If {send_event: false}, we won't send an $feature_flag_call event to PostHog.
      */
     isFeatureEnabled(key: string, options: { send_event?: boolean } = {}): boolean | undefined {
-        if (!this.instance.decideEndpointWasHit) {
+        if (!this.instance.decideEndpointWasHit && !(this.getFlags() && this.getFlags().length > 0)) {
             console.warn('isFeatureEnabled for key "' + key + '" failed. Feature flags didn\'t load in time.')
             return undefined
         }


### PR DESCRIPTION
…ut flags exist


## Changes

The previous change introduced a regression where if flags were loaded from a previous refresh, but decide wasn't hit yet in the current load, we wouldn't return flags correctly.

This fixes it.

https://posthog.slack.com/archives/C046D7C654H/p1689760062614959?thread_ts=1689753227.848669&cid=C046D7C654H
...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
