### PR TITLE
feat: allow regex patterns and wildcards in survey url

### DIFF
--- a/src/__tests__/surveys.js
+++ b/src/__tests__/surveys.js
@@ -139,7 +139,7 @@ describe('surveys', () => {
             description: 'survey with regex url description',
             type: SurveyType.Popover,
             questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with regex url?' }],
-            conditions: { url: '/test/' },
+            conditions: { url: 'regex-url', urlMatchType: 'regex' },
             start_date: new Date().toISOString(),
             end_date: null,
         }
@@ -148,7 +148,7 @@ describe('surveys', () => {
             description: 'survey with param regex url description',
             type: SurveyType.Popover,
             questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with param regex url?' }],
-            conditions: { url: '/(\\?|\\&)(name.*)\\=([^&]+)/' },
+            conditions: { url: '(\\?|\\&)(name.*)\\=([^&]+)', urlMatchType: 'regex' },
             start_date: new Date().toISOString(),
             end_date: null,
         }
@@ -157,7 +157,7 @@ describe('surveys', () => {
             description: 'survey with wildcard subdomain url description',
             type: SurveyType.Popover,
             questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with wildcard subdomain url?' }],
-            conditions: { url: '*.example.com' },
+            conditions: { url: '(.*.)?subdomain.com', urlMatchType: 'regex' },
             start_date: new Date().toISOString(),
             end_date: null,
         }
@@ -166,7 +166,16 @@ describe('surveys', () => {
             description: 'survey with wildcard route url description',
             type: SurveyType.Popover,
             questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with wildcard route url?' }],
-            conditions: { url: 'wildcard.com/*/other' },
+            conditions: { url: 'wildcard.com/(.*.)', urlMatchType: 'regex' },
+            start_date: new Date().toISOString(),
+            end_date: null,
+        }
+        const surveyWithExactUrlMatch = {
+            name: 'survey with wildcard route url',
+            description: 'survey with wildcard route url description',
+            type: SurveyType.Popover,
+            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with wildcard route url?' }],
+            conditions: { url: 'https://example.com/exact', urlMatchType: 'exact' },
             start_date: new Date().toISOString(),
             end_date: null,
         }
@@ -230,15 +239,7 @@ describe('surveys', () => {
 
         it('returns surveys based on url and selector matching', () => {
             given('surveysResponse', () => ({
-                surveys: [
-                    surveyWithUrl,
-                    surveyWithSelector,
-                    surveyWithUrlAndSelector,
-                    surveyWithRegexUrl,
-                    surveyWithParamRegexUrl,
-                    surveyWithWildcardRouteUrl,
-                    surveyWithWildcardSubdomainUrl,
-                ],
+                surveys: [surveyWithUrl, surveyWithSelector, surveyWithUrlAndSelector],
             }))
             const originalWindowLocation = window.location
             delete window.location
@@ -246,34 +247,6 @@ describe('surveys', () => {
             window.location = new URL('https://posthog.com')
             given.surveys.getActiveMatchingSurveys((data) => {
                 expect(data).toEqual([surveyWithUrl])
-            })
-            window.location = originalWindowLocation
-
-            // eslint-disable-next-line compat/compat
-            window.location = new URL('https://example.com/test')
-            given.surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithRegexUrl])
-            })
-            window.location = originalWindowLocation
-
-            // eslint-disable-next-line compat/compat
-            window.location = new URL('https://example.com?name=something')
-            given.surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithParamRegexUrl])
-            })
-            window.location = originalWindowLocation
-
-            // eslint-disable-next-line compat/compat
-            window.location = new URL('https://app.example.com')
-            given.surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithWildcardSubdomainUrl])
-            })
-            window.location = originalWindowLocation
-
-            // eslint-disable-next-line compat/compat
-            window.location = new URL('https://wildcard.com/something/other')
-            given.surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithWildcardRouteUrl])
             })
             window.location = originalWindowLocation
 
@@ -294,6 +267,55 @@ describe('surveys', () => {
             document.body.removeChild(document.querySelector('#foo'))
         })
 
