### PR TITLE
feat: Allow setting asset_host separately from api_host

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -65,6 +65,7 @@ describe('SessionRecording', () => {
 
         config = {
             api_host: 'https://test.com',
+            asset_host: 'https://test.com',
             disable_session_recording: false,
             enable_recording_console_log: false,
             autocapture: false, // Assert that session recording works even if `autocapture = false`

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -76,7 +76,7 @@ export class Decide {
         const surveysGenerator = window?.extendPostHogWithSurveys
 
         if (response['surveys'] && !surveysGenerator) {
-            loadScript(this.instance.config.api_host + `/static/surveys.js`, (err) => {
+            loadScript(this.instance.config.asset_host + `/static/surveys.js`, (err) => {
                 if (err) {
                     return logger.error(`Could not load surveys script`, err)
                 }
@@ -95,7 +95,7 @@ export class Decide {
             !!response['autocaptureExceptions'] &&
             _isUndefined(exceptionAutoCaptureAddedToWindow)
         ) {
-            loadScript(this.instance.config.api_host + `/static/exception-autocapture.js`, (err) => {
+            loadScript(this.instance.config.asset_host + `/static/exception-autocapture.js`, (err) => {
                 if (err) {
                     return logger.error(`Could not load exception autocapture script`, err)
                 }

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -362,7 +362,7 @@ export class SessionRecording {
         // imported) or matches the requested recorder version, don't load script. Otherwise, remotely import
         // recorder.js from cdn since it hasn't been loaded.
         if (this.instance.__loaded_recorder_version !== this.recordingVersion) {
-            loadScript(this.instance.config.api_host + `/static/${recorderJS}?v=${Config.LIB_VERSION}`, (err) => {
+            loadScript(this.instance.config.asset_host + `/static/${recorderJS}?v=${Config.LIB_VERSION}`, (err) => {
                 if (err) {
                     return logger.error(`Could not load ${recorderJS}`, err)
                 }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1725,7 +1725,12 @@ export class PostHog {
             this.config.api_host = this.config.api_host.replace(/\/$/, '')
 
             if (!this.config.asset_host) {
-                this.config.asset_host = this.config.api_host
+                // Default asset_host to api_host
+                // Map to our static domains for the default posthog API endpoints.
+                this.config.asset_host = {
+                    "https://app.posthog.com": "https://app-static-prod.posthog.com",
+                    "https://eu.posthog.com": "https://app-static.eu.posthog.com",
+                }[this.config.api_host] || this.config.api_host;
             }
 
             this.persistence?.update_config(this.config)

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -103,6 +103,7 @@ export const defaultConfig = (): PostHogConfig => ({
     api_host: 'https://app.posthog.com',
     api_method: 'POST',
     api_transport: 'XHR',
+    asset_host: null,
     ui_host: null,
     token: '',
     autocapture: true,
@@ -1722,6 +1723,11 @@ export class PostHog {
 
             // We assume the api_host is without a trailing slash in most places throughout the codebase
             this.config.api_host = this.config.api_host.replace(/\/$/, '')
+
+            if (!this.config.asset_host) {
+                this.config.asset_host = this.config.api_host
+            }
+
             this.persistence?.update_config(this.config)
             this.sessionPersistence?.update_config(this.config)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export interface PostHogConfig {
     api_host: string
     api_method: string
     api_transport: string
+    asset_host: string | null
     ui_host: string | null
     token: string
     autocapture: boolean | AutocaptureConfig


### PR DESCRIPTION
## Changes

Currently we fetch static assets from the api_host. This has a bunch of issues and we'd like to separate these (so that e.g. static assets can be behind a CDN but not the API)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
