### PR TITLE
chore: add debug logging for session id/recording

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -232,6 +232,7 @@ export class SessionRecording {
     startRecordingIfEnabled() {
         if (this.isRecordingEnabled) {
             this.startCaptureAndTrySendingQueuedSnapshots()
+            logger.info('[SessionRecording] started')
         } else {
             this.stopRecording()
             this.clearBuffer()
@@ -243,6 +244,7 @@ export class SessionRecording {
             this.stopRrweb()
             this.stopRrweb = undefined
             this._captureStarted = false
+            logger.info('[SessionRecording] stopped')
         }
     }
 

--- a/src/sessionid.ts
+++ b/src/sessionid.ts
@@ -212,6 +212,11 @@ export class SessionIdManager {
         if (noSessionId || activityTimeout || sessionPastMaximumLength) {
             sessionId = this._sessionIdGenerator()
             windowId = this._windowIdGenerator()
+            logger.info('[SessionId] new session ID generated', {
+                sessionId,
+                windowId,
+                changeReason: { noSessionId, activityTimeout, sessionPastMaximumLength },
+            })
             startTimestamp = timestamp
             valuesChanged = true
         } else if (!windowId) {


### PR DESCRIPTION
A customer expected to see information about session recording when `posthog.debug(true)`. That makes sense, let's add some.