### PR TITLE
feat: Require person processing for $set and $set_once

### DIFF
--- a/playground/nextjs/package.json
+++ b/playground/nextjs/package.json
@@ -18,7 +18,7 @@
         "eslint": "8.34.0",
         "eslint-config-next": "13.1.6",
         "next": "13.5.6",
-        "posthog-js": "1.120.3",
+        "posthog-js": "1.128.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "typescript": "4.9.5"

--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -60,6 +60,22 @@ export default function Home() {
                     >
                         Set user properties
                     </button>
+                    <button
+                        onClick={() =>
+                            posthog?.capture('$set', {
+                                'event property': 'value',
+                            })
+                        }
+                    >
+                        Send a $set event
+                    </button>
+                    <button
+                        onClick={() =>
+                            posthog?.capture('custom event', { $set: { email: `user-${randomID()}@posthog.com` } })
+                        }
+                    >
+                        Send a custom event with $set property
+                    </button>
 
                     <button onClick={() => posthog?.reset()}>Reset</button>
                 </div>

--- a/playground/nextjs/pnpm-lock.yaml
+++ b/playground/nextjs/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: 13.5.6
     version: 13.5.6(react-dom@18.2.0)(react@18.2.0)
   posthog-js:
-    specifier: 1.120.3
-    version: 1.120.3
+    specifier: 1.128.1
+    version: 1.128.1
   react:
     specifier: 18.2.0
     version: 18.2.0
@@ -2249,8 +2249,8 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
-  /posthog-js@1.120.3:
-    resolution: {integrity: sha512-J5o2aRNIrSCt6/kei+UN9RhTpZDa9bcRkwkauhjrtCz9Ne3yjCP9phfIlP5HJrJBpNGIzK/YlFuy8/57Tw+piQ==}
+  /posthog-js@1.128.1:
+    resolution: {integrity: sha512-+CIiZf+ijhgAF8g6K+PfaDbSBiADfRaXzrlYKmu5IEN8ghunFd06EV5QM68cwLUEkti4FXn7AAM3k9/KxJgvcA==}
     dependencies:
       fflate: 0.4.8
       preact: 10.20.1

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -104,7 +104,7 @@ describe('person processing', () => {
             // assert
             expect(jest.mocked(logger).error).toBeCalledTimes(1)
             expect(jest.mocked(logger).error).toHaveBeenCalledWith(
-                'posthog.identify was called, but process_person is set to "never". This call will be ignored.'
+                'posthog.identify was used, but process_person is set to "never". This call will be ignored.'
             )
             expect(onCapture).toBeCalledTimes(0)
         })
@@ -306,7 +306,7 @@ describe('person processing', () => {
             // assert
             expect(jest.mocked(logger).error).toBeCalledTimes(1)
             expect(jest.mocked(logger).error).toHaveBeenCalledWith(
-                'posthog.group was called, but process_person is set to "never". This call will be ignored.'
+                'posthog.group was used, but process_person is set to "never". This call will be ignored.'
             )
 
             expect(onCapture).toBeCalledTimes(2)
@@ -329,7 +329,7 @@ describe('person processing', () => {
             expect(onCapture).toBeCalledTimes(0)
             expect(jest.mocked(logger).error).toBeCalledTimes(1)
             expect(jest.mocked(logger).error).toHaveBeenCalledWith(
-                'posthog.setPersonProperties was called, but process_person is set to "never". This call will be ignored.'
+                'posthog.setPersonProperties was used, but process_person is set to "never". This call will be ignored.'
             )
         })
 
@@ -396,7 +396,7 @@ describe('person processing', () => {
             expect(onCapture).toBeCalledTimes(0)
             expect(jest.mocked(logger).error).toBeCalledTimes(1)
             expect(jest.mocked(logger).error).toHaveBeenCalledWith(
-                'posthog.alias was called, but process_person is set to "never". This call will be ignored.'
+                'posthog.alias was used, but process_person is set to "never". This call will be ignored.'
             )
         })
     })

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -272,6 +272,28 @@ describe('person processing', () => {
                 $initial_utm_source: 'foo',
             })
         })
