### PR TITLE
fix: Reacting to config changes

### DIFF
--- a/cypress/e2e/capture.cy.ts
+++ b/cypress/e2e/capture.cy.ts
@@ -305,7 +305,7 @@ describe('Event capture', () => {
     })
 
     describe('advanced_disable_decide config', () => {
-        it.only('does not autocapture anything when /decide is disabled', () => {
+        it('does not autocapture anything when /decide is disabled', () => {
             start({ options: { autocapture: false, advanced_disable_decide: true }, waitForDecide: false })
 
             cy.get('body').click(100, 100).click(98, 102).click(101, 103)

--- a/cypress/e2e/capture.cy.ts
+++ b/cypress/e2e/capture.cy.ts
@@ -305,8 +305,8 @@ describe('Event capture', () => {
     })
 
     describe('advanced_disable_decide config', () => {
-        it('does not autocapture anything when /decide is disabled', () => {
-            start({ options: { advanced_disable_decide: true }, waitForDecide: false })
+        it.only('does not autocapture anything when /decide is disabled', () => {
+            start({ options: { autocapture: false, advanced_disable_decide: true }, waitForDecide: false })
 
             cy.get('body').click(100, 100).click(98, 102).click(101, 103)
             cy.get('[data-cy-custom-event-button]').click()

--- a/playground/nextjs/README.md
+++ b/playground/nextjs/README.md
@@ -16,20 +16,12 @@ NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' NEXT_PUBLIC_POSTHOG_HOST='http://
 ```
 
 ### Testing local changes to posthog-js
-Follow the instructions to set up YALC in the [root README](../../README.md).
 
-After you have run `yalc publish` in the root directory, run `yalc add posthog-js` in this directory, and then you can
-run `pnpm dev` to see your changes reflected in the demo project.
+Running `pnpm dev` will run an additional script that uses pnpm to link `posthog-js` locally to this package.
 
-There is a shorthand script for running these 3 commands
+If you need to provide environment variables, you can do so:
 
 ```bash
-pnpm yalc-dev
-```
-
-If you need to provide environment variables, you can do so, like
-
-```bash
-NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' NEXT_PUBLIC_POSTHOG_HOST='http://localhost:8000' pnpm yalc-dev
+NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' NEXT_PUBLIC_POSTHOG_HOST='http://localhost:8000' pnpm dev
 ```
 

--- a/playground/nextjs/package.json
+++ b/playground/nextjs/package.json
@@ -4,11 +4,11 @@
     "private": true,
     "scripts": {
         "clean-react": "cd ../../react && rm -rf ./node_modules/",
-        "dev": "pnpm run clean-react && next dev",
+        "dev": "pnpm run link-posthog-js && pnpm run clean-react && next dev",
         "build": "next build",
         "start": "next start",
         "lint": "next lint",
-        "yalc-dev": "pnpm run -C ../.. yalc-publish && rm -r .next/cache .yalc/posthog-js && yalc add posthog-js && pnpm dev"
+        "link-posthog-js": "cd ../../ && pnpm link --global && cd playground/nextjs && pnpm link --global posthog-js",
     },
     "dependencies": {
         "@lottiefiles/react-lottie-player": "^3.5.3",

--- a/playground/nextjs/package.json
+++ b/playground/nextjs/package.json
@@ -8,7 +8,7 @@
         "build": "next build",
         "start": "next start",
         "lint": "next lint",
-        "link-posthog-js": "cd ../../ && pnpm link --global && cd playground/nextjs && pnpm link --global posthog-js",
+        "link-posthog-js": "cd ../../ && pnpm link --global && cd playground/nextjs && pnpm link --global posthog-js"
     },
     "dependencies": {
         "@lottiefiles/react-lottie-player": "^3.5.3",

--- a/playground/nextjs/pages/_app.tsx
+++ b/playground/nextjs/pages/_app.tsx
@@ -6,21 +6,8 @@ import { useRouter } from 'next/router'
 
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
-import { CookieBanner, cookieConsentGiven } from '@/src/CookieBanner'
-
-if (typeof window !== 'undefined') {
-    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || '', {
-        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
-        session_recording: {
-            recordCrossOriginIframes: true,
-        },
-        debug: true,
-        scroll_root_selector: ['#scroll_element', 'html'],
-        persistence: cookieConsentGiven() ? 'localStorage+cookie' : 'memory',
-        __preview_process_person: 'identified_only',
-    })
-    ;(window as any).posthog = posthog
-}
+import { CookieBanner } from '@/src/CookieBanner'
+import '@/src/posthog'
 
 export default function App({ Component, pageProps }: AppProps) {
     const router = useRouter()

--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import { useFeatureFlagEnabled, usePostHog } from 'posthog-js/react'
 import React, { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { cookieConsentGiven } from '@/src/posthog'
 
 export default function Home() {
     const posthog = usePostHog()
@@ -9,6 +10,7 @@ export default function Home() {
     const result = useFeatureFlagEnabled('test')
 
     const [time, setTime] = useState('')
+    const consentGiven = cookieConsentGiven()
 
     useEffect(() => {
         setIsClient(true)
@@ -71,6 +73,12 @@ export default function Home() {
 
                 {isClient && (
                     <>
+                        {!consentGiven && (
+                            <p className="border border-red-900 bg-red-200 rounded p-2">
+                                <b>Consent not given!</b> Session recording, surveys, and autocapture are disabled.
+                            </p>
+                        )}
+
                         <h2 className="mt-4">PostHog info</h2>
                         <ul className="text-xs bg-gray-100 rounded border-2 border-gray-800 p-4">
                             <li className="font-mono">

--- a/playground/nextjs/src/CookieBanner.tsx
+++ b/playground/nextjs/src/CookieBanner.tsx
@@ -1,10 +1,6 @@
 /* eslint-disable posthog-js/no-direct-null-check */
-import posthog from 'posthog-js'
 import { useEffect, useState } from 'react'
-
-export function cookieConsentGiven() {
-    return localStorage.getItem('cookie_consent') === 'true'
-}
+import { cookieConsentGiven, updatePostHogConsent } from './posthog'
 
 export function CookieBanner() {
     const [consentGiven, setConsentGiven] = useState<null | boolean>(null)
@@ -15,7 +11,8 @@ export function CookieBanner() {
 
     useEffect(() => {
         if (consentGiven === null) return
-        posthog.set_config({ persistence: consentGiven ? 'localStorage+cookie' : 'memory' })
+
+        updatePostHogConsent(consentGiven)
     }, [consentGiven])
 
     if (consentGiven === null) return null
@@ -27,7 +24,6 @@ export function CookieBanner() {
                     <p>I am a cookie banner - you wouldn't like me when I'm hangry.</p>
                     <button
                         onClick={() => {
-                            localStorage.setItem('cookie_consent', 'true')
                             setConsentGiven(true)
                         }}
                     >
@@ -38,7 +34,6 @@ export function CookieBanner() {
                 <>
                     <button
                         onClick={() => {
-                            localStorage.removeItem('cookie_consent')
                             setConsentGiven(false)
                         }}
                     >

--- a/playground/nextjs/src/CookieBanner.tsx
+++ b/playground/nextjs/src/CookieBanner.tsx
@@ -2,8 +2,8 @@
 import { useEffect, useState } from 'react'
 import { cookieConsentGiven, updatePostHogConsent } from './posthog'
 
-export function CookieBanner() {
-    const [consentGiven, setConsentGiven] = useState<null | boolean>(null)
+export function useCookieConsent(): [boolean | null, (consentGiven: boolean) => void] {
+    const [consentGiven, setConsentGiven] = useState<boolean | null>(null)
 
     useEffect(() => {
         setConsentGiven(cookieConsentGiven())
@@ -14,6 +14,12 @@ export function CookieBanner() {
 
         updatePostHogConsent(consentGiven)
     }, [consentGiven])
+
+    return [consentGiven, setConsentGiven]
+}
+
+export function CookieBanner() {
+    const [consentGiven, setConsentGiven] = useCookieConsent()
 
     if (consentGiven === null) return null
 

--- a/playground/nextjs/src/posthog.ts
+++ b/playground/nextjs/src/posthog.ts
@@ -1,0 +1,48 @@
+import posthog, { PostHogConfig } from 'posthog-js'
+
+/**
+ * Below is an example of a consent-driven config for PostHog
+ * Lots of things start in a disabled state and posthog will not use cookies without consent
+ *
+ * Once given, we enable autocapture, session recording, and use localStorage+cookie for persistence via set_config
+ * This is only an example - data privacy requirements are different for every project
+ */
+export function cookieConsentGiven() {
+    return localStorage.getItem('cookie_consent') === 'true'
+}
+
+export const configForConsent = (): Partial<PostHogConfig> => {
+    const consentGiven = localStorage.getItem('cookie_consent') === 'true'
+
+    return {
+        persistence: consentGiven ? 'localStorage+cookie' : 'memory',
+        disable_surveys: !consentGiven,
+        autocapture: consentGiven,
+        disable_session_recording: !consentGiven,
+    }
+}
+
+export const updatePostHogConsent = (consentGiven: boolean) => {
+    if (consentGiven) {
+        localStorage.setItem('cookie_consent', 'true')
+    } else {
+        localStorage.removeItem('cookie_consent')
+    }
+
+    posthog.set_config(configForConsent())
+}
+
+if (typeof window !== 'undefined') {
+    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || '', {
+        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+        session_recording: {
+            recordCrossOriginIframes: true,
+        },
+        debug: true,
+        scroll_root_selector: ['#scroll_element', 'html'],
+        // persistence: cookieConsentGiven() ? 'localStorage+cookie' : 'memory',
+        __preview_process_person: 'identified_only',
+        ...configForConsent(),
+    })
+    ;(window as any).posthog = posthog
+}

--- a/playground/nextjs/src/posthog.ts
+++ b/playground/nextjs/src/posthog.ts
@@ -7,7 +7,8 @@ import posthog, { PostHogConfig } from 'posthog-js'
  * Once given, we enable autocapture, session recording, and use localStorage+cookie for persistence via set_config
  * This is only an example - data privacy requirements are different for every project
  */
-export function cookieConsentGiven() {
+export function cookieConsentGiven(): null | boolean {
+    if (typeof window === 'undefined') return null
     return localStorage.getItem('cookie_consent') === 'true'
 }
 

--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -368,6 +368,8 @@ describe('Autocapture system', () => {
     describe('_captureEvent', () => {
         beforeEach(() => {
             posthog.config.rageclick = true
+            // Trigger proper enabling
+            autocapture.afterDecideResponse({} as DecideResponse)
         })
 
         it('should capture rageclick', () => {
@@ -924,7 +926,6 @@ describe('Autocapture system', () => {
         })
 
         it('should capture click events', () => {
-            autocapture['_addDomEventHandlers']()
             const button = document.createElement('button')
             document.body.appendChild(button)
             simulateClick(button)

--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -920,6 +920,7 @@ describe('Autocapture system', () => {
         beforeEach(() => {
             document.title = 'test page'
             posthog.config.mask_all_element_attributes = false
+            autocapture.afterDecideResponse({} as DecideResponse)
         })
 
         it('should capture click events', () => {
@@ -943,7 +944,12 @@ describe('Autocapture system', () => {
             jest.spyOn(autocapture, '_addDomEventHandlers')
         })
 
-        it('should be enabled before the decide response', () => {
+        it('should not be enabled before the decide response', () => {
+            expect(autocapture.isEnabled).toBe(false)
+        })
+
+        it('should be enabled before the decide response if decide is disabled', () => {
+            posthog.config.advanced_disable_decide = true
             expect(autocapture.isEnabled).toBe(true)
         })
 

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -3,7 +3,6 @@ import { PostHogPersistence } from '../posthog-persistence'
 import { RequestRouter } from '../utils/request-router'
 import { checkScriptsForSrc } from './helpers/script-utils'
 
-
 const expectDecodedSendRequest = (send_request, data, noCompression) => {
     const lastCall = send_request.mock.calls[send_request.mock.calls.length - 1]
 
@@ -20,7 +19,6 @@ const expectDecodedSendRequest = (send_request, data, noCompression) => {
         timeout: undefined,
     })
 }
-
 
 describe('Decide', () => {
     given('decide', () => new Decide(given.posthog))

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -1,7 +1,7 @@
 import { Decide } from '../decide'
 import { PostHogPersistence } from '../posthog-persistence'
 import { RequestRouter } from '../utils/request-router'
-import { checkScriptsForSrc } from './helpers/script-utils'
+import { expectScriptToExist, expectScriptToNotExist } from './helpers/script-utils'
 
 const expectDecodedSendRequest = (send_request, data, noCompression) => {
     const lastCall = send_request.mock.calls[send_request.mock.calls.length - 1]
@@ -222,7 +222,7 @@ describe('Decide', () => {
             given('config', () => ({ api_host: 'https://test.com', opt_in_site_apps: true, persistence: 'memory' }))
             given('decideResponse', () => ({ siteApps: [{ id: 1, url: '/site_app/1/tokentoken/hash/' }] }))
             given.subject()
-            expect(checkScriptsForSrc('https://test.com/site_app/1/tokentoken/hash/')).toBe(true)
+            expectScriptToExist('https://test.com/site_app/1/tokentoken/hash/')
         })
 
         it('does not run site apps code if not opted in', () => {
@@ -235,7 +235,7 @@ describe('Decide', () => {
                 // throwing only in tests, just an error in production
                 'Unexpected console.error: [PostHog.js],PostHog site apps are disabled. Enable the "opt_in_site_apps" config to proceed.'
             )
-            expect(checkScriptsForSrc('https://test.com/site_app/1/tokentoken/hash/', true)).toBe(true)
+            expectScriptToNotExist('https://test.com/site_app/1/tokentoken/hash/')
         })
     })
 })

--- a/src/__tests__/decide.js
+++ b/src/__tests__/decide.js
@@ -51,16 +51,6 @@ describe('Decide', () => {
         _afterDecideResponse: jest.fn(),
         get_distinct_id: jest.fn().mockImplementation(() => 'distinctid'),
         _send_request: jest.fn().mockImplementation(({ callback }) => callback?.({ config: given.decideResponse })),
-        toolbar: {
-            maybeLoadToolbar: jest.fn(),
-            afterDecideResponse: jest.fn(),
-        },
-        sessionRecording: {
-            afterDecideResponse: jest.fn(),
-        },
-        autocapture: {
-            afterDecideResponse: jest.fn(),
-        },
         featureFlags: {
             receivedFeatureFlags: jest.fn(),
             setReloadingPaused: jest.fn(),
@@ -197,11 +187,8 @@ describe('Decide', () => {
             given('decideResponse', () => ({}))
             given.subject()
 
-            expect(given.posthog.sessionRecording.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
-            expect(given.posthog.toolbar.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
             expect(given.posthog.featureFlags.receivedFeatureFlags).toHaveBeenCalledWith(given.decideResponse, false)
             expect(given.posthog._afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
-            expect(given.posthog.autocapture.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
         })
 
         it('Make sure receivedFeatureFlags is called with errors if the decide response fails', () => {
@@ -228,10 +215,7 @@ describe('Decide', () => {
 
             given.subject()
 
-            expect(given.posthog.autocapture.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
-            expect(given.posthog.sessionRecording.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
-            expect(given.posthog.toolbar.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
-
+            expect(given.posthog._afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
             expect(given.posthog.featureFlags.receivedFeatureFlags).not.toHaveBeenCalled()
         })
 
@@ -248,10 +232,7 @@ describe('Decide', () => {
 
             given.subject()
 
-            expect(given.posthog.autocapture.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
-            expect(given.posthog.sessionRecording.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
-            expect(given.posthog.toolbar.afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
-
+            expect(given.posthog._afterDecideResponse).toHaveBeenCalledWith(given.decideResponse)
             expect(given.posthog.featureFlags.receivedFeatureFlags).not.toHaveBeenCalled()
         })
 

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -216,7 +216,7 @@ describe('SessionRecording', () => {
         })
     })
 
-    describe('startOrStopIfEnabled', () => {
+    describe('startIfEnabledOrStop', () => {
         beforeEach(() => {
             // need to cast as any to mock private methods
             jest.spyOn(sessionRecording as any, '_startCapture')
@@ -225,12 +225,12 @@ describe('SessionRecording', () => {
         })
 
         it('call _startCapture if its enabled', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect((sessionRecording as any)._startCapture).toHaveBeenCalled()
         })
 
         it('emits an options event', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect((sessionRecording as any)['_tryAddCustomEvent']).toHaveBeenCalledWith('$session_options', {
                 activePlugins: [],
                 sessionRecordingOptions: {
@@ -253,18 +253,18 @@ describe('SessionRecording', () => {
 
         it('call stopRecording if its not enabled', () => {
             posthog.config.disable_session_recording = true
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(sessionRecording.stopRecording).toHaveBeenCalled()
         })
     })
 
     describe('afterDecideResponse()', () => {
         beforeEach(() => {
-            jest.spyOn(sessionRecording, 'startOrStopIfEnabled')
+            jest.spyOn(sessionRecording, 'startIfEnabledOrStop')
         })
 
         it('buffers snapshots until decide is received and drops them if disabled', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(loadScript).toHaveBeenCalled()
             expect(sessionRecording['status']).toBe('buffering')
             expect(sessionRecording['buffer']).toEqual(EMPTY_BUFFER)
@@ -285,7 +285,7 @@ describe('SessionRecording', () => {
         })
 
         it('emit is not active until decide is called', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(loadScript).toHaveBeenCalled()
             expect(sessionRecording['status']).toBe('buffering')
 
@@ -294,7 +294,7 @@ describe('SessionRecording', () => {
         })
 
         it('sample rate is null when decide does not return it', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(loadScript).toHaveBeenCalled()
             expect(sessionRecording['isSampled']).toBe(null)
 
@@ -355,7 +355,7 @@ describe('SessionRecording', () => {
                 })
             )
 
-            expect(sessionRecording.startOrStopIfEnabled).toHaveBeenCalled()
+            expect(sessionRecording.startIfEnabledOrStop).toHaveBeenCalled()
             expect(loadScript).toHaveBeenCalled()
             expect(posthog.get_property(SESSION_RECORDING_ENABLED_SERVER_SIDE)).toBe(true)
             expect(sessionRecording['_endpoint']).toEqual('/ses/')
@@ -365,7 +365,7 @@ describe('SessionRecording', () => {
     describe('recording', () => {
         describe('sampling', () => {
             it('does not emit to capture if the sample rate is 0', () => {
-                sessionRecording.startOrStopIfEnabled()
+                sessionRecording.startIfEnabledOrStop()
 
                 sessionRecording.afterDecideResponse(
                     makeDecideResponse({
@@ -380,7 +380,7 @@ describe('SessionRecording', () => {
             })
 
             it('does emit to capture if the sample rate is null', () => {
-                sessionRecording.startOrStopIfEnabled()
+                sessionRecording.startIfEnabledOrStop()
 
                 sessionRecording.afterDecideResponse(
                     makeDecideResponse({
@@ -392,7 +392,7 @@ describe('SessionRecording', () => {
             })
 
             it('stores excluded session when excluded', () => {
-                sessionRecording.startOrStopIfEnabled()
+                sessionRecording.startIfEnabledOrStop()
 
                 sessionRecording.afterDecideResponse(
                     makeDecideResponse({
@@ -404,7 +404,7 @@ describe('SessionRecording', () => {
             })
 
             it('does emit to capture if the sample rate is 1', () => {
-                sessionRecording.startOrStopIfEnabled()
+                sessionRecording.startIfEnabledOrStop()
 
                 _emit(createIncrementalSnapshot({ data: { source: 1 } }))
                 expect(posthog.capture).not.toHaveBeenCalled()
@@ -427,7 +427,7 @@ describe('SessionRecording', () => {
             })
 
             it('sets emit as expected when sample rate is 0.5', () => {
-                sessionRecording.startOrStopIfEnabled()
+                sessionRecording.startIfEnabledOrStop()
 
                 sessionRecording.afterDecideResponse(
                     makeDecideResponse({
@@ -465,7 +465,7 @@ describe('SessionRecording', () => {
                     },
                 })
 
-                sessionRecording.startOrStopIfEnabled()
+                sessionRecording.startIfEnabledOrStop()
 
                 sessionRecording['_onScriptLoaded']()
                 expect(assignableWindow.rrweb.record).toHaveBeenCalledWith(
@@ -481,7 +481,7 @@ describe('SessionRecording', () => {
             })
 
             it('skips when any config variable is missing', () => {
-                sessionRecording.startOrStopIfEnabled()
+                sessionRecording.startIfEnabledOrStop()
 
                 sessionRecording.afterDecideResponse(
                     makeDecideResponse({
@@ -501,7 +501,7 @@ describe('SessionRecording', () => {
         it('calls rrweb.record with the right options', () => {
             posthog.persistence?.register({ [CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE]: false })
 
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             // maskAllInputs should change from default
             // someUnregisteredProp should not be present
             expect(assignableWindow.rrweb.record).toHaveBeenCalledWith({
@@ -523,7 +523,7 @@ describe('SessionRecording', () => {
         })
 
         it('records events emitted before and after starting recording', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(loadScript).toHaveBeenCalled()
 
             _emit(createIncrementalSnapshot({ data: { source: 1 } }))
@@ -578,7 +578,7 @@ describe('SessionRecording', () => {
 
         it('buffers emitted events', () => {
             sessionRecording.afterDecideResponse(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(loadScript).toHaveBeenCalled()
 
             _emit(createIncrementalSnapshot({ data: { source: 1 } }))
@@ -613,7 +613,7 @@ describe('SessionRecording', () => {
 
         it('flushes buffer if the size of the buffer hits the limit', () => {
             sessionRecording.afterDecideResponse(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(loadScript).toHaveBeenCalled()
             const bigData = 'a'.repeat(RECORDING_MAX_EVENT_SIZE * 0.8)
 
@@ -632,7 +632,7 @@ describe('SessionRecording', () => {
         })
 
         it('maintains the buffer if the recording is buffering', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(loadScript).toHaveBeenCalled()
 
             const bigData = 'a'.repeat(RECORDING_MAX_EVENT_SIZE * 0.8)
@@ -658,7 +658,7 @@ describe('SessionRecording', () => {
 
         it('flushes buffer if the session_id changes', () => {
             sessionRecording.afterDecideResponse(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
 
             expect(sessionRecording['buffer']?.sessionId).toEqual(null)
 
@@ -711,12 +711,12 @@ describe('SessionRecording', () => {
 
         it("doesn't load recording script if already loaded", () => {
             addRRwebToWindow()
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(loadScript).not.toHaveBeenCalled()
         })
 
         it('loads recording script from right place', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
 
             expect(loadScript).toHaveBeenCalledWith('https://test.com/static/recorder.js?v=v0.0.1', expect.anything())
         })
@@ -724,7 +724,7 @@ describe('SessionRecording', () => {
         it('loads script after `_startCapture` if not previously loaded', () => {
             posthog.persistence?.register({ [SESSION_RECORDING_ENABLED_SERVER_SIDE]: false })
 
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(loadScript).not.toHaveBeenCalled()
 
             sessionRecording['_startCapture']()
@@ -735,7 +735,7 @@ describe('SessionRecording', () => {
         it('does not load script if disable_session_recording passed', () => {
             posthog.config.disable_session_recording = true
 
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             sessionRecording['_startCapture']()
 
             expect(loadScript).not.toHaveBeenCalled()
@@ -744,7 +744,7 @@ describe('SessionRecording', () => {
         it('session recording can be turned on and off', () => {
             expect(sessionRecording['stopRrweb']).toEqual(undefined)
 
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
 
             expect(sessionRecording.started).toEqual(true)
             expect(sessionRecording['stopRrweb']).not.toEqual(undefined)
@@ -758,7 +758,7 @@ describe('SessionRecording', () => {
         it('session recording can be turned on after being turned off', () => {
             expect(sessionRecording['stopRrweb']).toEqual(undefined)
 
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
 
             expect(sessionRecording.started).toEqual(true)
             expect(sessionRecording['stopRrweb']).not.toEqual(undefined)
@@ -773,7 +773,7 @@ describe('SessionRecording', () => {
             it('if not enabled, plugin is not used', () => {
                 posthog.config.enable_recording_console_log = false
 
-                sessionRecording.startOrStopIfEnabled()
+                sessionRecording.startIfEnabledOrStop()
 
                 expect(assignableWindow.rrwebConsoleRecord.getRecordConsolePlugin).not.toHaveBeenCalled()
             })
@@ -781,7 +781,7 @@ describe('SessionRecording', () => {
             it('if enabled, plugin is used', () => {
                 posthog.config.enable_recording_console_log = true
 
-                sessionRecording.startOrStopIfEnabled()
+                sessionRecording.startIfEnabledOrStop()
 
                 expect(assignableWindow.rrwebConsoleRecord.getRecordConsolePlugin).toHaveBeenCalled()
             })
@@ -792,7 +792,7 @@ describe('SessionRecording', () => {
                 sessionRecording['sessionId'] = 'old-session-id'
                 sessionRecording['windowId'] = 'old-window-id'
 
-                sessionRecording.startOrStopIfEnabled()
+                sessionRecording.startIfEnabledOrStop()
                 sessionRecording.afterDecideResponse(
                     makeDecideResponse({
                         sessionRecording: { endpoint: '/s/' },
@@ -859,7 +859,7 @@ describe('SessionRecording', () => {
 
                     expect(mockCallback).not.toHaveBeenCalled()
 
-                    sessionRecording.startOrStopIfEnabled()
+                    sessionRecording.startIfEnabledOrStop()
                     sessionRecording['_startCapture']()
 
                     expect(mockCallback).toHaveBeenCalledTimes(1)
@@ -931,7 +931,7 @@ describe('SessionRecording', () => {
                     sessionManager = new SessionIdManager(config, new PostHogPersistence(config))
                     posthog.sessionManager = sessionManager
 
-                    sessionRecording.startOrStopIfEnabled()
+                    sessionRecording.startIfEnabledOrStop()
                     sessionRecording['_startCapture']()
                 })
 
@@ -1083,7 +1083,7 @@ describe('SessionRecording', () => {
         }
 
         beforeEach(() => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             sessionRecording.afterDecideResponse(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
             expect(sessionRecording['status']).toEqual('active')
 
@@ -1386,13 +1386,13 @@ describe('SessionRecording', () => {
 
     describe('buffering minimum duration', () => {
         it('can report no duration when no data', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(sessionRecording['status']).toBe('buffering')
             expect(sessionRecording['sessionDuration']).toBe(null)
         })
 
         it('can report zero duration', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(sessionRecording['status']).toBe('buffering')
             const { sessionStartTimestamp } = sessionManager.checkAndGetSessionAndWindowId(true)
             _emit(createIncrementalSnapshot({ data: { source: 1 }, timestamp: sessionStartTimestamp }))
@@ -1400,7 +1400,7 @@ describe('SessionRecording', () => {
         })
 
         it('can report a duration', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(sessionRecording['status']).toBe('buffering')
             const { sessionStartTimestamp } = sessionManager.checkAndGetSessionAndWindowId(true)
             _emit(createIncrementalSnapshot({ data: { source: 1 }, timestamp: sessionStartTimestamp + 100 }))
@@ -1408,7 +1408,7 @@ describe('SessionRecording', () => {
         })
 
         it('starts with an undefined minimum duration', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(sessionRecording['minimumDuration']).toBe(null)
         })
 
@@ -1427,7 +1427,7 @@ describe('SessionRecording', () => {
                     sessionRecording: { minimumDurationMilliseconds: 1500 },
                 })
             )
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(sessionRecording['status']).toBe('active')
             const { sessionStartTimestamp } = sessionManager.checkAndGetSessionAndWindowId(true)
             _emit(createIncrementalSnapshot({ data: { source: 1 }, timestamp: sessionStartTimestamp + 100 }))
@@ -1447,7 +1447,7 @@ describe('SessionRecording', () => {
                     sessionRecording: { minimumDurationMilliseconds: 1500 },
                 })
             )
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(sessionRecording['status']).toBe('active')
             const { sessionStartTimestamp } = sessionManager.checkAndGetSessionAndWindowId(true)
 
@@ -1472,7 +1472,7 @@ describe('SessionRecording', () => {
                     sessionRecording: { minimumDurationMilliseconds: 1500 },
                 })
             )
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(sessionRecording['status']).toBe('active')
             const { sessionStartTimestamp } = sessionManager.checkAndGetSessionAndWindowId(true)
             _emit(createIncrementalSnapshot({ data: { source: 1 }, timestamp: sessionStartTimestamp + 100 }))
@@ -1513,7 +1513,7 @@ describe('SessionRecording', () => {
             })
 
             sessionRecording.afterDecideResponse(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(loadScript).toHaveBeenCalled()
 
             expect(sessionRecording['queuedRRWebEvents']).toHaveLength(0)
@@ -1551,12 +1551,12 @@ describe('SessionRecording', () => {
         })
 
         it('schedules a snapshot on start', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             expect(sessionRecording['_fullSnapshotTimer']).not.toBe(undefined)
         })
 
         it('reschedules a snapshot, when we take a full snapshot', () => {
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             const startTimer = sessionRecording['_fullSnapshotTimer']
 
             _emit(createFullSnapshot())
@@ -1570,7 +1570,7 @@ describe('SessionRecording', () => {
         beforeEach(() => {
             jest.spyOn(sessionRecording as any, '_tryAddCustomEvent')
             posthog.config.capture_pageview = false
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             // clear the spy calls
             ;(sessionRecording as any)._tryAddCustomEvent.mockClear()
         })
@@ -1609,7 +1609,7 @@ describe('SessionRecording', () => {
         beforeEach(() => {
             jest.spyOn(sessionRecording as any, '_tryAddCustomEvent')
             posthog.config.capture_pageview = true
-            sessionRecording.startOrStopIfEnabled()
+            sessionRecording.startIfEnabledOrStop()
             // clear the spy calls
             ;(sessionRecording as any)._tryAddCustomEvent.mockClear()
         })

--- a/src/__tests__/helpers/script-utils.ts
+++ b/src/__tests__/helpers/script-utils.ts
@@ -1,0 +1,18 @@
+export const checkScriptsForSrc = (src, negate = false) => {
+    const scripts = document.querySelectorAll('body > script')
+    let foundScript = false
+    for (let i = 0; i < scripts.length; i++) {
+        if (scripts[i].src === src) {
+            foundScript = true
+            break
+        }
+    }
+
+    if (foundScript && negate) {
+        throw new Error(`Script with src ${src} was found when it should not have been.`)
+    } else if (!foundScript && !negate) {
+        throw new Error(`Script with src ${src} was not found when it should have been.`)
+    } else {
+        return true
+    }
+}

--- a/src/__tests__/helpers/script-utils.ts
+++ b/src/__tests__/helpers/script-utils.ts
@@ -1,4 +1,4 @@
-export const checkScriptsForSrc = (src, negate = false) => {
+const checkScriptsForSrcExists = (src: string): boolean => {
     const scripts = document.querySelectorAll('body > script')
     let foundScript = false
     for (let i = 0; i < scripts.length; i++) {
@@ -8,11 +8,17 @@ export const checkScriptsForSrc = (src, negate = false) => {
         }
     }
 
-    if (foundScript && negate) {
-        throw new Error(`Script with src ${src} was found when it should not have been.`)
-    } else if (!foundScript && !negate) {
-        throw new Error(`Script with src ${src} was not found when it should have been.`)
-    } else {
-        return true
+    return foundScript
+}
+
+export const expectScriptToExist = (src: string) => {
+    if (!checkScriptsForSrcExists(src)) {
+        throw new Error(`Script with src ${src} was not found.`)
+    }
+}
+
+export const expectScriptToNotExist = (src: string) => {
+    if (checkScriptsForSrcExists(src)) {
+        throw new Error(`Script with src ${src} was found.`)
     }
 }

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -769,7 +769,7 @@ describe('posthog core', () => {
             given('overrides', () => ({
                 sessionRecording: {
                     afterDecideResponse: jest.fn(),
-                    startRecordingIfEnabled: jest.fn(),
+                    startOrStopIfEnabled: jest.fn(),
                 },
                 toolbar: {
                     maybeLoadToolbar: jest.fn(),

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -769,7 +769,7 @@ describe('posthog core', () => {
             given('overrides', () => ({
                 sessionRecording: {
                     afterDecideResponse: jest.fn(),
-                    startOrStopIfEnabled: jest.fn(),
+                    startIfEnabledOrStop: jest.fn(),
                 },
                 toolbar: {
                     maybeLoadToolbar: jest.fn(),

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -402,25 +402,24 @@ describe('surveys', () => {
         })
     })
 
-    describe("decide response", () => {
+    describe('decide response', () => {
         it('should not load when decide response says no', () => {
-            surveys.afterDecideResponse({ surveys: false} as DecideResponse)
+            surveys.afterDecideResponse({ surveys: false } as DecideResponse)
             // Make sure the script is not loaded
-            expect(checkScriptsForSrc('https://test.com/static/surveys.js', true)).toBe(true)
+            expect(checkScriptsForSrc('https://us-assets.i.posthog.com/static/surveys.js', true)).toBe(true)
         })
 
         it('should load when decide response says so', () => {
             surveys.afterDecideResponse({ surveys: true } as DecideResponse)
             // Make sure the script is loaded
-            expect(checkScriptsForSrc('https://test.com/static/surveys.js')).toBe(true)
+            expect(checkScriptsForSrc('https://us-assets.i.posthog.com/static/surveys.js')).toBe(true)
         })
 
         it('should not load when config says no', () => {
-
             config.disable_surveys = true
             surveys.afterDecideResponse({ surveys: true } as DecideResponse)
             // Make sure the script is not loaded
-            expect(checkScriptsForSrc('https://test.com/static/surveys.js', true)).toBe(true)
+            expect(checkScriptsForSrc('https://us-assets.i.posthog.com/static/surveys.js', true)).toBe(true)
         })
     })
 })

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -8,6 +8,7 @@ import { DecideResponse, PostHogConfig, Properties } from '../types'
 import { window } from '../utils/globals'
 import { RequestRouter } from '../utils/request-router'
 import { assignableWindow } from '../utils/globals'
+import { checkScriptsForSrc } from './helpers/script-utils'
 
 describe('surveys', () => {
     let config: PostHogConfig
@@ -398,6 +399,28 @@ describe('surveys', () => {
             surveys.getActiveMatchingSurveys((data) => {
                 expect(data).toEqual([activeSurvey, surveyWithSelector, surveyWithEverything])
             })
+        })
+    })
+
+    describe("decide response", () => {
+        it('should not load when decide response says no', () => {
+            surveys.afterDecideResponse({ surveys: false} as DecideResponse)
+            // Make sure the script is not loaded
+            expect(checkScriptsForSrc('https://test.com/static/surveys.js', true)).toBe(true)
+        })
+
+        it('should load when decide response says so', () => {
+            surveys.afterDecideResponse({ surveys: true } as DecideResponse)
+            // Make sure the script is loaded
+            expect(checkScriptsForSrc('https://test.com/static/surveys.js')).toBe(true)
+        })
+
+        it('should not load when config says no', () => {
+
+            config.disable_surveys = true
+            surveys.afterDecideResponse({ surveys: true } as DecideResponse)
+            // Make sure the script is not loaded
+            expect(checkScriptsForSrc('https://test.com/static/surveys.js', true)).toBe(true)
         })
     })
 })

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -8,7 +8,7 @@ import { DecideResponse, PostHogConfig, Properties } from '../types'
 import { window } from '../utils/globals'
 import { RequestRouter } from '../utils/request-router'
 import { assignableWindow } from '../utils/globals'
-import { checkScriptsForSrc } from './helpers/script-utils'
+import { expectScriptToExist, expectScriptToNotExist } from './helpers/script-utils'
 
 describe('surveys', () => {
     let config: PostHogConfig
@@ -412,20 +412,20 @@ describe('surveys', () => {
         it('should not load when decide response says no', () => {
             surveys.afterDecideResponse({ surveys: false } as DecideResponse)
             // Make sure the script is not loaded
-            expect(checkScriptsForSrc('https://us-assets.i.posthog.com/static/surveys.js', true)).toBe(true)
+            expectScriptToNotExist('https://us-assets.i.posthog.com/static/surveys.js')
         })
 
         it('should load when decide response says so', () => {
             surveys.afterDecideResponse({ surveys: true } as DecideResponse)
             // Make sure the script is loaded
-            expect(checkScriptsForSrc('https://us-assets.i.posthog.com/static/surveys.js')).toBe(true)
+            expectScriptToExist('https://us-assets.i.posthog.com/static/surveys.js')
         })
 
         it('should not load when config says no', () => {
             config.disable_surveys = true
             surveys.afterDecideResponse({ surveys: true } as DecideResponse)
             // Make sure the script is not loaded
-            expect(checkScriptsForSrc('https://us-assets.i.posthog.com/static/surveys.js', true)).toBe(true)
+            expectScriptToNotExist('https://us-assets.i.posthog.com/static/surveys.js')
         })
     })
 })

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -403,6 +403,12 @@ describe('surveys', () => {
     })
 
     describe('decide response', () => {
+        beforeEach(() => {
+            // clean the JSDOM to prevent interdependencies between tests
+            document.body.innerHTML = ''
+            document.head.innerHTML = ''
+        })
+
         it('should not load when decide response says no', () => {
             surveys.afterDecideResponse({ surveys: false } as DecideResponse)
             // Make sure the script is not loaded

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -95,7 +95,6 @@ export class Autocapture {
 
     public afterDecideResponse(response: DecideResponse) {
         if (this._initialized) {
-            logger.info('autocapture already initialized')
             return
         }
 

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -86,7 +86,7 @@ export class Autocapture {
         }
     }
 
-    public startOrStopIfEnabled() {
+    public startIfEnabled() {
         if (this.isEnabled && !this._initialized) {
             this._addDomEventHandlers()
             this._initialized = true
@@ -110,7 +110,7 @@ export class Autocapture {
             this._elementsChainAsString = response.elementsChainAsString
         }
 
-        this.startOrStopIfEnabled()
+        this.startIfEnabled()
     }
 
     public get isEnabled(): boolean {

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -86,6 +86,13 @@ export class Autocapture {
         }
     }
 
+    public startOrStopIfEnabled() {
+        if (this.isEnabled && !this._initialized) {
+            this._addDomEventHandlers()
+            this._initialized = true
+        }
+    }
+
     public afterDecideResponse(response: DecideResponse) {
         if (this._initialized) {
             logger.info('autocapture already initialized')
@@ -104,10 +111,7 @@ export class Autocapture {
             this._elementsChainAsString = response.elementsChainAsString
         }
 
-        if (this.isEnabled) {
-            this._addDomEventHandlers()
-            this._initialized = true
-        }
+        this.startOrStopIfEnabled()
     }
 
     public get isEnabled(): boolean {
@@ -224,6 +228,10 @@ export class Autocapture {
     }
 
     private _captureEvent(e: Event, eventName = '$autocapture'): boolean | void {
+        if (!this.isEnabled) {
+            return
+        }
+
         /*** Don't mess with this code without running IE8 tests on it ***/
         let target = this._getEventTarget(e)
         if (isTextNode(target)) {

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -70,8 +70,6 @@ export class Decide {
 
         this.instance._afterDecideResponse(response)
 
-        // TODO: Need to change this to be able to be more reactive 
-
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         const exceptionAutoCaptureAddedToWindow = window?.extendPostHogWithExceptionAutoCapture

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -70,22 +70,7 @@ export class Decide {
 
         this.instance._afterDecideResponse(response)
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        const surveysGenerator = window?.extendPostHogWithSurveys
-
         // TODO: Need to change this to be able to be more reactive 
-        if (!this.instance.config.disable_surveys && response['surveys'] && !surveysGenerator) {
-            loadScript(this.instance.requestRouter.endpointFor('assets', '/static/surveys.js'), (err) => {
-                if (err) {
-                    return logger.error(`Could not load surveys script`, err)
-                }
-
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                window.extendPostHogWithSurveys(this.instance)
-            })
-        }
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -74,6 +74,7 @@ export class Decide {
         // @ts-ignore
         const surveysGenerator = window?.extendPostHogWithSurveys
 
+        // TODO: Need to change this to be able to be more reactive 
         if (!this.instance.config.disable_surveys && response['surveys'] && !surveysGenerator) {
             loadScript(this.instance.requestRouter.endpointFor('assets', '/static/surveys.js'), (err) => {
                 if (err) {

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -68,9 +68,6 @@ export class Decide {
             return
         }
 
-        this.instance.toolbar.afterDecideResponse(response)
-        this.instance.sessionRecording?.afterDecideResponse(response)
-        this.instance.autocapture?.afterDecideResponse(response)
         this.instance._afterDecideResponse(response)
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -289,7 +289,7 @@ export class SessionRecording {
         this._setupSampling()
     }
 
-    startRecordingIfEnabled() {
+    startOrStopIfEnabled() {
         if (this.isRecordingEnabled) {
             this._startCapture()
             logger.info(LOGGER_PREFIX + ' started')
@@ -387,7 +387,7 @@ export class SessionRecording {
         }
 
         this.receivedDecide = true
-        this.startRecordingIfEnabled()
+        this.startOrStopIfEnabled()
     }
 
     private _samplingSessionListener: (() => void) | null = null

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -289,7 +289,7 @@ export class SessionRecording {
         this._setupSampling()
     }
 
-    startOrStopIfEnabled() {
+    startIfEnabledOrStop() {
         if (this.isRecordingEnabled) {
             this._startCapture()
             logger.info(LOGGER_PREFIX + ' started')
@@ -387,7 +387,7 @@ export class SessionRecording {
         }
 
         this.receivedDecide = true
-        this.startOrStopIfEnabled()
+        this.startIfEnabledOrStop()
     }
 
     private _samplingSessionListener: (() => void) | null = null

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -22,22 +22,6 @@ export class Toolbar {
         this.instance = instance
     }
 
-    afterDecideResponse(response: DecideResponse) {
-        const toolbarParams: ToolbarParams =
-            response['toolbarParams'] ||
-            response['editorParams'] ||
-            (response['toolbarVersion'] ? { toolbarVersion: response['toolbarVersion'] } : {})
-        if (
-            response['isAuthenticated'] &&
-            toolbarParams['toolbarVersion'] &&
-            toolbarParams['toolbarVersion'].indexOf('toolbar') === 0
-        ) {
-            this.loadToolbar({
-                ...toolbarParams,
-            })
-        }
-    }
-
     /**
      * To load the toolbar, we need an access token and other state. That state comes from one of three places:
      * 1. In the URL hash params

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -1,6 +1,6 @@
 import { _register_event, _try, loadScript } from '../utils'
 import { PostHog } from '../posthog-core'
-import { DecideResponse, ToolbarParams } from '../types'
+import { ToolbarParams } from '../types'
 import { _getHashParam } from '../utils/request-utils'
 import { logger } from '../utils/logger'
 import { window, document, assignableWindow } from '../utils/globals'

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -361,15 +361,15 @@ export class PostHog {
         this.sessionPropsManager = new SessionPropsManager(this.sessionManager, this.persistence)
 
         this.sessionRecording = new SessionRecording(this)
-        this.sessionRecording.startOrStopIfEnabled()
+        this.sessionRecording.startIfEnabledOrStop()
 
         if (!this.config.disable_scroll_properties) {
             this.pageViewManager.startMeasuringScrollPosition()
         }
 
         this.autocapture = new Autocapture(this)
-        this.autocapture.startOrStopIfEnabled()
-        this.surveys.startOrStopIfEnabled()
+        this.autocapture.startIfEnabled()
+        this.surveys.loadIfEnabled()
 
         // if any instance on the page has debug = true, we set the
         // global debug to be true
@@ -1666,9 +1666,9 @@ export class PostHog {
                 Config.DEBUG = true
             }
 
-            this.sessionRecording?.startOrStopIfEnabled()
-            this.autocapture?.startOrStopIfEnabled()
-            this.surveys.startOrStopIfEnabled()
+            this.sessionRecording?.startIfEnabledOrStop()
+            this.autocapture?.startIfEnabled()
+            this.surveys.loadIfEnabled()
         }
     }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -369,6 +369,7 @@ export class PostHog {
 
         this.autocapture = new Autocapture(this)
         this.autocapture.startOrStopIfEnabled()
+        this.surveys.startOrStopIfEnabled()
 
         // if any instance on the page has debug = true, we set the
         // global debug to be true
@@ -1667,6 +1668,7 @@ export class PostHog {
 
             this.sessionRecording?.startOrStopIfEnabled()
             this.autocapture?.startOrStopIfEnabled()
+            this.surveys.startOrStopIfEnabled()
         }
     }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -474,7 +474,7 @@ export class PostHog {
 
         this.sessionRecording?.afterDecideResponse(response)
         this.autocapture?.afterDecideResponse(response)
-
+        this.surveys?.afterDecideResponse(response)
     }
 
     _loaded(): void {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -361,13 +361,14 @@ export class PostHog {
         this.sessionPropsManager = new SessionPropsManager(this.sessionManager, this.persistence)
 
         this.sessionRecording = new SessionRecording(this)
-        this.sessionRecording.startRecordingIfEnabled()
+        this.sessionRecording.startOrStopIfEnabled()
 
         if (!this.config.disable_scroll_properties) {
             this.pageViewManager.startMeasuringScrollPosition()
         }
 
         this.autocapture = new Autocapture(this)
+        this.autocapture.startOrStopIfEnabled()
 
         // if any instance on the page has debug = true, we set the
         // global debug to be true
@@ -469,6 +470,10 @@ export class PostHog {
         if (response.analytics?.endpoint) {
             this.analyticsDefaultEndpoint = response.analytics.endpoint
         }
+
+        this.sessionRecording?.afterDecideResponse(response)
+        this.autocapture?.afterDecideResponse(response)
+
     }
 
     _loaded(): void {
@@ -1660,21 +1665,8 @@ export class PostHog {
                 Config.DEBUG = true
             }
 
-            if (this.sessionRecording && !_isUndefined(config.disable_session_recording)) {
-                const disable_session_recording_has_changed =
-                    oldConfig.disable_session_recording !== config.disable_session_recording
-                // if opting back in, this config might not have changed
-                const try_enable_after_opt_in =
-                    !userOptedOut(this) && !config.disable_session_recording && !this.sessionRecording.started
-
-                if (disable_session_recording_has_changed || try_enable_after_opt_in) {
-                    if (config.disable_session_recording) {
-                        this.sessionRecording.stopRecording()
-                    } else {
-                        this.sessionRecording.startRecordingIfEnabled()
-                    }
-                }
-            }
+            this.sessionRecording?.startOrStopIfEnabled()
+            this.autocapture?.startOrStopIfEnabled()
         }
     }
 

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -24,10 +24,10 @@ export class PostHogSurveys {
 
     afterDecideResponse(response: DecideResponse) {
         this._decideServerResponse = !!response['surveys']
-        this.startOrStopIfEnabled()
+        this.loadIfEnabled()
     }
 
-    startOrStopIfEnabled() {
+    loadIfEnabled() {
         const surveysGenerator = assignableWindow?.extendPostHogWithSurveys
 
         if (!this.instance.config.disable_surveys && this._decideServerResponse && !surveysGenerator) {

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -29,7 +29,7 @@ export class PostHogSurveys {
 
     startOrStopIfEnabled() {
         const surveysGenerator = assignableWindow?.extendPostHogWithSurveys
-    
+
         if (!this.instance.config.disable_surveys && this._decideServerResponse && !surveysGenerator) {
             loadScript(this.instance.requestRouter.endpointFor('assets', '/static/surveys.js'), (err) => {
                 if (err) {


### PR DESCRIPTION
## Changes

We enabled/ disable recordings due to config changes but not autocapture or surveys

* Refactors the code so that each class is responsible for its own intialisation
* Uses the nextjs example for consent driven dev

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
