### PR TITLE
fix: missing parentNode protection

### DIFF
--- a/patches/rrweb@2.0.0-alpha.12.patch
+++ b/patches/rrweb@2.0.0-alpha.12.patch
@@ -1,5 +1,18 @@
+diff --git a/es/rrweb/packages/rrweb/src/record/mutation.js b/es/rrweb/packages/rrweb/src/record/mutation.js
+index 60c42d46a7ee8f5c6f23a7538c7db726bdf17096..5d34de194ae203e34f1bc5a0742ae3f3d9a287ce 100644
+--- a/es/rrweb/packages/rrweb/src/record/mutation.js
++++ b/es/rrweb/packages/rrweb/src/record/mutation.js
+@@ -257,7 +257,7 @@ class MutationBuffer {
+                 texts: this.texts
+                     .map((text) => {
+                     const n = text.node;
+-                    if (n.parentNode.tagName === 'TEXTAREA') {
++                    if (n.parentNode && n.parentNode.tagName === 'TEXTAREA') {
+                         this.genTextAreaValueMutation(n.parentNode);
+                     }
+                     return {
 diff --git a/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js b/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
-index 8746997c9b849ac5c952fdbe0a8dd608d6680a3a..d4a23978d4d6ee5d060c281e1cc8459b2a76885c 100644
+index 8746997c9b849ac5c952fdbe0a8dd608d6680a3a..b7e0ee4b2a9d144fb86b60515e41ce9cc8adcd31 100644
 --- a/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
 +++ b/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
 @@ -91,11 +91,21 @@ class CanvasManager {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   rrweb@2.0.0-alpha.12:
-    hash: nyylzlnsejqdkzdjaj3uehgqdm
+    hash: ldno53whmzuyklnhekfhailjqu
     path: patches/rrweb@2.0.0-alpha.12.patch
 
 dependencies:
@@ -170,7 +170,7 @@ devDependencies:
     version: 5.12.0(rollup@4.9.6)
   rrweb:
     specifier: 2.0.0-alpha.12
-    version: 2.0.0-alpha.12(patch_hash=nyylzlnsejqdkzdjaj3uehgqdm)
+    version: 2.0.0-alpha.12(patch_hash=ldno53whmzuyklnhekfhailjqu)
   rrweb-snapshot:
     specifier: 2.0.0-alpha.12
     version: 2.0.0-alpha.12
@@ -9194,7 +9194,7 @@ packages:
     resolution: {integrity: sha512-i4sz9469dbsEGFiBzCkq+7I7M+imPeC3NrKgrrdJ2tXu9H+/eegNe4SrQgCsLBeSZHZDHU0o9L5rxTAiapWbGg==}
     dev: true
 
-  /rrweb@2.0.0-alpha.12(patch_hash=nyylzlnsejqdkzdjaj3uehgqdm):
+  /rrweb@2.0.0-alpha.12(patch_hash=ldno53whmzuyklnhekfhailjqu):
     resolution: {integrity: sha512-lUGwBV7gmbwz1dIgzo9EEayIVyxoTIF6NBF6+Jctqs4Uy45QkyARtikpQlCUfxVCGTCQ0FOee9jeVYsG39oq1g==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.12


### PR DESCRIPTION
## Changes

Patch for https://github.com/rrweb-io/rrweb/pull/1445 until the next version of rrweb is released