### PR TITLE
fix: Sanitize given api_host urls to not have a trailing slash

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -702,6 +702,15 @@ describe('posthog core', () => {
             expect(given.overrides._send_request.mock.calls.length).toBe(0) // No outgoing requests
         })
 
+        it('sanitizes api_host urls', () => {
+            given('config', () => ({
+                api_host: 'https://example.com/custom/',
+            }))
+            given.subject()
+
+            expect(given.lib.config.api_host).toBe('https://example.com/custom')
+        })
+
         it('does not set __loaded_recorder_version flag if recording script has not been included', () => {
             given('overrides', () => ({
                 __loaded_recorder_version: undefined,

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1712,6 +1712,8 @@ export class PostHog {
                 this.config.disable_persistence = this.config.disable_cookie
             }
 
+            // We assume the api_host is without a trailing slash in most places throughout the codebase
+            this.config.api_host = this.config.api_host.replace(/\/$/, '')
             this.persistence?.update_config(this.config)
             this.sessionPersistence?.update_config(this.config)
 


### PR DESCRIPTION
## Changes

A user had issues loading the recorder.js and this was down to a trailing slash in the api_host.

We always expect it to be without the trailing slash so this change ensures that.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
