### PR TITLE
chore: Add deprecation notice for disable_cookie

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,7 @@ export interface PostHogConfig {
     upgrade: boolean
     disable_session_recording: boolean
     disable_persistence: boolean
+    /** @deprecated - use `disable_persistence` instead  */
     disable_cookie: boolean
     enable_recording_console_log?: boolean
     secure_cookie: boolean


### PR DESCRIPTION
## Changes

Someone asked what this did and it seems it's basically an old property replaced by `disable_persistence`

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
