### PR TITLE
fix: safer custom event on return from idle

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -402,11 +402,10 @@ export class SessionRecording {
             if (this.isIdle) {
                 // Remove the idle state if set and trigger a full snapshot as we will have ignored previous mutations
                 this.isIdle = false
-                this.rrwebRecord?.addCustomEvent('sessionNoLongerIdle', {
-                    reason: 'user activity',
-                    type: event.type,
+                this._tryTakeFullSnapshot({
+                    tag: 'sessionNoLongerIdle',
+                    payload: { reason: 'user activity', type: event.type },
                 })
-                this._tryTakeFullSnapshot()
             }
         }
 
@@ -434,19 +433,31 @@ export class SessionRecording {
         this.sessionId = sessionId
     }
 
-    private _tryTakeFullSnapshot(): boolean {
-        // TODO this should ignore based on emit?
+    private _tryTakeFullSnapshot(withCustomEvent?: { tag: string; payload: any }): void {
         if (!this._captureStarted) {
-            return false
+            return
         }
-        try {
-            this.rrwebRecord?.takeFullSnapshot()
-            return true
-        } catch (e) {
-            // Sometimes a race can occur where the recorder is not fully started yet, so we can't take a full snapshot.
-            logger.error('Error taking full snapshot.', e)
-            return false
+        // try the same action three times 50 milliseconds apart
+        // if it fails all three times then we give up
+        // this is to account for the fact that the recorder might not be started yet
+        let tries = 0
+        const retryingFn = () => {
+            tries++
+            if (tries > 3) {
+                logger.warn('Could not take full snapshot after 150 milliseconds. Giving up.')
+                return
+            }
+
+            try {
+                if (withCustomEvent) {
+                    this.rrwebRecord?.addCustomEvent(withCustomEvent.tag, withCustomEvent.payload)
+                }
+                this.rrwebRecord?.takeFullSnapshot()
+            } catch (e) {
+                setTimeout(retryingFn, 50)
+            }
         }
+        retryingFn()
     }
 
     private _onScriptLoaded() {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -434,32 +434,26 @@ export class SessionRecording {
         this.sessionId = sessionId
     }
 
-    private _tryAddCustomEvent(tag: string, payload: any): boolean {
+    private _tryRRwebMethod(rrwebMethod: () => void): boolean {
         if (!this._captureStarted) {
             return false
         }
         try {
-            this.rrwebRecord?.addCustomEvent(tag, payload)
+            rrwebMethod()
             return true
         } catch (e) {
-            // Sometimes a race can occur where the recorder is not fully started yet, so we can't add a custom event
-            logger.error('Error adding custom event.', e)
+            // Sometimes a race can occur where the recorder is not fully started yet
+            logger.error('[Session-Recording] using rrweb when not started.', e)
             return false
         }
     }
 
+    private _tryAddCustomEvent(tag: string, payload: any): boolean {
+        return this._tryRRwebMethod(() => this.rrwebRecord?.addCustomEvent(tag, payload))
+    }
+
     private _tryTakeFullSnapshot(): boolean {
-        if (!this._captureStarted) {
-            return false
-        }
-        try {
-            this.rrwebRecord?.takeFullSnapshot()
-            return true
-        } catch (e) {
-            // Sometimes a race can occur where the recorder is not fully started yet, so we can't take a full snapshot.
-            logger.error('Error taking full snapshot.', e)
-            return false
-        }
+        return this._tryRRwebMethod(() => this.rrwebRecord?.takeFullSnapshot())
     }
 
     private _onScriptLoaded() {


### PR DESCRIPTION
https://posthog.sentry.io/issues/4662102372/?project=1899813&query=is%3Aunresolved+please+add+custom+event+after+start+recording+PostHog-Recording-URL%3A%22https%3A%2F%2Fapp.posthog.com%2Freplay%2F018c1241-c72e-7c77-855b-e0bd29823f63%3Ft%3D756%22&referrer=issue-stream&statsPeriod=24h&stream_index=0

We see an error where setting a custom event on the session on return from idle is failing because the rrweb recording isn't ready to accept events.

Immediately after that we try to take a full snapshot and swallow any errors

But the full snapshot is relatively important.

Let's make those activities one activity and add a simple retry. 