### PR TITLE
fix(surveys): open text value bug

### DIFF
--- a/src/extensions/surveys.ts
+++ b/src/extensions/surveys.ts
@@ -405,7 +405,7 @@ export const createOpenTextOrLinkPopup = (
     formElement.addEventListener('input', (e: any) => {
         if (formElement.querySelector('.form-submit')) {
             const submitButton = formElement.querySelector('.form-submit') as HTMLButtonElement
-            submitButton.disabled = !e.data
+            submitButton.disabled = !e.target.value
         }
     })
 


### PR DESCRIPTION
## Changes

Open text input value was using the on change value instead of the full textbox value, which meant when you typed and then went backspace, it would disable the submit button.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
