### PR TITLE
chore: Removed jsc callbacks

### DIFF
--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -575,7 +575,6 @@ describe('Autocapture system', () => {
 
         it('should add the custom property when an element matching any of the event selectors is clicked', () => {
             lib = makePostHog({
-                _prepare_callback: sandbox.spy((callback) => callback),
                 config: {
                     api_host: 'https://test.com',
                     token: 'testtoken',
@@ -752,7 +751,6 @@ describe('Autocapture system', () => {
 
         it('should not capture events when config returns false, when an element matching any of the event selectors is clicked', () => {
             lib = makePostHog({
-                _prepare_callback: sandbox.spy((callback) => callback),
                 config: {
                     api_host: 'https://test.com',
                     token: 'testtoken',
@@ -792,7 +790,6 @@ describe('Autocapture system', () => {
 
         it('should not capture events when config returns true but server setting is disabled', () => {
             lib = makePostHog({
-                _prepare_callback: sandbox.spy((callback) => callback),
                 config: {
                     api_host: 'https://test.com',
                     token: 'testtoken',

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -33,7 +33,6 @@ describe('Decide', () => {
         capture: jest.fn(),
         _addCaptureHook: jest.fn(),
         _afterDecideResponse: jest.fn(),
-        _prepare_callback: jest.fn().mockImplementation((callback) => callback),
         get_distinct_id: jest.fn().mockImplementation(() => 'distinctid'),
         _send_request: jest
             .fn()

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -19,7 +19,6 @@ describe('featureflags', () => {
         config,
         get_distinct_id: () => 'blah id',
         getGroups: () => {},
-        _prepare_callback: (callback) => callback,
         persistence: new PostHogPersistence(config),
         requestRouter: new RequestRouter({ config }),
         register: (props) => given.instance.persistence.register(props),

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -60,7 +60,6 @@ describe('surveys', () => {
 
         instance = {
             config: config,
-            _prepare_callback: (callback: any) => callback,
             persistence: new PostHogPersistence(config),
             requestRouter: new RequestRouter({ config } as any),
             register: (props: Properties) => instance.persistence?.register(props),

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -34,7 +34,6 @@ import {
     EarlyAccessFeatureCallback,
     GDPROptions,
     isFeatureEnabledOptions,
-    JSC,
     JsonType,
     OptInOutCapturingOptions,
     PostHogConfig,
@@ -170,7 +169,6 @@ export const defaultConfig = (): PostHogConfig => ({
     _onCapture: __NOOP,
     capture_performance: undefined,
     name: 'posthog',
-    callback_fn: 'posthog._jsc',
     bootstrap: {},
     disable_compression: false,
     session_idle_timeout_seconds: 30 * 60, // 30 minutes
@@ -305,7 +303,6 @@ export class PostHog {
 
     _triggered_notifs: any
     compression: Partial<Record<Compression, boolean>>
-    _jsc: JSC
     __captureHooks: ((eventName: string) => void)[]
     __request_queue: [url: string, data: Record<string, any>, options: XHROptions, callback?: RequestCallback][]
     __autocapture: boolean | AutocaptureConfig | undefined
@@ -333,7 +330,6 @@ export class PostHog {
         this.__loaded = false
         this.__loaded_recorder_version = undefined
         this.__autocapture = undefined
-        this._jsc = function () {} as JSC
         this.analyticsDefaultEndpoint = '/e/'
         this.elementsChainAsString = false
 
@@ -452,11 +448,8 @@ export class PostHog {
             _extend({}, defaultConfig(), config, {
                 name: name,
                 token: token,
-                callback_fn: (name === PRIMARY_INSTANCE_NAME ? name : PRIMARY_INSTANCE_NAME + '.' + name) + '._jsc',
             })
         )
-
-        this._jsc = function () {} as JSC
 
         // Check if recorder.js is already loaded
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -631,40 +624,6 @@ export class PostHog {
         this.__request_queue = []
 
         this._start_queue_if_opted_in()
-    }
-
-    /**
-     * _prepare_callback() should be called by callers of _send_request for use
-     * as the callback argument.
-     *
-     * If there is no callback, this returns null.
-     * If we are going to make XHR/XDR requests, this returns a function.
-     * If we are going to use script tags, this returns a string to use as the
-     * callback GET param.
-     */
-    // TODO: get rid of the "| string"
-    _prepare_callback(callback?: RequestCallback, data?: Properties): RequestCallback | null | string {
-        if (_isUndefined(callback)) {
-            return null
-        }
-
-        if (SUPPORTS_REQUEST) {
-            return function (response) {
-                callback(response, data)
-            }
-        }
-
-        // if the user gives us a callback, we store as a random
-        // property on this instances jsc function and update our
-        // callback string to reflect that.
-        const jsc = this._jsc
-        const randomized_cb = '' + Math.floor(Math.random() * 100000000)
-        const callback_string = this.config.callback_fn + '[' + randomized_cb + ']'
-        jsc[randomized_cb] = function (response: any) {
-            delete jsc[randomized_cb]
-            callback(response, data)
-        }
-        return callback_string
     }
 
     _handle_unload(): void {

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -7,7 +7,6 @@ import {
     EarlyAccessFeatureResponse,
     Properties,
     JsonType,
-    RequestCallback,
 } from './types'
 import { PostHogPersistence } from './posthog-persistence'
 

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -193,7 +193,7 @@ export class PostHogFeatureFlags {
             this.instance.requestRouter.endpointFor('api', '/decide/?v=3'),
             { data: encoded_data },
             { method: 'POST' },
-            this.instance._prepare_callback((response) => {
+            (response) => {
                 // reset anon_distinct_id after at least a single request with it
                 // makes it through
                 this.$anon_distinct_id = undefined
@@ -202,7 +202,7 @@ export class PostHogFeatureFlags {
                 // :TRICKY: Reload - start another request if queued!
                 this.setReloadingPaused(false)
                 this._startReloadTimer()
-            }) as RequestCallback
+            }
         )
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -359,11 +359,6 @@ export interface PostData {
     data?: string
 }
 
-export interface JSC {
-    (): void
-    [key: string]: (response: any) => void
-}
-
 export type SnippetArrayItem = [method: string, ...args: any[]]
 
 export type JsonType = string | number | boolean | null | { [key: string]: JsonType } | Array<JsonType>

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,7 +128,6 @@ export interface PostHogConfig {
     advanced_disable_toolbar_metrics: boolean
     get_device_id: (uuid: string) => string
     name: string
-    callback_fn: string
     _onCapture: (eventName: string, eventData: CaptureResult) => void
     capture_performance?: boolean
     // Should only be used for testing. Could negatively impact performance.


### PR DESCRIPTION
## Changes

We might have supported this along time ago but it is currently doing nothing at all 😅 
The idea was to use script callbacks but from what I can see there is literally nowhere in the code that we support this so it is just a bunch of extra confusing code.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