+
+        it('should enable person processing for identified_only users if the event name is $set', async () => {
+            const { posthog, onCapture } = await setup('identified_only')
+
+            // act
+            posthog.capture('$set')
+
+            // assert
+            const event = onCapture.mock.calls[0]
+            expect(event[1].properties.$process_person_profile).toEqual(true)
+        })
+
+        it('should enable person processing for identified_only users if an event property is $set', async () => {
+            const { posthog, onCapture } = await setup('identified_only')
+
+            // act
+            posthog.capture('custom event', { $set: { prop: 'value' } })
+
+            // assert
+            const event = onCapture.mock.calls[0]
+            expect(event[1].properties.$process_person_profile).toEqual(true)
+        })
     })
 
     describe('group', () => {

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -282,6 +282,7 @@ describe('person processing', () => {
             // assert
             const event = onCapture.mock.calls[0]
             expect(event[1].properties.$process_person_profile).toEqual(true)
+            expect(jest.mocked(logger).error).toBeCalledTimes(0)
         })
 
         it('should enable person processing for identified_only users if an event property is $set', async () => {
@@ -293,6 +294,7 @@ describe('person processing', () => {
             // assert
             const event = onCapture.mock.calls[0]
             expect(event[1].properties.$process_person_profile).toEqual(true)
+            expect(jest.mocked(logger).error).toBeCalledTimes(0)
         })
 
         it('should not enable person processing for identified_only users if an event property is $set, IF the object is empty', async () => {
@@ -304,6 +306,7 @@ describe('person processing', () => {
             // assert
             const event = onCapture.mock.calls[0]
             expect(event[1].properties.$process_person_profile).toEqual(false)
+            expect(jest.mocked(logger).error).toBeCalledTimes(0)
         })
 
         it('should drop $set events when set to "never"', async () => {
@@ -314,6 +317,10 @@ describe('person processing', () => {
 
             // assert
             expect(onCapture).toBeCalledTimes(0)
+            expect(jest.mocked(logger).error).toBeCalledTimes(1)
+            expect(jest.mocked(logger).error).toHaveBeenCalledWith(
+                '$set/$set_once was used, but process_person is set to "never". This call will be ignored.'
+            )
         })
 
         it('should drop $set properties when set to "never" but still send the event', async () => {
@@ -326,6 +333,10 @@ describe('person processing', () => {
             const event = onCapture.mock.calls[0]
             expect(event[1].properties.$process_person_profile).toEqual(false)
             expect(event[1].properties.$set).toEqual(undefined)
+            expect(jest.mocked(logger).error).toBeCalledTimes(1)
+            expect(jest.mocked(logger).error).toHaveBeenCalledWith(
+                '$set/$set_once was used, but process_person is set to "never". This property will be ignored.'
+            )
         })
     })
 

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -294,6 +294,39 @@ describe('person processing', () => {
             const event = onCapture.mock.calls[0]
             expect(event[1].properties.$process_person_profile).toEqual(true)
         })
+
+        it('should not enable person processing for identified_only users if an event property is $set, IF the object is empty', async () => {
+            const { posthog, onCapture } = await setup('identified_only')
+
+            // act
+            posthog.capture('custom event', { $set: {} })
+
+            // assert
+            const event = onCapture.mock.calls[0]
+            expect(event[1].properties.$process_person_profile).toEqual(false)
+        })
+
+        it('should drop $set events when set to "never"', async () => {
+            const { posthog, onCapture } = await setup('never')
+
+            // act
+            posthog.capture('$set', { $set: {} })
+
+            // assert
+            expect(onCapture).toBeCalledTimes(0)
+        })
+
+        it('should drop $set properties when set to "never" but still send the event', async () => {
+            const { posthog, onCapture } = await setup('never')
+
+            // act
+            posthog.capture('custom event', { $set: { prop: 'value' } })
+
+            // assert
+            const event = onCapture.mock.calls[0]
+            expect(event[1].properties.$process_person_profile).toEqual(false)
+            expect(event[1].properties.$set).toEqual(undefined)
+        })
     })
 
     describe('group', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -764,6 +764,19 @@ export class PostHog {
             this.persistence.set_initial_referrer_info()
         }
 
+        if (
+            event_name === `$set` ||
+            event_name === '$set_once' ||
+            properties?.$set ||
+            properties?.$set_once ||
+            options?.$set ||
+            options?.$set_once
+        ) {
+            if (!this._requirePersonProcessing('$set/$set_once')) {
+                return
+            }
+        }
+
         let data: CaptureResult = {
             uuid: uuidv7(),
             event: event_name,
@@ -1818,9 +1831,7 @@ export class PostHog {
      */
     _requirePersonProcessing(function_name: string): boolean {
         if (this.config.person_profiles === 'never') {
-            logger.error(
-                function_name + ' was called, but process_person is set to "never". This call will be ignored.'
-            )
+            logger.error(function_name + ' was used, but process_person is set to "never". This call will be ignored.')
             return false
         }
         this._register_single(ENABLE_PERSON_PROCESSING, true)

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -764,16 +764,26 @@ export class PostHog {
             this.persistence.set_initial_referrer_info()
         }
 
-        if (
-            event_name === `$set` ||
-            event_name === '$set_once' ||
-            properties?.$set ||
-            properties?.$set_once ||
-            options?.$set ||
-            options?.$set_once
-        ) {
+        if (event_name === `$set` || event_name === '$set_once') {
             if (!this._requirePersonProcessing('$set/$set_once')) {
                 return
+            }
+        }
+
+        let usesSetProp = false
+        eachArray([properties?.$set, properties?.$set_once, options?.$set, options?.$set_once], (prop) => {
+            if (prop && !isEmptyObject(prop)) {
+                usesSetProp = true
+            }
+        })
+        if (usesSetProp) {
+            if (!this._requirePersonProcessing('$set/$set_once')) {
+                properties = extend({}, properties || {})
+                delete properties.$set
+                delete properties.$set_once
+                options = extend({}, options || {})
+                delete options.$set
+                delete options.$set_once
             }
         }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -777,7 +777,7 @@ export class PostHog {
             }
         })
         if (usesSetProp) {
-            if (!this._requirePersonProcessing('$set/$set_once')) {
+            if (!this._requirePersonProcessing('$set/$set_once', 'property')) {
                 properties = extend({}, properties || {})
                 delete properties.$set
                 delete properties.$set_once
@@ -1838,10 +1838,16 @@ export class PostHog {
      * Enables person processing if possible, returns true if it does so or already enabled, false otherwise
      *
      * @param function_name
+     * @param noun
      */
-    _requirePersonProcessing(function_name: string): boolean {
+    _requirePersonProcessing(function_name: string, noun?: string): boolean {
         if (this.config.person_profiles === 'never') {
-            logger.error(function_name + ' was used, but process_person is set to "never". This call will be ignored.')
+            logger.error(
+                function_name +
+                    ' was used, but process_person is set to "never". This ' +
+                    (noun || 'call') +
+                    ' will be ignored.'
+            )
             return false
         }
         this._register_single(ENABLE_PERSON_PROCESSING, true)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
         "jsxFragmentFactory": "Fragment"
     },
     "include": ["src/*.ts*"],
-    "exclude": ["src/__tests__/**/*.ts*"]
+    "exclude": ["src/__tests__/**/*.ts*", "src/**/*.test.ts*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "outDir": "./lib",
         "target": "ES5",
-        "lib": ["dom", "dom.iterable", "esnext"],
+        "lib": ["dom", "dom.iterable", "esnext", "es2015.promise"],
         "allowJs": true,
         "checkJs": true,
         "skipLibCheck": false,


### PR DESCRIPTION
## Changes

Sending properties with $set or $set_once as the event name or an event property should count as person properties much like 

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
