### PR TITLE
feat: allow not operators in survey url targeting

### DIFF
--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -258,7 +258,7 @@ describe('surveys', () => {
             questions: [
                 { type: SurveyQuestionType.Open, question: 'what is a survey with url does not contain exact?' },
             ],
-            conditions: { url: 'https://example.com/exact', urlMatchType: 'not_exact' },
+            conditions: { url: 'https://example.com/exact', urlMatchType: 'is_not' },
             start_date: new Date().toISOString(),
             end_date: null,
         } as unknown as Survey

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -251,13 +251,11 @@ describe('surveys', () => {
             start_date: new Date().toISOString(),
             end_date: null,
         } as unknown as Survey
-        const surveyWithUrlNotExact: Survey = {
-            name: 'survey with url does not contain exact',
-            description: 'survey with url does not contain exact description',
+        const surveyWithIsNotUrlMatch: Survey = {
+            name: 'survey with is not url match',
+            description: 'survey with is not url match description',
             type: SurveyType.Popover,
-            questions: [
-                { type: SurveyQuestionType.Open, question: 'what is a survey with url does not contain exact?' },
-            ],
+            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with is not url match?' }],
             conditions: { url: 'https://example.com/exact', urlMatchType: 'is_not' },
             start_date: new Date().toISOString(),
             end_date: null,
@@ -432,14 +430,14 @@ describe('surveys', () => {
 
         it('returns surveys based on exclusion conditions', () => {
             surveysResponse = {
-                surveys: [surveyWithUrlDoesNotContain, surveyWithUrlNotExact, surveyWithUrlDoesNotContainRegex],
+                surveys: [surveyWithUrlDoesNotContain, surveyWithIsNotUrlMatch, surveyWithUrlDoesNotContainRegex],
             }
 
             // eslint-disable-next-line compat/compat
             assignableWindow.location = new URL('https://posthog.com') as unknown as Location
             surveys.getActiveMatchingSurveys((data) => {
-                // returns surveyWithUrlNotExact and surveyWithUrlDoesNotContainRegex because they don't contain posthog.com
-                expect(data).toEqual([surveyWithUrlNotExact, surveyWithUrlDoesNotContainRegex])
+                // returns surveyWithIsNotUrlMatch and surveyWithUrlDoesNotContainRegex because they don't contain posthog.com
+                expect(data).toEqual([surveyWithIsNotUrlMatch, surveyWithUrlDoesNotContainRegex])
             })
             assignableWindow.location = originalWindowLocation
 
@@ -454,8 +452,8 @@ describe('surveys', () => {
             // eslint-disable-next-line compat/compat
             assignableWindow.location = new URL('https://regex-url.com/test') as unknown as Location
             surveys.getActiveMatchingSurveys((data) => {
-                // returns surveyWithUrlDoesNotContain and surveyWithUrlNotExact because they are not regex matches
-                expect(data).toEqual([surveyWithUrlDoesNotContain, surveyWithUrlNotExact])
+                // returns surveyWithUrlDoesNotContain and surveyWithIsNotUrlMatch because they are not regex matches
+                expect(data).toEqual([surveyWithUrlDoesNotContain, surveyWithIsNotUrlMatch])
             })
             assignableWindow.location = originalWindowLocation
         })

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -204,6 +204,17 @@ describe('surveys', () => {
             start_date: new Date().toISOString(),
             end_date: null,
         } as unknown as Survey
+        const surveyWithUrlDoesNotContainRegex: Survey = {
+            name: 'survey with url does not contain regex',
+            description: 'survey with url does not contain regex description',
+            type: SurveyType.Popover,
+            questions: [
+                { type: SurveyQuestionType.Open, question: 'what is a survey with url does not contain regex?' },
+            ],
+            conditions: { url: 'regex-url', urlMatchType: 'not_regex' },
+            start_date: new Date().toISOString(),
+            end_date: null,
+        } as unknown as Survey
         const surveyWithParamRegexUrl: Survey = {
             name: 'survey with param regex url',
             description: 'survey with param regex url description',
@@ -237,6 +248,26 @@ describe('surveys', () => {
             type: SurveyType.Popover,
             questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with wildcard route url?' }],
             conditions: { url: 'https://example.com/exact', urlMatchType: 'exact' },
+            start_date: new Date().toISOString(),
+            end_date: null,
+        } as unknown as Survey
+        const surveyWithUrlNotExact: Survey = {
+            name: 'survey with url does not contain exact',
+            description: 'survey with url does not contain exact description',
+            type: SurveyType.Popover,
+            questions: [
+                { type: SurveyQuestionType.Open, question: 'what is a survey with url does not contain exact?' },
+            ],
+            conditions: { url: 'https://example.com/exact', urlMatchType: 'not_exact' },
+            start_date: new Date().toISOString(),
+            end_date: null,
+        } as unknown as Survey
+        const surveyWithUrlDoesNotContain: Survey = {
+            name: 'survey with url does not contain',
+            description: 'survey with url does not contain description',
+            type: SurveyType.Popover,
+            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with url does not contain?' }],
+            conditions: { url: 'posthog.com', urlMatchType: 'not_icontains' },
             start_date: new Date().toISOString(),
             end_date: null,
         } as unknown as Survey
@@ -395,6 +426,36 @@ describe('surveys', () => {
             assignableWindow.location = new URL('https://example.com/exact') as unknown as Location
             surveys.getActiveMatchingSurveys((data) => {
                 expect(data).toEqual([surveyWithExactUrlMatch])
+            })
+            assignableWindow.location = originalWindowLocation
+        })
+
+        it('returns surveys that based on exclusion conditions', () => {
+            surveysResponse = {
+                surveys: [surveyWithUrlDoesNotContain, surveyWithUrlNotExact, surveyWithUrlDoesNotContainRegex],
+            }
+
+            // eslint-disable-next-line compat/compat
+            assignableWindow.location = new URL('https://posthog.com') as unknown as Location
+            surveys.getActiveMatchingSurveys((data) => {
+                // returns surveyWithUrlNotExact and surveyWithUrlDoesNotContainRegex because they don't contain posthog.com
+                expect(data).toEqual([surveyWithUrlNotExact, surveyWithUrlDoesNotContainRegex])
+            })
+            assignableWindow.location = originalWindowLocation
+
+            // eslint-disable-next-line compat/compat
+            assignableWindow.location = new URL('https://example.com/exact') as unknown as Location
+            surveys.getActiveMatchingSurveys((data) => {
+                // returns surveyWithUrlDoesNotContain and surveyWithUrlDoesNotContainRegex because they are not exact matches
+                expect(data).toEqual([surveyWithUrlDoesNotContain, surveyWithUrlDoesNotContainRegex])
+            })
+            assignableWindow.location = originalWindowLocation
+
+            // eslint-disable-next-line compat/compat
+            assignableWindow.location = new URL('https://regex-url.com/test') as unknown as Location
+            surveys.getActiveMatchingSurveys((data) => {
+                // returns surveyWithUrlDoesNotContain and surveyWithUrlNotExact because they are not regex matches
+                expect(data).toEqual([surveyWithUrlDoesNotContain, surveyWithUrlNotExact])
             })
             assignableWindow.location = originalWindowLocation
         })

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -430,7 +430,7 @@ describe('surveys', () => {
             assignableWindow.location = originalWindowLocation
         })
 
-        it('returns surveys that based on exclusion conditions', () => {
+        it('returns surveys based on exclusion conditions', () => {
             surveysResponse = {
                 surveys: [surveyWithUrlDoesNotContain, surveyWithUrlNotExact, surveyWithUrlDoesNotContainRegex],
             }

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -89,7 +89,7 @@ export interface SurveyResponse {
 
 export type SurveyCallback = (surveys: Survey[]) => void
 
-export type SurveyUrlMatchType = 'regex' | 'not_regex' | 'exact' | 'not_exact' | 'icontains' | 'not_icontains'
+export type SurveyUrlMatchType = 'regex' | 'not_regex' | 'exact' | 'is_not' | 'icontains' | 'not_icontains'
 
 export interface Survey {
     // Sync this with the backend's SurveyAPISerializer!

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -89,7 +89,7 @@ export interface SurveyResponse {
 
 export type SurveyCallback = (surveys: Survey[]) => void
 
-export type SurveyUrlMatchType = 'regex' | 'exact' | 'icontains'
+export type SurveyUrlMatchType = 'regex' | 'not_regex' | 'exact' | 'not_exact' | 'icontains' | 'not_icontains'
 
 export interface Survey {
     // Sync this with the backend's SurveyAPISerializer!

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -10,8 +10,12 @@ import { logger } from './utils/logger'
 export const surveyUrlValidationMap: Record<SurveyUrlMatchType, (conditionsUrl: string) => boolean> = {
     icontains: (conditionsUrl) =>
         !!window && window.location.href.toLowerCase().indexOf(conditionsUrl.toLowerCase()) > -1,
+    not_icontains: (conditionsUrl) =>
+        !!window && window.location.href.toLowerCase().indexOf(conditionsUrl.toLowerCase()) === -1,
     regex: (conditionsUrl) => !!window && isUrlMatchingRegex(window.location.href, conditionsUrl),
+    not_regex: (conditionsUrl) => !!window && !isUrlMatchingRegex(window.location.href, conditionsUrl),
     exact: (conditionsUrl) => window?.location.href === conditionsUrl,
+    not_exact: (conditionsUrl) => window?.location.href !== conditionsUrl,
 }
 
 export class PostHogSurveys {

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -15,7 +15,7 @@ export const surveyUrlValidationMap: Record<SurveyUrlMatchType, (conditionsUrl: 
     regex: (conditionsUrl) => !!window && isUrlMatchingRegex(window.location.href, conditionsUrl),
     not_regex: (conditionsUrl) => !!window && !isUrlMatchingRegex(window.location.href, conditionsUrl),
     exact: (conditionsUrl) => window?.location.href === conditionsUrl,
-    not_exact: (conditionsUrl) => window?.location.href !== conditionsUrl,
+    is_not: (conditionsUrl) => window?.location.href !== conditionsUrl,
 }
 
 export class PostHogSurveys {


### PR DESCRIPTION
## Changes

Part of completing [Post/posthog/#22281](https://github.com/PostHog/posthog/issues/22281)

1. Added 3 new types to posthog-surveys-types.ts ('not_regex', 'not_exact', 'not_icontains')
2. Updates surveyUrlValidationMap to handle new types
3. New tests for exclusion conditions

related to [THIS PR](https://github.com/PostHog/posthog/pull/22653)

...

I keep running into issues trying to get all the pieces for local development to play nice together. I haven't been able to see this in action for myself. No big changes here but I'd still like to try and break things if I can. I wanted to get feedback while I troubleshoot my issues.


## Checklist
- [X] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [X] Accounted for the impact of any changes across different browsers
- [X] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
