### PR TITLE
Add wbraid and gbraid to campaignParams

### DIFF
--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -23,6 +23,8 @@ export const _info = {
             'utm_content',
             'utm_term',
             'gclid',
+            'gbraid',
+            'wbraid',
             'fbclid',
             'msclkid',
         ].concat(customParams || [])


### PR DESCRIPTION
## Changes

This adds `gbraid` and `wbraid` to campaign parameters captured from the URLs and stored as a property on the user, similar to [#277](https://github.com/PostHog/posthog-js/pull/277).

For more context, these are new tracking Ids being used by google as the result of recent legislation changes. [More here](https://support.google.com/analytics/answer/11367152?hl=en)

We need this to track conversion from google ad clicks.
...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
