### PR TITLE
feat: Add __posthog_debug query string

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -124,7 +124,7 @@ export const defaultConfig = (): PostHogConfig => ({
     save_referrer: true,
     capture_pageview: true,
     capture_pageleave: true, // We'll only capture pageleave events if capture_pageview is also true
-    debug: (location?.search && location.search.indexOf('__posthog_debug=true') !== -1) || false,
+    debug: (location && _isString(location?.search) && location.search.indexOf('__posthog_debug=true') !== -1) || false,
     verbose: false,
     cookie_expiration: 365,
     upgrade: false,

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -10,7 +10,7 @@ import {
     isCrossDomainCookie,
     isDistinctIdStringLike,
 } from './utils'
-import { window, assignableWindow } from './utils/globals'
+import { window, assignableWindow, location } from './utils/globals'
 import { autocapture } from './autocapture'
 import { PostHogFeatureFlags } from './posthog-featureflags'
 import { PostHogPersistence } from './posthog-persistence'
@@ -124,7 +124,7 @@ export const defaultConfig = (): PostHogConfig => ({
     save_referrer: true,
     capture_pageview: true,
     capture_pageleave: true, // We'll only capture pageleave events if capture_pageview is also true
-    debug: false,
+    debug: (location?.search && location.search.indexOf('__posthog_debug=true') !== -1) || false,
     verbose: false,
     cookie_expiration: 365,
     upgrade: false,


### PR DESCRIPTION
## Changes

Add a query string to help with debugging the first visit to a site.

We already have the local storage version of this, but the query string method allows testing the order of operations when first visiting a site in a private browser tab, where local storage doesn't exist

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
