### PR TITLE
chore: very slightly smaller bundle

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,7 @@ const plugins = [
         babelHelpers: 'bundled',
         presets: ['@babel/preset-env'],
     }),
-    terser({ toplevel: true }),
+    terser({ toplevel: true, compress: { passes: 3 } }),
     visualizer(),
 ]
 


### PR DESCRIPTION
reading through the terser docs we can tell terser to do more than one pass over modification

3 passes is ~1kb smaller (2 passes and >3 didn't make a difference)

not going to change the world but less is less