### PR TITLE
fix: Don't track heatmaps of toolbar

### DIFF
--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -33,7 +33,8 @@ function elementOrParentPositionMatches(el: Element, matches: string[], breakOnE
 const TOOLBAR_ID = '__POSTHOG_TOOLBAR__'
 
 function elementInToolbar(el: Element): boolean {
-    return el.id === TOOLBAR_ID || !!el.closest('#__POSTHOG_TOOLBAR__')
+    // NOTE: .closest is not supported in IE11 hence the operator check
+    return el.id === TOOLBAR_ID || !!el.closest?.('#__POSTHOG_TOOLBAR__')
 }
 
 export class Heatmaps {

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -30,6 +30,12 @@ function elementOrParentPositionMatches(el: Element, matches: string[], breakOnE
     return false
 }
 
+const TOOLBAR_ID = '__POSTHOG_TOOLBAR__'
+
+function elementInToolbar(el: Element): boolean {
+    return el.id === TOOLBAR_ID || !!el.closest('__POSTHOG_TOOLBAR__')
+}
+
 export class Heatmaps {
     instance: PostHog
     rageclicks = new RageClick()
@@ -91,6 +97,9 @@ export class Heatmaps {
     }
 
     private _onClick(e: MouseEvent): void {
+        if (elementInToolbar(e.target as Element)) {
+            return
+        }
         const properties = this._getProperties(e, 'click')
 
         if (this.rageclicks?.isRageClick(e.clientX, e.clientY, new Date().getTime())) {
@@ -106,6 +115,9 @@ export class Heatmaps {
     }
 
     private _onMouseMove(e: Event): void {
+        if (elementInToolbar(e.target as Element)) {
+            return
+        }
         clearTimeout(this._mouseMoveTimeout)
 
         this._mouseMoveTimeout = setTimeout(() => {

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -33,7 +33,7 @@ function elementOrParentPositionMatches(el: Element, matches: string[], breakOnE
 const TOOLBAR_ID = '__POSTHOG_TOOLBAR__'
 
 function elementInToolbar(el: Element): boolean {
-    return el.id === TOOLBAR_ID || !!el.closest('__POSTHOG_TOOLBAR__')
+    return el.id === TOOLBAR_ID || !!el.closest('#__POSTHOG_TOOLBAR__')
 }
 
 export class Heatmaps {


### PR DESCRIPTION
## Changes

We track interactions of the toolbar which can be pretty confusing, especially when you are first setting up and testing with it.

* Check for if the element clicked is or is in the toolbar
* If so ignore it

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
