### PR TITLE
chore: Move blocked UAs to own file

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -7,16 +7,10 @@
  * currently not supported in the browser lib).
  */
 
-import {
-    _copyAndTruncateStrings,
-    _isBlockedUA,
-    DEFAULT_BLOCKED_UA_STRS,
-    loadScript,
-    isCrossDomainCookie,
-    _base64Encode,
-} from '../utils'
+import { _copyAndTruncateStrings, loadScript, isCrossDomainCookie, _base64Encode } from '../utils'
 import { _info } from '../utils/event-utils'
 import { document } from '../utils/globals'
+import { _isBlockedUA, DEFAULT_BLOCKED_UA_STRS } from '../utils/blocked-uas'
 
 function userAgentFor(botString: string) {
     const randOne = (Math.random() + 1).toString(36).substring(7)

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -4,7 +4,6 @@ import {
     _each,
     _eachArray,
     _extend,
-    _isBlockedUA,
     _register_event,
     _safewrap_class,
     isCrossDomainCookie,
@@ -58,6 +57,7 @@ import { _info } from './utils/event-utils'
 import { logger } from './utils/logger'
 import { document, userAgent } from './utils/globals'
 import { SessionPropsManager } from './session-props'
+import { _isBlockedUA } from './utils/blocked-uas'
 
 /*
 SIMPLE STYLE GUIDE:

--- a/src/utils/blocked-uas.ts
+++ b/src/utils/blocked-uas.ts
@@ -1,0 +1,60 @@
+export const DEFAULT_BLOCKED_UA_STRS = [
+    'ahrefsbot',
+    'applebot',
+    'baiduspider',
+    'bingbot',
+    'bingpreview',
+    'bot.htm',
+    'bot.php',
+    'crawler',
+    'duckduckbot',
+    'facebookexternal',
+    'facebookcatalog',
+    'gptbot',
+    'hubspot',
+    'linkedinbot',
+    'mj12bot',
+    'petalbot',
+    'pinterest',
+    'prerender',
+    'rogerbot',
+    'screaming frog',
+    'semrushbot',
+    'sitebulb',
+    'twitterbot',
+    'yahoo! slurp',
+    'yandexbot',
+
+    // a whole bunch of goog-specific crawlers
+    // https://developers.google.com/search/docs/advanced/crawling/overview-google-crawlers
+    'adsbot-google',
+    'apis-google',
+    'duplexweb-google',
+    'feedfetcher-google',
+    'google favicon',
+    'google web preview',
+    'google-read-aloud',
+    'googlebot',
+    'googleweblight',
+    'mediapartners-google',
+    'storebot-google',
+]
+
+// _.isBlockedUA()
+// This is to block various web spiders from executing our JS and
+// sending false capturing data
+export const _isBlockedUA = function (ua: string, customBlockedUserAgents: string[]): boolean {
+    if (!ua) {
+        return false
+    }
+    const uaLower = ua.toLowerCase()
+    return DEFAULT_BLOCKED_UA_STRS.concat(customBlockedUserAgents || []).some((blockedUA) => {
+        const blockedUaLower = blockedUA.toLowerCase()
+        if (uaLower.includes) {
+            return uaLower.includes(blockedUaLower)
+        } else {
+            // IE 11 :/
+            return uaLower.indexOf(blockedUaLower) !== -1
+        }
+    })
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -363,67 +363,6 @@ export const _utf8Encode = function (string: string): string {
     return utftext
 }
 
-export const DEFAULT_BLOCKED_UA_STRS = [
-    'ahrefsbot',
-    'applebot',
-    'baiduspider',
-    'bingbot',
-    'bingpreview',
-    'bot.htm',
-    'bot.php',
-    'crawler',
-    'duckduckbot',
-    'facebookexternal',
-    'facebookcatalog',
-    'gptbot',
-    'hubspot',
-    'linkedinbot',
-    'mj12bot',
-    'petalbot',
-    'pinterest',
-    'prerender',
-    'rogerbot',
-    'screaming frog',
-    'semrushbot',
-    'sitebulb',
-    'twitterbot',
-    'yahoo! slurp',
-    'yandexbot',
-
-    // a whole bunch of goog-specific crawlers
-    // https://developers.google.com/search/docs/advanced/crawling/overview-google-crawlers
-    'adsbot-google',
-    'apis-google',
-    'duplexweb-google',
-    'feedfetcher-google',
-    'google favicon',
-    'google web preview',
-    'google-read-aloud',
-    'googlebot',
-    'googleweblight',
-    'mediapartners-google',
-    'storebot-google',
-]
-
-// _.isBlockedUA()
-// This is to block various web spiders from executing our JS and
-// sending false capturing data
-export const _isBlockedUA = function (ua: string, customBlockedUserAgents: string[]): boolean {
-    if (!ua) {
-        return false
-    }
-    const uaLower = ua.toLowerCase()
-    return DEFAULT_BLOCKED_UA_STRS.concat(customBlockedUserAgents || []).some((blockedUA) => {
-        const blockedUaLower = blockedUA.toLowerCase()
-        if (uaLower.includes) {
-            return uaLower.includes(blockedUaLower)
-        } else {
-            // IE 11 :/
-            return uaLower.indexOf(blockedUaLower) !== -1
-        }
-    })
-}
-
 export const _register_event = (function () {
     // written by Dean Edwards, 2005
     // with input from Tino Zijdel - crisp@xs4all.nl


### PR DESCRIPTION
## Changes

Move the list of blocked UAs to their own file. This allows us to send github links to the file when saying "these are the bots we block" without the line of the file changing or us needing to pin to a specific revision

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
