### PR TITLE
fix(surveys): multiple choice survey submit button bug

### DIFF
--- a/src/extensions/surveys.ts
+++ b/src/extensions/surveys.ts
@@ -631,11 +631,11 @@ export const createMultipleChoicePopup = (posthog: PostHog, survey: Survey, ques
     formElement.addEventListener('change', () => {
         const selectedChoices =
             singleOrMultiSelect === 'single_choice'
-                ? formElement.querySelector('input[type=radio]:checked')
+                ? formElement.querySelectorAll('input[type=radio]:checked')
                 : formElement.querySelectorAll('input[type=checkbox]:checked')
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore // TODO: Fix this, error because it doesn't recognize node list as an array
-        if ((singleOrMultiSelect === 'single_choice' && selectedChoices) || (selectedChoices.length ?? 0) > 0) {
+        if ((selectedChoices.length ?? 0) > 0) {
             ;(formElement.querySelector('.form-submit') as HTMLButtonElement).disabled = false
         } else {
             ;(formElement.querySelector('.form-submit') as HTMLButtonElement).disabled = true

--- a/src/extensions/surveys.ts
+++ b/src/extensions/surveys.ts
@@ -635,7 +635,7 @@ export const createMultipleChoicePopup = (posthog: PostHog, survey: Survey, ques
                 : formElement.querySelectorAll('input[type=checkbox]:checked')
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore // TODO: Fix this, error because it doesn't recognize node list as an array
-        if (selectedChoices && (selectedChoices.length ?? 0) > 0) {
+        if ((singleOrMultiSelect === 'single_choice' && selectedChoices) || (selectedChoices.length ?? 0) > 0) {
             ;(formElement.querySelector('.form-submit') as HTMLButtonElement).disabled = false
         } else {
             ;(formElement.querySelector('.form-submit') as HTMLButtonElement).disabled = true


### PR DESCRIPTION
## Changes

Single choice surveys could not be submitted bug

Regular `querySelector` here returns element instead of a list of elements so we should not check `.length` on it 

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
