### PR TITLE
fix: empty token should be invalid

### DIFF
--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -45,6 +45,9 @@ describe('request-router', () => {
         ['https://app.posthog.com', 'https://us.i.posthog.com/'],
         // accepts the empty string
         ['', '/'],
+        // ignores whitespace string
+        ['     ', '/'],
+        ['  https://app.posthog.com       ', 'https://us.i.posthog.com/'],
         ['https://example.com/', 'https://example.com/'],
     ])('should sanitize the api_host values for "%s"', (apiHost, expected) => {
         expect(router(apiHost).endpointFor('api', '/decide?v=3')).toEqual(`${expected}decide?v=3`)

--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -39,14 +39,15 @@ describe('request-router', () => {
         }
     )
 
-    it('should sanitize the api_host values', () => {
-        expect(router('https://app.posthog.com/').endpointFor('api', '/decide?v=3')).toEqual(
-            'https://us.i.posthog.com/decide?v=3'
-        )
-
-        expect(router('https://example.com/').endpointFor('api', '/decide?v=3')).toEqual(
-            'https://example.com/decide?v=3'
-        )
+    it.each([
+        ['https://app.posthog.com/', 'https://us.i.posthog.com/'],
+        // adds trailing slash
+        ['https://app.posthog.com', 'https://us.i.posthog.com/'],
+        // accepts the empty string
+        ['', '/'],
+        ['https://example.com/', 'https://example.com/'],
+    ])('should sanitize the api_host values for "%s"', (apiHost, expected) => {
+        expect(router(apiHost).endpointFor('api', '/decide?v=3')).toEqual(`${expected}decide?v=3`)
     })
 
     it('should use the ui_host if provided', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -56,6 +56,7 @@ import { SurveyCallback } from './posthog-surveys-types'
 import {
     _isArray,
     _isEmptyObject,
+    _isEmptyString,
     _isFunction,
     _isNumber,
     _isObject,
@@ -379,6 +380,12 @@ export class PostHog {
             logger.critical('You must name your new library: init(token, config, name)')
             return
         }
+
+        if (_isUndefined(token) || _isEmptyString(token)) {
+            logger.critical('You must provide a token to initialize posthog')
+            return
+        }
+
         if (name === PRIMARY_INSTANCE_NAME) {
             logger.critical(
                 'You must initialize the main posthog object right after you include the PostHog js snippet'

--- a/src/utils/request-router.ts
+++ b/src/utils/request-router.ts
@@ -22,7 +22,7 @@ export class RequestRouter {
     }
 
     get apiHost(): string {
-        return this.instance.config.api_host.replace(/\/$/, '')
+        return this.instance.config.api_host.trim().replace(/\/$/, '')
     }
     get uiHost(): string | undefined {
         return this.instance.config.ui_host?.replace(/\/$/, '')

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -38,9 +38,14 @@ export const _isEmptyObject = function (x: unknown): x is Record<string, any> {
 export const _isUndefined = function (x: unknown): x is undefined {
     return x === void 0
 }
+
 export const _isString = function (x: unknown): x is string {
     // eslint-disable-next-line posthog-js/no-direct-string-check
     return toString.call(x) == '[object String]'
+}
+
+export const _isEmptyString = function (x: unknown): boolean {
+    return _isString(x) && x.trim().length === 0
 }
 
 export const _isNull = function (x: unknown): x is null {


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/9991 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/12757)

a user was unintentionally initializing posthog with the empty string as a token, and the empty string as an api_host

we silently did nothing

let's warn the user and bail on setup when the token is the empty string