### PR TITLE
fix(flags): Fire callback when decide errors out

### DIFF
--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -151,19 +151,19 @@ describe('Decide', () => {
 
             expect(given.posthog.sessionRecording.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
             expect(given.posthog.toolbar.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
-            expect(given.posthog.featureFlags.receivedFeatureFlags).toHaveBeenCalledWith(given.decideResponse)
+            expect(given.posthog.featureFlags.receivedFeatureFlags).toHaveBeenCalledWith(given.decideResponse, false)
             expect(given.posthog._afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
             expect(autocapture.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse, given.posthog)
         })
 
-        it('Make sure receivedFeatureFlags is not called if the decide response fails', () => {
+        it('Make sure receivedFeatureFlags is called with errors if the decide response fails', () => {
             given('decideResponse', () => undefined)
             window.POSTHOG_DEBUG = true
             console.error = jest.fn()
 
             given.subject()
 
-            expect(given.posthog.featureFlags.receivedFeatureFlags).not.toHaveBeenCalled()
+            expect(given.posthog.featureFlags.receivedFeatureFlags).toHaveBeenCalledWith({}, true)
             expect(console.error).toHaveBeenCalledWith('[PostHog.js]', 'Failed to fetch feature flags from PostHog.')
         })
 

--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -235,7 +235,7 @@ describe('featureflags', () => {
                 called = true
                 _flags = flags
                 _variants = variants
-                _error = errors
+                _error = errors?.errorsLoading
             })
             expect(called).toEqual(false)
 
@@ -796,7 +796,7 @@ describe('featureflags', () => {
                 called = true
                 _flags = flags
                 _variants = variants
-                _errors = errors
+                _errors = errors?.errorsLoading
             })
             expect(called).toEqual(false)
 
@@ -819,7 +819,7 @@ describe('featureflags', () => {
                 called = true
                 _flags = flags
                 _variants = variants
-                _errors = errors
+                _errors = errors?.errorsLoading
             })
             expect(called).toEqual(false)
 
@@ -851,7 +851,7 @@ describe('featureflags', () => {
                 called = true
                 _flags = flags
                 _variants = variants
-                _errors = errors
+                _errors = errors?.errorsLoading
             })
             expect(called).toEqual(false)
 

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -48,7 +48,16 @@ export class Decide {
         // :TRICKY: Reload - start another request if queued!
         this.instance.featureFlags._startReloadTimer()
 
-        if (!response) {
+        const errorsLoading = !response
+
+        if (
+            !this.instance.config.advanced_disable_feature_flags_on_first_load &&
+            !this.instance.config.advanced_disable_feature_flags
+        ) {
+            this.instance.featureFlags.receivedFeatureFlags(response ?? {}, errorsLoading)
+        }
+
+        if (errorsLoading) {
             logger.error('Failed to fetch feature flags from PostHog.')
             return
         }
@@ -64,13 +73,6 @@ export class Decide {
         this.instance.sessionRecording?.afterDecideResponse(response)
         autocapture.afterDecideResponse(response, this.instance)
         this.instance._afterDecideResponse(response)
-
-        if (
-            !this.instance.config.advanced_disable_feature_flags_on_first_load &&
-            !this.instance.config.advanced_disable_feature_flags
-        ) {
-            this.instance.featureFlags.receivedFeatureFlags(response)
-        }
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -199,15 +199,20 @@ export class PostHogFeatureFlags {
             callback: (response) => {
                 this.setReloadingPaused(false)
 
-                if (response.statusCode !== 200) {
-                    return // or error out??
+                let errorsLoading = true
+
+                if (response.statusCode === 200) {
+                    // successful request
+                    // reset anon_distinct_id after at least a single request with it
+                    // makes it through
+                    this.$anon_distinct_id = undefined
+                    errorsLoading = false
                 }
-                // reset anon_distinct_id after at least a single request with it
-                // makes it through
-                this.$anon_distinct_id = undefined
-                if (response.json) {
-                    this.receivedFeatureFlags(response.json)
-                }
+                // :TRICKY: We want to fire the callback even if the request fails
+                // and return existing flags if they exist
+                // This is because we don't want to block clients waiting for flags to load.
+                // It's possible they're waiting for the callback to render the UI, but it never occurs.
+                this.receivedFeatureFlags(response.json ?? {}, errorsLoading)
 
                 // :TRICKY: Reload - start another request if queued!
                 this._startReloadTimer()
@@ -280,7 +285,7 @@ export class PostHogFeatureFlags {
         this.featureFlagEventHandlers = this.featureFlagEventHandlers.filter((h) => h !== handler)
     }
 
-    receivedFeatureFlags(response: Partial<DecideResponse>): void {
+    receivedFeatureFlags(response: Partial<DecideResponse>, errorsLoading?: boolean): void {
         if (!this.instance.persistence) {
             return
         }
@@ -288,7 +293,7 @@ export class PostHogFeatureFlags {
         const currentFlags = this.getFlagVariants()
         const currentFlagPayloads = this.getFlagPayloads()
         parseFeatureFlagDecideResponse(response, this.instance.persistence, currentFlags, currentFlagPayloads)
-        this._fireFeatureFlagsCallbacks()
+        this._fireFeatureFlagsCallbacks(errorsLoading)
     }
 
     /*
@@ -405,9 +410,9 @@ export class PostHogFeatureFlags {
         }
     }
 
-    _fireFeatureFlagsCallbacks(): void {
+    _fireFeatureFlagsCallbacks(errorsLoading?: boolean): void {
         const { flags, flagVariants } = this._prepareFeatureFlagsForCallbacks()
-        this.featureFlagEventHandlers.forEach((handler) => handler(flags, flagVariants))
+        this.featureFlagEventHandlers.forEach((handler) => handler(flags, flagVariants, errorsLoading))
     }
 
     /**

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -412,7 +412,7 @@ export class PostHogFeatureFlags {
 
     _fireFeatureFlagsCallbacks(errorsLoading?: boolean): void {
         const { flags, flagVariants } = this._prepareFeatureFlagsForCallbacks()
-        this.featureFlagEventHandlers.forEach((handler) => handler(flags, flagVariants, errorsLoading))
+        this.featureFlagEventHandlers.forEach((handler) => handler(flags, flagVariants, { errorsLoading }))
     }
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -286,7 +286,11 @@ export interface DecideResponse {
     siteApps: { id: number; url: string }[]
 }
 
-export type FeatureFlagsCallback = (flags: string[], variants: Record<string, string | boolean>) => void
+export type FeatureFlagsCallback = (
+    flags: string[],
+    variants: Record<string, string | boolean>,
+    errorsLoading?: boolean
+) => void
 
 // TODO: delete custom_properties after changeless typescript refactor
 export interface AutoCaptureCustomProperty {

--- a/src/types.ts
+++ b/src/types.ts
@@ -289,7 +289,9 @@ export interface DecideResponse {
 export type FeatureFlagsCallback = (
     flags: string[],
     variants: Record<string, string | boolean>,
-    errorsLoading?: boolean
+    context?: {
+        errorsLoading?: boolean
+    }
 ) => void
 
 // TODO: delete custom_properties after changeless typescript refactor


### PR DESCRIPTION
## Changes

Fire callbacks with error param so we don't block clients waiting for flags to load.

Noticed this isn't present on the first Decide response, will add it there too.
...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
