### PR TITLE
fix: return typing of global functions

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -136,7 +136,7 @@ export class SessionRecording {
     private _sampleRate: number | null = null
     private _minimumDuration: number | null = null
 
-    private _fullSnapshotTimer?: number
+    private _fullSnapshotTimer?: ReturnType<typeof setInterval>
 
     // Util to help developers working on this feature manually override
     _forceAllowLocalhostNetworkCapture = false

--- a/src/request-queue.ts
+++ b/src/request-queue.ts
@@ -7,7 +7,7 @@ export class RequestQueue {
     // We start in a paused state and only start flushing when enabled by the parent
     private isPaused: boolean = true
     private queue: QueuedRequestOptions[] = []
-    private flushTimeout?: number // to become interval for reference to clear later
+    private flushTimeout?: ReturnType<typeof setTimeout>
     private flushTimeoutMs = 3000
     private sendRequest: (req: QueuedRequestOptions) => void
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -150,7 +150,7 @@ const _fetch = (options: RequestOptions) => {
     }
 
     const url = options.url
-    let aborter: { signal: any; timeout: number } | null = null
+    let aborter: { signal: any; timeout: ReturnType<typeof setTimeout> } | null = null
 
     if (AbortController) {
         const controller = new AbortController()


### PR DESCRIPTION
## Changes

Seeing these errors locally

```
src/extensions/replay/sessionrecording.ts:644:9 - error TS2322: Type 'Timeout' is not assignable to type 'number'.

644         this._fullSnapshotTimer = setInterval(() => {
            ~~~~~~~~~~~~~~~~~~~~~~~

src/request-queue.ts:50:9 - error TS2322: Type 'Timeout' is not assignable to type 'number'.

50         this.flushTimeout = setTimeout(() => {
           ~~~~~~~~~~~~~~~~~

src/request.ts:159:13 - error TS2322: Type 'Timeout' is not assignable to type 'number'.

159             timeout: setTimeout(() => controller.abort(), options.timeout),
                ~~~~~~~


Found 3 errors.
```

Don't know why this only happens in my environment but TS suggests the return type should be `NodeJS.Timeout`. Depending on the environment posthog-js is running in we can support the global functions return type.

More context: https://stackoverflow.com/questions/45802988/typescript-use-correct-version-of-settimeout-node-vs-window

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
