### PR TITLE
chore: Add comment to remind about updating the plugin-server

### DIFF
--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -16,6 +16,7 @@ function isSafari(userAgent: string): boolean {
 
 export const _info = {
     campaignParams: function (customParams?: string[]): Record<string, any> {
+        // Should be kept in sync with https://github.com/PostHog/posthog/blob/master/plugin-server/src/utils/db/utils.ts#L60
         const campaign_keywords = [
             'utm_source',
             'utm_medium',


### PR DESCRIPTION
## Changes

Added a helper comment to remind us that the campaign params have special handling in the plugin-server.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
