### PR TITLE
feat: reecord when timestamp is overriden by caller

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -14,6 +14,8 @@ jest.mock('../gdpr-utils', () => ({
 }))
 jest.mock('../decide')
 
+jest.useFakeTimers().setSystemTime(new Date('2020-01-01'))
+
 given('lib', () => {
     const posthog = new PostHog()
     posthog._init('testtoken', given.config, 'testhog')
@@ -71,6 +73,22 @@ describe('posthog core', () => {
         it('adds a UUID to each message', () => {
             const captureData = given.subject()
             expect(captureData).toHaveProperty('uuid')
+        })
+
+        it('adds system time to events', () => {
+            const captureData = given.subject()
+            expect(captureData).toHaveProperty('timestamp')
+            // timer is fixed at 2020-01-01
+            expect(captureData.timestamp).toEqual(new Date(2020, 0, 1))
+        })
+
+        it('captures when time is overriden by caller', () => {
+            given.options = { timestamp: new Date(2020, 0, 2, 12, 34) }
+            const captureData = given.subject()
+            expect(captureData).toHaveProperty('timestamp')
+            expect(captureData.timestamp).toEqual(new Date(2020, 0, 2, 12, 34))
+            expect(captureData.properties['$event_time_override_provided']).toEqual(true)
+            expect(captureData.properties['$event_time_override_system_time']).toEqual(new Date(2020, 0, 1))
         })
 
         it('handles recursive objects', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -923,6 +923,10 @@ export class PostHog {
 
         data = _copyAndTruncateStrings(data, options._noTruncate ? null : this.config.properties_string_max_length)
         data.timestamp = options.timestamp || new Date()
+        if (!_isUndefined(options.timestamp)) {
+            data.properties['$event_time_override_provided'] = true
+            data.properties['$event_time_override_system_time'] = new Date()
+        }
 
         // Top-level $set overriding values from the one from properties is taken from the plugin-server normalizeEvent
         // This doesn't handle $set_once, because posthog-people doesn't either


### PR DESCRIPTION
While investigating a support ticket I discovered that we have a mechanism to let someone override the timestamp when capturing events. That feels open to confusion

Let's add properties when that happens so we know it did