### PR TITLE
feat: add Sentry v8 integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^11.1.6",
         "@rrweb/types": "2.0.0-alpha.13",
-        "@sentry/types": "7.37.2",
+        "@sentry/types": "8.0.0",
         "@testing-library/dom": "^9.3.0",
         "@types/eslint": "^8.44.6",
         "@types/jest": "^29.5.1",

--- a/playground/sentry.html
+++ b/playground/sentry.html
@@ -1,5 +1,5 @@
 <script
-  src="https://browser.sentry-cdn.com/5.25.0/bundle.min.js"
+  src="https://browser.sentry-cdn.com/8.0.0/bundle.min.js"
   integrity="sha384-2p7fXoWSRPG49ZgmmJlTEI/01BY1LgxCNFQFiWpImAERmS/bROOQm+cJMdq/kmWS"
   crossorigin="anonymous"
 ></script>
@@ -13,7 +13,7 @@
     Sentry.init({
         dsn: 'https://9946c76f89aa406da74bd05f66030c37@o344752.ingest.sentry.io/5455536',
         integrations: [
-            new posthog.SentryIntegration(posthog, 'posthog', 5455536)
+            posthog.sentryIntegration(posthog, 'posthog', 5455536)
         ]
     });
 </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ devDependencies:
     specifier: 2.0.0-alpha.13
     version: 2.0.0-alpha.13
   '@sentry/types':
-    specifier: 7.37.2
-    version: 7.37.2
+    specifier: 8.0.0
+    version: 8.0.0
   '@testing-library/dom':
     specifier: ^9.3.0
     version: 9.3.0
@@ -2664,9 +2664,9 @@ packages:
       rrweb-snapshot: 2.0.0-alpha.13
     dev: true
 
-  /@sentry/types@7.37.2:
-    resolution: {integrity: sha512-SxKQOCX94ZaQM4C2ysNjHdJsjYapu/NYZCz1cnPyCdDvYfhwiVge1uq6ZHiQ/ARfxAAOmc3R4Mh3VvEz7WUOdw==}
-    engines: {node: '>=8'}
+  /@sentry/types@8.0.0:
+    resolution: {integrity: sha512-Dtd8dtFEq1XtdAntkguYHaL4tokzm4Aq5t0HP6Vl1P+MPImokDE1UcpKglkh0Z5aym/vF6e0qW9/CM7lAI5R/A==}
+    engines: {node: '>=14.18'}
     dev: true
 
   /@sinclair/typebox@0.25.24:

--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -6,7 +6,7 @@
  *     Sentry.init({
  *          dsn: 'https://example',
  *          integrations: [
- *              new posthog.SentryIntegration(posthog)
+ *              posthog.sentryIntegration(posthog)
  *          ]
  *     })
  *
@@ -23,8 +23,6 @@ import { PostHog } from '../posthog-core'
 
 // import {
 //     Event as _SentryEvent,
-//     EventProcessor as _SentryEventProcessor,
-//     Hub as _SentryHub,
 //     Integration as _SentryIntegration,
 //     SeverityLevel as _SeverityLevel,
 // } from '@sentry/types'
@@ -32,12 +30,10 @@ import { PostHog } from '../posthog-core'
 // Uncomment the above and comment the below to get type checking for development
 
 type _SentryEvent = any
-type _SentryEventProcessor = any
-type _SentryHub = any
 
 interface _SentryIntegration {
     name: string
-    setupOnce(addGlobalEventProcessor: (callback: _SentryEventProcessor) => void, getCurrentHub: () => _SentryHub): void
+    processEvent?(event: Event): Event
 }
 
 // levels copied from Sentry to avoid relying on a frequently changing @sentry/types dependency
@@ -54,80 +50,66 @@ interface SentryExceptionProperties {
     $sentry_url?: string
 }
 
