### PR TITLE
fix: checkout every X minutes

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -18,7 +18,6 @@ import {
     RECORDING_IDLE_ACTIVITY_TIMEOUT_MS,
     RECORDING_MAX_EVENT_SIZE,
     SessionRecording,
-    TEN_MINUTES_IN_MS,
 } from '../../../extensions/replay/sessionrecording'
 
 // Type and source defined here designate a non-user-generated recording event
@@ -400,7 +399,6 @@ describe('SessionRecording', () => {
                 plugins: [],
                 inlineStylesheet: true,
                 recordCrossOriginIframes: false,
-                checkoutEveryNms: TEN_MINUTES_IN_MS,
             })
         })
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -32,7 +32,6 @@ import {
 const BASE_ENDPOINT = '/s/'
 
 export const RECORDING_IDLE_ACTIVITY_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
-export const TEN_MINUTES_IN_MS = 10 * 60 * 1000
 export const RECORDING_MAX_EVENT_SIZE = 1024 * 1024 * 0.9 // ~1mb (with some wiggle room)
 export const RECORDING_BUFFER_TIMEOUT = 2000 // 2 seconds
 export const SESSION_RECORDING_BATCH_KEY = 'recordings'
@@ -435,8 +434,6 @@ export class SessionRecording {
             collectFonts: false,
             inlineStylesheet: true,
             recordCrossOriginIframes: false,
-            //take a full snapshot after every N ms
-            checkoutEveryNms: TEN_MINUTES_IN_MS,
         }
         // We switched from loading all of rrweb to just the record part, but
         // keep backwards compatibility if someone hasn't upgraded PostHog


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog-js/pull/847

After that change, for example, when returning from a long period of inactivity we take two full snapshots. One because we have our own idle check, and one because rrweb only checks if time has passed on emit.

So, we need a more clever solution to have a checkout every X minutes _while active_