### PR TITLE
fix: full snapshot every 10 minutes

### DIFF
--- a/src/__tests__/extensions/sessionrecording.ts
+++ b/src/__tests__/extensions/sessionrecording.ts
@@ -5,7 +5,7 @@ import {
     RECORDING_IDLE_ACTIVITY_TIMEOUT_MS,
     RECORDING_MAX_EVENT_SIZE,
     SessionRecording,
-    THIRTY_MINUTES_IN_MS,
+    TEN_MINUTES_IN_MS,
 } from '../../extensions/sessionrecording'
 import { PostHogPersistence } from '../../posthog-persistence'
 import {
@@ -264,7 +264,7 @@ describe('SessionRecording', () => {
                 plugins: [],
                 inlineStylesheet: true,
                 recordCrossOriginIframes: false,
-                checkoutEveryNms: THIRTY_MINUTES_IN_MS,
+                checkoutEveryNms: TEN_MINUTES_IN_MS,
             })
         })
 

--- a/src/__tests__/extensions/sessionrecording.ts
+++ b/src/__tests__/extensions/sessionrecording.ts
@@ -5,6 +5,7 @@ import {
     RECORDING_IDLE_ACTIVITY_TIMEOUT_MS,
     RECORDING_MAX_EVENT_SIZE,
     SessionRecording,
+    THIRTY_MINUTES_IN_MS,
 } from '../../extensions/sessionrecording'
 import { PostHogPersistence } from '../../posthog-persistence'
 import {
@@ -263,6 +264,7 @@ describe('SessionRecording', () => {
                 plugins: [],
                 inlineStylesheet: true,
                 recordCrossOriginIframes: false,
+                checkoutEveryNms: THIRTY_MINUTES_IN_MS,
             })
         })
 

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -22,7 +22,7 @@ import { logger, loadScript, _timestamp, window } from '../utils'
 const BASE_ENDPOINT = '/s/'
 
 export const RECORDING_IDLE_ACTIVITY_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
-export const THIRTY_MINUTES_IN_MS = 30 * 60 * 1000
+export const TEN_MINUTES_IN_MS = 10 * 60 * 1000
 export const RECORDING_MAX_EVENT_SIZE = 1024 * 1024 * 0.9 // ~1mb (with some wiggle room)
 export const RECORDING_BUFFER_TIMEOUT = 2000 // 2 seconds
 export const SESSION_RECORDING_BATCH_KEY = 'recordings'
@@ -328,7 +328,7 @@ export class SessionRecording {
             inlineStylesheet: true,
             recordCrossOriginIframes: false,
             //take a full snapshot after every N ms
-            checkoutEveryNms: THIRTY_MINUTES_IN_MS,
+            checkoutEveryNms: TEN_MINUTES_IN_MS,
         }
         // We switched from loading all of rrweb to just the record part, but
         // keep backwards compatibility if someone hasn't upgraded PostHog

--- a/src/extensions/sessionrecording.ts
+++ b/src/extensions/sessionrecording.ts
@@ -404,17 +404,6 @@ export class SessionRecording {
             return
         }
 
-        const typeLookup = {
-            0: 'DomContentLoaded',
-            1: 'Load',
-            2: 'FullSnapshot',
-            3: 'IncrementalSnapshot',
-            4: 'Meta',
-            5: 'Custom',
-            6: 'Plugin',
-        }
-        logger.info('[onRRwebEmit] event type', { type: rawEvent.type, name: typeLookup[rawEvent.type] })
-
         if (rawEvent.type === EventType.Meta) {
             const href = this._maskUrl(rawEvent.data.href)
             if (!href) {


### PR DESCRIPTION
We don't configure regular checkouts on recordings. That is a common perf improvement for "long recordings"

Let's try auto checkout every 30 minutes.

Tested by setting a lower value and seeing full snapshots at expected interval (and checking I could play back the recordings)
