### PR TITLE
feat(web-analytics): Tweak session prop names

### DIFF
--- a/src/__tests__/session-props.test.ts
+++ b/src/__tests__/session-props.test.ts
@@ -114,7 +114,7 @@ describe('Session Props Manager', () => {
 
         //assert
         expect(properties).toEqual({
-            $client_session_utm_source: 'some-utm-source',
+            $client_session_initial_utm_source: 'some-utm-source',
         })
     })
 })

--- a/src/session-props.ts
+++ b/src/session-props.ts
@@ -76,13 +76,13 @@ export class SessionPropsManager {
         }
 
         return {
-            $client_session_referring_host: p.referringDomain,
+            $client_session_initial_referring_host: p.referringDomain,
             $client_session_initial_pathname: p.initialPathName,
-            $client_session_utm_source: p.utm_source,
-            $client_session_utm_campaign: p.utm_campaign,
-            $client_session_utm_medium: p.utm_medium,
-            $client_session_utm_content: p.utm_content,
-            $client_session_utm_term: p.utm_term,
+            $client_session_initial_utm_source: p.utm_source,
+            $client_session_initial_utm_campaign: p.utm_campaign,
+            $client_session_initial_utm_medium: p.utm_medium,
+            $client_session_initial_utm_content: p.utm_content,
+            $client_session_initial_utm_term: p.utm_term,
         }
     }
 }


### PR DESCRIPTION
## Changes

While updating taxonomy.tsx I realised that I could have done a better job with naming, and it's better to fix this now before anyone is using it.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
