### PR TITLE
fix: incorrect localhost handling

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -181,7 +181,9 @@ export const _safewrap = function <F extends (...args: any[]) => any = (...args:
             // @ts-ignore
             return f.apply(this, args)
         } catch (e) {
-            logger.critical('Implementation error. Please turn on debug mode and open a ticket on https://app.posthog.com/home#panel=support%3Asupport%3A.')
+            logger.critical(
+                'Implementation error. Please turn on debug mode and open a ticket on https://app.posthog.com/home#panel=support%3Asupport%3A.'
+            )
             logger.critical(e)
         }
     } as F


### PR DESCRIPTION
The plugin gathering was incorrect.

It was moved into session recording when deleting the web performance observer in #902. Previously it was correct to return early, now it meant that we couldn't start recording on localhost

🤦 🫠