### PR TITLE
fix: very defensive body redaction

### DIFF
--- a/src/__tests__/extensions/replay/config.test.ts
+++ b/src/__tests__/extensions/replay/config.test.ts
@@ -176,7 +176,7 @@ describe('config', () => {
                         'content-type': 'application/json',
                         'content-length': '1000001',
                     },
-                    requestBody: 'Request body too large to record',
+                    requestBody: '[SessionReplay] Request body too large to record',
                 })
             })
 
@@ -196,26 +196,25 @@ describe('config', () => {
                         'content-type': 'application/json',
                         'content-length': '1000001',
                     },
-                    responseBody: 'Response body too large to record',
+                    responseBody: '[SessionReplay] Response body too large to record',
                 })
             })
 
             it('cannot redact when there is no content length header', () => {
                 const networkOptions = buildNetworkRequestOptions(defaultConfig(), {})
-                const largeString = 'a'.repeat(1000001)
                 const cleaned = networkOptions.maskRequestFn!({
                     name: 'something',
                     requestHeaders: {
                         'content-type': 'application/json',
                     },
-                    requestBody: largeString,
+                    requestBody: 'some body that has no content length',
                 })
                 expect(cleaned).toEqual({
                     name: 'something',
                     requestHeaders: {
                         'content-type': 'application/json',
                     },
-                    requestBody: largeString,
+                    requestBody: '[SessionReplay] no content-length header for Request, cannot determine payload size',
                 })
             })
         })

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -1,5 +1,5 @@
 import { CapturedNetworkRequest, NetworkRecordOptions, PostHogConfig, Body } from '../../types'
-import { _isFunction } from '../../utils/type-utils'
+import { _isFunction, _isUndefined } from '../../utils/type-utils'
 import { convertToURL } from '../../utils/request-utils'
 import { logger } from '../../utils/logger'
 
@@ -86,12 +86,11 @@ function redactPayload(
     description: string
 ): Body {
     const requestContentLength = headers?.['content-length']
-    // in the interests of bundle size and the complexity of estimating payload size
-    // we only check the content-length header if it's present
-    // this might mean we can't always limit the payload, but that's better than
-    // having lots of code shipped to every browser that will rarely run
+    if (_isUndefined(requestContentLength)) {
+        return `[SessionReplay] no content-length header for ${description}, cannot determine payload size`
+    }
     if (requestContentLength && parseInt(requestContentLength) > limit) {
-        return `${description} body too large to record`
+        return `[SessionReplay] ${description} body too large to record`
     }
     return payload
 }


### PR DESCRIPTION
I would rather miss collecting some bodies than accidentally send un-processable payloads...

if there is no content-length header then we do not capture the body