### PR TITLE
feat: Added global state for toolbar

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,7 @@ export const CAPTURE_RATE_LIMIT = '$capture_rate_limit'
 export const INITIAL_CAMPAIGN_PARAMS = '$initial_campaign_params'
 export const INITIAL_REFERRER_INFO = '$initial_referrer_info'
 export const ENABLE_PERSON_PROCESSING = '$epp'
+export const TOOLBAR_ID = '__POSTHOG_TOOLBAR__'
 
 // These are properties that are reserved and will not be automatically included in events
 export const PERSISTENCE_RESERVED_PROPERTIES = [

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -5,7 +5,7 @@ import { PostHog } from './posthog-core'
 
 import { document, window } from './utils/globals'
 import { getParentElement, isTag } from './autocapture-utils'
-import { HEATMAPS_ENABLED_SERVER_SIDE } from './constants'
+import { HEATMAPS_ENABLED_SERVER_SIDE, TOOLBAR_ID } from './constants'
 import { isUndefined } from './utils/type-utils'
 import { logger } from './utils/logger'
 
@@ -32,8 +32,6 @@ function elementOrParentPositionMatches(el: Element, matches: string[], breakOnE
 
     return false
 }
-
-const TOOLBAR_ID = '__POSTHOG_TOOLBAR__'
 
 function elementInToolbar(el: Element): boolean {
     // NOTE: .closest is not supported in IE11 hence the operator check


### PR DESCRIPTION
## Changes

Fixes https://github.com/PostHog/posthog-js/issues/1172

You can have multiple SDKs running in different configs. This can lead to some issues with the toolbar as both instances willt try to load it.

* Save the loading state on the window so that mulitple SDKs reference the same thing
* Improve the load logic to check for the actual toolbar ID to decide whether to load it or not.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
