### PR TITLE
fix: less eager timeout

### DIFF
--- a/src/loader-recorder-v2.ts
+++ b/src/loader-recorder-v2.ts
@@ -397,7 +397,7 @@ async function _tryReadBody(res: Response): Promise<string> {
     // there are now already multiple places where we're using Promise...
     // eslint-disable-next-line compat/compat
     return new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => resolve('[rrweb/network@1] Timeout while trying to read response body'), 250)
+        const timeout = setTimeout(() => resolve('[SessionReplay] Timeout while trying to read response body'), 500)
         res.clone()
             .text()
             .then(


### PR DESCRIPTION
When this was incorrectly throwing we saw this cause errors when I wouldn't have expected it to.

Let's allow more time to clone and read the body