### PR TITLE
fix: page leave shouldn't start a new session

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -932,7 +932,10 @@ export class PostHog {
         const infoProperties = _info.properties()
 
         if (this.sessionManager) {
-            const { sessionId, windowId } = this.sessionManager.checkAndGetSessionAndWindowId()
+            // don't let a delayed page leave start a new session
+            const { sessionId, windowId } = this.sessionManager.checkAndGetSessionAndWindowId(
+                event_name !== '$pageleave'
+            )
             properties['$session_id'] = sessionId
             properties['$window_id'] = windowId
         }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -934,7 +934,7 @@ export class PostHog {
         if (this.sessionManager) {
             // don't let a delayed page leave start a new session
             const { sessionId, windowId } = this.sessionManager.checkAndGetSessionAndWindowId(
-                event_name !== '$pageleave'
+                event_name === '$pageleave'
             )
             properties['$session_id'] = sessionId
             properties['$window_id'] = windowId


### PR DESCRIPTION
Fly by while investigating other session problems. We saw a session that started with a page leave event because it came after a long enough delay. Logically page leave should not start a new session.