### PR TITLE
chore: add media examples to playground

### DIFF
--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -54,6 +54,7 @@ export default function Home() {
                 <div className="buttons">
                     <Link href="/animations">Animations</Link>
                     <Link href="/iframe">Iframe</Link>
+                    <Link href="/media">Media</Link>
                 </div>
 
                 <p>Feature flag response: {JSON.stringify(result)}</p>

--- a/playground/nextjs/pages/media.tsx
+++ b/playground/nextjs/pages/media.tsx
@@ -1,0 +1,29 @@
+import Head from 'next/head'
+
+export default function Home() {
+    return (
+        <>
+            <Head>
+                <title>PostHog</title>
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+            </Head>
+            <main>
+                <h1>Video</h1>
+                <p>Useful testing for Replay handling video elements</p>
+                <div style={{margin: 10}}>
+                    <h3>Video</h3>
+                    <video controls={true} style={{width: 500}}>
+                        <source src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" />
+                    </video>
+                </div>
+
+                <div style={{margin: 10}}>
+                    <h3>Audio</h3>
+                    <audio controls={true}>
+                        <source src="https://github.com/rafaelreis-hotmart/Audio-Sample-files/raw/master/sample.mp3" type="audio/mp3" />
+                    </audio>
+                </div>
+            </main>
+        </>
+    )
+}

--- a/playground/nextjs/yarn.lock
+++ b/playground/nextjs/yarn.lock
@@ -1920,7 +1920,7 @@ scheduler@^0.23.0:
   dependencies:
     loose-envify "^1.1.0"
 
-semver@^6.3.0:
+semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
 


### PR DESCRIPTION
## Changes

Add examples of media playback to the Next.js playground

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
