### PR TITLE
feat: measure identified events

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -370,7 +370,7 @@ describe('posthog core', () => {
         given('overrides', () => ({
             config: given.config,
             persistence: {
-                properties: () => ({ distinct_id: 'abc', persistent: 'prop' }),
+                properties: () => ({ distinct_id: 'abc', persistent: 'prop', $is_identified: false }),
                 remove_event_timer: jest.fn(),
             },
             sessionPersistence: {
@@ -407,6 +407,7 @@ describe('posthog core', () => {
                 persistent: 'prop',
                 $window_id: 'windowId',
                 $session_id: 'sessionId',
+                $is_identified: false,
             })
         })
 
@@ -427,11 +428,12 @@ describe('posthog core', () => {
                 $window_id: 'windowId',
                 $session_id: 'sessionId',
                 $lib_custom_api_host: 'https://custom.posthog.com',
+                $is_identified: false,
             })
         })
 
         it('respects property_denylist and property_blacklist', () => {
-            given('property_denylist', () => ['$lib', 'persistent'])
+            given('property_denylist', () => ['$lib', 'persistent', '$is_identified'])
             given('property_blacklist', () => ['token'])
 
             expect(given.subject).toEqual({

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -60,6 +60,7 @@ describe('posthog core', () => {
                     Object.assign(this.props, properties)
                 },
                 props: {},
+                get_user_state: () => 'anonymous',
             },
             sessionPersistence: {
                 update_search_keyword: jest.fn(),

--- a/src/__tests__/posthog-persistence.test.ts
+++ b/src/__tests__/posthog-persistence.test.ts
@@ -54,7 +54,7 @@ describe('persistence', () => {
             const lib = new PostHogPersistence(makePostHogConfig('bla', persistenceMode))
             lib.register({ distinct_id: 'testy', test_prop: 'test_value' })
             lib.set_user_state('identified')
-            expect(lib.properties()).toEqual({ distinct_id: 'testy', test_prop: 'test_value' })
+            expect(lib.properties()).toEqual({ distinct_id: 'testy', test_prop: 'test_value', $is_identified: true })
         })
 
         it(`should only call save if props changes`, () => {
@@ -107,6 +107,7 @@ describe('persistence', () => {
             expect(library.properties()).toEqual({
                 '$feature/flag': 'variant',
                 '$feature/other': true,
+                $is_identified: false,
             })
         })
     })
@@ -169,7 +170,7 @@ describe('persistence', () => {
         })
 
         it('should allow swapping between storage methods', () => {
-            const expectedProps = () => ({ distinct_id: 'test', test_prop: 'test_val' })
+            const expectedProps = () => ({ distinct_id: 'test', test_prop: 'test_val', $is_identified: false })
             let config = makePostHogConfig('test', 'localStorage+cookie')
             const lib = new PostHogPersistence(makePostHogConfig('test', 'localStorage+cookie'))
             lib.register(expectedProps())

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -899,6 +899,9 @@ export class PostHog {
             properties = sanitize_properties(properties, event_name)
         }
 
+        // Add as late as possible, so it can't be overridden
+        properties['$is_identified'] = this.persistence.get_user_state() === 'identified'
+
         return properties
     }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -899,9 +899,6 @@ export class PostHog {
             properties = sanitize_properties(properties, event_name)
         }
 
-        // Add as late as possible, so it can't be overridden
-        properties['$is_identified'] = this.persistence.get_user_state() === 'identified'
-
         return properties
     }
 

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -111,6 +111,9 @@ export class PostHogPersistence {
                 p[k] = v
             }
         })
+
+        p['$is_identified'] = this.get_user_state() === 'identified'
+
         return p
     }
 


### PR DESCRIPTION
## Changes

Send `$is_identified property` as a boolean, based on whether `identify` has been called

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
