### PR TITLE
fix: Send beacon request encoding

### DIFF
--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -8,10 +8,12 @@ jest.mock('../utils/globals', () => ({
     ...jest.requireActual('../utils/globals'),
     fetch: jest.fn(),
     XMLHttpRequest: jest.fn(),
-    sendBeacon: jest.fn(),
+    navigator: {
+        sendBeacon: jest.fn(),
+    },
 }))
 
-import { fetch, XMLHttpRequest, sendBeacon } from '../utils/globals'
+import { fetch, XMLHttpRequest, navigator } from '../utils/globals'
 
 jest.mock('../config', () => ({ DEBUG: false, LIB_VERSION: '1.23.45' }))
 
@@ -24,7 +26,7 @@ const flushPromises = async () => {
 describe('request', () => {
     const mockedFetch: jest.MockedFunction<any> = fetch as jest.MockedFunction<any>
     const mockedXMLHttpRequest: jest.MockedFunction<any> = XMLHttpRequest as jest.MockedFunction<any>
-    const mockedSendBeacon: jest.MockedFunction<any> = sendBeacon as jest.MockedFunction<any>
+    const mockedNavigator: jest.Mocked<typeof navigator> = navigator as jest.Mocked<typeof navigator>
     const mockedXHR = {
         open: jest.fn(),
         setRequestHeader: jest.fn(),
@@ -256,12 +258,12 @@ describe('request', () => {
                     data: { my: 'content' },
                 })
             )
-            expect(mockedSendBeacon).toHaveBeenCalledWith(
+            expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
                 'https://any.posthog-instance.com/?_=1700000000000&ver=1.23.45&beacon=1',
                 expect.any(Blob)
             )
 
-            const blob = mockedSendBeacon.mock.calls[0][1] as Blob
+            const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
 
             const reader = new FileReader()
             const result = await new Promise((resolve) => {
@@ -281,19 +283,19 @@ describe('request', () => {
                     data: { my: 'content' },
                 })
             )
-            expect(mockedSendBeacon).toHaveBeenCalledWith(
+            expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
                 'https://any.posthog-instance.com/?_=1700000000000&ver=1.23.45&compression=base64&beacon=1',
                 expect.any(Blob)
             )
 
-            const blob = mockedSendBeacon.mock.calls[0][1] as Blob
+            const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
             const reader = new FileReader()
             const result = await new Promise((resolve) => {
                 reader.onload = () => resolve(reader.result)
                 reader.readAsText(blob)
             })
 
-            expect(result).toBe('data=%7B%22my%22%3A%22content%22%7D')
+            expect(result).toBe('data=eyJteSI6ImNvbnRlbnQifQ%3D%3D')
         })
     })
 })

--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -297,5 +297,29 @@ describe('request', () => {
 
             expect(result).toBe('data=eyJteSI6ImNvbnRlbnQifQ%3D%3D')
         })
+
+        it('should respect gzip compression', async () => {
+            request(
+                createRequest({
+                    url: 'https://any.posthog-instance.com/',
+                    method: 'POST',
+                    compression: Compression.GZipJS,
+                    data: { my: 'content' },
+                })
+            )
+            expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
+                'https://any.posthog-instance.com/?_=1700000000000&ver=1.23.45&compression=gzip-js&beacon=1',
+                expect.any(Blob)
+            )
+
+            const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
+            const reader = new FileReader()
+            const result = await new Promise((resolve) => {
+                reader.onload = () => resolve(reader.result)
+                reader.readAsText(blob)
+            })
+
+            expect(result).toMatchInlineSnapshot(`"�      �VʭT�RJ��+I�+Q� �ԮM   "`)
+        })
     })
 })

--- a/src/request.ts
+++ b/src/request.ts
@@ -65,7 +65,7 @@ const encodePostData = ({ data, compression, transport, method }: RequestOptions
     }
 
     if (transport === 'sendBeacon') {
-        const body = compression === Compression.Base64 ? _base64Encode(JSON.stringify(data)) : encodeToDataString(data)
+        const body = compression === Compression.Base64 ? _base64Encode(JSON.stringify(data)) : data
         return new Blob([encodeToDataString(body)], { type: 'application/x-www-form-urlencoded' })
     }
 
@@ -196,7 +196,6 @@ const _sendBeacon = (options: RequestOptions) => {
         // eslint-disable-next-line compat/compat
         navigator!.sendBeacon!(url, encodePostData(options))
     } catch (e) {
-        console.error('Error sending message with')
         // send beacon is a best-effort, fire-and-forget mechanism on page unload,
         // we don't want to throw errors here
     }

