### PR TITLE
feat: Person processing 2 - handle group and setPersonProperties

### DIFF
--- a/playground/nextjs/package.json
+++ b/playground/nextjs/package.json
@@ -18,7 +18,7 @@
         "eslint": "8.34.0",
         "eslint-config-next": "13.1.6",
         "next": "13.5.6",
-        "posthog-js": "^1.118.0",
+        "posthog-js": "1.120.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "typescript": "4.9.5"

--- a/playground/nextjs/pages/_app.tsx
+++ b/playground/nextjs/pages/_app.tsx
@@ -17,9 +17,9 @@ if (typeof window !== 'undefined') {
         debug: true,
         scroll_root_selector: ['#scroll_element', 'html'],
         persistence: cookieConsentGiven() ? 'localStorage+cookie' : 'memory',
+        __preview_process_person: 'identified_only',
     })
-
-    window.posthog = posthog
+    ;(window as any).posthog = posthog
 }
 
 export default function App({ Component, pageProps }: AppProps) {

--- a/playground/nextjs/pnpm-lock.yaml
+++ b/playground/nextjs/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: 13.5.6
     version: 13.5.6(react-dom@18.2.0)(react@18.2.0)
   posthog-js:
-    specifier: ^1.118.0
-    version: 1.118.0
+    specifier: 1.120.3
+    version: 1.120.3
   react:
     specifier: 18.2.0
     version: 18.2.0
@@ -2249,8 +2249,8 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
-  /posthog-js@1.118.0:
-    resolution: {integrity: sha512-H/MwrSplQM8jeAQ7K261M+O0vZaSEk1Uh7q1B3tW/6Iky7qzAU+Wv5R2hevqvIySaH8phs4XOw2oURE7viCQUA==}
+  /posthog-js@1.120.3:
+    resolution: {integrity: sha512-J5o2aRNIrSCt6/kei+UN9RhTpZDa9bcRkwkauhjrtCz9Ne3yjCP9phfIlP5HJrJBpNGIzK/YlFuy8/57Tw+piQ==}
     dependencies:
       fflate: 0.4.8
       preact: 10.20.1

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -58,7 +58,7 @@ describe('person processing', () => {
             // assert
             expect(jest.mocked(logger).error).toBeCalledTimes(1)
             expect(jest.mocked(logger).error).toHaveBeenCalledWith(
-                'posthog.identify was called, but the process_person configuration is set to "never". This call will be ignored.'
+                'posthog.identify was called, but process_person is set to "never". This call will be ignored.'
             )
             expect(onCapture).toBeCalledTimes(0)
         })
@@ -198,6 +198,11 @@ describe('person processing', () => {
             posthog.capture('custom event after group')
 
             // assert
+            expect(jest.mocked(logger).error).toBeCalledTimes(1)
+            expect(jest.mocked(logger).error).toHaveBeenCalledWith(
+                'posthog.group was called, but process_person is set to "never". This call will be ignored.'
+            )
+
             expect(onCapture).toBeCalledTimes(2)
             const eventBeforeGroup = onCapture.mock.calls[0]
             expect(eventBeforeGroup[1].properties.$process_person).toEqual(false)
@@ -216,6 +221,10 @@ describe('person processing', () => {
 
             // assert
             expect(onCapture).toBeCalledTimes(0)
+            expect(jest.mocked(logger).error).toBeCalledTimes(1)
+            expect(jest.mocked(logger).error).toHaveBeenCalledWith(
+                'posthog.setPersonProperties was called, but process_person is set to "never". This call will be ignored.'
+            )
         })
 
         it("should send a $set event if process_person is set to 'always'", async () => {
@@ -238,14 +247,14 @@ describe('person processing', () => {
 
             // act
             posthog.capture('custom event before alias')
-            posthog.group('groupType', 'groupKey', { prop: 'value' })
+            posthog.alias('alias')
             posthog.capture('custom event after alias')
 
             // assert
             const eventBeforeGroup = onCapture.mock.calls[0]
             expect(eventBeforeGroup[1].properties.$process_person).toEqual(false)
             const groupIdentify = onCapture.mock.calls[1]
-            expect(groupIdentify[0]).toEqual('$groupidentify')
+            expect(groupIdentify[0]).toEqual('$create_alias')
             expect(groupIdentify[1].properties.$process_person).toEqual(true)
             const eventAfterGroup = onCapture.mock.calls[2]
             expect(eventAfterGroup[1].properties.$process_person).toEqual(true)
@@ -256,10 +265,14 @@ describe('person processing', () => {
             const { posthog, onCapture } = await setup('never')
 
             // act
-            posthog.group('groupType', 'groupKey', { prop: 'value' })
+            posthog.alias('alias')
 
             // assert
             expect(onCapture).toBeCalledTimes(0)
+            expect(jest.mocked(logger).error).toBeCalledTimes(1)
+            expect(jest.mocked(logger).error).toHaveBeenCalledWith(
+                'posthog.alias was called, but process_person is set to "never". This call will be ignored.'
+            )
         })
     })
 })

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -169,7 +169,7 @@ describe('person processing', () => {
     })
 
     describe('group', () => {
-        it('should start process_person', async () => {
+        it('should start person processing for identified_only users', async () => {
             // arrange
             const { posthog, onCapture } = await setup('identified_only')
 
@@ -186,6 +186,23 @@ describe('person processing', () => {
             expect(groupIdentify[1].properties.$process_person).toEqual(true)
             const eventAfterGroup = onCapture.mock.calls[2]
             expect(eventAfterGroup[1].properties.$process_person).toEqual(true)
+        })
+
+        it('should not send the $groupidentify event if person_processing is set to never', async () => {
+            // arrange
+            const { posthog, onCapture } = await setup('never')
+
+            // act
+            posthog.capture('custom event before group')
+            posthog.group('groupType', 'groupKey', { prop: 'value' })
+            posthog.capture('custom event after group')
+
+            // assert
+            expect(onCapture).toBeCalledTimes(2)
+            const eventBeforeGroup = onCapture.mock.calls[0]
+            expect(eventBeforeGroup[1].properties.$process_person).toEqual(false)
+            const eventAfterGroup = onCapture.mock.calls[1]
+            expect(eventAfterGroup[1].properties.$process_person).toEqual(false)
         })
     })
 
@@ -211,6 +228,38 @@ describe('person processing', () => {
             // assert
             expect(onCapture).toBeCalledTimes(1)
             expect(onCapture.mock.calls[0][0]).toEqual('$set')
+        })
+    })
+
+    describe('alias', () => {
+        it('should start person processing for identified_only users', async () => {
+            // arrange
+            const { posthog, onCapture } = await setup('identified_only')
+
+            // act
+            posthog.capture('custom event before alias')
+            posthog.group('groupType', 'groupKey', { prop: 'value' })
+            posthog.capture('custom event after alias')
+
+            // assert
+            const eventBeforeGroup = onCapture.mock.calls[0]
+            expect(eventBeforeGroup[1].properties.$process_person).toEqual(false)
+            const groupIdentify = onCapture.mock.calls[1]
+            expect(groupIdentify[0]).toEqual('$groupidentify')
+            expect(groupIdentify[1].properties.$process_person).toEqual(true)
+            const eventAfterGroup = onCapture.mock.calls[2]
+            expect(eventAfterGroup[1].properties.$process_person).toEqual(true)
+        })
+
+        it('should provide a warning if person processing is set to "never"', async () => {
+            // arrange
+            const { posthog, onCapture } = await setup('never')
+
+            // act
+            posthog.group('groupType', 'groupKey', { prop: 'value' })
+
+            // assert
+            expect(onCapture).toBeCalledTimes(0)
         })
     })
 })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,6 +30,7 @@ export const POSTHOG_QUOTA_LIMITED = '$posthog_quota_limited'
 export const CLIENT_SESSION_PROPS = '$client_session_props'
 export const INITIAL_CAMPAIGN_PARAMS = '$initial_campaign_params'
 export const INITIAL_REFERRER_INFO = '$initial_referrer_info'
+export const ENABLE_PERSON_PROCESSING = '$epp'
 
 // These are properties that are reserved and will not be automatically included in events
 export const PERSISTENCE_RESERVED_PROPERTIES = [
@@ -50,4 +51,5 @@ export const PERSISTENCE_RESERVED_PROPERTIES = [
     CLIENT_SESSION_PROPS,
     INITIAL_CAMPAIGN_PARAMS,
     INITIAL_REFERRER_INFO,
+    ENABLE_PERSON_PROCESSING,
 ]

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,6 @@
 import { _extend } from './utils'
 import { PersistentStore, Properties } from './types'
-import { DISTINCT_ID, SESSION_ID, SESSION_RECORDING_IS_SAMPLED } from './constants'
+import { DISTINCT_ID, ENABLE_PERSON_PROCESSING, SESSION_ID, SESSION_RECORDING_IS_SAMPLED } from './constants'
 
 import { _isNull, _isUndefined } from './utils/type-utils'
 import { logger } from './utils/logger'
@@ -248,7 +248,7 @@ export const localStore: PersistentStore = {
 // Use localstorage for most data but still use cookie for COOKIE_PERSISTED_PROPERTIES
 // This solves issues with cookies having too much data in them causing headers too large
 // Also makes sure we don't have to send a ton of data to the server
-const COOKIE_PERSISTED_PROPERTIES = [DISTINCT_ID, SESSION_ID, SESSION_RECORDING_IS_SAMPLED]
+const COOKIE_PERSISTED_PROPERTIES = [DISTINCT_ID, SESSION_ID, SESSION_RECORDING_IS_SAMPLED, ENABLE_PERSON_PROCESSING]
 
 export const localPlusCookieStore: PersistentStore = {
     ...localStore,


### PR DESCRIPTION
## Changes
Calling any of the following functions will activate person processing if set to `identified_only`, and fail if set to `never`:
* indentify
* alias
* setPersonProperties
* setPersonPropertiesForFlags
* group
* setGroupPropertiesForFlags

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
