### PR TITLE
chore: patch to fix broken worker

### DIFF
--- a/patches/rrweb@2.0.0-alpha.12.patch
+++ b/patches/rrweb@2.0.0-alpha.12.patch
@@ -1,5 +1,175 @@
+diff --git a/es/rrweb/_virtual/_rollup-plugin-web-worker-loader__helper__browser__createBase64WorkerFactory.js b/es/rrweb/_virtual/_rollup-plugin-web-worker-loader__helper__browser__createBase64WorkerFactory.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..aac399768d59f83e7dd7af272cdec8a4c90da236
+--- /dev/null
++++ b/es/rrweb/_virtual/_rollup-plugin-web-worker-loader__helper__browser__createBase64WorkerFactory.js
+@@ -0,0 +1,31 @@
++function decodeBase64(base64, enableUnicode) {
++    var binaryString = atob(base64);
++    if (enableUnicode) {
++        var binaryView = new Uint8Array(binaryString.length);
++        for (var i = 0, n = binaryString.length; i < n; ++i) {
++            binaryView[i] = binaryString.charCodeAt(i);
++        }
++        return String.fromCharCode.apply(null, new Uint16Array(binaryView.buffer));
++    }
++    return binaryString;
++}
++
++function createURL(base64, sourcemapArg, enableUnicodeArg) {
++    var sourcemap = sourcemapArg === undefined ? null : sourcemapArg;
++    var enableUnicode = enableUnicodeArg === undefined ? false : enableUnicodeArg;
++    var source = decodeBase64(base64, enableUnicode);
++    var start = source.indexOf('\n', 10) + 1;
++    var body = source.substring(start) + (sourcemap ? '\/\/# sourceMappingURL=' + sourcemap : '');
++    var blob = new Blob([body], { type: 'application/javascript' });
++    return URL.createObjectURL(blob);
++}
++
++function createBase64WorkerFactory(base64, sourcemapArg, enableUnicodeArg) {
++    var url;
++    return function WorkerFactory(options) {
++        url = url || createURL(base64, sourcemapArg, enableUnicodeArg);
++        return new Worker(url, options);
++    };
++}
++
++export { createBase64WorkerFactory };
+diff --git a/es/rrweb/_virtual/_rollup-plugin-web-worker-loader__helper__browser__createInlineWorkerFactory.js b/es/rrweb/_virtual/_rollup-plugin-web-worker-loader__helper__browser__createInlineWorkerFactory.js
+deleted file mode 100644
+index b39a7674a500ec96f95aa70dde959901bb964de7..0000000000000000000000000000000000000000
+diff --git a/es/rrweb/_virtual/_rollup-plugin-web-worker-loader__helper__funcToSource.js b/es/rrweb/_virtual/_rollup-plugin-web-worker-loader__helper__funcToSource.js
+deleted file mode 100644
+index a0b4e51fb7adeb3b615ad1d8876520779c8af2b1..0000000000000000000000000000000000000000
+diff --git a/es/rrweb/_virtual/image-bitmap-data-url-worker.js b/es/rrweb/_virtual/image-bitmap-data-url-worker.js
+index ea868845c4fad3276aa8e5f74abfd3568b466d11..965505de44975e718d431a4e9a62e753e4842158 100644
+--- a/es/rrweb/_virtual/image-bitmap-data-url-worker.js
++++ b/es/rrweb/_virtual/image-bitmap-data-url-worker.js
+@@ -1,120 +1,6 @@
+-import { createInlineWorkerFactory } from './_rollup-plugin-web-worker-loader__helper__browser__createInlineWorkerFactory.js';
++import { createBase64WorkerFactory } from './_rollup-plugin-web-worker-loader__helper__browser__createBase64WorkerFactory.js';
+ 
+-var WorkerFactory = createInlineWorkerFactory(/* rollup-plugin-web-worker-loader */function () {
+-(function () {
+-    '__worker_loader_strict__';
+-
+-    /*! *****************************************************************************
+-    Copyright (c) Microsoft Corporation.
+-
+-    Permission to use, copy, modify, and/or distribute this software for any
+-    purpose with or without fee is hereby granted.
+-
+-    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-    REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-    AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-    INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-    LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-    OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-    PERFORMANCE OF THIS SOFTWARE.
+-    ***************************************************************************** */
+-
+-    function __awaiter(thisArg, _arguments, P, generator) {
+-        function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+-        return new (P || (P = Promise))(function (resolve, reject) {
+-            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+-            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+-            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+-            step((generator = generator.apply(thisArg, _arguments || [])).next());
+-        });
+-    }
+-
+-    /*
+-     * base64-arraybuffer 1.0.1 <https://github.com/niklasvh/base64-arraybuffer>
+-     * Copyright (c) 2021 Niklas von Hertzen <https://hertzen.com>
+-     * Released under MIT License
+-     */
+-    var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+-    // Use a lookup table to find the index.
+-    var lookup = typeof Uint8Array === 'undefined' ? [] : new Uint8Array(256);
+-    for (var i = 0; i < chars.length; i++) {
+-        lookup[chars.charCodeAt(i)] = i;
+-    }
+-    var encode = function (arraybuffer) {
+-        var bytes = new Uint8Array(arraybuffer), i, len = bytes.length, base64 = '';
+-        for (i = 0; i < len; i += 3) {
+-            base64 += chars[bytes[i] >> 2];
+-            base64 += chars[((bytes[i] & 3) << 4) | (bytes[i + 1] >> 4)];
+-            base64 += chars[((bytes[i + 1] & 15) << 2) | (bytes[i + 2] >> 6)];
+-            base64 += chars[bytes[i + 2] & 63];
+-        }
+-        if (len % 3 === 2) {
+-            base64 = base64.substring(0, base64.length - 1) + '=';
+-        }
+-        else if (len % 3 === 1) {
+-            base64 = base64.substring(0, base64.length - 2) + '==';
+-        }
+-        return base64;
+-    };
+-
+-    const lastBlobMap = new Map();
+-    const transparentBlobMap = new Map();
+-    function getTransparentBlobFor(width, height, dataURLOptions) {
+-        return __awaiter(this, void 0, void 0, function* () {
+-            const id = `${width}-${height}`;
+-            if ('OffscreenCanvas' in globalThis) {
+-                if (transparentBlobMap.has(id))
+-                    return transparentBlobMap.get(id);
+-                const offscreen = new OffscreenCanvas(width, height);
+-                offscreen.getContext('2d');
+-                const blob = yield offscreen.convertToBlob(dataURLOptions);
+-                const arrayBuffer = yield blob.arrayBuffer();
+-                const base64 = encode(arrayBuffer);
+-                transparentBlobMap.set(id, base64);
+-                return base64;
+-            }
+-            else {
+-                return '';
+-            }
+-        });
+-    }
+-    const worker = self;
+-    worker.onmessage = function (e) {
+-        return __awaiter(this, void 0, void 0, function* () {
+-            if ('OffscreenCanvas' in globalThis) {
+-                const { id, bitmap, width, height, dataURLOptions } = e.data;
+-                const transparentBase64 = getTransparentBlobFor(width, height, dataURLOptions);
+-                const offscreen = new OffscreenCanvas(width, height);
+-                const ctx = offscreen.getContext('2d');
+-                ctx.drawImage(bitmap, 0, 0);
+-                bitmap.close();
+-                const blob = yield offscreen.convertToBlob(dataURLOptions);
+-                const type = blob.type;
+-                const arrayBuffer = yield blob.arrayBuffer();
+-                const base64 = encode(arrayBuffer);
+-                if (!lastBlobMap.has(id) && (yield transparentBase64) === base64) {
+-                    lastBlobMap.set(id, base64);
+-                    return worker.postMessage({ id });
+-                }
+-                if (lastBlobMap.get(id) === base64)
+-                    return worker.postMessage({ id });
+-                worker.postMessage({
+-                    id,
+-                    type,
+-                    base64,
+-                    width,
+-                    height,
+-                });
+-                lastBlobMap.set(id, base64);
+-            }
+-            else {
+-                return worker.postMessage({ id: e.data.id });
+-            }
+-        });
+-    };
+-
+-})();
+-}, null);
++var WorkerFactory = createBase64WorkerFactory('Lyogcm9sbHVwLXBsdWdpbi13ZWItd29ya2VyLWxvYWRlciAqLwooZnVuY3Rpb24gKCkgewogICAgJ3VzZSBzdHJpY3QnOwoKICAgIC8qISAqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKg0KICAgIENvcHlyaWdodCAoYykgTWljcm9zb2Z0IENvcnBvcmF0aW9uLg0KDQogICAgUGVybWlzc2lvbiB0byB1c2UsIGNvcHksIG1vZGlmeSwgYW5kL29yIGRpc3RyaWJ1dGUgdGhpcyBzb2Z0d2FyZSBmb3IgYW55DQogICAgcHVycG9zZSB3aXRoIG9yIHdpdGhvdXQgZmVlIGlzIGhlcmVieSBncmFudGVkLg0KDQogICAgVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIgQU5EIFRIRSBBVVRIT1IgRElTQ0xBSU1TIEFMTCBXQVJSQU5USUVTIFdJVEgNCiAgICBSRUdBUkQgVE8gVEhJUyBTT0ZUV0FSRSBJTkNMVURJTkcgQUxMIElNUExJRUQgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFkNCiAgICBBTkQgRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsDQogICAgSU5ESVJFQ1QsIE9SIENPTlNFUVVFTlRJQUwgREFNQUdFUyBPUiBBTlkgREFNQUdFUyBXSEFUU09FVkVSIFJFU1VMVElORyBGUk9NDQogICAgTE9TUyBPRiBVU0UsIERBVEEgT1IgUFJPRklUUywgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIE5FR0xJR0VOQ0UgT1INCiAgICBPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SDQogICAgUEVSRk9STUFOQ0UgT0YgVEhJUyBTT0ZUV0FSRS4NCiAgICAqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKiAqLw0KDQogICAgZnVuY3Rpb24gX19hd2FpdGVyKHRoaXNBcmcsIF9hcmd1bWVudHMsIFAsIGdlbmVyYXRvcikgew0KICAgICAgICBmdW5jdGlvbiBhZG9wdCh2YWx1ZSkgeyByZXR1cm4gdmFsdWUgaW5zdGFuY2VvZiBQID8gdmFsdWUgOiBuZXcgUChmdW5jdGlvbiAocmVzb2x2ZSkgeyByZXNvbHZlKHZhbHVlKTsgfSk7IH0NCiAgICAgICAgcmV0dXJuIG5ldyAoUCB8fCAoUCA9IFByb21pc2UpKShmdW5jdGlvbiAocmVzb2x2ZSwgcmVqZWN0KSB7DQogICAgICAgICAgICBmdW5jdGlvbiBmdWxmaWxsZWQodmFsdWUpIHsgdHJ5IHsgc3RlcChnZW5lcmF0b3IubmV4dCh2YWx1ZSkpOyB9IGNhdGNoIChlKSB7IHJlamVjdChlKTsgfSB9DQogICAgICAgICAgICBmdW5jdGlvbiByZWplY3RlZCh2YWx1ZSkgeyB0cnkgeyBzdGVwKGdlbmVyYXRvclsidGhyb3ciXSh2YWx1ZSkpOyB9IGNhdGNoIChlKSB7IHJlamVjdChlKTsgfSB9DQogICAgICAgICAgICBmdW5jdGlvbiBzdGVwKHJlc3VsdCkgeyByZXN1bHQuZG9uZSA/IHJlc29sdmUocmVzdWx0LnZhbHVlKSA6IGFkb3B0KHJlc3VsdC52YWx1ZSkudGhlbihmdWxmaWxsZWQsIHJlamVjdGVkKTsgfQ0KICAgICAgICAgICAgc3RlcCgoZ2VuZXJhdG9yID0gZ2VuZXJhdG9yLmFwcGx5KHRoaXNBcmcsIF9hcmd1bWVudHMgfHwgW10pKS5uZXh0KCkpOw0KICAgICAgICB9KTsNCiAgICB9CgogICAgLyoKICAgICAqIGJhc2U2NC1hcnJheWJ1ZmZlciAxLjAuMSA8aHR0cHM6Ly9naXRodWIuY29tL25pa2xhc3ZoL2Jhc2U2NC1hcnJheWJ1ZmZlcj4KICAgICAqIENvcHlyaWdodCAoYykgMjAyMSBOaWtsYXMgdm9uIEhlcnR6ZW4gPGh0dHBzOi8vaGVydHplbi5jb20+CiAgICAgKiBSZWxlYXNlZCB1bmRlciBNSVQgTGljZW5zZQogICAgICovCiAgICB2YXIgY2hhcnMgPSAnQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejAxMjM0NTY3ODkrLyc7CiAgICAvLyBVc2UgYSBsb29rdXAgdGFibGUgdG8gZmluZCB0aGUgaW5kZXguCiAgICB2YXIgbG9va3VwID0gdHlwZW9mIFVpbnQ4QXJyYXkgPT09ICd1bmRlZmluZWQnID8gW10gOiBuZXcgVWludDhBcnJheSgyNTYpOwogICAgZm9yICh2YXIgaSA9IDA7IGkgPCBjaGFycy5sZW5ndGg7IGkrKykgewogICAgICAgIGxvb2t1cFtjaGFycy5jaGFyQ29kZUF0KGkpXSA9IGk7CiAgICB9CiAgICB2YXIgZW5jb2RlID0gZnVuY3Rpb24gKGFycmF5YnVmZmVyKSB7CiAgICAgICAgdmFyIGJ5dGVzID0gbmV3IFVpbnQ4QXJyYXkoYXJyYXlidWZmZXIpLCBpLCBsZW4gPSBieXRlcy5sZW5ndGgsIGJhc2U2NCA9ICcnOwogICAgICAgIGZvciAoaSA9IDA7IGkgPCBsZW47IGkgKz0gMykgewogICAgICAgICAgICBiYXNlNjQgKz0gY2hhcnNbYnl0ZXNbaV0gPj4gMl07CiAgICAgICAgICAgIGJhc2U2NCArPSBjaGFyc1soKGJ5dGVzW2ldICYgMykgPDwgNCkgfCAoYnl0ZXNbaSArIDFdID4+IDQpXTsKICAgICAgICAgICAgYmFzZTY0ICs9IGNoYXJzWygoYnl0ZXNbaSArIDFdICYgMTUpIDw8IDIpIHwgKGJ5dGVzW2kgKyAyXSA+PiA2KV07CiAgICAgICAgICAgIGJhc2U2NCArPSBjaGFyc1tieXRlc1tpICsgMl0gJiA2M107CiAgICAgICAgfQogICAgICAgIGlmIChsZW4gJSAzID09PSAyKSB7CiAgICAgICAgICAgIGJhc2U2NCA9IGJhc2U2NC5zdWJzdHJpbmcoMCwgYmFzZTY0Lmxlbmd0aCAtIDEpICsgJz0nOwogICAgICAgIH0KICAgICAgICBlbHNlIGlmIChsZW4gJSAzID09PSAxKSB7CiAgICAgICAgICAgIGJhc2U2NCA9IGJhc2U2NC5zdWJzdHJpbmcoMCwgYmFzZTY0Lmxlbmd0aCAtIDIpICsgJz09JzsKICAgICAgICB9CiAgICAgICAgcmV0dXJuIGJhc2U2NDsKICAgIH07CgogICAgY29uc3QgbGFzdEJsb2JNYXAgPSBuZXcgTWFwKCk7DQogICAgY29uc3QgdHJhbnNwYXJlbnRCbG9iTWFwID0gbmV3IE1hcCgpOw0KICAgIGZ1bmN0aW9uIGdldFRyYW5zcGFyZW50QmxvYkZvcih3aWR0aCwgaGVpZ2h0LCBkYXRhVVJMT3B0aW9ucykgew0KICAgICAgICByZXR1cm4gX19hd2FpdGVyKHRoaXMsIHZvaWQgMCwgdm9pZCAwLCBmdW5jdGlvbiogKCkgew0KICAgICAgICAgICAgY29uc3QgaWQgPSBgJHt3aWR0aH0tJHtoZWlnaHR9YDsNCiAgICAgICAgICAgIGlmICgnT2Zmc2NyZWVuQ2FudmFzJyBpbiBnbG9iYWxUaGlzKSB7DQogICAgICAgICAgICAgICAgaWYgKHRyYW5zcGFyZW50QmxvYk1hcC5oYXMoaWQpKQ0KICAgICAgICAgICAgICAgICAgICByZXR1cm4gdHJhbnNwYXJlbnRCbG9iTWFwLmdldChpZCk7DQogICAgICAgICAgICAgICAgY29uc3Qgb2Zmc2NyZWVuID0gbmV3IE9mZnNjcmVlbkNhbnZhcyh3aWR0aCwgaGVpZ2h0KTsNCiAgICAgICAgICAgICAgICBvZmZzY3JlZW4uZ2V0Q29udGV4dCgnMmQnKTsNCiAgICAgICAgICAgICAgICBjb25zdCBibG9iID0geWllbGQgb2Zmc2NyZWVuLmNvbnZlcnRUb0Jsb2IoZGF0YVVSTE9wdGlvbnMpOw0KICAgICAgICAgICAgICAgIGNvbnN0IGFycmF5QnVmZmVyID0geWllbGQgYmxvYi5hcnJheUJ1ZmZlcigpOw0KICAgICAgICAgICAgICAgIGNvbnN0IGJhc2U2NCA9IGVuY29kZShhcnJheUJ1ZmZlcik7DQogICAgICAgICAgICAgICAgdHJhbnNwYXJlbnRCbG9iTWFwLnNldChpZCwgYmFzZTY0KTsNCiAgICAgICAgICAgICAgICByZXR1cm4gYmFzZTY0Ow0KICAgICAgICAgICAgfQ0KICAgICAgICAgICAgZWxzZSB7DQogICAgICAgICAgICAgICAgcmV0dXJuICcnOw0KICAgICAgICAgICAgfQ0KICAgICAgICB9KTsNCiAgICB9DQogICAgY29uc3Qgd29ya2VyID0gc2VsZjsNCiAgICB3b3JrZXIub25tZXNzYWdlID0gZnVuY3Rpb24gKGUpIHsNCiAgICAgICAgcmV0dXJuIF9fYXdhaXRlcih0aGlzLCB2b2lkIDAsIHZvaWQgMCwgZnVuY3Rpb24qICgpIHsNCiAgICAgICAgICAgIGlmICgnT2Zmc2NyZWVuQ2FudmFzJyBpbiBnbG9iYWxUaGlzKSB7DQogICAgICAgICAgICAgICAgY29uc3QgeyBpZCwgYml0bWFwLCB3aWR0aCwgaGVpZ2h0LCBkYXRhVVJMT3B0aW9ucyB9ID0gZS5kYXRhOw0KICAgICAgICAgICAgICAgIGNvbnN0IHRyYW5zcGFyZW50QmFzZTY0ID0gZ2V0VHJhbnNwYXJlbnRCbG9iRm9yKHdpZHRoLCBoZWlnaHQsIGRhdGFVUkxPcHRpb25zKTsNCiAgICAgICAgICAgICAgICBjb25zdCBvZmZzY3JlZW4gPSBuZXcgT2Zmc2NyZWVuQ2FudmFzKHdpZHRoLCBoZWlnaHQpOw0KICAgICAgICAgICAgICAgIGNvbnN0IGN0eCA9IG9mZnNjcmVlbi5nZXRDb250ZXh0KCcyZCcpOw0KICAgICAgICAgICAgICAgIGN0eC5kcmF3SW1hZ2UoYml0bWFwLCAwLCAwKTsNCiAgICAgICAgICAgICAgICBiaXRtYXAuY2xvc2UoKTsNCiAgICAgICAgICAgICAgICBjb25zdCBibG9iID0geWllbGQgb2Zmc2NyZWVuLmNvbnZlcnRUb0Jsb2IoZGF0YVVSTE9wdGlvbnMpOw0KICAgICAgICAgICAgICAgIGNvbnN0IHR5cGUgPSBibG9iLnR5cGU7DQogICAgICAgICAgICAgICAgY29uc3QgYXJyYXlCdWZmZXIgPSB5aWVsZCBibG9iLmFycmF5QnVmZmVyKCk7DQogICAgICAgICAgICAgICAgY29uc3QgYmFzZTY0ID0gZW5jb2RlKGFycmF5QnVmZmVyKTsNCiAgICAgICAgICAgICAgICBpZiAoIWxhc3RCbG9iTWFwLmhhcyhpZCkgJiYgKHlpZWxkIHRyYW5zcGFyZW50QmFzZTY0KSA9PT0gYmFzZTY0KSB7DQogICAgICAgICAgICAgICAgICAgIGxhc3RCbG9iTWFwLnNldChpZCwgYmFzZTY0KTsNCiAgICAgICAgICAgICAgICAgICAgcmV0dXJuIHdvcmtlci5wb3N0TWVzc2FnZSh7IGlkIH0pOw0KICAgICAgICAgICAgICAgIH0NCiAgICAgICAgICAgICAgICBpZiAobGFzdEJsb2JNYXAuZ2V0KGlkKSA9PT0gYmFzZTY0KQ0KICAgICAgICAgICAgICAgICAgICByZXR1cm4gd29ya2VyLnBvc3RNZXNzYWdlKHsgaWQgfSk7DQogICAgICAgICAgICAgICAgd29ya2VyLnBvc3RNZXNzYWdlKHsNCiAgICAgICAgICAgICAgICAgICAgaWQsDQogICAgICAgICAgICAgICAgICAgIHR5cGUsDQogICAgICAgICAgICAgICAgICAgIGJhc2U2NCwNCiAgICAgICAgICAgICAgICAgICAgd2lkdGgsDQogICAgICAgICAgICAgICAgICAgIGhlaWdodCwNCiAgICAgICAgICAgICAgICB9KTsNCiAgICAgICAgICAgICAgICBsYXN0QmxvYk1hcC5zZXQoaWQsIGJhc2U2NCk7DQogICAgICAgICAgICB9DQogICAgICAgICAgICBlbHNlIHsNCiAgICAgICAgICAgICAgICByZXR1cm4gd29ya2VyLnBvc3RNZXNzYWdlKHsgaWQ6IGUuZGF0YS5pZCB9KTsNCiAgICAgICAgICAgIH0NCiAgICAgICAgfSk7DQogICAgfTsKCn0pKCk7Cgo=', null, false);
+ /* eslint-enable */
+ 
+ export { WorkerFactory as default };
 diff --git a/es/rrweb/packages/rrweb/src/record/mutation.js b/es/rrweb/packages/rrweb/src/record/mutation.js
