### PR TITLE
fix: Add auto approver for JS prs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -177,7 +177,7 @@ jobs:
                 -H "Accept: application/vnd.github+json" \
                 -H "Authorization: Bearer ${{ steps.deployer.outputs.token }}" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/posthog/pulls/${pull_number}/reviews \
+                https://api.github.com/repos/posthog/posthog/pulls/${pull_number}/reviews \
                 -d '{"body":"PostHog JS auto approved.","event":"APPROVE","comments":[]}'
 
     create-posthog-com-repo-pull-request:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -155,6 +155,31 @@ jobs:
               run: |
                   echo "PostHog pull request for posthog-js version ${{ env.COMMITTED_VERSION }} ready: ${{ steps.main-repo-pr.outputs.pull-request-url }}"
 
+            - name: get deployer token
+              id: deployer
+              uses: getsentry/action-github-app-token@v2
+              with:
+                  app_id: ${{ secrets.DEPLOYER_APP_ID }}
+                  private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
+
+            - name: Stamp PR
+              run: |
+                # unbelievably github has a race condition where if you commit and
+                # approve too quickly on a PR with "auto-merge" enabled it can miss
+                # the new commit in the merge commit (but it looks like the PR has the change)
+                # Sleep 5 should work
+                sleep 5
+                pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+
+                pull_number=${{ steps.main-repo-pr.outputs.pull-request-number }}
+                curl -L \
+                -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ steps.deployer.outputs.token }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/posthog/pulls/${pull_number}/reviews \
+                -d '{"body":"PostHog JS auto approved.","event":"APPROVE","comments":[]}'
+
     create-posthog-com-repo-pull-request:
         name: Create posthog.com repo PR with new posthog-js version
         runs-on: ubuntu-20.04

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -7,6 +7,35 @@ on:
             - main
 
 jobs:
+    temp:
+        name: Unit tests
+        runs-on: ubuntu-latest
+        steps:
+            - name: get deployer token
+              id: deployer
+              uses: getsentry/action-github-app-token@v2
+              with:
+                  app_id: ${{ secrets.DEPLOYER_APP_ID }}
+                  private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
+
+            - name: Stamp PR
+              run: |
+                # unbelievably github has a race condition where if you commit and
+                # approve too quickly on a PR with "auto-merge" enabled it can miss
+                # the new commit in the merge commit (but it looks like the PR has the change)
+                # Sleep 5 should work
+                sleep 5
+                pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+
+                pull_number=22469
+                curl -L \
+                -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ steps.deployer.outputs.token }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/posthog/pulls/${pull_number}/reviews \
+                -d '{"body":"PostHog JS auto approved.","event":"APPROVE","comments":[]}'
+
     unit:
         name: Unit tests
         runs-on: ubuntu-latest

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -7,35 +7,6 @@ on:
             - main
 
 jobs:
-    temp:
-        name: Unit tests
-        runs-on: ubuntu-latest
-        steps:
-            - name: get deployer token
-              id: deployer
-              uses: getsentry/action-github-app-token@v2
-              with:
-                  app_id: ${{ secrets.DEPLOYER_APP_ID }}
-                  private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
-
-            - name: Stamp PR
-              run: |
-                # unbelievably github has a race condition where if you commit and
-                # approve too quickly on a PR with "auto-merge" enabled it can miss
-                # the new commit in the merge commit (but it looks like the PR has the change)
-                # Sleep 5 should work
-                sleep 5
-                pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-
-                pull_number=22469
-                curl -L \
-                -X POST \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer ${{ steps.deployer.outputs.token }}" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/posthog/posthog/pulls/${pull_number}/reviews \
-                -d '{"body":"PostHog JS auto approved.","event":"APPROVE","comments":[]}'
-
     unit:
         name: Unit tests
         runs-on: ubuntu-latest

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -33,7 +33,7 @@ jobs:
                 -H "Accept: application/vnd.github+json" \
                 -H "Authorization: Bearer ${{ steps.deployer.outputs.token }}" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/posthog/pulls/${pull_number}/reviews \
+                https://api.github.com/repos/posthog/posthog/pulls/${pull_number}/reviews \
                 -d '{"body":"PostHog JS auto approved.","event":"APPROVE","comments":[]}'
 
     unit:


### PR DESCRIPTION
## Changes

Auto approvals for JS PRs to PostHog. Tested with hard coded action here https://github.com/PostHog/posthog/pull/22469

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
