### PR TITLE
feat: enhance captured network requests

### DIFF
--- a/src/__tests__/extensions/replay/config.test.ts
+++ b/src/__tests__/extensions/replay/config.test.ts
@@ -4,31 +4,31 @@ import { CapturedNetworkRequest } from '../../../types'
 
 describe('config', () => {
     describe('network request options', () => {
+        it('can enable header recording remotely', () => {
+            const networkOptions = buildNetworkRequestOptions(defaultConfig(), { recordHeaders: true })
+            expect(networkOptions.recordHeaders).toBe(true)
+            expect(networkOptions.recordBody).toBe(undefined)
+        })
+
+        it('can enable body recording remotely', () => {
+            const networkOptions = buildNetworkRequestOptions(defaultConfig(), { recordBody: true })
+            expect(networkOptions.recordHeaders).toBe(undefined)
+            expect(networkOptions.recordBody).toBe(true)
+        })
+
+        it('client can force disable recording', () => {
+            const posthogConfig = defaultConfig()
+            posthogConfig.session_recording.recordHeaders = false
+            posthogConfig.session_recording.recordBody = false
+            const networkOptions = buildNetworkRequestOptions(posthogConfig, {
+                recordHeaders: true,
+                recordBody: true,
+            })
+            expect(networkOptions.recordHeaders).toBe(false)
+            expect(networkOptions.recordBody).toBe(false)
+        })
+
         describe('maskRequestFn', () => {
-            it('can enable header recording remotely', () => {
-                const networkOptions = buildNetworkRequestOptions(defaultConfig(), { recordHeaders: true })
-                expect(networkOptions.recordHeaders).toBe(true)
-                expect(networkOptions.recordBody).toBe(undefined)
-            })
-
-            it('can enable body recording remotely', () => {
-                const networkOptions = buildNetworkRequestOptions(defaultConfig(), { recordBody: true })
-                expect(networkOptions.recordHeaders).toBe(undefined)
-                expect(networkOptions.recordBody).toBe(true)
-            })
-
-            it('client can force disable recording', () => {
-                const posthogConfig = defaultConfig()
-                posthogConfig.session_recording.recordHeaders = false
-                posthogConfig.session_recording.recordBody = false
-                const networkOptions = buildNetworkRequestOptions(posthogConfig, {
-                    recordHeaders: true,
-                    recordBody: true,
-                })
-                expect(networkOptions.recordHeaders).toBe(false)
-                expect(networkOptions.recordBody).toBe(false)
-            })
-
             it('should cope with no headers when even if no other config is set', () => {
                 const networkOptions = buildNetworkRequestOptions(defaultConfig(), {})
                 const cleaned = networkOptions.maskRequestFn!({

--- a/src/loader-recorder.ts
+++ b/src/loader-recorder.ts
@@ -395,6 +395,7 @@ function prepareRequest(
             responseHeaders: networkRequest.responseHeaders,
             responseBody: networkRequest.responseBody,
             isInitial,
+            currentUrl: window ? window.location.href : undefined,
         },
     ]
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -403,6 +403,10 @@ export type InitiatorType =
 
 export type NetworkRecordOptions = {
     initiatorTypes?: InitiatorType[]
+    /**
+     * NB if you want to mask captured URLs you need to mask `name` and `currentURL` properties of CapturedNetworkRequest
+     * @param data
+     */
     maskRequestFn?: (data: CapturedNetworkRequest) => CapturedNetworkRequest | undefined
     recordHeaders?: boolean | { request: boolean; response: boolean }
     recordBody?: boolean | string[] | { request: boolean | string[]; response: boolean | string[] }
@@ -451,4 +455,6 @@ export type CapturedNetworkRequest = Omit<PerformanceEntry, 'toJSON'> & {
     responseBody?: string | null
     // was this captured before fetch/xhr could have been wrapped
     isInitial?: boolean
+    // the page this network request was made on (for navigations this should match the name prop)
+    currentUrl?: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -405,7 +405,6 @@ export type NetworkRecordOptions = {
     initiatorTypes?: InitiatorType[]
     /**
      * NB if you want to mask captured URLs you need to mask `name` and `currentURL` properties of CapturedNetworkRequest
-     * @param data
      */
     maskRequestFn?: (data: CapturedNetworkRequest) => CapturedNetworkRequest | undefined
     recordHeaders?: boolean | { request: boolean; response: boolean }


### PR DESCRIPTION
towards https://github.com/PostHog/posthog/pull/21684

when querying captured network requests we need them to carry their current url so we can find network requests by parent page