### PR TITLE
chore: add changelog value to release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,6 +68,14 @@ jobs:
                   REDIS_URL: 'redis://localhost'
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+            - name: Set LAST_CHANGELOG_ENTRY
+              run: |
+                # read from the first until the second header in the changelog file
+                # this assumes the formatting of the file
+                # and that this workflow is always running for the most recent entry in the file 
+                LAST_CHANGELOG_ENTRY=$(awk '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag' CHANGELOG.md)
+                echo "LAST_CHANGELOG_ENTRY=$LAST_CHANGELOG_ENTRY" >> $GITHUB_ENV
+
             - name: Create GitHub release
               uses: actions/create-release@v1
               env:
@@ -75,6 +83,7 @@ jobs:
               with:
                   tag_name: v${{ env.COMMITTED_VERSION }}
                   release_name: ${{ env.COMMITTED_VERSION }}
+                  body: ${{ env.LAST_CHANGELOG_ENTRY || 'see CHANGELOG.md' }}
 
     create-pull-request:
         name: Create main repo PR with new posthog-js version


### PR DESCRIPTION
we create the changelog in a separate workflow to creating a release

which leaves the changelog quite rich and the release quite bare

the action we use to create the release supports adding a body

so we can read the most recent entry from the changelog - with some arcane ChatGPT created awk command - and output that to release

defaulting to pointing to the changelog if that fails

## running locally this shows...

<img width="1176" alt="Screenshot 2024-02-03 at 11 49 50" src="https://github.com/PostHog/posthog-js/assets/984817/c8ef5954-4af4-4d75-b9c1-48d85112a405">

see #992 