### PR TITLE
fix(surveys): Send responded property with every type of survey

### DIFF
--- a/src/__tests__/extensions/surveys.js
+++ b/src/__tests__/extensions/surveys.js
@@ -99,6 +99,9 @@ describe('survey display logic', () => {
             $survey_question: 'How satisfied are you with our newest product?',
             $survey_response: 1,
             sessionRecordingUrl: undefined,
+            $set: {
+                '$survey_responded/testSurvey1': true,
+            },
         })
         expect(localStorage.getItem(`seenSurvey_${mockSurveys[0].id}`)).toBe('true')
 

--- a/src/extensions/surveys.ts
+++ b/src/extensions/surveys.ts
@@ -550,6 +550,9 @@ export const createRatingsPopup = (
                     // @ts-ignore // TODO: Fix this, error because it doesn't know that the target is a button
                     $survey_response: parseInt(activeRatingEl?.value),
                     sessionRecordingUrl: posthog.get_session_replay_url?.(),
+                    $set: {
+                        [`$survey_responded/${survey.id}`]: true,
+                    },
                 })
                 window.setTimeout(() => {
                     window.dispatchEvent(new Event('PHSurveySent'))
@@ -644,6 +647,9 @@ export const createMultipleChoicePopup = (
                     $survey_question: survey.questions[0].question,
                     $survey_response: selectedChoices,
                     sessionRecordingUrl: posthog.get_session_replay_url?.(),
+                    $set: {
+                        [`$survey_responded/${survey.id}`]: true,
+                    },
                 })
                 window.setTimeout(() => {
                     window.dispatchEvent(new Event('PHSurveySent'))
@@ -810,6 +816,9 @@ export const createMultipleQuestionSurvey = (posthog: PostHog, survey: Survey) =
                 $survey_questions: survey.questions.map((question) => question.question),
                 sessionRecordingUrl: posthog.get_session_replay_url?.(),
                 ...multipleQuestionResponses,
+                $set: {
+                    [`$survey_responded/${survey.id}`]: true,
+                },
             })
             window.setTimeout(() => {
                 window.dispatchEvent(new Event('PHSurveySent'))


### PR DESCRIPTION
## Changes

Missed a few places to send the property

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
