### PR TITLE
feat(web-analytics): Add root $el_text

### DIFF
--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -35,6 +35,10 @@ export default function Home() {
                 <div className="buttons">
                     <button onClick={() => posthog.capture('Clicked button')}>Capture event</button>
                     <button data-attr="autocapture-button">Autocapture buttons</button>
+                    <a data-attr="autocapture-button" href="#">
+                        <span>Autocapture a &gt; span</span>
+                    </a>
+
                     <button className="ph-no-capture">Ignore certain elements</button>
 
                     <button onClick={() => posthog?.identify('user-' + randomID())}>Identify</button>

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -886,10 +886,10 @@ describe('Autocapture system', () => {
             autocapture._captureEvent(e1, lib)
 
             const props1 = getCapturedProps(lib.capture)
-            expect(props1['$elements'][0]).toHaveProperty(
-                '$el_text',
+            const text1 =
                 "Some super duper really long Text with new lines that we'll strip out and also we will want to make this text shorter since it's not likely people really care about text content that's super long and it also takes up more space and bandwidth. Some super d"
-            )
+            expect(props1['$elements'][0]).toHaveProperty('$el_text', text1)
+            expect(props1['$el_text']).toEqual(text1)
             lib.capture.resetHistory()
 
             const e2 = {
@@ -899,6 +899,7 @@ describe('Autocapture system', () => {
             autocapture._captureEvent(e2, lib)
             const props2 = getCapturedProps(lib.capture)
             expect(props2['$elements'][0]).toHaveProperty('$el_text', 'Some text')
+            expect(props2['$el_text']).toEqual('Some text')
             lib.capture.resetHistory()
 
             const e3 = {
@@ -908,6 +909,7 @@ describe('Autocapture system', () => {
             autocapture._captureEvent(e3, lib)
             const props3 = getCapturedProps(lib.capture)
             expect(props3['$elements'][0]).toHaveProperty('$el_text', '')
+            expect(props3).not.toHaveProperty('$el_text')
         })
 
         it('does not capture sensitive text content', () => {

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -265,6 +265,7 @@ const autocapture = {
                 {
                     $elements: elementsJson,
                 },
+                elementsJson[0]?.['$el_text'] ? { $el_text: elementsJson[0]?.['$el_text'] } : {},
                 this._getCustomProperties(targetElementList),
                 autocaptureAugmentProperties
             )


### PR DESCRIPTION
## Changes
Send the root $el_text as its own property, needed by web analytics.

Add new assertions to existing tests.

Also ran it locally and could confirm that I was seeing it working.

<img width="1161" alt="Screenshot 2023-09-25 at 15 00 01" src="https://github.com/PostHog/posthog-js/assets/2056078/bb30ae10-3e09-4101-99a0-e24cfe678f06">

To pre-empt comments that I should be doing this in the plugin-server, that's probably right but this is much faster to implement, and there'd be no problem making that change later on as it would be completely compatible, so I'd rather just move fast and do it here.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
