### PR TITLE
feat: Add rate limit info to events

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -78,7 +78,7 @@ describe('posthog core', () => {
             __captureHooks: [],
             rateLimiter: {
                 isServerRateLimited: () => false,
-                isCaptureClientSideRateLimited: () => false,
+                clientRateLimitContext: () => false,
             },
         }))
 

--- a/src/__tests__/posthog-core.test.ts
+++ b/src/__tests__/posthog-core.test.ts
@@ -40,7 +40,7 @@ describe('posthog core', () => {
 
                 expect(onCapture.mock.calls[0][1]).toMatchObject({
                     properties: {
-                        $lib_rate_limit_tokens: 99,
+                        $lib_rate_limit_remaining_tokens: 99,
                     },
                 })
             })

--- a/src/__tests__/posthog-core.test.ts
+++ b/src/__tests__/posthog-core.test.ts
@@ -46,6 +46,9 @@ describe('posthog core', () => {
             })
 
             it('does not capture if rate limit is in place', () => {
+                jest.useFakeTimers()
+                jest.setSystemTime(Date.now())
+
                 console.error = jest.fn()
                 const { posthog, onCapture } = setup()
 

--- a/src/__tests__/rate-limiter.test.ts
+++ b/src/__tests__/rate-limiter.test.ts
@@ -53,12 +53,12 @@ describe('Rate Limiter', () => {
                 tokens: 100,
                 last: systemTime,
             })
-            expect(rateLimiter.isCaptureClientSideRateLimited()).toBe(false)
+            expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
         })
 
         it('subtracts a token with each call', () => {
             range(5).forEach(() => {
-                expect(rateLimiter.isCaptureClientSideRateLimited()).toBe(false)
+                expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
             })
             expect(persistedBucket['$capture_rate_limit']).toEqual({
                 tokens: 95,
@@ -68,7 +68,7 @@ describe('Rate Limiter', () => {
 
         it('adds tokens if time has passed ', () => {
             range(50).forEach(() => {
-                expect(rateLimiter.isCaptureClientSideRateLimited()).toBe(false)
+                expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
             })
             expect(persistedBucket['$capture_rate_limit']).toEqual({
                 tokens: 50,
@@ -76,7 +76,7 @@ describe('Rate Limiter', () => {
             })
 
             moveTimeForward(2000) // 2 seconds = 20 tokens
-            expect(rateLimiter.isCaptureClientSideRateLimited()).toBe(false)
+            expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
             expect(persistedBucket['$capture_rate_limit']).toEqual({
                 tokens: 69, // 50 + 20 - 1
                 last: systemTime,
@@ -85,10 +85,10 @@ describe('Rate Limiter', () => {
 
         it('rate limits when past the threshold ', () => {
             range(100).forEach(() => {
-                expect(rateLimiter.isCaptureClientSideRateLimited()).toBe(false)
+                expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
             })
             range(200).forEach(() => {
-                expect(rateLimiter.isCaptureClientSideRateLimited()).toBe(true)
+                expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(true)
             })
             expect(persistedBucket['$capture_rate_limit']).toEqual({
                 tokens: 0,
@@ -96,7 +96,7 @@ describe('Rate Limiter', () => {
             })
 
             moveTimeForward(2000) // 2 seconds = 20 tokens
-            expect(rateLimiter.isCaptureClientSideRateLimited()).toBe(false)
+            expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
             expect(persistedBucket['$capture_rate_limit']).toEqual({
                 tokens: 19, // 20 - 1
                 last: systemTime,
@@ -105,13 +105,13 @@ describe('Rate Limiter', () => {
 
         it('refills up to the maximum amount ', () => {
             range(100).forEach(() => {
-                expect(rateLimiter.isCaptureClientSideRateLimited()).toBe(false)
+                expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
             })
-            expect(rateLimiter.isCaptureClientSideRateLimited()).toBe(true)
+            expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(true)
             expect(persistedBucket['$capture_rate_limit'].tokens).toEqual(0)
 
             moveTimeForward(1000000)
-            expect(rateLimiter.isCaptureClientSideRateLimited()).toBe(false)
+            expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
             expect(persistedBucket['$capture_rate_limit'].tokens).toEqual(99) // limit - 1
         })
 

--- a/src/__tests__/rate-limiter.test.ts
+++ b/src/__tests__/rate-limiter.test.ts
@@ -48,17 +48,17 @@ describe('Rate Limiter', () => {
 
     describe('client side', () => {
         it('starts with the max tokens', () => {
-            rateLimiter.isCaptureClientSideRateLimited(true)
+            rateLimiter.clientRateLimitContext(true)
             expect(persistedBucket['$capture_rate_limit']).toEqual({
                 tokens: 100,
                 last: systemTime,
             })
-            expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
+            expect(rateLimiter.clientRateLimitContext().isRateLimited).toBe(false)
         })
 
         it('subtracts a token with each call', () => {
             range(5).forEach(() => {
-                expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
+                expect(rateLimiter.clientRateLimitContext().isRateLimited).toBe(false)
             })
             expect(persistedBucket['$capture_rate_limit']).toEqual({
                 tokens: 95,
@@ -68,7 +68,7 @@ describe('Rate Limiter', () => {
 
         it('adds tokens if time has passed ', () => {
             range(50).forEach(() => {
-                expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
+                expect(rateLimiter.clientRateLimitContext().isRateLimited).toBe(false)
             })
             expect(persistedBucket['$capture_rate_limit']).toEqual({
                 tokens: 50,
@@ -76,7 +76,7 @@ describe('Rate Limiter', () => {
             })
 
             moveTimeForward(2000) // 2 seconds = 20 tokens
-            expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
+            expect(rateLimiter.clientRateLimitContext().isRateLimited).toBe(false)
             expect(persistedBucket['$capture_rate_limit']).toEqual({
                 tokens: 69, // 50 + 20 - 1
                 last: systemTime,
@@ -85,10 +85,10 @@ describe('Rate Limiter', () => {
 
         it('rate limits when past the threshold ', () => {
             range(100).forEach(() => {
-                expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
+                expect(rateLimiter.clientRateLimitContext().isRateLimited).toBe(false)
             })
             range(200).forEach(() => {
-                expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(true)
+                expect(rateLimiter.clientRateLimitContext().isRateLimited).toBe(true)
             })
             expect(persistedBucket['$capture_rate_limit']).toEqual({
                 tokens: 0,
@@ -96,7 +96,7 @@ describe('Rate Limiter', () => {
             })
 
             moveTimeForward(2000) // 2 seconds = 20 tokens
-            expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
+            expect(rateLimiter.clientRateLimitContext().isRateLimited).toBe(false)
             expect(persistedBucket['$capture_rate_limit']).toEqual({
                 tokens: 19, // 20 - 1
                 last: systemTime,
@@ -105,19 +105,19 @@ describe('Rate Limiter', () => {
 
         it('refills up to the maximum amount ', () => {
             range(100).forEach(() => {
-                expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
+                expect(rateLimiter.clientRateLimitContext().isRateLimited).toBe(false)
             })
-            expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(true)
+            expect(rateLimiter.clientRateLimitContext().isRateLimited).toBe(true)
             expect(persistedBucket['$capture_rate_limit'].tokens).toEqual(0)
 
             moveTimeForward(1000000)
-            expect(rateLimiter.isCaptureClientSideRateLimited().isRateLimited).toBe(false)
+            expect(rateLimiter.clientRateLimitContext().isRateLimited).toBe(false)
             expect(persistedBucket['$capture_rate_limit'].tokens).toEqual(99) // limit - 1
         })
 
         it('captures a rate limit event the first time it is rate limited', () => {
             range(200).forEach(() => {
-                rateLimiter.isCaptureClientSideRateLimited()
+                rateLimiter.clientRateLimitContext()
             })
 
             expect(mockPostHog.capture).toBeCalledTimes(1)
@@ -135,7 +135,7 @@ describe('Rate Limiter', () => {
 
         it('does not capture a rate limit event if the persisted config was already rate limited', () => {
             range(200).forEach(() => {
-                rateLimiter.isCaptureClientSideRateLimited()
+                rateLimiter.clientRateLimitContext()
             })
 
             expect(mockPostHog.capture).toBeCalledTimes(1)
@@ -144,7 +144,7 @@ describe('Rate Limiter', () => {
             const newRateLimiter = new RateLimiter(mockPostHog as any)
 
             range(200).forEach(() => {
-                newRateLimiter.isCaptureClientSideRateLimited()
+                newRateLimiter.clientRateLimitContext()
             })
 
             expect(mockPostHog.capture).toBeCalledTimes(0)

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -746,7 +746,7 @@ export class PostHog {
         }
 
         const clientRateLimitContext = !options?.skip_client_rate_limiting
-            ? this.rateLimiter.isCaptureClientSideRateLimited()
+            ? this.rateLimiter.clientRateLimitContext()
             : undefined
 
         if (clientRateLimitContext?.isRateLimited) {
@@ -783,7 +783,7 @@ export class PostHog {
         }
 
         if (clientRateLimitContext) {
-            data.properties['$lib_rate_limit_tokens'] = clientRateLimitContext.remainingTokens
+            data.properties['$lib_rate_limit_remaining_tokens'] = clientRateLimitContext.remainingTokens
         }
 
         const setProperties = options?.$set

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -731,11 +731,6 @@ export class PostHog {
             return
         }
 
-        if (!options?.skip_client_rate_limiting && this.rateLimiter.isCaptureClientSideRateLimited()) {
-            logger.critical('This capture call is ignored due to client rate limiting.')
-            return
-        }
-
         // typing doesn't prevent interesting data
         if (isUndefined(event_name) || !isString(event_name)) {
             logger.error('No event name provided to posthog.capture')
@@ -747,6 +742,15 @@ export class PostHog {
             !this.config.opt_out_useragent_filter &&
             isBlockedUA(userAgent, this.config.custom_blocked_useragents)
         ) {
+            return
+        }
+
+        const clientRateLimitContext = !options?.skip_client_rate_limiting
+            ? this.rateLimiter.isCaptureClientSideRateLimited()
+            : undefined
+
+        if (clientRateLimitContext?.isRateLimited) {
+            logger.critical('This capture call is ignored due to client rate limiting.')
             return
         }
 
@@ -776,6 +780,10 @@ export class PostHog {
             if (heatmapsBuffer) {
                 data.properties['$heatmap_data'] = heatmapsBuffer
             }
+        }
+
+        if (clientRateLimitContext) {
+            data.properties['$lib_rate_limit_tokens'] = clientRateLimitContext.remainingTokens
         }
 
         const setProperties = options?.$set

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -27,10 +27,10 @@ export class RateLimiter {
             this.captureEventsPerSecond
         )
 
-        this.lastEventRateLimited = this.isCaptureClientSideRateLimited(true).isRateLimited
+        this.lastEventRateLimited = this.clientRateLimitContext(true).isRateLimited
     }
 
-    public isCaptureClientSideRateLimited(checkOnly = false): {
+    public clientRateLimitContext(checkOnly = false): {
         isRateLimited: boolean
         remainingTokens: number
     } {

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -27,10 +27,13 @@ export class RateLimiter {
             this.captureEventsPerSecond
         )
 
-        this.lastEventRateLimited = this.isCaptureClientSideRateLimited(true)
+        this.lastEventRateLimited = this.isCaptureClientSideRateLimited(true).isRateLimited
     }
 
-    public isCaptureClientSideRateLimited(checkOnly = false): boolean {
+    public isCaptureClientSideRateLimited(checkOnly = false): {
+        isRateLimited: boolean
+        remainingTokens: number
+    } {
         // This is primarily to prevent runaway loops from flooding capture with millions of events for a single user.
         // It's as much for our protection as theirs.
         const now = new Date().getTime()
@@ -67,7 +70,10 @@ export class RateLimiter {
         this.lastEventRateLimited = isRateLimited
         this.instance.persistence?.set_property(CAPTURE_RATE_LIMIT, bucket)
 
-        return isRateLimited
+        return {
+            isRateLimited,
+            remainingTokens: bucket.tokens,
+        }
     }
 
     public isServerRateLimited(batchKey: string | undefined): boolean {


### PR DESCRIPTION
## Changes

If the client rate limits, we send a subsequent event for ingestion warnings but that doesn't help much if you are trying to debug whats going on.

We could save the ingestion warning event but that would be added to the users event total.
_or_ we could add some info about the current rate limit to all events so that it is possible to filter for events where the rate limit was about to kick in.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
