### PR TITLE
fix: fallback size when resizing

### DIFF
--- a/patches/rrweb@2.0.0-alpha.13.patch
+++ b/patches/rrweb@2.0.0-alpha.13.patch
@@ -167,7 +167,7 @@ index ea868845c4fad3276aa8e5f74abfd3568b466d11..965505de44975e718d431a4e9a62e753
  
  export { WorkerFactory as default };
 diff --git a/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js b/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
-index da2c103fe6b1408a5996f0eb3bf047571e434cc2..f04750556f6d509a16678a94dca5b615eb8d3a1d 100644
+index da2c103fe6b1408a5996f0eb3bf047571e434cc2..745c0bee7ca8d49d5c3f4102d71fe965df75318d 100644
 --- a/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
 +++ b/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
 @@ -91,11 +91,21 @@ class CanvasManager {
@@ -197,13 +197,16 @@ index da2c103fe6b1408a5996f0eb3bf047571e434cc2..f04750556f6d509a16678a94dca5b615
              return matchedCanvas;
          };
          const takeCanvasSnapshots = (timestamp) => {
-@@ -120,12 +130,19 @@ class CanvasManager {
+@@ -120,12 +130,22 @@ class CanvasManager {
                          context.clear(context.COLOR_BUFFER_BIT);
                      }
                  }
 -                const bitmap = yield createImageBitmap(canvas);
-+                const width = canvas.clientWidth;
-+                const height = canvas.clientHeight;
++
++                // createImageBitmap throws if resizing to 0
++                // Fallback to intrinsic size if canvas has not yet rendered
++                const width = canvas.clientWidth || client.width;
++                const height = canvas.clientHeight || client.height;
 +
 +                const bitmap = yield createImageBitmap(canvas, {
 +                    resizeWidth: width,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   rrweb@2.0.0-alpha.13:
-    hash: xzot57gbh2vywrm2w2dzrqlgli
+    hash: noym65kmmvv7gbw7gn7uz3wq3m
     path: patches/rrweb@2.0.0-alpha.13.patch
 
 dependencies:
@@ -179,7 +179,7 @@ devDependencies:
     version: 5.12.0(rollup@4.9.6)
   rrweb:
     specifier: 2.0.0-alpha.13
-    version: 2.0.0-alpha.13(patch_hash=xzot57gbh2vywrm2w2dzrqlgli)
+    version: 2.0.0-alpha.13(patch_hash=noym65kmmvv7gbw7gn7uz3wq3m)
   rrweb-snapshot:
     specifier: 2.0.0-alpha.13
     version: 2.0.0-alpha.13
@@ -9216,7 +9216,7 @@ packages:
     resolution: {integrity: sha512-slbhNBCYjxLGCeH95a67ECCy5a22nloXp1F5wF7DCzUNw80FN7tF9Lef1sRGLNo32g3mNqTc2sWLATlKejMxYw==}
     dev: true
 
-  /rrweb@2.0.0-alpha.13(patch_hash=xzot57gbh2vywrm2w2dzrqlgli):
+  /rrweb@2.0.0-alpha.13(patch_hash=noym65kmmvv7gbw7gn7uz3wq3m):
     resolution: {integrity: sha512-a8GXOCnzWHNaVZPa7hsrLZtNZ3CGjiL+YrkpLo0TfmxGLhjNZbWY2r7pE06p+FcjFNlgUVTmFrSJbK3kO7yxvw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.13


### PR DESCRIPTION
## Changes

Fixes https://posthoghelp.zendesk.com/agent/tickets/13936 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/16456)
Closes https://github.com/PostHog/posthog-js/issues/1150

Because we resize the bitmap we rely on it being a non-zero value. Some canvas elements are captured before they are rendered and hence the `clientWidth` and `clientHeight` are zero values. In those cases we should fallback to the intrinsic `width` and `height` attributes on the canvas.