### PR TITLE
feat: warn when distinct id invalid for replay

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -860,6 +860,13 @@ export class PostHog {
         if (event_name === '$snapshot') {
             const persistenceProps = { ...this.persistence.properties(), ...this.sessionPersistence.properties() }
             properties['distinct_id'] = persistenceProps.distinct_id
+            if (
+                // we spotted one customer that was managing to send `false` for ~9k events a day
+                !(isString(properties['distinct_id']) || isNumber(properties['distinct_id'])) ||
+                isEmptyString(properties['distinct_id'])
+            ) {
+                logger.error('Invalid distinct_id for replay event. This indicates a bug in your implementation')
+            }
             return properties
         }
 


### PR DESCRIPTION
see https://posthog.sentry.io/issues/5544450836/?query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=2

it's all one customer but we should warn in this scenario