### PR TITLE
feat: track recording URL without pageview capture

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -1618,6 +1618,37 @@ describe('SessionRecording', () => {
             expect((sessionRecording as any)['_tryAddCustomEvent']).not.toHaveBeenCalled()
         })
 
+        it('does not captures pageview on non-meta event', () => {
+            fakeNavigateTo('https://test.com')
+
+            _emit(createIncrementalSnapshot({ type: 3 }))
+
+            expect((sessionRecording as any)['_tryAddCustomEvent']).not.toHaveBeenCalled()
+            ;(sessionRecording as any)._tryAddCustomEvent.mockClear()
+
+            fakeNavigateTo('https://test.com/other')
+            _emit(createIncrementalSnapshot({ type: 3 }))
+            // the window href has changed, even so we don't capture another pageview
+            expect((sessionRecording as any)['_tryAddCustomEvent']).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('when pageview capture is disabled and replay pageview capture is enabled', () => {
+        beforeEach(() => {
+            jest.spyOn(sessionRecording as any, '_tryAddCustomEvent')
+            posthog.config.capture_pageview = false
+            posthog.config.session_recording.forceCapturePageview = true
+            sessionRecording.startRecordingIfEnabled()
+            // clear the spy calls
+            ;(sessionRecording as any)._tryAddCustomEvent.mockClear()
+        })
+
+        it('does not capture pageview on meta event', () => {
+            _emit(createIncrementalSnapshot({ type: META_EVENT_TYPE }))
+
+            expect((sessionRecording as any)['_tryAddCustomEvent']).not.toHaveBeenCalled()
+        })
+
         it('captures pageview as expected on non-meta event', () => {
             fakeNavigateTo('https://test.com')
 

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -1618,37 +1618,6 @@ describe('SessionRecording', () => {
             expect((sessionRecording as any)['_tryAddCustomEvent']).not.toHaveBeenCalled()
         })
 
-        it('does not captures pageview on non-meta event', () => {
-            fakeNavigateTo('https://test.com')
-
-            _emit(createIncrementalSnapshot({ type: 3 }))
-
-            expect((sessionRecording as any)['_tryAddCustomEvent']).not.toHaveBeenCalled()
-            ;(sessionRecording as any)._tryAddCustomEvent.mockClear()
-
-            fakeNavigateTo('https://test.com/other')
-            _emit(createIncrementalSnapshot({ type: 3 }))
-            // the window href has changed, even so we don't capture another pageview
-            expect((sessionRecording as any)['_tryAddCustomEvent']).not.toHaveBeenCalled()
-        })
-    })
-
-    describe('when pageview capture is disabled and replay pageview capture is enabled', () => {
-        beforeEach(() => {
-            jest.spyOn(sessionRecording as any, '_tryAddCustomEvent')
-            posthog.config.capture_pageview = false
-            posthog.config.session_recording.forceCapturePageview = true
-            sessionRecording.startRecordingIfEnabled()
-            // clear the spy calls
-            ;(sessionRecording as any)._tryAddCustomEvent.mockClear()
-        })
-
-        it('does not capture pageview on meta event', () => {
-            _emit(createIncrementalSnapshot({ type: META_EVENT_TYPE }))
-
-            expect((sessionRecording as any)['_tryAddCustomEvent']).not.toHaveBeenCalled()
-        })
-
         it('captures pageview as expected on non-meta event', () => {
             fakeNavigateTo('https://test.com')
 

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -23,7 +23,7 @@ import {
     RECORDING_MAX_EVENT_SIZE,
     SessionRecording,
 } from '../../../extensions/replay/sessionrecording'
-import { assignableWindow } from '../../../utils/globals'
+import { assignableWindow, window } from '../../../utils/globals'
 import { RequestRouter } from '../../../utils/request-router'
 import { customEvent, EventType, eventWithTime, pluginEvent } from '@rrweb/types'
 import Mock = jest.Mock
@@ -77,6 +77,12 @@ const createPluginSnapshot = (event = {}): pluginEvent => ({
 
 function makeDecideResponse(partialResponse: Partial<DecideResponse>) {
     return partialResponse as unknown as DecideResponse
+}
+
+const originalLocation = window!.location
+function fakeNavigateTo(href: string) {
+    delete (window as any).location
+    window!.location = { href } as Location
 }
 
 describe('SessionRecording', () => {
@@ -151,6 +157,10 @@ describe('SessionRecording', () => {
         })
 
         sessionRecording = new SessionRecording(posthog)
+    })
+
+    afterEach(() => {
+        window!.location = originalLocation
     })
 
     describe('isRecordingEnabled', () => {
@@ -1590,6 +1600,61 @@ describe('SessionRecording', () => {
 
             expect(sessionRecording['_fullSnapshotTimer']).not.toBe(undefined)
             expect(sessionRecording['_fullSnapshotTimer']).not.toBe(startTimer)
+        })
+    })
+
+    describe('when pageview capture is disabled', () => {
+        beforeEach(() => {
+            jest.spyOn(sessionRecording as any, '_tryAddCustomEvent')
+            posthog.config.capture_pageview = false
+            sessionRecording.startRecordingIfEnabled()
+            // clear the spy calls
+            ;(sessionRecording as any)._tryAddCustomEvent.mockClear()
+        })
+
+        it('does not capture pageview on meta event', () => {
+            _emit(createIncrementalSnapshot({ type: META_EVENT_TYPE }))
+
+            expect((sessionRecording as any)['_tryAddCustomEvent']).not.toHaveBeenCalled()
+        })
+
+        it('captures pageview as expected on non-meta event', () => {
+            fakeNavigateTo('https://test.com')
+
+            _emit(createIncrementalSnapshot({ type: 3 }))
+
+            expect((sessionRecording as any)['_tryAddCustomEvent']).toHaveBeenCalledWith('$pageview', {
+                href: 'https://test.com',
+            })
+            ;(sessionRecording as any)._tryAddCustomEvent.mockClear()
+
+            _emit(createIncrementalSnapshot({ type: 3 }))
+            // the window href has not changed, so we don't capture another pageview
+            expect((sessionRecording as any)['_tryAddCustomEvent']).not.toHaveBeenCalled()
+
+            fakeNavigateTo('https://test.com/other')
+            _emit(createIncrementalSnapshot({ type: 3 }))
+
+            // the window href has changed, so we capture another pageview
+            expect((sessionRecording as any)['_tryAddCustomEvent']).toHaveBeenCalledWith('$pageview', {
+                href: 'https://test.com/other',
+            })
+        })
+    })
+
+    describe('when pageview capture is enabled', () => {
+        beforeEach(() => {
+            jest.spyOn(sessionRecording as any, '_tryAddCustomEvent')
+            posthog.config.capture_pageview = true
+            sessionRecording.startRecordingIfEnabled()
+            // clear the spy calls
+            ;(sessionRecording as any)._tryAddCustomEvent.mockClear()
+        })
+
+        it('does not capture pageview on rrweb events', () => {
+            _emit(createIncrementalSnapshot({ type: 3 }))
+
+            expect((sessionRecording as any)['_tryAddCustomEvent']).not.toHaveBeenCalled()
         })
     })
 })

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -1623,7 +1623,7 @@ describe('SessionRecording', () => {
 
             _emit(createIncrementalSnapshot({ type: 3 }))
 
-            expect((sessionRecording as any)['_tryAddCustomEvent']).toHaveBeenCalledWith('$pageview', {
+            expect((sessionRecording as any)['_tryAddCustomEvent']).toHaveBeenCalledWith('$url_changed', {
                 href: 'https://test.com',
             })
             ;(sessionRecording as any)._tryAddCustomEvent.mockClear()
@@ -1636,7 +1636,7 @@ describe('SessionRecording', () => {
             _emit(createIncrementalSnapshot({ type: 3 }))
 
             // the window href has changed, so we capture another pageview
-            expect((sessionRecording as any)['_tryAddCustomEvent']).toHaveBeenCalledWith('$pageview', {
+            expect((sessionRecording as any)['_tryAddCustomEvent']).toHaveBeenCalledWith('$url_changed', {
                 href: 'https://test.com/other',
             })
         })

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -693,10 +693,10 @@ export class SessionRecording {
 
         if (rawEvent.type === EventType.Meta) {
             const href = this._maskUrl(rawEvent.data.href)
+            this._lastHref = href
             if (!href) {
                 return
             }
-            this._lastHref = href
             rawEvent.data.href = href
         } else {
             this._pageViewFallBack()

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -522,16 +522,13 @@ export class SessionRecording {
             return true
         } catch (e) {
             // Sometimes a race can occur where the recorder is not fully started yet
-            if (this.queuedRRWebEvents.length < 10) {
+            logger.warn(LOGGER_PREFIX + ' could not emit queued rrweb event.', e)
+            this.queuedRRWebEvents.length < 10 &&
                 this.queuedRRWebEvents.push({
                     enqueuedAt: queuedRRWebEvent.enqueuedAt || Date.now(),
                     attempt: queuedRRWebEvent.attempt++,
                     rrwebMethod: queuedRRWebEvent.rrwebMethod,
                 })
-            } else {
-                logger.warn(LOGGER_PREFIX + ' could not emit queued rrweb event.', e, queuedRRWebEvent)
-            }
-
             return false
         }
     }
@@ -745,11 +742,7 @@ export class SessionRecording {
     }
 
     private _pageViewFallBack() {
-        if (
-            this.instance.config.capture_pageview ||
-            !window ||
-            !this.instance.config.session_recording.forceCapturePageview
-        ) {
+        if (this.instance.config.capture_pageview || !window) {
             return
         }
         const currentUrl = this._maskUrl(window.location.href)

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -522,13 +522,16 @@ export class SessionRecording {
             return true
         } catch (e) {
             // Sometimes a race can occur where the recorder is not fully started yet
-            logger.warn(LOGGER_PREFIX + ' could not emit queued rrweb event.', e)
-            this.queuedRRWebEvents.length < 10 &&
+            if (this.queuedRRWebEvents.length < 10) {
                 this.queuedRRWebEvents.push({
                     enqueuedAt: queuedRRWebEvent.enqueuedAt || Date.now(),
                     attempt: queuedRRWebEvent.attempt++,
                     rrwebMethod: queuedRRWebEvent.rrwebMethod,
                 })
+            } else {
+                logger.warn(LOGGER_PREFIX + ' could not emit queued rrweb event.', e, queuedRRWebEvent)
+            }
+
             return false
         }
     }

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -747,7 +747,7 @@ export class SessionRecording {
         }
         const currentUrl = this._maskUrl(window.location.href)
         if (this._lastHref !== currentUrl) {
-            this._tryAddCustomEvent('$pageview', { href: currentUrl })
+            this._tryAddCustomEvent('$url_changed', { href: currentUrl })
             this._lastHref = currentUrl
         }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,13 +184,6 @@ export interface SessionRecordingOptions {
     // our settings here only support a subset of those proposed for rrweb's network capture plugin
     recordHeaders?: boolean
     recordBody?: boolean
-    /**
-     * if capture_pageview is false, recordings will have no URL information associated
-     * if you want to disable page view capture _for events_ but allow URL capture for recordings
-     * you can set forceCapturePageview to true and capture_pageview to false
-     * we still apply the `maskNetworkRequestFn` to the URL before capture
-     */
-    forceCapturePageview?: boolean
 }
 
 export type SessionIdChangedCallback = (sessionId: string, windowId: string | null | undefined) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,6 +184,13 @@ export interface SessionRecordingOptions {
     // our settings here only support a subset of those proposed for rrweb's network capture plugin
     recordHeaders?: boolean
     recordBody?: boolean
+    /**
+     * if capture_pageview is false, recordings will have no URL information associated
+     * if you want to disable page view capture _for events_ but allow URL capture for recordings
+     * you can set forceCapturePageview to true and capture_pageview to false
+     * we still apply the `maskNetworkRequestFn` to the URL before capture
+     */
+    forceCapturePageview?: boolean
 }
 
 export type SessionIdChangedCallback = (sessionId: string, windowId: string | null | undefined) => void


### PR DESCRIPTION
see https://github.com/PostHog/product-internal/pull/571

We rely on rrweb meta events for some href capture, but in a single page app we can't be guaranteed meta event when there is a client side navigation, so we send a $pageview custom rrweb event 

however, if someone is not capturing $pageview events then we won't get those URLs

this adds a fallback so that when page view capture is disabled we still track URL in replay

if someone really wants to use replay but not capture any URLS want to they could provide a URL masking function and  always set the masked result to undefined

this needs changes in ingestion, which is anyway, it turns out, ignoring custom pageview events

----

We four cases

| case | |
|-|-|
|you have capture pageview enabled and event ingestion is working for you | existing code is fine - we capture URLs in recordings|
|you have capture pageview enabled and event ingestion is being dropped because you are over quota | existing code is fine - local capture is still called and we will capture URLs in recordings|
|you have capture pageview disabled but you're happy with URLs being captured in replay | this PR is fine we won't capture pageview events but replay will have URLs|
|you have capture pageview disabled - because you don't want to capture _any_ URLs - |  rrweb uses `window.location.href` for a meta event so it isn't possible to run replay without capturing URLs. So, the fix here is for someone to use the mask url function if they want to use replay without capturing any URLs|

since meta events capture href no matter what... this change isn't strictly useful _until_ we start grouping all urls on the replay events table so we can filter by URL without referencing the event table