### PR TITLE
fix(decide): Respect disable_compression for flags

### DIFF
--- a/src/__tests__/featureflags.js
+++ b/src/__tests__/featureflags.js
@@ -209,10 +209,12 @@ describe('featureflags', () => {
             },
         }
 
-        expect(given.featureFlags.getFlags()).toEqual(['alpha-feature-2', 'multivariate-flag'])
+        // should return both true and false flags
+        expect(given.featureFlags.getFlags()).toEqual(['beta-feature', 'alpha-feature-2', 'multivariate-flag'])
         expect(given.featureFlags.getFlagVariants()).toEqual({
             'alpha-feature-2': 'as-a-variant',
             'multivariate-flag': 'variant-1',
+            'beta-feature': false,
         })
     })
 
@@ -540,6 +542,9 @@ describe('featureflags', () => {
                 second: true,
             })
 
+            // check right compression is sent
+            expect(given.instance._send_request.mock.calls[0][0].compression).toEqual('base64')
+
             // check the request sent person properties
             expect(given.instance._send_request.mock.calls[0][0].data).toEqual({
                 token: 'random fake token',
@@ -584,6 +589,18 @@ describe('featureflags', () => {
 
             // check reload request was not sent
             expect(given.instance._send_request).not.toHaveBeenCalled()
+        })
+
+        it('on providing config disable_compression', () => {
+            given.instance.config = {
+                ...given.instance.config,
+                disable_compression: true,
+            }
+
+            given.featureFlags.reloadFeatureFlags()
+            jest.runAllTimers()
+
+            expect(given.instance._send_request.mock.calls[0][0].compression).toEqual(undefined)
         })
     })
 

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -37,7 +37,7 @@ export class Decide {
             method: 'POST',
             url: this.instance.requestRouter.endpointFor('api', '/decide/?v=3'),
             data,
-            compression: Compression.Base64,
+            compression: this.instance.config.disable_compression ? undefined : Compression.Base64,
             timeout: this.instance.config.feature_flag_request_timeout_ms,
             callback: (response) => this.parseDecideResponse(response.json as DecideResponse | undefined),
         })

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -110,11 +110,7 @@ export class PostHogFeatureFlags {
         const finalFlags = _extend({}, enabledFlags)
         const overriddenKeys = Object.keys(overriddenFlags)
         for (let i = 0; i < overriddenKeys.length; i++) {
-            if (overriddenFlags[overriddenKeys[i]] === false) {
-                delete finalFlags[overriddenKeys[i]]
-            } else {
-                finalFlags[overriddenKeys[i]] = overriddenFlags[overriddenKeys[i]]
-            }
+            finalFlags[overriddenKeys[i]] = overriddenFlags[overriddenKeys[i]]
         }
         if (!this._override_warning) {
             logger.warn(' Overriding feature flags!', {
@@ -194,7 +190,7 @@ export class PostHogFeatureFlags {
             method: 'POST',
             url: this.instance.requestRouter.endpointFor('api', '/decide/?v=3'),
             data: json_data,
-            compression: Compression.Base64,
+            compression: this.instance.config.disable_compression ? undefined : Compression.Base64,
             timeout: this.instance.config.feature_flag_request_timeout_ms,
             callback: (response) => {
                 this.setReloadingPaused(false)


### PR DESCRIPTION
## Changes

Don't compress decide requests when disable_compression is set.

Seems we missed this in the request refactor, as previously when this config option was set, decide would disable compression as well. Had a user request about this.
...

added unit tests, ran locally with posthog and see everything works as expected
## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
