### PR TITLE
fix: Reloading toolbar after closing

### DIFF
--- a/src/__tests__/extensions/toolbar.test.ts
+++ b/src/__tests__/extensions/toolbar.test.ts
@@ -35,7 +35,6 @@ describe('Toolbar', () => {
 
     beforeEach(() => {
         assignableWindow.ph_load_toolbar = jest.fn()
-        delete assignableWindow['_postHogToolbarLoaded']
     })
 
     describe('maybeLoadToolbar', () => {
@@ -175,6 +174,13 @@ describe('Toolbar', () => {
         it('should NOT load if previously loaded', () => {
             expect(toolbar.loadToolbar(toolbarParams)).toBe(true)
             expect(toolbar.loadToolbar(toolbarParams)).toBe(false)
+        })
+
+        it('should load if previously loaded but closed via localstorage', () => {
+            expect(toolbar.loadToolbar(toolbarParams)).toBe(true)
+            expect(toolbar.loadToolbar(toolbarParams)).toBe(false)
+            localStorage.removeItem('_postHogToolbarParams')
+            expect(toolbar.loadToolbar(toolbarParams)).toBe(true)
         })
     })
 

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -169,6 +169,7 @@ export class Toolbar {
             loadScript(toolbarUrl, (err) => {
                 if (err) {
                     logger.error('Failed to load toolbar', err)
+                    this._toolbarScriptLoaded = false
                     return
                 }
                 this._callLoadToolbar(toolbarParams)

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -129,7 +129,7 @@ export class Toolbar {
 
     loadToolbar(params?: ToolbarParams): boolean {
         if (!window || window.localStorage.getItem(LOCALSTORAGE_KEY)) {
-            // If we have a toolbar in localStorage, we don't want to load it again
+            // The toolbar will clear the localStorage key when it's done with it. If it is present that indicates the toolbar is already open and running
             return false
         }
 

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -128,7 +128,7 @@ export class Toolbar {
     }
 
     loadToolbar(params?: ToolbarParams): boolean {
-        if (!window || window.localStorage.getItem(LOCALSTORAGE_KEY)) {
+        if (!window || (window.localStorage.getItem(LOCALSTORAGE_KEY) && this._toolbarScriptLoaded)) {
             // The toolbar will clear the localStorage key when it's done with it. If it is present that indicates the toolbar is already open and running
             return false
         }
@@ -142,8 +142,13 @@ export class Toolbar {
             apiURL: this.instance.requestRouter.endpointFor('ui'),
             ...(disableToolbarMetrics ? { instrument: false } : {}),
         }
-        const { source: _discard, ...paramsToPersist } = toolbarParams // eslint-disable-line
-        window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(paramsToPersist))
+        window.localStorage.setItem(
+            LOCALSTORAGE_KEY,
+            JSON.stringify({
+                ...toolbarParams,
+                source: undefined,
+            })
+        )
 
         if (this._toolbarScriptLoaded) {
             this._callLoadToolbar(toolbarParams)


### PR DESCRIPTION
## Changes

Noticed you can't re-open the toolbar programatically after closing it.

* Changed the logic to check for existing localstorage key. If it exists then exit, otherwise re-open the toolbar.
* Also cleaned up some code around loading the script

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
