### PR TITLE
fix: Remove `baseUrl` from TypeScript compiler options

### DIFF
--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -1,4 +1,4 @@
-import { AutocaptureConfig, Properties } from 'types'
+import { AutocaptureConfig, Properties } from './types'
 import { _each, _entries, _includes, _trim } from './utils'
 
 import { _isArray, _isNull, _isString, _isUndefined } from './utils/type-utils'

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -1,4 +1,4 @@
-import { PostHog } from 'posthog-core'
+import { PostHog } from '../posthog-core'
 import { Survey, SurveyType } from '../posthog-surveys-types'
 import { SurveysWidget } from './surveys-widget'
 

--- a/src/extensions/surveys/surveys-utils.ts
+++ b/src/extensions/surveys/surveys-utils.ts
@@ -1,4 +1,4 @@
-import { PostHog } from 'posthog-core'
+import { PostHog } from '../../posthog-core'
 import {
     BasicSurveyQuestion,
     LinkSurveyQuestion,
@@ -68,7 +68,7 @@ export const style = (id: string, appearance: SurveyAppearance | null) => {
               padding-top: 10px;
               border-radius: 6px;
               border-color: ${appearance?.borderColor || '#c9c6c6'};
-              margin-top: 14px; 
+              margin-top: 14px;
           }
           .form-submit {
               box-sizing: border-box;

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,4 +1,4 @@
-import { MinimalHTTPResponse } from 'types'
+import { MinimalHTTPResponse } from './types'
 import { logger } from './utils/logger'
 
 const oneMinuteInMilliseconds = 60 * 1000

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "baseUrl": "./src",
         "outDir": "./lib",
         "target": "ES5",
         "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
## Changes

Fixes #994

`baseUrl` is currently [set to `./src` in `tsconfig.json`](https://github.com/PostHog/posthog-js/blob/54c8a97616cfc9f5cf692cad5eec4251f11be6f3/tsconfig.json#L3), which allows absolute imports of files within the package.

In v1.104.0, this resulted in the compiled `dist/module.d.ts` file [including an import from a spurious `"types"` package](https://app.renovatebot.com/package-diff?name=posthog-js&from=1.103.2&to=1.104.0#d2h-020126) instead of bundling the imported type (possibly because the imports weren't consistent - sometimes absolute and sometimes relative, leading to them being treated as different?).

This PR removes the `baseUrl` setting and replaces the absolute imports that relied on it with relative ones.