### PR TITLE
feat: Updated v8 sentry integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^11.1.6",
         "@rrweb/types": "2.0.0-alpha.13",
-        "@sentry/types": "7.37.2",
+        "@sentry/types": "8.7.0",
         "@testing-library/dom": "^9.3.0",
         "@types/eslint": "^8.44.6",
         "@types/jest": "^29.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -52,8 +52,8 @@ devDependencies:
     specifier: 2.0.0-alpha.13
     version: 2.0.0-alpha.13
   '@sentry/types':
-    specifier: 7.37.2
-    version: 7.37.2
+    specifier: 8.7.0
+    version: 8.7.0
   '@testing-library/dom':
     specifier: ^9.3.0
     version: 9.3.0
@@ -2664,9 +2664,9 @@ packages:
       rrweb-snapshot: 2.0.0-alpha.13
     dev: true
 
-  /@sentry/types@7.37.2:
-    resolution: {integrity: sha512-SxKQOCX94ZaQM4C2ysNjHdJsjYapu/NYZCz1cnPyCdDvYfhwiVge1uq6ZHiQ/ARfxAAOmc3R4Mh3VvEz7WUOdw==}
-    engines: {node: '>=8'}
+  /@sentry/types@8.7.0:
+    resolution: {integrity: sha512-11KLOKumP6akugVGLvSoEig+JlP0ZEzW3nN9P+ppgdIx9HAxMIh6UvumbieG4/DWjAh2kh6NPNfUw3gk2Gfq1A==}
+    engines: {node: '>=14.18'}
     dev: true
 
   /@sinclair/typebox@0.25.24:

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -46,7 +46,7 @@ import {
     SnippetArrayItem,
     ToolbarParams,
 } from './types'
-import { SentryIntegration } from './extensions/sentry-integration'
+import { SentryIntegration, SentryIntegrationOptions, sentryIntegration } from './extensions/sentry-integration'
 import { setupSegmentIntegration } from './extensions/segment-integration'
 import { PageViewManager } from './page-view'
 import { PostHogSurveys } from './posthog-surveys'
@@ -260,6 +260,7 @@ export class PostHog {
     analyticsDefaultEndpoint: string
 
     SentryIntegration: typeof SentryIntegration
+    sentryIntegration: (options?: SentryIntegrationOptions) => ReturnType<typeof sentryIntegration>
 
     private _debugEventEmitter = new SimpleEventEmitter()
 
@@ -273,6 +274,7 @@ export class PostHog {
         this.config = defaultConfig()
         this.decideEndpointWasHit = false
         this.SentryIntegration = SentryIntegration
+        this.sentryIntegration = (options?: SentryIntegrationOptions) => sentryIntegration(this, options)
         this.__request_queue = []
         this.__loaded = false
         this.analyticsDefaultEndpoint = '/e/'


### PR DESCRIPTION
## Changes

Adds support for the new v8 integration format ([see issue](https://posthog.com/questions/sentry-v8-class-based-integrations-deprecated))

We now have two methods, with the lower case one being the function based and upper case being classed based. I'll have a follow up PR for updated docs

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
