### PR TITLE
fix(surveys): fix emoji rating scale bug

### DIFF
--- a/src/__tests__/extensions/surveys.js
+++ b/src/__tests__/extensions/surveys.js
@@ -1,4 +1,10 @@
-import { createShadow, callSurveys, generateSurveys, createMultipleQuestionSurvey } from '../../extensions/surveys'
+import {
+    createShadow,
+    callSurveys,
+    generateSurveys,
+    createMultipleQuestionSurvey,
+    createRatingsPopup,
+} from '../../extensions/surveys'
 
 describe('survey display logic', () => {
     beforeEach(() => {
@@ -228,5 +234,49 @@ describe('survey display logic', () => {
             .querySelectorAll('input[type=radio]')
         const mappedInputNames2 = [...secondQuestionRadioInputs].map((input) => input.name)
         expect(mappedInputNames2.every((name) => name === 'question1')).toBe(true)
+    })
+
+    test('rating questions that are on the 10 scale start at 0', () => {
+        mockSurveys = [
+            {
+                id: 'testSurvey2',
+                name: 'Test survey 2',
+                appearance: null,
+                questions: [
+                    {
+                        question: 'How satisfied are you with our newest product?',
+                        description: 'This is a question description',
+                        type: 'rating',
+                        display: 'number',
+                        scale: 10,
+                        lower_bound_label: 'Not Satisfied',
+                        upper_bound_label: 'Very Satisfied',
+                    },
+                ],
+            },
+            {
+                id: 'testSurvey3',
+                name: 'Test survey 3',
+                appearance: null,
+                questions: [
+                    {
+                        question: 'How satisfied are you with our newest product?',
+                        description: 'This is a question description',
+                        type: 'rating',
+                        display: 'emoji',
+                        scale: 3,
+                        lower_bound_label: 'Not Satisfied',
+                        upper_bound_label: 'Very Satisfied',
+                    },
+                ],
+            },
+        ]
+        const ratingQuestion = createRatingsPopup(mockPostHog, mockSurveys[0], mockSurveys[0].questions[0], 0)
+        expect(ratingQuestion.querySelectorAll('.question-0-rating-0').length).toBe(1)
+
+        // expect the first value of the rating buttons to be 1 for other scales
+        const ratingQuestion2 = createRatingsPopup(mockPostHog, mockSurveys[1], mockSurveys[1].questions[0], 0)
+        expect(ratingQuestion2.querySelectorAll('.question-0-rating-0').length).toBe(0)
+        expect(ratingQuestion2.querySelectorAll('.question-0-rating-1').length).toBe(1)
     })
 })

--- a/src/extensions/surveys.ts
+++ b/src/extensions/surveys.ts
@@ -566,7 +566,8 @@ export const createRatingsPopup = (
         })
     }
     formElement.getElementsByClassName('rating-options')[0].insertAdjacentElement('afterbegin', ratingOptionsElement)
-    const allElements = question.scale === 10 ? [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] : [1, 2, 3, 4, 5]
+    const allElements =
+        question.scale === 10 ? [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] : question.scale === 5 ? [1, 2, 3, 4, 5] : [1, 2, 3]
     for (const x of allElements) {
         const ratingEl = formElement.getElementsByClassName(`question-${questionIndex}-rating-${x}`)[0]
         ratingEl.addEventListener('click', (e) => {


### PR DESCRIPTION
## Changes

Rating type question with emoji displays were bugging out because we were only accounting for the scales for 10 and 5

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
