### PR TITLE
fix: Change default storage type, migrate existing users

### DIFF
--- a/src/__tests__/session-props.test.ts
+++ b/src/__tests__/session-props.test.ts
@@ -1,4 +1,4 @@
-import { SessionPropsManager } from '../session-props'
+import { SessionPropsManager, StoredSessionSourceProps } from '../session-props'
 import { SessionIdManager } from '../sessionid'
 import { PostHogPersistence } from '../posthog-persistence'
 
@@ -46,12 +46,12 @@ describe('Session Props Manager', () => {
         expect(generateProps).toHaveBeenCalledTimes(1)
 
         expect(persistenceRegister).toBeCalledWith({
-            $client_session_props: {
-                props: {
-                    utm_source: 'some-utm-source',
+            $cl_ses_p: {
+                p: {
+                    s: 'some-utm-source',
                 },
-                sessionId: 'session-id',
-            },
+                s: 'session-id',
+            } as StoredSessionSourceProps,
         })
     })
 
@@ -60,10 +60,10 @@ describe('Session Props Manager', () => {
         const sessionId1 = 'session-id-1'
         const { onSessionId, persistence, generateProps, persistenceRegister } = createSessionPropsManager()
         persistence.props = {
-            $client_session_props: {
-                props: {},
-                sessionId: sessionId1,
-            },
+            $cl_ses_p: {
+                p: {},
+                s: sessionId1,
+            } as StoredSessionSourceProps,
         }
         const callback = onSessionId.mock.calls[0][0]
 
@@ -82,10 +82,10 @@ describe('Session Props Manager', () => {
 
         const { onSessionId, persistence, generateProps, persistenceRegister } = createSessionPropsManager()
         persistence.props = {
-            $client_session_props: {
-                props: {},
-                sessionId: sessionId1,
-            },
+            $cl_ses_p: {
+                p: {},
+                s: sessionId1,
+            } as StoredSessionSourceProps,
         }
         const callback = onSessionId.mock.calls[0][0]
 
@@ -101,12 +101,12 @@ describe('Session Props Manager', () => {
         // arrange
         const { persistence, sessionPropsManager } = createSessionPropsManager()
         persistence.props = {
-            $client_session_props: {
-                props: {
-                    utm_source: 'some-utm-source',
+            $cl_ses_p: {
+                p: {
+                    s: 'some-utm-source',
                 },
-                sessionId: 'session-id',
-            },
+                s: 'session-id',
+            } as StoredSessionSourceProps,
         }
 
         // act

--- a/src/__tests__/session-props.test.ts
+++ b/src/__tests__/session-props.test.ts
@@ -1,4 +1,4 @@
-import { SessionPropsManager, StoredSessionSourceProps } from '../session-props'
+import { SessionPropsManager, SessionSourceProps, StoredSessionSourceProps } from '../session-props'
 import { SessionIdManager } from '../sessionid'
 import { PostHogPersistence } from '../posthog-persistence'
 
@@ -36,7 +36,7 @@ describe('Session Props Manager', () => {
         const utmSource = 'some-utm-source'
         const sessionId = 'session-id'
         const { onSessionId, generateProps, persistenceRegister } = createSessionPropsManager()
-        generateProps.mockReturnValue({ utm_source: utmSource })
+        generateProps.mockReturnValue({ s: utmSource } as SessionSourceProps)
         const callback = onSessionId.mock.calls[0][0]
 
         // act

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,7 @@ export const SURVEYS = '$surveys'
 export const FLAG_CALL_REPORTED = '$flag_call_reported'
 export const USER_STATE = '$user_state'
 export const POSTHOG_QUOTA_LIMITED = '$posthog_quota_limited'
-export const CLIENT_SESSION_PROPS = '$client_session_props'
+export const CLIENT_SESSION_PROPS = '$cl_ses_p'
 
 // These are properties that are reserved and will not be automatically included in events
 export const PERSISTENCE_RESERVED_PROPERTIES = [

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -108,7 +108,7 @@ export const defaultConfig = (): PostHogConfig => ({
     autocapture: true,
     rageclick: true,
     cross_subdomain_cookie: isCrossDomainCookie(document?.location),
-    persistence: 'cookie',
+    persistence: 'default',
     persistence_name: '',
     cookie_name: '',
     loaded: __NOOP,

--- a/src/session-props.ts
+++ b/src/session-props.ts
@@ -14,7 +14,7 @@ import { CLIENT_SESSION_PROPS } from './constants'
 import { _strip_empty_properties } from './utils'
 
 // this might be stored in a cookie with a hard 4096 byte limit, so save characters on key names
-interface SessionSourceProps {
+export interface SessionSourceProps {
     p: string // initial pathname
     r: string // referring domain
     m?: string // utm medium

--- a/src/session-props.ts
+++ b/src/session-props.ts
@@ -15,8 +15,8 @@ import { _strip_empty_properties } from './utils'
 
 // this might be stored in a cookie with a hard 4096 byte limit, so save characters on key names
 export interface SessionSourceProps {
-    p: string // initial pathname
-    r: string // referring domain
+    p?: string // initial pathname
+    r?: string // referring domain
     m?: string // utm medium
     s?: string // utm source
     c?: string // utm campaign
@@ -31,17 +31,15 @@ export interface StoredSessionSourceProps {
 
 export const generateSessionSourceParams = (): SessionSourceProps => {
     const campaignParams = _info.campaignParams()
-    return {
+    return _strip_empty_properties({
         p: window?.location.pathname || '',
         r: _info.referringDomain(),
-        ..._strip_empty_properties({
-            m: campaignParams.utm_medium,
-            s: campaignParams.utm_source,
-            c: campaignParams.utm_campaign,
-            n: campaignParams.utm_content,
-            t: campaignParams.utm_term,
-        }),
-    }
+        m: campaignParams.utm_medium,
+        s: campaignParams.utm_source,
+        c: campaignParams.utm_campaign,
+        n: campaignParams.utm_content,
+        t: campaignParams.utm_term,
+    })
 }
 
 export class SessionPropsManager {

--- a/src/session-props.ts
+++ b/src/session-props.ts
@@ -23,7 +23,7 @@ interface SessionSourceProps {
     t?: string // utm term
 }
 
-interface StoredSessionSourceProps {
+export interface StoredSessionSourceProps {
     s: string // session id
     p: SessionSourceProps
 }

--- a/src/session-props.ts
+++ b/src/session-props.ts
@@ -11,6 +11,7 @@ import { _info } from './utils/event-utils'
 import { SessionIdManager } from './sessionid'
 import { PostHogPersistence } from './posthog-persistence'
 import { CLIENT_SESSION_PROPS } from './constants'
+import { _strip_empty_properties } from './utils'
 
 // this might be stored in a cookie with a hard 4096 byte limit, so save characters on key names
 interface SessionSourceProps {
@@ -33,11 +34,13 @@ export const generateSessionSourceParams = (): SessionSourceProps => {
     return {
         p: window?.location.pathname || '',
         r: _info.referringDomain(),
-        m: campaignParams.utm_medium,
-        s: campaignParams.utm_source,
-        c: campaignParams.utm_campaign,
-        n: campaignParams.utm_content,
-        t: campaignParams.utm_term,
+        ..._strip_empty_properties({
+            m: campaignParams.utm_medium,
+            s: campaignParams.utm_source,
+            c: campaignParams.utm_campaign,
+            n: campaignParams.utm_content,
+            t: campaignParams.utm_term,
+        }),
     }
 }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -236,7 +236,7 @@ export const localStore: PersistentStore = {
 // Use localstorage for most data but still use cookie for COOKIE_PERSISTED_PROPERTIES
 // This solves issues with cookies having too much data in them causing headers too large
 // Also makes sure we don't have to send a ton of data to the server
-const COOKIE_PERSISTED_PROPERTIES = [DISTINCT_ID, SESSION_ID, SESSION_RECORDING_IS_SAMPLED]
+export const COOKIE_PERSISTED_PROPERTIES = [DISTINCT_ID, SESSION_ID, SESSION_RECORDING_IS_SAMPLED]
 
 export const localPlusCookieStore: PersistentStore = {
     ...localStore,

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -140,6 +140,12 @@ export const cookieStore: PersistentStore = {
                 '; SameSite=Lax; path=/' +
                 cdomain +
                 secure
+
+            // 4096 bytes is the size at which firefox will not store a cookie, warn slightly before that
+            if (new_cookie_val.length > 4096 * 0.9) {
+                logger.warn('cookieStore warning: large cookie, len=' + new_cookie_val.length)
+            }
+
             document.cookie = new_cookie_val
             return new_cookie_val
         } catch (err) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export interface PostHogConfig {
     autocapture: boolean | AutocaptureConfig
     rageclick: boolean
     cross_subdomain_cookie: boolean
-    persistence: 'localStorage' | 'cookie' | 'memory' | 'localStorage+cookie' | 'sessionStorage'
+    persistence: 'localStorage' | 'cookie' | 'memory' | 'localStorage+cookie' | 'sessionStorage' | 'default'
     persistence_name: string
     cookie_name: string
     loaded: (posthog_instance: PostHog) => void

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -202,11 +202,11 @@ export const _safewrap_instance_methods = function (obj: Record<string, any>): v
     }
 }
 
-export const _strip_empty_properties = function (p: Properties): Properties {
-    const ret: Properties = {}
+export const _strip_empty_properties = function <T extends Record<string, any>>(p: T): { [k in keyof T]?: T[k] } {
+    const ret: Partial<T> = {}
     _each(p, function (v, k) {
         if (_isString(v) && v.length > 0) {
-            ret[k] = v
+            ;(ret as any)[k] = v
         }
     })
     return ret

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -202,11 +202,14 @@ export const _safewrap_instance_methods = function (obj: Record<string, any>): v
     }
 }
 
-export const _strip_empty_properties = function <T extends Record<string, any>>(p: T): { [k in keyof T]?: T[k] } {
-    const ret: Partial<T> = {}
+export const _strip_empty_properties = function <T extends Record<string, any>>(
+    p: T
+): // remove non-string properties from the type and all keys optional
+{ [k in keyof T as T[k] extends string ? k : never]?: T[k] } {
+    const ret = {} as any
     _each(p, function (v, k) {
         if (_isString(v) && v.length > 0) {
-            ;(ret as any)[k] = v
+            ret[k] = v
         }
     })
     return ret


### PR DESCRIPTION
See https://github.com/PostHog/posthog-js/issues/876

Follow up to https://github.com/PostHog/posthog-js/pull/869

## Changes
Move the session-scoped props to smaller keys in storage. Not really the right fix (which would be moving them to a separate cookie) but at least a quick fix.

Also limit the keys stored to only the ones actually used. This is quite a dramatic change, so might be enough on its own to avoid reworking the storage for now

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
