### PR TITLE
fix: posthog path to ignore

### DIFF
--- a/src/__tests__/extensions/replay/config.test.ts
+++ b/src/__tests__/extensions/replay/config.test.ts
@@ -150,7 +150,14 @@ describe('config', () => {
                 ],
                 [
                     {
-                        name: 'https://app.posthog.com/i/vo/e/',
+                        name: 'https://app.posthog.com/i/v0/e/',
+                    },
+                    undefined,
+                ],
+                [
+                    {
+                        // even an imaginary future world of rust session replay capture
+                        name: 'https://app.posthog.com/i/v0/s/',
                     },
                     undefined,
                 ],

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -68,12 +68,12 @@ const removeAuthorizationHeader = (data: CapturedNetworkRequest): CapturedNetwor
     return data
 }
 
-const POSTHOG_PATHS_TO_IGNORE = ['/s/', '/e/', '/i/v0/e/', '/i/vo/e/', '/decide/', '/static/recorder-v2.js']
+const POSTHOG_PATHS_TO_IGNORE = ['/s/', '/e/', '/i/']
 // want to ignore posthog paths when capturing requests, or we can get trapped in a loop
 // because calls to PostHog would be reported using a call to PostHog which would be reported....
 const ignorePostHogPaths = (data: CapturedNetworkRequest): CapturedNetworkRequest | undefined => {
     const url = convertToURL(data.name)
-    if (url && url.pathname && POSTHOG_PATHS_TO_IGNORE.includes(url.pathname)) {
+    if (url && url.pathname && POSTHOG_PATHS_TO_IGNORE.some((path) => url.pathname.startsWith(path))) {
         return undefined
     }
     return data

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -73,7 +73,7 @@ const POSTHOG_PATHS_TO_IGNORE = ['/s/', '/e/', '/i/']
 // because calls to PostHog would be reported using a call to PostHog which would be reported....
 const ignorePostHogPaths = (data: CapturedNetworkRequest): CapturedNetworkRequest | undefined => {
     const url = convertToURL(data.name)
-    if (url && url.pathname && POSTHOG_PATHS_TO_IGNORE.some((path) => url.pathname.startsWith(path))) {
+    if (url && url.pathname && POSTHOG_PATHS_TO_IGNORE.some((path) => url.pathname.indexOf(path) === 0)) {
         return undefined
     }
     return data

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -68,7 +68,7 @@ const removeAuthorizationHeader = (data: CapturedNetworkRequest): CapturedNetwor
     return data
 }
 
-const POSTHOG_PATHS_TO_IGNORE = ['/s/', '/e/', '/i/vo/e/']
+const POSTHOG_PATHS_TO_IGNORE = ['/s/', '/e/', '/i/v0/e/', '/i/vo/e/', '/decide/', '/static/recorder-v2.js']
 // want to ignore posthog paths when capturing requests, or we can get trapped in a loop
 // because calls to PostHog would be reported using a call to PostHog which would be reported....
 const ignorePostHogPaths = (data: CapturedNetworkRequest): CapturedNetworkRequest | undefined => {


### PR DESCRIPTION
We had a typo in the code that ignored ingestion paths so we were recording `i/v0/e/` 

well, not any more