### PR TITLE
chore: nit pick log message

### DIFF
--- a/functional_tests/identify.test.ts
+++ b/functional_tests/identify.test.ts
@@ -1,11 +1,10 @@
+import 'regenerator-runtime/runtime'
 import { waitFor } from '@testing-library/dom'
 import { v4 } from 'uuid'
 import { getRequests } from './mock-server'
 import { createPosthogInstance } from './posthog-instance'
 import { logger } from '../src/utils/logger'
-
 jest.mock('../src/utils/logger')
-
 test('identify sends a identify event', async () => {
     const token = v4()
     const posthog = await createPosthogInstance(token)
@@ -30,7 +29,7 @@ test('identify sends a identify event', async () => {
 })
 
 test('identify sends an engage request if identify called twice with the same distinct id and with $set/$set_once', async () => {
-    // The intention here is to reduce the number of unnecessary $identify
+    // The intention here is to reduce the number of unncecessary $identify
     // requests to process.
     const token = v4()
     const posthog = await createPosthogInstance(token)

--- a/functional_tests/identify.test.ts
+++ b/functional_tests/identify.test.ts
@@ -1,10 +1,11 @@
-import 'regenerator-runtime/runtime'
 import { waitFor } from '@testing-library/dom'
 import { v4 } from 'uuid'
 import { getRequests } from './mock-server'
 import { createPosthogInstance } from './posthog-instance'
 import { logger } from '../src/utils/logger'
+
 jest.mock('../src/utils/logger')
+
 test('identify sends a identify event', async () => {
     const token = v4()
     const posthog = await createPosthogInstance(token)
@@ -29,7 +30,7 @@ test('identify sends a identify event', async () => {
 })
 
 test('identify sends an engage request if identify called twice with the same distinct id and with $set/$set_once', async () => {
-    // The intention here is to reduce the number of unncecessary $identify
+    // The intention here is to reduce the number of unnecessary $identify
     // requests to process.
     const token = v4()
     const posthog = await createPosthogInstance(token)

--- a/src/__tests__/identify.test.ts
+++ b/src/__tests__/identify.test.ts
@@ -20,6 +20,7 @@ describe('identify', () => {
         // assert
         expect(posthog.persistence!.properties()['$user_id']).toEqual(distinctId)
         expect(jest.mocked(logger).error).toBeCalledTimes(0)
+        expect(jest.mocked(logger).warn).toBeCalledTimes(0)
     })
 
     it('should convert a numeric distinct_id to a string', async () => {
@@ -34,6 +35,7 @@ describe('identify', () => {
 
         // assert
         expect(posthog.persistence!.properties()['$user_id']).toEqual(distinctIdString)
-        expect(jest.mocked(logger).error).toBeCalledTimes(1)
+        expect(jest.mocked(logger).error).toBeCalledTimes(0)
+        expect(jest.mocked(logger).warn).toBeCalledTimes(1)
     })
 })

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1302,8 +1302,10 @@ export class PostHog {
             return logger.uninitializedWarning('posthog.identify')
         }
         if (_isNumber(new_distinct_id)) {
-            logger.error('The first argument to posthog.identify was a number, but it should be a string.')
             new_distinct_id = (new_distinct_id as number).toString()
+            logger.warn(
+                'The first argument to posthog.identify was a number, but it should be a string. It has been converted to a string.'
+            )
         }
 
         //if the new_distinct_id has not been set ignore the identify event


### PR DESCRIPTION
i was ill and missed a review on #993 ... rather than comment on a merged pr, i'll propose this here, which we can accept or not as if it was part of the review 😊

we log something as an error, but we also fix the thing immediately.

instead let's log it as a warning - since there's no action needed _really_ - and tell them we've fixed it

----

Fascinatingly... we don't run the functional tests locally... I haven't fixed them, and they still pass even though they're now wrong