### PR TITLE
chore: no only tests are allowed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ const rules = {
     'no-prototype-builtins': 'off',
     'no-empty': 'off',
     'no-console': 'error',
+    'no-only-tests/no-only-tests': 'error',
 }
 
 const extend = [
@@ -36,7 +37,14 @@ module.exports = {
         ecmaVersion: 2018,
         sourceType: 'module',
     },
-    plugins: ['prettier', '@typescript-eslint', 'eslint-plugin-react', 'eslint-plugin-react-hooks', 'jest'],
+    plugins: [
+        'prettier',
+        '@typescript-eslint',
+        'eslint-plugin-react',
+        'eslint-plugin-react-hooks',
+        'jest',
+        'no-only-tests',
+    ],
     extends: extend,
     rules,
     settings: {

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -85,7 +85,6 @@ jobs:
                   cache: 'pnpm'
             - run: pnpm install
 
-            - run: |
-                  pnpm prettier --check
-                  pnpm lint
-                  pnpm tsc -b
+            - run: pnpm prettier --check
+            - run: pnpm lint
+            - run: pnpm tsc -b

--- a/cypress/e2e/session-recording.cy.ts
+++ b/cypress/e2e/session-recording.cy.ts
@@ -395,7 +395,7 @@ describe('Session recording', () => {
                 })
         })
 
-        it('can override sampling when starting session recording', () => {
+        it.only('can override sampling when starting session recording', () => {
             cy.intercept('POST', '/decide/*', {
                 config: { enable_collect_everything: false },
                 editorParams: {},

--- a/cypress/e2e/session-recording.cy.ts
+++ b/cypress/e2e/session-recording.cy.ts
@@ -364,7 +364,7 @@ describe('Session recording', () => {
         })
     })
 
-    describe.only('with sampling', () => {
+    describe('with sampling', () => {
         beforeEach(() => {
             start({
                 decideResponseOverrides: {
@@ -395,7 +395,7 @@ describe('Session recording', () => {
                 })
         })
 
-        it.only('can override sampling when starting session recording', () => {
+        it('can override sampling when starting session recording', () => {
             cy.intercept('POST', '/decide/*', {
                 config: { enable_collect_everything: false },
                 editorParams: {},

--- a/cypress/e2e/session-recording.cy.ts
+++ b/cypress/e2e/session-recording.cy.ts
@@ -395,7 +395,7 @@ describe('Session recording', () => {
                 })
         })
 
-        it.only('can override sampling when starting session recording', () => {
+        it('can override sampling when starting session recording', () => {
             cy.intercept('POST', '/decide/*', {
                 config: { enable_collect_everything: false },
                 editorParams: {},

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
         "*.{ts,tsx,js,json}": "prettier --write",
         "*.js": "eslint --cache --fix",
         "*.{ts,tsx}": [
-            "eslint src --fix"
+            "eslint src --fix",
+            "eslint cypress --fix"
         ]
     },
     "browserslist": [

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-compat": "^4.1.4",
         "eslint-plugin-jest": "^27.2.3",
+        "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-posthog-js": "link:eslint-rules",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.30.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "build": "pnpm build-rollup && pnpm build-react",
         "build-rollup": "rm -rf lib && tsc -b && rollup -c --bundleConfigAsCjs",
         "build-react": "cd react; pnpm i; pnpm build;",
-        "lint": "eslint src",
+        "lint": "eslint src && eslint cypress",
         "prettier": "prettier --write src/ functional_tests/",
         "prepublishOnly": "pnpm lint && pnpm test && pnpm build && pnpm test:react",
         "test": "pnpm test:unit && pnpm test:custom-eslint-rules && pnpm test:functional",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ devDependencies:
   eslint-plugin-jest:
     specifier: ^27.2.3
     version: 27.2.3(@typescript-eslint/eslint-plugin@6.19.0)(eslint@8.56.0)(jest@27.5.1)(typescript@4.9.5)
+  eslint-plugin-no-only-tests:
+    specifier: ^3.1.0
+    version: 3.1.0
   eslint-plugin-posthog-js:
     specifier: link:eslint-rules
     version: link:eslint-rules
@@ -4945,6 +4948,11 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
+
+  /eslint-plugin-no-only-tests@3.1.0:
+    resolution: {integrity: sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==}
+    engines: {node: '>=5.0.0'}
     dev: true
 
   /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.5.0)(eslint@8.56.0)(prettier@2.7.1):


### PR DESCRIPTION
We have this linter in posthog but not posthog-js and it is very useful

<img width="681" alt="Screenshot 2024-04-10 at 16 53 07" src="https://github.com/PostHog/posthog-js/assets/984817/c85049cf-5cf7-4117-9a85-0991027c7a54">
