### PR TITLE
fix: protect against parent is not element

### DIFF
--- a/src/__tests__/autocapture-utils.test.ts
+++ b/src/__tests__/autocapture-utils.test.ts
@@ -116,21 +116,17 @@ describe(`Autocapture utility functions`, () => {
                 } as unknown as Event)
             ).toBe(true)
         })
-        ;[`input`, `SELECT`, `textarea`].forEach((tagName) => {
-            it(`should capture "change" events on <` + tagName.toLowerCase() + `> elements`, () => {
-                expect(
-                    shouldCaptureDomEvent(document!.createElement(tagName), {
-                        type: `change`,
-                    } as unknown as Event)
-                ).toBe(true)
-            })
+
+        it.each([`input`, `SELECT`, `textarea`])(`should capture "change" events on <%s> elements`, (tagName) => {
+            expect(
+                shouldCaptureDomEvent(document!.createElement(tagName), {
+                    type: `change`,
+                } as unknown as Event)
+            ).toBe(true)
         })
 
-        // [`div`, `sPan`, `A`, `strong`, `table`]
-        ;['a'].forEach((tagName) => {
-            it(`should capture "click" events on <` + tagName.toLowerCase() + `> elements`, () => {
-                expect(shouldCaptureDomEvent(document!.createElement(tagName), makeMouseEvent({}))).toBe(true)
-            })
+        it.each([`A`, `a`])(`should capture "click" events on <%s> elements`, (tagName) => {
+            expect(shouldCaptureDomEvent(document!.createElement(tagName), makeMouseEvent({}))).toBe(true)
         })
 
         it(`should capture "click" events on <button> elements`, () => {
@@ -153,10 +149,9 @@ describe(`Autocapture utility functions`, () => {
         it(`should NOT capture "click" events on <form> elements`, () => {
             expect(shouldCaptureDomEvent(document!.createElement(`form`), makeMouseEvent({}))).toBe(false)
         })
-        ;[`html`, 'body'].forEach((tagName) => {
-            it(`should NOT capture "click" events on <` + tagName.toLowerCase() + `> elements`, () => {
-                expect(shouldCaptureDomEvent(document!.createElement(tagName), makeMouseEvent({}))).toBe(false)
-            })
+
+        it.each([`html`, 'body'])(`should NOT capture "click" events on <%s> elements`, (tagName) => {
+            expect(shouldCaptureDomEvent(document!.createElement(tagName), makeMouseEvent({}))).toBe(false)
         })
 
         describe('css selector allowlist', () => {

--- a/src/__tests__/autocapture-utils.test.ts
+++ b/src/__tests__/autocapture-utils.test.ts
@@ -153,7 +153,7 @@ describe(`Autocapture utility functions`, () => {
         it(`should NOT capture "click" events on <form> elements`, () => {
             expect(shouldCaptureDomEvent(document!.createElement(`form`), makeMouseEvent({}))).toBe(false)
         })
-        ;[`html`].forEach((tagName) => {
+        ;[`html`, 'body'].forEach((tagName) => {
             it(`should NOT capture "click" events on <` + tagName.toLowerCase() + `> elements`, () => {
                 expect(shouldCaptureDomEvent(document!.createElement(tagName), makeMouseEvent({}))).toBe(false)
             })

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -70,7 +70,7 @@ export function getSafeText(el: Element): string {
  * @param {Element} el - element to check
  * @returns {boolean} whether el is of the correct nodeType
  */
-export function isElementNode(el: Element | undefined | null): el is HTMLElement {
+export function isElementNode(el: Node | Element | undefined | null): el is HTMLElement {
     return !!el && el.nodeType === 1 // Node.ELEMENT_NODE - use integer constant for browser portability
 }
 
@@ -163,6 +163,12 @@ function checkIfElementTreePassesCSSSelectorAllowList(
     return false
 }
 
+function getParentElement(curEl: Element): Element | false {
+    const parentNode = curEl.parentNode
+    if (!parentNode || !isElementNode(parentNode)) return false
+    return parentNode as Element
+}
+
 /*
  * Check whether a DOM event should be "captured" or if it may contain sentitive data
  * using a variety of heuristics.
@@ -206,7 +212,7 @@ export function shouldCaptureDomEvent(
             curEl = (curEl.parentNode as any).host
             continue
         }
-        parentNode = (curEl.parentNode as Element) || false
+        parentNode = getParentElement(curEl)
         if (!parentNode) break
         if (autocaptureCompatibleElements.indexOf(parentNode.tagName.toLowerCase()) > -1) {
             parentIsUsefulElement = true

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -70,7 +70,7 @@ export function getSafeText(el: Element): string {
  * @param {Element} el - element to check
  * @returns {boolean} whether el is of the correct nodeType
  */
-export function isElementNode(el: Node | Element | undefined | null): el is HTMLElement {
+export function isElementNode(el: Node | Element | undefined | null): el is Element {
     return !!el && el.nodeType === 1 // Node.ELEMENT_NODE - use integer constant for browser portability
 }
 

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -166,7 +166,7 @@ function checkIfElementTreePassesCSSSelectorAllowList(
 function getParentElement(curEl: Element): Element | false {
     const parentNode = curEl.parentNode
     if (!parentNode || !isElementNode(parentNode)) return false
-    return parentNode as Element
+    return parentNode
 }
 
 /*


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/10064 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15352)

The user reported that we managed to get to a point where the element being considered wasn't the body and it's parent was document.

In that scenario autocapture couldn't check if it should capture the click

This is partly because we cast the parent as an `Element` without checking it really is one.

Let's check that