### PR TITLE
chore: move posthog test instance helper

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -69,7 +69,7 @@ jobs:
                 node-version: '18'
                 cache: 'pnpm'
             - run: pnpm install
-            - run: pnpm jest functional_tests/
+            - run: pnpm run test:functional
 
     lint:
         name: Lint

--- a/functional_tests/feature-flags.test.ts
+++ b/functional_tests/feature-flags.test.ts
@@ -1,5 +1,5 @@
 import { v4 } from 'uuid'
-import { createPosthogInstance } from './posthog-instance'
+import { createPosthogInstance } from '../src/__tests__/helpers/posthog-instance'
 import { waitFor } from '@testing-library/dom'
 import { getRequests, resetRequests } from './mock-server'
 

--- a/functional_tests/identify.test.ts
+++ b/functional_tests/identify.test.ts
@@ -2,7 +2,7 @@ import 'regenerator-runtime/runtime'
 import { waitFor } from '@testing-library/dom'
 import { v4 } from 'uuid'
 import { getRequests } from './mock-server'
-import { createPosthogInstance } from './posthog-instance'
+import { createPosthogInstance } from '../src/__tests__/helpers/posthog-instance'
 import { logger } from '../src/utils/logger'
 jest.mock('../src/utils/logger')
 test('identify sends a identify event', async () => {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
         "lint": "eslint src",
         "prettier": "prettier --write src/ functional_tests/",
         "prepublishOnly": "pnpm lint && pnpm test && pnpm build && pnpm test:react",
-        "test": "pnpm test:unit && pnpm test:custom-eslint-rules",
+        "test": "pnpm test:unit && pnpm test:custom-eslint-rules && pnpm test:functional",
         "test:unit": "jest src",
         "test:custom-eslint-rules": "jest eslint-rules",
         "test:react": "cd react; pnpm test",
+        "test:functional": "jest functional_tests",
         "test-watch": "jest --watch src",
         "cypress": "cypress open",
         "prepare": "husky install"

--- a/src/__tests__/helpers/posthog-instance.ts
+++ b/src/__tests__/helpers/posthog-instance.ts
@@ -1,19 +1,24 @@
 // The library depends on having the module initialized before it can be used.
 
 import { v4 } from 'uuid'
-import { PostHog, init_as_module } from '../src/posthog-core'
+import { PostHog, init_as_module } from '../../posthog-core'
 import 'regenerator-runtime/runtime'
-import { PostHogConfig } from '../src/types'
+import { PostHogConfig } from '../../types'
 
 // It sets a global variable that is set and used to initialize subsequent libaries.
 beforeAll(() => init_as_module())
 
-export const createPosthogInstance = async (token: string = v4(), config: Partial<PostHogConfig> = {}) => {
+export const createPosthogInstance = async (
+    token: string = v4(),
+    config: Partial<PostHogConfig> = {}
+): Promise<PostHog> => {
     // We need to create a new instance of the library for each test, to ensure
     // that they are isolated from each other. The way the library is currently
     // written, we first create an instance, then call init on it which then
     // creates another instance.
     const posthog = new PostHog()
+
+    // eslint-disable-next-line compat/compat
     return await new Promise<PostHog>((resolve) =>
         posthog.init(
             // Use a random UUID for the token, such that we don't have to worry

--- a/src/__tests__/identify.test.ts
+++ b/src/__tests__/identify.test.ts
@@ -1,5 +1,5 @@
 import { v4 } from 'uuid'
-import { createPosthogInstance } from '../../functional_tests/posthog-instance'
+import { createPosthogInstance } from './helpers/posthog-instance'
 import { logger } from '../utils/logger'
 jest.mock('../utils/logger')
 


### PR DESCRIPTION
i've been meaning to make time to add a test instance factory so we can improve the typing of the tests

we do lots of 

```
{
/* snip */
} as unknown as PostHog
```

in test setup

it turns out we have functional tests that we don't run locally, that already have an instance factory.

It also felt wrong to import into `src/__tests__`  from `./function_tests` so this sets us up for using the factory in more tests and reverses that relationship