### PR TITLE
fix: Allow no capture of $opt_in event

### DIFF
--- a/src/__tests__/consent.test.ts
+++ b/src/__tests__/consent.test.ts
@@ -78,6 +78,34 @@ describe('consentManager', () => {
         expect(posthog.persistence?.disabled).toBe(true)
     })
 
+    it('should send opt in event if not disabled', () => {
+        const onCapture = jest.fn()
+        posthog = createPostHog({ opt_out_capturing_by_default: true, _onCapture: onCapture })
+        posthog.opt_in_capturing()
+        expect(onCapture).toHaveBeenCalledWith('$opt_in', expect.objectContaining({}))
+        onCapture.mockClear()
+
+        posthog.opt_in_capturing({
+            captureEventName: 'override-opt-in',
+            captureProperties: {
+                foo: 'bar',
+            },
+        })
+        expect(onCapture).toHaveBeenCalledWith(
+            'override-opt-in',
+            expect.objectContaining({
+                properties: expect.objectContaining({
+                    foo: 'bar',
+                }),
+            })
+        )
+        onCapture.mockClear()
+        posthog.opt_in_capturing({ captureEventName: null })
+        expect(onCapture).not.toHaveBeenCalled()
+        posthog.opt_in_capturing({ captureEventName: false })
+        expect(onCapture).not.toHaveBeenCalled()
+    })
+
     describe('with do not track setting', () => {
         beforeEach(() => {
             ;(navigator as any).doNotTrack = '1'

--- a/src/__tests__/consent.test.ts
+++ b/src/__tests__/consent.test.ts
@@ -78,32 +78,40 @@ describe('consentManager', () => {
         expect(posthog.persistence?.disabled).toBe(true)
     })
 
-    it('should send opt in event if not disabled', () => {
-        const onCapture = jest.fn()
-        posthog = createPostHog({ opt_out_capturing_by_default: true, _onCapture: onCapture })
-        posthog.opt_in_capturing()
-        expect(onCapture).toHaveBeenCalledWith('$opt_in', expect.objectContaining({}))
-        onCapture.mockClear()
-
-        posthog.opt_in_capturing({
-            captureEventName: 'override-opt-in',
-            captureProperties: {
-                foo: 'bar',
-            },
+    describe('opt out event', () => {
+        let onCapture = jest.fn()
+        beforeEach(() => {
+            onCapture = jest.fn()
+            posthog = createPostHog({ opt_out_capturing_by_default: true, _onCapture: onCapture })
         })
-        expect(onCapture).toHaveBeenCalledWith(
-            'override-opt-in',
-            expect.objectContaining({
-                properties: expect.objectContaining({
+
+        it('should send opt in event if not disabled', () => {
+            posthog.opt_in_capturing()
+            expect(onCapture).toHaveBeenCalledWith('$opt_in', expect.objectContaining({}))
+        })
+
+        it('should send opt in event with overrides', () => {
+            posthog.opt_in_capturing({
+                captureEventName: 'override-opt-in',
+                captureProperties: {
                     foo: 'bar',
-                }),
+                },
             })
-        )
-        onCapture.mockClear()
-        posthog.opt_in_capturing({ captureEventName: null })
-        expect(onCapture).not.toHaveBeenCalled()
-        posthog.opt_in_capturing({ captureEventName: false })
-        expect(onCapture).not.toHaveBeenCalled()
+            expect(onCapture).toHaveBeenCalledWith(
+                'override-opt-in',
+                expect.objectContaining({
+                    properties: expect.objectContaining({
+                        foo: 'bar',
+                    }),
+                })
+            )
+        })
+        it('should not send opt in event if null or false', () => {
+            posthog.opt_in_capturing({ captureEventName: null })
+            expect(onCapture).not.toHaveBeenCalled()
+            posthog.opt_in_capturing({ captureEventName: false })
+            expect(onCapture).not.toHaveBeenCalled()
+        })
     })
 
     describe('with do not track setting', () => {

--- a/src/__tests__/consent.test.ts
+++ b/src/__tests__/consent.test.ts
@@ -106,6 +106,7 @@ describe('consentManager', () => {
                 })
             )
         })
+
         it('should not send opt in event if null or false', () => {
             posthog.opt_in_capturing({ captureEventName: null })
             expect(onCapture).not.toHaveBeenCalled()

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1921,7 +1921,7 @@ export class PostHog {
         this.consent.optInOut(true)
         this._sync_opt_out_with_persistence()
 
-        if (!isUndefined(options?.captureEventName) && !options.captureEventName) {
+        if (!isUndefined(options?.captureEventName) && !options?.captureEventName) {
             // Don't capture if captureEventName is null or false
             return
         }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1929,7 +1929,7 @@ export class PostHog {
         }
 
         this.capture(
-            isString(options?.captureEventName) ? options.captureEventName : '$opt_in',
+            isString(options?.captureEventName) ? options?.captureEventName : '$opt_in',
             options?.captureProperties,
             { send_instantly: true }
         )

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -55,9 +55,11 @@ import { uuidv7 } from './uuidv7'
 import { SurveyCallback } from './posthog-surveys-types'
 import {
     isArray,
+    isBoolean,
     isEmptyObject,
     isEmptyString,
     isFunction,
+    isNull,
     isNumber,
     isObject,
     isString,
@@ -1921,11 +1923,16 @@ export class PostHog {
         this.consent.optInOut(true)
         this._sync_opt_out_with_persistence()
 
-        if (!isUndefined(options?.captureEventName) && !options?.captureEventName) {
+        if (isNull(options?.captureEventName) || options?.captureEventName === false) {
             // Don't capture if captureEventName is null or false
             return
         }
-        this.capture(options?.captureEventName ?? '$opt_in', options?.captureProperties, { send_instantly: true })
+
+        this.capture(
+            isString(options?.captureEventName) ? options.captureEventName : '$opt_in',
+            options?.captureProperties,
+            { send_instantly: true }
+        )
     }
 
     /**

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1915,13 +1915,16 @@ export class PostHog {
      * @param {Object} [config.capture_properties] Set of properties to be captured along with the opt-in action
      */
     opt_in_capturing(options?: {
-        captureEventName?: string /** event name to be used for capturing the opt-in action */
+        captureEventName?: string | null | false /** event name to be used for capturing the opt-in action */
         captureProperties?: Properties /** set of properties to be captured along with the opt-in action */
     }): void {
         this.consent.optInOut(true)
         this._sync_opt_out_with_persistence()
 
-        // TODO: Do we need it to be sent instantly?
+        if (!isUndefined(options?.captureEventName) && !options.captureEventName) {
+            // Don't capture if captureEventName is null or false
+            return
+        }
         this.capture(options?.captureEventName ?? '$opt_in', options?.captureProperties, { send_instantly: true })
     }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1911,7 +1911,7 @@ export class PostHog {
      *     });
      *
      * @param {Object} [config] A dictionary of config options to override
-     * @param {string} [config.capture_event_name=$opt_in] Event name to be used for capturing the opt-in action
+     * @param {string} [config.capture_event_name=$opt_in] Event name to be used for capturing the opt-in action. Set to `null` or `false` to skip capturing the optin event
      * @param {Object} [config.capture_properties] Set of properties to be captured along with the opt-in action
      */
     opt_in_capturing(options?: {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1923,16 +1923,12 @@ export class PostHog {
         this.consent.optInOut(true)
         this._sync_opt_out_with_persistence()
 
-        if (isNull(options?.captureEventName) || options?.captureEventName === false) {
+        if (!isUndefined(options?.captureEventName) && !options?.captureEventName) {
             // Don't capture if captureEventName is null or false
             return
         }
 
-        this.capture(
-            isString(options?.captureEventName) ? options?.captureEventName : '$opt_in',
-            options?.captureProperties,
-            { send_instantly: true }
-        )
+        this.capture(options?.captureEventName ?? '$opt_in', options?.captureProperties, { send_instantly: true })
     }
 
     /**

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -55,11 +55,9 @@ import { uuidv7 } from './uuidv7'
 import { SurveyCallback } from './posthog-surveys-types'
 import {
     isArray,
-    isBoolean,
     isEmptyObject,
     isEmptyString,
     isFunction,
-    isNull,
     isNumber,
     isObject,
     isString,


### PR DESCRIPTION
## Changes

[Ticket](https://posthoghelp.zendesk.com/agent/tickets/14282)

The consent changes I made removed the ability to ignore the opt in event which wasn't intended.

Adds an option to skip using the existing properties. This is slightly breaking but pretty certain it wasn't used this way before anyways

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
