### PR TITLE
chore: Add script to deprecate old versions

### DIFF
--- a/deprecation.json
+++ b/deprecation.json
@@ -1,0 +1,6 @@
+{
+    "//": "see scripts/deprecate-old-versions.mjs",
+    "deprecateBeforeVersion": "1.127.0",
+    "deprecateOlderThanDays": 180,
+    "message": "This version of posthog-js is deprecated, please update posthog-js, and do not use this version! Check out our JS docs at https://posthog.com/docs/libraries/js"
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "test:functional": "jest functional_tests",
         "test-watch": "jest --watch src",
         "cypress": "cypress open",
-        "prepare": "husky install"
+        "prepare": "husky install",
+        "deprecate-old-versions": "node scripts/deprecate-old-versions.mjs"
     },
     "main": "dist/module.js",
     "module": "dist/es.js",
@@ -58,8 +59,10 @@
         "@typescript-eslint/parser": "^6.19.0",
         "babel-eslint": "10.1.0",
         "babel-jest": "^26.6.3",
+        "compare-versions": "^6.1.0",
         "cypress": "13.6.3",
         "cypress-localstorage-commands": "^2.2.5",
+        "date-fns": "^3.6.0",
         "eslint": "8.56.0",
         "eslint-config-posthog-js": "link:eslint-rules",
         "eslint-config-prettier": "^8.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,12 +84,18 @@ devDependencies:
   babel-jest:
     specifier: ^26.6.3
     version: 26.6.3(@babel/core@7.18.9)
+  compare-versions:
+    specifier: ^6.1.0
+    version: 6.1.0
   cypress:
     specifier: 13.6.3
     version: 13.6.3
   cypress-localstorage-commands:
     specifier: ^2.2.5
     version: 2.2.5(cypress@13.6.3)
+  date-fns:
+    specifier: ^3.6.0
+    version: 3.6.0
   eslint:
     specifier: 8.56.0
     version: 8.56.0
@@ -4257,6 +4263,10 @@ packages:
     engines: {node: '>=4.0.0'}
     dev: true
 
+  /compare-versions@6.1.0:
+    resolution: {integrity: sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==}
+    dev: true
+
   /component-emitter@1.3.0:
     resolution: {integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==}
     dev: true
@@ -4411,7 +4421,7 @@ packages:
       cli-table3: 0.6.2
       commander: 6.2.1
       common-tags: 1.8.0
-      dayjs: 1.10.7
+      dayjs: 1.11.11
       debug: 4.3.4(supports-color@8.1.1)
       enquirer: 2.3.6
       eventemitter2: 6.4.7
@@ -4456,8 +4466,12 @@ packages:
       whatwg-url: 8.7.0
     dev: true
 
-  /dayjs@1.10.7:
-    resolution: {integrity: sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==}
+  /date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+    dev: true
+
+  /dayjs@1.11.11:
+    resolution: {integrity: sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg==}
     dev: true
 
   /debug@2.6.9:

