### PR TITLE
fix: include raw user agent in event properties

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -20,15 +20,6 @@ function userAgentFor(botString) {
     return `Mozilla/5.0 (compatible; ${botString}/${randOne}; +http://a.com/bot/${randTwo})`
 }
 
-describe(`utils.js`, () => {
-    it('should have $host and $pathname in properties', () => {
-        const properties = _info.properties()
-        expect(properties['$current_url']).toBeDefined()
-        expect(properties['$host']).toBeDefined()
-        expect(properties['$pathname']).toBeDefined()
-    })
-})
-
 describe('_.copyAndTruncateStrings', () => {
     given('subject', () => _copyAndTruncateStrings(given.target, given.maxStringLength))
 

--- a/src/__tests__/utils/event-utils.test.ts
+++ b/src/__tests__/utils/event-utils.test.ts
@@ -1,0 +1,32 @@
+import { _info } from '../../utils/event-utils'
+import * as globals from '../../utils/globals'
+
+jest.mock('../../utils/globals')
+
+describe(`event-utils`, () => {
+    it('should have $host and $pathname in properties', () => {
+        const properties = _info.properties()
+        expect(properties['$current_url']).toBeDefined()
+        expect(properties['$host']).toBeDefined()
+        expect(properties['$pathname']).toBeDefined()
+    })
+
+    it('should have user agent in properties', () => {
+        // TS doesn't like it but we can assign userAgent
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        globals['userAgent'] = 'blah'
+        const properties = _info.properties()
+        expect(properties['$raw_user_agent']).toBe('blah')
+    })
+
+    it('should truncate very long user agents in properties', () => {
+        // TS doesn't like it but we can assign userAgent
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        globals['userAgent'] = 'a'.repeat(1001)
+        const properties = _info.properties()
+        expect(properties['$raw_user_agent'].length).toBe(1000)
+        expect(properties['$raw_user_agent'].substring(995)).toBe('aa...')
+    })
+})

--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -258,6 +258,7 @@ export const _info = {
                 $current_url: window?.location.href,
                 $host: window?.location.host,
                 $pathname: window?.location.pathname,
+                $raw_user_agent: userAgent.length > 1000 ? userAgent.substring(0, 997) + '...' : userAgent,
                 $browser_version: _info.browserVersion(userAgent, navigator.vendor, (window as any).opera),
                 $browser_language: _info.browserLanguage(),
                 $screen_height: window?.screen.height,


### PR DESCRIPTION
I think there are bugs - or at least missing conditions - in our browser detection.

But we don't include the raw data in events so I can't check

Let's include the raw data...