### PR TITLE
fix: Mitigate testcafe flakiness

### DIFF
--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -38,12 +38,16 @@ jobs:
         uses: actions/setup-node@v3
         with:
             node-version: 18
+            cache: 'yarn'
 
       - name: Serve static files
         run: python -m http.server 8080 &
 
+      - name: Install node dependencies
+        run: yarn
+
       - name: Set up posthog-js
-        run: yarn && yarn build-rollup
+        run: yarn build-rollup
 
       - name: Run ${{ matrix.name }} test
         run: yarn testcafe "browserstack:${{ matrix.browserstack }}"

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -9,6 +9,7 @@ env:
   BROWSERSTACK_NETWORK_LOGS: 'true'
   BROWSERSTACK_CONSOLE: 'info'
   BROWSERSTACK_FORCE_PROXY: 'true'
+  BROWSERSTACK_USE_AUTOMATE: 'true'
 
 jobs:
   browsers:

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -8,6 +8,7 @@ env:
   BROWSERSTACK_DEBUG: 'true'
   BROWSERSTACK_NETWORK_LOGS: 'true'
   BROWSERSTACK_CONSOLE: 'info'
+  BROWSERSTACK_FORCE_PROXY: 'true'
 
 jobs:
   browsers:

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -44,4 +44,4 @@ jobs:
         run: yarn && yarn build-rollup
 
       - name: Run ${{ matrix.name }} test
-        run: yarn testcafe "browserstack:${{ matrix.browserstack }}" testcafe/*.spec.js
+        run: yarn testcafe "browserstack:${{ matrix.browserstack }}"

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -50,4 +50,4 @@ jobs:
         run: yarn build-rollup
 
       - name: Run ${{ matrix.name }} test
-        run: yarn testcafe "browserstack:${{ matrix.browserstack }}"
+        run: node scripts/run-testcafe-with-retries.mjs --browser "browserstack:${{ matrix.browserstack }}" --attempts 3

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -44,4 +44,4 @@ jobs:
         run: yarn && yarn build-rollup
 
       - name: Run ${{ matrix.name }} test
-        run: npx testcafe "browserstack:${{ matrix.browserstack }}" testcafe/*.spec.js
+        run: yarn testcafe "browserstack:${{ matrix.browserstack }}" testcafe/*.spec.js

--- a/.testcaferc.js
+++ b/.testcaferc.js
@@ -1,0 +1,3 @@
+module.exports = {
+    src: './testcafe',
+}

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
         "testcafe": "1.19.0",
         "testcafe-browser-provider-browserstack": "1.14.0",
         "tslib": "^2.4.0",
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "yargs": "^17.7.2"
     },
     "lint-staged": {
         "*.{ts,tsx,js,json}": "prettier --write",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
         "test-react": "cd react; yarn test",
         "test-watch": "jest --watch src",
         "cypress": "cypress open",
-        "prepare": "husky install"
+        "prepare": "husky install",
+        "testcafe": "testcafe"
     },
     "main": "dist/module.js",
     "module": "dist/es.js",
@@ -78,8 +79,8 @@
         "rrweb-snapshot": "2.0.0-alpha.8",
         "rrweb-v1": "npm:rrweb@1.1.3",
         "sinon": "9.0.2",
-        "testcafe": "^1.19.0",
-        "testcafe-browser-provider-browserstack": "^1.14.0",
+        "testcafe": "1.19.0",
+        "testcafe-browser-provider-browserstack": "1.14.0",
         "tslib": "^2.4.0",
         "typescript": "^4.7.4"
     },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
         "test-react": "cd react; yarn test",
         "test-watch": "jest --watch src",
         "cypress": "cypress open",
-        "prepare": "husky install",
-        "testcafe": "testcafe"
+        "prepare": "husky install"
     },
     "main": "dist/module.js",
     "module": "dist/es.js",

--- a/scripts/run-testcafe-with-retries.mjs
+++ b/scripts/run-testcafe-with-retries.mjs
@@ -1,0 +1,31 @@
+import yargs from "yargs"
+
+import {spawnSync} from "child_process"
+
+
+const main = async () => {
+  const argv= yargs(process.argv).argv
+  const attempts = argv.attempts || 3
+  const browser = argv.browser
+  if (!browser) {
+    throw new Error("Missing browser argument")
+  }
+
+
+  for (let i = 0; i < attempts; i++) {
+    console.log(`Attempt ${i + 1} of a maximum of ${attempts} attempts`)
+    const result = spawnSync("yarn", ["testcafe", browser], {stdio: "inherit"})
+    if (result.status === 0) {
+      console.log("Test succeeded")
+      return
+    }
+    console.log("Test failed")
+  }
+  throw new Error(`Test failed after ${retries} retries`)
+}
+
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/scripts/run-testcafe-with-retries.mjs
+++ b/scripts/run-testcafe-with-retries.mjs
@@ -21,7 +21,7 @@ const main = async () => {
     }
     console.log("Test failed")
   }
-  throw new Error(`Test failed after ${retries} retries`)
+  throw new Error(`Test failed after ${attempts} attempts`)
 }
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11182,7 +11182,7 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-testcafe-browser-provider-browserstack@^1.14.0:
+testcafe-browser-provider-browserstack@1.14.0:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/testcafe-browser-provider-browserstack/-/testcafe-browser-provider-browserstack-1.14.0.tgz#28cc6fd1cc632d13a76bf13c1de11fbdf5fd7956"
   integrity sha512-pH9R52qbXY0y5QuHYQ4eHafLVcLN77ypslsY21a8a+/Xp7f/Due7tfHBwGws4B7IydjXhcn/g0G39XXYJJf/2Q==
@@ -11349,7 +11349,7 @@ testcafe-safe-storage@^1.1.1:
   resolved "https://registry.yarnpkg.com/testcafe-safe-storage/-/testcafe-safe-storage-1.1.2.tgz#dacfda9a51c77f61f11b13506d4004dd7f27eb73"
   integrity sha512-6km7D26+KCQGeFlSQ9fVEU7tD8qdioSpqzxU8CCZkd2KzBS0jTFkqaJ54rPaLdd5+wdhgO3+as3LMm4F0EDeYA==
 
-testcafe@^1.19.0:
+testcafe@1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/testcafe/-/testcafe-1.19.0.tgz#e26bf04a59bae4ad8c17aa43deba12a8ffcb98b3"
   integrity sha512-HH6Z60N51SPw7WcNFhvbrcV1a6Dri1T0npFmE8BvxQEjsYog2whtdxj01yfaYrE87AZK/ep6lOwrqy0P6WmsfQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -12212,7 +12212,7 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.3.1, yargs@^17.5.1:
+yargs@^17.3.1, yargs@^17.5.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
## Changes

Attempting to fix https://github.com/PostHog/posthog-js/issues/778
* Add BROWSERSTACK_FORCE_PROXY and BROWSERSTACK_USE_AUTOMATE which fixed the specific problem around the cloud safari connecting to the test page
* Use a cache to speed up yarn install
* Add a script which will rerun testcafe tests up to 3 times

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
