### PR TITLE
fix: Choice of capture compression

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -573,6 +573,7 @@ export class PostHog {
             ip: this.config.ip ? 1 : 0,
         })
         options.headers = this.config.request_headers
+        options.compression = options.compression === 'best-available' ? this.compression : options.compression
 
         request({
             ...options,
@@ -762,7 +763,7 @@ export class PostHog {
             method: 'POST',
             url: options?._url ?? this.requestRouter.endpointFor('api', this.analyticsDefaultEndpoint),
             data,
-            compression: this.compression,
+            compression: 'best-available',
             batchKey: options?._batchKey,
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,7 +215,7 @@ export interface RequestOptions {
     callback?: RequestCallback
     timeout?: number
     noRetries?: boolean
-    compression?: Compression
+    compression?: Compression | 'best-available'
 }
 
 // Queued request types - the same as a request but with additional queueing information


### PR DESCRIPTION
## Changes

Some refactoring whilst improving the logic had one side effect - the compression is now a derived value but it is saved in the first event. This means that when the queue is filled, the compression from the first event is used instead of the last one.

To generally make this better I figured it makes sense to be explicit - have a "best-available" option which will select compression as the request is made based on what decide says (with base64 still as the default)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
