### PR TITLE
feat: don't report on file size of files we can infer from the main files

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -13,6 +13,6 @@ jobs:
           build-script: "build-rollup"
           compression: "none"
           # no need to report on files that aren't the interesting ones
-          exclude: "{./dist/es.js,./dist/module.js,./dist/array.full.js,./node_modules/*}"
-          # no need to report on very small byte changes which show as 0% changed
+          exclude: "{./dist/es.js,./dist/module.js,./dist/array.full.js,**/*.map,**/node_modules/**}"
+          # no need to report on very small byte changes which show as 0% change
           minimum-change-threshold: 300

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -13,6 +13,6 @@ jobs:
           build-script: "build-rollup"
           compression: "none"
           # no need to report on files that aren't the interesting ones
-          exclude: "{./dist/es.js,./dist/module.js,./dist/array.full.js,**/*.map,**/node_modules/**}"
+          exclude: "{dist/es.js,dist/module.js,**/*.map,**/node_modules/**}"
           # no need to report on very small byte changes which show as 0% change
           minimum-change-threshold: 300

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -12,4 +12,7 @@ jobs:
         with:
           build-script: "build-rollup"
           compression: "none"
+          # no need to report on files that aren't the interesting ones
           exclude: "{./dist/es.js,./dist/module.js,./dist/array.full.js}"
+          # no need to report on very small byte changes which show as 0% changed
+          minimum-change-threshold: 300

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -13,6 +13,6 @@ jobs:
           build-script: "build-rollup"
           compression: "none"
           # no need to report on files that aren't the interesting ones
-          exclude: "{./dist/es.js,./dist/module.js,./dist/array.full.js}"
+          exclude: "{./dist/es.js,./dist/module.js,./dist/array.full.js,./node_modules/*}"
           # no need to report on very small byte changes which show as 0% changed
           minimum-change-threshold: 300

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -12,3 +12,4 @@ jobs:
         with:
           build-script: "build-rollup"
           compression: "none"
+          exclude: "{./dist/es.js,./dist/module.js,./dist/array.full.js}"


### PR DESCRIPTION
We use automation to track bundle size but it reports on every file in the dist folder. We only care about some of the files.

The GitHub action supports inclusion and exclusion lists: https://github.com/preactjs/compressed-size-action#customizing-the-list-of-files

Let's 

* exclude the other files to improve signal to noise ratio
* not report on very tiny file size changes