### PR TITLE
fix: reverse options if unshuffled

### DIFF
--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -549,7 +549,7 @@ describe('surveys', () => {
             expect(shuffledOptions).toEqual(questionWithoutShufflingOptions.choices)
         })
 
-        it('should shuffle if shuffleOptions is false', () => {
+        it('should shuffle if shuffleOptions is true', () => {
             const shuffledOptions = getDisplayOrderChoices(questionWithShufflingOptions)
             expect(shuffledOptions).not.toEqual(questionWithShufflingOptions.choices)
         })

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -555,9 +555,17 @@ export const sendSurveyEvent = (
 // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
 export const shuffle = (array: any[]) => {
     return array
-        .map((a) => ({ sort: Math.random(), value: a }))
+        .map((a) => ({ sort: Math.floor(Math.random() * 10), value: a }))
         .sort((a, b) => a.sort - b.sort)
         .map((a) => a.value)
+}
+
+const reverseIfUnshuffled = (unshuffled: string[], shuffled: string[]): string[] => {
+    if (unshuffled.length === shuffled.length && unshuffled.every((val, index) => val === shuffled[index])) {
+        return shuffled.reverse()
+    }
+
+    return shuffled
 }
 
 export const getDisplayOrderChoices = (question: MultipleSurveyQuestion): string[] => {
@@ -565,21 +573,21 @@ export const getDisplayOrderChoices = (question: MultipleSurveyQuestion): string
         return question.choices
     }
 
-    let displayOrderChoices = question.choices
+    const displayOrderChoices = question.choices
     let openEndedChoice = ''
     if (question.hasOpenChoice) {
         // if the question has an open-ended choice, its always the last element in the choices array.
         openEndedChoice = displayOrderChoices.pop()!
     }
 
-    displayOrderChoices = shuffle(displayOrderChoices)
+    const shuffledOptions = reverseIfUnshuffled(displayOrderChoices, shuffle(displayOrderChoices))
 
     if (question.hasOpenChoice) {
         question.choices.push(openEndedChoice)
-        displayOrderChoices.push(openEndedChoice)
+        shuffledOptions.push(openEndedChoice)
     }
 
-    return displayOrderChoices
+    return shuffledOptions
 }
 
 export const getDisplayOrderQuestions = (survey: Survey): SurveyQuestion[] => {


### PR DESCRIPTION
## Changes

The `should shuffle if shuffleOptions is true` (name corrected) test is flaky because the `math.Random` value that our FIsher-yates algorithm depends on is pseudo random and can give us monotonically increasing values, making the shuffle algorithm shuffle nothing.  I tried using `crypto.getRandomValues(randomSeed)` and ran into the same issue with monotonically increasing values. 

To resolve this issue, I've introduce an `array.reverse()` if we discover that the shuffling didn't actually change the order of options.


...

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