--- a/src/request.ts
+++ b/src/request.ts
@@ -64,14 +64,16 @@ const encodePostData = ({ data, compression, transport, method }: RequestOptions
         return null
     }
 
-    if (transport === 'sendBeacon') {
-        const body = compression === Compression.Base64 ? _base64Encode(JSON.stringify(data)) : data
-        return new Blob([encodeToDataString(body)], { type: 'application/x-www-form-urlencoded' })
-    }
-
+    // Gzip is always a blob
     if (compression === Compression.GZipJS) {
         const gzipData = gzipSync(strToU8(JSON.stringify(data)), { mtime: 0 })
         return new Blob([gzipData], { type: 'text/plain' })
+    }
+
+    // sendBeacon is always a blob but can be base64 encoded internally
+    if (transport === 'sendBeacon') {
+        const body = compression === Compression.Base64 ? _base64Encode(JSON.stringify(data)) : data
+        return new Blob([encodeToDataString(body)], { type: 'application/x-www-form-urlencoded' })
     }
 
     if (compression === Compression.Base64) {

--- a/src/request.ts
+++ b/src/request.ts
@@ -4,7 +4,7 @@ import { Compression, RequestOptions, RequestResponse } from './types'
 import { _formDataToQuery } from './utils/request-utils'
 
 import { logger } from './utils/logger'
-import { fetch, document, window, XMLHttpRequest, AbortController } from './utils/globals'
+import { fetch, document, XMLHttpRequest, AbortController, sendBeacon } from './utils/globals'
 import { gzipSync, strToU8 } from 'fflate'
 
 // eslint-disable-next-line compat/compat
@@ -22,8 +22,8 @@ export const request = (_options: RequestOptions) => {
         compression: options.compression,
     })
 
-    if (options.transport === 'sendBeacon' && window?.navigator?.sendBeacon) {
-        return sendBeacon(options)
+    if (options.transport === 'sendBeacon' && sendBeacon) {
+        return _sendBeacon(options)
     }
 
     // NOTE: Until we are confident with it, we only use fetch if explicitly told so
@@ -184,7 +184,7 @@ const _fetch = (options: RequestOptions) => {
     return
 }
 
-const sendBeacon = (options: RequestOptions) => {
+const _sendBeacon = (options: RequestOptions) => {
     // beacon documentation https://w3c.github.io/beacon/
     // beacons format the message and use the type property
 
@@ -194,7 +194,7 @@ const sendBeacon = (options: RequestOptions) => {
 
     try {
         // eslint-disable-next-line compat/compat
-        window?.navigator?.sendBeacon(url, encodePostData(options))
+        sendBeacon!(url, encodePostData(options))
     } catch (e) {
         // send beacon is a best-effort, fire-and-forget mechanism on page unload,
         // we don't want to throw errors here

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -17,13 +17,12 @@ export const ArrayProto = Array.prototype
 export const nativeForEach = ArrayProto.forEach
 export const nativeIndexOf = ArrayProto.indexOf
 
-const navigator = global?.navigator
+export const navigator = global?.navigator
 export const document = global?.document
 export const location = global?.location
 export const fetch = global?.fetch
 export const XMLHttpRequest =
     global?.XMLHttpRequest && 'withCredentials' in new global.XMLHttpRequest() ? global.XMLHttpRequest : undefined
-export const sendBeacon = navigator?.sendBeacon
 export const AbortController = global?.AbortController
 export const userAgent = navigator?.userAgent
 export const assignableWindow: Window & typeof globalThis & Record<string, any> = win ?? ({} as any)

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -23,6 +23,7 @@ export const location = global?.location
 export const fetch = global?.fetch
 export const XMLHttpRequest =
     global?.XMLHttpRequest && 'withCredentials' in new global.XMLHttpRequest() ? global.XMLHttpRequest : undefined
+export const sendBeacon = navigator?.sendBeacon
 export const AbortController = global?.AbortController
 export const userAgent = navigator?.userAgent
 export const assignableWindow: Window & typeof globalThis & Record<string, any> = win ?? ({} as any)


### PR DESCRIPTION
## Changes

I was suspicious that sendBeacon was broken (it isn't) but either way it behaved slightly different to before and needed tests.
Validated it worked in the playground app locally.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
