### PR TITLE
fix: squash down recorder size a little

### DIFF
--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -4,29 +4,8 @@ import { convertToURL } from '../../utils/request-utils'
 import { logger } from '../../utils/logger'
 
 export const defaultNetworkOptions: NetworkRecordOptions = {
-    initiatorTypes: [
-        'audio',
-        'beacon',
-        'body',
-        'css',
-        'early-hint',
-        'embed',
-        'fetch',
-        'frame',
-        'iframe',
-        'icon',
-        'image',
-        'img',
-        'input',
-        'link',
-        'navigation',
-        'object',
-        'ping',
-        'script',
-        'track',
-        'video',
-        'xmlhttprequest',
-    ],
+    // by default, no initiator types are ignored
+    initiatorTypes: undefined,
     maskRequestFn: (data: CapturedNetworkRequest) => data,
     recordHeaders: false,
     recordBody: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -401,6 +401,11 @@ export type InitiatorType =
     | 'xmlhttprequest'
 
 export type NetworkRecordOptions = {
+    // controls which initiator types are recorded
+    // if not set, all initiator types are recorded
+    // if the array is empty, no initiator types are recorded
+    // if 'xmlhttprequest' is not in the array, no XHR requests will be recorded
+    // if 'fetch' is not in the array, no fetch requests will be recorded
     initiatorTypes?: InitiatorType[]
     maskRequestFn?: (data: CapturedNetworkRequest) => CapturedNetworkRequest | undefined
     recordHeaders?: boolean | { request: boolean; response: boolean }


### PR DESCRIPTION
This didn't have as big an impact as I'd hoped, but we can use the absence of initiator type allowlist to mean allow all, and keep an empty array meaning allow none. Which means we don't need to have a list of unminifiable strings in the bundle. 

And since we have multiple no-op functions in the recorder we can share them to save a few more bytes

tested by running recording locally with payload capture on and off