### PR TITLE
fix: heroku subdomain check

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -282,7 +282,7 @@ describe('loadScript', () => {
             [false, undefined],
             [true, 'https://bbc.co.uk'],
         ])('should return %s when hostname is %s', (expectedResult, hostname) => {
-            expect(isCrossDomainCookie(hostname)).toEqual(expectedResult)
+            expect(isCrossDomainCookie({ hostname })).toEqual(expectedResult)
         })
     })
 })

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -277,10 +277,14 @@ describe('loadScript', () => {
     describe('check for cross domain cookies', () => {
         it.each([
             [false, 'https://test.herokuapp.com'],
+            [false, 'test.herokuapp.com'],
+            [false, 'herokuapp.com'],
             // ensure it isn't matching herokuapp anywhere in the domain
             [true, 'https://test.herokuapp.com.impersonator.io'],
             [false, undefined],
             [true, 'https://bbc.co.uk'],
+            [true, 'bbc.co.uk'],
+            [true, 'www.bbc.co.uk'],
         ])('should return %s when hostname is %s', (expectedResult, hostname) => {
             expect(isCrossDomainCookie({ hostname })).toEqual(expectedResult)
         })

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -12,6 +12,7 @@ import {
     DEFAULT_BLOCKED_UA_STRS,
     loadScript,
     _isUrlMatchingRegex,
+    isCrossDomainCookie,
 } from '../utils'
 
 function userAgentFor(botString) {
@@ -270,6 +271,18 @@ describe('loadScript', () => {
             expect(_isUrlMatchingRegex('https://app.example.com', '(.*.)?example.com')).toEqual(true)
             // match route wildcard
             expect(_isUrlMatchingRegex('https://example.com/something/test', 'example.com/(.*.)/test')).toEqual(true)
+        })
+    })
+
+    describe('check for cross domain cookies', () => {
+        it.each([
+            [false, 'https://test.herokuapp.com'],
+            // ensure it isn't matching herokuapp anywhere in the domain
+            [true, 'https://test.herokuapp.com.impersonator.io'],
+            [false, undefined],
+            [true, 'https://bbc.co.uk'],
+        ])('should return %s when hostname is %s', (expectedResult, hostname) => {
+            expect(isCrossDomainCookie(hostname)).toEqual(expectedResult)
         })
     })
 })

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -110,7 +110,7 @@ const defaultConfig = (): PostHogConfig => ({
     token: '',
     autocapture: true,
     rageclick: true,
-    cross_subdomain_cookie: isCrossDomainCookie(document?.location?.hostname),
+    cross_subdomain_cookie: isCrossDomainCookie(document?.location),
     persistence: 'cookie',
     persistence_name: '',
     cookie_name: '',

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -16,6 +16,7 @@ import {
     userAgent,
     window,
     logger,
+    isCrossDomainCookie,
 } from './utils'
 import { autocapture } from './autocapture'
 import { PostHogFeatureFlags } from './posthog-featureflags'
@@ -109,7 +110,7 @@ const defaultConfig = (): PostHogConfig => ({
     token: '',
     autocapture: true,
     rageclick: true,
-    cross_subdomain_cookie: document?.location?.hostname?.indexOf('herokuapp.com') === -1,
+    cross_subdomain_cookie: isCrossDomainCookie(document?.location?.hostname),
     persistence: 'cookie',
     persistence_name: '',
     cookie_name: '',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -955,4 +955,14 @@ export const _info = {
     },
 }
 
+export function isCrossDomainCookie(hostname: string | undefined) {
+    if (!_isString(hostname)) {
+        return false
+    }
+    // split and slice isn't a great way to match arbitrary domains,
+    // but it's good enough for ensuring we only match herokuapp.com when it is the TLD
+    // for the hostname
+    return hostname.split('.').slice(-2).join('.').indexOf('herokuapp.com') === -1
+}
+
 export { win as window, userAgent, document }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -955,7 +955,9 @@ export const _info = {
     },
 }
 
-export function isCrossDomainCookie(hostname: string | undefined) {
+export function isCrossDomainCookie(documentLocation: Location | undefined) {
+    const hostname = documentLocation?.hostname
+
     if (!_isString(hostname)) {
         return false
     }


### PR DESCRIPTION
resolves https://github.com/PostHog/posthog-js/security/code-scanning/3

We checked for an herokuapp.com domain without caring about the position of the match within the hostname.

So, we would have treated `appname.herokuapp.com` and `appname.herokuapp.com.intercepting-domain.io` as the same.

Well, not any more!