### PR TITLE
feat: Add tests and fix regex for some obscure android browsers

### DIFF
--- a/src/__tests__/utils/event-utils.test.ts
+++ b/src/__tests__/utils/event-utils.test.ts
@@ -161,15 +161,6 @@ describe(`event-utils`, () => {
                 expectedBrowser: 'BlackBerry',
             },
             {
-                name: 'Android Mobile',
-                userAgent:
-                    'Mozilla/5.0 (Linux; StarOS Must use __system_property_read_callback() to read; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/100.0.4896.127 Mobile Safari/537.36',
-                vendor: '',
-                // TODO should we detect this as Chrome or Android Mobile?
-                expectedVersion: 100,
-                expectedBrowser: 'Chrome',
-            },
-            {
                 name: 'Samsung Internet',
                 userAgent:
                     'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-T550 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Safari/537.36',
@@ -219,7 +210,7 @@ describe(`event-utils`, () => {
                 name: 'Android Browser on Galaxy S3',
                 userAgent:
                     'Mozilla/5.0 (Linux; Android 4.4.4; en-us; SAMSUNG GT-I9300I Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36',
-                expectedVersion: 1.5,
+                expectedVersion: 4.4,
                 expectedBrowser: 'Android Mobile',
             },
         ]

--- a/src/__tests__/utils/event-utils.test.ts
+++ b/src/__tests__/utils/event-utils.test.ts
@@ -44,12 +44,42 @@ describe(`event-utils`, () => {
             expectedBrowser: string
         }[] = [
             {
-                name: 'Chrome 91',
+                name: 'Chrome 91 on Windows',
                 userAgent:
                     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
                 vendor: '',
                 expectedVersion: 91.0,
                 expectedBrowser: 'Chrome',
+            },
+            {
+                name: 'Chrome 112 on mac',
+                userAgent:
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36',
+                expectedVersion: 112.0,
+                expectedBrowser: 'Chrome',
+            },
+            {
+                name: 'Chrome 111 on Linux',
+                userAgent:
+                    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36',
+
+                expectedVersion: 111.0,
+                expectedBrowser: 'Chrome',
+            },
+            {
+                name: 'Chrome 16 on Android',
+                userAgent:
+                    'Mozilla/5.0 (Linux; U; Android-4.0.3; en-us; Galaxy Nexus Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.75 Mobile Safari/535.7',
+                expectedVersion: 16.0,
+                expectedBrowser: 'Chrome',
+            },
+            {
+                name: 'Chrome 21 iOS',
+                userAgent:
+                    'Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/21.0.1180.82 Mobile/9B206 Safari/7534.48.3',
+                vendor: '',
+                expectedVersion: 21.0,
+                expectedBrowser: 'Chrome iOS',
             },
             {
                 name: 'Firefox 89',
@@ -88,14 +118,6 @@ describe(`event-utils`, () => {
                 vendor: '',
                 expectedVersion: 44.17763,
                 expectedBrowser: 'Microsoft Edge',
-            },
-            {
-                name: 'Chrome 21 iOS',
-                userAgent:
-                    'Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/21.0.1180.82 Mobile/9B206 Safari/7534.48.3',
-                vendor: '',
-                expectedVersion: 21.0,
-                expectedBrowser: 'Chrome iOS',
             },
             {
                 name: 'UC Browser',

--- a/src/__tests__/utils/event-utils.test.ts
+++ b/src/__tests__/utils/event-utils.test.ts
@@ -208,6 +208,20 @@ describe(`event-utils`, () => {
                 expectedVersion: 106.0,
                 expectedBrowser: 'Firefox iOS',
             },
+            {
+                name: 'Android Browser on Galaxy Nexus',
+                userAgent:
+                    'Mozilla/5.0 (Linux; U; Android 4.0.2; en-us; Galaxy Nexus Build/ICL53F) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+                expectedVersion: 4.0,
+                expectedBrowser: 'Android Mobile',
+            },
+            {
+                name: 'Android Browser on Galaxy S3',
+                userAgent:
+                    'Mozilla/5.0 (Linux; Android 4.4.4; en-us; SAMSUNG GT-I9300I Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36',
+                expectedVersion: 1.5,
+                expectedBrowser: 'Android Mobile',
+            },
         ]
 
         test.each(browserTestcases)('browser version %s', ({ userAgent, vendor, expectedVersion }) => {

--- a/src/utils/user-agent-utils.ts
+++ b/src/utils/user-agent-utils.ts
@@ -109,12 +109,14 @@ export const detectBrowser = function (user_agent: string, vendor: string | unde
         return FACEBOOK + ' ' + MOBILE
     } else if (includes(user_agent, 'UCWEB') || includes(user_agent, 'UCBrowser')) {
         return 'UC Browser'
+    } else if (includes(user_agent, 'CriOS')) {
+        return CHROME_IOS // why not just Chrome?
+    } else if (includes(user_agent, 'CrMo')) {
+        return CHROME
     } else if (includes(user_agent, ANDROID) && includes(user_agent, SAFARI)) {
         return ANDROID_MOBILE
     } else if (includes(user_agent, CHROME)) {
         return CHROME
-    } else if (includes(user_agent, 'CriOS')) {
-        return CHROME_IOS
     } else if (includes(user_agent, 'FxiOS')) {
         return FIREFOX_IOS
     } else if (includes(user_agent.toLowerCase(), KONQUEROR.toLowerCase())) {
@@ -135,7 +137,7 @@ export const detectBrowser = function (user_agent: string, vendor: string | unde
 const versionRegexes: Record<string, RegExp[]> = {
     [INTERNET_EXPLORER_MOBILE]: [new RegExp('rv:' + BROWSER_VERSION_REGEX_SUFFIX)],
     [MICROSOFT_EDGE]: [new RegExp(EDGE + '?\\/' + BROWSER_VERSION_REGEX_SUFFIX)],
-    [CHROME]: [new RegExp(CHROME + '/' + BROWSER_VERSION_REGEX_SUFFIX)],
+    [CHROME]: [new RegExp('(' + CHROME + '|CrMo)\\/' + BROWSER_VERSION_REGEX_SUFFIX)],
     [CHROME_IOS]: [new RegExp('CriOS\\/' + BROWSER_VERSION_REGEX_SUFFIX)],
     'UC Browser': [new RegExp('(UCBrowser|UCWEB)\\/' + BROWSER_VERSION_REGEX_SUFFIX)],
     [SAFARI]: [DEFAULT_BROWSER_VERSION_REGEX],

--- a/src/utils/user-agent-utils.ts
+++ b/src/utils/user-agent-utils.ts
@@ -107,16 +107,16 @@ export const detectBrowser = function (user_agent: string, vendor: string | unde
         return MICROSOFT_EDGE
     } else if (includes(user_agent, 'FBIOS')) {
         return FACEBOOK + ' ' + MOBILE
+    } else if (includes(user_agent, 'UCWEB') || includes(user_agent, 'UCBrowser')) {
+        return 'UC Browser'
+    } else if (includes(user_agent, ANDROID) && includes(user_agent, SAFARI)) {
+        return ANDROID_MOBILE
     } else if (includes(user_agent, CHROME)) {
         return CHROME
     } else if (includes(user_agent, 'CriOS')) {
         return CHROME_IOS
-    } else if (includes(user_agent, 'UCWEB') || includes(user_agent, 'UCBrowser')) {
-        return 'UC Browser'
     } else if (includes(user_agent, 'FxiOS')) {
         return FIREFOX_IOS
-    } else if (includes(user_agent, ANDROID)) {
-        return ANDROID_MOBILE
     } else if (includes(user_agent.toLowerCase(), KONQUEROR.toLowerCase())) {
         return KONQUEROR
     } else if (safariCheck(user_agent, vendor)) {

--- a/src/utils/user-agent-utils.ts
+++ b/src/utils/user-agent-utils.ts
@@ -146,7 +146,7 @@ const versionRegexes: Record<string, RegExp[]> = {
     [KONQUEROR]: [new RegExp('Konqueror[:/]?' + BROWSER_VERSION_REGEX_SUFFIX, 'i')],
     // not every blackberry user agent has the version after the name
     [BLACKBERRY]: [new RegExp(BLACKBERRY + ' ' + BROWSER_VERSION_REGEX_SUFFIX), DEFAULT_BROWSER_VERSION_REGEX],
-    [ANDROID_MOBILE]: [new RegExp('android\\s' + BROWSER_VERSION_REGEX_SUFFIX)],
+    [ANDROID_MOBILE]: [new RegExp('android\\s' + BROWSER_VERSION_REGEX_SUFFIX, 'i')],
     [SAMSUNG_INTERNET]: [new RegExp(SAMSUNG_BROWSER + '\\/' + BROWSER_VERSION_REGEX_SUFFIX)],
     [INTERNET_EXPLORER]: [new RegExp('(rv:|MSIE )' + BROWSER_VERSION_REGEX_SUFFIX)],
     Mozilla: [new RegExp('rv:' + BROWSER_VERSION_REGEX_SUFFIX)],


### PR DESCRIPTION
## Changes
I got a support request from someone that was asking what Android Mobile means as a browser, so I did some digging and added a fix for our version number parsing https://posthoghelp.zendesk.com/agent/tickets/13622 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15771)

This led me down a further rabbit-hole and I found we had been mislabelling some traffic, e.g. this Galaxy S3 user agent should be Android Mobile but we were reporting it as Chrome: `Mozilla/5.0 (Linux; Android 4.4.4; en-us; SAMSUNG GT-I9300I Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36` - here's the code in ua-parser https://github.com/faisalman/ua-parser-js/blob/1.0.x/test/browser-test.json#L47

Very fun things

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
