### PR TITLE
fix: no empty requests

### DIFF
--- a/src/loader-recorder-v2.ts
+++ b/src/loader-recorder-v2.ts
@@ -551,7 +551,7 @@ function initNetworkObserver(
             }
         })
 
-        if (requests.length > 0 || data.isInitial) {
+        if (requests.length > 0) {
             callback({ ...data, requests })
         }
     }


### PR DESCRIPTION
When processing network requests in the replay network plugin it was possible  to emit a request that was 

```
{
   "isInitial": true,
   "requests: ": []
}
```

that is silly, so let's not do that