### PR TITLE
fix: autocapture allowlist should consider the tree

### DIFF
--- a/src/__tests__/autocapture-utils.test.ts
+++ b/src/__tests__/autocapture-utils.test.ts
@@ -218,7 +218,7 @@ describe(`Autocapture utility functions`, () => {
                     false,
                 ],
                 [
-                    'when the click target (and none of its parents) does not match the allowlist',
+                    'when the click target (or its parents) does not match the allowlist',
                     makeSingleBranchOfDomTree([
                         { tag: 'div' },
                         { tag: 'button' },

--- a/src/__tests__/autocapture-utils.test.ts
+++ b/src/__tests__/autocapture-utils.test.ts
@@ -180,100 +180,84 @@ describe(`Autocapture utility functions`, () => {
                 return finalElement
             }
 
-            it('will capture when there is no allowlist', () => {
-                const clickTarget = makeSingleBranchOfDomTree([
-                    { tag: 'div' },
-                    { tag: 'button', id: 'in-allowlist' },
-                    { tag: 'svg' },
-                ])
-                expect(shouldCaptureDomEvent(clickTarget, makeMouseEvent({}))).toBe(true)
-            })
-
-            it('will capture when there is a parent matching the allow list', () => {
-                const clickTarget = makeSingleBranchOfDomTree([
-                    { tag: 'div' },
-                    { tag: 'button', id: 'in-allowlist' },
-                    { tag: 'svg' },
-                ])
-                expect(
-                    shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), {
+            it.each([
+                [
+                    'when there is no allowlist',
+                    makeSingleBranchOfDomTree([{ tag: 'div' }, { tag: 'button', id: 'in-allowlist' }, { tag: 'svg' }]),
+                    undefined,
+                    true,
+                ],
+                [
+                    'when there is a parent matching the allow list',
+                    makeSingleBranchOfDomTree([{ tag: 'div' }, { tag: 'button', id: 'in-allowlist' }, { tag: 'svg' }]),
+                    {
                         css_selector_allowlist: ['[id]'],
-                    })
-                ).toBe(true)
-            })
-
-            it('will capture when the click target is matching in the allow list', () => {
-                const clickTarget = makeSingleBranchOfDomTree([
-                    { tag: 'div' },
-                    { tag: 'button' },
-                    { tag: 'svg', id: 'in-allowlist' },
-                ])
-                expect(
-                    shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), {
+                    },
+                    true,
+                ],
+                [
+                    'when the click target is matching in the allow list',
+                    makeSingleBranchOfDomTree([{ tag: 'div' }, { tag: 'button' }, { tag: 'svg', id: 'in-allowlist' }]),
+                    {
                         css_selector_allowlist: ['[id]'],
-                    })
-                ).toBe(true)
-            })
-
-            it('does not capture when the parent does not match the allowlist', () => {
-                const clickTarget = makeSingleBranchOfDomTree([
-                    { tag: 'div' },
-                    { tag: 'button', id: '[id=not-the-configured-value]' },
-                    { tag: 'svg' },
-                ])
-                expect(
-                    shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), {
+                    },
+                    true,
+                ],
+                [
+                    'when the parent does not match the allowlist',
+                    makeSingleBranchOfDomTree([
+                        { tag: 'div' },
+                        { tag: 'button', id: '[id=not-the-configured-value]' },
+                        { tag: 'svg' },
+                    ]),
+                    {
                         // the click was detected on the SVG, but the button is not in the allow list,
                         // so we should detect the click
                         css_selector_allowlist: ['in-allowlist'],
-                    })
-                ).toBe(false)
-            })
-
-            it('does not capture when the click target (and none of its parents) does not match the allowlist', () => {
-                const clickTarget = makeSingleBranchOfDomTree([
-                    { tag: 'div' },
-                    { tag: 'button' },
-                    { tag: 'svg', id: '[id=not-the-configured-value]' },
-                ])
-                expect(
-                    shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), {
+                    },
+                    false,
+                ],
+                [
+                    'when the click target (and none of its parents) does not match the allowlist',
+                    makeSingleBranchOfDomTree([
+                        { tag: 'div' },
+                        { tag: 'button' },
+                        { tag: 'svg', id: '[id=not-the-configured-value]' },
+                    ]),
+                    {
                         css_selector_allowlist: ['in-allowlist'],
-                    })
-                ).toBe(false)
-            })
-
-            it('can combin allow lists', () => {
-                const clickTarget = makeSingleBranchOfDomTree([
-                    { tag: 'div' },
-                    { tag: 'button', id: 'in-allowlist' },
-                    { tag: 'svg' },
-                ])
-                expect(
-                    shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), {
+                    },
+                    false,
+                ],
+                [
+                    'when combining allow lists',
+                    makeSingleBranchOfDomTree([{ tag: 'div' }, { tag: 'button', id: 'in-allowlist' }, { tag: 'svg' }]),
+                    {
                         // the tree for the click does have an id
                         css_selector_allowlist: ['[id]'],
                         // but we only detect if there is an img in the tree
                         element_allowlist: ['img'],
-                    })
-                ).toBe(false)
-            })
-
-            it('can combine allow lists - but it considers them separately', () => {
-                const clickTarget = makeSingleBranchOfDomTree([
-                    { tag: 'div' },
-                    { tag: 'button', id: 'in-allowlist' },
-                    { tag: 'img' },
-                    { tag: 'svg' },
-                ])
-                expect(
-                    shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), {
+                    },
+                    false,
+                ],
+                [
+                    'combine allow lists - but showing it considers them separately',
+                    makeSingleBranchOfDomTree([
+                        { tag: 'div' },
+                        { tag: 'button', id: 'in-allowlist' },
+                        { tag: 'img' },
+                        { tag: 'svg' },
+                    ]),
+                    {
                         // the tree for the click does have an id
                         css_selector_allowlist: ['[id]'],
                         // and the tree for the click does have an img
                         element_allowlist: ['img'],
-                    })
-                ).toBe(true)
+                    },
+                    true,
+                ],
+            ])('correctly respects the allow list: %s', (_, clickTarget, autoCaptureConfig, shouldCapture) => {
+                expect(shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), autoCaptureConfig)).toBe(shouldCapture)
             })
         })
     })

