### PR TITLE
feat: allow backend to specify a custom analytics endpoint

### DIFF
--- a/src/__tests__/compression.js
+++ b/src/__tests__/compression.js
@@ -1,8 +1,4 @@
-import sinon from 'sinon'
-import { autocapture } from '../autocapture'
 import { decideCompression, compressData } from '../compression'
-import { Decide } from '../decide'
-import { AUTOCAPTURE_DISABLED_SERVER_SIDE } from '../constants'
 
 describe('decideCompression()', () => {
     given('subject', () => decideCompression(given.compressionSupport))
@@ -44,70 +40,5 @@ describe('compressData()', () => {
         given('compression', () => 'gzip-js')
 
         expect(given.subject).toMatchSnapshot()
-    })
-})
-
-describe('Payload Compression', () => {
-    afterEach(() => {
-        document.getElementsByTagName('html')[0].innerHTML = ''
-    })
-
-    describe('compression', () => {
-        let lib, sandbox
-
-        beforeEach(() => {
-            document.title = 'test page'
-            sandbox = sinon.createSandbox()
-            autocapture._initializedTokens = []
-            lib = {
-                debug: true,
-                _prepare_callback: sandbox.spy((callback) => callback),
-                _send_request: sandbox.spy((url, params, options, callback) => {
-                    if (url === 'https://test.com/decide/?v=3') {
-                        callback({ config: { enable_collect_everything: true }, supportedCompression: ['gzip-js'] })
-                    } else {
-                        throw new Error('Should not get here')
-                    }
-                }),
-                config: {
-                    api_host: 'https://test.com',
-                    token: 'testtoken',
-                },
-                token: 'testtoken',
-                get_distinct_id() {
-                    return 'distinctid'
-                },
-                getGroups: () => ({}),
-
-                toolbar: {
-                    maybeLoadToolbar: jest.fn(),
-                    afterDecideResponse: jest.fn(),
-                },
-                sessionRecording: {
-                    afterDecideResponse: jest.fn(),
-                },
-                featureFlags: {
-                    receivedFeatureFlags: jest.fn(),
-                    setReloadingPaused: jest.fn(),
-                    _startReloadTimer: jest.fn(),
-                },
-                _hasBootstrappedFeatureFlags: jest.fn(),
-                get_property: (property_key) =>
-                    property_key === AUTOCAPTURE_DISABLED_SERVER_SIDE
-                        ? given.$autocapture_disabled_server_side
-                        : undefined,
-            }
-        })
-        given('$autocapture_disabled_server_side', () => false)
-
-        afterEach(() => {
-            sandbox.restore()
-        })
-
-        it('should save supported compression in instance', () => {
-            new Decide(lib).call()
-            autocapture.init(lib)
-            expect(lib.compression).toEqual({ 'gzip-js': true })
-        })
     })
 })

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -31,6 +31,7 @@ describe('Decide', () => {
         get_property: (key) => given.posthog.persistence.props[key],
         capture: jest.fn(),
         _addCaptureHook: jest.fn(),
+        _afterDecideResponse: jest.fn(),
         _prepare_callback: jest.fn().mockImplementation((callback) => callback),
         get_distinct_id: jest.fn().mockImplementation(() => 'distinctid'),
         _send_request: jest
@@ -154,31 +155,8 @@ describe('Decide', () => {
             expect(given.posthog.sessionRecording.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
             expect(given.posthog.toolbar.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
             expect(given.posthog.featureFlags.receivedFeatureFlags).toHaveBeenCalledWith(given.decideResponse)
+            expect(given.posthog._afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
             expect(autocapture.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse, given.posthog)
-        })
-
-        it('enables compression from decide response', () => {
-            given('decideResponse', () => ({ supportedCompression: ['gzip', 'lz64'] }))
-            given.subject()
-
-            expect(given.posthog.compression['gzip']).toBe(true)
-            expect(given.posthog.compression['lz64']).toBe(true)
-        })
-
-        it('enables compression from decide response when only one received', () => {
-            given('decideResponse', () => ({ supportedCompression: ['lz64'] }))
-            given.subject()
-
-            expect(given.posthog.compression).not.toHaveProperty('gzip')
-            expect(given.posthog.compression['lz64']).toBe(true)
-        })
-
-        it('does not enable compression from decide response if compression is disabled', () => {
-            given('config', () => ({ disable_compression: true, persistence: 'memory' }))
-            given('decideResponse', () => ({ supportedCompression: ['gzip', 'lz64'] }))
-            given.subject()
-
-            expect(given.posthog.compression).toEqual({})
         })
 
         it('Make sure receivedFeatureFlags is not called if the decide response fails', () => {

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -193,6 +193,48 @@ describe('capture()', () => {
     })
 })
 
+describe('_afterDecideResponse', () => {
+    given('subject', () => () => given.lib._afterDecideResponse(given.decideResponse))
+
+    it('enables compression from decide response', () => {
+        given('decideResponse', () => ({ supportedCompression: ['gzip', 'lz64'] }))
+        given.subject()
+
+        expect(given.lib.compression['gzip']).toBe(true)
+        expect(given.lib.compression['lz64']).toBe(true)
+    })
+
+    it('enables compression from decide response when only one received', () => {
+        given('decideResponse', () => ({ supportedCompression: ['lz64'] }))
+        given.subject()
+
+        expect(given.lib.compression).not.toHaveProperty('gzip')
+        expect(given.lib.compression['lz64']).toBe(true)
+    })
+
+    it('does not enable compression from decide response if compression is disabled', () => {
+        given('config', () => ({ disable_compression: true, persistence: 'memory' }))
+        given('decideResponse', () => ({ supportedCompression: ['gzip', 'lz64'] }))
+        given.subject()
+
+        expect(given.lib.compression).toEqual({})
+    })
+
+    it('defaults to /e if no endpoint is given', () => {
+        given('decideResponse', () => ({}))
+        given.subject()
+
+        expect(given.lib.analyticsDefaultEndpoint).toEqual('/e/')
+    })
+
+    it('uses the specified analytics endpoint if given', () => {
+        given('decideResponse', () => ({ analytics: { endpoint: '/i/v0/e/' } }))
+        given.subject()
+
+        expect(given.lib.analyticsDefaultEndpoint).toEqual('/i/v0/e/')
+    })
+})
+
 describe('_calculate_event_properties()', () => {
     given('subject', () =>
         given.lib._calculate_event_properties(given.event_name, given.properties, given.start_timestamp, given.options)

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -216,7 +216,7 @@ describe('capture()', () => {
         )
     })
 
-    it('sends payloads to given endpoint if given', () => {
+    it('sends payloads to overriden endpoint if given', () => {
         given.lib.capture('event-name', { foo: 'bar', length: 0 }, { endpoint: '/s/' })
         expect(given.lib._send_request).toHaveBeenCalledWith(
             'https://app.posthog.com/s/',
@@ -226,7 +226,7 @@ describe('capture()', () => {
         )
     })
 
-    it('sends payloads to given endpoint, even if alternative endpoint is set', () => {
+    it('sends payloads to overriden endpoint, even if alternative endpoint is set', () => {
         given.lib._afterDecideResponse({ analytics: { endpoint: '/i/v0/e/' } })
         given.lib.capture('event-name', { foo: 'bar', length: 0 }, { endpoint: '/s/' })
         expect(given.lib._send_request).toHaveBeenCalledWith(

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -59,14 +59,12 @@ export class Decide {
         this.instance.sessionRecording?.afterDecideResponse(response)
         autocapture.afterDecideResponse(response, this.instance)
         this.instance.webPerformance?.afterDecideResponse(response)
-        this.instance.exceptionAutocapture?.afterDecideResponse(response)
         this.instance._afterDecideResponse(response)
 
         if (!this.instance.config.advanced_disable_feature_flags_on_first_load) {
             this.instance.featureFlags.receivedFeatureFlags(response)
         }
 
-        // Check if recorder.js is already loaded
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         const surveysGenerator = window?.extendPostHogWithSurveys

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -1,7 +1,7 @@
 import { autocapture } from './autocapture'
 import { _base64Encode, loadScript, logger } from './utils'
 import { PostHog } from './posthog-core'
-import { Compression, DecideResponse } from './types'
+import { DecideResponse } from './types'
 import { STORED_GROUP_PROPERTIES_KEY, STORED_PERSON_PROPERTIES_KEY } from './constants'
 
 export class Decide {
@@ -60,18 +60,10 @@ export class Decide {
         autocapture.afterDecideResponse(response, this.instance)
         this.instance.webPerformance?.afterDecideResponse(response)
         this.instance.exceptionAutocapture?.afterDecideResponse(response)
+        this.instance._afterDecideResponse(response)
 
         if (!this.instance.config.advanced_disable_feature_flags_on_first_load) {
             this.instance.featureFlags.receivedFeatureFlags(response)
-        }
-
-        this.instance['compression'] = {}
-        if (response['supportedCompression'] && !this.instance.config.disable_compression) {
-            const compression: Partial<Record<Compression, boolean>> = {}
-            for (const method of response['supportedCompression']) {
-                compression[method] = true
-            }
-            this.instance['compression'] = compression
         }
 
         // Check if recorder.js is already loaded

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -537,16 +537,8 @@ export class PostHog {
             this.compression = compression
         }
 
-        // Allow the backend to override the `/e/` endpoint, check that it's reachable before using
-        // We can only run the check if XHR is available.
-        if (response.analytics?.endpoint && USE_XHR) {
-            const endpoint = response.analytics?.endpoint
-            this._send_request(
-                this.config.api_host + endpoint,
-                {},
-                { method: 'OPTIONS' },
-                () => (this.analyticsDefaultEndpoint = endpoint)
-            )
+        if (response.analytics?.endpoint) {
+            this.analyticsDefaultEndpoint = response.analytics.endpoint
         }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,7 +171,7 @@ export enum Compression {
 
 export interface XHROptions {
     transport?: 'XHR' | 'sendBeacon'
-    method?: 'POST' | 'GET'
+    method?: 'POST' | 'GET' | 'OPTIONS'
     urlQueryArgs?: { compression: Compression }
     verbose?: boolean
     blob?: boolean
@@ -221,6 +221,9 @@ export interface DecideResponse {
     errorsWhileComputingFlags: boolean
     autocapture_opt_out?: boolean
     capturePerformance?: boolean
+    analytics?: {
+        endpoint?: string
+    }
     // this is currently in development and may have breaking changes without a major version bump
     autocaptureExceptions?:
         | boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,7 +171,7 @@ export enum Compression {
 
 export interface XHROptions {
     transport?: 'XHR' | 'sendBeacon'
-    method?: 'POST' | 'GET' | 'OPTIONS'
+    method?: 'POST' | 'GET'
     urlQueryArgs?: { compression: Compression }
     verbose?: boolean
     blob?: boolean


### PR DESCRIPTION
## Changes

- Handle a new `analytics.endpoint` field in the decide response to allow us to slowly move posthog-js traffic to the new intake endpoint
- Move the compression configuration code to posthog-core.ts too for separation of concerns

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
