### PR TITLE
fix: Check for mutation rate limiter

### DIFF
--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -376,7 +376,9 @@ export class SessionRecording {
             return
         }
 
-        const throttledEvent = this.mutationRateLimiter!.throttleMutations(rawEvent)
+        const throttledEvent = this.mutationRateLimiter
+            ? this.mutationRateLimiter.throttleMutations(rawEvent)
+            : rawEvent
 
         if (!throttledEvent) {
             return


### PR DESCRIPTION
## Changes

Fixes an issue where emit is called before the recording has started (via the mutation rate limiter)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
