### PR TITLE
chore: re-enable bundle checker now master and branches both use pnpm

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -28,9 +28,7 @@ jobs:
       - name: Install package.json dependencies with pnpm
         run: pnpm install --frozen-lockfile
 
-# auto selects yarn because yarn.lock exists in master :/
-# need to re-enable _after_ moving to pnpm
-#      - uses: preactjs/compressed-size-action@v2
-#        with:
-#          build-script: "build-rollup"
-#          compression: "none"
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          build-script: "build-rollup"
+          compression: "none"


### PR DESCRIPTION
the bundle size checker autodetects the build tool but couldn't cope with yarn on master and pnpm on a branch

now that master is on pnpm we can turn it back on