### PR TITLE
chore: remove unused path

### DIFF
--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -3,7 +3,7 @@ import { _isNull } from './type-utils'
 import { Properties } from '../types'
 import Config from '../config'
 import { _each, _extend, _strip_empty_properties, _timestamp } from './index'
-import { assignableWindow, document, location, userAgent, window } from './globals'
+import { document, location, userAgent, window } from './globals'
 import { detectBrowser, detectBrowserVersion, detectDevice, detectDeviceType, detectOS } from './user-agent-utils'
 
 const URL_REGEX_PREFIX = 'https?://(.*)'
@@ -129,7 +129,7 @@ export const _info = {
             _strip_empty_properties({
                 $os: os_name,
                 $os_version: os_version,
-                $browser: _info.browser(userAgent, navigator.vendor, assignableWindow.opera),
+                $browser: _info.browser(userAgent, navigator.vendor),
                 $device: _info.device(userAgent),
                 $device_type: _info.deviceType(userAgent),
             }),
@@ -138,7 +138,7 @@ export const _info = {
                 $host: location?.host,
                 $pathname: location?.pathname,
                 $raw_user_agent: userAgent.length > 1000 ? userAgent.substring(0, 997) + '...' : userAgent,
-                $browser_version: _info.browserVersion(userAgent, navigator.vendor, assignableWindow.opera),
+                $browser_version: _info.browserVersion(userAgent, navigator.vendor),
                 $browser_language: _info.browserLanguage(),
                 $screen_height: window?.screen.height,
                 $screen_width: window?.screen.width,
@@ -162,10 +162,10 @@ export const _info = {
             _strip_empty_properties({
                 $os: os_name,
                 $os_version: os_version,
-                $browser: _info.browser(userAgent, navigator.vendor, assignableWindow.opera),
+                $browser: _info.browser(userAgent, navigator.vendor),
             }),
             {
-                $browser_version: _info.browserVersion(userAgent, navigator.vendor, assignableWindow.opera),
+                $browser_version: _info.browserVersion(userAgent, navigator.vendor),
             }
         )
     },

--- a/src/utils/user-agent-utils.ts
+++ b/src/utils/user-agent-utils.ts
@@ -88,10 +88,7 @@ const safariCheck = (ua: string, vendor?: string) => (vendor && _includes(vendor
  * The order of the checks are important since many user agents
  * include keywords used in later checks.
  */
-export const detectBrowser = function (user_agent: string, vendor: string | undefined, opera?: any): string {
-    if (opera) {
-        return OPERA
-    }
+export const detectBrowser = function (user_agent: string, vendor: string | undefined): string {
     vendor = vendor || '' // vendor is undefined for at least IE9
 
     if (_includes(user_agent, ' OPR/') && _includes(user_agent, 'Mini')) {
@@ -163,12 +160,8 @@ const versionRegexes: Record<string, RegExp[]> = {
  * `navigator.vendor` is passed in and used to help with detecting certain browsers
  * NB `navigator.vendor` is deprecated and not present in every browser
  */
-export const detectBrowserVersion = function (
-    userAgent: string,
-    vendor: string | undefined,
-    opera: string
-): number | null {
-    const browser = detectBrowser(userAgent, vendor, opera)
+export const detectBrowserVersion = function (userAgent: string, vendor: string | undefined): number | null {
+    const browser = detectBrowser(userAgent, vendor)
     const regexes: RegExp[] | undefined = versionRegexes[browser as keyof typeof versionRegexes]
     if (_isUndefined(regexes)) {
         return null


### PR DESCRIPTION
Browser detection used a value in assignable window `assignableWindow.opera` for Opera browser detection

We don't ever set it

I installed opera on my mac and it doesn't set `window.opera`

Let's remove it