### PR TITLE
fix: posthog init should reject invalid config in TypeScript

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -7,6 +7,7 @@ import { _info } from '../utils/event-utils'
 import { document, window } from '../utils/globals'
 import { uuidv7 } from '../uuidv7'
 import * as globals from '../utils/globals'
+import { createPosthogInstance } from './helpers/posthog-instance'
 
 jest.mock('../gdpr-utils', () => ({
     ...jest.requireActual('../gdpr-utils'),
@@ -32,6 +33,27 @@ describe('posthog core', () => {
         // Make sure there's no cached persistence
         given.lib.persistence?.clear?.()
     })
+
+    describe('bootstrap()', () => {
+        it('handles reasonable typos', async () => {
+            const ph = await createPosthogInstance(uuidv7(), {
+                advanced_disable_decide: false,
+                // NB typo of `distinctID` as `distinctId` (lower csae `d`)
+                bootstrap: { distinctId: 'anon-id' },
+            })
+            expect(ph.config.bootstrap.distinctID).toEqual('anon-id')
+        })
+
+        it('handles reasonable typos without overidding', async () => {
+            const ph = await createPosthogInstance(uuidv7(), {
+                advanced_disable_decide: false,
+                // NB typo of `distinctID` as `distinctId` (lower csae `d`)
+                bootstrap: { distinctId: 'anon-id', distinctID: 'correct-id' },
+            })
+            expect(ph.config.bootstrap.distinctID).toEqual('correct-id')
+        })
+    })
+
     describe('capture()', () => {
         given('eventName', () => '$event')
 

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -35,7 +35,7 @@ describe('posthog core', () => {
     })
 
     describe('bootstrap()', () => {
-        it('handles reasonable typos', async () => {
+        it('handles reasonable typo of distinctId', async () => {
             const ph = await createPosthogInstance(uuidv7(), {
                 advanced_disable_decide: false,
                 // NB typo of `distinctID` as `distinctId` (lower csae `d`)
@@ -44,7 +44,16 @@ describe('posthog core', () => {
             expect(ph.config.bootstrap.distinctID).toEqual('anon-id')
         })
 
-        it('handles reasonable typos without overidding', async () => {
+        it('handles reasonable typo of distinct_id', async () => {
+            const ph = await createPosthogInstance(uuidv7(), {
+                advanced_disable_decide: false,
+                // NB typo of `distinctID` as `distinctId` (lower csae `d`)
+                bootstrap: { distinct_id: 'anon-id' },
+            })
+            expect(ph.config.bootstrap.distinctID).toEqual('anon-id')
+        })
+
+        it('handles reasonable typos without overriding', async () => {
             const ph = await createPosthogInstance(uuidv7(), {
                 advanced_disable_decide: false,
                 // NB typo of `distinctID` as `distinctId` (lower csae `d`)

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -7,7 +7,6 @@ import { _info } from '../utils/event-utils'
 import { document, window } from '../utils/globals'
 import { uuidv7 } from '../uuidv7'
 import * as globals from '../utils/globals'
-import { createPosthogInstance } from './helpers/posthog-instance'
 
 jest.mock('../gdpr-utils', () => ({
     ...jest.requireActual('../gdpr-utils'),
@@ -32,35 +31,6 @@ describe('posthog core', () => {
         jest.useRealTimers()
         // Make sure there's no cached persistence
         given.lib.persistence?.clear?.()
-    })
-
-    describe('bootstrap()', () => {
-        it('handles reasonable typo of distinctId', async () => {
-            const ph = await createPosthogInstance(uuidv7(), {
-                advanced_disable_decide: false,
-                // NB typo of `distinctID` as `distinctId` (lower csae `d`)
-                bootstrap: { distinctId: 'anon-id' },
-            })
-            expect(ph.config.bootstrap.distinctID).toEqual('anon-id')
-        })
-
-        it('handles reasonable typo of distinct_id', async () => {
-            const ph = await createPosthogInstance(uuidv7(), {
-                advanced_disable_decide: false,
-                // NB typo of `distinctID` as `distinctId` (lower csae `d`)
-                bootstrap: { distinct_id: 'anon-id' },
-            })
-            expect(ph.config.bootstrap.distinctID).toEqual('anon-id')
-        })
-
-        it('handles reasonable typos without overriding', async () => {
-            const ph = await createPosthogInstance(uuidv7(), {
-                advanced_disable_decide: false,
-                // NB typo of `distinctID` as `distinctId` (lower csae `d`)
-                bootstrap: { distinctId: 'anon-id', distinctID: 'correct-id' },
-            })
-            expect(ph.config.bootstrap.distinctID).toEqual('correct-id')
-        })
     })
 
     describe('capture()', () => {

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -32,7 +32,6 @@ describe('posthog core', () => {
         // Make sure there's no cached persistence
         given.lib.persistence?.clear?.()
     })
-
     describe('capture()', () => {
         given('eventName', () => '$event')
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -78,10 +78,13 @@ this.__x === private - only use within the class
 Globals should be all caps
 */
 
-/* posthog.init is called with `Partial<PostHogConfig>` but we want to ensure that only valid keys are passed
- * to the config object.
- * This type ensures that only keys that are valid in the PostHogConfig type are allowed.
- * it even works for nested types
+/* posthog.init is called with `Partial<PostHogConfig>`
+ * and we want to ensure that only valid keys are passed to the config object.
+ * TypeScript does not enforce that the object passed does not have extra keys.
+ * So someone can call with { bootstrap: { distinctId: '123'} }
+ * which is not a valid key. They should have passed distinctID (upper case D).
+ * That's a really tricky mistake to spot.
+ * The OnlyValidKeys type ensures that only keys that are valid in the PostHogConfig type are allowed.
  */
 type OnlyValidKeys<T, Shape> = T extends Shape ? (Exclude<keyof T, keyof Shape> extends never ? T : never) : never
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -384,6 +384,17 @@ export class PostHog {
             }
         }
 
+        if (
+            !_isUndefined(config.bootstrap) &&
+            _isUndefined(config.bootstrap.distinctID) &&
+            (config.bootstrap as any).distinctId
+        ) {
+            // distinctId (lowercase d) is a reasonable typo for distinctID
+            // that we have seen in the wild
+            logger.warn('bootstrap distinctId is a typo. It should be distinctID (capital D). Copying the value.')
+            config.bootstrap.distinctID = (config.bootstrap as any)?.distinctId
+        }
+
         // isUndefined doesn't provide typehint here so wouldn't reduce bundle as we'd need to assign
         // eslint-disable-next-line posthog-js/no-direct-undefined-check
         if (config.bootstrap?.distinctID !== undefined) {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -387,12 +387,12 @@ export class PostHog {
         if (
             !_isUndefined(config.bootstrap) &&
             _isUndefined(config.bootstrap.distinctID) &&
-            (config.bootstrap as any).distinctId
+            ((config.bootstrap as any).distinctId || (config.bootstrap as any).distinct_id)
         ) {
             // distinctId (lowercase d) is a reasonable typo for distinctID
             // that we have seen in the wild
-            logger.warn('bootstrap distinctId is a typo. It should be distinctID (capital D). Copying the value.')
-            config.bootstrap.distinctID = (config.bootstrap as any)?.distinctId
+            logger.info('bootstrap distinctId is a typo. It should be distinctID (capital D). Copying the value.')
+            config.bootstrap.distinctID = (config.bootstrap as any).distinctId || (config.bootstrap as any).distinct_id
         }
 
         // isUndefined doesn't provide typehint here so wouldn't reduce bundle as we'd need to assign

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,13 @@ export interface AutocaptureConfig {
     capture_copied_text?: boolean
 }
 
+export interface BootstrapConfig {
+    distinctID?: string
+    isIdentifiedID?: boolean
+    featureFlags?: Record<string, boolean | string>
+    featureFlagPayloads?: Record<string, JsonType>
+}
+
 export interface PostHogConfig {
     api_host: string
     /** @deprecated - This property is no longer supported */
@@ -132,12 +139,7 @@ export interface PostHogConfig {
     capture_performance?: boolean
     // Should only be used for testing. Could negatively impact performance.
     disable_compression: boolean
-    bootstrap: {
-        distinctID?: string
-        isIdentifiedID?: boolean
-        featureFlags?: Record<string, boolean | string>
-        featureFlagPayloads?: Record<string, JsonType>
-    }
+    bootstrap: BootstrapConfig
     segment?: any
     __preview_send_client_session_params?: boolean
     disable_scroll_properties?: boolean


### PR DESCRIPTION
We've seen the reasonable typo of `Id` for `ID` when people use distinct id bootstrapping with this SDK

see https://twitter.com/illyism/status/1771586772067123490

Because we accept `Partial<PostHogConfig>` into init Typescript doesn't check for _additional_ keys 

With some typescript magic we can change that behavior without breaking the ability to only pass partial config

![2024-03-23 18 33 59](https://github.com/PostHog/posthog-js/assets/984817/d9c236e8-79f5-4005-8152-7824bba4b6cb)

