### PR TITLE
fix: no scheduled snapshots while idle

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -1335,7 +1335,6 @@ describe('SessionRecording', () => {
 
             sessionRecording.onRRwebEmit(createFullSnapshot({}) as eventWithTime)
 
-            // custom event is buffered
             expect(sessionRecording['buffer']).toEqual({
                 data: [
                     {
@@ -1361,7 +1360,6 @@ describe('SessionRecording', () => {
 
             sessionRecording.onRRwebEmit(createMetaSnapshot({}) as eventWithTime)
 
-            // custom event is buffered
             expect(sessionRecording['buffer']).toEqual({
                 data: [
                     {
@@ -1389,7 +1387,6 @@ describe('SessionRecording', () => {
 
             sessionRecording.onRRwebEmit(createStyleSnapshot({}) as eventWithTime)
 
-            // custom event is buffered
             expect(sessionRecording['buffer']).toEqual({
                 data: [
                     {
@@ -1445,11 +1442,7 @@ describe('SessionRecording', () => {
 
             // this triggers idle state and isn't a user interaction so does not take a full snapshot
             emitInactiveEvent(thirdActivityTimestamp, true)
-            expect(_addCustomEvent).toHaveBeenCalledWith('sessionIdle', {
-                reason: 'user inactivity',
-                threshold: 300000,
-                timeSinceLastActive: 300900,
-            })
+
             // event was not active so activity timestamp is not updated
             expect(sessionRecording['_lastActivityTimestamp']).toEqual(firstActivityTimestamp)
             expect(assignableWindow.rrweb.record.takeFullSnapshot).toHaveBeenCalledTimes(1)
@@ -1481,10 +1474,7 @@ describe('SessionRecording', () => {
 
             // this triggers exit from idle state _and_ is a user interaction, so we take a full snapshot
             const fourthSnapshot = emitActiveEvent(fourthActivityTimestamp)
-            expect(_addCustomEvent).toHaveBeenCalledWith('sessionNoLongerIdle', {
-                reason: 'user activity',
-                type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
-            })
+
             expect(sessionRecording['_lastActivityTimestamp']).toEqual(fourthActivityTimestamp)
             expect(assignableWindow.rrweb.record.takeFullSnapshot).toHaveBeenCalledTimes(2)
 
@@ -1543,11 +1533,7 @@ describe('SessionRecording', () => {
             // this triggers idle state and isn't a user interaction so does not take a full snapshot
 
             emitInactiveEvent(thirdActivityTimestamp, true)
-            expect(_addCustomEvent).toHaveBeenCalledWith('sessionIdle', {
-                reason: 'user inactivity',
-                threshold: 300000,
-                timeSinceLastActive: 1799901,
-            })
+
             // event was not active so activity timestamp is not updated
             expect(sessionRecording['_lastActivityTimestamp']).toEqual(firstActivityTimestamp)
             expect(assignableWindow.rrweb.record.takeFullSnapshot).toHaveBeenCalledTimes(1)
@@ -1583,10 +1569,7 @@ describe('SessionRecording', () => {
             // this triggers exit from idle state _and_ is a user interaction, so we take a full snapshot
 
             const fourthSnapshot = emitActiveEvent(fourthActivityTimestamp)
-            expect(_addCustomEvent).toHaveBeenCalledWith('sessionNoLongerIdle', {
-                reason: 'user activity',
-                type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
-            })
+
             expect(sessionRecording['_lastActivityTimestamp']).toEqual(fourthActivityTimestamp)
             expect(assignableWindow.rrweb.record.takeFullSnapshot).toHaveBeenCalledTimes(2)
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -212,6 +212,10 @@ export class SessionRecording {
         return this.instance.sessionManager
     }
 
+    private get fullSnapshotIntervalMillis(): number {
+        return this.instance.config.session_recording?.full_snapshot_interval_millis || FIVE_MINUTES
+    }
+
     private get isSampled(): boolean | null {
         const currentValue = this.instance.get_property(SESSION_RECORDING_IS_SAMPLED)
         return isBoolean(currentValue) ? currentValue : null
@@ -748,9 +752,14 @@ export class SessionRecording {
             return
         }
 
+        const interval = this.fullSnapshotIntervalMillis
+        if (!interval) {
+            return
+        }
+
         this._fullSnapshotTimer = setInterval(() => {
             this._tryTakeFullSnapshot()
-        }, FIVE_MINUTES) // 5 minutes
+        }, interval)
     }
 
     private _gatherRRWebPlugins() {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -587,6 +587,10 @@ export class SessionRecording {
             if (this.isIdle) {
                 // Remove the idle state
                 this.isIdle = false
+                this._tryAddCustomEvent('sessionNoLongerIdle', {
+                    reason: 'user activity',
+                    type: event.type,
+                })
                 returningFromIdle = true
             }
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,7 +223,7 @@ export interface SessionRecordingOptions {
     // our settings here only support a subset of those proposed for rrweb's network capture plugin
     recordHeaders?: boolean
     recordBody?: boolean
-    // ADVANCED: while a user is active we take a full snapshot of the browser every interval. For a very few sites playback performance might be better with different interval. Set to 0 to disable
+    // ADVANCED: while a user is active we take a full snapshot of the browser every interval. For very few sites playback performance might be better with different interval. Set to 0 to disable
     full_snapshot_interval_millis?: number
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,6 +223,8 @@ export interface SessionRecordingOptions {
     // our settings here only support a subset of those proposed for rrweb's network capture plugin
     recordHeaders?: boolean
     recordBody?: boolean
+    // ADVANCED: while a user is active we take a full snapshot of the browser every interval. For a very few sites playback performance might be better with different interval. Set to 0 to disable
+    full_snapshot_interval_millis?: number
 }
 
 export type SessionIdChangedCallback = (sessionId: string, windowId: string | null | undefined) => void


### PR DESCRIPTION
see: https://posthoghelp.zendesk.com/agent/tickets/14905 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/17005)

a user complained of long inactive sessions, when looking at them a number of them have a snapshot timer running even though idle

this

* makes sure we don't schedule full snapshots while idle
* reduces the amount of custom events we gather while idle