### PR TITLE
feat: Allow sending automatic pageleave with manual pageview

### DIFF
--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -504,13 +504,13 @@ describe('posthog core', () => {
         }))
 
         given('config', () => ({
-            capture_pageview: given.capturePageviews,
+            capture_pageview: given.capturePageview,
             capture_pageleave: given.capturePageleave,
             request_batching: given.batching,
         }))
 
-        given('capturePageviews', () => true)
-        given('capturePageleave', () => true)
+        given('capturePageview', () => true)
+        given('capturePageleave', () => 'if_capture_pageview')
         given('batching', () => true)
 
         it('captures $pageleave', () => {
@@ -519,12 +519,31 @@ describe('posthog core', () => {
             expect(given.overrides.capture).toHaveBeenCalledWith('$pageleave')
         })
 
-        it('does not capture $pageleave when capture_pageview=false', () => {
-            given('capturePageviews', () => false)
+        it('does not capture $pageleave when capture_pageview=false and capture_pageleave=if_capture_pageview', () => {
+            given('capturePageleave', () => 'if_capture_pageview')
+            given('capturePageview', () => false)
 
             given.subject()
 
             expect(given.overrides.capture).not.toHaveBeenCalled()
+        })
+
+        it('does capture $pageleave when capture_pageview=true and capture_pageleave=if_capture_pageview', () => {
+            given('capturePageleave', () => 'if_capture_pageview')
+            given('capturePageview', () => true)
+
+            given.subject()
+
+            expect(given.overrides.capture).toHaveBeenCalled()
+        })
+
+        it('does capture $pageleave when capture_pageview=false and capture_pageleave=true', () => {
+            given('capturePageleave', () => true)
+            given('capturePageview', () => false)
+
+            given.subject()
+
+            expect(given.overrides.capture).toHaveBeenCalled()
         })
 
         it('calls requestQueue unload', () => {
@@ -543,7 +562,7 @@ describe('posthog core', () => {
             })
 
             it('does not capture $pageleave when capture_pageview=false', () => {
-                given('capturePageviews', () => false)
+                given('capturePageview', () => false)
 
                 given.subject()
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { version } from '../package.json'
 
-// overriden in posthog-core,
+// overridden in posthog-core,
 // e.g.     Config.DEBUG = Config.DEBUG || instance.config.debug
 const Config = {
     DEBUG: false,

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -130,7 +130,7 @@ export const defaultConfig = (): PostHogConfig => ({
     custom_blocked_useragents: [],
     save_referrer: true,
     capture_pageview: true,
-    capture_pageleave: true, // We'll only capture pageleave events if capture_pageview is also true
+    capture_pageleave: 'if_capture_pageview', // We'll only capture pageleave events if capture_pageview is also true
     debug: (location && isString(location?.search) && location.search.indexOf('__posthog_debug=true') !== -1) || false,
     verbose: false,
     cookie_expiration: 365,
@@ -562,13 +562,13 @@ export class PostHog {
 
     _handle_unload(): void {
         if (!this.config.request_batching) {
-            if (this.config.capture_pageview && this.config.capture_pageleave) {
+            if (this._shouldCapturePageleave()) {
                 this.capture('$pageleave', null, { transport: 'sendBeacon' })
             }
             return
         }
 
-        if (this.config.capture_pageview && this.config.capture_pageleave) {
+        if (this._shouldCapturePageleave()) {
             this.capture('$pageleave')
         }
 
@@ -1817,6 +1817,13 @@ export class PostHog {
                 isEmptyObject(this.getGroups()) &&
                 !this.persistence?.props?.[ALIAS_ID_KEY] &&
                 !this.persistence?.props?.[ENABLE_PERSON_PROCESSING])
+        )
+    }
+
+    _shouldCapturePageleave(): boolean {
+        return (
+            this.config.capture_pageleave === true ||
+            (this.config.capture_pageleave === 'if_capture_pageview' && this.config.capture_pageview)
         )
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ export interface PostHogConfig {
     save_referrer: boolean
     verbose: boolean
     capture_pageview: boolean
-    capture_pageleave: boolean
+    capture_pageleave: boolean | 'if_capture_pageview'
     debug: boolean
     cookie_expiration: number
     upgrade: boolean


### PR DESCRIPTION
## Changes

Currently if you disable capture_pageview, there's no way to enable sending pageleave events automatically when the page closes.

Some people would like to do this! e.g. in nextjs you need to manually send pageview events, as this is done in a framework-specific way, but you might still want to send pageleave event when the page closes, and this is not framework-specific so could be done automatically.

To keep backwards compatibility, this is off by default. The new default value for capture_pageleave is `'if_capture_pageview'`.

The only users who would see a difference in behaviour are people who explicitly set:
```
capture_pageview: false
capture_pageleave: true
```

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
