### PR TITLE
fix(surveys): clearer user property names

### DIFF
--- a/src/__tests__/extensions/surveys.js
+++ b/src/__tests__/extensions/surveys.js
@@ -60,7 +60,7 @@ describe('survey display logic', () => {
             $survey_name: 'Test survey 1',
             sessionRecordingUrl: undefined,
             $set: {
-                '$survey_dismiss/testSurvey1': true,
+                '$survey_dismissed/testSurvey1': true,
             },
         })
         expect(localStorage.getItem(`seenSurvey_${mockSurveys[0].id}`)).toBe('true')

--- a/src/extensions/surveys.ts
+++ b/src/extensions/surveys.ts
@@ -384,7 +384,7 @@ export const createOpenTextOrLinkPopup = (
                     $survey_response: surveyQuestionType === 'open' ? e.target.survey.value : 'link clicked',
                     sessionRecordingUrl: posthog.get_session_replay_url?.(),
                     $set: {
-                        [`$survey_response/${survey.id}`]: true,
+                        [`$survey_responded/${survey.id}`]: true,
                     },
                 })
                 if (surveyQuestionType === 'link') {
@@ -461,7 +461,7 @@ export const addCancelListeners = (
                 $survey_id: surveyId,
                 sessionRecordingUrl: posthog.get_session_replay_url?.(),
                 $set: {
-                    [`$survey_dismiss/${surveyId}`]: true,
+                    [`$survey_dismissed/${surveyId}`]: true,
                 },
             })
         })


### PR DESCRIPTION
## Changes

small change to update the user survey properties naming

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
