### PR TITLE
feat: Rename process_person config option to person_profiles

### DIFF
--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -36,25 +36,37 @@ describe('person processing', () => {
         const onCapture = jest.fn()
         const posthog = await createPosthogInstance(token, {
             _onCapture: onCapture,
-            process_person: processPerson,
+            person_profiles: processPerson,
         })
         return { token, onCapture, posthog }
     }
 
     describe('init', () => {
-        it("should default to 'always' process_person", async () => {
+        it("should default to 'always' person_profiles", async () => {
             // arrange
             const token = uuidv7()
 
             // act
             const posthog = await createPosthogInstance(token, {
-                process_person: undefined,
+                person_profiles: undefined,
             })
 
             // assert
-            expect(posthog.config.process_person).toEqual('always')
+            expect(posthog.config.person_profiles).toEqual('always')
         })
-        it('should read process_person from init config', async () => {
+        it('should read person_profiles from init config', async () => {
+            // arrange
+            const token = uuidv7()
+
+            // act
+            const posthog = await createPosthogInstance(token, {
+                person_profiles: 'never',
+            })
+
+            // assert
+            expect(posthog.config.person_profiles).toEqual('never')
+        })
+        it('should read person_profiles from init config as process_person', async () => {
             // arrange
             const token = uuidv7()
 
@@ -64,7 +76,20 @@ describe('person processing', () => {
             })
 
             // assert
-            expect(posthog.config.process_person).toEqual('never')
+            expect(posthog.config.person_profiles).toEqual('never')
+        })
+        it('should prefer the correct name to the deprecated one', async () => {
+            // arrange
+            const token = uuidv7()
+
+            // act
+            const posthog = await createPosthogInstance(token, {
+                process_person: 'never',
+                person_profiles: 'identified_only',
+            })
+
+            // assert
+            expect(posthog.config.person_profiles).toEqual('identified_only')
         })
     })
 

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -432,19 +432,6 @@ describe('posthog core', () => {
             })
         })
 
-        it('respects property_denylist and property_blacklist', () => {
-            given('property_denylist', () => ['$lib', 'persistent', '$is_identified'])
-            given('property_blacklist', () => ['token'])
-
-            expect(given.subject).toEqual({
-                event: 'prop',
-                distinct_id: 'abc',
-                $window_id: 'windowId',
-                $session_id: 'sessionId',
-                $process_person: true,
-            })
-        })
-
         it("can't deny or blacklist $process_person", () => {
             given('property_denylist', () => ['$process_person'])
             given('property_blacklist', () => ['$process_person'])

--- a/src/__tests__/posthog-core.test.ts
+++ b/src/__tests__/posthog-core.test.ts
@@ -1,0 +1,35 @@
+import _posthog, { PostHogConfig } from '../loader-module'
+import { uuidv7 } from '../uuidv7'
+
+describe('posthog core', () => {
+    describe('capture()', () => {
+        const eventName = 'custom_event'
+        const properties = {
+            event: 'prop',
+        }
+        const setup = (config: Partial<PostHogConfig>) => {
+            const onCapture = jest.fn()
+            const posthog = _posthog.init('testtoken', { ...config, _onCapture: onCapture }, uuidv7())!
+            posthog.debug()
+            return { posthog, onCapture }
+        }
+
+        it('respects property_denylist and property_blacklist', () => {
+            // arrange
+            const { posthog } = setup({
+                property_denylist: ['$lib', 'persistent', '$is_identified'],
+                property_blacklist: ['token'],
+            })
+
+            // act
+            const actual = posthog._calculate_event_properties(eventName, properties)
+
+            // assert
+            expect(actual['event']).toBe('prop')
+            expect(actual['$lib']).toBeUndefined()
+            expect(actual['persistent']).toBeUndefined()
+            expect(actual['$is_identified']).toBeUndefined()
+            expect(actual['token']).toBeUndefined()
+        })
+    })
+})

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -121,7 +121,6 @@ export const defaultConfig = (): PostHogConfig => ({
     cross_subdomain_cookie: isCrossDomainCookie(document?.location),
     persistence: 'localStorage+cookie', // up to 1.92.0 this was 'cookie'. It's easy to migrate as 'localStorage+cookie' will migrate data from cookie storage
     persistence_name: '',
-    cookie_name: '',
     loaded: __NOOP,
     store_google: true,
     custom_campaign_params: [],
@@ -135,7 +134,6 @@ export const defaultConfig = (): PostHogConfig => ({
     upgrade: false,
     disable_session_recording: false,
     disable_persistence: false,
-    disable_cookie: undefined,
     disable_surveys: false,
     enable_recording_console_log: undefined, // When undefined, it falls back to the server-side setting
     secure_cookie: window?.location?.protocol === 'https:',
@@ -146,8 +144,6 @@ export const defaultConfig = (): PostHogConfig => ({
     opt_out_capturing_persistence_type: 'localStorage',
     opt_out_capturing_cookie_prefix: null,
     opt_in_site_apps: false,
-    // Deprecated, use property_denylist instead.
-    property_blacklist: [],
     property_denylist: [],
     respect_dnt: false,
     sanitize_properties: null,
@@ -176,7 +172,6 @@ export const defaultConfig = (): PostHogConfig => ({
     bootstrap: {},
     disable_compression: false,
     session_idle_timeout_seconds: 30 * 60, // 30 minutes
-    process_person: undefined,
     person_profiles: 'always',
 })
 
@@ -361,7 +356,7 @@ export class PostHog {
         this._triggered_notifs = []
 
         this.set_config(
-            _extend({}, defaultConfig(), configRenames(config), config, {
+            _extend({}, defaultConfig(), config, {
                 name: name,
                 token: token,
             })
@@ -1670,10 +1665,6 @@ export class PostHog {
         const oldConfig = { ...this.config }
         if (_isObject(config)) {
             _extend(this.config, configRenames(config), config)
-
-            if (!this.config.disable_persistence) {
-                this.config.disable_persistence = this.config.disable_cookie
-            }
 
             this.persistence?.update_config(this.config, oldConfig)
             this.sessionPersistence =

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -194,11 +194,11 @@ export const configRenames = (origConfig: Partial<PostHogConfig>): Partial<PostH
     // the original config takes priority over the renames
     const newConfig = _extend({}, renames, origConfig)
 
+    // merge property_blacklist into property_denylist
     if (_isArray(origConfig.property_blacklist)) {
         if (_isUndefined(origConfig.property_denylist)) {
             newConfig.property_denylist = origConfig.property_blacklist
         } else if (_isArray(origConfig.property_denylist)) {
-            // merge property_denylist and property_blacklist
             newConfig.property_denylist = [...origConfig.property_blacklist, ...origConfig.property_denylist]
         } else {
             logger.error('Invalid value for property_denylist config: ' + origConfig.property_denylist)

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,8 @@ export interface PostHogConfig {
     cross_subdomain_cookie: boolean
     persistence: 'localStorage' | 'cookie' | 'memory' | 'localStorage+cookie' | 'sessionStorage'
     persistence_name: string
-    cookie_name: string
+    /** @deprecated - Use 'persistence_name' instead */
+    cookie_name?: string
     loaded: (posthog_instance: PostHog) => void
     store_google: boolean
     custom_campaign_params: string[]
@@ -98,7 +99,7 @@ export interface PostHogConfig {
     disable_session_recording: boolean
     disable_persistence: boolean
     /** @deprecated - use `disable_persistence` instead  */
-    disable_cookie: boolean
+    disable_cookie?: boolean
     disable_surveys: boolean
     enable_recording_console_log?: boolean
     secure_cookie: boolean
@@ -152,6 +153,8 @@ export interface PostHogConfig {
      * - `process_person: 'never'` - we won't process persons for any event. This means that anonymous users will not be merged once they sign up or login, so you lose the ability to create funnels that track users from anonymous to identified. All events (including `$identify`) will be sent with `$process_person: False`.
      * - `process_person: 'identified_only'` - we will only process persons when you call `posthog.identify`, `posthog.alias`, `posthog.setPersonProperties`, `posthog.group`, `posthog.setPersonPropertiesForFlags` or `posthog.setGroupPropertiesForFlags` Anonymous users won't get person profiles.
      */
+    person_profiles?: 'always' | 'never' | 'identified_only'
+    /** @deprecated - use `person_profiles` instead  */
     process_person?: 'always' | 'never' | 'identified_only'
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,7 +113,7 @@ export interface PostHogConfig {
     opt_in_site_apps: boolean
     respect_dnt: boolean
     /** @deprecated - use `property_denylist` instead  */
-    property_blacklist: string[]
+    property_blacklist?: string[]
     property_denylist: string[]
     request_headers: { [header_name: string]: string }
     on_request_error?: (error: RequestResponse) => void


### PR DESCRIPTION
## Changes

Rename process_person config option to person_profiles

Add a more standardized way of handling renames and deprecations of config options

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
