### PR TITLE
fix: less strict idle event dropping

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -68,11 +68,11 @@ const typesAllowedWhenIdle = [EventType.Custom, EventType.Meta, EventType.FullSn
  * but allow data that the player might require for proper playback
  */
 function allowedWhenIdle(event: eventWithTime): boolean {
-    const isAllowedIncremental =
+    const isInactiveIncremental =
         event.type === EventType.IncrementalSnapshot &&
         !isNullish(event.data.source) &&
         !ACTIVE_SOURCES.includes(event.data.source)
-    return !typesAllowedWhenIdle.includes(event.type) || isAllowedIncremental
+    return typesAllowedWhenIdle.includes(event.type) || isInactiveIncremental
 }
 
 /**

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -812,9 +812,8 @@ export class SessionRecording {
 
         this._updateWindowAndSessionIds(event)
 
-        // allow custom events even when idle
-        if (this.isIdle && allowedWhenIdle(event)) {
-            // When in an idle state we keep recording, but don't capture the events
+        if (this.isIdle && !allowedWhenIdle(event)) {
+            // When in an idle state we keep recording, but don't capture all events
             return
         }
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -68,6 +68,9 @@ const typesAllowedWhenIdle = [EventType.Custom, EventType.Meta, EventType.FullSn
  * but allow data that the player might require for proper playback
  */
 function allowedWhenIdle(event: eventWithTime): boolean {
+    // TRICKY: technically we should never hit this method with an active incremental snapshot
+    // since we should already have switched out of idle mode if we see one,
+    // but we check here so that this method makes sense in isolation
     const isInactiveIncremental =
         event.type === EventType.IncrementalSnapshot &&
         !isNullish(event.data.source) &&

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -61,21 +61,25 @@ const ACTIVE_SOURCES = [
     IncrementalSource.Drag,
 ]
 
-const typesAllowedWhenIdle = [EventType.Custom, EventType.Meta, EventType.FullSnapshot]
+const STYLE_SOURCES = [
+    IncrementalSource.StyleSheetRule,
+    IncrementalSource.StyleDeclaration,
+    IncrementalSource.AdoptedStyleSheet,
+    IncrementalSource.Font,
+]
+
+const TYPES_ALLOWED_WHEN_IDLE = [EventType.Custom, EventType.Meta, EventType.FullSnapshot]
 
 /**
  * we want to restrict the data allowed when we've detected an idle session
  * but allow data that the player might require for proper playback
  */
 function allowedWhenIdle(event: eventWithTime): boolean {
-    // TRICKY: technically we should never hit this method with an active incremental snapshot
-    // since we should already have switched out of idle mode if we see one,
-    // but we check here so that this method makes sense in isolation
-    const isInactiveIncremental =
+    const isAllowedIncremental =
         event.type === EventType.IncrementalSnapshot &&
         !isNullish(event.data.source) &&
-        !ACTIVE_SOURCES.includes(event.data.source)
-    return typesAllowedWhenIdle.includes(event.type) || isInactiveIncremental
+        STYLE_SOURCES.includes(event.data.source)
+    return TYPES_ALLOWED_WHEN_IDLE.includes(event.type) || isAllowedIncremental
 }
 
 /**


### PR DESCRIPTION
(particularly in the mobile wireframe work) we're learning that rrweb playback is very intolerant of missing data

we drop events when idle since we don't want to extend active time

but we sometimes get unexpected playback artefacts

let's try being more permissive when idle