### PR TITLE
fix(surveys): survey popover improvements

### DIFF
--- a/cypress/e2e/surveys.cy.ts
+++ b/cypress/e2e/surveys.cy.ts
@@ -154,6 +154,28 @@ describe('Surveys', () => {
             onPageLoad()
             cy.get('.PostHogSurvey123').should('not.exist')
         })
+
+        it('does not allow user to submit non optional survey questions if they have not responded to it', () => {
+            cy.intercept('GET', '**/surveys/*', {
+                surveys: [
+                    {
+                        id: '123',
+                        name: 'Test survey',
+                        description: 'description',
+                        type: 'popover',
+                        start_date: '2021-01-01T00:00:00Z',
+                        questions: [{ ...openTextQuestion, optional: false }],
+                        appearance: { submitButtonColor: 'pink' },
+                    },
+                ],
+            }).as('surveys')
+            cy.visit('./playground/cypress')
+            onPageLoad()
+            cy.get('.PostHogSurvey123').shadow().find('.survey-form').should('be.visible')
+            cy.get('.PostHogSurvey123').shadow().find('.form-submit').click()
+            cy.get('.PostHogSurvey123').shadow().find('.form-submit').should('be.disabled')
+            cy.get('.PostHogSurvey123').shadow().find('.survey-form').should('be.visible')
+        })
     })
 
     describe('Survey question types', () => {

--- a/cypress/e2e/surveys.cy.ts
+++ b/cypress/e2e/surveys.cy.ts
@@ -172,9 +172,9 @@ describe('Surveys', () => {
             cy.visit('./playground/cypress')
             onPageLoad()
             cy.get('.PostHogSurvey123').shadow().find('.survey-form').should('be.visible')
-            cy.get('.PostHogSurvey123').shadow().find('.form-submit').click()
             cy.get('.PostHogSurvey123').shadow().find('.form-submit').should('be.disabled')
-            cy.get('.PostHogSurvey123').shadow().find('.survey-form').should('be.visible')
+            cy.get('.PostHogSurvey123').shadow().find('textarea').type('This is great!')
+            cy.get('.PostHogSurvey123').shadow().find('.form-submit').should('not.be.disabled')
         })
     })
 

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -33,7 +33,7 @@ export const style = (appearance: SurveyAppearance | null) => {
           }
           .form-submit[disabled] {
               opacity: 0.6;
-              filter: grayscale(100%);
+              filter: grayscale(50%);
               cursor: not-allowed;
           }
           .survey-form {

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -24,7 +24,7 @@ export const style = (appearance: SurveyAppearance | null) => {
               font-weight: normal;
               font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
               text-align: left;
-              max-width: ${parseInt(appearance?.maxWidth || '290')}px;
+              max-width: ${parseInt(appearance?.maxWidth || '300')}px;
               z-index: ${parseInt(appearance?.zIndex || '99999')};
               border: 1.5px solid ${appearance?.borderColor || '#c9c6c6'};
               border-bottom: 0px;
@@ -141,7 +141,8 @@ export const style = (appearance: SurveyAppearance | null) => {
           }
           .ratings-number {
               background-color: ${appearance?.ratingButtonColor || 'white'};
-              font-size: 14px;
+              font-size: 16px;
+              font-weight: 600;
               padding: 8px 0px;
               border: none;
           }
@@ -278,7 +279,7 @@ export const style = (appearance: SurveyAppearance | null) => {
               background: ${appearance?.backgroundColor || '#eeeded'};
               border: 1.5px solid ${appearance?.borderColor || '#c9c6c6'};
               text-align: center;
-              max-width: ${parseInt(appearance?.maxWidth || '290')}px;
+              max-width: ${parseInt(appearance?.maxWidth || '300')}px;
               min-width: 150px;
               width: 100%;
               ${positions[appearance?.position || 'right'] || 'right: 30px;'}


### PR DESCRIPTION
## Changes

Quick updates to improve accessibility with increased font sizes and more subtle grayscale button 

addresses a majority of https://github.com/PostHog/posthog/issues/20346

before:
<img width="369" alt="Screenshot 2024-02-17 at 2 49 07 PM" src="https://github.com/PostHog/posthog-js/assets/25164963/58474c5b-82d7-4dd5-a85f-4a6a1ee8838f">

after:
<img width="398" alt="Screenshot 2024-02-17 at 2 48 21 PM" src="https://github.com/PostHog/posthog-js/assets/25164963/4d9e2141-2dc4-4392-abf2-e1f936ff7118">


## Checklist
- [x ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
