### PR TITLE
fix(surveys branching): rename confirmation_message -> end

### DIFF
--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -801,29 +801,25 @@ describe('surveys', () => {
         } as Survey
 
         // Simple branching
-        it('when no branching specified, should return the index of the next question or confirmation_message', () => {
+        it('when no branching specified, should return the index of the next question or `end`', () => {
             survey.questions = [
                 { type: SurveyQuestionType.Open, question: 'Question A' },
                 { type: SurveyQuestionType.Open, question: 'Question B' },
             ] as SurveyQuestion[]
             expect(surveys.getNextSurveyStep(survey, 0, 'Some response')).toEqual(1)
-            expect(surveys.getNextSurveyStep(survey, 1, 'Some response')).toEqual(
-                SurveyQuestionBranchingType.ConfirmationMessage
-            )
+            expect(surveys.getNextSurveyStep(survey, 1, 'Some response')).toEqual(SurveyQuestionBranchingType.End)
         })
 
-        it('should branch out to confirmation_message', () => {
+        it('should branch out to `end`', () => {
             survey.questions = [
                 {
                     type: SurveyQuestionType.Open,
                     question: 'Question A',
-                    branching: { type: SurveyQuestionBranchingType.ConfirmationMessage },
+                    branching: { type: SurveyQuestionBranchingType.End },
                 },
                 { type: SurveyQuestionType.Open, question: 'Question B' },
             ] as SurveyQuestion[]
-            expect(surveys.getNextSurveyStep(survey, 0, 'Some response')).toEqual(
-                SurveyQuestionBranchingType.ConfirmationMessage
-            )
+            expect(surveys.getNextSurveyStep(survey, 0, 'Some response')).toEqual(SurveyQuestionBranchingType.End)
         })
 
         it('should branch out to a specific question', () => {
@@ -937,7 +933,7 @@ describe('surveys', () => {
                 {
                     type: SurveyQuestionType.Open,
                     question: 'B',
-                    branching: { type: SurveyQuestionBranchingType.ConfirmationMessage },
+                    branching: { type: SurveyQuestionBranchingType.End },
                 },
                 {
                     type: SurveyQuestionType.Open,
@@ -982,7 +978,7 @@ describe('surveys', () => {
             }
 
             expect(desiredOrder).toEqual(actualOrder)
-            expect(currentStep).toEqual(SurveyQuestionBranchingType.ConfirmationMessage)
+            expect(currentStep).toEqual(SurveyQuestionBranchingType.End)
         })
 
         it('should display questions in the correct order in a multi-step NPS survey', () => {
@@ -999,12 +995,12 @@ describe('surveys', () => {
                 {
                     type: SurveyQuestionType.Open,
                     question: 'Sorry to hear that. Please enter your email, a colleague will be in touch.',
-                    branching: { type: SurveyQuestionBranchingType.ConfirmationMessage },
+                    branching: { type: SurveyQuestionBranchingType.End },
                 },
                 {
                     type: SurveyQuestionType.Open,
                     question: 'Seems you are not completely happy. Tell us more!',
-                    branching: { type: SurveyQuestionBranchingType.ConfirmationMessage },
+                    branching: { type: SurveyQuestionBranchingType.End },
                 },
                 {
                     type: SurveyQuestionType.SingleChoice,
@@ -1018,7 +1014,7 @@ describe('surveys', () => {
                 {
                     type: SurveyQuestionType.Link,
                     question: 'Great! Here is the link:',
-                    branching: { type: SurveyQuestionBranchingType.ConfirmationMessage },
+                    branching: { type: SurveyQuestionBranchingType.End },
                 },
                 {
                     type: SurveyQuestionType.Open,
@@ -1040,7 +1036,7 @@ describe('surveys', () => {
                 currentStep = surveys.getNextSurveyStep(survey, currentStep, answer)
             }
             expect(desiredOrder).toEqual(actualOrder)
-            expect(currentStep).toEqual(SurveyQuestionBranchingType.ConfirmationMessage)
+            expect(currentStep).toEqual(SurveyQuestionBranchingType.End)
 
             // Passive customer
             desiredOrder = ['How happy are you?', 'Seems you are not completely happy. Tell us more!']
@@ -1053,7 +1049,7 @@ describe('surveys', () => {
                 currentStep = surveys.getNextSurveyStep(survey, currentStep, answer)
             }
             expect(desiredOrder).toEqual(actualOrder)
-            expect(currentStep).toEqual(SurveyQuestionBranchingType.ConfirmationMessage)
+            expect(currentStep).toEqual(SurveyQuestionBranchingType.End)
 
             // Promoter customer, won't leave a review
             desiredOrder = ['How happy are you?', 'Glad to hear that! Will you leave us a review?', 'Curious, why not?']
@@ -1066,7 +1062,7 @@ describe('surveys', () => {
                 currentStep = surveys.getNextSurveyStep(survey, currentStep, answer)
             }
             expect(desiredOrder).toEqual(actualOrder)
-            expect(currentStep).toEqual(SurveyQuestionBranchingType.ConfirmationMessage)
+            expect(currentStep).toEqual(SurveyQuestionBranchingType.End)
 
             // Promoter customer, will leave a review
             desiredOrder = [
@@ -1083,7 +1079,7 @@ describe('surveys', () => {
                 currentStep = surveys.getNextSurveyStep(survey, currentStep, answer)
             }
             expect(desiredOrder).toEqual(actualOrder)
-            expect(currentStep).toEqual(SurveyQuestionBranchingType.ConfirmationMessage)
+            expect(currentStep).toEqual(SurveyQuestionBranchingType.End)
         })
 
         it('should throw an error for an invalid scale', () => {

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -373,7 +373,7 @@ export function Questions({
         setQuestionsResponses({ ...questionsResponses, [responseKey]: res })
 
         const nextStep = posthog.getNextSurveyStep(survey, displayQuestionIndex, res)
-        if (nextStep === SurveyQuestionBranchingType.ConfirmationMessage) {
+        if (nextStep === SurveyQuestionBranchingType.End) {
             sendSurveyEvent({ ...questionsResponses, [responseKey]: res }, survey, posthog)
         } else {
             setCurrentQuestionIndex(nextStep)

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1179,12 +1179,12 @@ export class PostHog {
         this.surveys.getActiveMatchingSurveys(callback, forceReload)
     }
 
-    /** Get the next step of the survey: a question index or confirmation_message */
+    /** Get the next step of the survey: a question index or `end` */
     getNextSurveyStep(
         survey: Survey,
         currentQuestionIndex: number,
         response: string | string[] | number | null
-    ): number | SurveyQuestionBranchingType.ConfirmationMessage {
+    ): number | SurveyQuestionBranchingType.End {
         return this.surveys.getNextSurveyStep(survey, currentQuestionIndex, response)
     }
 

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -53,11 +53,7 @@ interface SurveyQuestionBase {
     optional?: boolean
     buttonText?: string
     originalQuestionIndex: number
-    branching?:
-        | NextQuestionBranching
-        | ConfirmationMessageBranching
-        | ResponseBasedBranching
-        | SpecificQuestionBranching
+    branching?: NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching
 }
 
 export interface BasicSurveyQuestion extends SurveyQuestionBase {
@@ -94,7 +90,7 @@ export enum SurveyQuestionType {
 
 export enum SurveyQuestionBranchingType {
     NextQuestion = 'next_question',
-    ConfirmationMessage = 'confirmation_message',
+    End = 'end',
     ResponseBased = 'response_based',
     SpecificQuestion = 'specific_question',
 }
@@ -103,8 +99,8 @@ interface NextQuestionBranching {
     type: SurveyQuestionBranchingType.NextQuestion
 }
 
-interface ConfirmationMessageBranching {
-    type: SurveyQuestionBranchingType.ConfirmationMessage
+interface EndBranching {
+    type: SurveyQuestionBranchingType.End
 }
 
 interface ResponseBasedBranching {

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -192,14 +192,14 @@ export class PostHogSurveys {
 
         if (!question.branching?.type) {
             if (currentQuestionIndex === survey.questions.length - 1) {
-                return SurveyQuestionBranchingType.ConfirmationMessage
+                return SurveyQuestionBranchingType.End
             }
 
             return nextQuestionIndex
         }
 
-        if (question.branching.type === SurveyQuestionBranchingType.ConfirmationMessage) {
-            return SurveyQuestionBranchingType.ConfirmationMessage
+        if (question.branching.type === SurveyQuestionBranchingType.End) {
+            return SurveyQuestionBranchingType.End
         } else if (question.branching.type === SurveyQuestionBranchingType.SpecificQuestion) {
             if (Number.isInteger(question.branching.index)) {
                 return question.branching.index
@@ -219,8 +219,8 @@ export class PostHogSurveys {
                         return nextStep
                     }
 
-                    if (nextStep === SurveyQuestionBranchingType.ConfirmationMessage) {
-                        return SurveyQuestionBranchingType.ConfirmationMessage
+                    if (nextStep === SurveyQuestionBranchingType.End) {
+                        return SurveyQuestionBranchingType.End
                     }
 
                     return nextQuestionIndex
@@ -240,8 +240,8 @@ export class PostHogSurveys {
                         return nextStep
                     }
 
-                    if (nextStep === SurveyQuestionBranchingType.ConfirmationMessage) {
-                        return SurveyQuestionBranchingType.ConfirmationMessage
+                    if (nextStep === SurveyQuestionBranchingType.End) {
+                        return SurveyQuestionBranchingType.End
                     }
 
                     return nextQuestionIndex


### PR DESCRIPTION
## Changes
Naming this branching type `confirmation_message` is confusing because not every survey ends with a confirmation message.

`posthog` changes to follow.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
