### PR TITLE
fix: Default api host to us.i.posthog.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Cypress: run `pnpm start` to have a test server running and separately `pnpm cyp
 Testing on IE11 requires a bit more setup. TestCafe tests will use the
 playground application to test the locally built array.full.js bundle. It will
 also verify that the events emitted during the testing of playground are loaded
-into the PostHog app. By default it uses https://app.posthog.com and the
+into the PostHog app. By default it uses https://us.i.posthog.com and the
 project with ID 11213. See the testcafe tests to see how to override these if
 needed. For PostHog internal users ask @benjackwhite or @hazzadous to invite you
 to the Project. You'll need to set `POSTHOG_API_KEY` to your personal API key, and

--- a/playground/nextjs/pages/_app.tsx
+++ b/playground/nextjs/pages/_app.tsx
@@ -10,7 +10,7 @@ import { CookieBanner, cookieConsentGiven } from '@/src/CookieBanner'
 
 if (typeof window !== 'undefined') {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || '', {
-        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
+        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
         session_recording: {
             recordCrossOriginIframes: true,
         },

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -1125,16 +1125,16 @@ describe('posthog core', () => {
         })
 
         it('returns the replay URL', () => {
-            expect(given.lib.get_session_replay_url()).toEqual('https://app.posthog.com/replay/sessionId')
+            expect(given.lib.get_session_replay_url()).toEqual('https://us.posthog.com/replay/sessionId')
         })
 
         it('returns the replay URL including timestamp', () => {
             expect(given.lib.get_session_replay_url({ withTimestamp: true })).toEqual(
-                'https://app.posthog.com/replay/sessionId?t=20' // default lookback is 10 seconds
+                'https://us.posthog.com/replay/sessionId?t=20' // default lookback is 10 seconds
             )
 
             expect(given.lib.get_session_replay_url({ withTimestamp: true, timestampLookBack: 0 })).toEqual(
-                'https://app.posthog.com/replay/sessionId?t=30'
+                'https://us.posthog.com/replay/sessionId?t=30'
             )
         })
     })

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -97,7 +97,7 @@ const PRIMARY_INSTANCE_NAME = 'posthog'
 let ENQUEUE_REQUESTS = !SUPPORTS_REQUEST && userAgent?.indexOf('MSIE') === -1 && userAgent?.indexOf('Mozilla') === -1
 
 export const defaultConfig = (): PostHogConfig => ({
-    api_host: 'https://app.posthog.com',
+    api_host: 'https://us.i.posthog.com',
     api_transport: 'XHR',
     ui_host: null,
     token: '',
@@ -1464,12 +1464,12 @@ export class PostHog {
      *
      *     {
      *       // PostHog API host
-     *       api_host: 'https://app.posthog.com',
+     *       api_host: 'https://us.i.posthog.com',
      *     *
      *       // PostHog web app host, currently only used by the Sentry integration.
      *       // This will only be different from api_host when using a reverse-proxied API host – in that case
      *       // the original web app host needs to be passed here so that links to the web app are still convenient.
-     *       ui_host: 'https://app.posthog.com',
+     *       ui_host: 'https://us.posthog.com',
      *
      *       // Automatically capture clicks, form submissions and change events
      *       autocapture: true

--- a/src/utils/request-router.ts
+++ b/src/utils/request-router.ts
@@ -15,6 +15,7 @@ export enum RequestRouterRegion {
 export type RequestRouterTarget = 'api' | 'ui' | 'assets'
 
 const ingestionDomain = 'i.posthog.com'
+
 export class RequestRouter {
     instance: PostHog
     private _regionCache: Record<string, RequestRouterRegion> = {}

--- a/src/utils/request-router.ts
+++ b/src/utils/request-router.ts
@@ -14,6 +14,7 @@ export enum RequestRouterRegion {
 
 export type RequestRouterTarget = 'api' | 'ui' | 'assets'
 
+const ingestionDomain = 'i.posthog.com'
 export class RequestRouter {
     instance: PostHog
     private _regionCache: Record<string, RequestRouterRegion> = {}
@@ -49,14 +50,14 @@ export class RequestRouter {
         }
 
         if (target === 'ui') {
-            return (this.uiHost || this.apiHost) + path
+            return (this.uiHost || this.apiHost.replace(`.${ingestionDomain}`, '.posthog.com')) + path
         }
 
         if (this.region === RequestRouterRegion.CUSTOM) {
             return this.apiHost + path
         }
 
-        const suffix = 'i.posthog.com' + path
+        const suffix = ingestionDomain + path
 
         switch (target) {
             case 'assets':


### PR DESCRIPTION
## Changes

* Change the default
* Fix so that ui_host removes the `.i.` part

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
