### PR TITLE
fix: Fix $is_identified

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "test:functional": "jest functional_tests",
         "test-watch": "jest --watch src",
         "cypress": "cypress open",
-        "prepare": "husky install"
+        "prepare": "husky install",
+        "yalc-publish": "yalc publish"
     },
     "main": "dist/module.js",
     "module": "dist/es.js",

--- a/playground/nextjs/README.md
+++ b/playground/nextjs/README.md
@@ -7,3 +7,29 @@ NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' pnpm dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+
+### Against a locally running PostHog instance
+
+```bash
+NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' NEXT_PUBLIC_POSTHOG_HOST='http://localhost:8000' pnpm dev
+```
+
+### Testing local changes to posthog-js
+Follow the instructions to set up YALC in the [root README](../../README.md).
+
+After you have run `yalc publish` in the root directory, run `yalc add posthog-js` in this directory, and then you can
+run `pnpm dev` to see your changes reflected in the demo project.
+
+There is a shorthand script for running these 3 commands
+
+```bash
+pnpm yalc-dev
+```
+
+If you need to provide environment variables, you can do so, like
+
+```bash
+NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' NEXT_PUBLIC_POSTHOG_HOST='http://localhost:8000' pnpm yalc-dev
+```
+

--- a/playground/nextjs/package.json
+++ b/playground/nextjs/package.json
@@ -7,7 +7,8 @@
         "dev": "pnpm run clean-react && next dev",
         "build": "next build",
         "start": "next start",
-        "lint": "next lint"
+        "lint": "next lint",
+        "yalc-dev": "pnpm run -C ../.. yalc-publish && rm -r .next/cache .yalc/posthog-js && yalc add posthog-js && pnpm dev"
     },
     "dependencies": {
         "@lottiefiles/react-lottie-player": "^3.5.3",
@@ -17,7 +18,7 @@
         "eslint": "8.34.0",
         "eslint-config-next": "13.1.6",
         "next": "13.5.6",
-        "posthog-js": "^1.103.1",
+        "posthog-js": "file:.yalc/posthog-js",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "typescript": "4.9.5"

--- a/src/__tests__/identify.test.ts
+++ b/src/__tests__/identify.test.ts
@@ -38,4 +38,26 @@ describe('identify', () => {
         expect(jest.mocked(logger).error).toBeCalledTimes(0)
         expect(jest.mocked(logger).warn).toBeCalledTimes(1)
     })
+
+    it('it should send $is_identified = true with the identify event and following events', async () => {
+        // arrange
+        const token = uuidv7()
+        const onCapture = jest.fn()
+        const posthog = await createPosthogInstance(token, { _onCapture: onCapture })
+        const distinctId = '123'
+
+        // act
+        posthog.capture('custom event before identify')
+        posthog.identify(distinctId)
+        posthog.capture('custom event after identify')
+
+        // assert
+        const eventBeforeIdentify = onCapture.mock.calls[0]
+        expect(eventBeforeIdentify[1].properties.$is_identified).toEqual(false)
+        const identifyCall = onCapture.mock.calls[1]
+        expect(identifyCall[0]).toEqual('$identify')
+        expect(identifyCall[1].properties.$is_identified).toEqual(true)
+        const eventAfterIdentify = onCapture.mock.calls[2]
+        expect(eventAfterIdentify[1].properties.$is_identified).toEqual(true)
+    })
 })

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -68,6 +68,7 @@ describe('posthog core', () => {
                 update_referrer_info: jest.fn(),
                 update_config: jest.fn(),
                 properties: jest.fn(),
+                get_user_state: () => 'anonymous',
             },
             _send_request: jest.fn(),
             compression: {},
@@ -372,9 +373,11 @@ describe('posthog core', () => {
             persistence: {
                 properties: () => ({ distinct_id: 'abc', persistent: 'prop', $is_identified: false }),
                 remove_event_timer: jest.fn(),
+                get_user_state: () => 'anonymous',
             },
             sessionPersistence: {
                 properties: () => ({ distinct_id: 'abc', persistent: 'prop' }),
+                get_user_state: () => 'anonymous',
             },
             sessionManager: {
                 checkAndGetSessionAndWindowId: jest.fn().mockReturnValue({

--- a/src/__tests__/posthog-persistence.test.ts
+++ b/src/__tests__/posthog-persistence.test.ts
@@ -54,7 +54,7 @@ describe('persistence', () => {
             const lib = new PostHogPersistence(makePostHogConfig('bla', persistenceMode))
             lib.register({ distinct_id: 'testy', test_prop: 'test_value' })
             lib.set_user_state('identified')
-            expect(lib.properties()).toEqual({ distinct_id: 'testy', test_prop: 'test_value', $is_identified: true })
+            expect(lib.properties()).toEqual({ distinct_id: 'testy', test_prop: 'test_value' })
         })
 
         it(`should only call save if props changes`, () => {
@@ -107,7 +107,6 @@ describe('persistence', () => {
             expect(library.properties()).toEqual({
                 '$feature/flag': 'variant',
                 '$feature/other': true,
-                $is_identified: false,
             })
         })
     })

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -878,6 +878,10 @@ export class PostHog {
             properties
         )
 
+        properties['$is_identified'] =
+            this.persistence.get_user_state() === 'identified' ||
+            this.sessionPersistence.get_user_state() === 'identified'
+
         if (_isArray(this.config.property_denylist) && _isArray(this.config.property_blacklist)) {
             // since property_blacklist is deprecated in favor of property_denylist, we merge both of them here
             // TODO: merge this only once, requires refactoring tests

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -111,9 +111,6 @@ export class PostHogPersistence {
                 p[k] = v
             }
         })
-
-        p['$is_identified'] = this.get_user_state() === 'identified'
-
         return p
     }
 


### PR DESCRIPTION
## Changes
Fix a big that was introduced in https://github.com/PostHog/posthog-js/pull/1114 where $is_identified can be false even when the user is identified.

Instead of letting the session_persistance take priority over the regular persistance, return true if either persistance know the user is identified.

Also added a test to cover this case, and some scripts + docs to make it simpler to use the nextjs playground as a place to test posthog-js changes.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
