### PR TITLE
chore: no more master switching

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+branch=$(git symbolic-ref --short HEAD)
+
+if [ "$branch" = "master" ]; then
+    echo "☢️☢️☢️☢️☢️☢️☢️☢️☢️☢️☢️☢️"
+    echo "Error: Switching to the 'master' branch is not allowed."
+    echo "☢️☢️☢️☢️☢️☢️☢️☢️☢️☢️☢️☢️"
+    git checkout -
+    exit 1
+fi


### PR DESCRIPTION
I keep checking out master in posthog-js, what a pain

I couldn't think of / don't know a different way to stop this

So, this post-checkout hook (there is no pre-checkout hook) warns when you try to checkout master and switches you back to wherever you were

<img width="465" alt="Screenshot 2024-05-22 at 18 48 12" src="https://github.com/PostHog/posthog-js/assets/984817/de66e099-02b1-4add-9ac5-5306253eb68e">
