### PR TITLE
Don't load toolbar if decide is disabled

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -466,7 +466,10 @@ export class PostHog {
         // Use `onpagehide` if available, see https://calendar.perfplanet.com/2020/beaconing-in-practice/#beaconing-reliability-avoiding-abandons
         window?.addEventListener?.('onpagehide' in self ? 'pagehide' : 'unload', this._handle_unload.bind(this))
 
-        this.toolbar.maybeLoadToolbar()
+        // If decide is disabled, toolbar won't work anyway
+        if (!this.config.advanced_disable_decide) {
+            this.toolbar.maybeLoadToolbar()
+        }
 
         // We wan't to avoid promises for IE11 compatibility, so we use callbacks here
         if (config.segment) {


### PR DESCRIPTION
Toolbar requires decide to work, so we may skip loading if decide is disabled.

## Changes

Don't try to load toolbar if decide is disabled.

In case it somehow does work and users may rely on it in this scenario, I'd propose to add an option to disable the toolbar.

In my use-case, I have two posthog instances on the same site (one is identifying and using decide, one is not) which leads to two toolbars being loaded at the same time and one displays the warning that it won't work without decide enabled.

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
