### PR TITLE
fix: Remove complex get_config

### DIFF
--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -1108,21 +1108,17 @@ describe('Autocapture system', () => {
         given('persistence', () => ({ props: {}, register: jest.fn() }))
 
         given('posthog', () => ({
-            config: given.config,
+            config: {
+                api_host: 'https://test.com',
+                token: 'testtoken',
+                autocapture: true,
+            },
             token: 'testtoken',
             capture: jest.fn(),
             get_distinct_id: () => 'distinctid',
             get_property: (property_key) =>
                 property_key === AUTOCAPTURE_DISABLED_SERVER_SIDE ? given.$autocapture_disabled_server_side : undefined,
             persistence: given.persistence,
-        }))
-
-        given('clientSideEnabled', () => true)
-
-        given('config', () => ({
-            api_host: 'https://test.com',
-            token: 'testtoken',
-            autocapture: given.clientSideEnabled,
         }))
 
         given('decideResponse', () => ({ config: { enable_collect_everything: true } }))
@@ -1149,7 +1145,7 @@ describe('Autocapture system', () => {
         })
 
         it('should be disabled before the decide response if client side opted out', () => {
-            given('clientSideEnabled', () => false)
+            given.posthog.config.autocapture = false
 
             // _setIsAutocaptureEnabled is called during init
             autocapture._setIsAutocaptureEnabled(given.posthog)
@@ -1166,7 +1162,7 @@ describe('Autocapture system', () => {
         ])(
             'when client side config is %p and remote opt out is %p - autocapture enabled should be %p',
             (clientSideOptIn, serverSideOptOut, expected) => {
-                given('clientSideEnabled', () => clientSideOptIn)
+                given.posthog.config.autocapture = clientSideOptIn
                 given('decideResponse', () => ({
                     config: { enable_collect_everything: true },
                     autocapture_opt_out: serverSideOptOut,
@@ -1184,11 +1180,11 @@ describe('Autocapture system', () => {
         })
 
         it('should not call _addDomEventHandlders if autocapture is disabled', () => {
-            given('config', () => ({
+            given.posthog.config = {
                 api_host: 'https://test.com',
                 token: 'testtoken',
                 autocapture: false,
-            }))
+            }
             given('$autocapture_disabled_server_side', () => true)
             given.subject()
             expect(autocapture._addDomEventHandlers).not.toHaveBeenCalled()

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -474,14 +474,10 @@ describe('Autocapture system', () => {
                     return 'distinctid'
                 },
                 capture: sandbox.spy(),
-                get_config: sandbox.spy(function (key) {
-                    switch (key) {
-                        case 'mask_all_element_attributes':
-                            return false
-                        case 'rageclick':
-                            return true
-                    }
-                }),
+                config: {
+                    mask_all_element_attributes: false,
+                    rageclick: true,
+                },
             }
         })
 
@@ -506,18 +502,12 @@ describe('Autocapture system', () => {
         it('should add the custom property when an element matching any of the event selectors is clicked', () => {
             lib = {
                 _prepare_callback: sandbox.spy((callback) => callback),
-                get_config: sandbox.spy(function (key) {
-                    switch (key) {
-                        case 'api_host':
-                            return 'https://test.com'
-                        case 'token':
-                            return 'testtoken'
-                        case 'mask_all_element_attributes':
-                            return false
-                        case 'autocapture':
-                            return true
-                    }
-                }),
+                config: {
+                    api_host: 'https://test.com',
+                    token: 'testtoken',
+                    mask_all_element_attributes: false,
+                    autocapture: true,
+                },
                 token: 'testtoken',
                 capture: sandbox.spy(),
                 get_distinct_id() {
@@ -614,21 +604,15 @@ describe('Autocapture system', () => {
             expect(captureProperties).toHaveProperty('parent-augment', 'the parent')
         })
 
-        it('should not capture events when get_config returns false, when an element matching any of the event selectors is clicked', () => {
+        it('should not capture events when config returns false, when an element matching any of the event selectors is clicked', () => {
             lib = {
                 _prepare_callback: sandbox.spy((callback) => callback),
-                get_config: sandbox.spy(function (key) {
-                    switch (key) {
-                        case 'api_host':
-                            return 'https://test.com'
-                        case 'token':
-                            return 'testtoken'
-                        case 'mask_all_element_attributes':
-                            return false
-                        case 'autocapture':
-                            return false
-                    }
-                }),
+                config: {
+                    api_host: 'https://test.com',
+                    token: 'testtoken',
+                    mask_all_element_attributes: false,
+                    autocapture: false,
+                },
                 token: 'testtoken',
                 capture: sandbox.spy(),
                 get_distinct_id() {
@@ -666,21 +650,15 @@ describe('Autocapture system', () => {
             lib.capture.resetHistory()
         })
 
-        it('should not capture events when get_config returns true but server setting is disabled', () => {
+        it('should not capture events when config returns true but server setting is disabled', () => {
             lib = {
                 _prepare_callback: sandbox.spy((callback) => callback),
-                get_config: sandbox.spy(function (key) {
-                    switch (key) {
-                        case 'api_host':
-                            return 'https://test.com'
-                        case 'token':
-                            return 'testtoken'
-                        case 'mask_all_element_attributes':
-                            return false
-                        case 'autocapture':
-                            return true
-                    }
-                }),
+                config: {
+                    api_host: 'https://test.com',
+                    token: 'testtoken',
+                    mask_all_element_attributes: false,
+                    autocapture: true,
+                },
                 token: 'testtoken',
                 capture: sandbox.spy(),
                 get_distinct_id() {
@@ -1035,7 +1013,12 @@ describe('Autocapture system', () => {
       </button>
       `
 
-            const newLib = { ...lib, get_config: jest.fn(() => true) }
+            const newLib = {
+                ...lib,
+                config: {
+                    // TODO
+                },
+            }
 
             document.body.innerHTML = dom
             const button1 = document.getElementById('button1')
@@ -1057,7 +1040,12 @@ describe('Autocapture system', () => {
         </a>
         `
 
-            const newLib = { ...lib, get_config: jest.fn(() => true) }
+            const newLib = {
+                ...lib,
+                config: {
+                    // TODO: Return true
+                },
+            }
 
             document.body.innerHTML = dom
             const a = document.getElementById('a1')
@@ -1075,19 +1063,14 @@ describe('Autocapture system', () => {
     })
 
     describe('_addDomEventHandlers', () => {
-        const sandbox = sinon.createSandbox()
-
         const lib = {
             capture: sinon.spy(),
             get_distinct_id() {
                 return 'distinctid'
             },
-            get_config: sandbox.spy(function (key) {
-                switch (key) {
-                    case 'mask_all_element_attributes':
-                        return false
-                }
-            }),
+            config: {
+                mask_all_element_attributes: false,
+            },
         }
 
         let navigateSpy
@@ -1125,7 +1108,7 @@ describe('Autocapture system', () => {
         given('persistence', () => ({ props: {}, register: jest.fn() }))
 
         given('posthog', () => ({
-            get_config: jest.fn().mockImplementation((key) => given.config[key]),
+            config: given.config,
             token: 'testtoken',
             capture: jest.fn(),
             get_distinct_id: () => 'distinctid',

--- a/src/__tests__/autocapture.js
+++ b/src/__tests__/autocapture.js
@@ -1016,7 +1016,8 @@ describe('Autocapture system', () => {
             const newLib = {
                 ...lib,
                 config: {
-                    // TODO
+                    ...lib.config,
+                    mask_all_element_attributes: true,
                 },
             }
 
@@ -1043,7 +1044,8 @@ describe('Autocapture system', () => {
             const newLib = {
                 ...lib,
                 config: {
-                    // TODO: Return true
+                    ...lib.config,
+                    mask_all_text: true,
                 },
             }
 
@@ -1212,7 +1214,7 @@ describe('Autocapture system', () => {
             autocapture.afterDecideResponse(given.decideResponse, given.posthog)
             expect(autocapture._addDomEventHandlers).toHaveBeenCalledTimes(1)
 
-            given('config', () => ({ api_host: 'https://test.com', token: 'anotherproject', autocapture: true }))
+            given.posthog.config = { api_host: 'https://test.com', token: 'anotherproject', autocapture: true }
             autocapture.afterDecideResponse(given.decideResponse, given.posthog)
             expect(autocapture._addDomEventHandlers).toHaveBeenCalledTimes(2)
         })

--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -69,14 +69,10 @@ describe('Payload Compression', () => {
                         throw new Error('Should not get here')
                     }
                 }),
-                get_config: sandbox.spy(function (key) {
-                    switch (key) {
-                        case 'api_host':
-                            return 'https://test.com'
-                        case 'token':
-                            return 'testtoken'
-                    }
-                }),
+                config: {
+                    api_host: 'https://test.com',
+                    token: 'testtoken',
+                },
                 token: 'testtoken',
                 get_distinct_id() {
                     return 'distinctid'

--- a/src/__tests__/extensions/exceptions/exception-observer.test.ts
+++ b/src/__tests__/extensions/exceptions/exception-observer.test.ts
@@ -13,7 +13,7 @@ describe('Exception Observer', () => {
 
     beforeEach(() => {
         mockPostHogInstance = {
-            get_config: jest.fn((key: string) => mockConfig[key as keyof PostHogConfig]),
+            config: mockConfig,
             get_distinct_id: jest.fn(() => 'mock-distinct-id'),
             capture: mockCapture,
         }

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -45,7 +45,7 @@ describe('SessionRecording', () => {
                 : property_key === SESSION_RECORDING_ENABLED_SERVER_SIDE
                 ? given.$session_recording_enabled_server_side
                 : given.$console_log_enabled_server_side,
-        get_config: jest.fn().mockImplementation((key) => given.config[key]),
+        config: given.config,
         capture: jest.fn(),
         persistence: { register: jest.fn() },
         sessionManager: given.sessionManager,

--- a/src/__tests__/extensions/sessionrecording.js
+++ b/src/__tests__/extensions/sessionrecording.js
@@ -55,7 +55,7 @@ describe('SessionRecording', () => {
 
     given('config', () => ({
         api_host: 'https://test.com',
-        disable_session_recording: given.disabled,
+        disable_session_recording: false,
         enable_recording_console_log: given.enable_recording_console_log_client_side,
         autocapture: false, // Assert that session recording works even if `autocapture = false`
         session_recording: {
@@ -68,7 +68,6 @@ describe('SessionRecording', () => {
     given('$session_recording_enabled_server_side', () => true)
     given('$console_log_enabled_server_side', () => false)
     given('$session_recording_recorder_version_server_side', () => undefined)
-    given('disabled', () => false)
     given('__loaded_recorder_version', () => undefined)
 
     beforeEach(() => {
@@ -90,7 +89,7 @@ describe('SessionRecording', () => {
         })
 
         it('is disabled if the client config is disabled', () => {
-            given('disabled', () => true)
+            given.posthog.config.disable_session_recording = true
             given.subject()
             expect(given.subject()).toBe(false)
         })
@@ -164,7 +163,7 @@ describe('SessionRecording', () => {
         })
 
         it('call stopRecording if its not enabled', () => {
-            given('disabled', () => true)
+            given.posthog.config.disable_session_recording = true
             given.subject()
             expect(given.sessionRecording.stopRecording).toHaveBeenCalled()
         })
@@ -427,7 +426,7 @@ describe('SessionRecording', () => {
         })
 
         it('does not load script if disable_session_recording passed', () => {
-            given('disabled', () => true)
+            given.posthog.config.disable_session_recording = true
 
             given.sessionRecording.startRecordingIfEnabled()
             given.sessionRecording.startCaptureAndTrySendingQueuedSnapshots()

--- a/src/__tests__/extensions/toolbar.js
+++ b/src/__tests__/extensions/toolbar.js
@@ -10,7 +10,7 @@ describe('Toolbar', () => {
     given('toolbar', () => new Toolbar(given.lib))
 
     given('lib', () => ({
-        get_config: jest.fn().mockImplementation((key) => given.config[key]),
+        config: given.config,
         set_config: jest.fn(),
     }))
 

--- a/src/__tests__/extensions/web-performance.test.ts
+++ b/src/__tests__/extensions/web-performance.test.ts
@@ -35,7 +35,7 @@ describe('WebPerformance', () => {
 
     beforeEach(() => {
         mockPostHogInstance = {
-            get_config: jest.fn((key: string) => mockConfig[key as keyof PostHogConfig]),
+            config: mockConfig,
             sessionRecording: {
                 onRRwebEmit: jest.fn(),
             },

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -13,7 +13,7 @@ describe('featureflags', () => {
         persistence: 'memory',
     })),
         given('instance', () => ({
-            get_config: jest.fn().mockImplementation((key) => given.config[key]),
+            config: given.config,
             get_distinct_id: () => 'blah id',
             getGroups: () => {},
             _prepare_callback: (callback) => callback,

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -8,26 +8,25 @@ jest.spyOn(global, 'setTimeout')
 
 describe('featureflags', () => {
     given('decideEndpointWasHit', () => false)
-    given('config', () => ({
-        token: 'testtoken',
+
+    const config = {
+        token: 'random fake token',
         persistence: 'memory',
-    })),
-        given('instance', () => ({
-            config: given.config,
-            get_distinct_id: () => 'blah id',
-            getGroups: () => {},
-            _prepare_callback: (callback) => callback,
-            persistence: new PostHogPersistence(given.config),
-            register: (props) => given.instance.persistence.register(props),
-            unregister: (key) => given.instance.persistence.unregister(key),
-            get_property: (key) => given.instance.persistence.props[key],
-            capture: () => {},
-            decideEndpointWasHit: given.decideEndpointWasHit,
-            _send_request: jest
-                .fn()
-                .mockImplementation((url, data, headers, callback) => callback(given.decideResponse)),
-            reloadFeatureFlags: () => given.featureFlags.reloadFeatureFlags(),
-        }))
+    }
+    given('instance', () => ({
+        config,
+        get_distinct_id: () => 'blah id',
+        getGroups: () => {},
+        _prepare_callback: (callback) => callback,
+        persistence: new PostHogPersistence(config),
+        register: (props) => given.instance.persistence.register(props),
+        unregister: (key) => given.instance.persistence.unregister(key),
+        get_property: (key) => given.instance.persistence.props[key],
+        capture: () => {},
+        decideEndpointWasHit: given.decideEndpointWasHit,
+        _send_request: jest.fn().mockImplementation((url, data, headers, callback) => callback(given.decideResponse)),
+        reloadFeatureFlags: () => given.featureFlags.reloadFeatureFlags(),
+    }))
 
     given('featureFlags', () => new PostHogFeatureFlags(given.instance))
 
@@ -216,11 +215,6 @@ describe('featureflags', () => {
             },
         }))
 
-        given('config', () => ({
-            token: 'random fake token',
-            persistence: 'memory',
-        }))
-
         it('onFeatureFlags should not be called immediately if feature flags not loaded', () => {
             var called = false
             let _flags = []
@@ -323,10 +317,12 @@ describe('featureflags', () => {
             earlyAccessFeatures: [EARLY_ACCESS_FEATURE_FIRST],
         }))
 
-        given('config', () => ({
-            token: 'random fake token',
-            api_host: 'https://decide.com',
-        }))
+        beforeEach(() => {
+            given.instance.config = {
+                ...given.instance.config,
+                api_host: 'https://decide.com',
+            }
+        })
 
         it('getEarlyAccessFeatures requests early access features if not present', () => {
             given.featureFlags.getEarlyAccessFeatures((data) => {
@@ -467,11 +463,6 @@ describe('featureflags', () => {
             },
         }))
 
-        given('config', () => ({
-            token: 'random fake token',
-            persistence: 'memory',
-        }))
-
         it('on providing anonDistinctId', () => {
             given.featureFlags.setAnonymousDistinctId('rando_id')
             given.featureFlags.reloadFeatureFlags()
@@ -561,11 +552,11 @@ describe('featureflags', () => {
         })
 
         it('on providing config advanced_disable_feature_flags', () => {
-            given('config', () => ({
-                token: 'random fake token',
-                persistence: 'memory',
+            given.instance.config = {
+                ...given.instance.config,
                 advanced_disable_feature_flags: true,
-            }))
+            }
+
             given.featureFlags.reloadFeatureFlags()
 
             jest.runAllTimers()
@@ -593,11 +584,6 @@ describe('featureflags', () => {
                 first: 'variant-1',
                 second: true,
             },
-        }))
-
-        given('config', () => ({
-            token: 'random fake token',
-            persistence: 'memory',
         }))
 
         it('on providing personProperties updates properties successively', () => {
@@ -736,11 +722,6 @@ describe('featureflags', () => {
             errorsWhileComputingFlags: true,
         }))
 
-        given('config', () => ({
-            token: 'random fake token',
-            persistence: 'memory',
-        }))
-
         it('should return combined results', () => {
             given.featureFlags.reloadFeatureFlags()
 
@@ -761,11 +742,6 @@ describe('featureflags', () => {
         given('decideResponse', () => ({
             featureFlags: { 'x-flag': 'x-value', 'feature-1': false },
             errorsWhileComputingFlags: false,
-        }))
-
-        given('config', () => ({
-            token: 'random fake token',
-            persistence: 'memory',
         }))
 
         it('should return combined results', () => {

--- a/src/__tests__/gdpr-utils.js
+++ b/src/__tests__/gdpr-utils.js
@@ -473,13 +473,12 @@ describe(`GDPR utils`, () => {
     describe(`addOptOutCheckPostHogLib`, () => {
         const captureEventName = `єνєηт`
         const captureProperties = { '𝖕𝖗𝖔𝖕𝖊𝖗𝖙𝖞': `𝓿𝓪𝓵𝓾𝓮` }
-        let getConfig, capture, postHogLib
+        let capture, postHogLib
 
-        function setupMocks(getConfigFunc, silenceErrors = false) {
-            getConfig = sinon.spy((name) => getConfigFunc()[name])
+        function setupMocks(config, silenceErrors = false) {
             capture = sinon.spy()
             postHogLib = {
-                get_config: getConfig,
+                config,
                 capture: undefined,
             }
             postHogLib.capture = gdpr.addOptOutCheck(postHogLib, capture, silenceErrors)
@@ -488,7 +487,7 @@ describe(`GDPR utils`, () => {
         forPersistenceTypes(function (persistenceType) {
             it(`should call the wrapped method if the user is neither opted in or opted out`, () => {
                 TOKENS.forEach((token) => {
-                    setupMocks(() => ({ token, opt_out_capturing_persistence_type: persistenceType }))
+                    setupMocks({ token, opt_out_capturing_persistence_type: persistenceType })
 
                     postHogLib.capture(captureEventName, captureProperties)
 
@@ -498,7 +497,7 @@ describe(`GDPR utils`, () => {
 
             it(`should call the wrapped method if the user is opted in`, () => {
                 TOKENS.forEach((token) => {
-                    setupMocks(() => ({ token, opt_out_capturing_persistence_type: persistenceType }))
+                    setupMocks({ token, opt_out_capturing_persistence_type: persistenceType })
 
                     gdpr.optIn(token, { persistenceType })
                     postHogLib.capture(captureEventName, captureProperties)
@@ -509,7 +508,7 @@ describe(`GDPR utils`, () => {
 
             it(`should not call the wrapped method if the user is opted out`, () => {
                 TOKENS.forEach((token) => {
-                    setupMocks(() => ({ token, opt_out_capturing_persistence_type: persistenceType }))
+                    setupMocks({ token, opt_out_capturing_persistence_type: persistenceType })
 
                     gdpr.optOut(token, { persistenceType })
                     postHogLib.capture(captureEventName, captureProperties)
@@ -520,7 +519,7 @@ describe(`GDPR utils`, () => {
 
             it(`should not invoke the callback directly if the user is neither opted in or opted out`, () => {
                 TOKENS.forEach((token) => {
-                    setupMocks(() => ({ token, opt_out_capturing_persistence_type: persistenceType }))
+                    setupMocks({ token, opt_out_capturing_persistence_type: persistenceType })
                     const callback = sinon.spy()
 
                     postHogLib.capture(captureEventName, captureProperties, callback)
@@ -531,7 +530,7 @@ describe(`GDPR utils`, () => {
 
             it(`should not invoke the callback directly if the user is opted in`, () => {
                 TOKENS.forEach((token) => {
-                    setupMocks(() => ({ token, opt_out_capturing_persistence_type: persistenceType }))
+                    setupMocks({ token, opt_out_capturing_persistence_type: persistenceType })
                     const callback = sinon.spy()
 
                     gdpr.optIn(token, { persistenceType })
@@ -543,7 +542,7 @@ describe(`GDPR utils`, () => {
 
             it(`should invoke the callback directly if the user is opted out`, () => {
                 TOKENS.forEach((token) => {
-                    setupMocks(() => ({ token, opt_out_capturing_persistence_type: persistenceType }))
+                    setupMocks({ token, opt_out_capturing_persistence_type: persistenceType })
                     const callback = sinon.spy()
 
                     gdpr.optOut(token, { persistenceType })
@@ -555,7 +554,7 @@ describe(`GDPR utils`, () => {
 
             it(`should call the wrapped method if there is no token available`, () => {
                 TOKENS.forEach((token) => {
-                    setupMocks(() => ({ token: null, opt_out_capturing_persistence_type: persistenceType }))
+                    setupMocks({ token: null, opt_out_capturing_persistence_type: persistenceType })
 
                     gdpr.optIn(token, { persistenceType })
                     postHogLib.capture(captureEventName, captureProperties)
@@ -593,11 +592,11 @@ describe(`GDPR utils`, () => {
 
             it(`should allow use of a custom "persistence prefix" string`, () => {
                 TOKENS.forEach((token) => {
-                    setupMocks(() => ({
+                    setupMocks({
                         token,
                         opt_out_capturing_persistence_type: persistenceType,
                         opt_out_capturing_cookie_prefix: CUSTOM_PERSISTENCE_PREFIX,
-                    }))
+                    })
 
                     gdpr.optOut(token, { persistenceType, persistencePrefix: CUSTOM_PERSISTENCE_PREFIX })
                     postHogLib.capture(captureEventName, captureProperties)

--- a/src/__tests__/gdpr-utils.js
+++ b/src/__tests__/gdpr-utils.js
@@ -563,22 +563,9 @@ describe(`GDPR utils`, () => {
                 })
             })
 
-            it(`should call the wrapped method if an unexpected error occurs`, () => {
-                TOKENS.forEach((token) => {
-                    setupMocks(() => {
-                        throw new Error(`Unexpected error!`)
-                    }, true)
-
-                    gdpr.optIn(token, { persistenceType })
-                    postHogLib.capture(captureEventName, captureProperties)
-
-                    expect(capture.calledOnceWith(captureEventName, captureProperties)).toBe(true)
-                })
-            })
-
             it(`should call the wrapped method if config is undefined`, () => {
                 TOKENS.forEach((token) => {
-                    setupMocks(() => undefined, false)
+                    setupMocks(undefined, false)
                     console.error = jest.fn()
 
                     gdpr.optIn(token, { persistenceType })

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -576,7 +576,7 @@ describe('init()', () => {
                 'a-name'
             )
         )
-        expect(given.subject.get_config('on_xhr_error')).toBe(fakeOnXHRError)
+        expect(given.subject.config.on_xhr_error).toBe(fakeOnXHRError)
     })
 
     it('does not load decide endpoint on advanced_disable_decide', () => {

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -38,7 +38,6 @@ describe('capture()', () => {
 
     given('overrides', () => ({
         __loaded: true,
-        get_config: (key) => given.config?.[key],
         config: given.config,
         persistence: {
             remove_event_timer: jest.fn(),
@@ -187,7 +186,7 @@ describe('_calculate_event_properties()', () => {
     given('options', () => ({}))
 
     given('overrides', () => ({
-        get_config: (key) => given.config[key],
+        config: given.config,
         persistence: {
             properties: () => ({ distinct_id: 'abc', persistent: 'prop' }),
             remove_event_timer: jest.fn(),
@@ -298,7 +297,7 @@ describe('_handle_unload()', () => {
     given('subject', () => () => given.lib._handle_unload())
 
     given('overrides', () => ({
-        get_config: (key) => given.config[key],
+        config: given.config,
         capture: jest.fn(),
         compression: {},
         _requestQueue: {
@@ -369,7 +368,7 @@ describe('__compress_and_send_json_request', () => {
     given('overrides', () => ({
         compression: {},
         _send_request: jest.fn(),
-        get_config: () => false,
+        config: {},
     }))
 
     it('handles base64 compression', () => {
@@ -888,7 +887,7 @@ describe('_loaded()', () => {
     given('subject', () => () => given.lib._loaded())
 
     given('overrides', () => ({
-        get_config: (key) => given.config?.[key],
+        config: given.config,
         capture: jest.fn(),
         featureFlags: {
             setReloadingPaused: jest.fn(),

--- a/src/__tests__/posthog-core.loaded.js
+++ b/src/__tests__/posthog-core.loaded.js
@@ -13,7 +13,7 @@ describe('loaded() with flags', () => {
     given('subject', () => () => given.lib._loaded())
 
     given('overrides', () => ({
-        get_config: (key) => given.config?.[key],
+        config: given.config,
         capture: jest.fn(),
         featureFlags: {
             setReloadingPaused: jest.fn(),
@@ -39,7 +39,7 @@ describe('loaded() with flags', () => {
         }))
 
         given('overrides', () => ({
-            get_config: (key) => given.config?.[key],
+            config: given.config,
             capture: jest.fn(),
             _send_request: jest.fn((host, data, header, callback) => setTimeout(() => callback({ status: 200 }), 1000)),
             _start_queue_if_opted_in: jest.fn(),

--- a/src/__tests__/surveys.js
+++ b/src/__tests__/surveys.js
@@ -9,7 +9,7 @@ describe('surveys', () => {
         persistence: 'memory',
     }))
     given('instance', () => ({
-        get_config: jest.fn().mockImplementation((key) => given.config[key]),
+        config: given.config,
         _prepare_callback: (callback) => callback,
         persistence: new PostHogPersistence(given.config),
         register: (props) => given.instance.persistence.register(props),

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -46,7 +46,7 @@ const autocapture = {
             this._isDisabledServerSide === null
                 ? !!instance.persistence?.props[AUTOCAPTURE_DISABLED_SERVER_SIDE]
                 : this._isDisabledServerSide
-        const enabled_client_side = !!instance.get_config('autocapture')
+        const enabled_client_side = !!instance.config.autocapture
         this._isAutocaptureEnabled = enabled_client_side && !disabled_server_side
     },
 
@@ -233,8 +233,8 @@ const autocapture = {
                 elementsJson.push(
                     this._getPropertiesFromElement(
                         el,
-                        instance.get_config('mask_all_element_attributes'),
-                        instance.get_config('mask_all_text')
+                        instance.config.mask_all_element_attributes,
+                        instance.config.mask_all_text
                     )
                 )
 
@@ -242,7 +242,7 @@ const autocapture = {
                 _extend(autocaptureAugmentProperties, augmentProperties)
             })
 
-            if (!instance.get_config('mask_all_text')) {
+            if (!instance.config.mask_all_text) {
                 // if the element is a button or anchor tag get the span text from any
                 // children and include it as/with the text property on the parent element
                 if (target.tagName.toLowerCase() === 'a' || target.tagName.toLowerCase() === 'button') {
@@ -305,11 +305,11 @@ const autocapture = {
             this.config.url_allowlist = this.config.url_allowlist.map((url) => new RegExp(url))
         }
 
-        this.rageclicks = new RageClick(instance.get_config('rageclick'))
+        this.rageclicks = new RageClick(instance.config.rageclick)
     },
 
     afterDecideResponse: function (response: DecideResponse, instance: PostHog): void {
-        const token = instance.get_config('token')
+        const token = instance.config.token
         if (this._initializedTokens.indexOf(token) > -1) {
             logger.log('autocapture already initialized for token "' + token + '"')
             return

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { version } from '../package.json'
 
 // overriden in posthog-core,
-// e.g.     Config.DEBUG = Config.DEBUG || instance.get_config('debug')
+// e.g.     Config.DEBUG = Config.DEBUG || instance.config.debug
 const Config = {
     DEBUG: false,
     LIB_VERSION: version,

--- a/src/extensions/exceptions/exception-autocapture.ts
+++ b/src/extensions/exceptions/exception-autocapture.ts
@@ -19,7 +19,7 @@ export class ExceptionObserver {
     }
 
     private debugLog(...args: any[]) {
-        if (this.instance.get_config('debug')) {
+        if (this.instance.config.debug) {
             console.log('PostHog.js [PostHog.ExceptionObserver]', ...args)
         }
     }
@@ -125,7 +125,7 @@ export class ExceptionObserver {
 
         const propertiesToSend = { ...properties, ...errorProperties }
 
-        const posthogHost = this.instance.get_config('ui_host') || this.instance.get_config('api_host')
+        const posthogHost = this.instance.config.ui_host || this.instance.config.api_host
         errorProperties.$exception_personURL = posthogHost + '/person/' + this.instance.get_distinct_id()
 
         this.sendExceptionEvent(propertiesToSend)

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -132,19 +132,19 @@ export class SessionRecording {
 
     isRecordingEnabled() {
         const enabled_server_side = !!this.instance.get_property(SESSION_RECORDING_ENABLED_SERVER_SIDE)
-        const enabled_client_side = !this.instance.get_config('disable_session_recording')
+        const enabled_client_side = !this.instance.config.disable_session_recording
         return enabled_server_side && enabled_client_side
     }
 
     isConsoleLogCaptureEnabled() {
         const enabled_server_side = !!this.instance.get_property(CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE)
-        const enabled_client_side = this.instance.get_config('enable_recording_console_log')
+        const enabled_client_side = this.instance.config.enable_recording_console_log
         return enabled_client_side ?? enabled_server_side
     }
 
     getRecordingVersion() {
         const recordingVersion_server_side = this.instance.get_property(SESSION_RECORDING_RECORDER_VERSION_SERVER_SIDE)
-        const recordingVersion_client_side = this.instance.get_config('session_recording')?.recorderVersion
+        const recordingVersion_client_side = this.instance.config.session_recording?.recorderVersion
         return recordingVersion_client_side || recordingVersion_server_side || 'v1'
     }
 
@@ -210,7 +210,7 @@ export class SessionRecording {
         }
 
         // We do not switch recorder versions midway through a recording.
-        if (this.captureStarted || this.instance.get_config('disable_session_recording')) {
+        if (this.captureStarted || this.instance.config.disable_session_recording) {
             return
         }
 
@@ -224,16 +224,13 @@ export class SessionRecording {
         // imported) or matches the requested recorder version, don't load script. Otherwise, remotely import
         // recorder.js from cdn since it hasn't been loaded.
         if (this.instance.__loaded_recorder_version !== this.getRecordingVersion()) {
-            loadScript(
-                this.instance.get_config('api_host') + `/static/${recorderJS}?v=${Config.LIB_VERSION}`,
-                (err) => {
-                    if (err) {
-                        return logger.error(`Could not load ${recorderJS}`, err)
-                    }
-
-                    this._onScriptLoaded()
+            loadScript(this.instance.config.api_host + `/static/${recorderJS}?v=${Config.LIB_VERSION}`, (err) => {
+                if (err) {
+                    return logger.error(`Could not load ${recorderJS}`, err)
                 }
-            )
+
+                this._onScriptLoaded()
+            })
         } else {
             this._onScriptLoaded()
         }
@@ -330,7 +327,7 @@ export class SessionRecording {
         this.rrwebRecord = window.rrweb ? window.rrweb.record : window.rrwebRecord
 
         // only allows user to set our 'allowlisted' options
-        const userSessionRecordingOptions = this.instance.get_config('session_recording')
+        const userSessionRecordingOptions = this.instance.config.session_recording
         for (const [key, value] of Object.entries(userSessionRecordingOptions || {})) {
             if (key in sessionRecordingOptions) {
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -79,7 +79,7 @@ export class Toolbar {
                 delete toolbarParams.userIntent
             }
 
-            if (toolbarParams['token'] && this.instance.get_config('token') === toolbarParams['token']) {
+            if (toolbarParams['token'] && this.instance.config.token === toolbarParams['token']) {
                 this.loadToolbar(toolbarParams)
                 return true
             } else {
@@ -97,7 +97,7 @@ export class Toolbar {
         // only load the toolbar once, even if there are multiple instances of PostHogLib
         ;(window as any)['_postHogToolbarLoaded'] = true
 
-        const host = this.instance.get_config('api_host')
+        const host = this.instance.config.api_host
         // toolbar.js is served from the PostHog CDN, this has a TTL of 24 hours.
         // the toolbar asset includes a rotating "token" that is valid for 5 minutes.
         const fiveMinutesInMillis = 5 * 60 * 1000
@@ -105,11 +105,11 @@ export class Toolbar {
         const timestampToNearestFiveMinutes = Math.floor(Date.now() / fiveMinutesInMillis) * fiveMinutesInMillis
         const toolbarUrl = `${host}${host.endsWith('/') ? '' : '/'}static/toolbar.js?t=${timestampToNearestFiveMinutes}`
         const disableToolbarMetrics =
-            !POSTHOG_MANAGED_HOSTS.includes(this.instance.get_config('api_host')) &&
-            this.instance.get_config('advanced_disable_toolbar_metrics')
+            !POSTHOG_MANAGED_HOSTS.includes(this.instance.config.api_host) &&
+            this.instance.config.advanced_disable_toolbar_metrics
 
         const toolbarParams = {
-            token: this.instance.get_config('token'),
+            token: this.instance.config.token,
             ...params,
             apiURL: host, // defaults to api_host from the instance config if nothing else set
             ...(disableToolbarMetrics ? { instrument: false } : {}),

--- a/src/extensions/web-performance.ts
+++ b/src/extensions/web-performance.ts
@@ -147,7 +147,7 @@ export class WebPerformanceObserver {
     }
 
     isEnabled() {
-        return this.instance.get_config('capture_performance') ?? this.remoteEnabled ?? false
+        return this.instance.config.capture_performance ?? this.remoteEnabled ?? false
     }
 
     afterDecideResponse(response: DecideResponse) {
@@ -160,8 +160,8 @@ export class WebPerformanceObserver {
     _capturePerformanceEvent(event: PerformanceEntry) {
         // NOTE: We don't want to capture our own request events.
 
-        if (event.name.indexOf(this.instance.get_config('api_host')) === 0) {
-            const path = event.name.replace(this.instance.get_config('api_host'), '')
+        if (event.name.indexOf(this.instance.config.api_host) === 0) {
+            const path = event.name.replace(this.instance.config.api_host, '')
 
             if (POSTHOG_PATHS_TO_IGNORE.find((x) => path.indexOf(x) === 0)) {
                 return
@@ -174,7 +174,7 @@ export class WebPerformanceObserver {
             url: event.name,
         }
 
-        const userSessionRecordingOptions = this.instance.get_config('session_recording')
+        const userSessionRecordingOptions = this.instance.config.session_recording
 
         if (userSessionRecordingOptions.maskNetworkRequestFn) {
             networkRequest = userSessionRecordingOptions.maskNetworkRequestFn(networkRequest)

--- a/src/gdpr-utils.ts
+++ b/src/gdpr-utils.ts
@@ -214,11 +214,11 @@ export function userOptedOut(posthog: PostHog, silenceErrors: boolean | undefine
     let optedOut = false
 
     try {
-        const token = posthog.get_config('token')
-        const respectDnt = posthog.get_config('respect_dnt')
-        const persistenceType = posthog.get_config('opt_out_capturing_persistence_type')
-        const persistencePrefix = posthog.get_config('opt_out_capturing_cookie_prefix') || undefined
-        const win = posthog.get_config('window' as any) as Window | undefined // used to override window during browser tests
+        const token = posthog.config.token
+        const respectDnt = posthog.config.respect_dnt
+        const persistenceType = posthog.config.opt_out_capturing_persistence_type
+        const persistencePrefix = posthog.config.opt_out_capturing_cookie_prefix || undefined
+        const win = (posthog.config as any).window as Window | undefined // used to override window during browser tests
 
         if (token) {
             // if there was an issue getting the token, continue method execution as normal

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -120,6 +120,7 @@ const defaultConfig = (): PostHogConfig => ({
     capture_pageview: true,
     capture_pageleave: true, // We'll only capture pageleave events if capture_pageview is also true
     debug: false,
+    verbose: false,
     cookie_expiration: 365,
     upgrade: false,
     disable_session_recording: false,

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1742,13 +1742,6 @@ export class PostHog {
     }
 
     /**
-     * returns the current config object for the library.
-     */
-    get_config<K extends keyof PostHogConfig>(prop_name: K): PostHogConfig[K] {
-        return this.config?.[prop_name]
-    }
-
-    /**
      * Returns the value of the super property named property_name. If no such
      * property is set, get_property() will return the undefined value.
      *

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -350,7 +350,7 @@ export class PostHogFeatureFlags {
 
         if (!existing_early_access_features || force_reload) {
             this.instance._send_request(
-                `${this.instance.config.api_host}/api/early_access_features/?token=${this.config.                    'token                )}`,
+                `${this.instance.config.api_host}/api/early_access_features/?token=${this.instance.config.token}`,
                 {},
                 { method: 'GET' },
                 (response) => {

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -168,7 +168,7 @@ export class PostHogFeatureFlags {
 
     _reloadFeatureFlagsRequest(): void {
         this.setReloadingPaused(true)
-        const token = this.instance.get_config('token')
+        const token = this.instance.config.token
         const personProperties = this.instance.get_property(STORED_PERSON_PROPERTIES_KEY)
         const groupProperties = this.instance.get_property(STORED_GROUP_PROPERTIES_KEY)
         const json_data = JSON.stringify({
@@ -178,12 +178,12 @@ export class PostHogFeatureFlags {
             $anon_distinct_id: this.$anon_distinct_id,
             person_properties: personProperties,
             group_properties: groupProperties,
-            disable_flags: this.instance.get_config('advanced_disable_feature_flags') || undefined,
+            disable_flags: this.instance.config.advanced_disable_feature_flags || undefined,
         })
 
         const encoded_data = _base64Encode(json_data)
         this.instance._send_request(
-            this.instance.get_config('api_host') + '/decide/?v=3',
+            this.instance.config.api_host + '/decide/?v=3',
             { data: encoded_data },
             { method: 'POST' },
             this.instance._prepare_callback((response) => {
@@ -350,9 +350,7 @@ export class PostHogFeatureFlags {
 
         if (!existing_early_access_features || force_reload) {
             this.instance._send_request(
-                `${this.instance.get_config('api_host')}/api/early_access_features/?token=${this.instance.get_config(
-                    'token'
-                )}`,
+                `${this.instance.config.api_host}/api/early_access_features/?token=${this.config.                    'token                )}`,
                 {},
                 { method: 'GET' },
                 (response) => {

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -13,7 +13,7 @@ export class PostHogSurveys {
         const existingSurveys = this.instance.get_property(SURVEYS)
         if (!existingSurveys || forceReload) {
             this.instance._send_request(
-                `${this.instance.get_config('api_host')}/api/surveys/?token=${this.instance.get_config('token')}`,
+                `${this.instance.config.api_host}/api/surveys/?token=${this.instance.config.token}`,
                 {},
                 { method: 'GET' },
                 (response) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,6 @@ export interface PostHogConfig {
     // defaults to the empty array
     custom_blocked_useragents: string[]
     save_referrer: boolean
-    test: boolean
     verbose: boolean
     capture_pageview: boolean
     capture_pageleave: boolean


### PR DESCRIPTION
## Changes

Removes a legacy param asked about [here](https://posthog.com/questions/post-hog-config-test-param)

We have a special accessor for the config that doesn't actually do anything whilst also making it really hard to infer types.
This PR gets rid of it and simply accesses the config object.

The "given" concept in tests is a real headache we should move away from... Tried to fix tests without getting too lost in refactoring for now


## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
