### PR TITLE
fix: Increase timeout to 60 seconds

### DIFF
--- a/src/send-request.ts
+++ b/src/send-request.ts
@@ -66,7 +66,7 @@ export const xhr = ({
     retriesPerformedSoFar,
     retryQueue,
     onXHRError,
-    timeout = 10000,
+    timeout = 60000,
     onResponse,
 }: XHRParams) => {
     const req = new XMLHttpRequest()


### PR DESCRIPTION
## Changes

We are killing requests after 10 seconds, causing retries. However, timeouts everywhere else in the system are 60 seconds. If the capture endpoint is slow, we just end up ddos'ing ourselves more

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
