### PR TITLE
fix: patch rrweb zero width canvas bug

### DIFF
--- a/patches/rrweb@2.0.0-alpha.11.patch
+++ b/patches/rrweb@2.0.0-alpha.11.patch
@@ -1,5 +1,5 @@
 diff --git a/es/rrweb/packages/rrweb/src/record/mutation.js b/es/rrweb/packages/rrweb/src/record/mutation.js
-index 81ad4520d1435d088752a85f9a55a68ad6e0f514..39d96af4f65eb32ba13eb7d5a81076e996c9df26 100644
+index 81ad4520d1435d088752a85f9a55a68ad6e0f514..e19dec6cc98ea782d53328853ca1b46d96e129f7 100644
 --- a/es/rrweb/packages/rrweb/src/record/mutation.js
 +++ b/es/rrweb/packages/rrweb/src/record/mutation.js
 @@ -1,563 +1,607 @@
@@ -1132,3 +1132,20 @@ index 81ad4520d1435d088752a85f9a55a68ad6e0f514..39d96af4f65eb32ba13eb7d5a81076e9
  }
  
  export { MutationBuffer as default };
+diff --git a/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js b/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
+index 8746997c9b849ac5c952fdbe0a8dd608d6680a3a..534c6076f1cf63dfde972bb45991fc70694427b3 100644
+--- a/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
++++ b/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
+@@ -118,6 +118,12 @@ class CanvasManager {
+                         context.clear(context.COLOR_BUFFER_BIT);
+                     }
+                 }
++
++                // The browser throws if the canvas is 0 in size
++                // Uncaught (in promise) DOMException: Failed to execute 'createImageBitmap' on 'Window': The source image width is 0.
++                // Assuming the same happens with height
++                if (canvas.width === 0 || canvas.height === 0) return;
++                
+                 const bitmap = yield createImageBitmap(canvas);
+                 worker.postMessage({
+                     id,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   rrweb@2.0.0-alpha.11:
-    hash: ehkxvj2dnc4d5fb4tq7odeskvu
+    hash: tjoktulcrliiekxagfypcvjnr4
     path: patches/rrweb@2.0.0-alpha.11.patch
 
 dependencies:
@@ -170,7 +170,7 @@ devDependencies:
     version: 5.12.0(rollup@4.9.6)
   rrweb:
     specifier: 2.0.0-alpha.11
-    version: 2.0.0-alpha.11(patch_hash=ehkxvj2dnc4d5fb4tq7odeskvu)
+    version: 2.0.0-alpha.11(patch_hash=tjoktulcrliiekxagfypcvjnr4)
   rrweb-snapshot:
     specifier: 2.0.0-alpha.11
     version: 2.0.0-alpha.11
@@ -9216,7 +9216,7 @@ packages:
       rrweb-snapshot: 1.1.14
     dev: true
 
-  /rrweb@2.0.0-alpha.11(patch_hash=ehkxvj2dnc4d5fb4tq7odeskvu):
+  /rrweb@2.0.0-alpha.11(patch_hash=tjoktulcrliiekxagfypcvjnr4):
     resolution: {integrity: sha512-vJ2gNvF+pUG9C2aaau7iSNqhWBSc4BwtUO4FpegOtDObuH4PIaxNJOlgHz82+WxKr9XPm93ER0LqmNpy0KYdKg==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.11


### PR DESCRIPTION
ran `pnpm patch rrweb@2.0.0-alpha.11`
then added the fix from https://github.com/rrweb-io/rrweb/pull/1422
then ran `pnpm patch-commit the-location-the-patch-created-for-me`

verified I can still record locally with it