### PR TITLE
feat: allow linked flag variants to control recording

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -223,14 +223,14 @@ describe('SessionRecording', () => {
     describe('startRecordingIfEnabled', () => {
         beforeEach(() => {
             // need to cast as any to mock private methods
-            jest.spyOn(sessionRecording as any, 'startCaptureAndTrySendingQueuedSnapshots')
+            jest.spyOn(sessionRecording as any, '_startCapture')
             jest.spyOn(sessionRecording, 'stopRecording')
             jest.spyOn(sessionRecording as any, '_tryAddCustomEvent')
         })
 
-        it('call startCaptureAndTrySendingQueuedSnapshots if its enabled', () => {
+        it('call _startCapture if its enabled', () => {
             sessionRecording.startRecordingIfEnabled()
-            expect((sessionRecording as any).startCaptureAndTrySendingQueuedSnapshots).toHaveBeenCalled()
+            expect((sessionRecording as any)._startCapture).toHaveBeenCalled()
         })
 
         it('emits an options event', () => {
@@ -754,13 +754,13 @@ describe('SessionRecording', () => {
             )
         })
 
-        it('loads script after `startCaptureAndTrySendingQueuedSnapshots` if not previously loaded', () => {
+        it('loads script after `_startCapture` if not previously loaded', () => {
             posthog.persistence?.register({ [SESSION_RECORDING_ENABLED_SERVER_SIDE]: false })
 
             sessionRecording.startRecordingIfEnabled()
             expect(loadScript).not.toHaveBeenCalled()
 
-            sessionRecording['startCaptureAndTrySendingQueuedSnapshots']()
+            sessionRecording['_startCapture']()
 
             expect(loadScript).toHaveBeenCalled()
         })
@@ -769,7 +769,7 @@ describe('SessionRecording', () => {
             posthog.config.disable_session_recording = true
 
             sessionRecording.startRecordingIfEnabled()
-            sessionRecording['startCaptureAndTrySendingQueuedSnapshots']()
+            sessionRecording['_startCapture']()
 
             expect(loadScript).not.toHaveBeenCalled()
         })
@@ -831,7 +831,7 @@ describe('SessionRecording', () => {
                         sessionRecording: { endpoint: '/s/' },
                     })
                 )
-                sessionRecording['startCaptureAndTrySendingQueuedSnapshots']()
+                sessionRecording['_startCapture']()
             })
 
             it('sends a full snapshot if there is a new session/window id and the event is not type FullSnapshot or Meta', () => {
@@ -894,7 +894,7 @@ describe('SessionRecording', () => {
                     expect(mockCallback).not.toHaveBeenCalled()
 
                     sessionRecording.startRecordingIfEnabled()
-                    sessionRecording['startCaptureAndTrySendingQueuedSnapshots']()
+                    sessionRecording['_startCapture']()
 
                     expect(mockCallback).toHaveBeenCalledTimes(1)
                 })
@@ -966,7 +966,7 @@ describe('SessionRecording', () => {
                     posthog.sessionManager = sessionManager
 
                     sessionRecording.startRecordingIfEnabled()
-                    sessionRecording['startCaptureAndTrySendingQueuedSnapshots']()
+                    sessionRecording['_startCapture']()
                 })
 
                 it('takes a full snapshot for the first _emit', () => {

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -1,7 +1,7 @@
 import { AutocaptureConfig, Properties } from './types'
 import { _each, _entries, _includes, _trim } from './utils'
 
-import { _isArray, _isNull, _isString, _isUndefined } from './utils/type-utils'
+import { _isArray, _isNullish, _isString, _isUndefined } from './utils/type-utils'
 import { logger } from './utils/logger'
 import { window } from './utils/globals'
 
@@ -334,7 +334,7 @@ export function isSensitiveElement(el: Element): boolean {
  * @returns {boolean} whether the element should be captured
  */
 export function shouldCaptureValue(value: string): boolean {
-    if (_isNull(value) || _isUndefined(value)) {
+    if (_isNullish(value)) {
         return false
     }
 

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -1,5 +1,5 @@
 import { CapturedNetworkRequest, NetworkRecordOptions, PostHogConfig } from '../../types'
-import { _isFunction, _isNull, _isString, _isUndefined } from '../../utils/type-utils'
+import { _isFunction, _isNullish, _isString } from '../../utils/type-utils'
 import { convertToURL } from '../../utils/request-utils'
 import { logger } from '../../utils/logger'
 
@@ -89,7 +89,7 @@ function redactPayload(
     limit: number,
     description: string
 ): string | null | undefined {
-    if (_isUndefined(payload) || _isNull(payload)) {
+    if (_isNullish(payload)) {
         return payload
     }
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -271,7 +271,7 @@ export class SessionRecording {
 
     startRecordingIfEnabled() {
         if (this.isRecordingEnabled) {
-            this.startCaptureAndTrySendingQueuedSnapshots()
+            this._startCapture()
             logger.info('[SessionRecording] started')
         } else {
             this.stopRecording()
@@ -390,11 +390,6 @@ export class SessionRecording {
             timestamp: _timestamp(),
         })
     }
-
-    private startCaptureAndTrySendingQueuedSnapshots() {
-        this._startCapture()
-    }
-
     private _startCapture() {
         if (_isUndefined(Object.assign)) {
             // According to the rrweb docs, rrweb is not supported on IE11 and below:

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -370,12 +370,14 @@ export class SessionRecording {
             const linkedVariant = _isString(this._linkedFlag) ? null : this._linkedFlag?.variant
             this.instance.onFeatureFlags((_flags, variants) => {
                 const flagIsPresent = _isObject(variants) && linkedFlag in variants
-                logger.info(LOGGER_PREFIX + ' evaluating linked flag', {
-                    flagMatches: flagIsPresent,
-                    linkedFlag,
-                    linkedVariant,
-                })
-                this._linkedFlagSeen = linkedVariant ? variants[linkedFlag] === linkedVariant : flagIsPresent
+                const linkedFlagMatches = linkedVariant ? variants[linkedFlag] === linkedVariant : flagIsPresent
+                if (linkedFlagMatches) {
+                    logger.info(LOGGER_PREFIX + ' linked flag matched', {
+                        linkedFlag,
+                        linkedVariant,
+                    })
+                }
+                this._linkedFlagSeen = linkedFlagMatches
             })
         }
 

--- a/src/loader-recorder-v2.ts
+++ b/src/loader-recorder-v2.ts
@@ -25,6 +25,7 @@ import {
     _isFormData,
     _isFunction,
     _isNull,
+    _isNullish,
     _isObject,
     _isString,
     _isUndefined,
@@ -219,7 +220,7 @@ async function getRequestPerformanceEntry(
  * XHR request body is Document | XMLHttpRequestBodyInit | null | undefined
  */
 function _tryReadXHRBody(body: Document | XMLHttpRequestBodyInit | any | null | undefined): string | null {
-    if (_isNull(body) || _isUndefined(body)) {
+    if (_isNullish(body)) {
         return null
     }
 
@@ -323,7 +324,7 @@ function initXhrObserver(cb: networkCallback, win: IWindow, options: Required<Ne
                         networkRequest.responseHeaders = responseHeaders
                     }
                     if (shouldRecordBody('response', options.recordBody, responseHeaders)) {
-                        if (_isUndefined(xhr.response) || _isNull(xhr.response)) {
+                        if (_isNullish(xhr.response)) {
                             networkRequest.responseBody = null
                         } else {
                             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,6 +238,8 @@ export interface RequestData extends QueuedRequestData {
     onResponse?: (req: MinimalHTTPResponse) => void
 }
 
+export type FlagVariant = { flag: string; variant: string }
+
 export interface DecideResponse {
     status: number
     supportedCompression: Compression[]
@@ -272,7 +274,7 @@ export interface DecideResponse {
         canvasFps?: number | null
         // the API returns a decimal between 0 and 1 as a string
         canvasQuality?: string | null
-        linkedFlag?: string | null
+        linkedFlag?: string | FlagVariant | null
         networkPayloadCapture?: Pick<NetworkRecordOptions, 'recordBody' | 'recordHeaders'>
     }
     surveys?: boolean

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,9 +5,9 @@ import {
     _isFormData,
     _isFunction,
     _isNull,
+    _isNullish,
     _isObject,
     _isString,
-    _isUndefined,
     hasOwnProperty,
 } from './type-utils'
 import { logger } from './logger'
@@ -53,7 +53,7 @@ export function _eachArray<E = any>(
  * @param {Object=} thisArg
  */
 export function _each(obj: any, iterator: (value: any, key: any) => void | Breaker, thisArg?: any): void {
-    if (_isNull(obj) || _isUndefined(obj)) {
+    if (_isNullish(obj)) {
         return
     }
     if (_isArray(obj)) {

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -52,6 +52,15 @@ export const _isNull = function (x: unknown): x is null {
     // eslint-disable-next-line posthog-js/no-direct-null-check
     return x === null
 }
+
+/*
+    sometimes you want to check if something is null or undefined
+    that's what this is for
+ */
+export const _isNullish = function (x: unknown): x is null | undefined {
+    return _isUndefined(x) || _isNull(x)
+}
+
 export const _isDate = function (x: unknown): x is Date {
     // eslint-disable-next-line posthog-js/no-direct-date-check
     return toString.call(x) == '[object Date]'


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/10806 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/13499)

Prepares the ground for a change in posthog allowing people to choose boolean linked flags _or a particular variant of a multivariant flag_ to control recordings

fly-by adds an `_isNullish` check since typing `_isNull(blah) || _isUndefined(blah)` was tiring me out