### PR TITLE
fix: Ensure enqueued requests are retriable

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -385,7 +385,7 @@ export class PostHog {
                 ? this.persistence
                 : new PostHogPersistence({ ...this.config, persistence: 'sessionStorage' })
 
-        this._requestQueue = new RequestQueue((req) => this._send_request(req))
+        this._requestQueue = new RequestQueue((req) => this._send_retriable_request(req))
         this._retryQueue = new RetryQueue(this)
         this.__request_queue = []
 


### PR DESCRIPTION
## Changes

Noticed whilst looking at a different PR - I think the request queue _should_ be sending a retriable request but instead is only sending a one off request...

* Fixes it

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