-index 60c42d46a7ee8f5c6f23a7538c7db726bdf17096..5d34de194ae203e34f1bc5a0742ae3f3d9a287ce 100644
+index 60c42d46a7ee8f5c6f23a7538c7db726bdf17096..d02b140ddacc923579f1ccf89590962b5ded2179 100644
 --- a/es/rrweb/packages/rrweb/src/record/mutation.js
 +++ b/es/rrweb/packages/rrweb/src/record/mutation.js
 @@ -257,7 +257,7 @@ class MutationBuffer {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   rrweb@2.0.0-alpha.12:
-    hash: ldno53whmzuyklnhekfhailjqu
+    hash: tvatazbysybcdte3poiroo42za
     path: patches/rrweb@2.0.0-alpha.12.patch
 
 dependencies:
@@ -173,7 +173,7 @@ devDependencies:
     version: 5.12.0(rollup@4.9.6)
   rrweb:
     specifier: 2.0.0-alpha.12
-    version: 2.0.0-alpha.12(patch_hash=ldno53whmzuyklnhekfhailjqu)
+    version: 2.0.0-alpha.12(patch_hash=tvatazbysybcdte3poiroo42za)
   rrweb-snapshot:
     specifier: 2.0.0-alpha.12
     version: 2.0.0-alpha.12
@@ -9202,7 +9202,7 @@ packages:
     resolution: {integrity: sha512-i4sz9469dbsEGFiBzCkq+7I7M+imPeC3NrKgrrdJ2tXu9H+/eegNe4SrQgCsLBeSZHZDHU0o9L5rxTAiapWbGg==}
     dev: true
 
-  /rrweb@2.0.0-alpha.12(patch_hash=ldno53whmzuyklnhekfhailjqu):
+  /rrweb@2.0.0-alpha.12(patch_hash=tvatazbysybcdte3poiroo42za):
     resolution: {integrity: sha512-lUGwBV7gmbwz1dIgzo9EEayIVyxoTIF6NBF6+Jctqs4Uy45QkyARtikpQlCUfxVCGTCQ0FOee9jeVYsG39oq1g==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.12


### PR DESCRIPTION
## Changes
The worker used to process canvas mutations on a background thread is referenced from the `_virtual` directory
<img width="792" alt="Screenshot 2024-04-12 at 10 38 58" src="https://github.com/PostHog/posthog-js/assets/6685876/a0106685-e39e-4a44-b2f7-2e11ca6846d2">

Since https://github.com/rrweb-io/rrweb/pull/1309 was included in `rrweb@2.0.0-alpha.12` the contents of the outputted `_virtual` directory has changed. This is what I think is causing canvas mutations not to be captured.

While we wait for https://github.com/rrweb-io/rrweb/pull/1448 (or an alternative) to be merged and released we need to patch the worker output from rollout. I chose to revert to the contents of `rrweb@2.0.0-alpha.11`

|Before|After|
|----|----|
| <img width="678" alt="Screenshot 2024-04-12 at 10 47 38" src="https://github.com/PostHog/posthog-js/assets/6685876/1e10aafd-785a-48b7-a7b1-b7df1cb7af47"> | <img width="695" alt="Screenshot 2024-04-12 at 10 43 54" src="https://github.com/PostHog/posthog-js/assets/6685876/c05ad60f-5c1e-4428-91c8-cf574d7e778a"> |

Quite difficult to test this locally because the `yalc` was still referencing the remote files of for recording related content. I think this is pretty safe given 1) it reintroduces the previous implementation we know worked and 2) things are broken as they are right now