### PR TITLE
feat(web-analytics): Add site_name in config and $site_name property

### DIFF
--- a/playground/nextjs/pages/_app.tsx
+++ b/playground/nextjs/pages/_app.tsx
@@ -15,6 +15,7 @@ if (typeof window !== 'undefined') {
         },
         debug: true,
         __preview_send_client_session_params: true,
+        site_name: 'playground-nextjs',
     })
     ;(window as any).posthog = posthog
 }

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -234,6 +234,26 @@ describe('posthog core', () => {
                 undefined
             )
         })
+
+        it('includes $site_name from config', () => {
+            given('config', () => ({
+                site_name: 'test site name',
+                property_blacklist: [],
+                _onCapture: jest.fn(),
+            }))
+            const event = given.subject()
+            expect(event.properties['$site_name']).toBe('test site name')
+        })
+
+        it('doesnt include $site_name if not set', () => {
+            given('config', () => ({
+                site_name: undefined,
+                property_blacklist: [],
+                _onCapture: jest.fn(),
+            }))
+            const event = given.subject()
+            expect(event.properties).not.toHaveProperty('$site_name')
+        })
     })
 
     describe('_afterDecideResponse', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -988,6 +988,10 @@ export class PostHog {
             properties['$duration'] = parseFloat((duration_in_ms / 1000).toFixed(3))
         }
 
+        if (this.config.site_name) {
+            properties['$site_name'] = this.config.site_name
+        }
+
         // note: extend writes to the first object, so lets make sure we
         // don't write to the persistence properties object and info
         // properties object by passing in a new object

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,7 @@ export interface PostHogConfig {
         featureFlagPayloads?: Record<string, JsonType>
     }
     segment?: any
+    site_name?: string
     __preview_measure_pageview_stats?: boolean
     __preview_send_client_session_params?: boolean
 }


### PR DESCRIPTION
## Changes
Add site_name to config, and $site_name property which is sent with this value. See https://github.com/PostHog/posthog/issues/18863 for context

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
