### PR TITLE
fix: don't modify history state when loading toolbar

### DIFF
--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -81,7 +81,7 @@ export class Toolbar {
                         // hash that was in the url before the redirect
                         location.hash = state['desiredHash']
                     } else if (history) {
-                        history.replaceState('', document.title, location.pathname + location.search) // completely remove hash
+                        history.replaceState(history.state, document.title, location.pathname + location.search) // completely remove hash
                     } else {
                         location.hash = '' // clear hash (but leaves # unfortunately)
                     }

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -81,7 +81,8 @@ export class Toolbar {
                         // hash that was in the url before the redirect
                         location.hash = state['desiredHash']
                     } else if (history) {
-                        history.replaceState(history.state, document.title, location.pathname + location.search) // completely remove hash
+                        // second param is unused see https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState
+                        history.replaceState(history.state, "", location.pathname + location.search) // completely remove hash
                     } else {
                         location.hash = '' // clear hash (but leaves # unfortunately)
                     }


### PR DESCRIPTION
Modifying state may break on applications that use it, like Next.js.

## Changes

Reuses the current history state when calling `replaceState` that removes hash from the URL.

Next.js apps rely on the state object. Calling `replaceState("", ...)` throws making the toolbar unusable.

...

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
