### PR TITLE
fix: class string separator

### DIFF
--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -1123,7 +1123,7 @@ describe('Autocapture system', () => {
             const props1 = getCapturedProps(newLib.capture)
 
             expect(props1['$elements_chain']).toBe(
-                'a.test-class,test-class2,test-class3,test-class4,test-class5:nth-child="1"nth-of-type="1"href="http://test.com"attr__href="http://test.com"attr__class="test-class,test-class2,test-class3,test-class4,test-class5";span:nth-child="1"nth-of-type="1"'
+                'a.test-class.test-class2.test-class3.test-class4.test-class5:nth-child="1"nth-of-type="1"href="http://test.com"attr__href="http://test.com"attr__class="test-class test-class2 test-class3 test-class4 test-class5";span:nth-child="1"nth-of-type="1"'
             )
         })
     })

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -110,7 +110,7 @@ const autocapture = {
                     // html attributes can _technically_ contain linebreaks,
                     // but we're very intolerant of them in the class string,
                     // so we strip them.
-                    value = splitClassString(value).join()
+                    value = splitClassString(value).join(' ')
                 }
                 props['attr__' + attr.name] = limitText(1024, value)
             }


### PR DESCRIPTION
Default join character in JS (it turns out 🤦) is the comma. 

So, [in the change to handle newlines in class strings](https://github.com/PostHog/posthog-js/pull/925/files#diff-f2912c4edd0d573f1786f0face818249e3c6965630c7118ea572bc36b6e283afR113) the split string was accidentally joined with a comma instead of a space.

Frustratingly easy bug to introduce but at least now has an assertion to protect us in future

I checked old events in the explorer (pre 1.94.0) to see what format the elements string is presented in. So I think this now formats correctly