### PR TITLE
fix: continue recording after reset

### DIFF
--- a/cypress/e2e/session-recording.cy.ts
+++ b/cypress/e2e/session-recording.cy.ts
@@ -363,7 +363,7 @@ describe('Session recording', () => {
                 })
         })
 
-        it('starts a new recordings after calling reset', () => {
+        it('starts a new recording after calling reset', () => {
             cy.phCaptures({ full: true }).then((captures) => {
                 // should be a pageview at the beginning
                 expect(captures.map((c) => c.event)).to.deep.equal(['$pageview'])
@@ -375,16 +375,11 @@ describe('Session recording', () => {
                 startingSessionId = ph.get_session_id()
             })
 
-            cy.get('[data-cy-input]').type('hello world!')
-            cy.wait(500)
             ensureActivitySendsSnapshots()
+
             cy.posthog().then((ph) => {
                 ph.reset()
             })
-
-            cy.get('[data-cy-input]').type('a new world!')
-            cy.wait(500)
-            ensureActivitySendsSnapshots()
 
             // the session id is rotated after reset is called
             cy.posthog().then((ph) => {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -390,14 +390,14 @@ export class SessionRecording {
         this.startRecordingIfEnabled()
     }
 
-    private _onSessionIdListener: (() => void) | null = null
+    private _samplingSessionListener: (() => void) | null = null
 
     /**
      * This might be called more than once so needs to be idempotent
      */
     private _setupSampling() {
-        if (_isNumber(this.sampleRate) && _isNull(this._onSessionIdListener)) {
-            this._onSessionIdListener = this.sessionManager.onSessionId((sessionId) => {
+        if (_isNumber(this.sampleRate) && _isNull(this._samplingSessionListener)) {
+            this._samplingSessionListener = this.sessionManager.onSessionId((sessionId) => {
                 this.makeSamplingDecision(sessionId)
             })
         }


### PR DESCRIPTION
## Changes

Addresses https://posthog.com/questions/session-recordings-not-being-resumed-after-calling-posthog-restart

Because we rely on the `decide` response to know whether session recording is enabled, we assume a falsey value when the persistent storage is cleared as part of the `reset` call.

This change sets up a listener `onSessionId` rotation that will re-establish the keys returned by the decide response. We need to re-register all keys otherwise things like the minimum session duration would not be available for the new session.

The sampling decision for the new session is handled separately in the `_samplingSessionListener`

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
