### PR TITLE
fix: Loading the toolbar via JS

### DIFF
--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -140,7 +140,7 @@ export class Toolbar {
         const toolbarParams = {
             token: this.instance.config.token,
             ...params,
-            apiURL: this.instance.requestRouter.endpointFor('api'), // defaults to api_host from the instance config if nothing else set
+            apiURL: this.instance.requestRouter.endpointFor('ui'),
             ...(disableToolbarMetrics ? { instrument: false } : {}),
         }
 


### PR DESCRIPTION
## Changes

Fixes https://github.com/PostHog/posthog-js/issues/1041

We pass in the ingestion api url to the toolbar loader but this isn't quite right. We load the toolbar from the assets endpoint but authorisation etc. has to go via the actual app url.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
