### PR TITLE
hack: add convenience log method

### DIFF
--- a/src/__tests__/posthog-log.test.ts
+++ b/src/__tests__/posthog-log.test.ts
@@ -12,20 +12,22 @@ describe('posthog log', () => {
 
         it('captures manual logs', () => {
             const { posthog, onCapture } = setup()
-            posthog.log('test log')
+            posthog.log('test log', 'warn')
             expect(onCapture.mock.calls[0][0]).toBe('$log')
             expect(onCapture.mock.calls[0][1].properties).toMatchObject({
                 message: 'test log',
+                level: 'warn',
             })
         })
 
         it('captures logs properties', () => {
             const { posthog, onCapture } = setup()
-            posthog.log('test log', { wat: 'is this value' })
+            posthog.log('test log', 'info', { wat: 'is this value' })
             expect(onCapture.mock.calls[0][0]).toBe('$log')
             expect(onCapture.mock.calls[0][1].properties).toMatchObject({
                 message: 'test log',
                 wat: 'is this value',
+                level: 'info',
             })
         })
     })

--- a/src/__tests__/posthog-log.test.ts
+++ b/src/__tests__/posthog-log.test.ts
@@ -1,0 +1,32 @@
+import _posthog, { PostHogConfig } from '../loader-module'
+import { uuidv7 } from '../uuidv7'
+
+describe('posthog log', () => {
+    describe('capture()', () => {
+        const setup = (config: Partial<PostHogConfig> = {}) => {
+            const onCapture = jest.fn()
+            const posthog = _posthog.init('testtoken', { ...config, _onCapture: onCapture }, uuidv7())!
+            posthog.debug()
+            return { posthog, onCapture }
+        }
+
+        it('captures manual logs', () => {
+            const { posthog, onCapture } = setup()
+            posthog.log('test log')
+            expect(onCapture.mock.calls[0][0]).toBe('$log')
+            expect(onCapture.mock.calls[0][1].properties).toMatchObject({
+                message: 'test log',
+            })
+        })
+
+        it('captures logs properties', () => {
+            const { posthog, onCapture } = setup()
+            posthog.log('test log', { wat: 'is this value' })
+            expect(onCapture.mock.calls[0][0]).toBe('$log')
+            expect(onCapture.mock.calls[0][1].properties).toMatchObject({
+                message: 'test log',
+                wat: 'is this value',
+            })
+        })
+    })
+})

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -701,8 +701,13 @@ export class PostHog {
         this._execute_array([item])
     }
 
-    log(message: string, properties?: Properties | null, options?: CaptureOptions): CaptureResult | void {
-        return this.capture('$log', { message, ...properties }, options)
+    log(
+        message: string,
+        level: 'info' | 'warn' | 'error' | 'debug',
+        properties?: Properties | null,
+        options?: CaptureOptions
+    ): CaptureResult | void {
+        return this.capture('$log', { message, level, ...properties }, options)
     }
 
     /**

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -701,6 +701,10 @@ export class PostHog {
         this._execute_array([item])
     }
 
+    log(message: string, properties?: Properties | null, options?: CaptureOptions): CaptureResult | void {
+        return this.capture('$log', { message, ...properties }, options)
+    }
+
     /**
      * Capture an event. This is the most important and
      * frequently used PostHog function.


### PR DESCRIPTION
a convenience method to log from posthog-js

rrweb's console logger is already wrapping console log but not easily exposed without some silliness so let's merge them on the backend with HogQL rather than allow someone to have replay off but console log autocapture on ?? 🤷 