### PR TITLE
feat: report browser visibility state in replay

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -32,7 +32,7 @@ import {
     _isUndefined,
 } from '../../utils/type-utils'
 import { logger } from '../../utils/logger'
-import { assignableWindow, window } from '../../utils/globals'
+import { document, assignableWindow, window } from '../../utils/globals'
 import { buildNetworkRequestOptions } from './config'
 import { isLocalhost } from '../../utils/request-utils'
 import { userOptedOut } from '../../gdpr-utils'
@@ -261,6 +261,13 @@ export class SessionRecording {
 
         window?.addEventListener('online', () => {
             this._tryAddCustomEvent('browser online', {})
+        })
+
+        window?.addEventListener('visibilitychange', () => {
+            if (document?.visibilityState) {
+                const label = 'window ' + document.visibilityState
+                this._tryAddCustomEvent(label, {})
+            }
         })
 
         if (!this.instance.sessionManager) {


### PR DESCRIPTION
We want to keep adding to the information we can provide to help people understand user behavior.

The browser will tell us as it is hidden or becomes visible.

We can send a custom event when that happens to display in the player inspector