### PR TITLE
chore: logging on start

### DIFF
--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -7,6 +7,7 @@ import { document, window } from './utils/globals'
 import { getParentElement, isTag } from './autocapture-utils'
 import { HEATMAPS_ENABLED_SERVER_SIDE } from './constants'
 import { isUndefined } from './utils/type-utils'
+import { logger } from './utils/logger'
 
 type HeatmapEventBuffer =
     | {
@@ -56,6 +57,7 @@ export class Heatmaps {
 
     public startIfEnabled(): void {
         if (this.isEnabled && !this._initialized) {
+            logger.info('[heatmaps] Heatmaps enabled, starting...')
             this._setupListeners()
         }
     }


### PR DESCRIPTION
I wasn't sure if I was missing heatmap data because my local plugin server hadn't caught up or I hadn't started it...

Adds logging to help the future traveller