### PR TITLE
feat: add opt_out_useragent_filter and $browser_type

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -6,6 +6,7 @@ import { autocapture } from '../autocapture'
 import { truth } from './helpers/truth'
 import { _info } from '../utils/event-utils'
 import { document, window } from '../utils/globals'
+import * as globals from '../utils/globals'
 
 jest.mock('../gdpr-utils', () => ({
     ...jest.requireActual('../gdpr-utils'),
@@ -125,6 +126,44 @@ describe('posthog core', () => {
             expect(() => given.subject()).not.toThrow()
             expect(hook).not.toHaveBeenCalled()
             expect(console.error).toHaveBeenCalledWith('[PostHog.js]', 'No event name provided to posthog.capture')
+        })
+
+        it('respects opt_out_useragent_filter (default: false)', () => {
+            const originalUseragent = globals.userAgent
+            // eslint-disable-next-line no-import-assign
+            globals['userAgent'] =
+                'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/W.X.Y.Z Safari/537.36'
+
+            const hook = jest.fn()
+            given.lib._addCaptureHook(hook)
+            given.subject()
+            expect(hook).not.toHaveBeenCalledWith('$event')
+
+            // eslint-disable-next-line no-import-assign
+            globals['userAgent'] = originalUseragent
+        })
+
+        it('respects opt_out_useragent_filter', () => {
+            const originalUseragent = globals.userAgent
+
+            given('config', () => ({
+                opt_out_useragent_filter: true,
+                property_blacklist: [],
+                _onCapture: jest.fn(),
+            }))
+
+            // eslint-disable-next-line no-import-assign
+            globals['userAgent'] =
+                'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/W.X.Y.Z Safari/537.36'
+
+            const hook = jest.fn()
+            given.lib._addCaptureHook(hook)
+            const event = given.subject()
+            expect(hook).toHaveBeenCalledWith('$event')
+            expect(event.properties['$browser_type']).toEqual('bot')
+
+            // eslint-disable-next-line no-import-assign
+            globals['userAgent'] = originalUseragent
         })
 
         it('truncates long properties', () => {
@@ -330,6 +369,7 @@ describe('posthog core', () => {
 
         it('returns calculated properties', () => {
             expect(given.subject).toEqual({
+                $browser_type: 'browser',
                 token: 'testtoken',
                 event: 'prop',
                 $lib: 'web',
@@ -344,6 +384,7 @@ describe('posthog core', () => {
             given('property_blacklist', () => ['$lib', 'persistent'])
 
             expect(given.subject).toEqual({
+                $browser_type: 'browser',
                 token: 'testtoken',
                 event: 'prop',
                 distinct_id: 'abc',

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -161,6 +161,7 @@ describe('posthog core', () => {
             const event = given.subject()
             expect(hook).toHaveBeenCalledWith('$event')
             expect(event.properties['$browser_type']).toEqual('bot')
+            expect(event.properties['$useragent']).toContain('Googlebot')
 
             // eslint-disable-next-line no-import-assign
             globals['userAgent'] = originalUseragent

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -161,7 +161,6 @@ describe('posthog core', () => {
             const event = given.subject()
             expect(hook).toHaveBeenCalledWith('$event')
             expect(event.properties['$browser_type']).toEqual('bot')
-            expect(event.properties['$useragent']).toContain('Googlebot')
 
             // eslint-disable-next-line no-import-assign
             globals['userAgent'] = originalUseragent

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -369,7 +369,6 @@ describe('posthog core', () => {
 
         it('returns calculated properties', () => {
             expect(given.subject).toEqual({
-                $browser_type: 'browser',
                 token: 'testtoken',
                 event: 'prop',
                 $lib: 'web',
@@ -384,7 +383,6 @@ describe('posthog core', () => {
             given('property_blacklist', () => ['$lib', 'persistent'])
 
             expect(given.subject).toEqual({
-                $browser_type: 'browser',
                 token: 'testtoken',
                 event: 'prop',
                 distinct_id: 'abc',

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -130,6 +130,7 @@ export const defaultConfig = (): PostHogConfig => ({
     ip: true,
     opt_out_capturing_by_default: false,
     opt_out_persistence_by_default: false,
+    opt_out_useragent_filter: false,
     opt_out_capturing_persistence_type: 'localStorage',
     opt_out_capturing_cookie_prefix: null,
     opt_in_site_apps: false,
@@ -866,7 +867,11 @@ export class PostHog {
             return
         }
 
-        if (userAgent && _isBlockedUA(userAgent, this.config.custom_blocked_useragents)) {
+        if (
+            userAgent &&
+            !this.config.opt_out_useragent_filter &&
+            _isBlockedUA(userAgent, this.config.custom_blocked_useragents)
+        ) {
             return
         }
 
@@ -988,6 +993,9 @@ export class PostHog {
             const duration_in_ms = new Date().getTime() - start_timestamp
             properties['$duration'] = parseFloat((duration_in_ms / 1000).toFixed(3))
         }
+
+        properties['$browser_type'] =
+            userAgent && _isBlockedUA(userAgent, this.config.custom_blocked_useragents) ? 'bot' : 'browser'
 
         // note: extend writes to the first object, so lets make sure we
         // don't write to the persistence properties object and info
@@ -1630,6 +1638,9 @@ export class PostHog {
      *
      *       // opt users out of browser data storage by this PostHog instance by default
      *       opt_out_persistence_by_default: false
+     *
+     *       // opt out of user agent filtering such as googlebot or other bots
+     *       opt_out_useragent_filter: false
      *
      *       // persistence mechanism used by opt-in/opt-out methods - cookie
      *       // or localStorage - falls back to cookie if localStorage is unavailable

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -998,7 +998,6 @@ export class PostHog {
             properties['$browser_type'] = _isBlockedUA(userAgent, this.config.custom_blocked_useragents)
                 ? 'bot'
                 : 'browser'
-            properties['$useragent'] = userAgent
         }
 
         // note: extend writes to the first object, so lets make sure we

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -994,7 +994,7 @@ export class PostHog {
             properties['$duration'] = parseFloat((duration_in_ms / 1000).toFixed(3))
         }
 
-        if (userAgent) {
+        if (userAgent && this.config.opt_out_useragent_filter) {
             properties['$browser_type'] = _isBlockedUA(userAgent, this.config.custom_blocked_useragents)
                 ? 'bot'
                 : 'browser'

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -994,8 +994,11 @@ export class PostHog {
             properties['$duration'] = parseFloat((duration_in_ms / 1000).toFixed(3))
         }
 
-        properties['$browser_type'] =
-            userAgent && _isBlockedUA(userAgent, this.config.custom_blocked_useragents) ? 'bot' : 'browser'
+        if (userAgent) {
+            properties['$browser_type'] = _isBlockedUA(userAgent, this.config.custom_blocked_useragents)
+                ? 'bot'
+                : 'browser'
+        }
 
         // note: extend writes to the first object, so lets make sure we
         // don't write to the persistence properties object and info

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -998,6 +998,7 @@ export class PostHog {
             properties['$browser_type'] = _isBlockedUA(userAgent, this.config.custom_blocked_useragents)
                 ? 'bot'
                 : 'browser'
+            properties['$useragent'] = userAgent
         }
 
         // note: extend writes to the first object, so lets make sure we

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,8 @@ export interface PostHogConfig {
     ip: boolean
     opt_out_capturing_by_default: boolean
     opt_out_persistence_by_default: boolean
+    /** Opt out of user agent filtering such as googlebot or other bots. Defaults to `false` */
+    opt_out_useragent_filter: boolean
     opt_out_capturing_persistence_type: 'localStorage' | 'cookie'
     opt_out_capturing_cookie_prefix: string | null
     opt_in_site_apps: boolean

--- a/src/utils/blocked-uas.ts
+++ b/src/utils/blocked-uas.ts
@@ -48,9 +48,9 @@ export const DEFAULT_BLOCKED_UA_STRS = [
     'storebot-google',
 ]
 
-// _.isBlockedUA()
-// This is to block various web spiders from executing our JS and
-// sending false capturing data
+/**
+ * Block various web spiders from executing our JS and sending false capturing data
+ */
 export const _isBlockedUA = function (ua: string, customBlockedUserAgents: string[]): boolean {
     if (!ua) {
         return false


### PR DESCRIPTION
## Description

We at Cambly would love to capture bot traffic through PostHog. Currently bot traffic is automatically filtered out and there is no way to disable the filter. https://github.com/PostHog/posthog-js/blob/958fec4df19246513264d69d52d5e36a5cf6ed52/src/posthog-core.ts#L869

## Changes

* Add `opt_out_useragent_filter` config option to allow clients to opt out of user agent filtering (e.g. bots)
* Add `$browser_type` to every capture event to be able to differentiate between bots and regular browsers. Based on [User Agent Populator](https://posthog.com/docs/cdp/user-agent-populator)

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
