### PR TITLE
fix: Add warning and conversion for number distinct_id

### DIFF
--- a/functional_tests/identify.test.ts
+++ b/functional_tests/identify.test.ts
@@ -28,29 +28,6 @@ test('identify sends a identify event', async () => {
     expect(jest.mocked(logger).error).toBeCalledTimes(0)
 })
 
-test('identify warns and succeed when given a number distinct_id', async () => {
-    const token = v4()
-    const posthog = await createPosthogInstance(token)
-
-    const distinctIdNum = 123
-    const distinctIdString = '123'
-
-    posthog.identify(distinctIdNum as any)
-
-    await waitFor(() =>
-        expect(getRequests(token)['/e/']).toContainEqual(
-            expect.objectContaining({
-                event: '$identify',
-                properties: expect.objectContaining({
-                    distinct_id: distinctIdString,
-                    token: posthog.config.token,
-                }),
-            })
-        )
-    )
-    expect(jest.mocked(logger).error).toBeCalledTimes(1)
-})
-
 test('identify sends an engage request if identify called twice with the same distinct id and with $set/$set_once', async () => {
     // The intention here is to reduce the number of unncecessary $identify
     // requests to process.

--- a/functional_tests/identify.test.ts
+++ b/functional_tests/identify.test.ts
@@ -3,7 +3,8 @@ import { waitFor } from '@testing-library/dom'
 import { v4 } from 'uuid'
 import { getRequests } from './mock-server'
 import { createPosthogInstance } from './posthog-instance'
-
+import { logger } from '../src/utils/logger'
+jest.mock('../src/utils/logger')
 test('identify sends a identify event', async () => {
     const token = v4()
     const posthog = await createPosthogInstance(token)
@@ -24,6 +25,30 @@ test('identify sends a identify event', async () => {
             })
         )
     )
+    expect(jest.mocked(logger).error).toBeCalledTimes(0)
+})
+
+test('identify warns and succeed when given a number distinct_id', async () => {
+    const token = v4()
+    const posthog = await createPosthogInstance(token)
+
+    const distinctIdNum = 123
+    const distinctIdString = '123'
+
+    posthog.identify(distinctIdNum as any)
+
+    await waitFor(() =>
+        expect(getRequests(token)['/e/']).toContainEqual(
+            expect.objectContaining({
+                event: '$identify',
+                properties: expect.objectContaining({
+                    distinct_id: distinctIdString,
+                    token: posthog.config.token,
+                }),
+            })
+        )
+    )
+    expect(jest.mocked(logger).error).toBeCalledTimes(1)
 })
 
 test('identify sends an engage request if identify called twice with the same distinct id and with $set/$set_once', async () => {

--- a/src/__tests__/identify.test.ts
+++ b/src/__tests__/identify.test.ts
@@ -1,0 +1,39 @@
+import { v4 } from 'uuid'
+import { createPosthogInstance } from '../../functional_tests/posthog-instance'
+import { logger } from '../utils/logger'
+jest.mock('../utils/logger')
+
+describe('identify', () => {
+    // Note that there are other tests for identify in posthog-core.identify.js
+    // These are in the old style of tests, if you are feeling helpful you could
+    // convert them to the new style in this file.
+
+    it('should persist the distinct_id', async () => {
+        // arrange
+        const token = v4()
+        const posthog = await createPosthogInstance(token)
+        const distinctId = '123'
+
+        // act
+        posthog.identify(distinctId)
+
+        // assert
+        expect(posthog.persistence!.properties()['$user_id']).toEqual(distinctId)
+        expect(jest.mocked(logger).error).toBeCalledTimes(0)
+    })
+
+    it('should convert a numeric distinct_id to a string', async () => {
+        // arrange
+        const token = v4()
+        const posthog = await createPosthogInstance(token)
+        const distinctIdNum = 123
+        const distinctIdString = '123'
+
+        // act
+        posthog.identify(distinctIdNum as any)
+
+        // assert
+        expect(posthog.persistence!.properties()['$user_id']).toEqual(distinctIdString)
+        expect(jest.mocked(logger).error).toBeCalledTimes(1)
+    })
+})

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -52,7 +52,15 @@ import { PostHogSurveys } from './posthog-surveys'
 import { RateLimiter } from './rate-limiter'
 import { uuidv7 } from './uuidv7'
 import { SurveyCallback } from './posthog-surveys-types'
-import { _isArray, _isEmptyObject, _isFunction, _isObject, _isString, _isUndefined } from './utils/type-utils'
+import {
+    _isArray,
+    _isEmptyObject,
+    _isFunction,
+    _isNumber,
+    _isObject,
+    _isString,
+    _isUndefined,
+} from './utils/type-utils'
 import { _info } from './utils/event-utils'
 import { logger } from './utils/logger'
 import { document, userAgent } from './utils/globals'
@@ -1293,6 +1301,11 @@ export class PostHog {
         if (!this.__loaded || !this.persistence) {
             return logger.uninitializedWarning('posthog.identify')
         }
+        if (_isNumber(new_distinct_id)) {
+            logger.error('The first argument to posthog.identify was a number, but it should be a string.')
+            new_distinct_id = (new_distinct_id as number).toString()
+        }
+
         //if the new_distinct_id has not been set ignore the identify event
         if (!new_distinct_id) {
             logger.error('Unique user id has not been set in posthog.identify')


### PR DESCRIPTION
## Changes
This support request https://posthoghelp.zendesk.com/agent/tickets/10072 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/14152) was from someone passing a number as a distinct_id. TypeScript would prevent this where it applies, but it doesn't apply everywhere.

* Add a conversion to string for numeric distinct_ids
* Add a warning for when this happens
* Add a test that this warning happens when a number is passed
* Add a test that this warning doesn't happen when a string is passed

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
