### PR TITLE
fix: use includes over contains

### DIFF
--- a/patches/rrweb@2.0.0-alpha.13.patch
+++ b/patches/rrweb@2.0.0-alpha.13.patch
@@ -224,20 +224,22 @@ index da2c103fe6b1408a5996f0eb3bf047571e434cc2..f5b060c7e0728a3e2c6cf62b01d97282
                  }, [bitmap]);
              }));
 diff --git a/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js b/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
-index 0fc7d4bcafc9be822347f9437658478fd77d9972..a2400dbd745664cc94335f9a0d04bb52af91ee13 100644
+index 0fc7d4bcafc9be822347f9437658478fd77d9972..5dcd1dcbd5380567110378269f3bc8d7b7ca6440 100644
 --- a/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
 +++ b/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
-@@ -641,9 +641,17 @@ function serializeElementNode(n, options) {
+@@ -641,9 +641,18 @@ function serializeElementNode(n, options) {
          }
      }
      if (tagName === 'link' && inlineStylesheet) {
 -        const stylesheet = Array.from(doc.styleSheets).find((s) => {
+-            return s.href === n.href;
++        const href = n.href
 +        let stylesheet = Array.from(doc.styleSheets).find((s) => {
-             return s.href === n.href;
++            return s.href === href;
          });
-+        if (!stylesheet && n.href.contains('.css')) {
++        if (!stylesheet && href.includes('.css')) {
 +            const rootDomain = window.location.origin
-+            const stylesheetPath = n.href.replace(window.location.href, '')
++            const stylesheetPath = href.replace(window.location.href, '')
 +            const potentialStylesheetHref = rootDomain + '/' + stylesheetPath
 +            stylesheet = Array.from(doc.styleSheets).find((s) => {
 +                return s.href === potentialStylesheetHref;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   rrweb@2.0.0-alpha.13:
-    hash: r7tadzcafyums4uktydxz6hwry
+    hash: zfkdpmdytjgvxaxif5jxg5ibpy
     path: patches/rrweb@2.0.0-alpha.13.patch
 
 dependencies:
@@ -191,7 +191,7 @@ devDependencies:
     version: 5.12.0(rollup@4.9.6)
   rrweb:
     specifier: 2.0.0-alpha.13
-    version: 2.0.0-alpha.13(patch_hash=r7tadzcafyums4uktydxz6hwry)
+    version: 2.0.0-alpha.13(patch_hash=zfkdpmdytjgvxaxif5jxg5ibpy)
   rrweb-snapshot:
     specifier: 2.0.0-alpha.13
     version: 2.0.0-alpha.13
@@ -9319,7 +9319,7 @@ packages:
     resolution: {integrity: sha512-slbhNBCYjxLGCeH95a67ECCy5a22nloXp1F5wF7DCzUNw80FN7tF9Lef1sRGLNo32g3mNqTc2sWLATlKejMxYw==}
     dev: true
 
-  /rrweb@2.0.0-alpha.13(patch_hash=r7tadzcafyums4uktydxz6hwry):
+  /rrweb@2.0.0-alpha.13(patch_hash=zfkdpmdytjgvxaxif5jxg5ibpy):
     resolution: {integrity: sha512-a8GXOCnzWHNaVZPa7hsrLZtNZ3CGjiL+YrkpLo0TfmxGLhjNZbWY2r7pE06p+FcjFNlgUVTmFrSJbK3kO7yxvw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.13


### PR DESCRIPTION
## Changes

Use includes to check substring. `contains` is throwing a weird error as reported in https://github.com/PostHog/posthog-js/pull/1272#issuecomment-2191304203

|Before|After|
|----|----|
| ![Screenshot 2024-06-26 at 11 20 36](https://github.com/PostHog/posthog-js/assets/6685876/462a4cce-ab74-4b0b-b89a-491ee5302d49) | ![Screenshot 2024-06-26 at 11 20 42](https://github.com/PostHog/posthog-js/assets/6685876/43401df4-3731-4bd4-bcf3-c066bee75ca5) |

|Before|After|
|----|----|
| ![Screenshot 2024-06-26 at 11 20 16](https://github.com/PostHog/posthog-js/assets/6685876/ccf2438e-82d5-4463-a545-88ed01f48299) | ![Screenshot 2024-06-26 at 11 21 09](https://github.com/PostHog/posthog-js/assets/6685876/0bfd81c3-ee75-40c6-83d9-7f5ae8edfa04) |
