### PR TITLE
fix: reference canvas not client

### DIFF
--- a/patches/rrweb@2.0.0-alpha.13.patch
+++ b/patches/rrweb@2.0.0-alpha.13.patch
@@ -167,7 +167,7 @@ index ea868845c4fad3276aa8e5f74abfd3568b466d11..965505de44975e718d431a4e9a62e753
  
  export { WorkerFactory as default };
 diff --git a/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js b/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
-index da2c103fe6b1408a5996f0eb3bf047571e434cc2..745c0bee7ca8d49d5c3f4102d71fe965df75318d 100644
+index da2c103fe6b1408a5996f0eb3bf047571e434cc2..3b34097a089791bd1043f313dcab9ad4c3733830 100644
 --- a/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
 +++ b/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
 @@ -91,11 +91,21 @@ class CanvasManager {
@@ -205,8 +205,8 @@ index da2c103fe6b1408a5996f0eb3bf047571e434cc2..745c0bee7ca8d49d5c3f4102d71fe965
 +
 +                // createImageBitmap throws if resizing to 0
 +                // Fallback to intrinsic size if canvas has not yet rendered
-+                const width = canvas.clientWidth || client.width;
-+                const height = canvas.clientHeight || client.height;
++                const width = canvas.clientWidth || canvas.width;
++                const height = canvas.clientHeight || canvas.height;
 +
 +                const bitmap = yield createImageBitmap(canvas, {
 +                    resizeWidth: width,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   rrweb@2.0.0-alpha.13:
-    hash: noym65kmmvv7gbw7gn7uz3wq3m
+    hash: kbttqqcqy44k7qdfsxzockfufy
     path: patches/rrweb@2.0.0-alpha.13.patch
 
 dependencies:
@@ -179,7 +179,7 @@ devDependencies:
     version: 5.12.0(rollup@4.9.6)
   rrweb:
     specifier: 2.0.0-alpha.13
-    version: 2.0.0-alpha.13(patch_hash=noym65kmmvv7gbw7gn7uz3wq3m)
+    version: 2.0.0-alpha.13(patch_hash=kbttqqcqy44k7qdfsxzockfufy)
   rrweb-snapshot:
     specifier: 2.0.0-alpha.13
     version: 2.0.0-alpha.13
@@ -9216,7 +9216,7 @@ packages:
     resolution: {integrity: sha512-slbhNBCYjxLGCeH95a67ECCy5a22nloXp1F5wF7DCzUNw80FN7tF9Lef1sRGLNo32g3mNqTc2sWLATlKejMxYw==}
     dev: true
 
-  /rrweb@2.0.0-alpha.13(patch_hash=noym65kmmvv7gbw7gn7uz3wq3m):
+  /rrweb@2.0.0-alpha.13(patch_hash=kbttqqcqy44k7qdfsxzockfufy):
     resolution: {integrity: sha512-a8GXOCnzWHNaVZPa7hsrLZtNZ3CGjiL+YrkpLo0TfmxGLhjNZbWY2r7pE06p+FcjFNlgUVTmFrSJbK3kO7yxvw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.13


### PR DESCRIPTION
## Changes

The problem with patches... we don't have typing.

I referenced the wrong variable in [this PR](https://github.com/PostHog/posthog-js/pull/1208) which is causing an issue in production