### PR TITLE
feat: react to rate limiting responses

### DIFF
--- a/src/__tests__/rate-limiter.ts
+++ b/src/__tests__/rate-limiter.ts
@@ -1,0 +1,58 @@
+import { RateLimiter } from '../rate-limiter'
+import { PostHogPersistence } from '../posthog-persistence'
+
+describe('Rate Limiter', () => {
+    const mockGetQuotaLimited = jest.fn()
+    const mockSetQuotaLimited = jest.fn()
+    const fakePersistence = {
+        get_quota_limited: mockGetQuotaLimited,
+        set_quota_limited: mockSetQuotaLimited,
+    }
+    let rateLimiter: RateLimiter
+
+    beforeEach(() => {
+        mockGetQuotaLimited.mockReset()
+        mockSetQuotaLimited.mockReset()
+        rateLimiter = new RateLimiter(fakePersistence as unknown as PostHogPersistence)
+    })
+
+    it('is not rate limited if there is nothing in persistence', () => {
+        expect(rateLimiter.isRateLimited()).toBe(false)
+    })
+
+    it('is not rate limited if there is false in persistence', () => {
+        mockGetQuotaLimited.mockReturnValue(false)
+
+        expect(rateLimiter.isRateLimited()).toBe(false)
+    })
+
+    it('is not rate limited if the retryAfter is in the past', () => {
+        mockGetQuotaLimited.mockReturnValue(new Date(Date.now() - 1000).getTime())
+
+        expect(rateLimiter.isRateLimited()).toBe(false)
+    })
+
+    it('is rate limited if the retryAfter is in the future', () => {
+        mockGetQuotaLimited.mockReturnValue(new Date(Date.now() + 1000).getTime())
+
+        expect(rateLimiter.isRateLimited()).toBe(true)
+    })
+
+    it('sets the retryAfter on429Resposne', () => {
+        rateLimiter.on429Response({
+            status: 429,
+            getResponseHeader: () => '150',
+        } as unknown as XMLHttpRequest)
+
+        expect(mockSetQuotaLimited).toHaveBeenCalledWith(new Date().getTime() + 150)
+    })
+
+    it('defaults to 3600 if no Retry-After header is present', () => {
+        rateLimiter.on429Response({
+            status: 429,
+            getResponseHeader: () => null,
+        } as unknown as XMLHttpRequest)
+
+        expect(mockSetQuotaLimited).toHaveBeenCalledWith(new Date().getTime() + 3600)
+    })
+})

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -57,6 +57,7 @@ import { createSegmentIntegration } from './extensions/segment-integration'
 import { PageViewIdManager } from './page-view-id'
 import { ExceptionObserver } from './extensions/exceptions/exception-autocapture'
 import { PostHogSurveys, SurveyCallback } from './posthog-surveys'
