### PR TITLE
fix: do not rate limit removes

### DIFF
--- a/src/extensions/replay/sessionrecording-utils.ts
+++ b/src/extensions/replay/sessionrecording-utils.ts
@@ -203,6 +203,13 @@ export class MutationRateLimiter {
         const data = event.data as Partial<mutationCallbackParam>
         const initialMutationCount = this.numberOfChanges(data)
 
+        // do not rate limit events that only remove nodes
+        const removes = data.removes?.length ?? 0
+        const adds = data.adds?.length ?? 0
+        if (removes != 0 && adds === 0) {
+            return
+        }
+
         if (data.attributes) {
             // Most problematic mutations come from attrs where the style or minor properties are changed rapidly
             data.attributes = data.attributes.filter((attr) => {


### PR DESCRIPTION
## Changes

Related to https://posthoghelp.zendesk.com/agent/tickets/13821 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/16247)

- We skipped removing a rate limited element
- We should never skip an event if it only contains `removes`