### PR TITLE
feat(web-analytics): Add property for autocapture link click

### DIFF
--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -36,6 +36,7 @@ export default function Home() {
                 <a className="Button" data-attr="autocapture-button" href="#">
                     <span>Autocapture a &gt; span</span>
                 </a>
+                <a href={'https://www.google.com'}>External link</a>
 
                 <button className="ph-no-capture">Ignore certain elements</button>
 

--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -557,6 +557,7 @@ describe('Autocapture system', () => {
             expect(props['$elements'][1]).toHaveProperty('tag_name', 'span')
             expect(props['$elements'][2]).toHaveProperty('tag_name', 'div')
             expect(props['$elements'][props['$elements'].length - 1]).toHaveProperty('tag_name', 'body')
+            expect(props['$click_external_href']).toEqual('https://test.com')
         })
 
         it('truncate any element property value to 1024 bytes', () => {
@@ -594,7 +595,9 @@ describe('Autocapture system', () => {
                     target: elTarget,
                 })
             )
-            expect(captureMock.mock.calls[0][1]['$elements'][0]).toHaveProperty('attr__href', 'https://test.com')
+            const props = captureMock.mock.calls[0][1]
+            expect(props['$elements'][0]).toHaveProperty('attr__href', 'https://test.com')
+            expect(props['$click_external_href']).toEqual('https://test.com')
         })
 
         it('does not capture href attribute values from password elements', () => {

--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -615,7 +615,7 @@ describe('Autocapture system', () => {
             )
             const props = captureMock.mock.calls[0][1]
             expect(props['$elements'][0]).toHaveProperty('attr__href', 'https://www.example.com/link')
-            expect(props['external_click_url']).toBeUndefined()
+            expect(props['$external_click_url']).toBeUndefined()
         })
 
         it('does not capture href attribute values from password elements', () => {

--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -557,7 +557,7 @@ describe('Autocapture system', () => {
             expect(props['$elements'][1]).toHaveProperty('tag_name', 'span')
             expect(props['$elements'][2]).toHaveProperty('tag_name', 'div')
             expect(props['$elements'][props['$elements'].length - 1]).toHaveProperty('tag_name', 'body')
-            expect(props['$click_external_href']).toEqual('https://test.com')
+            expect(props['$external_click_url']).toEqual('https://test.com')
         })
 
         it('truncate any element property value to 1024 bytes', () => {
@@ -597,7 +597,7 @@ describe('Autocapture system', () => {
             )
             const props = captureMock.mock.calls[0][1]
             expect(props['$elements'][0]).toHaveProperty('attr__href', 'https://test.com')
-            expect(props['$click_external_href']).toEqual('https://test.com')
+            expect(props['$external_click_url']).toEqual('https://test.com')
         })
 
         it('does not include $click_external_href for same site', () => {
@@ -615,7 +615,7 @@ describe('Autocapture system', () => {
             )
             const props = captureMock.mock.calls[0][1]
             expect(props['$elements'][0]).toHaveProperty('attr__href', 'https://www.example.com/link')
-            expect(props['$click_external_href']).toBeUndefined()
+            expect(props['external_click_url']).toBeUndefined()
         })
 
         it('does not capture href attribute values from password elements', () => {

--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -600,6 +600,24 @@ describe('Autocapture system', () => {
             expect(props['$click_external_href']).toEqual('https://test.com')
         })
 
+        it('does not include $click_external_href for same site', () => {
+            window!.location = new URL('https://www.example.com/location') as unknown as Location
+            const elTarget = document.createElement('img')
+            const elParent = document.createElement('span')
+            elParent.appendChild(elTarget)
+            const elGrandparent = document.createElement('a')
+            elGrandparent.setAttribute('href', 'https://www.example.com/link')
+            elGrandparent.appendChild(elParent)
+            autocapture['_captureEvent'](
+                makeMouseEvent({
+                    target: elTarget,
+                })
+            )
+            const props = captureMock.mock.calls[0][1]
+            expect(props['$elements'][0]).toHaveProperty('attr__href', 'https://www.example.com/link')
+            expect(props['$click_external_href']).toBeUndefined()
+        })
+
         it('does not capture href attribute values from password elements', () => {
             const elTarget = document.createElement('span')
             const elParent = document.createElement('span')

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -347,7 +347,7 @@ export class Autocapture {
                           $elements: elementsJson,
                       },
                 elementsJson[0]?.['$el_text'] ? { $el_text: elementsJson[0]?.['$el_text'] } : {},
-                externalHref && e.type === 'click' ? { $click_external_href: externalHref } : {},
+                externalHref && e.type === 'click' ? { $external_click_url: externalHref } : {},
                 autocaptureAugmentProperties
             )
 

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -24,7 +24,7 @@ import { AUTOCAPTURE_DISABLED_SERVER_SIDE } from './constants'
 
 import { isBoolean, isFunction, isNull, isObject, isUndefined } from './utils/type-utils'
 import { logger } from './utils/logger'
-import { document, location, window } from './utils/globals'
+import { document, window } from './utils/globals'
 import { convertToURL } from './utils/request-utils'
 
 const COPY_AUTOCAPTURE_EVENT = '$copy_autocapture'
@@ -327,7 +327,8 @@ export class Autocapture {
             if (href) {
                 elementsJson[0]['attr__href'] = href
                 const hrefHost = convertToURL(href)?.host
-                if (hrefHost && location?.host && hrefHost !== location.host) {
+                const locationHost = window?.location?.host
+                if (hrefHost && locationHost && hrefHost !== locationHost) {
                     externalHref = href
                 }
             }

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -340,6 +340,7 @@ export class Autocapture {
                           $elements: elementsJson,
                       },
                 elementsJson[0]?.['$el_text'] ? { $el_text: elementsJson[0]?.['$el_text'] } : {},
+                e.type === 'click' && href ? { $click_href: href } : {},
                 autocaptureAugmentProperties
             )
 

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -24,7 +24,8 @@ import { AUTOCAPTURE_DISABLED_SERVER_SIDE } from './constants'
 
 import { isBoolean, isFunction, isNull, isObject, isUndefined } from './utils/type-utils'
 import { logger } from './utils/logger'
-import { document, window } from './utils/globals'
+import { document, location, window } from './utils/globals'
+import { convertToURL } from './utils/request-utils'
 
 const COPY_AUTOCAPTURE_EVENT = '$copy_autocapture'
 
@@ -322,8 +323,13 @@ export class Autocapture {
                 }
             }
 
+            let externalHref: string | undefined
             if (href) {
                 elementsJson[0]['attr__href'] = href
+                const hrefHost = convertToURL(href)?.host
+                if (hrefHost && location?.host && hrefHost !== location.host) {
+                    externalHref = href
+                }
             }
 
             if (explicitNoCapture) {
@@ -340,7 +346,7 @@ export class Autocapture {
                           $elements: elementsJson,
                       },
                 elementsJson[0]?.['$el_text'] ? { $el_text: elementsJson[0]?.['$el_text'] } : {},
-                e.type === 'click' && href ? { $click_href: href } : {},
+                externalHref && e.type === 'click' ? { $click_external_href: externalHref } : {},
                 autocaptureAugmentProperties
             )
 


### PR DESCRIPTION
## Changes

This PR creates a new property, which is the href when an external link is clicked. External is defined as a different host, and the intention here is for people to measure things like which landing pages lead to which external link clicks.

(I was basically nerd-sniped into adding this by some customer feedback)

We already capture this, but it's very buried inside the $element array, and not always at the same place (not always $elements.0.attr_href), so its hard to add to the sessions MV.

Tested this manually by adding an external link to the nextjs playground, and confirming that I could see the event and property.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
