### PR TITLE
feat: Simplify to just -api and -assets

### DIFF
--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -15,16 +15,16 @@ describe('request-router', () => {
         // US domain
         ['https://app.posthog.com', 'ui', 'https://app.posthog.com'],
         ['https://app.posthog.com', 'assets', 'https://us-assets.i.posthog.com'],
-        ['https://app.posthog.com', 'api', 'https://us-api.i.posthog.com'],
+        ['https://app.posthog.com', 'api', 'https://us.i.posthog.com'],
         // US domain via app domain
         ['https://us.posthog.com', 'ui', 'https://us.posthog.com'],
         ['https://us.posthog.com', 'assets', 'https://us-assets.i.posthog.com'],
-        ['https://us.posthog.com', 'api', 'https://us-api.i.posthog.com'],
+        ['https://us.posthog.com', 'api', 'https://us.i.posthog.com'],
 
         // EU domain
         ['https://eu.posthog.com', 'ui', 'https://eu.posthog.com'],
         ['https://eu.posthog.com', 'assets', 'https://eu-assets.i.posthog.com'],
-        ['https://eu.posthog.com', 'api', 'https://eu-api.i.posthog.com'],
+        ['https://eu.posthog.com', 'api', 'https://eu.i.posthog.com'],
 
         // custom domain
         ['https://my-custom-domain.com', 'ui', 'https://my-custom-domain.com'],
@@ -41,7 +41,7 @@ describe('request-router', () => {
 
     it('should sanitize the api_host values', () => {
         expect(router('https://app.posthog.com/').endpointFor('api', '/decide?v=3')).toEqual(
-            'https://us-api.i.posthog.com/decide?v=3'
+            'https://us.i.posthog.com/decide?v=3'
         )
 
         expect(router('https://example.com/').endpointFor('api', '/decide?v=3')).toEqual(
@@ -59,9 +59,9 @@ describe('request-router', () => {
         const mockPostHog = { config: { api_host: 'https://app.posthog.com', __preview_ingestion_endpoints: true } }
 
         const router = new RequestRouter(mockPostHog as any)
-        expect(router.endpointFor('api')).toEqual('https://us-api.i.posthog.com')
+        expect(router.endpointFor('api')).toEqual('https://us.i.posthog.com')
 
         mockPostHog.config.api_host = 'https://eu.posthog.com'
-        expect(router.endpointFor('api')).toEqual('https://eu-api.i.posthog.com')
+        expect(router.endpointFor('api')).toEqual('https://eu.i.posthog.com')
     })
 })

--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -14,32 +14,20 @@ describe('request-router', () => {
     const testCases: [string, RequestRouterTarget, string][] = [
         // US domain
         ['https://app.posthog.com', 'ui', 'https://app.posthog.com'],
-        ['https://app.posthog.com', 'capture_events', 'https://us-c.i.posthog.com'],
-        ['https://app.posthog.com', 'capture_recordings', 'https://us-s.i.posthog.com'],
-        ['https://app.posthog.com', 'decide', 'https://us-d.i.posthog.com'],
         ['https://app.posthog.com', 'assets', 'https://us-assets.i.posthog.com'],
         ['https://app.posthog.com', 'api', 'https://us-api.i.posthog.com'],
         // US domain via app domain
         ['https://us.posthog.com', 'ui', 'https://us.posthog.com'],
-        ['https://us.posthog.com', 'capture_events', 'https://us-c.i.posthog.com'],
-        ['https://us.posthog.com', 'capture_recordings', 'https://us-s.i.posthog.com'],
-        ['https://us.posthog.com', 'decide', 'https://us-d.i.posthog.com'],
         ['https://us.posthog.com', 'assets', 'https://us-assets.i.posthog.com'],
         ['https://us.posthog.com', 'api', 'https://us-api.i.posthog.com'],
 
         // EU domain
         ['https://eu.posthog.com', 'ui', 'https://eu.posthog.com'],
-        ['https://eu.posthog.com', 'capture_events', 'https://eu-c.i.posthog.com'],
-        ['https://eu.posthog.com', 'capture_recordings', 'https://eu-s.i.posthog.com'],
-        ['https://eu.posthog.com', 'decide', 'https://eu-d.i.posthog.com'],
         ['https://eu.posthog.com', 'assets', 'https://eu-assets.i.posthog.com'],
         ['https://eu.posthog.com', 'api', 'https://eu-api.i.posthog.com'],
 
         // custom domain
         ['https://my-custom-domain.com', 'ui', 'https://my-custom-domain.com'],
-        ['https://my-custom-domain.com', 'capture_events', 'https://my-custom-domain.com'],
-        ['https://my-custom-domain.com', 'capture_recordings', 'https://my-custom-domain.com'],
-        ['https://my-custom-domain.com', 'decide', 'https://my-custom-domain.com'],
         ['https://my-custom-domain.com', 'assets', 'https://my-custom-domain.com'],
         ['https://my-custom-domain.com', 'api', 'https://my-custom-domain.com'],
     ]
@@ -52,11 +40,11 @@ describe('request-router', () => {
     )
 
     it('should sanitize the api_host values', () => {
-        expect(router('https://app.posthog.com/').endpointFor('decide', '/decide?v=3')).toEqual(
-            'https://us-d.i.posthog.com/decide?v=3'
+        expect(router('https://app.posthog.com/').endpointFor('api', '/decide?v=3')).toEqual(
+            'https://us-api.i.posthog.com/decide?v=3'
         )
 
-        expect(router('https://example.com/').endpointFor('decide', '/decide?v=3')).toEqual(
+        expect(router('https://example.com/').endpointFor('api', '/decide?v=3')).toEqual(
             'https://example.com/decide?v=3'
         )
     })
@@ -71,9 +59,9 @@ describe('request-router', () => {
         const mockPostHog = { config: { api_host: 'https://app.posthog.com', __preview_ingestion_endpoints: true } }
 
         const router = new RequestRouter(mockPostHog as any)
-        expect(router.endpointFor('capture_events')).toEqual('https://us-c.i.posthog.com')
+        expect(router.endpointFor('api')).toEqual('https://us-api.i.posthog.com')
 
         mockPostHog.config.api_host = 'https://eu.posthog.com'
-        expect(router.endpointFor('capture_events')).toEqual('https://eu-c.i.posthog.com')
+        expect(router.endpointFor('api')).toEqual('https://eu-c.i.posthog.com')
     })
 })

--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -62,6 +62,6 @@ describe('request-router', () => {
         expect(router.endpointFor('api')).toEqual('https://us-api.i.posthog.com')
 
         mockPostHog.config.api_host = 'https://eu.posthog.com'
-        expect(router.endpointFor('api')).toEqual('https://eu-c.i.posthog.com')
+        expect(router.endpointFor('api')).toEqual('https://eu-api.i.posthog.com')
     })
 })

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -35,7 +35,7 @@ export class Decide {
 
         const encoded_data = _base64Encode(json_data)
         this.instance._send_request(
-            this.instance.requestRouter.endpointFor('decide', '/decide/?v=3'),
+            this.instance.requestRouter.endpointFor('api', '/decide/?v=3'),
             { data: encoded_data, verbose: true },
             { method: 'POST' },
             (response) => this.parseDecideResponse(response as DecideResponse)

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -845,7 +845,7 @@ export class SessionRecording {
         // :TRICKY: Make sure we batch these requests, use a custom endpoint and don't truncate the strings.
         this.instance.capture('$snapshot', properties, {
             method: 'POST',
-            _url: this.instance.requestRouter.endpointFor('capture_recordings', this._endpoint),
+            _url: this.instance.requestRouter.endpointFor('api', this._endpoint),
             _noTruncate: true,
             _batchKey: SESSION_RECORDING_BATCH_KEY,
             _metrics: {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -927,7 +927,7 @@ export class PostHog {
         logger.info('send', data)
         const jsonData = JSON.stringify(data)
 
-        const url = options._url ?? this.requestRouter.endpointFor('capture_events', this.analyticsDefaultEndpoint)
+        const url = options._url ?? this.requestRouter.endpointFor('api', this.analyticsDefaultEndpoint)
 
         const has_unique_traits = options !== __NOOPTIONS
 

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -190,7 +190,7 @@ export class PostHogFeatureFlags {
 
         const encoded_data = _base64Encode(json_data)
         this.instance._send_request(
-            this.instance.requestRouter.endpointFor('decide', '/decide/?v=3'),
+            this.instance.requestRouter.endpointFor('api', '/decide/?v=3'),
             { data: encoded_data },
             { method: 'POST' },
             this.instance._prepare_callback((response) => {

--- a/src/utils/request-router.ts
+++ b/src/utils/request-router.ts
@@ -12,7 +12,7 @@ export enum RequestRouterRegion {
     CUSTOM = 'custom',
 }
 
-export type RequestRouterTarget = 'ui' | 'capture_events' | 'capture_recordings' | 'decide' | 'assets' | 'api'
+export type RequestRouterTarget = 'api' | 'ui' | 'assets'
 
 export class RequestRouter {
     instance: PostHog
@@ -56,12 +56,6 @@ export class RequestRouter {
         const suffix = 'i.posthog.com' + path
 
         switch (target) {
-            case 'capture_events':
-                return `https://${this.region}-c.${suffix}`
-            case 'capture_recordings':
-                return `https://${this.region}-s.${suffix}`
-            case 'decide':
-                return `https://${this.region}-d.${suffix}`
             case 'assets':
                 return `https://${this.region}-assets.${suffix}`
             case 'api':

--- a/src/utils/request-router.ts
+++ b/src/utils/request-router.ts
@@ -59,7 +59,7 @@ export class RequestRouter {
             case 'assets':
                 return `https://${this.region}-assets.${suffix}`
             case 'api':
-                return `https://${this.region}-api.${suffix}`
+                return `https://${this.region}.${suffix}`
         }
     }
 }


### PR DESCRIPTION
## Changes

Simplifies request router to just use `-api` or `-assets` 

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
