### PR TITLE
fix(surveys): polishing the popup survey UI

### DIFF
--- a/src/extensions/surveys/components/QuestionTypes.tsx
+++ b/src/extensions/surveys/components/QuestionTypes.tsx
@@ -140,6 +140,12 @@ export function RatingQuestion({
                                         onClick={() => {
                                             setRating(idx + 1)
                                         }}
+                                        style={{
+                                            fill: active
+                                                ? appearance.ratingButtonActiveColor
+                                                : appearance.ratingButtonColor,
+                                            borderColor: appearance.borderColor,
+                                        }}
                                     >
                                         {emoji}
                                     </button>
@@ -195,7 +201,7 @@ export function RatingButton({
     num: number
     active: boolean
     displayQuestionIndex: number
-    appearance: any
+    appearance: SurveyAppearance
     setActiveNumber: (num: number) => void
 }) {
     const { textColor, ref } = useContrastingTextColor({ appearance, defaultTextColor: 'black', forceUpdate: active })

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -57,6 +57,9 @@ export const style = (appearance: SurveyAppearance | null) => {
               border-color: ${appearance?.borderColor || '#c9c6c6'};
               margin-top: 14px;
           }
+          .survey-box:has(.survey-question:empty) textarea {
+              margin-top: 0;
+          }
           .form-submit {
               box-sizing: border-box;
               margin: 0;
@@ -197,6 +200,9 @@ export const style = (appearance: SurveyAppearance | null) => {
           .multiple-choice-options {
               margin-top: 13px;
               font-size: 14px;
+          }
+          .survey-box > div:has(.survey-question:empty) + .multiple-choice-options {
+              margin-top: 0;
           }
           .multiple-choice-options .choice-option {
               display: flex;

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -57,7 +57,7 @@ export const style = (appearance: SurveyAppearance | null) => {
               border-color: ${appearance?.borderColor || '#c9c6c6'};
               margin-top: 14px;
           }
-          .survey-box:has(.survey-question:empty) textarea {
+          .survey-box:has(.survey-question:empty):not(:has(.description)) textarea {
               margin-top: 0;
           }
           .form-submit {
@@ -201,7 +201,7 @@ export const style = (appearance: SurveyAppearance | null) => {
               margin-top: 13px;
               font-size: 14px;
           }
-          .survey-box > div:has(.survey-question:empty) + .multiple-choice-options {
+          .survey-box:has(.survey-question:empty):not(:has(.description)) .multiple-choice-options {
               margin-top: 0;
           }
           .multiple-choice-options .choice-option {

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -146,7 +146,6 @@ export const style = (appearance: SurveyAppearance | null) => {
               background: ${appearance?.backgroundColor || '#eeeded'};
           }
           .ratings-number {
-              background-color: ${appearance?.ratingButtonColor || 'white'};
               font-size: 16px;
               font-weight: 600;
               padding: 8px 0px;
@@ -190,7 +189,7 @@ export const style = (appearance: SurveyAppearance | null) => {
               fill: ${appearance?.ratingButtonActiveColor || 'black'};
           }
           .emoji-svg {
-              fill: ${appearance?.ratingButtonColor || '#c9c6c6'};
+              fill: '#939393';
           }
           .rating-text {
               display: flex;

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -16,7 +16,7 @@ export const style = (appearance: SurveyAppearance | null) => {
           `,
     }
     return `
-          .survey-form {
+          .survey-form, .thank-you-message {
               position: fixed;
               margin: 0px;
               bottom: 0px;
@@ -25,23 +25,33 @@ export const style = (appearance: SurveyAppearance | null) => {
               font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
               text-align: left;
               max-width: ${parseInt(appearance?.maxWidth || '300')}px;
+              width: 100%;
               z-index: ${parseInt(appearance?.zIndex || '99999')};
               border: 1.5px solid ${appearance?.borderColor || '#c9c6c6'};
               border-bottom: 0px;
-              width: 100%;
               ${positions[appearance?.position || 'right'] || 'right: 30px;'}
-          }
-          .form-submit[disabled] {
-              opacity: 0.6;
-              filter: grayscale(50%);
-              cursor: not-allowed;
-          }
-          .survey-form {
               flex-direction: column;
               background: ${appearance?.backgroundColor || '#eeeded'};
               border-top-left-radius: 10px;
               border-top-right-radius: 10px;
               box-shadow: -6px 0 16px -8px rgb(0 0 0 / 8%), -9px 0 28px 0 rgb(0 0 0 / 5%), -12px 0 48px 16px rgb(0 0 0 / 3%);
+          }
+          
+          .survey-box, .thank-you-message-container {
+              padding: 20px 25px 10px;
+              display: flex;
+              flex-direction: column;
+              border-radius: 10px;
+          }
+
+          .thank-you-message {
+              text-align: center;
+          }
+
+          .form-submit[disabled] {
+              opacity: 0.6;
+              filter: grayscale(50%);
+              cursor: not-allowed;
           }
           .survey-form textarea {
               color: #2d2d2d;
@@ -120,12 +130,6 @@ export const style = (appearance: SurveyAppearance | null) => {
               font-weight: 500;
               background: ${appearance?.backgroundColor || '#eeeded'};
               text-decoration: none;
-          }
-          .survey-box {
-              padding: 20px 25px 10px;
-              display: flex;
-              flex-direction: column;
-              border-radius: 10px;
           }
           .survey-question {
               font-weight: 500;
@@ -271,23 +275,6 @@ export const style = (appearance: SurveyAppearance | null) => {
               flex-grow: 1;
               border: 0;
               outline: 0;
-          }
-          .thank-you-message {
-              position: fixed;
-              bottom: 0px;
-              z-index: ${parseInt(appearance?.zIndex || '99999')};
-              box-shadow: -6px 0 16px -8px rgb(0 0 0 / 8%), -9px 0 28px 0 rgb(0 0 0 / 5%), -12px 0 48px 16px rgb(0 0 0 / 3%);
-              font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-              border-top-left-radius: 10px;
-              border-top-right-radius: 10px;
-              padding: 20px 25px 10px;
-              background: ${appearance?.backgroundColor || '#eeeded'};
-              border: 1.5px solid ${appearance?.borderColor || '#c9c6c6'};
-              text-align: center;
-              max-width: ${parseInt(appearance?.maxWidth || '300')}px;
-              min-width: 150px;
-              width: 100%;
-              ${positions[appearance?.position || 'right'] || 'right: 30px;'}
           }
           .thank-you-message-body {
               margin-top: 6px;


### PR DESCRIPTION
## Changes

Closes issues 1,3, and 4 from this ticket https://github.com/PostHog/posthog/issues/20851.

Fixing 4 requires some changes to posthog, too: https://github.com/PostHog/posthog/pull/23460

Issue 2 I wasn't able to reproduce; I need more context from @annikaschmid and/or @jurajmajerik 

Quick note on browser compatibility: I'm using the `:has` pseudo-selector for determining whether to apply margins or not.  Per [caniuse](https://caniuse.com/css-has), this has been supported in all major browsers since 2023, but is this a risky change still?

## Visual Diff For Part 1

### Before

![2024-07-01 16 46 43](https://github.com/PostHog/posthog-js/assets/4853149/e82e3ee9-3a3d-4ff7-bcaf-b9ed8ff445fc)


### After

![2024-07-01 16 41 07](https://github.com/PostHog/posthog-js/assets/4853149/fb794ba8-2213-4c76-b4eb-611db0bdd8bf)

## Visual Diff for Part 3

### Before

![2024-07-02 12 28 27](https://github.com/PostHog/posthog-js/assets/4853149/b5e8a857-ad96-43d2-bb48-ddb305c41241)


### After

![2024-07-02 11 57 41](https://github.com/PostHog/posthog-js/assets/4853149/606ba841-d5b6-40a8-9e09-bd1cefe1b239)

## Visual Diff for Part 4

### Before

![2024-07-03 13 47 07](https://github.com/PostHog/posthog-js/assets/4853149/9560011b-49f1-4b0f-8a8f-22377a6072c3)

### After


![2024-07-03 13 21 12](https://github.com/PostHog/posthog-js/assets/4853149/6776ce10-9e06-4ba2-bbc8-d5e24845dbbc)

...

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing)) 
- I manually tested this for each survey type
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
