### PR TITLE
feat(personless-events): set_once more initial properties accurately when a person is created

### DIFF
--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -288,9 +288,9 @@ describe('person processing', () => {
             const identifyCall = onCapture.mock.calls[0]
             expect(identifyCall[0]).toEqual('$identify')
             expect(identifyCall[1].$set_once).toEqual({
-                $initial_referrer: 'https://legacy-referrer.com',
-                $initial_referring_domain: 'legacy-referrer.com',
-                $initial_utm_source: 'legacy-source',
+                $initial_referrer: 'https://deprecated-referrer.com',
+                $initial_referring_domain: 'deprecated-referrer.com',
+                $initial_utm_source: 'deprecated-source',
             })
         })
     })

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -20,6 +20,13 @@ jest.mock('../utils/globals', () => {
                 return mockURLGetter()
             },
         },
+        get location() {
+            const url = mockURLGetter()
+            return {
+                href: url,
+                toString: () => url,
+            }
+        },
     }
 })
 
@@ -158,6 +165,9 @@ describe('person processing', () => {
             const identifyCall = onCapture.mock.calls[0]
             expect(identifyCall[0]).toEqual('$identify')
             expect(identifyCall[1].$set_once).toEqual({
+                $initial_current_url: 'https://example.com?utm_source=foo',
+                $initial_host: 'example.com',
+                $initial_pathname: '/',
                 $initial_referrer: 'https://referrer.com',
                 $initial_referring_domain: 'referrer.com',
                 $initial_utm_source: 'foo',
@@ -168,7 +178,7 @@ describe('person processing', () => {
             // arrange
             const { posthog, onCapture } = await setup('identified_only')
             mockReferrerGetter.mockReturnValue('https://referrer1.com')
-            mockURLGetter.mockReturnValue('https://example1.com?utm_source=foo1')
+            mockURLGetter.mockReturnValue('https://example1.com/pathname1?utm_source=foo1')
 
             // act
             // s1
@@ -180,7 +190,7 @@ describe('person processing', () => {
 
             // s2
             mockReferrerGetter.mockReturnValue('https://referrer2.com')
-            mockURLGetter.mockReturnValue('https://example2.com?utm_source=foo2')
+            mockURLGetter.mockReturnValue('https://example2.com/pathname2?utm_source=foo2')
             posthog.capture('event s2 before identify')
             posthog.identify(distinctId)
             posthog.capture('event s2 after identify')
@@ -197,6 +207,9 @@ describe('person processing', () => {
 
             expect(eventS2Identify[0]).toEqual('$identify')
             expect(eventS2Identify[1].$set_once).toEqual({
+                $initial_current_url: 'https://example1.com/pathname1?utm_source=foo1',
+                $initial_host: 'example1.com',
+                $initial_pathname: '/pathname1',
                 $initial_referrer: 'https://referrer1.com',
                 $initial_referring_domain: 'referrer1.com',
                 $initial_utm_source: 'foo1',
@@ -204,6 +217,9 @@ describe('person processing', () => {
 
             expect(eventS2After[0]).toEqual('event s2 after identify')
             expect(eventS2After[1].$set_once).toEqual({
+                $initial_current_url: 'https://example1.com/pathname1?utm_source=foo1',
+                $initial_host: 'example1.com',
+                $initial_pathname: '/pathname1',
                 $initial_referrer: 'https://referrer1.com',
                 $initial_referring_domain: 'referrer1.com',
                 $initial_utm_source: 'foo1',
@@ -221,6 +237,9 @@ describe('person processing', () => {
             const identifyCall = onCapture.mock.calls[0]
             expect(identifyCall[0]).toEqual('$identify')
             expect(identifyCall[1].$set_once).toEqual({
+                $initial_current_url: 'https://example.com?utm_source=foo',
+                $initial_host: 'example.com',
+                $initial_pathname: '/',
                 $initial_referrer: 'https://referrer.com',
                 $initial_referring_domain: 'referrer.com',
                 $initial_utm_source: 'foo',
@@ -243,6 +262,9 @@ describe('person processing', () => {
             expect(eventBeforeIdentify[1].$set_once).toBeUndefined()
             const eventAfterIdentify = onCapture.mock.calls[2]
             expect(eventAfterIdentify[1].$set_once).toEqual({
+                $initial_current_url: 'https://example.com?utm_source=foo',
+                $initial_host: 'example.com',
+                $initial_pathname: '/',
                 $initial_referrer: 'https://referrer.com',
                 $initial_referring_domain: 'referrer.com',
                 $initial_utm_source: 'foo',
@@ -261,12 +283,18 @@ describe('person processing', () => {
             // assert
             const eventBeforeIdentify = onCapture.mock.calls[0]
             expect(eventBeforeIdentify[1].$set_once).toEqual({
+                $initial_current_url: 'https://example.com?utm_source=foo',
+                $initial_host: 'example.com',
+                $initial_pathname: '/',
                 $initial_referrer: 'https://referrer.com',
                 $initial_referring_domain: 'referrer.com',
                 $initial_utm_source: 'foo',
             })
             const eventAfterIdentify = onCapture.mock.calls[2]
             expect(eventAfterIdentify[1].$set_once).toEqual({
+                $initial_current_url: 'https://example.com?utm_source=foo',
+                $initial_host: 'example.com',
+                $initial_pathname: '/',
                 $initial_referrer: 'https://referrer.com',
                 $initial_referring_domain: 'referrer.com',
                 $initial_utm_source: 'foo',

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -230,6 +230,26 @@ describe('person processing', () => {
         it('should include initial referrer info in identify event if always', async () => {
             // arrange
             const { posthog, onCapture } = await setup('always')
+
+            // act
+            posthog.identify(distinctId)
+
+            // assert
+            const identifyCall = onCapture.mock.calls[0]
+            expect(identifyCall[0]).toEqual('$identify')
+            expect(identifyCall[1].$set_once).toEqual({
+                $initial_current_url: 'https://example.com?utm_source=foo',
+                $initial_host: 'example.com',
+                $initial_pathname: '/',
+                $initial_referrer: 'https://referrer.com',
+                $initial_referring_domain: 'referrer.com',
+                $initial_utm_source: 'foo',
+            })
+        })
+
+        it('should include initial search params', async () => {
+            // arrange
+            const { posthog, onCapture } = await setup('always')
             mockReferrerGetter.mockReturnValue('https://www.google.com?q=bar')
 
             // act
@@ -247,26 +267,6 @@ describe('person processing', () => {
                 $initial_utm_source: 'foo',
                 $initial_ph_keyword: 'bar',
                 $initial_search_engine: 'google',
-            })
-        })
-
-        it('should include initial search params', async () => {
-            // arrange
-            const { posthog, onCapture } = await setup('always')
-
-            // act
-            posthog.identify(distinctId)
-
-            // assert
-            const identifyCall = onCapture.mock.calls[0]
-            expect(identifyCall[0]).toEqual('$identify')
-            expect(identifyCall[1].$set_once).toEqual({
-                $initial_current_url: 'https://example.com?utm_source=foo',
-                $initial_host: 'example.com',
-                $initial_pathname: '/',
-                $initial_referrer: 'https://referrer.com',
-                $initial_referring_domain: 'referrer.com',
-                $initial_utm_source: 'foo',
             })
         })
 

--- a/src/__tests__/posthog-core.js
+++ b/src/__tests__/posthog-core.js
@@ -57,8 +57,7 @@ describe('posthog core', () => {
                 },
                 props: {},
                 get_property: () => 'anonymous',
-                set_initial_campaign_params: jest.fn(),
-                set_initial_referrer_info: jest.fn(),
+                set_initial_person_info: jest.fn(),
                 get_initial_props: () => ({}),
             },
             sessionPersistence: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,6 +31,7 @@ export const CLIENT_SESSION_PROPS = '$client_session_props'
 export const CAPTURE_RATE_LIMIT = '$capture_rate_limit'
 export const INITIAL_CAMPAIGN_PARAMS = '$initial_campaign_params'
 export const INITIAL_REFERRER_INFO = '$initial_referrer_info'
+export const INITIAL_PERSON_INFO = '$initial_person_info'
 export const ENABLE_PERSON_PROCESSING = '$epp'
 export const TOOLBAR_ID = '__POSTHOG_TOOLBAR__'
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,7 +29,10 @@ export const FLAG_CALL_REPORTED = '$flag_call_reported'
 export const USER_STATE = '$user_state'
 export const CLIENT_SESSION_PROPS = '$client_session_props'
 export const CAPTURE_RATE_LIMIT = '$capture_rate_limit'
+
+/** @deprecated Delete this when INITIAL_PERSON_INFO has been around for long enough to ignore backwards compat */
 export const INITIAL_CAMPAIGN_PARAMS = '$initial_campaign_params'
+/** @deprecated Delete this when INITIAL_PERSON_INFO has been around for long enough to ignore backwards compat */
 export const INITIAL_REFERRER_INFO = '$initial_referrer_info'
 export const INITIAL_PERSON_INFO = '$initial_person_info'
 export const ENABLE_PERSON_PROCESSING = '$epp'

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -761,11 +761,12 @@ export class PostHog {
         // with every event and used by the session table to create session-initial props.
         if (this.config.store_google) {
             this.sessionPersistence.update_campaign_params()
-            this.persistence.set_initial_campaign_params()
         }
         if (this.config.save_referrer) {
             this.sessionPersistence.update_referrer_info()
-            this.persistence.set_initial_referrer_info()
+        }
+        if (this.config.store_google || this.config.save_referrer) {
+            this.persistence.set_initial_person_info()
         }
 
         let data: CaptureResult = {

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -231,6 +231,11 @@ export class PostHogPersistence {
     }
 
     set_initial_person_info(): void {
+        if (this.props[INITIAL_CAMPAIGN_PARAMS] || this.props[INITIAL_REFERRER_INFO]) {
+            // the user has initial properties stored the previous way, don't save them again
+            return
+        }
+
         this.register_once(
             {
                 [INITIAL_PERSON_INFO]: Info.initialPersonInfo(),

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -7,6 +7,7 @@ import {
     ENABLED_FEATURE_FLAGS,
     EVENT_TIMERS_KEY,
     INITIAL_CAMPAIGN_PARAMS,
+    INITIAL_PERSON_INFO,
     INITIAL_REFERRER_INFO,
     PERSISTENCE_RESERVED_PROPERTIES,
 } from './constants'
@@ -221,13 +222,6 @@ export class PostHogPersistence {
             this.campaign_params_saved = true
         }
     }
-    set_initial_campaign_params(): void {
-        this.register_once(
-            { [INITIAL_CAMPAIGN_PARAMS]: Info.campaignParams(this.config.custom_campaign_params) },
-            undefined
-        )
-    }
-
     update_search_keyword(): void {
         this.register(Info.searchInfo())
     }
@@ -236,10 +230,10 @@ export class PostHogPersistence {
         this.register(Info.referrerInfo())
     }
 
-    set_initial_referrer_info(): void {
+    set_initial_person_info(): void {
         this.register_once(
             {
-                [INITIAL_REFERRER_INFO]: Info.referrerInfo(),
+                [INITIAL_PERSON_INFO]: Info.initialPersonInfo(),
             },
             undefined
         )
@@ -254,6 +248,9 @@ export class PostHogPersistence {
 
     get_initial_props(): Properties {
         const p: Properties = {}
+
+        // this section isn't written to anymore, but we should keep reading from it for backwards compatibility
+        // for a while
         each([INITIAL_REFERRER_INFO, INITIAL_CAMPAIGN_PARAMS], (key) => {
             const initialReferrerInfo = this.props[key]
             if (initialReferrerInfo) {
@@ -262,6 +259,15 @@ export class PostHogPersistence {
                 })
             }
         })
+        const initialPersonInfo = this.props[INITIAL_PERSON_INFO]
+        if (initialPersonInfo) {
+            const initialPersonProps = Info.initialPersonPropsFromInfo(initialPersonInfo)
+            extend(p, initialPersonProps)
+        }
+
+        // eslint-disable-next-line no-console
+        console.log({ p })
+
         return p
     }
 

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -270,9 +270,6 @@ export class PostHogPersistence {
             extend(p, initialPersonProps)
         }
 
-        // eslint-disable-next-line no-console
-        console.log({ p })
-
         return p
     }
 


### PR DESCRIPTION
## Changes
Some context: when the person profiles mode is set to identified_only, we want to be able to eventually create the user with the real initial props. We do this by storing them in persistence.

The old way of doing this was to store the props themselves, for a limited subset of props. The problem with this is that we derive a lot of props from the same data, with quite a bit of overlap, and there's some size pressure to keep it small as this data is stored in the cookie which can store a max of 4kB. This meant that we didn't store everything that could be useful.

This PR changes this, and now stores just the initial URL and initial referrer, and derives everything else from those later. This means that we now send everything we sent before, plus additionally we send: 
* initial_host
* initial_pathname
* initial_current_url
* initial_search_engine
* initial_ph_keyword.

We still don't send things like initial_browser etc, as those are most likely ok to send the value of those at the time the person profile was created.

I've added backwards compatibility + tests for the previous way of handling this.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
