### PR TITLE
chore(surveys): refactor survey popup (vol. 1)

### DIFF
--- a/playground/vite-surveys/src/list.tsx
+++ b/playground/vite-surveys/src/list.tsx
@@ -1,4 +1,4 @@
-import { Surveys } from '../../../src/extensions/surveys'
+import { SurveyPopup } from '../../../src/extensions/surveys'
 import {
     BasicSurveyQuestion,
     RatingSurveyQuestion,
@@ -166,7 +166,7 @@ export function List() {
         <div style={{ width: '100%', paddingLeft: '40px', paddingRight: '40px', display: 'flex', flexWrap: 'wrap' }}>
             {surveys.map((survey) => (
                 <div style={{ width: '33%', paddingTop: '40px' }}>
-                    <Surveys
+                    <SurveyPopup
                         readOnly={true}
                         style={{
                             position: 'relative',

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -90,7 +90,7 @@ describe('preview renders', () => {
         }
         const surveyDiv = document.createElement('div')
         expect(surveyDiv.innerHTML).toBe('')
-        renderSurveysPreview(mockSurvey as Survey, surveyDiv, 'survey', 0)
+        renderSurveysPreview(mockSurvey as Survey, surveyDiv, 0)
         expect(surveyDiv.getElementsByTagName('style').length).toBe(1)
         expect(surveyDiv.getElementsByClassName('survey-form').length).toBe(1)
         expect(surveyDiv.getElementsByClassName('survey-question').length).toBe(1)

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -490,8 +490,9 @@ describe('surveys', () => {
 
         it('should retain original index of question if shuffleQuestions is true', () => {
             const shuffledQuestions = getDisplayOrderQuestions(surveyWithShufflingQuestions)
+            console.log('************************************', shuffledQuestions)
             for (let i = 0; i < shuffledQuestions.length; i++) {
-                const originalQuestionIndex = shuffledQuestions[i].questionIndex
+                const originalQuestionIndex = shuffledQuestions[i].originalQuestionIndex
                 expect(shuffledQuestions[i].question).toEqual(
                     surveyWithShufflingQuestions.questions[originalQuestionIndex].question
                 )

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -172,9 +172,9 @@ export function SurveyPopup({
     // Ensure the popup stays in the same position for the preview
     if (readOnly) {
         style = style || {}
-        style.left = 'initial'
-        style.right = 'initial'
-        style.transform = 'initial'
+        style.left = 'unset'
+        style.right = 'unset'
+        style.transform = 'unset'
     }
 
     useEffect(() => {

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -96,18 +96,18 @@ export const callSurveys = (posthog: PostHog, forceReload: boolean = false) => {
     }, forceReload)
 }
 
-export const renderSurveysPreview = (survey: Survey, root: HTMLElement, previewPageIndex: number) => {
+export const renderSurveysPreview = (survey: Survey, parentElement: HTMLElement, previewPageIndex: number) => {
     const surveyStyleSheet = style(survey.appearance)
     const styleElement = Object.assign(document.createElement('style'), { innerText: surveyStyleSheet })
 
     // Remove previously attached <style>
-    Array.from(root.children).forEach((child) => {
+    Array.from(parentElement.children).forEach((child) => {
         if (child instanceof HTMLStyleElement) {
-            root.removeChild(child)
+            parentElement.removeChild(child)
         }
     })
 
-    root.appendChild(styleElement)
+    parentElement.appendChild(styleElement)
     const textColor = getContrastingTextColor(
         survey.appearance?.backgroundColor || defaultSurveyAppearance.backgroundColor || 'white'
     )
@@ -125,7 +125,7 @@ export const renderSurveysPreview = (survey: Survey, root: HTMLElement, previewP
             }}
             previewPageIndex={previewPageIndex}
         />,
-        root
+        parentElement
     )
 }
 

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -166,6 +166,16 @@ export function SurveyPopup({
 }) {
     const [isPopupVisible, setIsPopupVisible] = useState(true)
     const [isSurveySent, setIsSurveySent] = useState(false)
+    const shouldShowConfirmation = isSurveySent || previewQuestionIndex === survey.questions.length
+    const confirmationBoxLeftStyle = style?.left && isNumber(style?.left) ? { left: style.left - 40 } : {}
+
+    // Ensure the popup stays in the same position for the preview
+    if (readOnly) {
+        style = style || {}
+        style.left = 'initial'
+        style.right = 'initial'
+        style.transform = 'initial'
+    }
 
     useEffect(() => {
         if (readOnly || !posthog) {
@@ -197,9 +207,6 @@ export function SurveyPopup({
             }
         })
     }, [])
-    const confirmationBoxLeftStyle = style?.left && isNumber(style?.left) ? { left: style.left - 40 } : {}
-
-    const shouldShowConfirmation = isSurveySent || previewQuestionIndex === survey.questions.length
 
     return isPopupVisible ? (
         <SurveyContext.Provider

--- a/src/extensions/surveys/components/BottomSection.tsx
+++ b/src/extensions/surveys/components/BottomSection.tsx
@@ -24,18 +24,18 @@ export function BottomSection({
     onSubmit: () => void
     link?: string | null
 }) {
-    const { readOnly } = useContext(SurveyContext)
+    const { isPreviewMode } = useContext(SurveyContext)
     const textColor = getContrastingTextColor(appearance.submitButtonColor || defaultSurveyAppearance.submitButtonColor)
     return (
         <div className="bottom-section">
             <div className="buttons">
                 <button
                     className="form-submit"
-                    disabled={submitDisabled && !readOnly}
+                    disabled={submitDisabled && !isPreviewMode}
                     type="button"
                     style={{ color: textColor }}
                     onClick={() => {
-                        if (readOnly) return
+                        if (isPreviewMode) return
                         if (link) {
                             window?.open(link)
                         }

--- a/src/extensions/surveys/components/ConfirmationMessage.tsx
+++ b/src/extensions/surveys/components/ConfirmationMessage.tsx
@@ -4,14 +4,14 @@ import { SurveyAppearance } from '../../../posthog-surveys-types'
 import { defaultSurveyAppearance, getContrastingTextColor } from '../surveys-utils'
 
 export function ConfirmationMessage({
-    confirmationHeader,
-    confirmationDescription,
+    header,
+    description,
     appearance,
     onClose,
     styleOverrides,
 }: {
-    confirmationHeader: string
-    confirmationDescription: string
+    header: string
+    description: string
     appearance: SurveyAppearance
     onClose: () => void
     styleOverrides?: React.CSSProperties
@@ -24,13 +24,13 @@ export function ConfirmationMessage({
                 <div className="thank-you-message-container">
                     <Cancel onClick={() => onClose()} />
                     <h3 className="thank-you-message-header" style={{ color: textColor }}>
-                        {confirmationHeader}
+                        {header}
                     </h3>
-                    {confirmationDescription && (
+                    {description && (
                         <div
                             style={{ color: textColor }}
                             className="thank-you-message-body"
-                            dangerouslySetInnerHTML={{ __html: confirmationDescription }}
+                            dangerouslySetInnerHTML={{ __html: description }}
                         />
                     )}
                     <BottomSection

--- a/src/extensions/surveys/components/QuestionHeader.tsx
+++ b/src/extensions/surveys/components/QuestionHeader.tsx
@@ -20,11 +20,11 @@ export function QuestionHeader({
 }
 
 export function Cancel({ onClick }: { onClick: () => void }) {
-    const { readOnly } = useContext(SurveyContext)
+    const { isPreviewMode } = useContext(SurveyContext)
 
     return (
         <div className="cancel-btn-wrapper">
-            <button className="form-cancel" onClick={onClick} disabled={readOnly}>
+            <button className="form-cancel" onClick={onClick} disabled={isPreviewMode}>
                 {cancelSVG}
             </button>
         </div>

--- a/src/extensions/surveys/components/QuestionTypes.tsx
+++ b/src/extensions/surveys/components/QuestionTypes.tsx
@@ -86,12 +86,12 @@ export function LinkQuestion({
 
 export function RatingQuestion({
     question,
-    questionIndex,
+    displayQuestionIndex,
     appearance,
     onSubmit,
 }: {
     question: RatingSurveyQuestion
-    questionIndex: number
+    displayQuestionIndex: number
     appearance: SurveyAppearance
     onSubmit: (rating: number | null) => void
 }) {
@@ -116,7 +116,7 @@ export function RatingQuestion({
                                 const active = idx + 1 === rating
                                 return (
                                     <button
-                                        className={`ratings-emoji question-${questionIndex}-rating-${idx} ${
+                                        className={`ratings-emoji question-${displayQuestionIndex}-rating-${idx} ${
                                             active ? 'rating-active' : null
                                         }`}
                                         value={idx + 1}
@@ -142,7 +142,7 @@ export function RatingQuestion({
                                 return (
                                     <RatingButton
                                         key={idx}
-                                        questionIndex={questionIndex}
+                                        displayQuestionIndex={displayQuestionIndex}
                                         active={active}
                                         appearance={appearance}
                                         num={number}
@@ -173,13 +173,13 @@ export function RatingQuestion({
 export function RatingButton({
     num,
     active,
-    questionIndex,
+    displayQuestionIndex,
     appearance,
     setActiveNumber,
 }: {
     num: number
     active: boolean
-    questionIndex: number
+    displayQuestionIndex: number
     appearance: any
     setActiveNumber: (num: number) => void
 }) {
@@ -187,7 +187,9 @@ export function RatingButton({
     return (
         <button
             ref={ref as RefObject<HTMLButtonElement>}
-            className={`ratings-number question-${questionIndex}-rating-${num} ${active ? 'rating-active' : null}`}
+            className={`ratings-number question-${displayQuestionIndex}-rating-${num} ${
+                active ? 'rating-active' : null
+            }`}
             type="button"
             onClick={() => {
                 setActiveNumber(num)
@@ -205,12 +207,12 @@ export function RatingButton({
 
 export function MultipleChoiceQuestion({
     question,
-    questionIndex,
+    displayQuestionIndex,
     appearance,
     onSubmit,
 }: {
     question: MultipleSurveyQuestion
-    questionIndex: number
+    displayQuestionIndex: number
     appearance: SurveyAppearance
     onSubmit: (choices: string | string[] | null) => void
 }) {
@@ -251,8 +253,8 @@ export function MultipleChoiceQuestion({
                         <div className={choiceClass}>
                             <input
                                 type={inputType}
-                                id={`surveyQuestion${questionIndex}Choice${idx}`}
-                                name={`question${questionIndex}`}
+                                id={`surveyQuestion${displayQuestionIndex}Choice${idx}`}
+                                name={`question${displayQuestionIndex}`}
                                 value={val}
                                 disabled={!val}
                                 onInput={() => {
@@ -276,14 +278,17 @@ export function MultipleChoiceQuestion({
                                     }
                                 }}
                             />
-                            <label htmlFor={`surveyQuestion${questionIndex}Choice${idx}`} style={{ color: 'black' }}>
+                            <label
+                                htmlFor={`surveyQuestion${displayQuestionIndex}Choice${idx}`}
+                                style={{ color: 'black' }}
+                            >
                                 {question.hasOpenChoice && idx === question.choices.length - 1 ? (
                                     <>
                                         <span>{option}:</span>
                                         <input
                                             type="text"
-                                            id={`surveyQuestion${questionIndex}Choice${idx}Open`}
-                                            name={`question${questionIndex}`}
+                                            id={`surveyQuestion${displayQuestionIndex}Choice${idx}Open`}
+                                            name={`question${displayQuestionIndex}`}
                                             onInput={(e) => {
                                                 const userValue = e.currentTarget.value
                                                 if (question.type === SurveyQuestionType.SingleChoice) {

--- a/src/extensions/surveys/components/QuestionTypes.tsx
+++ b/src/extensions/surveys/components/QuestionTypes.tsx
@@ -7,7 +7,7 @@ import {
     SurveyQuestionType,
 } from '../../../posthog-surveys-types'
 import { RefObject } from 'preact'
-import { useRef, useState, useMemo } from 'preact/hooks'
+import { useRef, useState, useMemo, useContext } from 'preact/hooks'
 import { isNull, isArray } from '../../../utils/type-utils'
 import { useContrastingTextColor } from '../hooks/useContrastingTextColor'
 import {
@@ -18,7 +18,7 @@ import {
     veryDissatisfiedEmoji,
     verySatisfiedEmoji,
 } from '../icons'
-import { defaultSurveyAppearance, getDisplayOrderChoices } from '../surveys-utils'
+import { defaultSurveyAppearance, getDisplayOrderChoices, SurveyContext } from '../surveys-utils'
 import { BottomSection } from './BottomSection'
 import { Cancel, QuestionHeader } from './QuestionHeader'
 
@@ -26,15 +26,14 @@ export function OpenTextQuestion({
     question,
     appearance,
     onSubmit,
-    closeSurveyPopup,
 }: {
     question: BasicSurveyQuestion
     appearance: SurveyAppearance
     onSubmit: (text: string) => void
-    closeSurveyPopup: () => void
 }) {
     const textRef = useRef(null)
     const [text, setText] = useState('')
+    const { handleCloseSurveyPopup } = useContext(SurveyContext)
 
     return (
         <div
@@ -42,7 +41,7 @@ export function OpenTextQuestion({
             style={{ backgroundColor: appearance.backgroundColor || defaultSurveyAppearance.backgroundColor }}
             ref={textRef}
         >
-            <Cancel onClick={() => closeSurveyPopup()} />
+            <Cancel onClick={() => handleCloseSurveyPopup()} />
             <QuestionHeader
                 question={question.question}
                 description={question.description}
@@ -63,16 +62,16 @@ export function LinkQuestion({
     question,
     appearance,
     onSubmit,
-    closeSurveyPopup,
 }: {
     question: LinkSurveyQuestion
     appearance: SurveyAppearance
     onSubmit: (clicked: string) => void
-    closeSurveyPopup: () => void
 }) {
+    const { handleCloseSurveyPopup } = useContext(SurveyContext)
+
     return (
         <div className="survey-box">
-            <Cancel onClick={() => closeSurveyPopup()} />
+            <Cancel onClick={() => handleCloseSurveyPopup()} />
             <QuestionHeader question={question.question} description={question.description} />
             <BottomSection
                 text={question.buttonText || 'Submit'}
@@ -90,21 +89,20 @@ export function RatingQuestion({
     questionIndex,
     appearance,
     onSubmit,
-    closeSurveyPopup,
 }: {
     question: RatingSurveyQuestion
     questionIndex: number
     appearance: SurveyAppearance
     onSubmit: (rating: number | null) => void
-    closeSurveyPopup: () => void
 }) {
     const scale = question.scale
     const starting = question.scale === 10 ? 0 : 1
     const [rating, setRating] = useState<number | null>(null)
+    const { handleCloseSurveyPopup } = useContext(SurveyContext)
 
     return (
         <div className="survey-box">
-            <Cancel onClick={() => closeSurveyPopup()} />
+            <Cancel onClick={() => handleCloseSurveyPopup()} />
             <QuestionHeader
                 question={question.question}
                 description={question.description}
@@ -210,13 +208,11 @@ export function MultipleChoiceQuestion({
     questionIndex,
     appearance,
     onSubmit,
-    closeSurveyPopup,
 }: {
     question: MultipleSurveyQuestion
     questionIndex: number
     appearance: SurveyAppearance
     onSubmit: (choices: string | string[] | null) => void
-    closeSurveyPopup: () => void
 }) {
     const textRef = useRef(null)
     const choices = useMemo(() => getDisplayOrderChoices(question), [question])
@@ -225,6 +221,7 @@ export function MultipleChoiceQuestion({
     )
     const [openChoiceSelected, setOpenChoiceSelected] = useState(false)
     const [openEndedInput, setOpenEndedInput] = useState('')
+    const { handleCloseSurveyPopup } = useContext(SurveyContext)
 
     const inputType = question.type === SurveyQuestionType.SingleChoice ? 'radio' : 'checkbox'
     return (
@@ -233,7 +230,7 @@ export function MultipleChoiceQuestion({
             style={{ backgroundColor: appearance.backgroundColor || defaultSurveyAppearance.backgroundColor }}
             ref={textRef}
         >
-            <Cancel onClick={() => closeSurveyPopup()} />
+            <Cancel onClick={() => handleCloseSurveyPopup()} />
             <QuestionHeader
                 question={question.question}
                 description={question.description}

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -605,10 +605,10 @@ export const getDisplayOrderQuestions = (survey: Survey): SurveyQuestion[] => {
 
 export const SurveyContext = createContext<{
     readOnly: boolean
-    previewQuestionIndex: number
-    textColor: string
+    previewQuestionIndex: number | undefined
+    handleCloseSurveyPopup: () => void
 }>({
     readOnly: false,
     previewQuestionIndex: 0,
-    textColor: 'black',
+    handleCloseSurveyPopup: () => {},
 })

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -591,14 +591,14 @@ export const getDisplayOrderChoices = (question: MultipleSurveyQuestion): string
 }
 
 export const getDisplayOrderQuestions = (survey: Survey): SurveyQuestion[] => {
+    // retain the original questionIndex so we can correlate values in the webapp
+    survey.questions.forEach((question, idx) => {
+        question.originalQuestionIndex = idx
+    })
+
     if (!survey.appearance || !survey.appearance.shuffleQuestions) {
         return survey.questions
     }
-
-    // retain the original questionIndex so we can correlate values in the webapp
-    survey.questions.forEach((element, idx) => {
-        element.questionIndex = idx
-    })
 
     return shuffle(survey.questions)
 }

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -604,11 +604,11 @@ export const getDisplayOrderQuestions = (survey: Survey): SurveyQuestion[] => {
 }
 
 export const SurveyContext = createContext<{
-    readOnly: boolean
-    previewQuestionIndex: number | undefined
+    isPreviewMode: boolean
+    previewPageIndex: number | undefined
     handleCloseSurveyPopup: () => void
 }>({
-    readOnly: false,
-    previewQuestionIndex: 0,
+    isPreviewMode: false,
+    previewPageIndex: 0,
     handleCloseSurveyPopup: () => {},
 })

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -48,7 +48,7 @@ interface SurveyQuestionBase {
     description?: string | null
     optional?: boolean
     buttonText?: string
-    questionIndex?: number
+    originalQuestionIndex: number
 }
 
 export interface BasicSurveyQuestion extends SurveyQuestionBase {


### PR DESCRIPTION
## Changes
_Needs to go in with https://github.com/PostHog/posthog/pull/22617_

- Remove any previously attached `<style>` tags - previously, a new tag was attached on any re-render, bloating the HTML and leading to some CSS issues
- Simplify local state for displaying/hiding the popup and showing questions vs confirmation
- Make sure the popup stays in place when left/center/right properties are changed
- Clean up SurveyContext: remove some unused fields of the state + add relevant fields
- Render `<ConfirmationMessage />` in a single code path and outside `<Questions />`
- Simplify the factory method for returning a survey question for rendering (`questionTypeMap` -> `getQuestionComponent`)
- Rename `previewQuestionIndex` to `previewPageIndex`, since the indexing also applies to the confirmation message, which is not a question
- Bunch of other naming changes for improved clarity

Notes:
- More refactoring might be needed on the individual questions level, but this should be enough to start with the branching logic.
- After this is reviewed, I want to split some code into individual files. For now I'm keeping it as-is for an easier review.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
