### PR TITLE
feat: Remotely enable heatmaps via decide

### DIFF
--- a/src/__tests__/heatmaps.test.ts
+++ b/src/__tests__/heatmaps.test.ts
@@ -1,6 +1,8 @@
 import { createPosthogInstance } from './helpers/posthog-instance'
 import { uuidv7 } from '../uuidv7'
 import { PostHog } from '../posthog-core'
+import { HEATMAPS_ENABLED_SERVER_SIDE } from '../constants'
+import { DecideResponse } from '../types'
 jest.mock('../utils/logger')
 
 describe('heatmaps', () => {
@@ -104,5 +106,39 @@ describe('heatmaps', () => {
             })
         )
         expect(posthog.heatmaps?.['buffer']).not.toEqual(undefined)
+    })
+
+    describe('afterDecideResponse()', () => {
+        it('should not be enabled before the decide response', () => {
+            expect(posthog.heatmaps!.isEnabled).toBe(false)
+        })
+
+        it('should be enabled if client config option is enabled', () => {
+            posthog.config.__preview_heatmaps = true
+            expect(posthog.heatmaps!.isEnabled).toBe(true)
+        })
+
+        it.each([
+            // Client not defined
+            [undefined, false, false],
+            [undefined, true, true],
+            [undefined, false, false],
+            // Client false
+            [false, false, false],
+            [false, true, false],
+
+            // Client true
+            [true, false, true],
+            [true, true, true],
+        ])(
+            'when client side config is %p and remote opt in is %p - heatmaps enabled should be %p',
+            (clientSideOptIn, serverSideOptIn, expected) => {
+                posthog.config.__preview_heatmaps = clientSideOptIn
+                posthog.heatmaps!.afterDecideResponse({
+                    heatmaps: serverSideOptIn,
+                } as DecideResponse)
+                expect(posthog.heatmaps!.isEnabled).toBe(expected)
+            }
+        )
     })
 })

--- a/src/__tests__/heatmaps.test.ts
+++ b/src/__tests__/heatmaps.test.ts
@@ -1,7 +1,6 @@
 import { createPosthogInstance } from './helpers/posthog-instance'
 import { uuidv7 } from '../uuidv7'
 import { PostHog } from '../posthog-core'
-import { HEATMAPS_ENABLED_SERVER_SIDE } from '../constants'
 import { DecideResponse } from '../types'
 jest.mock('../utils/logger')
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,7 @@ export const ALIAS_ID_KEY = '__alias'
 export const CAMPAIGN_IDS_KEY = '__cmpns'
 export const EVENT_TIMERS_KEY = '__timers'
 export const AUTOCAPTURE_DISABLED_SERVER_SIDE = '$autocapture_disabled_server_side'
+export const HEATMAPS_ENABLED_SERVER_SIDE = '$heatmaps_enabled_server_side'
 export const SESSION_RECORDING_ENABLED_SERVER_SIDE = '$session_recording_enabled_server_side'
 export const CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE = '$console_log_recording_enabled_server_side'
 export const SESSION_RECORDING_NETWORK_PAYLOAD_CAPTURE = '$session_recording_network_payload_capture'
@@ -39,6 +40,7 @@ export const PERSISTENCE_RESERVED_PROPERTIES = [
     CAMPAIGN_IDS_KEY,
     EVENT_TIMERS_KEY,
     SESSION_RECORDING_ENABLED_SERVER_SIDE,
+    HEATMAPS_ENABLED_SERVER_SIDE,
     SESSION_ID,
     ENABLED_FEATURE_FLAGS,
     USER_STATE,

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -5,7 +5,7 @@ import { PostHog } from './posthog-core'
 
 import { document, window } from './utils/globals'
 import { getParentElement, isTag } from './autocapture-utils'
-import { AUTOCAPTURE_DISABLED_SERVER_SIDE, HEATMAPS_ENABLED_SERVER_SIDE } from './constants'
+import { HEATMAPS_ENABLED_SERVER_SIDE } from './constants'
 
 type HeatmapEventBuffer =
     | {
@@ -59,7 +59,11 @@ export class Heatmaps {
     }
 
     public get isEnabled(): boolean {
-        return !!this.instance.config.__preview_heatmaps || !!this._enabledServerSide
+        return (
+            !!this.instance.config.__preview_heatmaps ||
+            !!this._enabledServerSide ||
+            !!this.instance.persistence?.props[HEATMAPS_ENABLED_SERVER_SIDE]
+        )
     }
 
     public afterDecideResponse(response: DecideResponse) {

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -6,6 +6,7 @@ import { PostHog } from './posthog-core'
 import { document, window } from './utils/globals'
 import { getParentElement, isTag } from './autocapture-utils'
 import { HEATMAPS_ENABLED_SERVER_SIDE } from './constants'
+import { isUndefined } from './utils/type-utils'
 
 type HeatmapEventBuffer =
     | {
@@ -50,6 +51,7 @@ export class Heatmaps {
 
     constructor(instance: PostHog) {
         this.instance = instance
+        this._enabledServerSide = !!this.instance.persistence?.props[HEATMAPS_ENABLED_SERVER_SIDE]
     }
 
     public startIfEnabled(): void {
@@ -59,11 +61,9 @@ export class Heatmaps {
     }
 
     public get isEnabled(): boolean {
-        return (
-            !!this.instance.config.__preview_heatmaps ||
-            !!this._enabledServerSide ||
-            !!this.instance.persistence?.props[HEATMAPS_ENABLED_SERVER_SIDE]
-        )
+        return !isUndefined(this.instance.config.__preview_heatmaps)
+            ? this.instance.config.__preview_heatmaps
+            : this._enabledServerSide
     }
 
     public afterDecideResponse(response: DecideResponse) {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -499,6 +499,7 @@ export class PostHog {
 
         this.sessionRecording?.afterDecideResponse(response)
         this.autocapture?.afterDecideResponse(response)
+        this.heatmaps?.afterDecideResponse(response)
         this.surveys?.afterDecideResponse(response)
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -303,6 +303,7 @@ export interface DecideResponse {
     toolbarVersion: 'toolbar' /** @deprecated, moved to toolbarParams */
     isAuthenticated: boolean
     siteApps: { id: number; url: string }[]
+    heatmaps?: boolean
 }
 
 export type FeatureFlagsCallback = (


### PR DESCRIPTION
## Changes

Client side component of https://github.com/PostHog/posthog/pull/21807

* Adds support for turning heatmaps on via server side setting

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
