### PR TITLE
fix: redact not hide headers

### DIFF
--- a/src/__tests__/extensions/replay/config.test.ts
+++ b/src/__tests__/extensions/replay/config.test.ts
@@ -61,6 +61,7 @@ describe('config', () => {
                 expect(cleaned).toEqual({
                     name: 'edited',
                     requestHeaders: {
+                        Authorization: 'redacted',
                         'content-type': 'application/json',
                     },
                 })
@@ -197,6 +198,7 @@ describe('config', () => {
             expect(cleaned).toEqual({
                 name: 'something',
                 requestHeaders: {
+                    Authorization: 'redacted',
                     'content-type': 'application/json',
                 },
             })
@@ -225,6 +227,7 @@ describe('config', () => {
             expect(cleaned).toEqual({
                 name: 'something',
                 requestHeaders: {
+                    Authorization: 'redacted',
                     'content-type': 'edited',
                 },
             })
@@ -244,6 +247,7 @@ describe('config', () => {
             expect(cleaned).toEqual({
                 name: 'something',
                 requestHeaders: {
+                    Authorization: 'redacted',
                     'content-type': 'application/json',
                 },
                 requestBody: '[SessionRecording] Request body redacted as might contain: password',
@@ -278,6 +282,7 @@ describe('config', () => {
             expect(cleaned).toEqual({
                 name: 'something',
                 requestHeaders: {
+                    Authorization: 'redacted',
                     'content-type': 'edited',
                 },
                 requestBody: 'the provided function ran',
@@ -297,6 +302,7 @@ describe('config', () => {
             expect(cleaned).toEqual({
                 name: 'something',
                 requestHeaders: {
+                    AuThOrIzAtIoN: 'redacted',
                     'content-type': 'application/json',
                 },
             })
@@ -316,6 +322,7 @@ describe('config', () => {
             expect(cleaned).toEqual({
                 name: 'something',
                 requestHeaders: {
+                    Authorization: 'redacted',
                     'content-type': 'application/json',
                 },
                 requestBody: '[SessionRecording] Request body redacted',


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/13730 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/16100)

When a header is on the denylist we drop it completely so there's no way to explain what's happening in the UI

Let's replace its content with `redacted` so that we can replace that in the UI with a helpful link