### PR TITLE
feat: Enable scroll stats by default

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -213,7 +213,7 @@ const create_phlib = function (
     instance.sessionRecording = new SessionRecording(instance)
     instance.sessionRecording.startRecordingIfEnabled()
 
-    if (instance.config.__preview_measure_pageview_stats) {
+    if (!instance.config.disable_scroll_properties) {
         instance.pageViewManager.startMeasuringScrollPosition()
     }
 
@@ -966,7 +966,7 @@ export class PostHog {
             properties = _extend(properties, sessionProps)
         }
 
-        if (this.config.__preview_measure_pageview_stats) {
+        if (!this.config.disable_scroll_properties) {
             let performanceProperties: Record<string, any> = {}
             if (event_name === '$pageview') {
                 performanceProperties = this.pageViewManager.doPageView()

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,8 +126,8 @@ export interface PostHogConfig {
         featureFlagPayloads?: Record<string, JsonType>
     }
     segment?: any
-    __preview_measure_pageview_stats?: boolean
     __preview_send_client_session_params?: boolean
+    disable_scroll_properties?: boolean
     // Let the pageview scroll stats use a custom css selector for the root element, e.g. `main`
     scroll_root_selector?: string | string[]
 }


### PR DESCRIPTION
## Changes
Remove the setting and replace it with a negated one to disable it, also remove the `__` prefix.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