--- a/src/__tests__/autocapture-utils.test.ts
+++ b/src/__tests__/autocapture-utils.test.ts
@@ -158,6 +158,124 @@ describe(`Autocapture utility functions`, () => {
                 expect(shouldCaptureDomEvent(document!.createElement(tagName), makeMouseEvent({}))).toBe(false)
             })
         })
+
+        describe('css selector allowlist', () => {
+            function makeSingleBranchOfDomTree(tree: { tag: string; id?: string }[]): Element {
+                let finalElement: Element | null = null
+                for (const { tag, id } of tree) {
+                    const el = document!.createElement(tag)
+                    if (id) {
+                        el.id = id
+                    }
+                    if (finalElement) {
+                        finalElement.appendChild(el)
+                        finalElement = el
+                    } else {
+                        finalElement = el
+                    }
+                }
+                if (!finalElement) {
+                    throw new Error('No elements in tree')
+                }
+                return finalElement
+            }
+
+            it('will capture when there is no allowlist', () => {
+                const clickTarget = makeSingleBranchOfDomTree([
+                    { tag: 'div' },
+                    { tag: 'button', id: 'in-allowlist' },
+                    { tag: 'svg' },
+                ])
+                expect(shouldCaptureDomEvent(clickTarget, makeMouseEvent({}))).toBe(true)
+            })
+
+            it('will capture when there is a parent matching the allow list', () => {
+                const clickTarget = makeSingleBranchOfDomTree([
+                    { tag: 'div' },
+                    { tag: 'button', id: 'in-allowlist' },
+                    { tag: 'svg' },
+                ])
+                expect(
+                    shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), {
+                        css_selector_allowlist: ['[id]'],
+                    })
+                ).toBe(true)
+            })
+
+            it('will capture when the click target is matching in the allow list', () => {
+                const clickTarget = makeSingleBranchOfDomTree([
+                    { tag: 'div' },
+                    { tag: 'button' },
+                    { tag: 'svg', id: 'in-allowlist' },
+                ])
+                expect(
+                    shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), {
+                        css_selector_allowlist: ['[id]'],
+                    })
+                ).toBe(true)
+            })
+
+            it('does not capture when the parent does not match the allowlist', () => {
+                const clickTarget = makeSingleBranchOfDomTree([
+                    { tag: 'div' },
+                    { tag: 'button', id: '[id=not-the-configured-value]' },
+                    { tag: 'svg' },
+                ])
+                expect(
+                    shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), {
+                        // the click was detected on the SVG, but the button is not in the allow list,
+                        // so we should detect the click
+                        css_selector_allowlist: ['in-allowlist'],
+                    })
+                ).toBe(false)
+            })
+
+            it('does not capture when the click target (and none of its parents) does not match the allowlist', () => {
+                const clickTarget = makeSingleBranchOfDomTree([
+                    { tag: 'div' },
+                    { tag: 'button' },
+                    { tag: 'svg', id: '[id=not-the-configured-value]' },
+                ])
+                expect(
+                    shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), {
+                        css_selector_allowlist: ['in-allowlist'],
+                    })
+                ).toBe(false)
+            })
+
+            it('can combin allow lists', () => {
+                const clickTarget = makeSingleBranchOfDomTree([
+                    { tag: 'div' },
+                    { tag: 'button', id: 'in-allowlist' },
+                    { tag: 'svg' },
+                ])
+                expect(
+                    shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), {
+                        // the tree for the click does have an id
+                        css_selector_allowlist: ['[id]'],
+                        // but we only detect if there is an img in the tree
+                        element_allowlist: ['img'],
+                    })
+                ).toBe(false)
+            })
+
+            it('can combine allow lists - but it considers them separately', () => {
+                const clickTarget = makeSingleBranchOfDomTree([
+                    { tag: 'div' },
+                    { tag: 'button', id: 'in-allowlist' },
+                    { tag: 'img' },
+                    { tag: 'svg' },
+                ])
+                expect(
+                    shouldCaptureDomEvent(clickTarget, makeMouseEvent({}), {
+                        // the tree for the click does have an id
+                        css_selector_allowlist: ['[id]'],
+                        // and the tree for the click does have an img
+                        element_allowlist: ['img'],
+                    })
+                ).toBe(true)
+            })
+        })
     })
 
     describe(`isSensitiveElement`, () => {

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -141,7 +141,7 @@ function checkIfElementTreePassesElementAllowList(
  only elements that match the css selector in the allow list are allowed
  assumes that some other code is checking this element's parents
  */
-function checkIfElementIsInCSSAllowList(
+function checkIfElementTreePassesCSSSelectorAllowList(
     elements: Element[],
     autocaptureConfig: AutocaptureConfig | undefined
 ): boolean {
@@ -225,7 +225,7 @@ export function shouldCaptureDomEvent(
         return false
     }
 
-    if (!checkIfElementIsInCSSAllowList(targetElementList, autocaptureConfig)) {
+    if (!checkIfElementTreePassesCSSSelectorAllowList(targetElementList, autocaptureConfig)) {
         return false
     }
 

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -107,6 +107,62 @@ export function isDocumentFragment(el: Element | ParentNode | undefined | null):
 }
 
 export const autocaptureCompatibleElements = ['a', 'button', 'form', 'input', 'select', 'textarea', 'label']
+
+/*
+ if there is no config, then all elements are allowed
+ if there is a config, and there is an allow list, then only elements in the allow list are allowed
+ assumes that some other code is checking this element's parents
+ */
+function checkIfElementTreePassesElementAllowList(
+    elements: Element[],
+    autocaptureConfig: AutocaptureConfig | undefined
+): boolean {
+    const allowlist = autocaptureConfig?.element_allowlist
+    if (_isUndefined(allowlist)) {
+        // everything is allowed, when there is no allow list
+        return true
+    }
+
+    // check each element in the tree
+    // if any of the elements are in the allow list, then the tree is allowed
+    for (const el of elements) {
+        if (allowlist.some((elementType) => el.tagName.toLowerCase() === elementType)) {
+            return true
+        }
+    }
+
+    // otherwise there is an allow list and this element tree didn't match it
+    return false
+}
+
+/*
+ if there is no config, then all elements are allowed
+ if there is a config, and there is an allow list, then
+ only elements that match the css selector in the allow list are allowed
+ assumes that some other code is checking this element's parents
+ */
+function checkIfElementIsInCSSAllowList(
+    elements: Element[],
+    autocaptureConfig: AutocaptureConfig | undefined
+): boolean {
+    const allowlist = autocaptureConfig?.css_selector_allowlist
+    if (_isUndefined(allowlist)) {
+        // everything is allowed, when there is no allow list
+        return true
+    }
+
+    // check each element in the tree
+    // if any of the elements are in the allow list, then the tree is allowed
+    for (const el of elements) {
+        if (allowlist.some((selector) => el.matches(selector))) {
+            return true
+        }
+    }
+
+    // otherwise there is an allow list and this element tree didn't match it
+    return false
+}
+
 /*
  * Check whether a DOM event should be "captured" or if it may contain sentitive data
  * using a variety of heuristics.
@@ -139,22 +195,8 @@ export function shouldCaptureDomEvent(
         }
     }
 
-    if (autocaptureConfig?.element_allowlist) {
-        const allowlist = autocaptureConfig.element_allowlist
-        if (allowlist && !allowlist.some((elementType) => el.tagName.toLowerCase() === elementType)) {
-            return false
-        }
-    }
-
-    if (autocaptureConfig?.css_selector_allowlist) {
-        const allowlist = autocaptureConfig.css_selector_allowlist
-        if (allowlist && !allowlist.some((selector) => el.matches(selector))) {
-            return false
-        }
-    }
-
     let parentIsUsefulElement = false
-    const targetElementList: Element[] = [el] // TODO: remove this var, it's never queried
+    const targetElementList: Element[] = [el]
     let parentNode: Element | boolean = true
     let curEl: Element = el
     while (curEl.parentNode && !isTag(curEl, 'body')) {
@@ -177,6 +219,14 @@ export function shouldCaptureDomEvent(
 
         targetElementList.push(parentNode)
         curEl = parentNode
+    }
+
+    if (!checkIfElementTreePassesElementAllowList(targetElementList, autocaptureConfig)) {
+        return false
+    }
+
+    if (!checkIfElementIsInCSSAllowList(targetElementList, autocaptureConfig)) {
+        return false
     }
 
     const compStyles = window.getComputedStyle(el)

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,12 +37,20 @@ export interface AutocaptureConfig {
     /**
      * List of DOM elements to allow autocapture on
      * e.g. ['a', 'button', 'form', 'input', 'select', 'textarea', 'label']
+     * we consider the tree of elements from the root to the target element of the click event
+     * so for the tree div > div > button > svg
+     * if the allowlist has button then we allow the capture when the button or the svg is the click target
+     * but not if either of the divs are detected as the click target
      */
     element_allowlist?: AutocaptureCompatibleElement[]
 
     /**
      * List of CSS selectors to allow autocapture on
      * e.g. ['[ph-capture]']
+     * we consider the tree of elements from the root to the target element of the click event
+     * so for the tree div > div > button > svg
+     * and allow list config `['[id]']`
+     * we will capture the click if any of the four elements has any id
      */
     css_selector_allowlist?: string[]
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export interface AutocaptureConfig {
      * we consider the tree of elements from the root to the target element of the click event
      * so for the tree div > div > button > svg
      * and allow list config `['[id]']`
-     * we will capture the click if any of the four elements has any id
+     * we will capture the click if the click-target or its parents has any id
      */
     css_selector_allowlist?: string[]
 


### PR DESCRIPTION
A customer set the autocapture config to have a `css_selector_allowlist` of `['[id]']` so that only clicks on elements with IDs are captured.

However we only consider literally the click target so with the tree

```
<button id="any-value">
 <svg class="my-icon"/>
</button>
```

if the browser detected the click as coming from the svg then we wouldn't capture the event...

it makes more sense to capture the event if _any_ element in the tree matches the allow list