### PR TITLE
fix(surveys): Render feedback preview

### DIFF
--- a/cypress/e2e/surveys.cy.ts
+++ b/cypress/e2e/surveys.cy.ts
@@ -514,6 +514,31 @@ describe('Surveys', () => {
             cy.phCaptures().should('include', 'survey shown')
             cy.phCaptures().should('include', 'survey sent')
         })
+
+        it('auto contrasts text color for feedback tab', () => {
+            cy.intercept('GET', '**/surveys/*', {
+                surveys: [
+                    {
+                        id: '123',
+                        name: 'Feedback tab survey',
+                        type: 'widget',
+                        start_date: '2021-01-01T00:00:00Z',
+                        questions: [openTextQuestion],
+                        appearance: {
+                            widgetLabel: 'Feedback',
+                            widgetType: 'tab',
+                            widgetColor: 'white',
+                        },
+                    },
+                ],
+            }).as('surveys')
+            const black = 'rgb(0, 0, 0)'
+            const white = 'rgb(255, 255, 255)'
+            cy.visit('./playground/cypress')
+            onPageLoad()
+            cy.get('.PostHogWidget123').shadow().find('.ph-survey-widget-tab').should('have.css', 'background-color', white)
+            cy.get('.PostHogWidget123').shadow().find('.ph-survey-widget-tab').should('have.css', 'color', black)
+        })
     })
 
     describe('Thank you message', () => {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -58,8 +58,14 @@ export default [
                     preact: 'preact',
                 },
             },
+        ],
+        plugins: [...plugins],
+    },
+    {
+        input: 'src/loader-surveys-preview.ts',
+        output: [
             {
-                file: 'dist/surveys.esm.js',
+                file: 'dist/surveys-module-previews.js',
                 format: 'es',
                 sourcemap: true,
             },

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -1,5 +1,5 @@
 import 'regenerator-runtime/runtime'
-import { generateSurveys, renderSurveysPreview } from '../../extensions/surveys'
+import { generateSurveys, renderSurveysPreview, renderFeedbackWidgetPreview } from '../../extensions/surveys'
 import { createShadow } from '../../extensions/surveys/surveys-utils'
 import { Survey, SurveyQuestionType, SurveyType } from '../../posthog-surveys-types'
 
@@ -57,7 +57,7 @@ describe('survey display logic', () => {
     })
 })
 
