### PR TITLE
feat: Rollout new ingestion endpoints

### DIFF
--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -329,7 +329,7 @@ describe('featureflags', () => {
             })
 
             expect(given.instance._send_request).toHaveBeenCalledWith(
-                'https://app.posthog.com/api/early_access_features/?token=random fake token',
+                'https://us.i.posthog.com/api/early_access_features/?token=random fake token',
                 {},
                 { method: 'GET' },
                 expect.any(Function)
@@ -355,7 +355,7 @@ describe('featureflags', () => {
             })
 
             expect(given.instance._send_request).toHaveBeenCalledWith(
-                'https://app.posthog.com/api/early_access_features/?token=random fake token',
+                'https://us.i.posthog.com/api/early_access_features/?token=random fake token',
                 {},
                 { method: 'GET' },
                 expect.any(Function)

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -237,7 +237,7 @@ describe('posthog core', () => {
         it('sends payloads to /e/ by default', () => {
             given.lib.capture('event-name', { foo: 'bar', length: 0 })
             expect(given.lib._send_request).toHaveBeenCalledWith(
-                'https://app.posthog.com/e/',
+                'https://us.i.posthog.com/e/',
                 expect.any(Object),
                 expect.any(Object),
                 undefined
@@ -249,7 +249,7 @@ describe('posthog core', () => {
             given.lib.capture('event-name', { foo: 'bar', length: 0 })
 
             expect(given.lib._send_request).toHaveBeenCalledWith(
-                'https://app.posthog.com/i/v0/e/',
+                'https://us.i.posthog.com/i/v0/e/',
                 expect.any(Object),
                 expect.any(Object),
                 undefined

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -103,7 +103,7 @@ describe('surveys', () => {
             expect(data).toEqual(firstSurveys)
         })
         expect(instance._send_request).toHaveBeenCalledWith(
-            'https://app.posthog.com/api/surveys/?token=testtoken',
+            'https://us.i.posthog.com/api/surveys/?token=testtoken',
             {},
             { method: 'GET' },
             expect.any(Function)
@@ -124,7 +124,7 @@ describe('surveys', () => {
             expect(data).toEqual(firstSurveys)
         })
         expect(instance._send_request).toHaveBeenCalledWith(
-            'https://app.posthog.com/api/surveys/?token=testtoken',
+            'https://us.i.posthog.com/api/surveys/?token=testtoken',
             {},
             { method: 'GET' },
             expect.any(Function)

--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -6,7 +6,6 @@ describe('request-router', () => {
             config: {
                 api_host,
                 ui_host,
-                __preview_ingestion_endpoints: true,
             },
         } as any)
     }
@@ -60,7 +59,7 @@ describe('request-router', () => {
     })
 
     it('should react to config changes', () => {
-        const mockPostHog = { config: { api_host: 'https://app.posthog.com', __preview_ingestion_endpoints: true } }
+        const mockPostHog = { config: { api_host: 'https://app.posthog.com' } }
 
         const router = new RequestRouter(mockPostHog as any)
         expect(router.endpointFor('api')).toEqual('https://us.i.posthog.com')

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -574,10 +574,6 @@ export class PostHog {
         if (response.elementsChainAsString) {
             this.elementsChainAsString = response.elementsChainAsString
         }
-
-        if (response.__preview_ingestion_endpoints) {
-            this.config.__preview_ingestion_endpoints = response.__preview_ingestion_endpoints
-        }
     }
 
     _loaded(): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,8 +142,6 @@ export interface PostHogConfig {
     disable_scroll_properties?: boolean
     // Let the pageview scroll stats use a custom css selector for the root element, e.g. `main`
     scroll_root_selector?: string | string[]
-    /** WARNING: This is an experimental option not meant for public use. */
-    __preview_ingestion_endpoints?: boolean
 }
 
 export interface OptInOutCapturingOptions {
@@ -283,7 +281,6 @@ export interface DecideResponse {
     toolbarVersion: 'toolbar' /** @deprecated, moved to toolbarParams */
     isAuthenticated: boolean
     siteApps: { id: number; url: string }[]
-    __preview_ingestion_endpoints?: boolean
 }
 
 export type FeatureFlagsCallback = (flags: string[], variants: Record<string, string | boolean>) => void

--- a/src/utils/request-router.ts
+++ b/src/utils/request-router.ts
@@ -49,7 +49,7 @@ export class RequestRouter {
             return (this.uiHost || this.apiHost) + path
         }
 
-        if (!this.instance.config.__preview_ingestion_endpoints || this.region === RequestRouterRegion.CUSTOM) {
+        if (this.region === RequestRouterRegion.CUSTOM) {
             return this.apiHost + path
         }
 


### PR DESCRIPTION
## Changes

We have this behind a preview flag. Once we are confident this PR makes it the default to use the new `i.posthog.com` endpoints.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
