### PR TITLE
chore: log browser offline status

### DIFF
--- a/src/retry-queue.ts
+++ b/src/retry-queue.ts
@@ -60,7 +60,13 @@ export class RetryQueue extends RequestQueueScaffold {
         const retryAt = new Date(Date.now() + msToNextRetry)
 
         this.queue.push({ retryAt, requestData })
-        logger.warn(`Enqueued failed request for retry in ${msToNextRetry}`)
+
+        let logMessage = `Enqueued failed request for retry in ${msToNextRetry}`
+        if (!navigator.onLine) {
+            logMessage += ' (Browser is offline)'
+        }
+        logger.warn(logMessage)
+
         if (!this.isPolling) {
             this.isPolling = true
             this.poll()


### PR DESCRIPTION
## Changes
Add `Browser is offline` to logs when the browser is offline.
We're seeing frequent "Failed to fetch feature flags" errors with one of our users and want to rule out connection issues as the cause.

Slack thread: https://posthog.slack.com/archives/C0522G09STW/p1698051029628329

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
