### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,7 +88,7 @@ jobs:
               id: pnpm-upgrade
               run: |
                   OUTGOING_VERSION=$(jq '.dependencies["posthog-js"]' package.json -r)
-                  echo "::set-output name=outgoing-version::$OUTGOING_VERSION"
+                  echo "outgoing-version=$OUTGOING_VERSION" >> $GITHUB_OUTPUT
                   for i in $(seq 1 $RETRY_TIMES); do
                       # Retry loop because of npm being _eventually_ consistent
                       if pnpm upgrade posthog-js@${{ env.COMMITTED_VERSION }}; then

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,7 +88,7 @@ jobs:
               id: pnpm-upgrade
               run: |
                   OUTGOING_VERSION=$(jq '.dependencies["posthog-js"]' package.json -r)
-                  echo "outgoing-version=$OUTGOING_VERSION" >> $GITHUB_OUTPUT
+                  echo "outgoing-version=$OUTGOING_VERSION" >> "$GITHUB_OUTPUT"
                   for i in $(seq 1 $RETRY_TIMES); do
                       # Retry loop because of npm being _eventually_ consistent
                       if pnpm upgrade posthog-js@${{ env.COMMITTED_VERSION }}; then

--- a/.github/workflows/label-version-bump.yml
+++ b/.github/workflows/label-version-bump.yml
@@ -36,7 +36,7 @@ jobs:
                   if [[ $BUMP_MAJOR_PRESENT == 'true' ]]; then
                       BUMP_TYPE=major
                   fi
-                  echo "::set-output name=bump-type::$BUMP_TYPE"
+                  echo "bump-type=$BUMP_TYPE" >> $GITHUB_OUTPUT
               env:
                   BUMP_PATCH_PRESENT: ${{ contains(github.event.pull_request.labels.*.name, 'bump patch') }}
                   BUMP_MINOR_PRESENT: ${{ contains(github.event.pull_request.labels.*.name, 'bump minor') }}
@@ -48,8 +48,8 @@ jobs:
               run: |
                   OLD_VERSION=$(jq ".version" package.json -r)
                   NEW_VERSION=$(npx semver $OLD_VERSION -i ${{ steps.bump-type.outputs.bump-type }})
-                  echo "::set-output name=old-version::$OLD_VERSION"
-                  echo "::set-output name=new-version::$NEW_VERSION"
+                  echo "old-version=$OLD_VERSION" >> $GITHUB_OUTPUT
+                  echo "new-version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
             - name: Update version in package.json
               if: steps.bump-type.outputs.bump-type != 'null'

--- a/.github/workflows/label-version-bump.yml
+++ b/.github/workflows/label-version-bump.yml
@@ -36,7 +36,7 @@ jobs:
                   if [[ $BUMP_MAJOR_PRESENT == 'true' ]]; then
                       BUMP_TYPE=major
                   fi
-                  echo "bump-type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+                  echo "bump-type=$BUMP_TYPE" >> "$GITHUB_OUTPUT"
               env:
                   BUMP_PATCH_PRESENT: ${{ contains(github.event.pull_request.labels.*.name, 'bump patch') }}
                   BUMP_MINOR_PRESENT: ${{ contains(github.event.pull_request.labels.*.name, 'bump minor') }}
@@ -48,8 +48,8 @@ jobs:
               run: |
                   OLD_VERSION=$(jq ".version" package.json -r)
                   NEW_VERSION=$(npx semver $OLD_VERSION -i ${{ steps.bump-type.outputs.bump-type }})
-                  echo "old-version=$OLD_VERSION" >> $GITHUB_OUTPUT
-                  echo "new-version=$NEW_VERSION" >> $GITHUB_OUTPUT
+                  echo "old-version=$OLD_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "new-version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
             - name: Update version in package.json
               if: steps.bump-type.outputs.bump-type != 'null'

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -19,9 +19,9 @@ jobs:
                   )
                   echo "::debug::Filtered PR body to $FILTERED_BODY"
                   if [[ -z "${FILTERED_BODY//[[:space:]]/}" ]]; then
-                      echo "is-shame-worthy=true" >> $GITHUB_OUTPUT
+                      echo "is-shame-worthy=true" >> "$GITHUB_OUTPUT"
                   else
-                      echo "is-shame-worthy=false" >> $GITHUB_OUTPUT
+                      echo "is-shame-worthy=false" >> "$GITHUB_OUTPUT"
                   fi
               env:
                   RAW_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -19,9 +19,9 @@ jobs:
                   )
                   echo "::debug::Filtered PR body to $FILTERED_BODY"
                   if [[ -z "${FILTERED_BODY//[[:space:]]/}" ]]; then
-                      echo "::set-output name=is-shame-worthy::true"
+                      echo "is-shame-worthy=true" >> $GITHUB_OUTPUT
                   else
-                      echo "::set-output name=is-shame-worthy::false"
+                      echo "is-shame-worthy=false" >> $GITHUB_OUTPUT
                   fi
               env:
                   RAW_BODY: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


