### PR TITLE
feat: add an explicit in-memory buffer

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -351,7 +351,7 @@ describe('SessionRecording', () => {
 
             sessionRecording.afterDecideResponse(makeDecideResponse({ sessionRecording: undefined }))
             expect(sessionRecording['status']).toBe('disabled')
-            expect(sessionRecording['buffer']?.data.length).toEqual(undefined)
+            expect(sessionRecording['buffer'].data.length).toEqual(0)
             expect(posthog.capture).not.toHaveBeenCalled()
         })
 
@@ -624,7 +624,7 @@ describe('SessionRecording', () => {
 
             // access private method 🤯so we don't need to wait for the timer
             sessionRecording['_flushBuffer']()
-            expect(sessionRecording['buffer']?.data.length).toEqual(undefined)
+            expect(sessionRecording['buffer'].data.length).toEqual(0)
 
             expect(posthog.capture).toHaveBeenCalledTimes(1)
             expect(posthog.capture).toHaveBeenCalledWith(
@@ -700,7 +700,7 @@ describe('SessionRecording', () => {
             // Another big event means the old data will be flushed
             _emit(createIncrementalSnapshot({ data: { source: 1, payload: bigData } }))
             expect(posthog.capture).toHaveBeenCalled()
-            expect(sessionRecording['buffer']?.data.length).toEqual(1) // The new event
+            expect(sessionRecording['buffer'].data.length).toEqual(1) // The new event
             expect(sessionRecording['buffer']).toMatchObject({ size: 755017 })
         })
 
@@ -712,7 +712,7 @@ describe('SessionRecording', () => {
 
             _emit(createIncrementalSnapshot({ data: { source: 1, payload: bigData } }))
             expect(sessionRecording['buffer']).toMatchObject({ size: 755037 }) // the size of the big data event
-            expect(sessionRecording['buffer']?.data.length).toEqual(2) // full snapshot and a big event
+            expect(sessionRecording['buffer'].data.length).toEqual(2) // full snapshot and a big event
 
             _emit(createIncrementalSnapshot({ data: { source: 1, payload: 1 } }))
             _emit(createIncrementalSnapshot({ data: { source: 1, payload: 2 } }))
@@ -725,7 +725,7 @@ describe('SessionRecording', () => {
             // but the recording is still buffering
             expect(sessionRecording['status']).toBe('buffering')
             expect(posthog.capture).not.toHaveBeenCalled()
-            expect(sessionRecording['buffer']?.data.length).toEqual(5) // + the new event
+            expect(sessionRecording['buffer'].data.length).toEqual(5) // + the new event
             expect(sessionRecording['buffer']).toMatchObject({ size: 755037 + 755101 }) // the size of the big data event
         })
 
@@ -733,13 +733,13 @@ describe('SessionRecording', () => {
             sessionRecording.afterDecideResponse(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
             sessionRecording.startIfEnabledOrStop()
 
-            expect(sessionRecording['buffer']?.sessionId).toEqual(sessionId)
+            expect(sessionRecording['buffer'].sessionId).toEqual(sessionId)
 
             _emit(createIncrementalSnapshot({ emit: 1 }))
 
             expect(posthog.capture).not.toHaveBeenCalled()
-            expect(sessionRecording['buffer']?.sessionId).not.toEqual(null)
-            expect(sessionRecording['buffer']?.data).toEqual([
+            expect(sessionRecording['buffer'].sessionId).not.toEqual(null)
+            expect(sessionRecording['buffer'].data).toEqual([
                 createFullSnapshot(),
                 { data: { source: 1 }, emit: 1, type: 3 },
             ])
@@ -1524,7 +1524,7 @@ describe('SessionRecording', () => {
             expect(sessionRecording['sessionDuration']).toBe(100)
             expect(sessionRecording['minimumDuration']).toBe(1500)
 
-            expect(sessionRecording['buffer']?.data.length).toBe(2) // full snapshot and the emitted incremental event
+            expect(sessionRecording['buffer'].data.length).toBe(2) // full snapshot and the emitted incremental event
             // call the private method to avoid waiting for the timer
             sessionRecording['_flushBuffer']()
 
@@ -1549,7 +1549,7 @@ describe('SessionRecording', () => {
             expect(sessionRecording['sessionDuration']).toBe(-1000)
             expect(sessionRecording['minimumDuration']).toBe(1500)
 
-            expect(sessionRecording['buffer']?.data.length).toBe(2) // full snapshot and the emitted incremental event
+            expect(sessionRecording['buffer'].data.length).toBe(2) // full snapshot and the emitted incremental event
             // call the private method to avoid waiting for the timer
             sessionRecording['_flushBuffer']()
 
@@ -1569,7 +1569,7 @@ describe('SessionRecording', () => {
             expect(sessionRecording['sessionDuration']).toBe(100)
             expect(sessionRecording['minimumDuration']).toBe(1500)
 
-            expect(sessionRecording['buffer']?.data.length).toBe(2) // full snapshot and the emitted incremental event
+            expect(sessionRecording['buffer'].data.length).toBe(2) // full snapshot and the emitted incremental event
             // call the private method to avoid waiting for the timer
             sessionRecording['_flushBuffer']()
 
@@ -1577,21 +1577,21 @@ describe('SessionRecording', () => {
 
             _emit(createIncrementalSnapshot({ data: { source: 1 }, timestamp: sessionStartTimestamp + 1501 }))
 
-            expect(sessionRecording['buffer']?.data.length).toBe(3) // full snapshot and two emitted incremental events
+            expect(sessionRecording['buffer'].data.length).toBe(3) // full snapshot and two emitted incremental events
             // call the private method to avoid waiting for the timer
             sessionRecording['_flushBuffer']()
 
             expect(posthog.capture).toHaveBeenCalled()
-            expect(sessionRecording['buffer']?.data.length).toBe(undefined)
+            expect(sessionRecording['buffer'].data.length).toBe(0)
             expect(sessionRecording['sessionDuration']).toBe(null)
             _emit(createIncrementalSnapshot({ data: { source: 1 }, timestamp: sessionStartTimestamp + 1502 }))
-            expect(sessionRecording['buffer']?.data.length).toBe(1)
+            expect(sessionRecording['buffer'].data.length).toBe(1)
             expect(sessionRecording['sessionDuration']).toBe(1502)
             // call the private method to avoid waiting for the timer
             sessionRecording['_flushBuffer']()
 
             expect(posthog.capture).toHaveBeenCalled()
-            expect(sessionRecording['buffer']?.data.length).toBe(undefined)
+            expect(sessionRecording['buffer'].data.length).toBe(0)
         })
     })
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -92,10 +92,10 @@ type SessionRecordingStatus = 'disabled' | 'sampled' | 'active' | 'buffering'
 interface SnapshotBuffer {
     size: number
     data: any[]
-    sessionId: string | null
-    windowId: string | null
+    sessionId: string
+    windowId: string
 
-    readonly mostRecentSnapshot: any
+    readonly mostRecentSnapshotTimestamp: number | null
     add(properties: Properties): void
 }
 
@@ -105,8 +105,8 @@ class InMemoryBuffer implements SnapshotBuffer {
     sessionId: string
     windowId: string
 
-    get mostRecentSnapshot(): any | null {
-        return this.data.length > 0 ? this.data[this.data.length - 1] : null
+    get mostRecentSnapshotTimestamp(): number | null {
+        return this.data.length ? this.data[this.data.length - 1].timestamp : null
     }
 
     constructor(sessionId: string, windowId: string) {
@@ -191,9 +191,9 @@ export class SessionRecording {
     }
 
     private get sessionDuration(): number | null {
-        const mostRecentSnapshot = this.buffer?.data[this.buffer?.data.length - 1]
+        const mostRecentSnapshotTimestamp = this.buffer.mostRecentSnapshotTimestamp
         const { sessionStartTimestamp } = this.sessionManager.checkAndGetSessionAndWindowId(true)
-        return mostRecentSnapshot ? mostRecentSnapshot.timestamp - sessionStartTimestamp : null
+        return mostRecentSnapshotTimestamp ? mostRecentSnapshotTimestamp - sessionStartTimestamp : null
     }
 
     private get isRecordingEnabled() {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -309,7 +309,7 @@ export class SessionRecording {
         this.sessionId = sessionId
         this.windowId = windowId
 
-        this.buffer = this.clearBuffer()
+        this.clearBuffer()
 
         // on reload there might be an already sampled session that should be continued before decide response,
         // so we call this here _and_ in the decide response
@@ -874,13 +874,7 @@ export class SessionRecording {
         return this.buffer
     }
 
-    // the intention is a buffer that (currently) is used only after a decide response enables session recording
-    // it is called ever X seconds using the flushBufferTimer so that we don't have to wait for the buffer to fill up
-    // when it is called on a timer it assumes that it can definitely flush
-    // it is flushed when the session id changes or the size of the buffered data gets too great (1mb by default)
-    // first change: if the recording is in buffering mode,
-    //  flush buffer simply resets the timer and returns the existing flush buffer
-    private _flushBuffer() {
+    private _flushBuffer(): void {
         if (this.flushBufferTimer) {
             clearTimeout(this.flushBufferTimer)
             this.flushBufferTimer = undefined
@@ -898,7 +892,7 @@ export class SessionRecording {
             this.flushBufferTimer = setTimeout(() => {
                 this._flushBuffer()
             }, RECORDING_BUFFER_TIMEOUT)
-            return this.buffer || this.clearBuffer()
+            return
         }
 
         if (this.buffer.data.length > 0) {
@@ -909,9 +903,7 @@ export class SessionRecording {
                 $window_id: this.buffer.windowId,
             })
 
-            return this.clearBuffer()
-        } else {
-            return this.buffer || this.clearBuffer()
+            this.clearBuffer()
         }
     }
 
@@ -921,7 +913,7 @@ export class SessionRecording {
             this.buffer.size + properties.$snapshot_bytes + additionalBytes > RECORDING_MAX_EVENT_SIZE ||
             this.buffer.sessionId !== this.sessionId
         ) {
-            this.buffer = this._flushBuffer()
+            this._flushBuffer()
         }
 
         this.buffer.add(properties)

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -891,6 +891,7 @@ export class SessionRecording {
             this.flushBufferTimer = setTimeout(() => {
                 this._flushBuffer()
             }, RECORDING_BUFFER_TIMEOUT)
+
             return
         }
 
@@ -901,9 +902,8 @@ export class SessionRecording {
                 $session_id: this.buffer.sessionId,
                 $window_id: this.buffer.windowId,
             })
-
-            this.clearBuffer()
         }
+        this.clearBuffer()
     }
 
     private _captureSnapshotBuffered(properties: Properties) {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -178,7 +178,6 @@ export class SessionRecording {
 
     private get sessionManager() {
         if (!this.instance.sessionManager) {
-            logger.error(LOGGER_PREFIX + ' started without valid sessionManager')
             throw new Error(LOGGER_PREFIX + ' started without valid sessionManager. This is a bug.')
         }
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -309,7 +309,7 @@ export class SessionRecording {
         this.sessionId = sessionId
         this.windowId = windowId
 
-        this.clearBuffer()
+        this.buffer = new InMemoryBuffer(this.sessionId, this.windowId)
 
         // on reload there might be an already sampled session that should be continued before decide response,
         // so we call this here _and_ in the decide response

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -869,9 +869,8 @@ export class SessionRecording {
         return url
     }
 
-    private clearBuffer(): SnapshotBuffer {
+    private clearBuffer(): void {
         this.buffer = new InMemoryBuffer(this.sessionId, this.windowId)
-        return this.buffer
     }
 
     private _flushBuffer(): void {


### PR DESCRIPTION
* stacked on top of: https://github.com/PostHog/posthog-js/pull/1215
* towards: https://github.com/PostHog/posthog-js/issues/1099

if someone has persistence set to memory only then we don't want to use local storage for replay
as a step towards a persistent queue for replay this moves buffering into an explicit in-memory buffer
clarifying the interface so that we can then add a persistent storage buffer