### PR TITLE
feat: mangle private properties

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,7 @@ const plugins = [
         babelHelpers: 'bundled',
         presets: ['@babel/preset-env'],
     }),
-    terser({ toplevel: true }),
+    terser({ toplevel: true, mangle: { properties: { regex: /^_/ } } }),
     visualizer(),
 ]
 


### PR DESCRIPTION
terser will mangle properties that match a regex, otherwise class fields don't get mangled

we have field names like `startCaptureAndTrySendingQueuedSnapshots`

makes everything private in session recording class prefixed with an `_` and tells terser to mangle it

opening PR to see whether it helps, if each field is only referenced once then it won't have much impact