### PR TITLE
fix: meaningful recordings integration tests

### DIFF
--- a/cypress/e2e/session-recording.cy.js
+++ b/cypress/e2e/session-recording.cy.js
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+import { _isNull } from '../../src/utils/type-utils'
+
 describe('Session recording', () => {
     given('options', () => ({}))
 
@@ -26,7 +28,7 @@ describe('Session recording', () => {
             cy.wait('@decide')
         })
 
-        it('captures pageviews, autocapture, custom events', () => {
+        it('captures session events', () => {
             cy.get('[data-cy-input]').type('hello world! ')
             cy.wait(500)
             cy.get('[data-cy-input]')
@@ -74,7 +76,7 @@ describe('Session recording', () => {
             cy.wait('@recorder')
         })
 
-        it('captures pageviews, autocapture, custom events', () => {
+        it('captures session events', () => {
             cy.get('[data-cy-input]').type('hello world! ')
             cy.wait(500)
             cy.get('[data-cy-input]')
@@ -96,6 +98,61 @@ describe('Session recording', () => {
                         ).to.deep.equal(new Set([3]))
                     })
                 })
+        })
+
+        it('captures snapshots when the mouse moves', () => {
+            let sessionId = null
+
+            // cypress time handling can confuse when to run full snapshot, let's force that to happen...
+            cy.get('[data-cy-input]').type('hello world! ')
+            cy.wait('@session-recording').then(() => {
+                cy.phCaptures({ full: true }).then((captures) => {
+                    captures.forEach((c) => {
+                        if (_isNull(sessionId)) {
+                            sessionId = c.properties['$session_id']
+                        }
+                        // all captures should be from one session
+                        expect(c.properties['$session_id']).to.equal(sessionId)
+                    })
+                    expect(sessionId).not.to.be.null
+                })
+            })
+            // and then reset
+            cy.resetPhCaptures().then(() => {
+                cy.get('body')
+                    .trigger('mousemove', 50, 10)
+                    .trigger('mousemove', 52, 10)
+                    .trigger('mousemove', 54, 10)
+                    .trigger('mousemove', 56, 10)
+                cy.wait('@session-recording').then(() => {
+                    cy.phCaptures({ full: true }).then((captures) => {
+                        // should be a $snapshot for the current session
+                        expect(captures.map((c) => c.event)).to.deep.equal(['$snapshot'])
+                        expect(captures[0].properties['$session_id']).to.equal(sessionId)
+
+                        // the amount of captured data should be deterministic
+                        // but of course that would be too easy
+                        expect(captures[0]['properties']['$snapshot_data']).to.have.length.above(0)
+
+                        /**
+                         * the snapshots will look a little like:
+                         * [
+                         *  {"type":3,"data":{"source":6,"positions":[{"x":58,"y":18,"id":15,"timeOffset":0}]},"timestamp":1699814887222},
+                         *  {"type":3,"data":{"source":6,"positions":[{"x":58,"y":18,"id":15,"timeOffset":-430}]},"timestamp":1699814887722}
+                         *  ]
+                         */
+
+                        const xPositions = []
+                        for (let i = 0; i < captures[0]['properties']['$snapshot_data'].length; i++) {
+                            expect(captures[0]['properties']['$snapshot_data'][i].type).to.equal(3)
+                            expect(captures[0]['properties']['$snapshot_data'][i].data.source).to.equal(6)
+                            xPositions.push(captures[0]['properties']['$snapshot_data'][i].data.positions[0].x)
+                        }
+
+                        expect(xPositions).to.eql([58, 64])
+                    })
+                })
+            })
         })
     })
 })

--- a/cypress/e2e/session-recording.cy.js
+++ b/cypress/e2e/session-recording.cy.js
@@ -89,8 +89,6 @@ describe('Session recording', () => {
                     cy.phCaptures({ full: true }).then((captures) => {
                         // should be a pageview and a $snapshot
                         expect(captures.map((c) => c.event)).to.deep.equal(['$pageview', '$snapshot'])
-                        // the amount of captured data should be deterministic
-                        // but of course that would be too easy
                         expect(captures[1]['properties']['$snapshot_data']).to.have.length.above(33).and.below(38)
                         // a meta and then a full snapshot
                         expect(captures[1]['properties']['$snapshot_data'][0].type).to.equal(4) // meta
@@ -135,8 +133,6 @@ describe('Session recording', () => {
                     expect(captures.map((c) => c.event)).to.deep.equal(['$snapshot'])
                     expect(captures[0].properties['$session_id']).to.equal(sessionId)
 
-                    // the amount of captured data should be deterministic
-                    // but of course that would be too easy
                     expect(captures[0]['properties']['$snapshot_data']).to.have.length.above(0)
 
                     /**
@@ -158,11 +154,10 @@ describe('Session recording', () => {
                     }
 
                     // even though we trigger 4 events, only 2 snapshots should be captured
-                    // I _think_ this is because Cypress is faking things and they happen too fast
+                    // This is because rrweb doesn't try to capture _every_ mouse move
                     expect(xPositions).to.have.length(2)
                     expect(xPositions[0]).to.equal(200)
-                    // timing seems to vary if this value picks up 220 or 240
-                    // given it's going to be hard to make it deterministic with Celery
+                    // smoothing varies if this value picks up 220 or 240
                     // all we _really_ care about is that it's greater than the previous value
                     expect(xPositions[1]).to.be.above(xPositions[0])
                 })
@@ -205,8 +200,6 @@ describe('Session recording', () => {
                     expect(captures[0].properties['$session_id']).to.equal(sessionId)
                     expect(captures[1].properties['$session_id']).to.equal(sessionId)
 
-                    // the amount of captured data should be deterministic
-                    // but of course that would be too easy
                     expect(captures[1]['properties']['$snapshot_data']).to.have.length.above(0)
 
                     /**
@@ -233,11 +226,10 @@ describe('Session recording', () => {
                     }
 
                     // even though we trigger 4 events, only 2 snapshots should be captured
-                    // I _think_ this is because Cypress is faking things and they happen too fast
+                    // This is because rrweb doesn't try to capture _every_ mouse move
                     expect(xPositions).to.have.length(2)
                     expect(xPositions[0]).to.equal(200)
-                    // timing seems to vary if this value picks up 220 or 240
-                    // given it's going to be hard to make it deterministic with Celery
+                    // smoothing varies if this value picks up 220 or 240
                     // all we _really_ care about is that it's greater than the previous value
                     expect(xPositions[1]).to.be.above(xPositions[0])
                 })
@@ -284,9 +276,6 @@ describe('Session recording', () => {
                     cy.phCaptures({ full: true }).then((captures) => {
                         // should be a pageview and a $snapshot
                         expect(captures[0].event).to.equal('$snapshot')
-                        // // the amount of captured data should be deterministic
-                        // // but of course that would be too easy
-                        // expect(captures[1]['properties']['$snapshot_data']).to.have.length.above(33).and.below(40)
 
                         expect(captures[0]['properties']['$session_id']).to.be.a('string')
                         expect(captures[0]['properties']['$session_id']).not.to.eq(firstSessionId)

--- a/cypress/e2e/session-recording.cy.js
+++ b/cypress/e2e/session-recording.cy.js
@@ -18,7 +18,6 @@ describe('Session recording', () => {
                     sessionRecording: {
                         endpoint: '/ses/',
                     },
-                    supportedCompression: ['None'],
                     capture_performance: true,
                 },
             }).as('decide')

--- a/cypress/e2e/session-recording.cy.js
+++ b/cypress/e2e/session-recording.cy.js
@@ -119,10 +119,11 @@ describe('Session recording', () => {
             // and then reset
             cy.resetPhCaptures().then(() => {
                 cy.get('body')
-                    .trigger('mousemove', 50, 10)
-                    .trigger('mousemove', 52, 10)
-                    .trigger('mousemove', 54, 10)
-                    .trigger('mousemove', 56, 10)
+                    .trigger('mousemove', { clientX: 200, clientY: 300 })
+                    .trigger('mousemove', { clientX: 210, clientY: 300 })
+                    .trigger('mousemove', { clientX: 220, clientY: 300 })
+                    .trigger('mousemove', { clientX: 240, clientY: 300 })
+
                 cy.wait('@session-recording').then(() => {
                     cy.phCaptures({ full: true }).then((captures) => {
                         // should be a $snapshot for the current session
@@ -148,7 +149,7 @@ describe('Session recording', () => {
                             xPositions.push(captures[0]['properties']['$snapshot_data'][i].data.positions[0].x)
                         }
 
-                        expect(xPositions).to.eql([58, 64])
+                        expect(xPositions).to.eql([200, 240])
                     })
                 })
             })

--- a/cypress/e2e/session-recording.cy.js
+++ b/cypress/e2e/session-recording.cy.js
@@ -149,6 +149,8 @@ describe('Session recording', () => {
                             xPositions.push(captures[0]['properties']['$snapshot_data'][i].data.positions[0].x)
                         }
 
+                        // even though we trigger 4 events, only 2 snapshots should be captured
+                        // I _think_ this is because Cypress is faking things and they happen too fast
                         expect(xPositions).to.eql([200, 240])
                     })
                 })


### PR DESCRIPTION
I want to get to a place where the session id bug fixed in #878 would be impossible to merge.

Our session recording integration tests currently check that  

* when you type in a box 
* PostHog sends two things to capture

They don't even have to be $snapshot events let alone correct $snapshot events 🙈 

----

This changes the integration tests to look at what was captured and make some assertions on the content.

It wouldn't protect us from that specific bug we can build on this much more easily