### PR TITLE
fix: protect against bundling bugs

### DIFF
--- a/src/uuidv7.ts
+++ b/src/uuidv7.ts
@@ -83,11 +83,16 @@ export class UUID {
     toString(): string {
         let text = ''
         for (let i = 0; i < this.bytes.length; i++) {
-            text += DIGITS.charAt(this.bytes[i] >>> 4)
-            text += DIGITS.charAt(this.bytes[i] & 0xf)
+            text = text + DIGITS.charAt(this.bytes[i] >>> 4) + DIGITS.charAt(this.bytes[i] & 0xf)
             if (i === 3 || i === 5 || i === 7 || i === 9) {
                 text += '-'
             }
+        }
+
+        if (text.length !== 36) {
+            // We saw one customer whose bundling code was mangling the UUID generation
+            // rather than accept a bad UUID, we throw an error here.
+            throw new Error('Invalid UUIDv7 was generated')
         }
         return text
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4735,15 +4735,10 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001400:
-  version "1.0.30001421"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001421.tgz#979993aaacff5ab72a8d0d58c28ddbcb7b4deba6"
-  integrity sha512-Sw4eLbgUJAEhjLs1Fa+mk45sidp1wRn5y6GtDpHGBaNJ9OCDJaVh2tIaWWUnGfuXfKf1JCBaIarak3FkVAvEeA==
-
-caniuse-lite@^1.0.30001473, caniuse-lite@^1.0.30001489:
-  version "1.0.30001492"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz#4a06861788a52b4c81fd3344573b68cc87fe062b"
-  integrity sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==
+caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001473, caniuse-lite@^1.0.30001489:
+  version "1.0.30001517"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz"
+  integrity sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Changes

We saw one customer where 

```
text += DIGITS.charAt(this.bytes[i] >>> 4)
text += DIGITS.charAt(this.bytes[i] & 0xf)
```

was being incorrectly bundled by their JS bundler as

```
text = X + Y
```

so the generated UUID could never be 36 characters long

To try and protect against this I've reorganised the code to not rely on addition assignment

And added a throw if the UUID is invalid. We'd rather find out about this from a console error than bad data in PostHog

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
