### PR TITLE
fix: for want of a v the war was lost

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,7 +86,7 @@ jobs:
                   -H "Accept: application/vnd.github+json" \
                   -H "X-GitHub-Api-Version: 2022-11-28" \
                   /repos/posthog/posthog-js/releases \
-                  -f tag_name="${{ env.COMMITTED_VERSION }}" \
+                  -f tag_name="v${{ env.COMMITTED_VERSION }}" \
                 -f target_commitish='main' \
                 -f name="${{ env.COMMITTED_VERSION }}" \
                 -f body="$LAST_CHANGELOG_ENTRY" \


### PR DESCRIPTION
I updated the release mechanism for #992 

I missed a `v` from the tag which mean the first page of `tags` in the GitHub API didn't include that tag which broke the version checker banner in replay 🤯 

(see https://github.com/PostHog/posthog/pull/20263)