### PR TITLE
fix: Relax upgrading on setPersonPropertiesForFlags and setGroupPropertiesForFlags

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1373,9 +1373,6 @@ export class PostHog {
      * to update user properties.
      */
     setPersonPropertiesForFlags(properties: Properties, reloadFeatureFlags = true): void {
-        if (!this._requirePersonProcessing('posthog.setPersonPropertiesForFlags')) {
-            return
-        }
         this.featureFlags.setPersonPropertiesForFlags(properties, reloadFeatureFlags)
     }
 
@@ -1392,9 +1389,6 @@ export class PostHog {
      *     setGroupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } })
      */
     setGroupPropertiesForFlags(properties: { [type: string]: Properties }, reloadFeatureFlags = true): void {
-        if (!this._requirePersonProcessing('posthog.setGroupPropertiesForFlags')) {
-            return
-        }
         this.featureFlags.setGroupPropertiesForFlags(properties, reloadFeatureFlags)
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,8 +152,8 @@ export interface PostHogConfig {
 
     /** You can control whether events from PostHog-js have person processing enabled with the `person_profiles` config setting. There are three options:
      * - `person_profiles: 'always'` _(default)_ - we will process persons data for all events
+     * - `person_profiles: 'identified_only'` - we will only process persons when you call `posthog.identify`, `posthog.alias`, `posthog.setPersonProperties`, `posthog.group`. Anonymous users won't get person profiles.
      * - `person_profiles: 'never'` - we won't process persons for any event. This means that anonymous users will not be merged once they sign up or login, so you lose the ability to create funnels that track users from anonymous to identified. All events (including `$identify`) will be sent with `$process_person_profile: False`.
-     * - `person_profiles: 'identified_only'` - we will only process persons when you call `posthog.identify`, `posthog.alias`, `posthog.setPersonProperties`, `posthog.group`, `posthog.setPersonPropertiesForFlags` or `posthog.setGroupPropertiesForFlags` Anonymous users won't get person profiles.
      */
     person_profiles?: 'always' | 'never' | 'identified_only'
     /** @deprecated - use `person_profiles` instead  */


### PR DESCRIPTION
See discussion https://posthog.slack.com/archives/C06R39WNY5B/p1713460311008769

## Changes

Make setPersonPropertiesForFlags and setGroupPropertiesForFlags no longer cause a person profile to be created

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
