### PR TITLE
chore: update pnpm action setup worfklow version

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8.x.x
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
                   fetch-depth: 0
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            - uses: pnpm/action-setup@v2
+            - uses: pnpm/action-setup@v4
               with:
                 version: 8.x.x
 
@@ -109,7 +109,7 @@ jobs:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v2
+              uses: pnpm/action-setup@v4
 
             - name: Set up Node.js
               uses: actions/setup-node@v3

--- a/.github/workflows/label-version-bump.yml
+++ b/.github/workflows/label-version-bump.yml
@@ -23,7 +23,7 @@ jobs:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
                   fetch-depth: 0
 
-            - uses: pnpm/action-setup@v2
+            - uses: pnpm/action-setup@v4
               with:
                 version: 8.x.x
 

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v2
+            - uses: pnpm/action-setup@v4
               with:
                 version: 8.x.x
             - uses: actions/setup-node@v4
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v2
+            - uses: pnpm/action-setup@v4
               with:
                 version: 8.x.x
             - uses: actions/setup-node@v4
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v2
+            - uses: pnpm/action-setup@v4
               with:
                 version: 8.x.x
             - uses: actions/setup-node@v4
@@ -76,7 +76,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v2
+            - uses: pnpm/action-setup@v4
               with:
                   version: 8.x.x
             - uses: actions/setup-node@v4

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 8.x.x
       - uses: actions/setup-node@v4

--- a/.github/workflows/ssr-es-check.yml
+++ b/.github/workflows/ssr-es-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 8.x.x
       - uses: actions/setup-node@v4

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 8.x.x
       - uses: actions/setup-node@v4

--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -49,7 +49,7 @@ interface _SentryIntegration {
 // levels copied from Sentry to avoid relying on a frequently changing @sentry/types dependency
 // but provided as an array of literal types, so we can constrain the level below
 const severityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug'] as const
-declare type _SeverityLevel = (typeof severityLevels)[number]
+declare type _SeverityLevel = typeof severityLevels[number]
 
 interface SentryExceptionProperties {
     $sentry_event_id: any

--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -49,7 +49,7 @@ interface _SentryIntegration {
 // levels copied from Sentry to avoid relying on a frequently changing @sentry/types dependency
 // but provided as an array of literal types, so we can constrain the level below
 const severityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug'] as const
-declare type _SeverityLevel = typeof severityLevels[number]
+declare type _SeverityLevel = (typeof severityLevels)[number]
 
 interface SentryExceptionProperties {
     $sentry_event_id: any


### PR DESCRIPTION
we were using 2
it gives warnings about node 16 when running
latest is 4
lets use 4