### PR TITLE
fix: Pass `retriesPerformedSoFar` to keep count of retries

### DIFF
--- a/src/retry-queue.ts
+++ b/src/retry-queue.ts
@@ -66,6 +66,7 @@ export class RetryQueue {
                 if (response.statusCode !== 200 && (response.statusCode < 400 || response.statusCode >= 500)) {
                     if ((retriesPerformedSoFar ?? 0) < 10) {
                         this.enqueue({
+                            retriesPerformedSoFar,
                             ...options,
                         })
                         return


### PR DESCRIPTION
## Changes

Fixes a bug in retry-queue which discarded the count of retries, which caused it to retry in a tight-loop forever.

See this post for more details: https://posthog.com/questions/posthog-retries-s-snapshot-request-indefinitely

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
