### PR TITLE
chore: update default rrweb in array.full.js

### DIFF
--- a/src/loader-globals-full.ts
+++ b/src/loader-globals-full.ts
@@ -1,6 +1,6 @@
 // Same as loader-globals.ts except includes rrweb scripts.
 
-import './loader-recorder'
+import './loader-recorder-v2'
 import { init_from_snippet } from './posthog-core'
 
 init_from_snippet()


### PR DESCRIPTION
## Changes

Default to using rrweb v2 in the `array.full.js`

Following up with a change to remove v1 entirely, but this we certainly want to do.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