-export class SentryIntegration implements _SentryIntegration {
-    name: string
-
-    setupOnce: (
-        addGlobalEventProcessor: (callback: _SentryEventProcessor) => void,
-        getCurrentHub: () => _SentryHub
-    ) => void
-
-    constructor(
-        _posthog: PostHog,
-        organization?: string,
-        projectId?: number,
-        prefix?: string,
-        /**
-         * By default, only errors are sent to PostHog. You can set this to '*' to send all events.
-         * Or to an error of SeverityLevel to only send events matching the provided levels.
-         * e.g. ['error', 'fatal'] to send only errors and fatals
-         * e.g. ['error'] to send only errors -- the default when omitted
-         * e.g. '*' to send all events
-         */
-        severityAllowList: _SeverityLevel[] | '*' = ['error']
-    ) {
-        // setupOnce gets called by Sentry when it intializes the plugin
-        this.name = 'posthog-js'
-        this.setupOnce = function (addGlobalEventProcessor: (callback: _SentryEventProcessor) => void) {
-            addGlobalEventProcessor((event: _SentryEvent) => {
-                const shouldProcessLevel =
-                    severityAllowList === '*' || severityAllowList.includes(event.level as _SeverityLevel)
-                if (!shouldProcessLevel || !_posthog.__loaded) return event
-                if (!event.tags) event.tags = {}
-
-                const personUrl = _posthog.requestRouter.endpointFor(
-                    'ui',
-                    `/project/${_posthog.config.token}/person/${_posthog.get_distinct_id()}`
-                )
-                event.tags['PostHog Person URL'] = personUrl
-                if (_posthog.sessionRecordingStarted()) {
-                    event.tags['PostHog Recording URL'] = _posthog.get_session_replay_url({ withTimestamp: true })
-                }
-
-                const exceptions = event.exception?.values || []
-
-                const data: SentryExceptionProperties & {
-                    // two properties added to match any exception auto-capture
-                    // added manually to avoid any dependency on the lazily loaded content
-                    $exception_message: any
-                    $exception_type: any
-                    $exception_personURL: string
-                    $level: _SeverityLevel
-                } = {
-                    // PostHog Exception Properties,
-                    $exception_message: exceptions[0]?.value || event.message,
-                    $exception_type: exceptions[0]?.type,
-                    $exception_personURL: personUrl,
-                    // Sentry Exception Properties
-                    $sentry_event_id: event.event_id,
-                    $sentry_exception: event.exception,
-                    $sentry_exception_message: exceptions[0]?.value || event.message,
-                    $sentry_exception_type: exceptions[0]?.type,
-                    $sentry_tags: event.tags,
-                    $level: event.level,
-                }
-
-                if (organization && projectId)
-                    data['$sentry_url'] =
-                        (prefix || 'https://sentry.io/organizations/') +
-                        organization +
-                        '/issues/?project=' +
-                        projectId +
-                        '&query=' +
-                        event.event_id
-                _posthog.capture('$exception', data)
-                return event
-            })
-        }
+export function sentryIntegration(
+    _posthog: PostHog,
+    organization?: string,
+    projectId?: number,
+    prefix?: string,
+    /**
+     * By default, only errors are sent to PostHog. You can set this to '*' to send all events.
+     * Or to an error of SeverityLevel to only send events matching the provided levels.
+     * e.g. ['error', 'fatal'] to send only errors and fatals
+     * e.g. ['error'] to send only errors -- the default when omitted
+     * e.g. '*' to send all events
+     */
+    severityAllowList: _SeverityLevel[] | '*' = ['error']
+): _SentryIntegration {
+    return {
+        name: 'posthog-js',
+        processEvent(event: _SentryEvent) {
+            const shouldProcessLevel =
+                severityAllowList === '*' || severityAllowList.includes(event.level as _SeverityLevel)
+            if (!shouldProcessLevel || !_posthog.__loaded) return event
+            if (!event.tags) event.tags = {}
+            const personUrl = _posthog.requestRouter.endpointFor(
+                'ui',
+                `/project/${_posthog.config.token}/person/${_posthog.get_distinct_id()}`
+            )
+            event.tags['PostHog Person URL'] = personUrl
+            if (_posthog.sessionRecordingStarted()) {
+                event.tags['PostHog Recording URL'] = _posthog.get_session_replay_url({ withTimestamp: true })
+            }
+            const exceptions = event.exception?.values || []
+            const data: SentryExceptionProperties & {
+                // two properties added to match any exception auto-capture
+                // added manually to avoid any dependency on the lazily loaded content
+                $exception_message: any
+                $exception_type: any
+                $exception_personURL: string
+                $level: _SeverityLevel
+            } = {
+                // PostHog Exception Properties,
+                $exception_message: exceptions[0]?.value || event.message,
+                $exception_type: exceptions[0]?.type,
+                $exception_personURL: personUrl,
+                // Sentry Exception Properties
+                $sentry_event_id: event.event_id,
+                $sentry_exception: event.exception,
+                $sentry_exception_message: exceptions[0]?.value || event.message,
+                $sentry_exception_type: exceptions[0]?.type,
+                $sentry_tags: event.tags,
+                $level: event.level,
+            }
+            if (organization && projectId)
+                data['$sentry_url'] =
+                    (prefix || 'https://sentry.io/organizations/') +
+                    organization +
+                    '/issues/?project=' +
+                    projectId +
+                    '&query=' +
+                    event.event_id
+            _posthog.capture('$exception', data)
+            return event
+        },
     }
 }

--- a/src/extensions/sentry-v7-integration.ts
+++ b/src/extensions/sentry-v7-integration.ts
@@ -1,0 +1,133 @@
+/**
+ * Integrate Sentry with PostHog. This will add a direct link to the person in Sentry, and an $exception event in PostHog
+ *
+ * ### Usage
+ *
+ *     Sentry.init({
+ *          dsn: 'https://example',
+ *          integrations: [
+ *              new posthog.SentryIntegration(posthog)
+ *          ]
+ *     })
+ *
+ * @param {Object} [posthog] The posthog object
+ * @param {string} [organization] Optional: The Sentry organization, used to send a direct link from PostHog to Sentry
+ * @param {Number} [projectId] Optional: The Sentry project id, used to send a direct link from PostHog to Sentry
+ * @param {string} [prefix] Optional: Url of a self-hosted sentry instance (default: https://sentry.io/organizations/)
+ */
+
+import { PostHog } from '../posthog-core'
+
+// NOTE - we can't import from @sentry/types because it changes frequently and causes clashes
+// We only use a small subset of the types, so we can just define the integration overall and use any for the rest
+
+// import {
+//     Event as _SentryEvent,
+//     EventProcessor as _SentryEventProcessor,
+//     Hub as _SentryHub,
+//     Integration as _SentryIntegration,
+//     SeverityLevel as _SeverityLevel,
+// } from '@sentry/types'
+
+// Uncomment the above and comment the below to get type checking for development
+
+type _SentryEvent = any
+type _SentryEventProcessor = any
+type _SentryHub = any
+
+interface _SentryIntegration {
+    name: string
+    setupOnce(addGlobalEventProcessor: (callback: _SentryEventProcessor) => void, getCurrentHub: () => _SentryHub): void
+}
+
+// levels copied from Sentry to avoid relying on a frequently changing @sentry/types dependency
+// but provided as an array of literal types, so we can constrain the level below
+const severityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug'] as const
+declare type _SeverityLevel = typeof severityLevels[number]
+
+interface SentryExceptionProperties {
+    $sentry_event_id: any
+    $sentry_exception: any
+    $sentry_exception_message: any
+    $sentry_exception_type: any
+    $sentry_tags: any
+    $sentry_url?: string
+}
+
+export class SentryIntegration implements _SentryIntegration {
+    name: string
+
+    setupOnce: (
+        addGlobalEventProcessor: (callback: _SentryEventProcessor) => void,
+        getCurrentHub: () => _SentryHub
+    ) => void
+
+    constructor(
+        _posthog: PostHog,
+        organization?: string,
+        projectId?: number,
+        prefix?: string,
+        /**
+         * By default, only errors are sent to PostHog. You can set this to '*' to send all events.
+         * Or to an error of SeverityLevel to only send events matching the provided levels.
+         * e.g. ['error', 'fatal'] to send only errors and fatals
+         * e.g. ['error'] to send only errors -- the default when omitted
+         * e.g. '*' to send all events
+         */
+        severityAllowList: _SeverityLevel[] | '*' = ['error']
+    ) {
+        // setupOnce gets called by Sentry when it intializes the plugin
+        this.name = 'posthog-js'
+        this.setupOnce = function (addGlobalEventProcessor: (callback: _SentryEventProcessor) => void) {
+            addGlobalEventProcessor((event: _SentryEvent) => {
+                const shouldProcessLevel =
+                    severityAllowList === '*' || severityAllowList.includes(event.level as _SeverityLevel)
+                if (!shouldProcessLevel || !_posthog.__loaded) return event
+                if (!event.tags) event.tags = {}
+
+                const personUrl = _posthog.requestRouter.endpointFor(
+                    'ui',
+                    `/project/${_posthog.config.token}/person/${_posthog.get_distinct_id()}`
+                )
+                event.tags['PostHog Person URL'] = personUrl
+                if (_posthog.sessionRecordingStarted()) {
+                    event.tags['PostHog Recording URL'] = _posthog.get_session_replay_url({ withTimestamp: true })
+                }
+
+                const exceptions = event.exception?.values || []
+
+                const data: SentryExceptionProperties & {
+                    // two properties added to match any exception auto-capture
+                    // added manually to avoid any dependency on the lazily loaded content
+                    $exception_message: any
+                    $exception_type: any
+                    $exception_personURL: string
+                    $level: _SeverityLevel
+                } = {
+                    // PostHog Exception Properties,
+                    $exception_message: exceptions[0]?.value || event.message,
+                    $exception_type: exceptions[0]?.type,
+                    $exception_personURL: personUrl,
+                    // Sentry Exception Properties
+                    $sentry_event_id: event.event_id,
+                    $sentry_exception: event.exception,
+                    $sentry_exception_message: exceptions[0]?.value || event.message,
+                    $sentry_exception_type: exceptions[0]?.type,
+                    $sentry_tags: event.tags,
+                    $level: event.level,
+                }
+
+                if (organization && projectId)
+                    data['$sentry_url'] =
+                        (prefix || 'https://sentry.io/organizations/') +
+                        organization +
+                        '/issues/?project=' +
+                        projectId +
+                        '&query=' +
+                        event.event_id
+                _posthog.capture('$exception', data)
+                return event
+            })
+        }
+    }
+}

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -46,7 +46,8 @@ import {
     SnippetArrayItem,
     ToolbarParams,
 } from './types'
-import { SentryIntegration } from './extensions/sentry-integration'
+import { SentryIntegration } from './extensions/sentry-v7-integration'
+import { sentryIntegration } from './extensions/sentry-integration'
 import { setupSegmentIntegration } from './extensions/segment-integration'
 import { PageViewManager } from './page-view'
 import { PostHogSurveys } from './posthog-surveys'
@@ -260,6 +261,7 @@ export class PostHog {
     analyticsDefaultEndpoint: string
 
     SentryIntegration: typeof SentryIntegration
+    sentryIntegration: typeof sentryIntegration
 
     private _debugEventEmitter = new SimpleEventEmitter()
 
@@ -273,6 +275,7 @@ export class PostHog {
         this.config = defaultConfig()
         this.decideEndpointWasHit = false
         this.SentryIntegration = SentryIntegration
+        this.sentryIntegration = sentryIntegration
         this.__request_queue = []
         this.__loaded = false
         this.analyticsDefaultEndpoint = '/e/'


### PR DESCRIPTION
## Changes

- Added Sentry integration for v8 under `posthog.sentryIntegration` (fixes #1205)
- Moved the old/legacy/v7 Sentry integration to `sentry-v7-integration.ts` and is still available
