### PR TITLE
fix: Add missing retry info and test

### DIFF
--- a/src/retry-queue.ts
+++ b/src/retry-queue.ts
@@ -66,6 +66,7 @@ export class RetryQueue {
                 if (response.statusCode !== 200 && (response.statusCode < 400 || response.statusCode >= 500)) {
                     if ((retriesPerformedSoFar ?? 0) < 10) {
                         this.enqueue({
+                            retriesPerformedSoFar,
                             ...options,
                         })
                         return


### PR DESCRIPTION
## Changes

Adds a test to cover https://github.com/PostHog/posthog-js/pull/1201

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
