### PR TITLE
fix(surveys): Publish types in module

### DIFF
--- a/src/loader-module.ts
+++ b/src/loader-module.ts
@@ -1,5 +1,6 @@
 import { init_as_module } from './posthog-core'
 export { PostHog } from './posthog-core'
 export * from './types'
+export * from './posthog-surveys-types'
 export const posthog = init_as_module()
 export default posthog

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -28,9 +28,6 @@ export interface SurveyAppearance {
 
 export enum SurveyType {
     Popover = 'popover',
-    Button = 'button',
-    FullScreen = 'full_screen',
-    Email = 'email',
     API = 'api',
 }
 


### PR DESCRIPTION
## Changes

Publish survey types alongside other types in the module. @xrdt noticed this wasn't working, which isn't great for API based surveys.
...

Confirmed this issue doesn't come back: https://github.com/PostHog/posthog-js/issues/698

Tested that `import { Survey } from "posthog-js"` works

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
