### PR TITLE
fix: custom event on sampling decision

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -381,16 +381,19 @@ export class SessionRecording {
         }
 
         if (!_isNullish(this._linkedFlag)) {
-            const linkedFlag = _isString(this._linkedFlag) ? this._linkedFlag : this._linkedFlag?.flag
-            const linkedVariant = _isString(this._linkedFlag) ? null : this._linkedFlag?.variant
+            const linkedFlag = _isString(this._linkedFlag) ? this._linkedFlag : this._linkedFlag.flag
+            const linkedVariant = _isString(this._linkedFlag) ? null : this._linkedFlag.variant
             this.instance.onFeatureFlags((_flags, variants) => {
                 const flagIsPresent = _isObject(variants) && linkedFlag in variants
                 const linkedFlagMatches = linkedVariant ? variants[linkedFlag] === linkedVariant : flagIsPresent
                 if (linkedFlagMatches) {
-                    logger.info(LOGGER_PREFIX + ' linked flag matched', {
+                    const payload = {
                         linkedFlag,
                         linkedVariant,
-                    })
+                    }
+                    const tag = 'linked flag matched'
+                    logger.info(LOGGER_PREFIX + ' ' + tag, payload)
+                    this._tryAddCustomEvent(tag, payload)
                 }
                 this._linkedFlagSeen = linkedFlagMatches
             })


### PR DESCRIPTION
see: https://posthoghelp.zendesk.com/agent/tickets/11870 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15045)

customer had a 10% sampling rate set. it was hard to determine if that was the cause of the reported issue because we couldn't see when in the larger session the decision was made

let's add custom events that we can see in the doctor tab when sampling happens or when a linked flag matches