### PR TITLE
feat: add an attribute denylist for autocapture

### DIFF
--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -112,6 +112,19 @@ describe('Autocapture system', () => {
             expect(props['_ngcontent-dpm-c448']).toBeUndefined()
             expect(props['_nghost-dpm-c448']).toBeUndefined()
         })
+
+        it('should filter element attributes based on the denylist', () => {
+            autocapture.config = {
+                element_attribute_denylist: ['data-attr', 'data-attr-2'],
+            }
+            div.setAttribute('data-attr', 'value')
+            div.setAttribute('data-attr-2', 'value')
+            div.setAttribute('data-attr-3', 'value')
+            const props = autocapture._getPropertiesFromElement(div)
+            expect(props['attr__data-attr']).toBeUndefined()
+            expect(props['attr__data-attr-2']).toBeUndefined()
+            expect(props['attr__data-attr-3']).toBe('value')
+        })
     })
 
     describe('_getAugmentPropertiesFromElement', () => {

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -113,9 +113,9 @@ describe('Autocapture system', () => {
             expect(props['_nghost-dpm-c448']).toBeUndefined()
         })
 
-        it('should filter element attributes based on the denylist', () => {
+        it('should filter element attributes based on the ignorelist', () => {
             autocapture.config = {
-                element_attribute_denylist: ['data-attr', 'data-attr-2'],
+                element_attribute_ignorelist: ['data-attr', 'data-attr-2'],
             }
             div.setAttribute('data-attr', 'value')
             div.setAttribute('data-attr-2', 'value')

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -102,12 +102,12 @@ const autocapture = {
             })
 
         // capture the deny list here because this not-a-class class makes it tricky to use this.config in the function below
-        const elementAttributeDenylist = this.config?.element_attribute_denylist
+        const elementAttributeIgnorelist = this.config?.element_attribute_ignorelist
         _each(elem.attributes, function (attr: Attr) {
             // Only capture attributes we know are safe
             if (isSensitiveElement(elem) && ['name', 'id', 'class'].indexOf(attr.name) === -1) return
 
-            if (elementAttributeDenylist?.includes(attr.name)) return
+            if (elementAttributeIgnorelist?.includes(attr.name)) return
 
             if (!maskInputs && shouldCaptureValue(attr.value) && !isAngularStyleAttr(attr.name)) {
                 props['attr__' + attr.name] = limitText(1024, attr.value)

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -101,9 +101,13 @@ const autocapture = {
                 return c !== ''
             })
 
+        // capture the deny list here because this not-a-class class makes it tricky to use this.config in the function below
+        const elementAttributeDenylist = this.config?.element_attribute_denylist
         _each(elem.attributes, function (attr: Attr) {
             // Only capture attributes we know are safe
             if (isSensitiveElement(elem) && ['name', 'id', 'class'].indexOf(attr.name) === -1) return
+
+            if (elementAttributeDenylist?.includes(attr.name)) return
 
             if (!maskInputs && shouldCaptureValue(attr.value) && !isAngularStyleAttr(attr.name)) {
                 props['attr__' + attr.name] = limitText(1024, attr.value)

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export interface AutocaptureConfig {
      * Exclude certain element attributes from autocapture
      * E.g. ['aria-label'] or [data-attr-pii]
      */
-    element_attribute_denylist?: string[]
+    element_attribute_ignorelist?: string[]
 }
 
 export type UUIDVersion = 'og' | 'v7'

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,12 @@ export interface AutocaptureConfig {
      * e.g. ['[ph-capture]']
      */
     css_selector_allowlist?: string[]
+
+    /**
+     * Exclude certain element attributes from autocapture
+     * E.g. ['aria-label'] or [data-attr-pii]
+     */
+    element_attribute_denylist?: string[]
 }
 
 export type UUIDVersion = 'og' | 'v7'


### PR DESCRIPTION
We have seen instances where an element attribute is used to store complex data which can break autocapture parsing.

While it's better to fix those instances, let's also provide our users with an escape hatch,

* Adds a denylist to autocapture config
* Skips capturing element attributes based on that deny list