### PR TITLE
chore: obey @typescript-eslint/no-unused-vars

### DIFF
--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,5 +1,4 @@
 import { logger } from './utils'
-import Config from './config'
 
 const oneMinuteInMilliseconds = 60 * 1000
 


### PR DESCRIPTION
The lint rules have changed since opening #765 so it merged successfully but linting failed and it couldn't be published

Fix the code that fails the linter