### PR TITLE
feat: Allow overriding api_host for analytics/session recording

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -234,6 +234,39 @@ describe('posthog core', () => {
                 undefined
             )
         })
+
+        it('sends payloads to alternative api_host if given', () => {
+            given.lib._afterDecideResponse({ analytics: { api_host: 'https://c.posthog.com' } })
+            given.lib.capture('event-name', { foo: 'bar', length: 0 })
+
+            expect(given.lib._send_request).toHaveBeenCalledWith(
+                'https://c.posthog.com/e/',
+                expect.any(Object),
+                expect.any(Object),
+                undefined
+            )
+        })
+
+        it('sends payloads to overriden api_host if given', () => {
+            given.lib.capture('event-name', { foo: 'bar', length: 0 }, { api_host: 'https://s.posthog.com', endpoint: '/s/' })
+            expect(given.lib._send_request).toHaveBeenCalledWith(
+                'https://s.posthog.com/s/',
+                expect.any(Object),
+                expect.any(Object),
+                undefined
+            )
+        })
+
+        it('sends payloads to overriden api_host, even if alternative api_host is set', () => {
+            given.lib._afterDecideResponse({ analytics: { api_host: 'https://c.posthog.com' } })
+            given.lib.capture('event-name', { foo: 'bar', length: 0 }, { api_host: 'https://s.posthog.com' })
+            expect(given.lib._send_request).toHaveBeenCalledWith(
+                'https://s.posthog.com/e/',
+                expect.any(Object),
+                expect.any(Object),
+                undefined
+            )
+        })
     })
 
     describe('_afterDecideResponse', () => {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -86,6 +86,7 @@ interface SnapshotBuffer {
 export class SessionRecording {
     private instance: PostHog
     private _endpoint: string
+    private _api_host?: string
     private flushBufferTimer?: any
     private buffer?: SnapshotBuffer
     private mutationRateLimiter?: MutationRateLimiter
@@ -202,6 +203,7 @@ export class SessionRecording {
         this.instance = instance
         this._captureStarted = false
         this._endpoint = BASE_ENDPOINT
+        this._api_host = undefined
         this.stopRrweb = undefined
         this.receivedDecide = false
 
@@ -296,6 +298,10 @@ export class SessionRecording {
 
         if (response.sessionRecording?.endpoint) {
             this._endpoint = response.sessionRecording?.endpoint
+        }
+
+        if (response.sessionRecording?.api_host) {
+            this._api_host = response.sessionRecording?.api_host
         }
 
         if (_isNumber(this._sampleRate)) {
@@ -714,6 +720,7 @@ export class SessionRecording {
             transport: 'XHR',
             method: 'POST',
             endpoint: this._endpoint,
+            api_host: this._api_host,
             _noTruncate: true,
             _batchKey: SESSION_RECORDING_BATCH_KEY,
             _metrics: {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -297,6 +297,7 @@ export class PostHog {
     __autocapture: boolean | AutocaptureConfig | undefined
     decideEndpointWasHit: boolean
     analyticsDefaultEndpoint: string
+    analyticsDefaultApiHost?: string
     elementsChainAsString: boolean
 
     SentryIntegration: typeof SentryIntegration
@@ -321,6 +322,7 @@ export class PostHog {
         this.__autocapture = undefined
         this._jsc = function () {} as JSC
         this.analyticsDefaultEndpoint = '/e/'
+        this.analyticsDefaultApiHost = undefined
         this.elementsChainAsString = false
 
         this.featureFlags = new PostHogFeatureFlags(this)
@@ -547,6 +549,10 @@ export class PostHog {
 
         if (response.analytics?.endpoint) {
             this.analyticsDefaultEndpoint = response.analytics.endpoint
+        }
+
+        if (response.analytics?.api_host) {
+            this.analyticsDefaultApiHost = response.analytics.api_host
         }
 
         if (response.elementsChainAsString) {
@@ -904,7 +910,7 @@ export class PostHog {
         logger.info('send', data)
         const jsonData = JSON.stringify(data)
 
-        const url = this.config.api_host + (options.endpoint || this.analyticsDefaultEndpoint)
+        const url = (options.api_host || this.analyticsDefaultApiHost || this.config.api_host) + (options.endpoint || this.analyticsDefaultEndpoint)
 
         const has_unique_traits = options !== __NOOPTIONS
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,6 +192,7 @@ export interface CaptureOptions extends XHROptions {
     _metrics?: Properties
     _noTruncate?: boolean /** if set, overrides and disables config.properties_string_max_length */
     endpoint?: string /** defaults to '/e/' */
+    api_host?: string /** defaults to global api host */
     send_instantly?: boolean /** if set skips the batched queue */
     timestamp?: Date
 }
@@ -230,6 +231,7 @@ export interface DecideResponse {
     capturePerformance?: boolean
     analytics?: {
         endpoint?: string
+        api_host?: string
     }
     elementsChainAsString?: boolean
     // this is currently in development and may have breaking changes without a major version bump
@@ -241,6 +243,7 @@ export interface DecideResponse {
           }
     sessionRecording?: {
         endpoint?: string
+        api_host?: string
         consoleLogRecordingEnabled?: boolean
         recorderVersion?: 'v1' | 'v2'
         // the API returns a decimal between 0 and 1 as a string


### PR DESCRIPTION
## Changes
Currently we can override the endpoint path but not the hostname

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