+        it('returns surveys based on url with urlMatchType settings', () => {
+            given('surveysResponse', () => ({
+                surveys: [
+                    surveyWithRegexUrl,
+                    surveyWithParamRegexUrl,
+                    surveyWithWildcardRouteUrl,
+                    surveyWithWildcardSubdomainUrl,
+                    surveyWithExactUrlMatch,
+                ],
+            }))
+
+            const originalWindowLocation = window.location
+            delete window.location
+            // eslint-disable-next-line compat/compat
+            window.location = new URL('https://regex-url.com/test')
+            given.surveys.getActiveMatchingSurveys((data) => {
+                expect(data).toEqual([surveyWithRegexUrl])
+            })
+            window.location = originalWindowLocation
+
+            // eslint-disable-next-line compat/compat
+            window.location = new URL('https://example.com?name=something')
+            given.surveys.getActiveMatchingSurveys((data) => {
+                expect(data).toEqual([surveyWithParamRegexUrl])
+            })
+            window.location = originalWindowLocation
+
+            // eslint-disable-next-line compat/compat
+            window.location = new URL('https://app.subdomain.com')
+            given.surveys.getActiveMatchingSurveys((data) => {
+                expect(data).toEqual([surveyWithWildcardSubdomainUrl])
+            })
+            window.location = originalWindowLocation
+
+            // eslint-disable-next-line compat/compat
+            window.location = new URL('https://wildcard.com/something/other')
+            given.surveys.getActiveMatchingSurveys((data) => {
+                expect(data).toEqual([surveyWithWildcardRouteUrl])
+            })
+            window.location = originalWindowLocation
+
+            // eslint-disable-next-line compat/compat
+            window.location = new URL('https://example.com/exact')
+            given.surveys.getActiveMatchingSurveys((data) => {
+                expect(data).toEqual([surveyWithExactUrlMatch])
+            })
+            window.location = originalWindowLocation
+        })
+
         given('decideResponse', () => ({
             featureFlags: {
                 'linked-flag-key': true,
@@ -302,6 +324,7 @@ describe('surveys', () => {
                 'survey-targeting-flag-key2': false,
             },
         }))
+
         it('returns surveys that match linked and targeting feature flags', () => {
             given('surveysResponse', () => ({ surveys: [activeSurvey, surveyWithFlags, surveyWithEverything] }))
             given.surveys.getActiveMatchingSurveys((data) => {

--- a/src/__tests__/surveys.js
+++ b/src/__tests__/surveys.js
@@ -133,6 +133,42 @@ describe('surveys', () => {
             start_date: new Date().toISOString(),
             end_date: null,
         }
+        const surveyWithRegexUrl = {
+            name: 'survey with regex url',
+            description: 'survey with regex url description',
+            type: SurveyType.Popover,
+            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with regex url?' }],
+            conditions: { url: '/test/' },
+            start_date: new Date().toISOString(),
+            end_date: null,
+        }
+        const surveyWithParamRegexUrl = {
+            name: 'survey with param regex url',
+            description: 'survey with param regex url description',
+            type: SurveyType.Popover,
+            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with param regex url?' }],
+            conditions: { url: '/(\\?|\\&)(name.*)\\=([^&]+)/' },
+            start_date: new Date().toISOString(),
+            end_date: null,
+        }
+        const surveyWithWildcardSubdomainUrl = {
+            name: 'survey with wildcard subdomain url',
+            description: 'survey with wildcard subdomain url description',
+            type: SurveyType.Popover,
+            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with wildcard subdomain url?' }],
+            conditions: { url: '*.example.com' },
+            start_date: new Date().toISOString(),
+            end_date: null,
+        }
+        const surveyWithWildcardRouteUrl = {
+            name: 'survey with wildcard route url',
+            description: 'survey with wildcard route url description',
+            type: SurveyType.Popover,
+            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with wildcard route url?' }],
+            conditions: { url: 'wildcard.com/*/other' },
+            start_date: new Date().toISOString(),
+            end_date: null,
+        }
         const surveyWithSelector = {
             name: 'survey with selector',
             description: 'survey with selector description',
@@ -192,7 +228,17 @@ describe('surveys', () => {
         })
 
         it('returns surveys based on url and selector matching', () => {
-            given('surveysResponse', () => ({ surveys: [surveyWithUrl, surveyWithSelector, surveyWithUrlAndSelector] }))
+            given('surveysResponse', () => ({
+                surveys: [
+                    surveyWithUrl,
+                    surveyWithSelector,
+                    surveyWithUrlAndSelector,
+                    surveyWithRegexUrl,
+                    surveyWithParamRegexUrl,
+                    surveyWithWildcardRouteUrl,
+                    surveyWithWildcardSubdomainUrl,
+                ],
+            }))
             const originalWindowLocation = window.location
             delete window.location
             // eslint-disable-next-line compat/compat
@@ -201,6 +247,35 @@ describe('surveys', () => {
                 expect(data).toEqual([surveyWithUrl])
             })
             window.location = originalWindowLocation
+
+            // eslint-disable-next-line compat/compat
+            window.location = new URL('https://example.com/test')
+            given.surveys.getActiveMatchingSurveys((data) => {
+                expect(data).toEqual([surveyWithRegexUrl])
+            })
+            window.location = originalWindowLocation
+
+            // eslint-disable-next-line compat/compat
+            window.location = new URL('https://example.com?name=something')
+            given.surveys.getActiveMatchingSurveys((data) => {
+                expect(data).toEqual([surveyWithParamRegexUrl])
+            })
+            window.location = originalWindowLocation
+
+            // eslint-disable-next-line compat/compat
+            window.location = new URL('https://app.example.com')
+            given.surveys.getActiveMatchingSurveys((data) => {
+                expect(data).toEqual([surveyWithWildcardSubdomainUrl])
+            })
+            window.location = originalWindowLocation
+
+            // eslint-disable-next-line compat/compat
+            window.location = new URL('https://wildcard.com/something/other')
+            given.surveys.getActiveMatchingSurveys((data) => {
+                expect(data).toEqual([surveyWithWildcardRouteUrl])
+            })
+            window.location = originalWindowLocation
+
             document.body.appendChild(document.createElement('div')).className = 'test-selector'
             given.surveys.getActiveMatchingSurveys((data) => {
                 expect(data).toEqual([surveyWithSelector])

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -5,7 +5,14 @@
  * currently not supported in the browser lib).
  */
 
-import { _copyAndTruncateStrings, _info, _isBlockedUA, DEFAULT_BLOCKED_UA_STRS, loadScript } from '../utils'
+import {
+    _copyAndTruncateStrings,
+    _info,
+    _isBlockedUA,
+    DEFAULT_BLOCKED_UA_STRS,
+    loadScript,
+    _isUrlMatchingRegex,
+} from '../utils'
 
 function userAgentFor(botString) {
     const randOne = (Math.random() + 1).toString(36).substring(7)
@@ -224,5 +231,27 @@ describe('loadScript', () => {
                 expect(_isBlockedUA(randomisedUserAgent, ['testington'])).toBe(true)
             }
         )
+    })
+
+    describe('_isUrlMatchingRegex', () => {
+        it('returns false when url does not match regex pattern', () => {
+            // test query params
+            expect(_isUrlMatchingRegex('https://example.com', '(\\?|\\&)(name.*)\\=([^&]+)')).toEqual(false)
+            // incorrect route
+            expect(_isUrlMatchingRegex('https://example.com/something/test', 'example.com/test')).toEqual(false)
+            // incorrect domain
+            expect(_isUrlMatchingRegex('https://example.com', 'anotherone.com')).toEqual(false)
+        })
+
+        it('returns true when url matches regex pattern', () => {
+            // match query params
+            expect(_isUrlMatchingRegex('https://example.com?name=something', '(\\?|\\&)(name.*)\\=([^&]+)')).toEqual(
+                true
+            )
+            // match subdomain wildcard
+            expect(_isUrlMatchingRegex('https://app.example.com', '(.*.)?example.com')).toEqual(true)
+            // match route wildcard
+            expect(_isUrlMatchingRegex('https://example.com/something/test', 'example.com/(.*.)/test')).toEqual(true)
+        })
     })
 })

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -74,6 +74,8 @@ export interface SurveyResponse {
 
 export type SurveyCallback = (surveys: Survey[]) => void
 
+export type SurveyUrlMatchType = 'regex' | 'exact' | 'contains'
+
 export interface Survey {
     // Sync this with the backend's SurveyAPISerializer!
     id: string
@@ -84,7 +86,12 @@ export interface Survey {
     targeting_flag_key: string | null
     questions: SurveyQuestion[]
     appearance: SurveyAppearance | null
-    conditions: { url?: string; selector?: string; seenSurveyWaitPeriodInDays?: number } | null
+    conditions: {
+        url?: string
+        selector?: string
+        seenSurveyWaitPeriodInDays?: number
+        urlMatchType?: SurveyUrlMatchType
+    } | null
     start_date: string | null
     end_date: string | null
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -237,6 +237,15 @@ export const _isNumber = function (obj: any): obj is number {
     return toString.call(obj) == '[object Number]'
 }
 
+export const _isValidRegex = function (str: string): boolean {
+    try {
+        new RegExp(str)
+    } catch (error) {
+        return false
+    }
+    return true
+}
+
 export const _encodeDates = function (obj: Properties): Properties {
     _each(obj, function (v, k) {
         if (_isDate(v)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -246,6 +246,11 @@ export const _isValidRegex = function (str: string): boolean {
     return true
 }
 
+export const _isUrlMatchingRegex = function (url: string, pattern: string): boolean {
+    if (!_isValidRegex(pattern)) return false
+    return new RegExp(pattern).test(url)
+}
+
 export const _encodeDates = function (obj: Properties): Properties {
     _each(obj, function (v, k) {
         if (_isDate(v)) {


### PR DESCRIPTION
## Changes
- handles regex pattern and wildcards in survey url
- added _isValidRegex util function
- all changes use built in JS functionality an should be cross-browser compatible
- related to https://github.com/PostHog/posthog/issues/17472

## Caveats
- Developing locally with a demo, I do not have the Surveys beta feature. What is the best way to have that enabled to fully test these changes in the example nextjs playground?
- I'm not 100% confident that checking for `/` at the beginning and end of the string is a great method for determining whether it is a regex. It requires education for the user to follow that pattern to have their pattern picked up correctly. I would love some feedback on whether that is acceptable.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
