### PR TITLE
fix: mac and github actions don't agree on usable awk variables

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,7 +74,7 @@ jobs:
                 # read from the first until the second header in the changelog file
                 # this assumes the formatting of the file
                 # and that this workflow is always running for the most recent entry in the file 
-                LAST_CHANGELOG_ENTRY=$(awk -v default='see CHANGELOG.md' '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print default}' CHANGELOG.md)
+                awk -v defText='see CHANGELOG.md' '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md
                 echo "LAST_CHANGELOG_ENTRY=$LAST_CHANGELOG_ENTRY" >> "$GITHUB_OUTPUT"
 
             - name: Create GitHub release


### PR DESCRIPTION
follow up to: #1002 

mac and GH Actions disagree on what variables are safe to use with AWK.

Fun!

going to YOLO this since it's a CI only change to a workflow that doesn't run right now :/