### PR TITLE
fix: eslint does not fail build

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -77,5 +77,5 @@ jobs:
 
             - run: |
                   yarn prettier --check
-                  yarn eslint
+                  yarn lint
                   yarn tsc -b

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -598,6 +598,10 @@ export class SessionRecording {
         const isBelowMinimumDuration =
             _isNumber(minimumDuration) && _isNumber(sessionDuration) && sessionDuration < minimumDuration
 
+        if (minimumDuration === null || sessionDuration === null) {
+            logger.warn(`ESLint should fail in CI`)
+        }
+
         if (this.status === 'buffering' || isBelowMinimumDuration) {
             this.flushBufferTimer = setTimeout(() => {
                 this._flushBuffer()

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -598,10 +598,6 @@ export class SessionRecording {
         const isBelowMinimumDuration =
             _isNumber(minimumDuration) && _isNumber(sessionDuration) && sessionDuration < minimumDuration
 
-        if (minimumDuration === null || sessionDuration === null) {
-            logger.warn(`ESLint should fail in CI`)
-        }
-
         if (this.status === 'buffering' || isBelowMinimumDuration) {
             this.flushBufferTimer = setTimeout(() => {
                 this._flushBuffer()


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog-js/pull/843

that PR introduced new linting and didn't actually fix all of the errors

we were running `yarn eslint` as the CI step, this would run successfully with zero output regardless of whether the `src` folder was lint-able

Well, not any more!

<img width="929" alt="Screenshot 2023-10-24 at 18 45 48" src="https://github.com/PostHog/posthog-js/assets/984817/5bd67da7-67f3-4d5e-8259-7d3b94757246">
