### PR TITLE
fix(capture): Always update stored person props from $set

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -43,6 +43,11 @@ describe('capture()', () => {
             remove_event_timer: jest.fn(),
             properties: jest.fn(),
             update_config: jest.fn(),
+            register(properties) {
+                // Simplified version of the real thing
+                Object.assign(this.props, properties)
+            },
+            props: {},
         },
         sessionPersistence: {
             update_search_keyword: jest.fn(),
@@ -167,6 +172,18 @@ describe('capture()', () => {
         expect(captureResult).toEqual(
             expect.objectContaining({ $set: { email: 'john@example.com' }, $set_once: { howOftenAmISet: 'once!' } })
         )
+    })
+
+    it('updates persisted person properties for feature flags if $set is present', () => {
+        given('config', () => ({
+            property_blacklist: [],
+            _onCapture: jest.fn(),
+        }))
+        given('eventProperties', () => ({
+            $set: { foo: 'bar' },
+        }))
+        given.subject()
+        expect(given.overrides.persistence.props.$stored_person_properties).toMatchObject({ foo: 'bar' })
     })
 
     it('correctly handles the "length" property', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -7,6 +7,7 @@ import {
     _info,
     _isArray,
     _isBlockedUA,
+    _isEmptyObject,
     _isObject,
     _isUndefined,
     _register_event,
@@ -880,6 +881,13 @@ export class PostHog {
 
         data = _copyAndTruncateStrings(data, options._noTruncate ? null : this.config.properties_string_max_length)
         data.timestamp = options.timestamp || new Date()
+
+        // Top-level $set overriding values from the one from properties is taken from the plugin-server normalizeEvent
+        // This doesn't handle $set_once, because posthog-people doesn't either
+        const finalSet = { ...data.properties['$set'], ...data['$set'] }
+        if (!_isEmptyObject(finalSet)) {
+            this.setPersonPropertiesForFlags(finalSet)
+        }
 
         if (this.config.debug) {
             logger.log('PostHog.js send', data)


### PR DESCRIPTION
## Changes

@simfish85 [brought to my attention](https://posthog.slack.com/archives/C02E3BKC78F/p1696361572769039) that every `posthog.people.set()` call fires an event, and I realized this can't quite be optimized away just by using the `$set` property in `posthog.capture()`'d events. That's because in the latter case, stored person properties don't get updated, potentially messing up feature flags.

This PR adds the handling around stored person props that `posthog-people` had to `posthog-core`. Let me know if this makes sense, I've not been involved in posthog-js lately.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
