### PR TITLE
fix(survey): Fix issue with shuffling questions on every render

### DIFF
--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -23,7 +23,7 @@ import {
 } from './surveys/surveys-utils'
 import * as Preact from 'preact'
 import { createWidgetShadow, createWidgetStyle } from './surveys-widget'
-import { useState, useEffect, useRef, useContext } from 'preact/hooks'
+import { useState, useEffect, useRef, useContext, useMemo } from 'preact/hooks'
 import { isNumber } from '../utils/type-utils'
 import { ConfirmationMessage } from './surveys/components/ConfirmationMessage'
 import {
@@ -306,7 +306,7 @@ export function Questions({
     const [questionsResponses, setQuestionsResponses] = useState({})
     const { readOnly, previewQuestionIndex } = useContext(SurveyContext)
     const [currentQuestion, setCurrentQuestion] = useState(readOnly ? previewQuestionIndex : 0)
-    const surveyQuestions = getDisplayOrderQuestions(survey)
+    const surveyQuestions = useMemo(() => getDisplayOrderQuestions(survey), [survey])
 
     const onNextClick = (res: string | string[] | number | null, idx: number) => {
         const responseKey = idx === 0 ? `$survey_response` : `$survey_response_${idx}`


### PR DESCRIPTION
## Changes

This PR makes a fix to followup on #1177 where we discovered a bug that we weren't shuffling questions correctly. 
The bug was in the survey rendering where we would repeatedly shuffle questions, causing us to sometimes lose questions when the component re-renders.  This is now fixed by using the `useMemo` react hook to shuffle the questions for a given Survey only once.

![duplicate_question_bug_fix](https://github.com/PostHog/posthog-js/assets/82819/5bc8adc2-8a58-48c3-af01-400e86b12b14)


## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
