### PR TITLE
fix: do not start recording buffer without id

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -129,8 +129,8 @@ export class SessionRecording {
 
     private _linkedFlagSeen: boolean = false
     private _lastActivityTimestamp: number = Date.now()
-    private windowId: string | null = null
-    private sessionId: string | null = null
+    private windowId: string
+    private sessionId: string
     private _linkedFlag: string | FlagVariant | null = null
 
     private _fullSnapshotTimer?: ReturnType<typeof setInterval>


### PR DESCRIPTION
Things used to start undefined, and they do so much less now

As an effect of that, we start session recording with an absent session and window id

This makes [a persistent buffer](https://github.com/PostHog/posthog-js/issues/1099) hard to make since we have no reproducible key

We always have a session manager when we start now, so we can always start with an id

This is mostly tricky in tests, because we have a mock rrweb and then fake around the behavior of snapshots on initialisation