### PR TITLE
fix(surveys): Handle filtering on undefined

### DIFF
--- a/src/__tests__/surveys.js
+++ b/src/__tests__/surveys.js
@@ -102,7 +102,7 @@ describe('surveys', () => {
     })
 
     it('getSurveys returns empty array if surveys are undefined', () => {
-        given('surveysResponse', () => ({ surveys: undefined }))
+        given('surveysResponse', () => ({ status: 0 }))
         given.surveys.getSurveys((data) => {
             expect(data).toEqual([])
         })

--- a/src/__tests__/surveys.js
+++ b/src/__tests__/surveys.js
@@ -101,6 +101,13 @@ describe('surveys', () => {
         expect(given.instance._send_request).toHaveBeenCalledTimes(2)
     })
 
+    it('getSurveys returns empty array if surveys are undefined', () => {
+        given('surveysResponse', () => ({ surveys: undefined }))
+        given.surveys.getSurveys((data) => {
+            expect(data).toEqual([])
+        })
+    })
+
     describe('getActiveMatchingSurveys', () => {
         const draftSurvey = {
             name: 'draft survey',

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -29,6 +29,9 @@ export class PostHogSurveys {
 
     getActiveMatchingSurveys(callback: SurveyCallback, forceReload = false) {
         this.getSurveys((surveys) => {
+            if (!surveys) {
+                return callback([])
+            }
             const activeSurveys = surveys.filter((survey) => {
                 return !!(survey.start_date && !survey.end_date)
             })

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -10,7 +10,7 @@ export class PostHogSurveys {
     }
 
     getSurveys(callback: SurveyCallback, forceReload = false) {
-        const existingSurveys = this.instance.get_property(SURVEYS) || []
+        const existingSurveys = this.instance.get_property(SURVEYS)
         if (!existingSurveys || forceReload) {
             this.instance._send_request(
                 `${this.instance.get_config('api_host')}/api/surveys/?token=${this.instance.get_config('token')}`,

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -10,14 +10,14 @@ export class PostHogSurveys {
     }
 
     getSurveys(callback: SurveyCallback, forceReload = false) {
-        const existingSurveys = this.instance.get_property(SURVEYS)
+        const existingSurveys = this.instance.get_property(SURVEYS) || []
         if (!existingSurveys || forceReload) {
             this.instance._send_request(
                 `${this.instance.get_config('api_host')}/api/surveys/?token=${this.instance.get_config('token')}`,
                 {},
                 { method: 'GET' },
                 (response) => {
-                    const surveys = response.surveys
+                    const surveys = response.surveys || []
                     this.instance.persistence?.register({ [SURVEYS]: surveys })
                     return callback(surveys)
                 }
@@ -29,9 +29,6 @@ export class PostHogSurveys {
 
     getActiveMatchingSurveys(callback: SurveyCallback, forceReload = false) {
         this.getSurveys((surveys) => {
-            if (!surveys) {
-                return callback([])
-            }
             const activeSurveys = surveys.filter((survey) => {
                 return !!(survey.start_date && !survey.end_date)
             })


### PR DESCRIPTION
## Changes

[sentry error link](https://posthog.sentry.io/issues/4504159510/?alert_rule_id=14548021&alert_type=issue&notification_uuid=55f52d61-d28f-44f9-8999-5ebae0d73ab1&project=1899813&referrer=slack)

problem: Filtering on undefined surveys causes an error

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
