### PR TITLE
fix: Disabled compression and application json

### DIFF
--- a/cypress/support/compression.ts
+++ b/cypress/support/compression.ts
@@ -1,10 +1,5 @@
 import { decompressSync, strFromU8 } from 'fflate'
 
-export function getUnencodedPayload(request) {
-    const data = decodeURIComponent(request.body.match(/data=(.*)/)[1])
-    return JSON.parse(data)
-}
-
 export function getBase64EncodedPayload(request) {
     const data = decodeURIComponent(request.body.match(/data=(.*)/)[1])
     return JSON.parse(Buffer.from(data, 'base64').toString())
@@ -22,6 +17,6 @@ export async function getPayload(request) {
     } else if (request.url.includes('compression=base64')) {
         return getBase64EncodedPayload(request)
     } else {
-        return getUnencodedPayload(request)
+        return request.body
     }
 }

--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -258,7 +258,7 @@ describe('request', () => {
                 createRequest({
                     url: 'https://any.posthog-instance.com/',
                     method: 'POST',
-                    data: { my: 'content' },
+                    data: { foo: 'bar' },
                 })
             )
             expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
@@ -274,7 +274,7 @@ describe('request', () => {
                 reader.readAsText(blob)
             })
 
-            expect(result).toBe('data=%7B%22my%22%3A%22content%22%7D')
+            expect(result).toMatchInlineSnapshot(`"{\\"foo\\":\\"bar\\"}"`)
         })
 
         it('should respect base64 compression', async () => {
@@ -283,7 +283,7 @@ describe('request', () => {
                     url: 'https://any.posthog-instance.com/',
                     method: 'POST',
                     compression: Compression.Base64,
-                    data: { my: 'content' },
+                    data: { foo: 'bar' },
                 })
             )
             expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
@@ -298,7 +298,7 @@ describe('request', () => {
                 reader.readAsText(blob)
             })
 
-            expect(result).toBe('data=eyJteSI6ImNvbnRlbnQifQ%3D%3D')
+            expect(result).toMatchInlineSnapshot(`"data=eyJmb28iOiJiYXIifQ%3D%3D"`)
         })
 
         it('should respect gzip compression', async () => {
@@ -307,7 +307,7 @@ describe('request', () => {
                     url: 'https://any.posthog-instance.com/',
                     method: 'POST',
                     compression: Compression.GZipJS,
-                    data: { my: 'content' },
+                    data: { foo: 'bar' },
                 })
             )
             expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
@@ -322,7 +322,10 @@ describe('request', () => {
                 reader.readAsText(blob)
             })
 
-            expect(result).toMatchInlineSnapshot(`"�      �VʭT�RJ��+I�+Q� �ԮM   "`)
+            expect(result).toMatchInlineSnapshot(`
+                "�      �VJ��W�RJJ,R� ��+�
+                   "
+            `)
         })
     })
 })

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -203,7 +203,7 @@ export class PostHog {
     webPerformance = new DeprecatedWebPerformanceObserver()
 
     _triggered_notifs: any
-    compression?: Compression = Compression.Base64 // Upgrades to gzip if decide response supports it
+    compression?: Compression
     __captureHooks: ((eventName: string) => void)[]
     __request_queue: QueuedRequestOptions[]
     __autocapture: boolean | AutocaptureConfig | undefined
@@ -335,6 +335,8 @@ export class PostHog {
             // @ts-ignore
             this.__loaded_recorder_version = window?.rrweb?.version
         }
+
+        this.compression = config.disable_compression ? undefined : Compression.Base64
 
         this.persistence = new PostHogPersistence(this.config)
         this.sessionPersistence =

--- a/src/request.ts
+++ b/src/request.ts
@@ -10,9 +10,9 @@ import { gzipSync, strToU8 } from 'fflate'
 // eslint-disable-next-line compat/compat
 export const SUPPORTS_REQUEST = !!XMLHttpRequest || !!fetch
 
-const CT_PLAIN = 'text/plain'
-const CT_JSON = 'application/json'
-const CT_FORM = 'application/x-www-form-urlencoded'
+const CONTENT_TYPE_PLAIN = 'text/plain'
+const CONTENT_TYPE_JSON = 'application/json'
+const CONTENT_TYPE_FORM = 'application/x-www-form-urlencoded'
 
 // This is the entrypoint. It takes care of sanitizing the options and then calls the appropriate request method.
 export const request = (_options: RequestOptions) => {
@@ -81,8 +81,8 @@ const encodePostData = ({
     if (compression === Compression.GZipJS) {
         const gzipData = gzipSync(strToU8(JSON.stringify(data)), { mtime: 0 })
         return {
-            contentType: CT_PLAIN,
-            body: new Blob([gzipData], { type: CT_PLAIN }),
+            contentType: CONTENT_TYPE_PLAIN,
+            body: new Blob([gzipData], { type: CONTENT_TYPE_PLAIN }),
         }
     }
 
@@ -90,8 +90,8 @@ const encodePostData = ({
     if (transport === 'sendBeacon') {
         const body = compression === Compression.Base64 ? _base64Encode(JSON.stringify(data)) : data
         return {
-            contentType: CT_FORM,
-            body: new Blob([encodeToDataString(body)], { type: CT_FORM }),
+            contentType: CONTENT_TYPE_FORM,
+            body: new Blob([encodeToDataString(body)], { type: CONTENT_TYPE_FORM }),
         }
     }
 
@@ -99,13 +99,13 @@ const encodePostData = ({
         const b64data = _base64Encode(JSON.stringify(data))
 
         return {
-            contentType: CT_FORM,
+            contentType: CONTENT_TYPE_FORM,
             body: encodeToDataString(b64data),
         }
     }
 
     return {
-        contentType: CT_JSON,
+        contentType: CONTENT_TYPE_JSON,
         body: JSON.stringify(data),
     }
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -67,12 +67,14 @@ const encodePostData = ({
     data,
     compression,
     transport,
-}: RequestOptions): {
-    contentType?: string
-    body: string | BlobPart | null
-} | null => {
+}: RequestOptions):
+    | {
+          contentType: string
+          body: string | BlobPart
+      }
+    | undefined => {
     if (!data) {
-        return null
+        return
     }
 
     // Gzip is always a blob


### PR DESCRIPTION
## Changes

* Fixed compression not respecting the `disable_compression` option
* Fixed uncompressed data - it now sends as application/json which works for both old and new capture.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