+import { RateLimiter } from './rate-limiter'
 
 /*
 SIMPLE STYLE GUIDE:
@@ -262,6 +263,7 @@ export class PostHog {
     config: PostHogConfig
 
     persistence: PostHogPersistence
+    rateLimiter: RateLimiter
     sessionPersistence: PostHogPersistence
     sessionManager: SessionIdManager
     pageViewIdManager: PageViewIdManager
@@ -321,6 +323,7 @@ export class PostHog {
         this.persistence = undefined as any
         this.sessionPersistence = undefined as any
         this.sessionManager = undefined as any
+        this.rateLimiter = undefined as any
 
         // NOTE: See the property definition for deprecation notice
         this.people = {
@@ -439,13 +442,15 @@ export class PostHog {
             this.__loaded_recorder_version = window?.rrweb?.version
         }
 
+        this.persistence = new PostHogPersistence(this.config)
+        this.rateLimiter = new RateLimiter(this.persistence)
+
         this._captureMetrics = new CaptureMetrics(this.get_config('_capture_metrics'))
         this._requestQueue = new RequestQueue(this._captureMetrics, this._handle_queued_event.bind(this))
-        this._retryQueue = new RetryQueue(this._captureMetrics, this.get_config('on_xhr_error'))
+        this._retryQueue = new RetryQueue(this._captureMetrics, this.get_config('on_xhr_error'), this.rateLimiter)
         this.__captureHooks = []
         this.__request_queue = []
 
-        this.persistence = new PostHogPersistence(this.config)
         this.sessionManager = new SessionIdManager(this.config, this.persistence, this.uuidFn)
         this.sessionPersistence =
             this.config.persistence === 'sessionStorage'
@@ -649,6 +654,13 @@ export class PostHog {
     }
 
     _send_request(url: string, data: Record<string, any>, options: XHROptions, callback?: RequestCallback): void {
+        if (this.rateLimiter.isRateLimited()) {
+            if (this.get_config('debug')) {
+                console.warn('[PostHog SendRequest] is quota limited. Dropping request.')
+            }
+            return
+        }
+
         if (ENQUEUE_REQUESTS) {
             this.__request_queue.push([url, data, options, callback])
             return
@@ -691,6 +703,7 @@ export class PostHog {
                     retriesPerformedSoFar: 0,
                     retryQueue: this._retryQueue,
                     onXHRError: this.get_config('on_xhr_error'),
+                    onRateLimited: this.rateLimiter.on429Response,
                 })
             } catch (e) {
                 console.error(e)

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -25,6 +25,7 @@ export const SURVEYS = '$surveys'
 export const FLAG_CALL_REPORTED = '$flag_call_reported'
 
 const USER_STATE = '$user_state'
+const POSTHOG_QUOTA_LIMITED = '$posthog_quota_limited'
 
 export const RESERVED_PROPERTIES = [
     PEOPLE_DISTINCT_ID_KEY,
@@ -35,6 +36,7 @@ export const RESERVED_PROPERTIES = [
     SESSION_ID,
     ENABLED_FEATURE_FLAGS,
     USER_STATE,
+    POSTHOG_QUOTA_LIMITED,
     PERSISTENCE_EARLY_ACCESS_FEATURES,
     STORED_GROUP_PROPERTIES_KEY,
     STORED_PERSON_PROPERTIES_KEY,
@@ -330,6 +332,16 @@ export class PostHogPersistence {
 
     set_user_state(state: 'anonymous' | 'identified'): void {
         this.props[USER_STATE] = state
+        this.save()
+    }
+
+    get_quota_limited(): number | false {
+        return this.props[POSTHOG_QUOTA_LIMITED] || false
+    }
+
+    // receives the timestamp of the next time a call to PostHog is valid
+    set_quota_limited(state: number): void {
+        this.props[POSTHOG_QUOTA_LIMITED] = state
         this.save()
     }
 }

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,0 +1,21 @@
+import { PostHogPersistence } from './posthog-persistence'
+
+export class RateLimiter {
+    constructor(private persistence: PostHogPersistence) {}
+
+    isRateLimited(): boolean {
+        const retryAfter = this.persistence.get_quota_limited()
+        if (retryAfter === false) {
+            return false
+        }
+        return new Date().getTime() < retryAfter
+    }
+
+    on429Response(response: XMLHttpRequest): void {
+        if (response.status !== 429) {
+            return
+        }
+        const retryAfter = parseInt(response.getResponseHeader('Retry-After') || '3600', 10)
+        this.persistence.set_quota_limited(new Date().getTime() + retryAfter)
+    }
+}

--- a/src/retry-queue.ts
+++ b/src/retry-queue.ts
@@ -3,6 +3,7 @@ import { encodePostData, xhr } from './send-request'
 import { CaptureMetrics } from './capture-metrics'
 import { QueuedRequestData, RetryQueueElement } from './types'
 import Config from './config'
+import { RateLimiter } from './rate-limiter'
 
 const thirtyMinutes = 30 * 60 * 1000
 
@@ -31,14 +32,20 @@ export class RetryQueue extends RequestQueueScaffold {
     isPolling: boolean
     areWeOnline: boolean
     onXHRError: (failedRequest: XMLHttpRequest) => void
+    rateLimiter: RateLimiter
 
-    constructor(captureMetrics: CaptureMetrics, onXHRError: (failedRequest: XMLHttpRequest) => void) {
+    constructor(
+        captureMetrics: CaptureMetrics,
+        onXHRError: (failedRequest: XMLHttpRequest) => void,
+        rateLimiter: RateLimiter
+    ) {
         super()
         this.captureMetrics = captureMetrics
         this.isPolling = false
         this.queue = []
         this.areWeOnline = true
         this.onXHRError = onXHRError
+        this.rateLimiter = rateLimiter
 
         if (typeof window !== 'undefined' && 'onLine' in window.navigator) {
             this.areWeOnline = window.navigator.onLine
@@ -78,7 +85,7 @@ export class RetryQueue extends RequestQueueScaffold {
     }
 
     flush(): void {
-        // using Date.now to make tests easier as recommended here https://codewithhugo.com/mocking-the-current-date-in-jest-tests/
+        // using Date.now to make tests easier, as recommended here https://codewithhugo.com/mocking-the-current-date-in-jest-tests/
         const now = new Date(Date.now())
         const toFlush = this.queue.filter(({ retryAt }) => retryAt < now)
         if (toFlush.length > 0) {
@@ -94,6 +101,15 @@ export class RetryQueue extends RequestQueueScaffold {
             clearTimeout(this._poller)
             this._poller = undefined
         }
+
+        if (this.rateLimiter.isRateLimited()) {
+            if (Config.DEBUG) {
+                console.warn('[PostHog RetryQueue] is quota limited. Dropping request.')
+            }
+            this.queue = []
+            return
+        }
+
         for (const { requestData } of this.queue) {
             const { url, data, options } = requestData
             try {
@@ -101,7 +117,7 @@ export class RetryQueue extends RequestQueueScaffold {
                 // eslint-disable-next-line compat/compat
                 window.navigator.sendBeacon(url, encodePostData(data, { ...options, sendBeacon: true }))
             } catch (e) {
-                // Note sendBeacon automatically retries, and after the first retry it will loose reference to contextual `this`.
+                // Note sendBeacon automatically retries, and after the first retry it will lose reference to contextual `this`.
                 // This means in some cases `this.getConfig` will be undefined.
                 if (Config.DEBUG) {
                     console.error(e)
@@ -112,6 +128,13 @@ export class RetryQueue extends RequestQueueScaffold {
     }
 
     _executeXhrRequest({ url, data, options, headers, callback, retriesPerformedSoFar }: QueuedRequestData): void {
+        if (this.rateLimiter.isRateLimited()) {
+            if (Config.DEBUG) {
+                console.warn('[PostHog RetryQueue] in quota limited mode. Dropping request.')
+            }
+            return
+        }
+
         xhr({
             url,
             data: data || {},
@@ -122,6 +145,7 @@ export class RetryQueue extends RequestQueueScaffold {
             captureMetrics: this.captureMetrics,
             retryQueue: this,
             onXHRError: this.onXHRError,
+            onRateLimited: this.rateLimiter.on429Response,
         })
     }
 

--- a/src/send-request.ts
+++ b/src/send-request.ts
@@ -68,6 +68,7 @@ export const xhr = ({
     retryQueue,
     onXHRError,
     timeout = 10000,
+    onRateLimited,
 }: XHRParams) => {
     const req = new XMLHttpRequest()
     req.open(options.method || 'GET', url, true)
@@ -122,6 +123,10 @@ export const xhr = ({
                         retriesPerformedSoFar: (retriesPerformedSoFar || 0) + 1,
                         callback,
                     })
+                }
+
+                if (req.status === 429) {
+                    onRateLimited?.(req)
                 }
 
                 if (callback) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,6 +202,7 @@ export interface XHRParams extends QueuedRequestData {
     retryQueue: RetryQueue
     onXHRError: (req: XMLHttpRequest) => void
     timeout?: number
+    onRateLimited?: (req: XMLHttpRequest) => void
 }
 
 export interface DecideResponse {


### PR DESCRIPTION
## Changes

If the server returns 429 on sending a request, then the SDK should obey this and not send messages.

It checks for a Retry-After header and uses that number of seconds or 3600 as the delay until the next sending.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
