### PR TITLE
chore: Swap to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - main
-            - master
 
 jobs:
     check-package-version:

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -4,7 +4,7 @@ on:
     pull_request:
     push:
         branches:
-            - master
+            - main
 
 jobs:
     unit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - feat: safer rrweb events and regular full snapshots (#973)
 - chore: update rollup (#974)
-- chore: re-enable bundle checker now master and branches both use pnpm (#972)
+- chore: re-enable bundle checker now main and branches both use pnpm (#972)
 
 ## 1.103.0 - 2024-01-26
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Install Yalc to link a local version of `posthog-js` in another JS project: `npm
 
 Just put a `bump patch/minor/major` label on your PR! Once the PR is merged, a new version with the appropriate version bump will be released, and the dependency will be updated in [posthog/PostHog](https://github.com/posthog/PostHog) – automatically.
   
-If you want to release a new version without a PR (e.g. because you forgot to use the label), check out the `master` branch and run `npm version [major | minor | patch] && git push --tags` - this will trigger the automated release process just like the label.
+If you want to release a new version without a PR (e.g. because you forgot to use the label), check out the `main` branch and run `npm version [major | minor | patch] && git push --tags` - this will trigger the automated release process just like the label.
 
 ### Prereleases
 
@@ -79,7 +79,7 @@ To release an alpha or beta version, you'll need to use the CLI locally:
 
 1. Make sure you're a collaborator on `posthog-js` in npm ([check here](https://www.npmjs.com/package/posthog-js)).
 2. Make sure you're logged into the npm CLI (`npm login`).
-3. Check out your work-in-progress branch (do not release an alpha/beta from `master`).
+3. Check out your work-in-progress branch (do not release an alpha/beta from `main`).
 4. Run the following commands, using the same bump level (major/minor/patch) as your PR:
     ```bash
     npm version [premajor | preminor | prepatch] --preid=beta


### PR DESCRIPTION
## Changes

3 missed attempts at `gco main` made me realise this is an easy repo to swap over. Pretty sure it isn't linked anywhere else via github in a breaking way and its low enough impact to just find out if so.

## TODO
- [ ] Pre-merge use the github tooling to rename the default branch

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
