### PR TITLE
fix: change log update can't be written to env

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,12 +69,13 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Set LAST_CHANGELOG_ENTRY
+              id: set-last-changelog-entry
               run: |
                 # read from the first until the second header in the changelog file
                 # this assumes the formatting of the file
                 # and that this workflow is always running for the most recent entry in the file 
-                LAST_CHANGELOG_ENTRY=$(awk '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag' CHANGELOG.md)
-                echo "LAST_CHANGELOG_ENTRY=$LAST_CHANGELOG_ENTRY" >> $GITHUB_ENV
+                LAST_CHANGELOG_ENTRY=$(awk -v default='see CHANGELOG.md' '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print default}' CHANGELOG.md)
+                echo "LAST_CHANGELOG_ENTRY=$LAST_CHANGELOG_ENTRY" >> "$GITHUB_OUTPUT"
 
             - name: Create GitHub release
               uses: actions/create-release@v1
@@ -83,7 +84,7 @@ jobs:
               with:
                   tag_name: v${{ env.COMMITTED_VERSION }}
                   release_name: ${{ env.COMMITTED_VERSION }}
-                  body: ${{ env.LAST_CHANGELOG_ENTRY || 'see CHANGELOG.md' }}
+                  body: ${{ steps.set-last-changelog-entry.outputs.LAST_CHANGELOG_ENTRY }}
 
     create-pull-request:
         name: Create main repo PR with new posthog-js version


### PR DESCRIPTION
to update the changelog we were reading from the changelog file into the environment but that value had characters bash considered special characters and wasn't escaped... let's use step output instead to pass the value

see failing action here https://github.com/PostHog/posthog-js/actions/runs/7814213308/job/21314998992

<img width="861" alt="Screenshot 2024-02-07 at 11 44 39" src="https://github.com/PostHog/posthog-js/assets/984817/1c224d3d-826c-4625-a736-0060c1a2fde6">
