### PR TITLE
feat: Rename $process_person to $process_person_profile

### DIFF
--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -31,12 +31,12 @@ describe('person processing', () => {
         mockURLGetter.mockReturnValue('https://example.com?utm_source=foo')
     })
 
-    const setup = async (processPerson: 'always' | 'identified_only' | 'never' | undefined) => {
+    const setup = async (person_profiles: 'always' | 'identified_only' | 'never' | undefined) => {
         const token = uuidv7()
         const onCapture = jest.fn()
         const posthog = await createPosthogInstance(token, {
             _onCapture: onCapture,
-            person_profiles: processPerson,
+            person_profiles,
         })
         return { token, onCapture, posthog }
     }
@@ -120,12 +120,12 @@ describe('person processing', () => {
             // assert
             expect(jest.mocked(logger).error).toBeCalledTimes(0)
             const eventBeforeIdentify = onCapture.mock.calls[0]
-            expect(eventBeforeIdentify[1].properties.$process_person).toEqual(false)
+            expect(eventBeforeIdentify[1].properties.$process_person_profile).toEqual(false)
             const identifyCall = onCapture.mock.calls[1]
             expect(identifyCall[0]).toEqual('$identify')
-            expect(identifyCall[1].properties.$process_person).toEqual(true)
+            expect(identifyCall[1].properties.$process_person_profile).toEqual(true)
             const eventAfterIdentify = onCapture.mock.calls[2]
-            expect(eventAfterIdentify[1].properties.$process_person).toEqual(true)
+            expect(eventAfterIdentify[1].properties.$process_person_profile).toEqual(true)
         })
 
         it('should not change $person_process if process_person is always', async () => {
@@ -139,12 +139,12 @@ describe('person processing', () => {
             // assert
             expect(jest.mocked(logger).error).toBeCalledTimes(0)
             const eventBeforeIdentify = onCapture.mock.calls[0]
-            expect(eventBeforeIdentify[1].properties.$process_person).toEqual(true)
+            expect(eventBeforeIdentify[1].properties.$process_person_profile).toEqual(true)
             const identifyCall = onCapture.mock.calls[1]
             expect(identifyCall[0]).toEqual('$identify')
-            expect(identifyCall[1].properties.$process_person).toEqual(true)
+            expect(identifyCall[1].properties.$process_person_profile).toEqual(true)
             const eventAfterIdentify = onCapture.mock.calls[2]
-            expect(eventAfterIdentify[1].properties.$process_person).toEqual(true)
+            expect(eventAfterIdentify[1].properties.$process_person_profile).toEqual(true)
         })
 
         it('should include initial referrer info in identify event if identified_only', async () => {
@@ -286,12 +286,12 @@ describe('person processing', () => {
 
             // assert
             const eventBeforeGroup = onCapture.mock.calls[0]
-            expect(eventBeforeGroup[1].properties.$process_person).toEqual(false)
+            expect(eventBeforeGroup[1].properties.$process_person_profile).toEqual(false)
             const groupIdentify = onCapture.mock.calls[1]
             expect(groupIdentify[0]).toEqual('$groupidentify')
-            expect(groupIdentify[1].properties.$process_person).toEqual(true)
+            expect(groupIdentify[1].properties.$process_person_profile).toEqual(true)
             const eventAfterGroup = onCapture.mock.calls[2]
-            expect(eventAfterGroup[1].properties.$process_person).toEqual(true)
+            expect(eventAfterGroup[1].properties.$process_person_profile).toEqual(true)
         })
 
         it('should not send the $groupidentify event if person_processing is set to never', async () => {
@@ -311,9 +311,9 @@ describe('person processing', () => {
 
             expect(onCapture).toBeCalledTimes(2)
             const eventBeforeGroup = onCapture.mock.calls[0]
-            expect(eventBeforeGroup[1].properties.$process_person).toEqual(false)
+            expect(eventBeforeGroup[1].properties.$process_person_profile).toEqual(false)
             const eventAfterGroup = onCapture.mock.calls[1]
-            expect(eventAfterGroup[1].properties.$process_person).toEqual(false)
+            expect(eventAfterGroup[1].properties.$process_person_profile).toEqual(false)
         })
     })
 
@@ -356,12 +356,12 @@ describe('person processing', () => {
 
             // assert
             const eventBeforeGroup = onCapture.mock.calls[0]
-            expect(eventBeforeGroup[1].properties.$process_person).toEqual(false)
+            expect(eventBeforeGroup[1].properties.$process_person_profile).toEqual(false)
             const set = onCapture.mock.calls[1]
             expect(set[0]).toEqual('$set')
-            expect(set[1].properties.$process_person).toEqual(true)
+            expect(set[1].properties.$process_person_profile).toEqual(true)
             const eventAfterGroup = onCapture.mock.calls[2]
-            expect(eventAfterGroup[1].properties.$process_person).toEqual(true)
+            expect(eventAfterGroup[1].properties.$process_person_profile).toEqual(true)
         })
     })
 
@@ -377,12 +377,12 @@ describe('person processing', () => {
 
             // assert
             const eventBeforeGroup = onCapture.mock.calls[0]
-            expect(eventBeforeGroup[1].properties.$process_person).toEqual(false)
+            expect(eventBeforeGroup[1].properties.$process_person_profile).toEqual(false)
             const alias = onCapture.mock.calls[1]
             expect(alias[0]).toEqual('$create_alias')
-            expect(alias[1].properties.$process_person).toEqual(true)
+            expect(alias[1].properties.$process_person_profile).toEqual(true)
             const eventAfterGroup = onCapture.mock.calls[2]
-            expect(eventAfterGroup[1].properties.$process_person).toEqual(true)
+            expect(eventAfterGroup[1].properties.$process_person_profile).toEqual(true)
         })
 
         it('should not send a $create_alias event if person processing is set to "never"', async () => {

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -406,7 +406,7 @@ describe('posthog core', () => {
                 $window_id: 'windowId',
                 $session_id: 'sessionId',
                 $is_identified: false,
-                $process_person: true,
+                $process_person_profile: true,
             })
         })
 
@@ -428,15 +428,15 @@ describe('posthog core', () => {
                 $session_id: 'sessionId',
                 $lib_custom_api_host: 'https://custom.posthog.com',
                 $is_identified: false,
-                $process_person: true,
+                $process_person_profile: true,
             })
         })
 
-        it("can't deny or blacklist $process_person", () => {
-            given('property_denylist', () => ['$process_person'])
-            given('property_blacklist', () => ['$process_person'])
+        it("can't deny or blacklist $process_person_profile", () => {
+            given('property_denylist', () => ['$process_person_profile'])
+            given('property_blacklist', () => ['$process_person_profile'])
 
-            expect(given.subject['$process_person']).toEqual(true)
+            expect(given.subject['$process_person_profile']).toEqual(true)
         })
 
         it('only adds token and distinct_id if event_name is $snapshot', () => {
@@ -467,7 +467,7 @@ describe('posthog core', () => {
             expect(given.subject).toEqual({
                 event_name: given.event_name,
                 token: 'testtoken',
-                $process_person: true,
+                $process_person_profile: true,
             })
         })
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -903,7 +903,7 @@ export class PostHog {
         }
 
         // add person processing flag as very last step, so it cannot be overridden. process_person=true is default
-        properties['$process_person'] = this._hasPersonProcessing()
+        properties['$process_person_profile'] = this._hasPersonProcessing()
 
         return properties
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,10 +149,10 @@ export interface PostHogConfig {
     // Let the pageview scroll stats use a custom css selector for the root element, e.g. `main`
     scroll_root_selector?: string | string[]
 
-    /** You can control whether events from PostHog-js have person processing enabled with the `process_person` config setting. There are three options:
-     * - `process_person: 'always'` _(default)_ - we will process persons data for all events
-     * - `process_person: 'never'` - we won't process persons for any event. This means that anonymous users will not be merged once they sign up or login, so you lose the ability to create funnels that track users from anonymous to identified. All events (including `$identify`) will be sent with `$process_person: False`.
-     * - `process_person: 'identified_only'` - we will only process persons when you call `posthog.identify`, `posthog.alias`, `posthog.setPersonProperties`, `posthog.group`, `posthog.setPersonPropertiesForFlags` or `posthog.setGroupPropertiesForFlags` Anonymous users won't get person profiles.
+    /** You can control whether events from PostHog-js have person processing enabled with the `person_profiles` config setting. There are three options:
+     * - `person_profiles: 'always'` _(default)_ - we will process persons data for all events
+     * - `person_profiles: 'never'` - we won't process persons for any event. This means that anonymous users will not be merged once they sign up or login, so you lose the ability to create funnels that track users from anonymous to identified. All events (including `$identify`) will be sent with `$process_person_profile: False`.
+     * - `person_profiles: 'identified_only'` - we will only process persons when you call `posthog.identify`, `posthog.alias`, `posthog.setPersonProperties`, `posthog.group`, `posthog.setPersonPropertiesForFlags` or `posthog.setGroupPropertiesForFlags` Anonymous users won't get person profiles.
      */
     person_profiles?: 'always' | 'never' | 'identified_only'
     /** @deprecated - use `person_profiles` instead  */


### PR DESCRIPTION
## Changes

Rename $process_person to $process_person_profile

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
