### PR TITLE
fix: really fix subdomain check to satisfy codeql

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -279,9 +279,10 @@ describe('loadScript', () => {
             [false, 'https://test.herokuapp.com'],
             [false, 'test.herokuapp.com'],
             [false, 'herokuapp.com'],
+            [false, undefined],
             // ensure it isn't matching herokuapp anywhere in the domain
             [true, 'https://test.herokuapp.com.impersonator.io'],
-            [false, undefined],
+            [true, 'mysite-herokuapp.com'],
             [true, 'https://bbc.co.uk'],
             [true, 'bbc.co.uk'],
             [true, 'www.bbc.co.uk'],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -964,7 +964,7 @@ export function isCrossDomainCookie(documentLocation: Location | undefined) {
     // split and slice isn't a great way to match arbitrary domains,
     // but it's good enough for ensuring we only match herokuapp.com when it is the TLD
     // for the hostname
-    return hostname.split('.').slice(-2).join('.').indexOf('herokuapp.com') === -1
+    return hostname.split('.').slice(-2).join('.') !== 'herokuapp.com'
 }
 
 export { win as window, userAgent, document }


### PR DESCRIPTION
follow-up to #842 codeql is still unhappy (see https://github.com/PostHog/posthog-js/security/code-scanning/3)

looks like the indexOf check was what is still triggering the alert. given the change we made we can check direct equality instead. Of course I only realised this once I'd merged the previous PR