### PR TITLE
fix: Cross-subdomain tracking is not working for long TLDs

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -3,7 +3,7 @@ import { PersistentStore, Properties } from './types'
 import Config from './config'
 import { DISTINCT_ID, SESSION_ID } from './constants'
 
-const DOMAIN_MATCH_REGEX = /[a-z0-9][a-z0-9-]+\.[a-z.]{2,6}$/i
+const DOMAIN_MATCH_REGEX = /[a-z0-9][a-z0-9-]+\.[a-z]{2,}$/i
 
 // Methods partially borrowed from quirksmode.org/js/cookies.html
 export const cookieStore: PersistentStore = {


### PR DESCRIPTION
## Changes

Fixes #786.

Changed `DOMAIN_MATCH_REGEX` variable from `[a-z0-9][a-z0-9-]+\.[a-z.]{2,6}$` to `[a-z0-9][a-z0-9-]+\.[a-z]{2,}$`.

It accepts any domain with a TLD length of at least 2 characters, and extracts the domain name only. 

(I'm not sure why there were a `.` in the final section of previous regex, as it also fails on cases such as `me.you.co` as well, where whole string matches with the previous pattern. The new pattern should work fine and extract the domain name.)

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
