### PR TITLE
fix: only wrap once when patching

### DIFF
--- a/src/__tests__/extensions/replay/rrweb-plugins/patch.test.ts
+++ b/src/__tests__/extensions/replay/rrweb-plugins/patch.test.ts
@@ -1,0 +1,15 @@
+import { patch } from '../../../../extensions/replay/rrweb-plugins/patch'
+
+const fakeWindow = {
+    fakeFetch: () => {},
+}
+
+// JS-DOM doesn't have fetch and its fake XHR doesn't work with our patch,
+// so we can't test them directly
+describe('patch', () => {
+    it('marks a function as wrapped', () => {
+        patch(fakeWindow, 'fakeFetch', () => () => {})
+        // eslint-disable-next-line compat/compat
+        expect((fakeWindow.fakeFetch as any).__posthog_wrapped__).toBe(true)
+    })
+})

--- a/src/extensions/replay/rrweb-plugins/patch.ts
+++ b/src/extensions/replay/rrweb-plugins/patch.ts
@@ -9,7 +9,10 @@ export function patch(
     replacement: (...args: unknown[]) => unknown
 ): () => void {
     try {
-        if (!(name in source)) {
+        // we check if already wrapped
+        // as in the past we've seen this code called multiple times in customer code
+        // even though it should only be called once, so we're extra careful here
+        if (!(name in source) || (source[name] as any).__posthog_wrapped__) {
             return () => {
                 //
             }
@@ -20,9 +23,7 @@ export function patch(
 
         // Make sure it's a function first, as we need to attach an empty prototype for `defineProperties` to work
         // otherwise it'll throw "TypeError: Object.defineProperties called on non-object"
-        // we check if already wrapped as in the past we've seen this code called multiple times in customer
-        // code even though it should only be called once, so we're extra safe
-        if (isFunction(wrapped) && !(wrapped as any).__posthog_wrapped__) {
+        if (isFunction(wrapped)) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             wrapped.prototype = wrapped.prototype || {}
             Object.defineProperties(wrapped, {

--- a/src/extensions/replay/rrweb-plugins/patch.ts
+++ b/src/extensions/replay/rrweb-plugins/patch.ts
@@ -20,7 +20,9 @@ export function patch(
 
         // Make sure it's a function first, as we need to attach an empty prototype for `defineProperties` to work
         // otherwise it'll throw "TypeError: Object.defineProperties called on non-object"
-        if (isFunction(wrapped)) {
+        // we check if already wrapped as in the past we've seen this code called multiple times in customer
+        // code even though it should only be called once, so we're extra safe
+        if (isFunction(wrapped) && !(wrapped as any).__posthog_wrapped__) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             wrapped.prototype = wrapped.prototype || {}
             Object.defineProperties(wrapped, {

--- a/src/extensions/replay/rrweb-plugins/patch.ts
+++ b/src/extensions/replay/rrweb-plugins/patch.ts
@@ -9,10 +9,7 @@ export function patch(
     replacement: (...args: unknown[]) => unknown
 ): () => void {
     try {
-        // we check if already wrapped
-        // as in the past we've seen this code called multiple times in customer code
-        // even though it should only be called once, so we're extra careful here
-        if (!(name in source) || (source[name] as any).__posthog_wrapped__) {
+        if (!(name in source)) {
             return () => {
                 //
             }

--- a/src/loader-recorder.ts
+++ b/src/loader-recorder.ts
@@ -497,7 +497,9 @@ function initNetworkObserver(
 
     if (initialisedHandler) {
         logger.warn('Network observer already initialised, doing nothing')
-        return initialisedHandler
+        return () => {
+            // the first caller should already have this handler and will be responsible for teardown
+        }
     }
 
     const networkOptions = (

--- a/src/loader-recorder.ts
+++ b/src/loader-recorder.ts
@@ -483,6 +483,7 @@ function initFetchObserver(
     }
 }
 
+let initialisedHandler: listenerHandler | null = null
 function initNetworkObserver(
     callback: networkCallback,
     win: IWindow, // top window or in an iframe
@@ -493,6 +494,12 @@ function initNetworkObserver(
             //
         }
     }
+
+    if (initialisedHandler) {
+        logger.warn('Network observer already initialised, doing nothing')
+        return initialisedHandler
+    }
+
     const networkOptions = (
         options ? Object.assign({}, defaultNetworkOptions, options) : defaultNetworkOptions
     ) as Required<NetworkRecordOptions>
@@ -520,11 +527,12 @@ function initNetworkObserver(
         fetchObserver = initFetchObserver(cb, win, networkOptions)
     }
 
-    return () => {
+    initialisedHandler = () => {
         performanceObserver()
         xhrObserver()
         fetchObserver()
     }
+    return initialisedHandler
 }
 
 // use the plugin name so that when this functionality is adopted into rrweb


### PR DESCRIPTION
While investigating a customer issue (See: https://posthog.slack.com/archives/C074A08LP1B/p1718291948667569) I saw the patch function being called more than once for each wrapped thing

This is unexpected - but I guess clearly possible 🙈 

So, if `initNetworkObserver` is requested and it is already init'd, do nothing, the original caller is responsible

(we don't catch this in patch since we might want to patch things twice. e.g. trace header additionally wraps patch)