### PR TITLE
fix: set the session id as soon as it changes

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -969,78 +969,78 @@ describe('SessionRecording', () => {
                     expect(assignableWindow.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(2)
                 })
             })
+        })
+    })
 
-            describe('idle timeouts', () => {
-                it("enters idle state if the activity is non-user generated and there's no activity for 5 seconds", () => {
-                    sessionRecording.startRecordingIfEnabled()
-                    const lastActivityTimestamp = sessionRecording['_lastActivityTimestamp']
-                    expect(lastActivityTimestamp).toBeGreaterThan(0)
+    describe('idle timeouts', () => {
+        it("enters idle state if the activity is non-user generated and there's no activity for 5 seconds", () => {
+            sessionRecording.startRecordingIfEnabled()
+            const lastActivityTimestamp = sessionRecording['_lastActivityTimestamp']
+            expect(lastActivityTimestamp).toBeGreaterThan(0)
 
-                    expect(assignableWindow.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(0)
+            expect(assignableWindow.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(0)
 
-                    _emit({
-                        event: 123,
-                        type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
-                        data: {
-                            source: 1,
-                        },
-                        timestamp: lastActivityTimestamp + 100,
-                    })
-                    expect(sessionRecording['isIdle']).toEqual(false)
-                    expect(sessionRecording['_lastActivityTimestamp']).toEqual(lastActivityTimestamp + 100)
-
-                    expect(assignableWindow.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
-
-                    _emit({
-                        event: 123,
-                        type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
-                        data: {
-                            source: 0,
-                        },
-                        timestamp: lastActivityTimestamp + 200,
-                    })
-                    expect(sessionRecording['isIdle']).toEqual(false)
-                    expect(sessionRecording['_lastActivityTimestamp']).toEqual(lastActivityTimestamp + 100)
-                    expect(assignableWindow.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
-
-                    // this triggers idle state and isn't a user interaction so does not take a full snapshot
-                    _emit({
-                        event: 123,
-                        type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
-                        data: {
-                            source: 0,
-                        },
-                        timestamp: lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 1000,
-                    })
-                    expect(sessionRecording['isIdle']).toEqual(true)
-                    expect(_addCustomEvent).toHaveBeenCalledWith('sessionIdle', {
-                        reason: 'user inactivity',
-                        threshold: 300000,
-                        timeSinceLastActive: 300900,
-                    })
-                    expect(sessionRecording['_lastActivityTimestamp']).toEqual(lastActivityTimestamp + 100)
-                    expect(assignableWindow.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
-
-                    // this triggers idle state _and_ is a user interaction, so we take a full snapshot
-                    _emit({
-                        event: 123,
-                        type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
-                        data: {
-                            source: 1,
-                        },
-                        timestamp: lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 2000,
-                    })
-                    expect(sessionRecording['isIdle']).toEqual(false)
-                    expect(_addCustomEvent).toHaveBeenCalledWith('sessionNoLongerIdle', {
-                        reason: 'user activity',
-                        type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
-                    })
-                    expect(sessionRecording['_lastActivityTimestamp']).toEqual(
-                        lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 2000
-                    )
-                    expect(assignableWindow.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(2)
-                })
+            _emit({
+                event: 123,
+                type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
+                data: {
+                    source: 1,
+                },
+                timestamp: lastActivityTimestamp + 100,
             })
+            expect(sessionRecording['isIdle']).toEqual(false)
+            expect(sessionRecording['_lastActivityTimestamp']).toEqual(lastActivityTimestamp + 100)
+
+            expect(assignableWindow.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
+
+            _emit({
+                event: 123,
+                type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
+                data: {
+                    source: 0,
+                },
+                timestamp: lastActivityTimestamp + 200,
+            })
+            expect(sessionRecording['isIdle']).toEqual(false)
+            expect(sessionRecording['_lastActivityTimestamp']).toEqual(lastActivityTimestamp + 100)
+            expect(assignableWindow.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
+
+            // this triggers idle state and isn't a user interaction so does not take a full snapshot
+            _emit({
+                event: 123,
+                type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
+                data: {
+                    source: 0,
+                },
+                timestamp: lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 1000,
+            })
+            expect(sessionRecording['isIdle']).toEqual(true)
+            expect(_addCustomEvent).toHaveBeenCalledWith('sessionIdle', {
+                reason: 'user inactivity',
+                threshold: 300000,
+                timeSinceLastActive: 300900,
+            })
+            expect(sessionRecording['_lastActivityTimestamp']).toEqual(lastActivityTimestamp + 100)
+            expect(assignableWindow.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(1)
+
+            // this triggers idle state _and_ is a user interaction, so we take a full snapshot
+            _emit({
+                event: 123,
+                type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
+                data: {
+                    source: 1,
+                },
+                timestamp: lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 2000,
+            })
+            expect(sessionRecording['isIdle']).toEqual(false)
+            expect(_addCustomEvent).toHaveBeenCalledWith('sessionNoLongerIdle', {
+                reason: 'user activity',
+                type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
+            })
+            expect(sessionRecording['_lastActivityTimestamp']).toEqual(
+                lastActivityTimestamp + RECORDING_IDLE_ACTIVITY_TIMEOUT_MS + 2000
+            )
+            expect(assignableWindow.rrwebRecord.takeFullSnapshot).toHaveBeenCalledTimes(2)
         })
     })
 

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -251,20 +251,10 @@ describe('SessionRecording', () => {
             expect(sessionRecording['status']).toBe('buffering')
             expect(sessionRecording['buffer']).toEqual(EMPTY_BUFFER)
 
-            _emit(createIncrementalSnapshot({ data: { source: 1 } }))
+            const incrementalSnapshot = createIncrementalSnapshot({ data: { source: 1 } })
+            _emit(incrementalSnapshot)
             expect(sessionRecording['buffer']).toEqual({
-                data: [
-                    {
-                        data: {},
-                        type: 2,
-                    },
-                    {
-                        data: {
-                            source: 1,
-                        },
-                        type: 3,
-                    },
-                ],
+                data: [createFullSnapshot(), incrementalSnapshot],
                 sessionId: sessionId,
                 size: 50,
                 windowId: 'windowId',

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -397,6 +397,7 @@ export class SessionRecording {
             }
         }
 
+        let returningFromIdle = false
         if (isUserInteraction) {
             this._lastActivityTimestamp = event.timestamp
             if (this.isIdle) {
@@ -406,7 +407,7 @@ export class SessionRecording {
                     reason: 'user activity',
                     type: event.type,
                 })
-                this._tryTakeFullSnapshot()
+                returningFromIdle = true
             }
         }
 
@@ -427,8 +428,9 @@ export class SessionRecording {
         this.sessionId = sessionId
 
         if (
-            [FULL_SNAPSHOT_EVENT_TYPE, META_EVENT_TYPE].indexOf(event.type) === -1 &&
-            (windowIdChanged || sessionIdChanged)
+            returningFromIdle ||
+            ([FULL_SNAPSHOT_EVENT_TYPE, META_EVENT_TYPE].indexOf(event.type) === -1 &&
+                (windowIdChanged || sessionIdChanged))
         ) {
             this._tryTakeFullSnapshot()
         }

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -423,15 +423,15 @@ export class SessionRecording {
         const sessionIdChanged = this.sessionId !== sessionId
         const windowIdChanged = this.windowId !== windowId
 
+        this.windowId = windowId
+        this.sessionId = sessionId
+
         if (
             [FULL_SNAPSHOT_EVENT_TYPE, META_EVENT_TYPE].indexOf(event.type) === -1 &&
             (windowIdChanged || sessionIdChanged)
         ) {
             this._tryTakeFullSnapshot()
         }
-
-        this.windowId = windowId
-        this.sessionId = sessionId
     }
 
     private _tryRRwebMethod(rrwebMethod: () => void): boolean {


### PR DESCRIPTION
We've a bug where the full snapshot is missing at the start of some recordings. 

I think this fixes it - certainly resetting sessions locally I couldn't get it to trigger any more.