### PR TITLE
chore: Make ratings start at 0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,7 +52,10 @@ module.exports = {
             // but excluding the 'plugin:compat/recommended' rule
             // we don't mind using the latest features in our tests
             extends: extend.filter((s) => s !== 'plugin:compat/recommended'),
-            rules: rules.filter((s) => s !== 'no-console'),
+            rules: {
+                ...rules,
+                'no-console': 'off',
+            },
         },
     ],
     root: true,

--- a/src/extensions/surveys.ts
+++ b/src/extensions/surveys.ts
@@ -463,13 +463,14 @@ export const addCancelListeners = (
 
 export const createRatingsPopup = (posthog: PostHog, survey: Survey, question: RatingSurveyQuestion) => {
     const scale = question.scale
+    const starting = question.scale === 10 ? 0 : 1
     const displayType = question.display
     const isOptional = !!question.optional
     const ratingOptionsElement = document.createElement('div')
     if (displayType === 'number') {
         ratingOptionsElement.className = 'rating-options-buttons'
-        ratingOptionsElement.style.gridTemplateColumns = `repeat(${scale}, minmax(0, 1fr))`
-        for (let i = 1; i <= scale; i++) {
+        ratingOptionsElement.style.gridTemplateColumns = `repeat(${scale - starting + 1}, minmax(0, 1fr))`
+        for (let i = starting; i <= scale; i++) {
             const buttonElement = document.createElement('button')
             buttonElement.className = `ratings-number rating_${i} auto-text-color`
             buttonElement.type = 'submit'

--- a/src/retry-queue.ts
+++ b/src/retry-queue.ts
@@ -2,7 +2,6 @@ import { RequestQueueScaffold } from './base-request-queue'
 import { encodePostData, xhr } from './send-request'
 import { QueuedRequestData, RetryQueueElement } from './types'
 import { logger } from './utils'
-import Config from './config'
 import { RateLimiter } from './rate-limiter'
 
 const thirtyMinutes = 30 * 60 * 1000

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,5 @@
 import { _extend, logger } from './utils'
 import { PersistentStore, Properties } from './types'
-import Config from './config'
 import { DISTINCT_ID, SESSION_ID } from './constants'
 
 const DOMAIN_MATCH_REGEX = /[a-z0-9][a-z0-9-]+\.[a-z]{2,}$/i


### PR DESCRIPTION
## Changes

Not too happy with the data model here, but will wait to generalise it till we get more examples of ratings we want to support. See https://github.com/PostHog/posthog/pull/18011 for demo. 

This change does imply that existing NPS surveys will get the 0 added to them.

Also fixes some unrelated eslintrc issues. `filter` on a dictionary wasn't working correctly.
...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