-describe('survey render preview', () => {
+describe('preview renders', () => {
     test('renderSurveysPreview', () => {
         const mockSurvey = {
             id: 'testSurvey1',
@@ -88,5 +88,31 @@ describe('survey render preview', () => {
         expect(surveyDiv.getElementsByTagName('style').length).toBe(1)
         expect(surveyDiv.getElementsByClassName('survey-form').length).toBe(1)
         expect(surveyDiv.getElementsByClassName('survey-question').length).toBe(1)
+    })
+
+    test('renderFeedbackWidgetPreview', () => {
+        const mockSurvey = {
+            id: 'testSurvey1',
+            name: 'Test survey 1',
+            type: SurveyType.Widget,
+            appearance: {},
+            start_date: '2021-01-01T00:00:00.000Z',
+            description: 'This is a survey description',
+            linked_flag_key: null,
+            questions: [
+                {
+                    question: 'What would you like to see next?',
+                    type: SurveyQuestionType.Open,
+                },
+            ],
+            conditions: { widgetLabel: 'preview test', widgetColor: 'black' },
+            end_date: null,
+            targeting_flag_key: null,
+        }
+        const surveyDiv = document.createElement('div')
+        expect(surveyDiv.innerHTML).toBe('')
+        renderFeedbackWidgetPreview(mockSurvey as Survey, surveyDiv)
+        expect(surveyDiv.getElementsByTagName('style').length).toBe(1)
+        expect(surveyDiv.getElementsByClassName('ph-survey-widget-tab').length).toBe(1)
     })
 })

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -58,6 +58,13 @@ describe('survey display logic', () => {
 })
 
 describe('preview renders', () => {
+    beforeEach(() => {
+        // we have to manually reset the DOM before each test
+        document.getElementsByTagName('html')[0].innerHTML = ''
+        localStorage.clear()
+        jest.clearAllMocks()
+    })
+
     test('renderSurveysPreview', () => {
         const mockSurvey = {
             id: 'testSurvey1',
@@ -95,7 +102,7 @@ describe('preview renders', () => {
             id: 'testSurvey1',
             name: 'Test survey 1',
             type: SurveyType.Widget,
-            appearance: {},
+            appearance: { widgetLabel: 'preview test', widgetColor: 'black', widgetType: 'tab' },
             start_date: '2021-01-01T00:00:00.000Z',
             description: 'This is a survey description',
             linked_flag_key: null,
@@ -105,14 +112,14 @@ describe('preview renders', () => {
                     type: SurveyQuestionType.Open,
                 },
             ],
-            conditions: { widgetLabel: 'preview test', widgetColor: 'black' },
             end_date: null,
             targeting_flag_key: null,
         }
-        const surveyDiv = document.createElement('div')
-        expect(surveyDiv.innerHTML).toBe('')
-        renderFeedbackWidgetPreview(mockSurvey as Survey, surveyDiv)
-        expect(surveyDiv.getElementsByTagName('style').length).toBe(1)
-        expect(surveyDiv.getElementsByClassName('ph-survey-widget-tab').length).toBe(1)
+        const root = document.createElement('div')
+        expect(root.innerHTML).toBe('')
+        renderFeedbackWidgetPreview(mockSurvey as Survey, root)
+        expect(root.getElementsByTagName('style').length).toBe(1)
+        expect(root.getElementsByClassName('ph-survey-widget-tab').length).toBe(1)
+        expect(root.getElementsByClassName('ph-survey-widget-tab')[0].innerHTML).toContain('preview test')
     })
 })

--- a/src/extensions/surveys-widget.ts
+++ b/src/extensions/surveys-widget.ts
@@ -8,12 +8,19 @@ export function createWidgetShadow(survey: Survey) {
     const div = document.createElement('div')
     div.className = `PostHogWidget${survey.id}`
     const shadow = div.attachShadow({ mode: 'open' })
-    const widgetStyleSheet = `
+    const widgetStyleSheet = createWidgetStyle(survey.appearance?.widgetColor)
+    shadow.append(Object.assign(document.createElement('style'), { innerText: widgetStyleSheet }))
+    document.body.appendChild(div)
+    return shadow
+}
+
+export function createWidgetStyle(widgetColor?: string) {
+    return `
         .ph-survey-widget-tab {
             position: fixed;
             top: 50%;
             right: 0;
-            background: ${survey.appearance?.widgetColor || '#e0a045'};
+            background: ${widgetColor || '#e0a045'};
             color: white;
             transform: rotate(-90deg) translate(0, -100%);
             transform-origin: right top;
@@ -32,7 +39,4 @@ export function createWidgetShadow(survey: Survey) {
             position: fixed;
         }
     `
-    shadow.append(Object.assign(document.createElement('style'), { innerText: widgetStyleSheet }))
-    document.body.appendChild(div)
-    return shadow
 }

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -41,7 +41,7 @@ const handleWidget = (posthog: PostHog, survey: Survey) => {
     const shadow = createWidgetShadow(survey)
     const surveyStyleSheet = style(survey.appearance)
     shadow.appendChild(Object.assign(document.createElement('style'), { innerText: surveyStyleSheet }))
-    Preact.render(<FeedbackWidget posthog={posthog} survey={survey} />, shadow)
+    Preact.render(<FeedbackWidget key={'feedback-survey'} posthog={posthog} survey={survey} />, shadow)
 }
 
 export const callSurveys = (posthog: PostHog, forceReload: boolean = false) => {
@@ -99,7 +99,7 @@ export const callSurveys = (posthog: PostHog, forceReload: boolean = false) => {
 
                 if (!localStorage.getItem(`seenSurvey_${survey.id}`)) {
                     const shadow = createShadow(style(survey?.appearance), survey.id)
-                    Preact.render(<Surveys posthog={posthog} survey={survey} />, shadow)
+                    Preact.render(<Surveys key={'popover-survey'} posthog={posthog} survey={survey} />, shadow)
                 }
             }
         })
@@ -120,6 +120,7 @@ export const renderSurveysPreview = (
     )
     const surveyHtml = render(
         <Surveys
+            key={'surveys-render-preview'}
             survey={survey}
             readOnly={true}
             initialDisplayState={displayState}
@@ -142,7 +143,7 @@ export const renderFeedbackWidgetPreview = (survey: Survey, root: HTMLElement) =
     const widgetStyleSheet = createWidgetStyle(survey.appearance?.widgetColor)
     const styleElement = Object.assign(document.createElement('style'), { innerText: widgetStyleSheet })
     root.appendChild(styleElement)
-    const widgetHtml = render(<FeedbackWidget survey={survey} readOnly={true} />)
+    const widgetHtml = render(<FeedbackWidget key={'feedback-render-preview'} survey={survey} readOnly={true} />)
     const widgetDiv = document.createElement('div')
     widgetDiv.innerHTML = widgetHtml
     root.appendChild(widgetDiv)
@@ -427,7 +428,9 @@ export function FeedbackWidget({
                     {survey.appearance?.widgetLabel || ''}
                 </div>
             )}
-            {showSurvey && <Surveys posthog={posthog} survey={survey} style={styleOverrides} />}
+            {showSurvey && (
+                <Surveys key={'feedback-widget-survey'} posthog={posthog} survey={survey} style={styleOverrides} />
+            )}
         </>
     )
 }

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -139,11 +139,13 @@ export const renderSurveysPreview = (
 }
 
 export const renderFeedbackWidgetPreview = (survey: Survey, root: HTMLElement) => {
-    const shadow = createWidgetShadow(survey)
-    const surveyStyleSheet = createWidgetStyle(survey.appearance?.widgetColor)
-    shadow.appendChild(Object.assign(document.createElement('style'), { innerText: surveyStyleSheet }))
-    Preact.render(<FeedbackWidget posthog={null as any} survey={survey} readOnly={true} />, shadow)
-    root.appendChild(shadow)
+    const widgetStyleSheet = createWidgetStyle(survey.appearance?.widgetColor)
+    const styleElement = Object.assign(document.createElement('style'), { innerText: widgetStyleSheet })
+    root.appendChild(styleElement)
+    const widgetHtml = render(<FeedbackWidget survey={survey} readOnly={true} />)
+    const widgetDiv = document.createElement('div')
+    widgetDiv.innerHTML = widgetHtml
+    root.appendChild(widgetDiv)
 }
 
 // This is the main exported function
@@ -373,12 +375,12 @@ const closeSurveyPopup = (survey: Survey, posthog?: PostHog, readOnly?: boolean)
 }
 
 export function FeedbackWidget({
-    posthog,
     survey,
+    posthog,
     readOnly,
 }: {
-    posthog: PostHog
     survey: Survey
+    posthog?: PostHog
     readOnly?: boolean
 }): JSX.Element {
     const [showSurvey, setShowSurvey] = useState(false)
@@ -386,7 +388,7 @@ export function FeedbackWidget({
     const widgetRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
-        if (readOnly) {
+        if (readOnly || !posthog) {
             return
         }
 

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -22,7 +22,7 @@ import {
 } from './surveys/surveys-utils'
 import * as Preact from 'preact'
 import { render } from 'preact-render-to-string'
-import { createWidgetShadow } from './surveys-widget'
+import { createWidgetShadow, createWidgetStyle } from './surveys-widget'
 import { useState, useEffect, useRef, useContext } from 'preact/hooks'
 import { _isNumber } from '../utils/type-utils'
 import { ConfirmationMessage } from './surveys/components/ConfirmationMessage'
@@ -395,7 +395,7 @@ export function FeedbackWidget({ posthog, survey }: { posthog: PostHog; survey: 
     return (
         <>
             {survey.appearance?.widgetType === 'tab' && (
-                <div className="ph-survey-widget-tab" ref={widgetRef} onClick={() => setShowSurvey(!showSurvey)}>
+                <div className="ph-survey-widget-tab" ref={widgetRef} onClick={() => !readOnly && setShowSurvey(!showSurvey)} style={{color: getContrastingTextColor(survey.appearance.widgetColor)}}>
                     <div className="ph-survey-widget-tab-icon"></div>
                     {survey.appearance?.widgetLabel || ''}
                 </div>

--- a/src/loader-surveys-preview.ts
+++ b/src/loader-surveys-preview.ts
@@ -1,0 +1,1 @@
+export { renderSurveysPreview, renderFeedbackWidgetPreview } from './extensions/surveys'

--- a/src/loader-surveys.ts
+++ b/src/loader-surveys.ts
@@ -1,7 +1,7 @@
 import { generateSurveys } from './extensions/surveys'
 
 import { window } from './utils/globals'
-export { renderSurveysPreview } from './extensions/surveys'
+export { renderSurveysPreview, renderFeedbackWidgetPreview } from './extensions/surveys'
 
 if (window) {
     ;(window as any).extendPostHogWithSurveys = generateSurveys

--- a/src/loader-surveys.ts
+++ b/src/loader-surveys.ts
@@ -1,7 +1,6 @@
 import { generateSurveys } from './extensions/surveys'
 
 import { window } from './utils/globals'
-export { renderSurveysPreview, renderFeedbackWidgetPreview } from './extensions/surveys'
 
 if (window) {
     ;(window as any).extendPostHogWithSurveys = generateSurveys


### PR DESCRIPTION
## Changes

1. Adds support for feedback widget previews
2. Fixes a major issue when loading survey preview methods for https://github.com/PostHog/posthog/pull/20321 where `generateSurveys` from the modules file was overriding the `generateSurveys` that we want from the iife file, causing `callSurveys` to not show surveys normally. So we have to either split them up into separate loader files or find a way to distinguish moment in time which script is calling `loader-surveys` 🤔 

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
