### PR TITLE
feat: Show warning if identifying with "distinct_id"

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -7,6 +7,7 @@ import {
     _register_event,
     _safewrap_class,
     isCrossDomainCookie,
+    isDistinctIdStringLike,
 } from './utils'
 import { assignableWindow, window } from './utils/globals'
 import { autocapture } from './autocapture'
@@ -1279,6 +1280,13 @@ export class PostHog {
         //if the new_distinct_id has not been set ignore the identify event
         if (!new_distinct_id) {
             logger.error('Unique user id has not been set in posthog.identify')
+            return
+        }
+
+        if (isDistinctIdStringLike(new_distinct_id)) {
+            logger.error(
+                `The string "${new_distinct_id}" was set in posthog.identify which indicates an error. This ID should be unique to the user and not a hardcoded string.`
+            )
             return
         }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1284,7 +1284,7 @@ export class PostHog {
         }
 
         if (isDistinctIdStringLike(new_distinct_id)) {
-            logger.error(
+            logger.critical(
                 `The string "${new_distinct_id}" was set in posthog.identify which indicates an error. This ID should be unique to the user and not a hardcoded string.`
             )
             return

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -487,3 +487,7 @@ export function isCrossDomainCookie(documentLocation: Location | undefined) {
     // for the hostname
     return hostname.split('.').slice(-2).join('.') !== 'herokuapp.com'
 }
+
+export function isDistinctIdStringLike(value: string): boolean {
+    return ['distinct_id', 'distinctid'].includes(value.toLowerCase())
+}


### PR DESCRIPTION
## Changes

Came across enough cases of this in support that I figured it was worth making this not possible. We document all over the place "distinct_id" and many people for sure just copy and paste... 

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
