### PR TITLE
feat(surveys): Make selector targeting work, add user props

### DIFF
--- a/src/__tests__/extensions/surveys.js
+++ b/src/__tests__/extensions/surveys.js
@@ -59,6 +59,9 @@ describe('survey display logic', () => {
             $survey_id: 'testSurvey1',
             $survey_name: 'Test survey 1',
             sessionRecordingUrl: undefined,
+            $set: {
+                '$survey_dismiss/testSurvey1': true,
+            },
         })
         expect(localStorage.getItem(`seenSurvey_${mockSurveys[0].id}`)).toBe('true')
 

--- a/src/__tests__/extensions/surveys.js
+++ b/src/__tests__/extensions/surveys.js
@@ -148,12 +148,16 @@ describe('survey display logic', () => {
         expect(mockPostHog.capture).toBeCalledTimes(1)
     })
 
-    test('when url changes, callSurveys runs again', () => {
+    test('callSurveys runs on interval irrespective of url change', () => {
         jest.useFakeTimers()
         jest.spyOn(global, 'setInterval')
         generateSurveys(mockPostHog)
         expect(mockPostHog.getActiveMatchingSurveys).toBeCalledTimes(1)
-        expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), 1500)
+        expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), 3000)
+
+        jest.advanceTimersByTime(3000)
+        expect(mockPostHog.getActiveMatchingSurveys).toBeCalledTimes(2)
+        expect(setInterval).toHaveBeenLastCalledWith(expect.any(Function), 3000)
     })
 
     test('multiple choice type question elements are unique', () => {

--- a/src/extensions/surveys.ts
+++ b/src/extensions/surveys.ts
@@ -382,6 +382,9 @@ export const createOpenTextOrLinkPopup = (
                     $survey_question: survey.questions[0].question,
                     $survey_response: surveyQuestionType === 'open' ? e.target.survey.value : 'link clicked',
                     sessionRecordingUrl: posthog.get_session_replay_url?.(),
+                    $set: {
+                        [`$survey_response/${survey.id}`]: true,
+                    },
                 })
                 if (surveyQuestionType === 'link') {
                     window.open(question.link || undefined)
@@ -457,6 +460,9 @@ export const addCancelListeners = (
             $survey_name: surveyEventName,
             $survey_id: surveyId,
             sessionRecordingUrl: posthog.get_session_replay_url(),
+            $set: {
+                [`$survey_dismiss/${surveyId}`]: true,
+            },
         })
         window.dispatchEvent(new Event('PHSurveyClosed'))
     })
@@ -887,13 +893,8 @@ function nextQuestion(currentQuestionIdx: number, surveyId: string) {
 export function generateSurveys(posthog: PostHog) {
     callSurveys(posthog, true)
 
-    let currentUrl = location.href
-    if (location.href) {
-        setInterval(() => {
-            if (location.href !== currentUrl) {
-                currentUrl = location.href
-                callSurveys(posthog, false)
-            }
-        }, 1500)
-    }
+    // recalculate surveys every 1.5 seconds to check if URL or selectors have changed
+    setInterval(() => {
+        callSurveys(posthog, false)
+    }, 1500)
 }

--- a/src/extensions/surveys.ts
+++ b/src/extensions/surveys.ts
@@ -894,8 +894,8 @@ function nextQuestion(currentQuestionIdx: number, surveyId: string) {
 export function generateSurveys(posthog: PostHog) {
     callSurveys(posthog, true)
 
-    // recalculate surveys every 1.5 seconds to check if URL or selectors have changed
+    // recalculate surveys every 3 seconds to check if URL or selectors have changed
     setInterval(() => {
         callSurveys(posthog, false)
-    }, 1500)
+    }, 3000)
 }


### PR DESCRIPTION
## Changes

implements option 3 from: https://github.com/PostHog/posthog/issues/17863

and fixes https://github.com/PostHog/posthog/issues/17652

~~Still need to test perf impact of the setInterval 👀 ~~ - processing takes about 2-3ms per run, and minimal CPU resources, so ok to run on a regular interval. I doubled the interval anyway to keep the check at 1/1000th of the cycle (3s cycle, 3ms per run)

Still need to add a few tests here

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
