### PR TITLE
feat: scrub payloads with forbidden words

### DIFF
--- a/src/__tests__/extensions/replay/config.test.ts
+++ b/src/__tests__/extensions/replay/config.test.ts
@@ -121,7 +121,7 @@ describe('config', () => {
                         'content-type': 'application/json',
                         'content-length': '1000001',
                     },
-                    requestBody: '[SessionReplay] Request body too large to record (1000001 bytes)',
+                    requestBody: '[SessionRecording] Request body too large to record (1000001 bytes)',
                 })
             })
 
@@ -141,7 +141,7 @@ describe('config', () => {
                         'content-type': 'application/json',
                         'content-length': '1000001',
                     },
-                    responseBody: '[SessionReplay] Response body too large to record (1000001 bytes)',
+                    responseBody: '[SessionRecording] Response body too large to record (1000001 bytes)',
                 })
             })
 
@@ -177,7 +177,7 @@ describe('config', () => {
                     requestHeaders: {
                         'content-type': 'application/json',
                     },
-                    requestBody: '[SessionReplay] Request body too large to record (1000001 bytes)',
+                    requestBody: '[SessionRecording] Request body too large to record (1000001 bytes)',
                 })
             })
         })
@@ -245,8 +245,8 @@ describe('config', () => {
                 requestHeaders: {
                     'content-type': 'application/json',
                 },
-                requestBody: '[SessionReplay] Request body might contain: password',
-                responseBody: '[SessionReplay] Response body might contain: password',
+                requestBody: '[SessionRecording] Request body might contain: password',
+                responseBody: '[SessionRecording] Response body might contain: password',
             })
         })
 
@@ -277,8 +277,8 @@ describe('config', () => {
                 requestHeaders: {
                     'content-type': 'edited',
                 },
-                requestBody: '[SessionReplay] Request body might contain: password',
-                responseBody: '[SessionReplay] Response body might contain: password',
+                requestBody: '[SessionRecording] Request body might contain: password',
+                responseBody: '[SessionRecording] Response body might contain: password',
             })
         })
 
@@ -315,8 +315,8 @@ describe('config', () => {
                 requestHeaders: {
                     'content-type': 'application/json',
                 },
-                requestBody: '[SessionReplay] Request body redacted',
-                responseBody: '[SessionReplay] Response body redacted',
+                requestBody: '[SessionRecording] Request body redacted',
+                responseBody: '[SessionRecording] Response body redacted',
             })
         })
     })

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -340,13 +340,28 @@ export function isSensitiveElement(el: Element): boolean {
     return false
 }
 
+// Define the core pattern for matching credit card numbers
+const coreCCPattern = `(4[0-9]{12}(?:[0-9]{3})?)|(5[1-5][0-9]{14})|(6(?:011|5[0-9]{2})[0-9]{12})|(3[47][0-9]{13})|(3(?:0[0-5]|[68][0-9])[0-9]{11})|((?:2131|1800|35[0-9]{3})[0-9]{11})`
+// Create the Anchored version of the regex by adding '^' at the start and '$' at the end
+const anchoredCCRegex = new RegExp(`^(?:${coreCCPattern})$`)
+// The Unanchored version is essentially the core pattern, usable as is for partial matches
+const unanchoredCCRegex = new RegExp(coreCCPattern)
+
+// Define the core pattern for matching SSNs with optional dashes
+const coreSSNPattern = `\\d{3}-?\\d{2}-?\\d{4}`
+// Create the Anchored version of the regex by adding '^' at the start and '$' at the end
+const anchoredSSNRegex = new RegExp(`^(${coreSSNPattern})$`)
+// The Unanchored version is essentially the core pattern itself, usable for partial matches
+const unanchoredSSNRegex = new RegExp(`(${coreSSNPattern})`)
+
 /*
- * Check whether a string value should be "captured" or if it may contain sentitive data
+ * Check whether a string value should be "captured" or if it may contain sensitive data
  * using a variety of heuristics.
  * @param {string} value - string value to check
+ * @param {boolean} anchorRegexes - whether to anchor the regexes to the start and end of the string
  * @returns {boolean} whether the element should be captured
  */
