### PR TITLE
fix: Update ui_host if using old app one

### DIFF
--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -12,7 +12,7 @@ describe('request-router', () => {
 
     const testCases: [string, RequestRouterTarget, string][] = [
         // US domain
-        ['https://app.posthog.com', 'ui', 'https://us.posthog.com'],
+        ['https://app.posthog.com', 'ui', 'https://app.posthog.com'],
         ['https://app.posthog.com', 'assets', 'https://us-assets.i.posthog.com'],
         ['https://app.posthog.com', 'api', 'https://us.i.posthog.com'],
         // US domain via app domain
@@ -61,8 +61,12 @@ describe('request-router', () => {
     })
 
     it('should use the ui_host if provided', () => {
+        expect(router('https://my.domain.com/', 'https://eu.posthog.com/').endpointFor('ui')).toEqual(
+            'https://eu.posthog.com'
+        )
+
         expect(router('https://my.domain.com/', 'https://app.posthog.com/').endpointFor('ui')).toEqual(
-            'https://app.posthog.com'
+            'https://us.posthog.com'
         )
     })
 

--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -12,7 +12,7 @@ describe('request-router', () => {
 
     const testCases: [string, RequestRouterTarget, string][] = [
         // US domain
-        ['https://app.posthog.com', 'ui', 'https://app.posthog.com'],
+        ['https://app.posthog.com', 'ui', 'https://us.posthog.com'],
         ['https://app.posthog.com', 'assets', 'https://us-assets.i.posthog.com'],
         ['https://app.posthog.com', 'api', 'https://us.i.posthog.com'],
         // US domain via app domain

--- a/src/utils/request-router.ts
+++ b/src/utils/request-router.ts
@@ -28,7 +28,12 @@ export class RequestRouter {
         return this.instance.config.api_host.trim().replace(/\/$/, '')
     }
     get uiHost(): string | undefined {
-        return this.instance.config.ui_host?.replace(/\/$/, '')
+        const host = this.instance.config.ui_host?.replace(/\/$/, '')
+
+        if (host === 'https://app.posthog.com') {
+            return 'https://us.posthog.com'
+        }
+        return host
     }
 
     get region(): RequestRouterRegion {


### PR DESCRIPTION
## Changes

Convert app.posthog.com to us.posthog.com for ui_host as well

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
