### PR TITLE
fix: add a comment explaining browser type prop

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -994,6 +994,8 @@ export class PostHog {
             properties['$duration'] = parseFloat((duration_in_ms / 1000).toFixed(3))
         }
 
+        // this is only added when this.config.opt_out_useragent_filter is true,
+        // or it would always add "browser"
         if (userAgent && this.config.opt_out_useragent_filter) {
             properties['$browser_type'] = _isBlockedUA(userAgent, this.config.custom_blocked_useragents)
                 ? 'bot'


### PR DESCRIPTION
follow up to #949 

occurred to me to add a comment, but wanted to add that in a PR not from a fork so I can see the testcafe tests pass

this PR will bump minor - despite being only a comment - since #949 can't bump the version as it came from a fork