-export function shouldCaptureValue(value: string): boolean {
+export function shouldCaptureValue(value: string, anchorRegexes = true): boolean {
     if (_isNullish(value)) {
         return false
     }
@@ -356,14 +371,13 @@ export function shouldCaptureValue(value: string): boolean {
 
         // check to see if input value looks like a credit card number
         // see: https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9781449327453/ch04s20.html
-        const ccRegex =
-            /^(?:(4[0-9]{12}(?:[0-9]{3})?)|(5[1-5][0-9]{14})|(6(?:011|5[0-9]{2})[0-9]{12})|(3[47][0-9]{13})|(3(?:0[0-5]|[68][0-9])[0-9]{11})|((?:2131|1800|35[0-9]{3})[0-9]{11}))$/
+        const ccRegex = anchorRegexes ? anchoredCCRegex : unanchoredCCRegex
         if (ccRegex.test((value || '').replace(/[- ]/g, ''))) {
             return false
         }
 
         // check to see if input value looks like a social security number
-        const ssnRegex = /(^\d{3}-?\d{2}-?\d{4}$)/
+        const ssnRegex = anchorRegexes ? anchoredSSNRegex : unanchoredSSNRegex
         if (ssnRegex.test(value)) {
             return false
         }

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -42,7 +42,7 @@ export function makeSafeText(s: string | null | undefined): string | null {
         _trim(s)
             // scrub potentially sensitive values
             .split(/(\s+)/)
-            .filter(shouldCaptureValue)
+            .filter((s) => shouldCaptureValue(s))
             .join('')
             // normalize whitespace
             .replace(/[\r\n]/g, ' ')

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -4,7 +4,6 @@ import { convertToURL } from '../../utils/request-utils'
 import { logger } from '../../utils/logger'
 import { shouldCaptureValue } from '../../autocapture-utils'
 import { LOGGER_PREFIX } from './sessionrecording'
-import { _each } from '../../utils'
 
 export const defaultNetworkOptions: NetworkRecordOptions = {
     initiatorTypes: [
@@ -79,7 +78,7 @@ const PAYLOAD_CONTENT_DENY_LIST = [
 
 // we always remove headers on the deny list because we never want to capture this sensitive data
 const removeAuthorizationHeader = (data: CapturedNetworkRequest): CapturedNetworkRequest => {
-    _each(Object.keys(data.requestHeaders ?? {}), (header) => {
+    Object.keys(data.requestHeaders ?? {}).forEach((header) => {
         if (HEADER_DENY_LIST.includes(header.toLowerCase())) delete data.requestHeaders?.[header]
     })
     return data
@@ -151,7 +150,7 @@ function scrubPayload(payload: string | null | undefined, label: 'Request' | 'Re
     if (!shouldCaptureValue(scrubbed, false)) {
         scrubbed = LOGGER_PREFIX + ' ' + label + ' body redacted'
     }
-    _each(PAYLOAD_CONTENT_DENY_LIST, (text) => {
+    PAYLOAD_CONTENT_DENY_LIST.forEach((text) => {
         if (scrubbed?.length && scrubbed?.indexOf(text) !== -1) {
             scrubbed = LOGGER_PREFIX + ' ' + label + ' body might contain: ' + text
         }

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -45,7 +45,7 @@ export const defaultNetworkOptions: NetworkRecordOptions = {
     payloadSizeLimitBytes: 1000000,
 }
 
-const HEADER_DENYLIST = [
+const HEADER_DENY_LIST = [
     'authorization',
     'x-forwarded-for',
     'authorization',
@@ -61,10 +61,24 @@ const HEADER_DENYLIST = [
     'x-xsrf-token',
 ]
 
+const PAYLOAD_CONTENT_DENY_LIST = [
+    'password',
+    'secret',
+    'passwd',
+    'api_key',
+    'apikey',
+    'auth',
+    'credentials',
+    'mysql_pwd',
+    'privatekey',
+    'private_key',
+    'tokenconst',
+]
+
 // we always remove headers on the deny list because we never want to capture this sensitive data
 const removeAuthorizationHeader = (data: CapturedNetworkRequest): CapturedNetworkRequest => {
     Object.keys(data.requestHeaders ?? {}).forEach((header) => {
-        if (HEADER_DENYLIST.includes(header.toLowerCase())) delete data.requestHeaders?.[header]
+        if (HEADER_DENY_LIST.includes(header.toLowerCase())) delete data.requestHeaders?.[header]
     })
     return data
 }
@@ -126,14 +140,12 @@ const limitPayloadSize = (
     }
 }
 
-const payloadContentDenyList = ['password']
-
 function scrubPayloads(capturedRequest: CapturedNetworkRequest) {
     if (capturedRequest.requestBody) {
         if (!shouldCaptureValue(capturedRequest.requestBody, false)) {
             capturedRequest.requestBody = '[SessionReplay] Request body redacted'
         }
-        payloadContentDenyList.forEach((text) => {
+        PAYLOAD_CONTENT_DENY_LIST.forEach((text) => {
             if (capturedRequest.requestBody?.length && capturedRequest.requestBody?.indexOf(text) !== -1) {
                 capturedRequest.requestBody = '[SessionReplay] Request body might contain: ' + text
             }
@@ -143,7 +155,7 @@ function scrubPayloads(capturedRequest: CapturedNetworkRequest) {
         if (!shouldCaptureValue(capturedRequest.responseBody, false)) {
             capturedRequest.responseBody = '[SessionReplay] Response body redacted'
         }
-        payloadContentDenyList.forEach((text) => {
+        PAYLOAD_CONTENT_DENY_LIST.forEach((text) => {
             if (capturedRequest.responseBody?.length && capturedRequest.responseBody?.indexOf(text) !== -1) {
                 capturedRequest.responseBody = '[SessionReplay] Response body might contain: ' + text
             }

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -141,21 +141,21 @@ const limitPayloadSize = (
     }
 }
 
-function scrubPayload(
-    requestBody: string | null | undefined,
-    label: 'Request' | 'Response'
-): string | null | undefined {
-    let scrubbed = requestBody
-    if (scrubbed) {
-        if (!shouldCaptureValue(scrubbed, false)) {
-            scrubbed = LOGGER_PREFIX + ' ' + label + ' body redacted'
-        }
-        PAYLOAD_CONTENT_DENY_LIST.forEach((text) => {
-            if (scrubbed?.length && scrubbed?.indexOf(text) !== -1) {
-                scrubbed = LOGGER_PREFIX + ' ' + label + ' body might contain: ' + text
-            }
-        })
+function scrubPayload(payload: string | null | undefined, label: 'Request' | 'Response'): string | null | undefined {
+    if (_isNullish(payload)) {
+        return payload
     }
+    let scrubbed = payload
+
+    if (!shouldCaptureValue(scrubbed, false)) {
+        scrubbed = LOGGER_PREFIX + ' ' + label + ' body redacted'
+    }
+    PAYLOAD_CONTENT_DENY_LIST.forEach((text) => {
+        if (scrubbed?.length && scrubbed?.indexOf(text) !== -1) {
+            scrubbed = LOGGER_PREFIX + ' ' + label + ' body might contain: ' + text
+        }
+    })
+
     return scrubbed
 }
 

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -4,6 +4,7 @@ import { convertToURL } from '../../utils/request-utils'
 import { logger } from '../../utils/logger'
 import { shouldCaptureValue } from '../../autocapture-utils'
 import { LOGGER_PREFIX } from './sessionrecording'
+import { _each } from '../../utils'
 
 export const defaultNetworkOptions: NetworkRecordOptions = {
     initiatorTypes: [
@@ -78,7 +79,7 @@ const PAYLOAD_CONTENT_DENY_LIST = [
 
 // we always remove headers on the deny list because we never want to capture this sensitive data
 const removeAuthorizationHeader = (data: CapturedNetworkRequest): CapturedNetworkRequest => {
-    Object.keys(data.requestHeaders ?? {}).forEach((header) => {
+    _each(Object.keys(data.requestHeaders ?? {}), (header) => {
         if (HEADER_DENY_LIST.includes(header.toLowerCase())) delete data.requestHeaders?.[header]
     })
     return data
@@ -150,7 +151,7 @@ function scrubPayload(payload: string | null | undefined, label: 'Request' | 'Re
     if (!shouldCaptureValue(scrubbed, false)) {
         scrubbed = LOGGER_PREFIX + ' ' + label + ' body redacted'
     }
-    PAYLOAD_CONTENT_DENY_LIST.forEach((text) => {
+    _each(PAYLOAD_CONTENT_DENY_LIST, (text) => {
         if (scrubbed?.length && scrubbed?.indexOf(text) !== -1) {
             scrubbed = LOGGER_PREFIX + ' ' + label + ' body might contain: ' + text
         }

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -125,10 +125,10 @@ const limitPayloadSize = (
     }
 }
 
-const forbiddenText = ['password']
+const payloadContentDenyList = ['password']
 
 function scrubPayloads(capturedRequest: CapturedNetworkRequest) {
-    forbiddenText.forEach((text) => {
+    payloadContentDenyList.forEach((text) => {
         if (capturedRequest.requestBody?.length && capturedRequest.requestBody?.indexOf(text) !== -1) {
             capturedRequest.requestBody = '[SessionReplay] Request body contained password'
         }

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -3,8 +3,9 @@ import { _isFunction, _isNullish, _isString, _isUndefined } from '../../utils/ty
 import { convertToURL } from '../../utils/request-utils'
 import { logger } from '../../utils/logger'
 import { shouldCaptureValue } from '../../autocapture-utils'
-import { LOGGER_PREFIX } from './sessionrecording'
 import { _each } from '../../utils'
+
+const LOGGER_PREFIX = '[SessionRecording]'
 
 export const defaultNetworkOptions: NetworkRecordOptions = {
     initiatorTypes: [

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -130,11 +130,11 @@ const payloadContentDenyList = ['password']
 function scrubPayloads(capturedRequest: CapturedNetworkRequest) {
     payloadContentDenyList.forEach((text) => {
         if (capturedRequest.requestBody?.length && capturedRequest.requestBody?.indexOf(text) !== -1) {
-            capturedRequest.requestBody = '[SessionReplay] Request body contained password'
+            capturedRequest.requestBody = '[SessionReplay] Request body contained: ' + text
         }
 
         if (capturedRequest.responseBody?.length && capturedRequest.responseBody?.indexOf(text) !== -1) {
-            capturedRequest.responseBody = '[SessionReplay] Response body contained password'
+            capturedRequest.responseBody = '[SessionReplay] Response body contained: ' + text
         }
     })
     return capturedRequest

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -109,7 +109,7 @@ const newQueuedEvent = (rrwebMethod: () => void): QueuedRRWebEvent => ({
     attempt: 1,
 })
 
-export const LOGGER_PREFIX = '[SessionRecording]'
+const LOGGER_PREFIX = '[SessionRecording]'
 
 export class SessionRecording {
     private instance: PostHog

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -109,7 +109,7 @@ const newQueuedEvent = (rrwebMethod: () => void): QueuedRRWebEvent => ({
     attempt: 1,
 })
 
-const LOGGER_PREFIX = '[SessionRecording]'
+export const LOGGER_PREFIX = '[SessionRecording]'
 
 export class SessionRecording {
     private instance: PostHog


### PR DESCRIPTION
Just like with headers we should be conservative in what we capture in payloads

If the body of the request (or response) contains any of the following we don't capture it

    'password',
    'secret',
    'passwd',
    'api_key',
    'apikey',
    'auth',
    'credentials',
    'mysql_pwd',
    'privatekey',
    'private_key',
    'tokenconst',
    
    If it matches SSN or CC regex we don't capture it
    
    You can add to this but not replace it