--- a/scripts/deprecate-old-versions.mjs
+++ b/scripts/deprecate-old-versions.mjs
@@ -1,0 +1,109 @@
+
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+import { spawnSync } from 'child_process'
+import { subDays, startOfDay, format, isBefore } from 'date-fns'
+import { compare } from 'compare-versions'
+
+// edit this file to change the deprecation settings
+import deprecationJson from '../deprecation.json' with { type: 'json' }
+const { deprecateOlderThanDays, deprecateBeforeVersion, message } = deprecationJson
+
+const argv = yargs(hideBin(process.argv)).argv
+const dryRun = argv.dryRun !== 'false'
+
+const runNpmView = () => {
+    const result = spawnSync('npm', ['view', 'posthog-js', '--json'], { encoding: 'utf-8' })
+    return JSON.parse(result.stdout.trim())
+}
+
+const runNpmDeprecateBeforeVersion = () => {
+    const command = ['deprecate', `posthog-js@<${deprecateBeforeVersion}`, message]
+    if (dryRun) {
+        console.log('Dry run: command', 'npm', command)
+    } else {
+        spawnSync('npm', command, { stdio: 'inherit' })
+    }
+}
+const runNpmDeprecateBeforeOrEqualVersion = (version) => {
+    const command = ['deprecate', `posthog-js@<=${version}`, message]
+    if (dryRun) {
+        console.log('Dry run: command', 'npm', command)
+    } else {
+        spawnSync('npm', command, { stdio: 'inherit' })
+    }
+}
+
+const main = async () => {
+    if (dryRun) {
+        console.log()
+        console.log('!!! Doing dry run, run with --dry-run=false to actually deprecate versions !!!')
+        console.log()
+    }
+
+    let viewResult = runNpmView()
+    let currentVersion = viewResult.version
+    console.log(`Current version: ${currentVersion}`)
+
+    if (compare(currentVersion, deprecateBeforeVersion, '<')) {
+        throw new Error('Current version is older than the deprecation version! Aborting.')
+    }
+
+    // were there any versions older than the deprecation version?
+    let shouldDeprecateBeforeVersion = false
+    for (const [version, dateString] of Object.entries(viewResult.time)) {
+        if (version === 'created' || version === 'modified') {
+            continue
+        }
+        if (compare(version, deprecateBeforeVersion, '<')) {
+            shouldDeprecateBeforeVersion = true
+            break
+        }
+    }
+
+    if (shouldDeprecateBeforeVersion) {
+        runNpmDeprecateBeforeVersion()
+    } else {
+        console.log(`No versions older than ${deprecateBeforeVersion} to deprecate, skipping...`)
+    }
+
+    // fetch the latest metadata
+    viewResult = runNpmView()
+    currentVersion = viewResult.version
+
+    const now = new Date()
+    const deprecateBeforeDate = startOfDay(subDays(now, deprecateOlderThanDays))
+    console.log(`Finding versions older than ${format(deprecateBeforeDate, 'yyyy-MM-dd')} to deprecate...`)
+
+    let highestVersionToDeprecate = undefined
+    let highestVersionToDeprecateDate = undefined
+    for (const [version, dateString] of Object.entries(viewResult.time)) {
+        if (version === 'created' || version === 'modified') {
+            continue
+        }
+        if (compare(currentVersion, version, '=')) {
+            continue
+        }
+        if (compare(currentVersion, version, '<')) {
+            console.log(`Skipping future version ${version} released on ${dateString}`)
+            continue
+        }
+        const date = new Date(dateString)
+        if (isBefore(date, deprecateBeforeDate)) {
+            if (!highestVersionToDeprecate || compare(highestVersionToDeprecate, version, '<')) {
+                highestVersionToDeprecate = version
+                highestVersionToDeprecateDate = date
+            }
+        }
+    }
+    if (highestVersionToDeprecate) {
+        console.log(`Deprecating up to and including version ${highestVersionToDeprecate} released on ${format(highestVersionToDeprecateDate, 'yyyy-MM-dd')} ...`)
+        runNpmDeprecateBeforeOrEqualVersion(highestVersionToDeprecate)
+    }
+}
+
+
+main().catch(e => {
+    console.error(e)
+    process.exit(1)
+})

--- a/scripts/deprecate-old-versions.mjs
+++ b/scripts/deprecate-old-versions.mjs
@@ -97,6 +97,11 @@ const main = async () => {
         }
     }
     if (highestVersionToDeprecate) {
+        if (compare(currentVersion, highestVersionToDeprecate, '<=')) {
+            // should never be able to hit this, but be defensive
+            throw new Error("Dev error")
+        }
+
         console.log(`Deprecating up to and including version ${highestVersionToDeprecate} released on ${format(highestVersionToDeprecateDate, 'yyyy-MM-dd')} ...`)
         runNpmDeprecateBeforeOrEqualVersion(highestVersionToDeprecate)
     }


### PR DESCRIPTION
## Changes

Add a script to deprecate old versions. We can deprecate versions before a certain semver and that are older than a certain number of days!

Very intentionally does not deprecate the current version 🙃 

Runs in `dry-run` mode by default.

I think maybe only @timgl can run this... doesn't look like you can automate as it requires 2fa

## Checklist
n/a
