### PR TITLE
fix: handle newlines in classnames

### DIFF
--- a/src/__tests__/autocapture-utils.test.ts
+++ b/src/__tests__/autocapture-utils.test.ts
@@ -12,6 +12,7 @@ import {
     getNestedSpanText,
     getDirectAndNestedSpanText,
     getElementsChainString,
+    getClassNames,
 } from '../autocapture-utils'
 import { document } from '../utils/globals'
 import { makeMouseEvent } from './autocapture.test'
@@ -395,6 +396,32 @@ describe(`Autocapture utility functions`, () => {
             ])
 
             expect(elementChain).toEqual('div:text="text"nth-child="1"nth-of-type="2"')
+        })
+    })
+
+    describe('getClassNames', () => {
+        it('should return an empty string with no elements', () => {
+            const el = document!.createElement('div')
+            const classNames = getClassNames(el)
+            expect(classNames).toEqual([])
+        })
+        it('should cope with a normal class list', () => {
+            const el = document!.createElement('div')
+            el.className = 'class1 class2'
+            const classNames = getClassNames(el)
+            expect(classNames).toEqual(['class1', 'class2'])
+        })
+        it('should cope with a class list with empty strings and tabs', () => {
+            const el = document!.createElement('div')
+            el.className = '  class1        class2  '
+            const classNames = getClassNames(el)
+            expect(classNames).toEqual(['class1', 'class2'])
+        })
+        it('should cope with a class list with unexpected new lines', () => {
+            const el = document!.createElement('div')
+            el.className = '  class1\r\n   \r\n     \n     class2  '
+            const classNames = getClassNames(el)
+            expect(classNames).toEqual(['class1', 'class2'])
         })
     })
 })

--- a/src/__tests__/autocapture-utils.test.ts
+++ b/src/__tests__/autocapture-utils.test.ts
@@ -400,8 +400,14 @@ describe(`Autocapture utility functions`, () => {
     })
 
     describe('getClassNames', () => {
-        it('should return an empty string with no elements', () => {
+        it('should cope when there is no classNames attribute', () => {
             const el = document!.createElement('div')
+            const classNames = getClassNames(el)
+            expect(classNames).toEqual([])
+        })
+        it('should cope when there is an empty classNames attribute', () => {
+            const el = document!.createElement('div')
+            el.className = ''
             const classNames = getClassNames(el)
             expect(classNames).toEqual([])
         })

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -8,7 +8,7 @@ import { window } from './utils/globals'
 /*
  * Get the className of an element, accounting for edge cases where element.className is an object
  *
- * In use the classes are always split before being used. Because this is a string it can contain unexpected characters
+ * Because this is a string it can contain unexpected characters
  * So, this method safely splits the className and returns that array.
  */
 export function getClassNames(el: Element): string[] {

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -22,6 +22,8 @@ export function getClassNames(el: Element): string[] {
             className =
                 ('baseVal' in el.className ? (el.className as any).baseVal : null) || el.getAttribute('class') || ''
             break
+        default:
+            className = ''
     }
 
     return className.length ? _trim(className).split(/\s+/) : []

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -1,6 +1,6 @@
 import { _bind_instance_methods, _each, _extend, _includes, _register_event, _safewrap_instance_methods } from './utils'
 import {
-    getClassName,
+    getClassNames,
     getSafeText,
     isElementNode,
     isSensitiveElement,
@@ -89,9 +89,9 @@ const autocapture = {
             }
         }
 
-        const classes = getClassName(elem)
+        const classes = getClassNames(elem)
         if (classes.length > 0)
-            props['classes'] = classes.split(' ').filter(function (c) {
+            props['classes'] = classes.filter(function (c) {
                 return c !== ''
             })
 
@@ -219,7 +219,7 @@ const autocapture = {
                 }
 
                 // allow users to programmatically prevent capturing of elements by adding class 'ph-no-capture'
-                const classes = getClassName(el).split(' ')
+                const classes = getClassNames(el)
                 if (_includes(classes, 'ph-no-capture')) {
                     explicitNoCapture = true
                 }


### PR DESCRIPTION
related to https://github.com/PostHog/posthog/issues/19068

The site in question has `\r\n` style new lines and runs of whitespace in the className on the element that is not being captured correctly.

Switching how we split classes out of elements can quickly support these unexpected class strings.