### PR TITLE
fix: Return this if already loaded

### DIFF
--- a/src/__tests__/loader.test.ts
+++ b/src/__tests__/loader.test.ts
@@ -5,7 +5,7 @@
  * currently not supported in the browser lib).
  */
 
-import posthog from '../loader-module'
+import posthog, { PostHog } from '../loader-module'
 import sinon from 'sinon'
 import { window } from '../utils/globals'
 
@@ -47,5 +47,23 @@ describe(`Module-based loader in Node env`, () => {
 
     it(`supports capture()`, () => {
         expect(() => posthog.capture(`Pat`)).not.toThrow()
+    })
+
+    it(`always returns posthog from init`, () => {
+        console.error = jest.fn()
+        console.warn = jest.fn()
+        expect(posthog.init(`my-test`, undefined, 'sdk-1')).toBeInstanceOf(PostHog)
+        expect(posthog.init(``, undefined, 'sdk-2')).toBeInstanceOf(PostHog)
+        expect(console.error).toHaveBeenCalledTimes(1)
+        expect(console.error).toHaveBeenCalledWith(
+            '[PostHog.js]',
+            'PostHog was initialized without a token. This likely indicates a misconfiguration. Please check the first argument passed to posthog.init()'
+        )
+        // Already loaded
+        expect(posthog.init(`my-test`, undefined, 'sdk-1')).toBeInstanceOf(PostHog)
+        expect(console.warn).toHaveBeenCalledWith(
+            '[PostHog.js]',
+            'You have already initialized PostHog! Re-initializing is a no-op'
+        )
     })
 })

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -273,7 +273,7 @@ export class PostHog {
      */
     init(token: string, config?: Partial<PostHogConfig>, name?: string): PostHog | void {
         if (!name || name === PRIMARY_INSTANCE_NAME) {
-            // This means we are initialising the primary instance (i.e. this)
+            // This means we are initializing the primary instance (i.e. this)
             return this._init(token, config, name)
         } else {
             const namedPosthog = instances[name] ?? new PostHog()
@@ -308,7 +308,7 @@ export class PostHog {
         }
 
         if (this.__loaded) {
-            logger.warn('You have already initialized PostHog! Re-initialising is a no-op')
+            logger.warn('You have already initialized PostHog! Re-initializing is a no-op')
             return this
         }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -299,12 +299,12 @@ export class PostHog {
     // IE11 compatible. We could use polyfills, which would make the
     // code a bit cleaner, but will add some overhead.
     //
-    _init(token: string, config: Partial<PostHogConfig> = {}, name?: string): PostHog | void {
+    _init(token: string, config: Partial<PostHogConfig> = {}, name?: string): PostHog {
         if (_isUndefined(token) || _isEmptyString(token)) {
             logger.critical(
                 'PostHog was initialized without a token. This likely indicates a misconfiguration. Please check the first argument passed to posthog.init()'
             )
-            return
+            return this
         }
 
         if (this.__loaded) {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -309,7 +309,7 @@ export class PostHog {
 
         if (this.__loaded) {
             logger.warn('You have already initialized PostHog! Re-initialising is a no-op')
-            return
+            return this
         }
 
         this.__loaded = true


### PR DESCRIPTION
## Changes

Related to https://github.com/PostHog/posthog-js/issues/1090

We don't return posthog if the SDK is already initialised or if the token is missing. This appears to be a regression

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
