### PR TITLE
fix: Path for site apps

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -109,7 +109,7 @@ export class Decide {
         if (response['siteApps']) {
             if (this.instance.config.opt_in_site_apps) {
                 for (const { id, url } of response['siteApps']) {
-                    const scriptUrl = this.instance.requestRouter.endpointFor('assets', url)
+                    const scriptUrl = this.instance.requestRouter.endpointFor('api', url)
 
                     assignableWindow[`__$$ph_site_app_${id}`] = this.instance
 


### PR DESCRIPTION
## Changes

Site apps should be loaded from the api not the CDN

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
