### PR TITLE
fix: Don't allow us.posthog.com to be used

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1738,6 +1738,11 @@ export class PostHog {
 
             // We assume the api_host is without a trailing slash in most places throughout the codebase
             this.config.api_host = this.config.api_host.replace(/\/$/, '')
+
+            // us.posthog.com is only for the web app, so we don't allow that to be used as a capture endpoint
+            if (this.config.api_host === 'https://us.posthog.com') {
+                this.config.api_host = 'https://app.posthog.com'
+            }
             this.persistence?.update_config(this.config)
             this.sessionPersistence?.update_config(this.config)
 


### PR DESCRIPTION
## Changes

We don't want us.posthog.com to be used for any tracking. The plan is to
1. Push this PR
2. Automatically redirect array.js from us to cloudfront
3. return 301 for any of these endpoints on us (which will break anyone calling those endpoints for the frontend, if they're not on the latest version of posthog-js once this is in)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
