### PR TITLE
fix: Remove debug code from survey-utils

### DIFF
--- a/src/extensions/surveys/surveys-utils.ts
+++ b/src/extensions/surveys/surveys-utils.ts
@@ -642,7 +642,6 @@ export const createMultipleChoicePopup = (
         </div>
         <div class="survey-question auto-text-color">${surveyQuestion}</div>
         ${surveyDescription ? `<span class="description auto-text-color">${surveyDescription}</span>` : ''}
-        random words in the description testing
         <div class="multiple-choice-options">
         ${surveyQuestionChoices
             .map((option, idx) => {


### PR DESCRIPTION
## Changes

This debug code made it in during a previous PR, and is breaking all live surveys
...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
