### PR TITLE
fix: dropped styles on route transition

### DIFF
--- a/patches/rrweb@2.0.0-alpha.13.patch
+++ b/patches/rrweb@2.0.0-alpha.13.patch
@@ -167,7 +167,7 @@ index ea868845c4fad3276aa8e5f74abfd3568b466d11..965505de44975e718d431a4e9a62e753
  
  export { WorkerFactory as default };
 diff --git a/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js b/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
-index da2c103fe6b1408a5996f0eb3bf047571e434cc2..3b34097a089791bd1043f313dcab9ad4c3733830 100644
+index da2c103fe6b1408a5996f0eb3bf047571e434cc2..f5b060c7e0728a3e2c6cf62b01d97282f2484ac3 100644
 --- a/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
 +++ b/es/rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.js
 @@ -91,11 +91,21 @@ class CanvasManager {
@@ -223,3 +223,26 @@ index da2c103fe6b1408a5996f0eb3bf047571e434cc2..3b34097a089791bd1043f313dcab9ad4
                      dataURLOptions: options.dataURLOptions,
                  }, [bitmap]);
              }));
+diff --git a/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js b/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
+index 0fc7d4bcafc9be822347f9437658478fd77d9972..a2400dbd745664cc94335f9a0d04bb52af91ee13 100644
+--- a/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
++++ b/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
+@@ -641,9 +641,17 @@ function serializeElementNode(n, options) {
+         }
+     }
+     if (tagName === 'link' && inlineStylesheet) {
+-        const stylesheet = Array.from(doc.styleSheets).find((s) => {
++        let stylesheet = Array.from(doc.styleSheets).find((s) => {
+             return s.href === n.href;
+         });
++        if (!stylesheet && n.href.contains('.css')) {
++            const rootDomain = window.location.origin
++            const stylesheetPath = n.href.replace(window.location.href, '')
++            const potentialStylesheetHref = rootDomain + '/' + stylesheetPath
++            stylesheet = Array.from(doc.styleSheets).find((s) => {
++                return s.href === potentialStylesheetHref;
++            });
++        }
+         let cssText = null;
+         if (stylesheet) {
+             cssText = stringifyStylesheet(stylesheet);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   rrweb@2.0.0-alpha.13:
-    hash: kbttqqcqy44k7qdfsxzockfufy
+    hash: r7tadzcafyums4uktydxz6hwry
     path: patches/rrweb@2.0.0-alpha.13.patch
 
 dependencies:
@@ -191,7 +191,7 @@ devDependencies:
     version: 5.12.0(rollup@4.9.6)
   rrweb:
     specifier: 2.0.0-alpha.13
-    version: 2.0.0-alpha.13(patch_hash=kbttqqcqy44k7qdfsxzockfufy)
+    version: 2.0.0-alpha.13(patch_hash=r7tadzcafyums4uktydxz6hwry)
   rrweb-snapshot:
     specifier: 2.0.0-alpha.13
     version: 2.0.0-alpha.13
@@ -9319,7 +9319,7 @@ packages:
     resolution: {integrity: sha512-slbhNBCYjxLGCeH95a67ECCy5a22nloXp1F5wF7DCzUNw80FN7tF9Lef1sRGLNo32g3mNqTc2sWLATlKejMxYw==}
     dev: true
 
-  /rrweb@2.0.0-alpha.13(patch_hash=kbttqqcqy44k7qdfsxzockfufy):
+  /rrweb@2.0.0-alpha.13(patch_hash=r7tadzcafyums4uktydxz6hwry):
     resolution: {integrity: sha512-a8GXOCnzWHNaVZPa7hsrLZtNZ3CGjiL+YrkpLo0TfmxGLhjNZbWY2r7pE06p+FcjFNlgUVTmFrSJbK3kO7yxvw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.13


### PR DESCRIPTION
## Problem

Relates to https://posthoghelp.zendesk.com/agent/tickets/14512 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18047) (and probably a bunch more support tickets)

This could also be related to https://github.com/rrweb-io/rrweb/issues/1230

Addresses an issue in recordings where styles were being dropped during some route changes in SPAs

### Reproduction
It's not fully clear to me how this happens or what the correct behaviour is but the problem exists when:

1. You have a relative link element on the page:
```
<link href="./_app/immutable/assets/filename.css" rel="stylesheet">
```
2. This gets loaded into the documents `styleSheets` array with the href set as `https://domainname.com/_app/immutable/assets/filename.css`

3. Sometime later the domain changes away from the index page to another root e.g. `https://domainname.com/home`
4. When taking the next full snapshot [rrweb tries to fetch the stylesheet associated with the href](https://github.com/rrweb-io/rrweb/blob/4f44bd17aa888c041e9a4c8c0f4c921af92a4b12/packages/rrweb-snapshot/src/snapshot.ts#L657-L659):
```
const stylesheet = Array.from(doc.styleSheets).find((s) => {
  return s.href === (n as HTMLLinkElement).href;
});
```
5. `n.href` now evaluates to `https://domainname.com/home/_app/immutable/assets/filename.css` which no longer matches the `href` of the stylesheet on the document and hence cannot be "found". Presumably the href on the document stylesheet does not change because the SPA is not doing a full page transition

## Changes

This PR adds a backup check to look for the CSS on the root of the domain
- It only does this for CSS files
- It only does the lookup if a stylesheet cannot initially be found

This feels like the safest change for now but will get the opinion of others in the rrweb community too