### PR TITLE
fix: defensive about unload logging

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -673,13 +673,15 @@ export class PostHog {
         if (useSendBeacon) {
             // beacon documentation https://w3c.github.io/beacon/
             // beacons format the message and use the type property
-            // also no need to try catch as sendBeacon does not report errors
-            //   and is defined as best effort attempt
             try {
                 window.navigator.sendBeacon(url, encodePostData(data, { ...options, sendBeacon: true }))
             } catch (e) {
-                if (this.get_config('debug')) {
-                    console.error(e)
+                // very defensive over reading config and logging
+                // as this can be called during unload
+                // and some customers have seen errors where `this` might not actually be available
+                // by the time it is called... thanks JS
+                if (this?.get_config('debug') && console?.error) {
+                    console?.error(e)
                 }
             }
         } else if (USE_XHR) {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -676,13 +676,8 @@ export class PostHog {
             try {
                 window.navigator.sendBeacon(url, encodePostData(data, { ...options, sendBeacon: true }))
             } catch (e) {
-                // very defensive over reading config and logging
-                // as this can be called during unload
-                // and some customers have seen errors where `this` might not actually be available
-                // by the time it is called... thanks JS
-                if (this?.get_config('debug') && console?.error) {
-                    console?.error(e)
-                }
+                // send beacon is a best-effort, fire-and-forget mechanism on page unload,
+                // we don't want to throw errors here
             }
         } else if (USE_XHR) {
             try {


### PR DESCRIPTION
## Changes

see community slack thread https://posthogusers.slack.com/archives/CTLTM70RM/p1689788353368449

`this` is undefined when logging errors during `handle_unload`

We could be extra defensive about logging the errors, but since this is when the page is being shut down are we really going to see the console? 

Send beacon is beset effort, let's allow it to silently fail