### PR TITLE
fix: extend header denylist

### DIFF
--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -31,8 +31,24 @@ export const defaultNetworkOptions: NetworkRecordOptions = {
     recordInitialRequests: false,
 }
 
+const HEADER_DENYLIST = [
+    'Authorization',
+    'X-FORWARDED-FOR',
+    'AUTHORIZATION',
+    'COOKIE',
+    'SET-COOKIE',
+    'X-API-KEY',
+    'X-REAL-IP',
+    'REMOTE-ADDR',
+    'FORWARDED',
+    'PROXY-AUTHORIZATION',
+    'X-CSRF-TOKEN',
+    'X-CSRFTOKEN',
+    'X-XSRF-TOKEN',
+]
+
 const removeAuthorizationHeader = (data: NetworkRequest): NetworkRequest => {
-    delete data.requestHeaders?.['Authorization']
+    HEADER_DENYLIST.forEach((header) => delete data.requestHeaders?.[header])
     return data
 }
 


### PR DESCRIPTION
Extend the header sanitization to use a longer deny list 

see: https://posthog.slack.com/archives/C03PB072FMJ/p1699954288200509?thread_ts=1699894781.926149&cid=C03PB072FMJ