### PR TITLE
fix(surveys): fix emoji scale

### DIFF
--- a/src/extensions/surveys/components/QuestionTypes.tsx
+++ b/src/extensions/surveys/components/QuestionTypes.tsx
@@ -335,7 +335,7 @@ export function MultipleChoiceQuestion({
     )
 }
 
-const threeScaleEmojis = [dissatisfiedEmoji, neutralEmoji, satisfiedEmojig]
+const threeScaleEmojis = [dissatisfiedEmoji, neutralEmoji, satisfiedEmoji]
 const fiveScaleEmojis = [veryDissatisfiedEmoji, dissatisfiedEmoji, neutralEmoji, satisfiedEmoji, verySatisfiedEmoji]
 const fiveScaleNumbers = [1, 2, 3, 4, 5]
 const tenScaleNumbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/src/extensions/surveys/components/QuestionTypes.tsx
+++ b/src/extensions/surveys/components/QuestionTypes.tsx
@@ -335,7 +335,7 @@ export function MultipleChoiceQuestion({
     )
 }
 
-const threeScaleEmojis = [dissatisfiedEmoji, neutralEmoji, dissatisfiedEmoji]
+const threeScaleEmojis = [dissatisfiedEmoji, neutralEmoji, satisfiedEmojig]
 const fiveScaleEmojis = [veryDissatisfiedEmoji, dissatisfiedEmoji, neutralEmoji, satisfiedEmoji, verySatisfiedEmoji]
 const fiveScaleNumbers = [1, 2, 3, 4, 5]
 const tenScaleNumbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]


### PR DESCRIPTION
## Changes

emoji 3 scale was using the dissatisfied emoji as the satisfied one :(

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
