### PR TITLE
feat: allow override sampling

### DIFF
--- a/cypress/e2e/opting-out.cy.ts
+++ b/cypress/e2e/opting-out.cy.ts
@@ -1,20 +1,4 @@
-import { assertWhetherPostHogRequestsWereCalled } from '../support/assertions'
-
-function pollPhCaptures(event, wait = 200, attempts = 0, maxAttempts = 50) {
-    return cy.phCaptures().then((capturesArray) => {
-        if (capturesArray.some((capture) => capture === event)) {
-            return cy.wrap(true)
-        } else if (attempts < maxAttempts) {
-            // If not found and the max attempts are not reached, wait for a moment and try again
-            return cy.wait(wait).then(() => {
-                return pollPhCaptures(event, wait, attempts + 1, maxAttempts)
-            })
-        } else {
-            // Log the failure to find the value after max attempts
-            throw new Error('Max attempts reached without finding the expected event')
-        }
-    })
-}
+import { assertWhetherPostHogRequestsWereCalled, pollPhCaptures } from '../support/assertions'
 
 function assertThatRecordingStarted() {
     cy.phCaptures({ full: true }).then((captures) => {

--- a/cypress/support/assertions.ts
+++ b/cypress/support/assertions.ts
@@ -1,5 +1,21 @@
 import Chainable = Cypress.Chainable
 
+export function pollPhCaptures(event, wait = 200, attempts = 0, maxAttempts = 50): Chainable<any> {
+    return cy.phCaptures().then((capturesArray) => {
+        if (capturesArray.some((capture) => capture === event)) {
+            return cy.wrap(true)
+        } else if (attempts < maxAttempts) {
+            // If not found and the max attempts are not reached, wait for a moment and try again
+            return cy.wait(wait).then(() => {
+                return pollPhCaptures(event, wait, attempts + 1, maxAttempts)
+            })
+        } else {
+            // Log the failure to find the value after max attempts
+            throw new Error('Max attempts reached without finding the expected event')
+        }
+    })
+}
+
 /**
  * Receives an object with keys as the name of the route and values as whether the route should have been called.
  * e.g. { '@recorder': true, '@decide': false }

--- a/cypress/support/assertions.ts
+++ b/cypress/support/assertions.ts
@@ -1,18 +1,20 @@
+import Chainable = Cypress.Chainable
+
 /**
  * Receives an object with keys as the name of the route and values as whether the route should have been called.
  * e.g. { '@recorder': true, '@decide': false }
  * the keys must match a `cy.intercept` alias
  **/
-export function assertWhetherPostHogRequestsWereCalled(expectedCalls: Record<string, boolean>) {
-    cy.wait(200)
-
-    for (const [key, value] of Object.entries(expectedCalls)) {
-        cy.get(key).then((interceptions) => {
-            if (value) {
-                expect(interceptions).to.be.an('object')
-            } else {
-                expect(interceptions).not.to.be.an('object')
-            }
-        })
-    }
+export function assertWhetherPostHogRequestsWereCalled(expectedCalls: Record<string, boolean>): Chainable<undefined> {
+    return cy.wait(200).then(() => {
+        for (const [key, value] of Object.entries(expectedCalls)) {
+            cy.get(key).then((interceptions) => {
+                if (value) {
+                    expect(interceptions).to.be.an('object')
+                } else {
+                    expect(interceptions).not.to.be.an('object')
+                }
+            })
+        }
+    })
 }

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -1409,7 +1409,7 @@ describe('SessionRecording', () => {
 
         it('starts with an undefined minimum duration', () => {
             sessionRecording.startRecordingIfEnabled()
-            expect(sessionRecording['_minimumDuration']).toBe(null)
+            expect(sessionRecording['minimumDuration']).toBe(null)
         })
 
         it('can set minimum duration from decide response', () => {
@@ -1418,7 +1418,7 @@ describe('SessionRecording', () => {
                     sessionRecording: { minimumDurationMilliseconds: 1500 },
                 })
             )
-            expect(sessionRecording['_minimumDuration']).toBe(1500)
+            expect(sessionRecording['minimumDuration']).toBe(1500)
         })
 
         it('does not flush if below the minimum duration', () => {
@@ -1432,7 +1432,7 @@ describe('SessionRecording', () => {
             const { sessionStartTimestamp } = sessionManager.checkAndGetSessionAndWindowId(true)
             _emit(createIncrementalSnapshot({ data: { source: 1 }, timestamp: sessionStartTimestamp + 100 }))
             expect(sessionRecording['sessionDuration']).toBe(100)
-            expect(sessionRecording['_minimumDuration']).toBe(1500)
+            expect(sessionRecording['minimumDuration']).toBe(1500)
 
             expect(sessionRecording['buffer']?.data.length).toBe(2) // full snapshot and the emitted incremental event
             // call the private method to avoid waiting for the timer
@@ -1457,7 +1457,7 @@ describe('SessionRecording', () => {
             _emit(createIncrementalSnapshot({ data: { source: 1 }, timestamp: sessionStartTimestamp - 1000 }))
 
             expect(sessionRecording['sessionDuration']).toBe(-1000)
-            expect(sessionRecording['_minimumDuration']).toBe(1500)
+            expect(sessionRecording['minimumDuration']).toBe(1500)
 
             expect(sessionRecording['buffer']?.data.length).toBe(2) // full snapshot and the emitted incremental event
             // call the private method to avoid waiting for the timer
@@ -1477,7 +1477,7 @@ describe('SessionRecording', () => {
             const { sessionStartTimestamp } = sessionManager.checkAndGetSessionAndWindowId(true)
             _emit(createIncrementalSnapshot({ data: { source: 1 }, timestamp: sessionStartTimestamp + 100 }))
             expect(sessionRecording['sessionDuration']).toBe(100)
-            expect(sessionRecording['_minimumDuration']).toBe(1500)
+            expect(sessionRecording['minimumDuration']).toBe(1500)
 
             expect(sessionRecording['buffer']?.data.length).toBe(2) // full snapshot and the emitted incremental event
             // call the private method to avoid waiting for the timer

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -6,6 +6,7 @@ import {
     SESSION_RECORDING_CANVAS_RECORDING,
     SESSION_RECORDING_ENABLED_SERVER_SIDE,
     SESSION_RECORDING_IS_SAMPLED,
+    SESSION_RECORDING_SAMPLE_RATE,
 } from '../../../constants'
 import { SessionIdManager } from '../../../sessionid'
 import {
@@ -342,7 +343,8 @@ describe('SessionRecording', () => {
                 })
             )
 
-            expect(sessionRecording['_sampleRate']).toBe(0.7)
+            expect(sessionRecording['sampleRate']).toBe(0.7)
+            expect(posthog.get_property(SESSION_RECORDING_SAMPLE_RATE)).toBe(0.7)
         })
 
         it('starts session recording, saves setting and endpoint when enabled', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export const CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE = '$console_log_recording
 export const SESSION_RECORDING_NETWORK_PAYLOAD_CAPTURE = '$session_recording_network_payload_capture'
 export const SESSION_RECORDING_CANVAS_RECORDING = '$session_recording_canvas_recording'
 export const SESSION_RECORDING_SAMPLE_RATE = '$replay_sample_rate'
+export const SESSION_RECORDING_MINIMUM_DURATION = '$replay_minimum_duration'
 export const SESSION_ID = '$sesid'
 export const SESSION_RECORDING_IS_SAMPLED = '$session_is_sampled'
 export const ENABLED_FEATURE_FLAGS = '$enabled_feature_flags'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const SESSION_RECORDING_ENABLED_SERVER_SIDE = '$session_recording_enabled
 export const CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE = '$console_log_recording_enabled_server_side'
 export const SESSION_RECORDING_NETWORK_PAYLOAD_CAPTURE = '$session_recording_network_payload_capture'
 export const SESSION_RECORDING_CANVAS_RECORDING = '$session_recording_canvas_recording'
+export const SESSION_RECORDING_SAMPLE_RATE = '$replay_sample_rate'
 export const SESSION_ID = '$sesid'
 export const SESSION_RECORDING_IS_SAMPLED = '$session_is_sampled'
 export const ENABLED_FEATURE_FLAGS = '$enabled_feature_flags'

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -14,7 +14,7 @@ import { window, assignableWindow } from './utils/globals'
 import { autocapture } from './autocapture'
 import { PostHogFeatureFlags } from './posthog-featureflags'
 import { PostHogPersistence } from './posthog-persistence'
-import { ALIAS_ID_KEY, FLAG_CALL_REPORTED, PEOPLE_DISTINCT_ID_KEY } from './constants'
+import { ALIAS_ID_KEY, FLAG_CALL_REPORTED, PEOPLE_DISTINCT_ID_KEY, SESSION_RECORDING_IS_SAMPLED } from './constants'
 import { SessionRecording } from './extensions/replay/sessionrecording'
 import { Decide } from './decide'
 import { Toolbar } from './extensions/toolbar'
@@ -176,12 +176,14 @@ class DeprecatedWebPerformanceObserver {
     get _forceAllowLocalhost(): boolean {
         return this.__forceAllowLocalhost
     }
+
     set _forceAllowLocalhost(value: boolean) {
         logger.error(
             'WebPerformanceObserver is deprecated and has no impact on network capture. Use `_forceAllowLocalhostNetworkCapture` on `posthog.sessionRecording`'
         )
         this.__forceAllowLocalhost = value
     }
+
     private __forceAllowLocalhost: boolean = false
 }
 
@@ -1648,8 +1650,18 @@ export class PostHog {
     /**
      * turns session recording on, and updates the config option
      * disable_session_recording to false
+     * @param override.sampling - optional boolean to override the default sampling behavior - ensures the next session recording to start will not be skipped by sampling config.
      */
-    startSessionRecording(): void {
+    startSessionRecording(override: { sampling?: boolean }): void {
+        if (override?.sampling) {
+            // allow the session id check to rotate session id if necessary
+            const ids = this.sessionManager?.checkAndGetSessionAndWindowId()
+            this.persistence?.register({
+                // short-circuits the `makeSamplingDecision` function in the session recording module
+                [SESSION_RECORDING_IS_SAMPLED]: true,
+            })
+            logger.info('Session recording started with sampling override for session: ', ids?.sessionId)
+        }
         this.set_config({ disable_session_recording: false })
     }
 


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog-js/issues/1065

allows calling `startSessionRecording` with an override config 

passing `{sampling: true}` overrides sampling decision by setting the current session as sampled so that recording will start regardless of the sample rate

also adds ability to poll for events to fix the opt out cypress tests

---

while testing this i noticed that the sample rate is only stored in memory, and its presence is verified before applying sampling logic, so if a session was sampled and then the page reloaded, we'd not check that whether the session had been sampled on reload, and might re-make the decision (and so not sample the session)

so I switched to storing the sample rate in memory and added a cypress test to verify that the sampling decision survives a reload

----

![2024-03-30 11 10 43](https://github.com/PostHog/posthog-js/assets/984817/103048c5-c789-4899-8d91-4afb0c779579)
