### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/playground/nuxtjs/plugins/posthog.client.js
+++ b/playground/nuxtjs/plugins/posthog.client.js
@@ -1,5 +1,5 @@
 // plugins/posthog.client.js
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 import posthog from 'posthog-js'
 export default defineNuxtPlugin((nuxtApp) => {
     const runtimeConfig = useRuntimeConfig()


### PR DESCRIPTION
## Changes

This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
