### PR TITLE
chore: really really write changelog to release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,23 +68,31 @@ jobs:
                   REDIS_URL: 'redis://localhost'
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-            - name: Set LAST_CHANGELOG_ENTRY
-              id: set-last-changelog-entry
+            - name: Create GitHub release
+              env:
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                 # read from the first until the second header in the changelog file
                 # this assumes the formatting of the file
                 # and that this workflow is always running for the most recent entry in the file 
-                awk -v defText='see CHANGELOG.md' '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md
-                echo "LAST_CHANGELOG_ENTRY=$LAST_CHANGELOG_ENTRY" >> "$GITHUB_OUTPUT"
-
-            - name: Create GitHub release
-              uses: actions/create-release@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  tag_name: v${{ env.COMMITTED_VERSION }}
-                  release_name: ${{ env.COMMITTED_VERSION }}
-                  body: ${{ steps.set-last-changelog-entry.outputs.LAST_CHANGELOG_ENTRY }}
+                LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
+                # the action we used to use was archived, and made it really difficult to create a release with a body
+                # because the LAST_CHANGELOG_ENTRY contains bash special characters so passing it between steps
+                # was a pain.
+                # we can use the github cli to create a release with a body
+                # all as part of one step
+                gh api \
+                  --method POST \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  /repos/posthog/posthog-js/releases \
+                  -f tag_name="${{ env.COMMITTED_VERSION }}" \
+                -f target_commitish='main' \
+                -f name="${{ env.COMMITTED_VERSION }}" \
+                -f body="$LAST_CHANGELOG_ENTRY" \
+                -F draft=false \
+                -F prerelease=false \
+                -F generate_release_notes=false 
 
     create-pull-request:
         name: Create main repo PR with new posthog-js version


### PR DESCRIPTION
Writing the last changelog section to the release turned out to be tricky

* [The action we use is archived](https://github.com/actions/create-release)
* The value we want to write contains bash special characters
* GitHub Actions was very allergic to passing those special characters between steps in a way the action could use

But the GH CLI is pretty cool, so we can create a release using that in the same step that reads the changelog value.

you can see that working in a fork e.g. here https://github.com/pauldambra/posthog-js-fork-for-changelog-cd/releases/tag/v1.0.055as5 from https://github.com/pauldambra/posthog-js-fork-for-changelog-cd/blob/0c8250caaab776124ae5aeee107449e021ec78ac/.github/workflows/cd.yml