### PR TITLE
fix: no throwing when reading the body

### DIFF
--- a/src/loader-recorder-v2.ts
+++ b/src/loader-recorder-v2.ts
@@ -397,10 +397,7 @@ async function _tryReadBody(res: Response): Promise<string> {
     // there are now already multiple places where we're using Promise...
     // eslint-disable-next-line compat/compat
     return new Promise((resolve, reject) => {
-        const timeout = setTimeout(
-            () => reject(new Error('[rrweb/network@1] Timeout while trying to read response body')),
-            250
-        )
+        const timeout = setTimeout(() => resolve('[rrweb/network@1] Timeout while trying to read response body'), 250)
         res.clone()
             .text()
             .then(


### PR DESCRIPTION
An early contender for funniest bug of the year 

![image](https://github.com/PostHog/posthog-js/assets/984817/59cb293d-ee8f-4556-b71e-73a72a96bcc6)

let's not throw in this case - it's expected to happen at least sometimes - let's set that as the body so we can at least see something / display it nicely when in playback