### PR TITLE
fix(flags): Enqueue follow up requests without dropping

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This README is intended for developing the library itself.
 ## Testing
 
 Unit tests: run `yarn test`.
-Cypress: run `yarn serve` to have a test server running and separately `yarn cypress` to launch Cypress test engine.
+Cypress: run `yarn start` to have a test server running and separately `yarn cypress` to launch Cypress test engine.
 
 ### Running TestCafe E2E tests with BrowserStack
 

--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -92,8 +92,8 @@ describe('Payload Compression', () => {
                 },
                 featureFlags: {
                     receivedFeatureFlags: jest.fn(),
-                    resetRequestQueue: jest.fn(),
                     setReloadingPaused: jest.fn(),
+                    _startReloadTimer: jest.fn(),
                 },
                 _hasBootstrappedFeatureFlags: jest.fn(),
                 get_property: (property_key) =>

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -27,8 +27,8 @@ describe('Decide', () => {
         },
         featureFlags: {
             receivedFeatureFlags: jest.fn(),
-            resetRequestQueue: jest.fn(),
             setReloadingPaused: jest.fn(),
+            _startReloadTimer: jest.fn(),
         },
         _hasBootstrappedFeatureFlags: jest.fn(),
         getGroups: () => ({ organization: '5' }),

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -892,6 +892,7 @@ describe('_loaded()', () => {
         capture: jest.fn(),
         featureFlags: {
             setReloadingPaused: jest.fn(),
+            resetRequestQueue: jest.fn(),
             _startReloadTimer: jest.fn(),
         },
         _start_queue_if_opted_in: jest.fn(),

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -892,7 +892,7 @@ describe('_loaded()', () => {
         capture: jest.fn(),
         featureFlags: {
             setReloadingPaused: jest.fn(),
-            resetRequestQueue: jest.fn(),
+            _startReloadTimer: jest.fn(),
         },
         _start_queue_if_opted_in: jest.fn(),
     }))

--- a/src/__tests__/posthog-core.loaded.js
+++ b/src/__tests__/posthog-core.loaded.js
@@ -17,6 +17,7 @@ describe('loaded() with flags', () => {
         capture: jest.fn(),
         featureFlags: {
             setReloadingPaused: jest.fn(),
+            resetRequestQueue: jest.fn(),
             _startReloadTimer: jest.fn(),
             receivedFeatureFlags: jest.fn(),
         },
@@ -49,6 +50,7 @@ describe('loaded() with flags', () => {
             jest.spyOn(given.lib.featureFlags, 'setGroupPropertiesForFlags')
             jest.spyOn(given.lib.featureFlags, 'setReloadingPaused')
             jest.spyOn(given.lib.featureFlags, '_startReloadTimer')
+            jest.spyOn(given.lib.featureFlags, 'resetRequestQueue')
             jest.spyOn(given.lib.featureFlags, '_reloadFeatureFlagsRequest')
         })
 
@@ -59,6 +61,7 @@ describe('loaded() with flags', () => {
 
             expect(given.lib.featureFlags.setGroupPropertiesForFlags).toHaveBeenCalled() // loaded ph.group() calls setGroupPropertiesForFlags
             expect(given.lib.featureFlags.setReloadingPaused).toHaveBeenCalledWith(true)
+            expect(given.lib.featureFlags.resetRequestQueue).toHaveBeenCalledTimes(1)
             expect(given.lib.featureFlags._startReloadTimer).toHaveBeenCalled()
             expect(given.lib.featureFlags.setReloadingPaused).toHaveBeenCalledWith(false)
 

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -39,8 +39,9 @@ export class Decide {
     }
 
     parseDecideResponse(response: DecideResponse): void {
-        this.instance.featureFlags.resetRequestQueue()
         this.instance.featureFlags.setReloadingPaused(false)
+        // :TRICKY: Reload - start another request if queued!
+        this.instance.featureFlags._startReloadTimer()
 
         if (response?.status === 0) {
             console.error('Failed to fetch feature flags from PostHog.')

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -550,7 +550,7 @@ export class PostHog {
             new Decide(this).call()
 
             // TRICKY: Reset any decide reloads queued during config.loaded because they'll be
-            // covered by the decide call right below
+            // covered by the decide call right above.
             this.featureFlags.resetRequestQueue()
         }
     }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -543,15 +543,15 @@ export class PostHog {
             this.capture('$pageview', { title: document.title }, { send_instantly: true })
         }
 
-        // TRICKY: Reset any decide reloads queued during config.loaded because they'll be
-        // covered by the decide call right below
-        this.featureFlags.resetRequestQueue()
-
         // Call decide to get what features are enabled and other settings.
         // As a reminder, if the /decide endpoint is disabled, feature flags, toolbar, session recording, autocapture,
         // and compression will not be available.
         if (!disableDecide) {
             new Decide(this).call()
+
+            // TRICKY: Reset any decide reloads queued during config.loaded because they'll be
+            // covered by the decide call right below
+            this.featureFlags.resetRequestQueue()
         }
     }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -543,6 +543,10 @@ export class PostHog {
             this.capture('$pageview', { title: document.title }, { send_instantly: true })
         }
 
+        // TRICKY: Reset any decide reloads queued during config.loaded because they'll be
+        // covered by the decide call right below
+        this.featureFlags.resetRequestQueue()
+
         // Call decide to get what features are enabled and other settings.
         // As a reminder, if the /decide endpoint is disabled, feature flags, toolbar, session recording, autocapture,
         // and compression will not be available.

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -151,10 +151,6 @@ export class PostHogFeatureFlags {
         this.reloadFeatureFlagsInAction = isPaused
     }
 
-    resetRequestQueue(): void {
-        this.reloadFeatureFlagsQueued = false
-    }
-
     _startReloadTimer(): void {
         if (this.reloadFeatureFlagsQueued && !this.reloadFeatureFlagsInAction) {
             setTimeout(() => {

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -151,6 +151,10 @@ export class PostHogFeatureFlags {
         this.reloadFeatureFlagsInAction = isPaused
     }
 
+    resetRequestQueue(): void {
+        this.reloadFeatureFlagsQueued = false
+    }
+
     _startReloadTimer(): void {
         if (this.reloadFeatureFlagsQueued && !this.reloadFeatureFlagsInAction) {
             setTimeout(() => {


### PR DESCRIPTION
## Changes

My previous PR delayed reloading to the end of the decide request: https://github.com/PostHog/posthog-js/pull/791 , and for some reason I copied the wrong queue deletion behaviour instead of fixing it right in that PR 🤦 .

If `posthog.identify()` was called while we were requesting flags, we should queue this up and not drop it, as otherwise flags will stick around for the anon user rather than the identified one.

Fixes this behaviour, ~~and removes the now-unused `resetRequestQueue` function~~

...

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
