### PR TITLE
fix: Allow capturing `aria-label` attribute on sensitive elements

### DIFF
--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -103,7 +103,7 @@ const autocapture = {
         const elementAttributeIgnorelist = this.config?.element_attribute_ignorelist
         _each(elem.attributes, function (attr: Attr) {
             // Only capture attributes we know are safe
-            if (isSensitiveElement(elem) && ['name', 'id', 'class'].indexOf(attr.name) === -1) return
+            if (isSensitiveElement(elem) && ['name', 'id', 'class', 'aria-label'].indexOf(attr.name) === -1) return
 
             if (elementAttributeIgnorelist?.includes(attr.name)) return
 


### PR DESCRIPTION
## Changes

When autocapturing events on sensitive elements (`input` (except `type="button"` etc.), `textarea` etc.), PostHog currently only allows the capture of the following attributes: `name`, `id`, `class`.

For autocapture events when e.g. a text `input` is edited,  it can be difficult to identify from the event which input has been edited, if it does not have an identifying `name` attribute.

With this change, the `aria-label` attribute is also captured.