### PR TITLE
fix(surveys): fix description background style

### DIFF
--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -135,8 +135,7 @@ export const style = (appearance: SurveyAppearance | null) => {
           }
           .description {
               font-size: 13px;
-              margin-top: 5px;
-              opacity: .60;
+              padding-top: 5px;
               background: ${appearance?.backgroundColor || '#eeeded'};
           }
           .ratings-number {


### PR DESCRIPTION
## Changes
Not sure why the opacity was there in the first place, any ideas?

Before
<img width="326" alt="Screenshot 2024-03-11 at 16 07 48" src="https://github.com/PostHog/posthog-js/assets/22996112/1a473d68-6c1b-48db-8b99-92f4e70f2dc1">

After
(white bg)
<img width="325" alt="Screenshot 2024-03-11 at 16 10 36" src="https://github.com/PostHog/posthog-js/assets/22996112/299aa3e8-a8f0-46df-90a0-73a3a8b97658">

(default/blank bg)
<img width="326" alt="Screenshot 2024-03-11 at 16 11 39" src="https://github.com/PostHog/posthog-js/assets/22996112/5ec4b9ac-bf12-41dc-bcac-8d3538badcb2">