### PR TITLE
feat(surveys): lazy load survey event receiver

### DIFF
--- a/cypress/e2e/error-tracking.cy.ts
+++ b/cypress/e2e/error-tracking.cy.ts
@@ -19,7 +19,7 @@ describe('Exception autocapture', () => {
         cy.get('[data-cy-button-throws-error]').click()
 
         // ugh
-        cy.wait(1500)
+        cy.wait(3000)
 
         cy.phCaptures({ full: true }).then((captures) => {
             expect(captures.map((c) => c.event)).to.deep.equal(['$pageview', '$autocapture', '$exception'])

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -9,7 +9,12 @@ import {
     SurveyQuestionBranchingType,
     SurveyQuestion,
 } from '../posthog-surveys-types'
-import { getDisplayOrderChoices, getDisplayOrderQuestions } from '../extensions/surveys/surveys-utils'
+import {
+    canActivateRepeatedly,
+    getDisplayOrderChoices,
+    getDisplayOrderQuestions,
+    hasEvents,
+} from '../extensions/surveys/surveys-utils'
 import { PostHogPersistence } from '../posthog-persistence'
 import { PostHog } from '../posthog-core'
 import { DecideResponse, PostHogConfig, Properties } from '../types'
@@ -17,12 +22,17 @@ import { window } from '../utils/globals'
 import { RequestRouter } from '../utils/request-router'
 import { assignableWindow } from '../utils/globals'
 import { expectScriptToExist, expectScriptToNotExist } from './helpers/script-utils'
+import { generateSurveys } from '../extensions/surveys'
+import { SurveyEventReceiver } from '../extensions/surveys/survey-event-receiver'
 
 describe('surveys', () => {
     let config: PostHogConfig
     let instance: PostHog
     let surveys: PostHogSurveys
     let surveysResponse: { status?: number; surveys?: Survey[] }
+
+    const loadScriptMock = jest.fn()
+
     const originalWindowLocation = assignableWindow.location
 
     const decideResponse = {
@@ -34,6 +44,7 @@ describe('surveys', () => {
             'enabled-internal-targeting-flag-key': true,
             'disabled-internal-targeting-flag-key': false,
         },
+        surveys: true,
     } as unknown as DecideResponse
 
     const firstSurveys: Survey[] = [
@@ -59,6 +70,7 @@ describe('surveys', () => {
             questions: [{ type: SurveyQuestionType.Open, question: 'what is a moblin?' }],
         } as unknown as Survey,
     ]
+
     const surveysWithEvents: Survey[] = [
         {
             name: 'first survey',
@@ -116,650 +128,679 @@ describe('surveys', () => {
         } as unknown as Survey,
     ]
 
-    beforeEach(() => {
-        surveysResponse = { surveys: firstSurveys }
+    describe('when enabled by decide', () => {
+        beforeEach(() => {
+            surveysResponse = { surveys: firstSurveys }
 
-        config = {
-            token: 'testtoken',
-            api_host: 'https://app.posthog.com',
-            persistence: 'memory',
-        } as unknown as PostHogConfig
+            config = {
+                token: 'testtoken',
+                api_host: 'https://app.posthog.com',
+                persistence: 'memory',
+            } as unknown as PostHogConfig
 
-        instance = {
-            config: config,
-            persistence: new PostHogPersistence(config),
-            requestRouter: new RequestRouter({ config } as any),
-            _addCaptureHook: jest.fn(),
-            register: (props: Properties) => instance.persistence?.register(props),
-            unregister: (key: string) => instance.persistence?.unregister(key),
-            get_property: (key: string) => instance.persistence?.props[key],
-            _send_request: jest
-                .fn()
-                .mockImplementation(({ callback }) => callback({ statusCode: 200, json: surveysResponse })),
-            featureFlags: {
+            instance = {
+                config: config,
+                persistence: new PostHogPersistence(config),
+                requestRouter: new RequestRouter({ config } as any),
+                _addCaptureHook: jest.fn(),
+                register: (props: Properties) => instance.persistence?.register(props),
+                unregister: (key: string) => instance.persistence?.unregister(key),
+                get_property: (key: string) => instance.persistence?.props[key],
                 _send_request: jest
                     .fn()
-                    .mockImplementation(({ callback }) => callback({ statusCode: 200, json: decideResponse })),
-                getFeatureFlag: jest.fn().mockImplementation((featureFlag) => decideResponse.featureFlags[featureFlag]),
-                isFeatureEnabled: jest
-                    .fn()
-                    .mockImplementation((featureFlag) => decideResponse.featureFlags[featureFlag]),
-            },
-        } as unknown as PostHog
-
-        surveys = new PostHogSurveys(instance)
-
-        Object.defineProperty(window, 'location', {
-            configurable: true,
-            enumerable: true,
-            writable: true,
-            // eslint-disable-next-line compat/compat
-            value: new URL('https://example.com'),
-        })
-    })
-
-    afterEach(() => {
-        instance.persistence?.clear()
-
-        Object.defineProperty(window, 'location', {
-            configurable: true,
-            enumerable: true,
-            value: originalWindowLocation,
-        })
-    })
-
-    it('getSurveys gets a list of surveys if not present already', () => {
-        surveys.getSurveys((data) => {
-            expect(data).toEqual(firstSurveys)
-        })
-        expect(instance._send_request).toHaveBeenCalledWith({
-            url: 'https://us.i.posthog.com/api/surveys/?token=testtoken',
-            method: 'GET',
-            transport: 'XHR',
-            callback: expect.any(Function),
-        })
-        expect(instance._send_request).toHaveBeenCalledTimes(1)
-        expect(instance.persistence?.props.$surveys).toEqual(firstSurveys)
-
-        surveysResponse = { surveys: secondSurveys }
-        surveys.getSurveys((data) => {
-            expect(data).toEqual(firstSurveys)
-        })
-        // request again, shouldn't call _send_request again, so 1 total call instead of 2
-        expect(instance._send_request).toHaveBeenCalledTimes(1)
-    })
-
-    it('getSurveys registers the survey event receiver if a survey has events', () => {
-        surveysResponse = { surveys: surveysWithEvents }
-        surveys.getSurveys((data) => {
-            expect(data).toEqual(surveysWithEvents)
-        }, true)
-
-        const registry = surveys._surveyEventReceiver?.getEventRegistry()
-        expect(registry.has('second-survey')).toBeFalsy()
-        expect(registry.has('first-survey')).toBeTruthy()
-        expect(registry.get('first-survey')).toEqual([
-            'user_subscribed',
-            'user_unsubscribed',
-            'billing_changed',
-            'billing_removed',
-        ])
-
-        expect(registry.has('third-survey')).toBeTruthy()
-        expect(registry.get('third-survey')).toEqual(['user_subscribed', 'user_unsubscribed', 'address_changed'])
-    })
-
-    it('getSurveys force reloads when called with true', () => {
-        surveys.getSurveys((data) => {
-            expect(data).toEqual(firstSurveys)
-        })
-        expect(instance._send_request).toHaveBeenCalledWith({
-            url: 'https://us.i.posthog.com/api/surveys/?token=testtoken',
-            method: 'GET',
-            transport: 'XHR',
-            callback: expect.any(Function),
-        })
-        expect(instance._send_request).toHaveBeenCalledTimes(1)
-        expect(instance.persistence?.props.$surveys).toEqual(firstSurveys)
-
-        surveysResponse = { surveys: secondSurveys }
-
-        surveys.getSurveys((data) => {
-            expect(data).toEqual(secondSurveys)
-        }, true)
-        expect(instance.persistence?.props.$surveys).toEqual(secondSurveys)
-        expect(instance._send_request).toHaveBeenCalledTimes(2)
-    })
-
-    it('getSurveys returns empty array if surveys are undefined', () => {
-        surveysResponse = { status: 0 }
-        surveys.getSurveys((data) => {
-            expect(data).toEqual([])
-        })
-    })
-
-    it('getSurveys returns empty array if surveys are disabled', () => {
-        instance.config.disable_surveys = true
-        surveys.getSurveys((data) => {
-            expect(data).toEqual([])
-        })
-        expect(instance._send_request).not.toHaveBeenCalled()
-    })
-
-    describe('getActiveMatchingSurveys', () => {
-        const draftSurvey: Survey = {
-            name: 'draft survey',
-            description: 'draft survey description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a draft survey?' }],
-            start_date: null,
-        } as unknown as Survey
-        const activeSurvey: Survey = {
-            name: 'active survey',
-            description: 'active survey description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a active survey?' }],
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const completedSurvey: Survey = {
-            name: 'completed survey',
-            description: 'completed survey description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a completed survey?' }],
-            start_date: new Date('09/10/2022').toISOString(),
-            end_date: new Date('10/10/2022').toISOString(),
-        } as unknown as Survey
-        const surveyWithUrl: Survey = {
-            name: 'survey with url',
-            description: 'survey with url description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with url?' }],
-            conditions: { url: 'posthog.com' },
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithRegexUrl: Survey = {
-            name: 'survey with regex url',
-            description: 'survey with regex url description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with regex url?' }],
-            conditions: { url: 'regex-url', urlMatchType: 'regex' },
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithUrlDoesNotContainRegex: Survey = {
-            name: 'survey with url does not contain regex',
-            description: 'survey with url does not contain regex description',
-            type: SurveyType.Popover,
-            questions: [
-                { type: SurveyQuestionType.Open, question: 'what is a survey with url does not contain regex?' },
-            ],
-            conditions: { url: 'regex-url', urlMatchType: 'not_regex' },
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithParamRegexUrl: Survey = {
-            name: 'survey with param regex url',
-            description: 'survey with param regex url description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with param regex url?' }],
-            conditions: { url: '(\\?|\\&)(name.*)\\=([^&]+)', urlMatchType: 'regex' },
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithWildcardSubdomainUrl: Survey = {
-            name: 'survey with wildcard subdomain url',
-            description: 'survey with wildcard subdomain url description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with wildcard subdomain url?' }],
-            conditions: { url: '(.*.)?subdomain.com', urlMatchType: 'regex' },
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithWildcardRouteUrl: Survey = {
-            name: 'survey with wildcard route url',
-            description: 'survey with wildcard route url description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with wildcard route url?' }],
-            conditions: { url: 'wildcard.com/(.*.)', urlMatchType: 'regex' },
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithExactUrlMatch: Survey = {
-            name: 'survey with wildcard route url',
-            description: 'survey with wildcard route url description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with wildcard route url?' }],
-            conditions: { url: 'https://example.com/exact', urlMatchType: 'exact' },
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithIsNotUrlMatch: Survey = {
-            name: 'survey with is not url match',
-            description: 'survey with is not url match description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with is not url match?' }],
-            conditions: { url: 'https://example.com/exact', urlMatchType: 'is_not' },
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithUrlDoesNotContain: Survey = {
-            name: 'survey with url does not contain',
-            description: 'survey with url does not contain description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with url does not contain?' }],
-            conditions: { url: 'posthog.com', urlMatchType: 'not_icontains' },
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithSelector: Survey = {
-            name: 'survey with selector',
-            description: 'survey with selector description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with selector?' }],
-            conditions: { selector: '.test-selector' },
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithUrlAndSelector: Survey = {
-            name: 'survey with url and selector',
-            description: 'survey with url and selector description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with url and selector?' }],
-            conditions: { url: 'posthogapp.com', selector: '#foo' },
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithFlags: Survey = {
-            name: 'survey with flags',
-            description: 'survey with flags description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with flags?' }],
-            linked_flag_key: 'linked-flag-key',
-            targeting_flag_key: 'survey-targeting-flag-key',
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithUnmatchedFlags: Survey = {
-            name: 'survey with flags2',
-            description: 'survey with flags description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with flags?' }],
-            linked_flag_key: 'linked-flag-key2',
-            targeting_flag_key: 'survey-targeting-flag-key2',
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithEnabledInternalFlag: Survey = {
-            name: 'survey with enabled internal flags',
-            description: 'survey with flags description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with flags?' }],
-            linked_flag_key: 'linked-flag-key',
-            internal_targeting_flag_key: 'enabled-internal-targeting-flag-key',
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithDisabledInternalFlag: Survey = {
-            name: 'survey with disabled internal flag',
-            description: 'survey with flags description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with flags?' }],
-            linked_flag_key: 'linked-flag-key2',
-            internal_targeting_flag_key: 'disabled-internal-targeting-flag-key',
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithEvents: Survey = {
-            name: 'survey with events',
-            description: 'survey with events description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with flags?' }],
-            linked_flag_key: 'linked-flag-key',
-            internal_targeting_flag_key: 'enabled-internal-targeting-flag-key',
-            conditions: {
-                events: {
-                    values: [
-                        {
-                            name: 'user_subscribed',
-                        },
-                        {
-                            name: 'user_unsubscribed',
-                        },
-                    ],
+                    .mockImplementation(({ callback }) => callback({ statusCode: 200, json: surveysResponse })),
+                featureFlags: {
+                    _send_request: jest
+                        .fn()
+                        .mockImplementation(({ callback }) => callback({ statusCode: 200, json: decideResponse })),
+                    getFeatureFlag: jest
+                        .fn()
+                        .mockImplementation((featureFlag) => decideResponse.featureFlags[featureFlag]),
+                    isFeatureEnabled: jest
+                        .fn()
+                        .mockImplementation((featureFlag) => decideResponse.featureFlags[featureFlag]),
                 },
-            },
-            start_date: new Date().toISOString(),
-            end_date: null,
-        } as unknown as Survey
-        const surveyWithEverything: Survey = {
-            name: 'survey with everything',
-            description: 'survey with everything description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with everything?' }],
-            start_date: new Date().toISOString(),
-            end_date: null,
-            conditions: { url: 'posthogapp.com', selector: '.test-selector' },
-            linked_flag_key: 'linked-flag-key',
-            targeting_flag_key: 'survey-targeting-flag-key',
-        } as unknown as Survey
+            } as unknown as PostHog
 
-        it('returns surveys that are active', () => {
-            surveysResponse = { surveys: [draftSurvey, activeSurvey, completedSurvey] }
+            loadScriptMock.mockImplementation((_path, callback) => {
+                assignableWindow.__PosthogExtensions__ = assignableWindow.__Posthog__ || {}
+                assignableWindow.extendPostHogWithSurveys = generateSurveys
+                assignableWindow.__PosthogExtensions__.SurveysEventReceiver = SurveyEventReceiver
+                assignableWindow.__PosthogExtensions__.canActivateRepeatedly = canActivateRepeatedly
+                assignableWindow.__PosthogExtensions__.hasEvents = hasEvents
 
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([activeSurvey])
+                callback()
+            })
+
+            instance.requestRouter.loadScript = loadScriptMock
+
+            surveys = new PostHogSurveys(instance)
+
+            // TODO wat
+            instance.surveys = surveys
+            // TODO oh mocks, you fun
+            instance.getActiveMatchingSurveys = surveys.getActiveMatchingSurveys
+
+            surveys.afterDecideResponse(decideResponse)
+            surveys.loadIfEnabled()
+
+            Object.defineProperty(window, 'location', {
+                configurable: true,
+                enumerable: true,
+                writable: true,
+                // eslint-disable-next-line compat/compat
+                value: new URL('https://example.com'),
             })
         })
 
-        it('returns surveys based on url and selector matching', () => {
-            surveysResponse = {
-                surveys: [surveyWithUrl, surveyWithSelector, surveyWithUrlAndSelector],
-            }
-            // eslint-disable-next-line compat/compat
-            assignableWindow.location = new URL('https://posthog.com') as unknown as Location
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithUrl])
-            })
-            assignableWindow.location = originalWindowLocation
+        afterEach(() => {
+            instance.persistence?.clear()
 
-            document.body.appendChild(document.createElement('div')).className = 'test-selector'
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithSelector])
+            Object.defineProperty(window, 'location', {
+                configurable: true,
+                enumerable: true,
+                value: originalWindowLocation,
             })
-            const testSelectorEl = document!.querySelector('.test-selector')
-            if (testSelectorEl) {
-                document.body.removeChild(testSelectorEl)
-            }
-
-            // eslint-disable-next-line compat/compat
-            assignableWindow.location = new URL('https://posthogapp.com') as unknown as Location
-            document.body.appendChild(document.createElement('div')).id = 'foo'
-
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithUrlAndSelector])
-            })
-            const child = document.querySelector('#foo')
-            if (child) {
-                document.body.removeChild(child)
-            }
         })
 
-        it('returns surveys based on url with urlMatchType settings', () => {
-            surveysResponse = {
-                surveys: [
-                    surveyWithRegexUrl,
-                    surveyWithParamRegexUrl,
-                    surveyWithWildcardRouteUrl,
-                    surveyWithWildcardSubdomainUrl,
-                    surveyWithExactUrlMatch,
+        it('getSurveys gets a list of surveys if not present already', () => {
+            surveys.getSurveys((data) => {
+                expect(data).toEqual(firstSurveys)
+            })
+            expect(instance._send_request).toHaveBeenCalledWith({
+                url: 'https://us.i.posthog.com/api/surveys/?token=testtoken',
+                method: 'GET',
+                transport: 'XHR',
+                callback: expect.any(Function),
+            })
+            expect(instance._send_request).toHaveBeenCalledTimes(1)
+            expect(instance.persistence?.props.$surveys).toEqual(firstSurveys)
+
+            surveysResponse = { surveys: secondSurveys }
+            surveys.getSurveys((data) => {
+                expect(data).toEqual(firstSurveys)
+            })
+            // request again, shouldn't call _send_request again, so 1 total call instead of 2
+            expect(instance._send_request).toHaveBeenCalledTimes(1)
+        })
+
+        it('getSurveys registers the survey event receiver if a survey has events', () => {
+            surveysResponse = { surveys: surveysWithEvents }
+            surveys.getSurveys((data) => {
+                expect(data).toEqual(surveysWithEvents)
+            }, true)
+
+            const registry = surveys._surveyEventReceiver?.getEventRegistry()
+            expect(registry.has('second-survey')).toBeFalsy()
+            expect(registry.has('first-survey')).toBeTruthy()
+            expect(registry.get('first-survey')).toEqual([
+                'user_subscribed',
+                'user_unsubscribed',
+                'billing_changed',
+                'billing_removed',
+            ])
+
+            expect(registry.has('third-survey')).toBeTruthy()
+            expect(registry.get('third-survey')).toEqual(['user_subscribed', 'user_unsubscribed', 'address_changed'])
+        })
+
+        it('getSurveys force reloads when called with true', () => {
+            surveys.getSurveys((data) => {
+                expect(data).toEqual(firstSurveys)
+            })
+            expect(instance._send_request).toHaveBeenCalledWith({
+                url: 'https://us.i.posthog.com/api/surveys/?token=testtoken',
+                method: 'GET',
+                transport: 'XHR',
+                callback: expect.any(Function),
+            })
+            expect(instance._send_request).toHaveBeenCalledTimes(1)
+            expect(instance.persistence?.props.$surveys).toEqual(firstSurveys)
+
+            surveysResponse = { surveys: secondSurveys }
+
+            surveys.getSurveys((data) => {
+                expect(data).toEqual(secondSurveys)
+            }, true)
+            expect(instance.persistence?.props.$surveys).toEqual(secondSurveys)
+            expect(instance._send_request).toHaveBeenCalledTimes(2)
+        })
+
+        it('getSurveys returns empty array if surveys are undefined', () => {
+            surveysResponse = { status: 0 }
+            surveys.getSurveys((data) => {
+                expect(data).toEqual([])
+            })
+        })
+
+        it('getSurveys returns empty array if surveys are disabled', () => {
+            instance.config.disable_surveys = true
+            surveys.getSurveys((data) => {
+                expect(data).toEqual([])
+            })
+            expect(instance._send_request).not.toHaveBeenCalled()
+        })
+
+        describe('getActiveMatchingSurveys', () => {
+            const draftSurvey: Survey = {
+                name: 'draft survey',
+                description: 'draft survey description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a draft survey?' }],
+                start_date: null,
+            } as unknown as Survey
+            const activeSurvey: Survey = {
+                name: 'active survey',
+                description: 'active survey description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a active survey?' }],
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const completedSurvey: Survey = {
+                name: 'completed survey',
+                description: 'completed survey description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a completed survey?' }],
+                start_date: new Date('09/10/2022').toISOString(),
+                end_date: new Date('10/10/2022').toISOString(),
+            } as unknown as Survey
+            const surveyWithUrl: Survey = {
+                name: 'survey with url',
+                description: 'survey with url description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with url?' }],
+                conditions: { url: 'posthog.com' },
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithRegexUrl: Survey = {
+                name: 'survey with regex url',
+                description: 'survey with regex url description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with regex url?' }],
+                conditions: { url: 'regex-url', urlMatchType: 'regex' },
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithUrlDoesNotContainRegex: Survey = {
+                name: 'survey with url does not contain regex',
+                description: 'survey with url does not contain regex description',
+                type: SurveyType.Popover,
+                questions: [
+                    { type: SurveyQuestionType.Open, question: 'what is a survey with url does not contain regex?' },
                 ],
-            }
+                conditions: { url: 'regex-url', urlMatchType: 'not_regex' },
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithParamRegexUrl: Survey = {
+                name: 'survey with param regex url',
+                description: 'survey with param regex url description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with param regex url?' }],
+                conditions: { url: '(\\?|\\&)(name.*)\\=([^&]+)', urlMatchType: 'regex' },
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithWildcardSubdomainUrl: Survey = {
+                name: 'survey with wildcard subdomain url',
+                description: 'survey with wildcard subdomain url description',
+                type: SurveyType.Popover,
+                questions: [
+                    {
+                        type: SurveyQuestionType.Open,
+                        question: 'what is a survey with wildcard subdomain url?',
+                    },
+                ],
+                conditions: { url: '(.*.)?subdomain.com', urlMatchType: 'regex' },
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithWildcardRouteUrl: Survey = {
+                name: 'survey with wildcard route url',
+                description: 'survey with wildcard route url description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with wildcard route url?' }],
+                conditions: { url: 'wildcard.com/(.*.)', urlMatchType: 'regex' },
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithExactUrlMatch: Survey = {
+                name: 'survey with wildcard route url',
+                description: 'survey with wildcard route url description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with wildcard route url?' }],
+                conditions: { url: 'https://example.com/exact', urlMatchType: 'exact' },
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithIsNotUrlMatch: Survey = {
+                name: 'survey with is not url match',
+                description: 'survey with is not url match description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with is not url match?' }],
+                conditions: { url: 'https://example.com/exact', urlMatchType: 'is_not' },
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithUrlDoesNotContain: Survey = {
+                name: 'survey with url does not contain',
+                description: 'survey with url does not contain description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with url does not contain?' }],
+                conditions: { url: 'posthog.com', urlMatchType: 'not_icontains' },
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithSelector: Survey = {
+                name: 'survey with selector',
+                description: 'survey with selector description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with selector?' }],
+                conditions: { selector: '.test-selector' },
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithUrlAndSelector: Survey = {
+                name: 'survey with url and selector',
+                description: 'survey with url and selector description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with url and selector?' }],
+                conditions: { url: 'posthogapp.com', selector: '#foo' },
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithFlags: Survey = {
+                name: 'survey with flags',
+                description: 'survey with flags description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with flags?' }],
+                linked_flag_key: 'linked-flag-key',
+                targeting_flag_key: 'survey-targeting-flag-key',
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithUnmatchedFlags: Survey = {
+                name: 'survey with flags2',
+                description: 'survey with flags description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with flags?' }],
+                linked_flag_key: 'linked-flag-key2',
+                targeting_flag_key: 'survey-targeting-flag-key2',
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithEnabledInternalFlag: Survey = {
+                name: 'survey with enabled internal flags',
+                description: 'survey with flags description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with flags?' }],
+                linked_flag_key: 'linked-flag-key',
+                internal_targeting_flag_key: 'enabled-internal-targeting-flag-key',
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithDisabledInternalFlag: Survey = {
+                name: 'survey with disabled internal flag',
+                description: 'survey with flags description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with flags?' }],
+                linked_flag_key: 'linked-flag-key2',
+                internal_targeting_flag_key: 'disabled-internal-targeting-flag-key',
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithEvents: Survey = {
+                name: 'survey with events',
+                description: 'survey with events description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with flags?' }],
+                linked_flag_key: 'linked-flag-key',
+                internal_targeting_flag_key: 'enabled-internal-targeting-flag-key',
+                conditions: {
+                    events: {
+                        values: [
+                            {
+                                name: 'user_subscribed',
+                            },
+                            {
+                                name: 'user_unsubscribed',
+                            },
+                        ],
+                    },
+                },
+                start_date: new Date().toISOString(),
+                end_date: null,
+            } as unknown as Survey
+            const surveyWithEverything: Survey = {
+                name: 'survey with everything',
+                description: 'survey with everything description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a survey with everything?' }],
+                start_date: new Date().toISOString(),
+                end_date: null,
+                conditions: { url: 'posthogapp.com', selector: '.test-selector' },
+                linked_flag_key: 'linked-flag-key',
+                targeting_flag_key: 'survey-targeting-flag-key',
+            } as unknown as Survey
 
-            const originalWindowLocation = assignableWindow.location
-            // eslint-disable-next-line compat/compat
-            assignableWindow.location = new URL('https://regex-url.com/test') as unknown as Location
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithRegexUrl])
-            })
-            assignableWindow.location = originalWindowLocation
+            it('returns surveys that are active', () => {
+                surveysResponse = { surveys: [draftSurvey, activeSurvey, completedSurvey] }
 
-            // eslint-disable-next-line compat/compat
-            assignableWindow.location = new URL('https://example.com?name=something') as unknown as Location
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithParamRegexUrl])
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([activeSurvey])
+                })
             })
-            assignableWindow.location = originalWindowLocation
 
-            // eslint-disable-next-line compat/compat
-            assignableWindow.location = new URL('https://app.subdomain.com') as unknown as Location
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithWildcardSubdomainUrl])
-            })
-            assignableWindow.location = originalWindowLocation
+            it('returns surveys based on url and selector matching', () => {
+                surveysResponse = {
+                    surveys: [surveyWithUrl, surveyWithSelector, surveyWithUrlAndSelector],
+                }
+                // eslint-disable-next-line compat/compat
+                assignableWindow.location = new URL('https://posthog.com') as unknown as Location
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithUrl])
+                })
+                assignableWindow.location = originalWindowLocation
 
-            // eslint-disable-next-line compat/compat
-            assignableWindow.location = new URL('https://wildcard.com/something/other') as unknown as Location
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithWildcardRouteUrl])
-            })
-            assignableWindow.location = originalWindowLocation
+                document.body.appendChild(document.createElement('div')).className = 'test-selector'
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithSelector])
+                })
+                const testSelectorEl = document!.querySelector('.test-selector')
+                if (testSelectorEl) {
+                    document.body.removeChild(testSelectorEl)
+                }
 
-            // eslint-disable-next-line compat/compat
-            assignableWindow.location = new URL('https://example.com/exact') as unknown as Location
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithExactUrlMatch])
+                // eslint-disable-next-line compat/compat
+                assignableWindow.location = new URL('https://posthogapp.com') as unknown as Location
+                document.body.appendChild(document.createElement('div')).id = 'foo'
+
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithUrlAndSelector])
+                })
+                const child = document.querySelector('#foo')
+                if (child) {
+                    document.body.removeChild(child)
+                }
             })
-            assignableWindow.location = originalWindowLocation
+
+            it('returns surveys based on url with urlMatchType settings', () => {
+                surveysResponse = {
+                    surveys: [
+                        surveyWithRegexUrl,
+                        surveyWithParamRegexUrl,
+                        surveyWithWildcardRouteUrl,
+                        surveyWithWildcardSubdomainUrl,
+                        surveyWithExactUrlMatch,
+                    ],
+                }
+
+                const originalWindowLocation = assignableWindow.location
+                // eslint-disable-next-line compat/compat
+                assignableWindow.location = new URL('https://regex-url.com/test') as unknown as Location
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithRegexUrl])
+                })
+                assignableWindow.location = originalWindowLocation
+
+                // eslint-disable-next-line compat/compat
+                assignableWindow.location = new URL('https://example.com?name=something') as unknown as Location
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithParamRegexUrl])
+                })
+                assignableWindow.location = originalWindowLocation
+
+                // eslint-disable-next-line compat/compat
+                assignableWindow.location = new URL('https://app.subdomain.com') as unknown as Location
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithWildcardSubdomainUrl])
+                })
+                assignableWindow.location = originalWindowLocation
+
+                // eslint-disable-next-line compat/compat
+                assignableWindow.location = new URL('https://wildcard.com/something/other') as unknown as Location
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithWildcardRouteUrl])
+                })
+                assignableWindow.location = originalWindowLocation
+
+                // eslint-disable-next-line compat/compat
+                assignableWindow.location = new URL('https://example.com/exact') as unknown as Location
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithExactUrlMatch])
+                })
+                assignableWindow.location = originalWindowLocation
+            })
+
+            it('returns surveys based on exclusion conditions', () => {
+                surveysResponse = {
+                    surveys: [surveyWithUrlDoesNotContain, surveyWithIsNotUrlMatch, surveyWithUrlDoesNotContainRegex],
+                }
+
+                // eslint-disable-next-line compat/compat
+                assignableWindow.location = new URL('https://posthog.com') as unknown as Location
+                surveys.getActiveMatchingSurveys((data) => {
+                    // returns surveyWithIsNotUrlMatch and surveyWithUrlDoesNotContainRegex because they don't contain posthog.com
+                    expect(data).toEqual([surveyWithIsNotUrlMatch, surveyWithUrlDoesNotContainRegex])
+                })
+                assignableWindow.location = originalWindowLocation
+
+                // eslint-disable-next-line compat/compat
+                assignableWindow.location = new URL('https://example.com/exact') as unknown as Location
+                surveys.getActiveMatchingSurveys((data) => {
+                    // returns surveyWithUrlDoesNotContain and surveyWithUrlDoesNotContainRegex because they are not exact matches
+                    expect(data).toEqual([surveyWithUrlDoesNotContain, surveyWithUrlDoesNotContainRegex])
+                })
+                assignableWindow.location = originalWindowLocation
+
+                // eslint-disable-next-line compat/compat
+                assignableWindow.location = new URL('https://regex-url.com/test') as unknown as Location
+                surveys.getActiveMatchingSurveys((data) => {
+                    // returns surveyWithUrlDoesNotContain and surveyWithIsNotUrlMatch because they are not regex matches
+                    expect(data).toEqual([surveyWithUrlDoesNotContain, surveyWithIsNotUrlMatch])
+                })
+                assignableWindow.location = originalWindowLocation
+            })
+
+            it('returns surveys that match linked and targeting feature flags', () => {
+                surveysResponse = { surveys: [activeSurvey, surveyWithFlags, surveyWithEverything] }
+                surveys.getActiveMatchingSurveys((data) => {
+                    // active survey is returned because it has no flags aka there are no restrictions on flag enabled for it
+                    expect(data).toEqual([activeSurvey, surveyWithFlags])
+                })
+            })
+
+            it('does not return surveys that have flag keys but no matching flags', () => {
+                surveysResponse = { surveys: [surveyWithFlags, surveyWithUnmatchedFlags] }
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithFlags])
+                })
+            })
+
+            it('returns surveys that match internal feature flags', () => {
+                surveysResponse = {
+                    surveys: [surveyWithEnabledInternalFlag, surveyWithDisabledInternalFlag],
+                }
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithEnabledInternalFlag])
+                })
+            })
+
+            it('does not return event based surveys that didnt observe an event', () => {
+                surveysResponse = {
+                    surveys: [surveyWithEnabledInternalFlag, surveyWithEvents],
+                }
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithEnabledInternalFlag])
+                })
+            })
+
+            it('returns event based surveys that observed an event', () => {
+                surveysResponse = {
+                    surveys: [surveyWithEnabledInternalFlag, surveyWithEvents],
+                }
+
+                surveys._surveyEventReceiver?.on('user_subscribed')
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithEnabledInternalFlag])
+                })
+            })
+            it('does not return surveys that have internal flag keys but no matching internal flags', () => {
+                surveysResponse = { surveys: [surveyWithEnabledInternalFlag, surveyWithDisabledInternalFlag] }
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([surveyWithEnabledInternalFlag])
+                })
+            })
+
+            it('returns surveys that inclusively matches any of the above', () => {
+                // eslint-disable-next-line compat/compat
+                assignableWindow.location = new URL('https://posthogapp.com') as unknown as Location
+                document.body.appendChild(document.createElement('div')).className = 'test-selector'
+                surveysResponse = { surveys: [activeSurvey, surveyWithSelector, surveyWithEverything] }
+                // activeSurvey returns because there are no restrictions on conditions or flags on it
+                surveys.getActiveMatchingSurveys((data) => {
+                    expect(data).toEqual([activeSurvey, surveyWithSelector, surveyWithEverything])
+                })
+            })
         })
 
-        it('returns surveys based on exclusion conditions', () => {
-            surveysResponse = {
-                surveys: [surveyWithUrlDoesNotContain, surveyWithIsNotUrlMatch, surveyWithUrlDoesNotContainRegex],
-            }
+        describe('shuffling questions', () => {
+            const surveyWithoutShufflingQuestions: Survey = {
+                name: 'survey without shuffling questions',
+                description: 'survey without shuffling questions',
+                type: SurveyType.Popover,
+                questions: [
+                    { type: SurveyQuestionType.Open, question: 'Question A' },
+                    { type: SurveyQuestionType.Open, question: 'Question B' },
+                ],
+                start_date: new Date().toISOString(),
+                end_date: null,
+                appearance: {
+                    shuffleQuestions: false,
+                },
+            } as unknown as Survey
 
-            // eslint-disable-next-line compat/compat
-            assignableWindow.location = new URL('https://posthog.com') as unknown as Location
-            surveys.getActiveMatchingSurveys((data) => {
-                // returns surveyWithIsNotUrlMatch and surveyWithUrlDoesNotContainRegex because they don't contain posthog.com
-                expect(data).toEqual([surveyWithIsNotUrlMatch, surveyWithUrlDoesNotContainRegex])
-            })
-            assignableWindow.location = originalWindowLocation
+            const surveyWithShufflingQuestions: Survey = {
+                name: 'survey without shuffling questions',
+                description: 'survey without shuffling questions',
+                type: SurveyType.Popover,
+                questions: [
+                    { type: SurveyQuestionType.Open, question: 'Question A' },
+                    { type: SurveyQuestionType.Open, question: 'Question B' },
+                    { type: SurveyQuestionType.Open, question: 'Question C' },
+                    { type: SurveyQuestionType.Open, question: 'Question D' },
+                    { type: SurveyQuestionType.Open, question: 'Question E' },
+                ],
+                start_date: new Date().toISOString(),
+                end_date: null,
+                appearance: {
+                    shuffleQuestions: true,
+                },
+            } as unknown as Survey
 
-            // eslint-disable-next-line compat/compat
-            assignableWindow.location = new URL('https://example.com/exact') as unknown as Location
-            surveys.getActiveMatchingSurveys((data) => {
-                // returns surveyWithUrlDoesNotContain and surveyWithUrlDoesNotContainRegex because they are not exact matches
-                expect(data).toEqual([surveyWithUrlDoesNotContain, surveyWithUrlDoesNotContainRegex])
-            })
-            assignableWindow.location = originalWindowLocation
-
-            // eslint-disable-next-line compat/compat
-            assignableWindow.location = new URL('https://regex-url.com/test') as unknown as Location
-            surveys.getActiveMatchingSurveys((data) => {
-                // returns surveyWithUrlDoesNotContain and surveyWithIsNotUrlMatch because they are not regex matches
-                expect(data).toEqual([surveyWithUrlDoesNotContain, surveyWithIsNotUrlMatch])
-            })
-            assignableWindow.location = originalWindowLocation
-        })
-
-        it('returns surveys that match linked and targeting feature flags', () => {
-            surveysResponse = { surveys: [activeSurvey, surveyWithFlags, surveyWithEverything] }
-            surveys.getActiveMatchingSurveys((data) => {
-                // active survey is returned because it has no flags aka there are no restrictions on flag enabled for it
-                expect(data).toEqual([activeSurvey, surveyWithFlags])
-            })
-        })
-
-        it('does not return surveys that have flag keys but no matching flags', () => {
-            surveysResponse = { surveys: [surveyWithFlags, surveyWithUnmatchedFlags] }
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithFlags])
-            })
-        })
-
-        it('returns surveys that match internal feature flags', () => {
-            surveysResponse = {
-                surveys: [surveyWithEnabledInternalFlag, surveyWithDisabledInternalFlag],
-            }
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithEnabledInternalFlag])
-            })
-        })
-
-        it('does not return event based surveys that didnt observe an event', () => {
-            surveysResponse = {
-                surveys: [surveyWithEnabledInternalFlag, surveyWithEvents],
-            }
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithEnabledInternalFlag])
-            })
-        })
-
-        it('returns event based surveys that observed an event', () => {
-            surveysResponse = {
-                surveys: [surveyWithEnabledInternalFlag, surveyWithEvents],
-            }
-
-            surveys._surveyEventReceiver?.on('user_subscribed')
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithEnabledInternalFlag])
-            })
-        })
-        it('does not return surveys that have internal flag keys but no matching internal flags', () => {
-            surveysResponse = { surveys: [surveyWithEnabledInternalFlag, surveyWithDisabledInternalFlag] }
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([surveyWithEnabledInternalFlag])
-            })
-        })
-
-        it('returns surveys that inclusively matches any of the above', () => {
-            // eslint-disable-next-line compat/compat
-            assignableWindow.location = new URL('https://posthogapp.com') as unknown as Location
-            document.body.appendChild(document.createElement('div')).className = 'test-selector'
-            surveysResponse = { surveys: [activeSurvey, surveyWithSelector, surveyWithEverything] }
-            // activeSurvey returns because there are no restrictions on conditions or flags on it
-            surveys.getActiveMatchingSurveys((data) => {
-                expect(data).toEqual([activeSurvey, surveyWithSelector, surveyWithEverything])
-            })
-        })
-    })
-
-    describe('shuffling questions', () => {
-        const surveyWithoutShufflingQuestions: Survey = {
-            name: 'survey without shuffling questions',
-            description: 'survey without shuffling questions',
-            type: SurveyType.Popover,
-            questions: [
-                { type: SurveyQuestionType.Open, question: 'Question A' },
-                { type: SurveyQuestionType.Open, question: 'Question B' },
-            ],
-            start_date: new Date().toISOString(),
-            end_date: null,
-            appearance: {
-                shuffleQuestions: false,
-            },
-        } as unknown as Survey
-
-        const surveyWithShufflingQuestions: Survey = {
-            name: 'survey without shuffling questions',
-            description: 'survey without shuffling questions',
-            type: SurveyType.Popover,
-            questions: [
-                { type: SurveyQuestionType.Open, question: 'Question A' },
-                { type: SurveyQuestionType.Open, question: 'Question B' },
-                { type: SurveyQuestionType.Open, question: 'Question C' },
-                { type: SurveyQuestionType.Open, question: 'Question D' },
-                { type: SurveyQuestionType.Open, question: 'Question E' },
-            ],
-            start_date: new Date().toISOString(),
-            end_date: null,
-            appearance: {
-                shuffleQuestions: true,
-            },
-        } as unknown as Survey
-
-        it('should not shuffle questions if shuffleQuestions is false', () => {
-            expect(surveyWithoutShufflingQuestions.questions).toEqual(
-                getDisplayOrderQuestions(surveyWithoutShufflingQuestions)
-            )
-        })
-
-        it('should shuffle questions if shuffleQuestions is true', () => {
-            expect(surveyWithShufflingQuestions.questions).not.toEqual(
-                getDisplayOrderQuestions(surveyWithShufflingQuestions)
-            )
-        })
-
-        it('should retain original index of question if shuffleQuestions is true', () => {
-            const shuffledQuestions = getDisplayOrderQuestions(surveyWithShufflingQuestions)
-            console.log('************************************', shuffledQuestions)
-            for (let i = 0; i < shuffledQuestions.length; i++) {
-                const originalQuestionIndex = shuffledQuestions[i].originalQuestionIndex
-                expect(shuffledQuestions[i].question).toEqual(
-                    surveyWithShufflingQuestions.questions[originalQuestionIndex].question
+            it('should not shuffle questions if shuffleQuestions is false', () => {
+                expect(surveyWithoutShufflingQuestions.questions).toEqual(
+                    getDisplayOrderQuestions(surveyWithoutShufflingQuestions)
                 )
-            }
-        })
-
-        it('shuffle should preserve all elements', () => {
-            const shuffledQuestions = getDisplayOrderQuestions(surveyWithShufflingQuestions)
-
-            const sortedQuestions = surveyWithShufflingQuestions.questions.sort(function (a, b) {
-                return a.question.localeCompare(b.question)
             })
 
-            expect(sortedQuestions.length).toEqual(shuffledQuestions.length)
-            const sortedShuffledQuestions = shuffledQuestions.sort(function (a, b) {
-                return a.question.localeCompare(b.question)
+            it('should shuffle questions if shuffleQuestions is true', () => {
+                expect(surveyWithShufflingQuestions.questions).not.toEqual(
+                    getDisplayOrderQuestions(surveyWithShufflingQuestions)
+                )
             })
-            expect(sortedQuestions).toEqual(sortedShuffledQuestions)
-        })
-    })
 
-    describe('shuffling options', () => {
-        const questionWithoutShufflingOptions: MultipleSurveyQuestion = {
-            type: SurveyQuestionType.MultipleChoice,
-            question: "We're sorry to see you go. What's your reason for unsubscribing?",
-            choices: [
-                'I no longer need the product',
-                'I found a better product',
-                'I found the product too difficult to use',
-                'Other',
-            ],
-            hasOpenChoice: true,
-            shuffleOptions: false,
-        } as unknown as MultipleSurveyQuestion
+            it('should retain original index of question if shuffleQuestions is true', () => {
+                const shuffledQuestions = getDisplayOrderQuestions(surveyWithShufflingQuestions)
+                console.log('************************************', shuffledQuestions)
+                for (let i = 0; i < shuffledQuestions.length; i++) {
+                    const originalQuestionIndex = shuffledQuestions[i].originalQuestionIndex
+                    expect(shuffledQuestions[i].question).toEqual(
+                        surveyWithShufflingQuestions.questions[originalQuestionIndex].question
+                    )
+                }
+            })
 
-        const questionWithShufflingOptions: MultipleSurveyQuestion = {
-            type: SurveyQuestionType.MultipleChoice,
-            question: "We're sorry to see you go. What's your reason for unsubscribing?",
-            choices: [
-                'I no longer need the product',
-                'I found a better product',
-                'I found the product too difficult to use',
-                'Other',
-            ],
-            hasOpenChoice: true,
-            shuffleOptions: true,
-        } as unknown as MultipleSurveyQuestion
+            it('shuffle should preserve all elements', () => {
+                const shuffledQuestions = getDisplayOrderQuestions(surveyWithShufflingQuestions)
 
-        const questionWithOpenEndedChoice: MultipleSurveyQuestion = {
-            type: SurveyQuestionType.MultipleChoice,
-            question: "We're sorry to see you go. What's your reason for unsubscribing?",
-            choices: [
-                'I no longer need the product',
-                'I found a better product',
-                'I found the product too difficult to use',
-                'open-ended-choice',
-            ],
-            hasOpenChoice: true,
-            shuffleOptions: true,
-        } as unknown as MultipleSurveyQuestion
+                const sortedQuestions = surveyWithShufflingQuestions.questions.sort(function (a, b) {
+                    return a.question.localeCompare(b.question)
+                })
 
-        it('should not shuffle if shuffleOptions is false', () => {
-            const shuffledOptions = getDisplayOrderChoices(questionWithoutShufflingOptions)
-            expect(shuffledOptions).toEqual(questionWithoutShufflingOptions.choices)
+                expect(sortedQuestions.length).toEqual(shuffledQuestions.length)
+                const sortedShuffledQuestions = shuffledQuestions.sort(function (a, b) {
+                    return a.question.localeCompare(b.question)
+                })
+                expect(sortedQuestions).toEqual(sortedShuffledQuestions)
+            })
         })
 
-        it('should shuffle if shuffleOptions is true', () => {
-            const shuffledOptions = getDisplayOrderChoices(questionWithShufflingOptions)
-            expect(shuffledOptions).not.toEqual(questionWithShufflingOptions.choices)
-        })
+        describe('shuffling options', () => {
+            const questionWithoutShufflingOptions: MultipleSurveyQuestion = {
+                type: SurveyQuestionType.MultipleChoice,
+                question: "We're sorry to see you go. What's your reason for unsubscribing?",
+                choices: [
+                    'I no longer need the product',
+                    'I found a better product',
+                    'I found the product too difficult to use',
+                    'Other',
+                ],
+                hasOpenChoice: true,
+                shuffleOptions: false,
+            } as unknown as MultipleSurveyQuestion
 
-        it('should keep open-ended coice as the last option', () => {
-            let shuffledOptions = getDisplayOrderChoices(questionWithOpenEndedChoice)
-            shuffledOptions = getDisplayOrderChoices(questionWithOpenEndedChoice)
-            expect(shuffledOptions.pop()).toEqual('open-ended-choice')
-        })
+            const questionWithShufflingOptions: MultipleSurveyQuestion = {
+                type: SurveyQuestionType.MultipleChoice,
+                question: "We're sorry to see you go. What's your reason for unsubscribing?",
+                choices: [
+                    'I no longer need the product',
+                    'I found a better product',
+                    'I found the product too difficult to use',
+                    'Other',
+                ],
+                hasOpenChoice: true,
+                shuffleOptions: true,
+            } as unknown as MultipleSurveyQuestion
 
-        it('shuffle should preserve all elements', () => {
-            const shuffledOptions = getDisplayOrderChoices(questionWithOpenEndedChoice)
-            const sortedOptions = questionWithOpenEndedChoice.choices.sort()
-            const sortedShuffledOptions = shuffledOptions.sort()
+            const questionWithOpenEndedChoice: MultipleSurveyQuestion = {
+                type: SurveyQuestionType.MultipleChoice,
+                question: "We're sorry to see you go. What's your reason for unsubscribing?",
+                choices: [
+                    'I no longer need the product',
+                    'I found a better product',
+                    'I found the product too difficult to use',
+                    'open-ended-choice',
+                ],
+                hasOpenChoice: true,
+                shuffleOptions: true,
+            } as unknown as MultipleSurveyQuestion
 
-            expect(sortedOptions).toEqual(sortedShuffledOptions)
+            it('should not shuffle if shuffleOptions is false', () => {
+                const shuffledOptions = getDisplayOrderChoices(questionWithoutShufflingOptions)
+                expect(shuffledOptions).toEqual(questionWithoutShufflingOptions.choices)
+            })
+
+            it('should shuffle if shuffleOptions is true', () => {
+                const shuffledOptions = getDisplayOrderChoices(questionWithShufflingOptions)
+                expect(shuffledOptions).not.toEqual(questionWithShufflingOptions.choices)
+            })
+
+            it('should keep open-ended coice as the last option', () => {
+                let shuffledOptions = getDisplayOrderChoices(questionWithOpenEndedChoice)
+                shuffledOptions = getDisplayOrderChoices(questionWithOpenEndedChoice)
+                expect(shuffledOptions.pop()).toEqual('open-ended-choice')
+            })
+
+            it('shuffle should preserve all elements', () => {
+                const shuffledOptions = getDisplayOrderChoices(questionWithOpenEndedChoice)
+                const sortedOptions = questionWithOpenEndedChoice.choices.sort()
+                const sortedShuffledOptions = shuffledOptions.sort()
+
+                expect(sortedOptions).toEqual(sortedShuffledOptions)
+            })
         })
     })
 

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -181,6 +181,9 @@ describe('surveys', () => {
                 enumerable: true,
                 value: originalWindowLocation,
             })
+
+            delete assignableWindow.__PosthogExtensions__
+            delete assignableWindow.extendPostHogWithSurveys
         })
 
         it('getSurveys gets a list of surveys if not present already', () => {

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -24,6 +24,7 @@ import { PostHogFeatureFlags } from '../posthog-featureflags'
 import { generateSurveys } from '../extensions/surveys'
 import { SurveyEventReceiver } from '../extensions/surveys/survey-event-receiver'
 import { expect } from '@jest/globals'
+import { PostHogSurveys } from '../posthog-surveys'
 
 describe('surveys', () => {
     let instance: PostHog
@@ -166,6 +167,8 @@ describe('surveys', () => {
             // eslint-disable-next-line compat/compat
             value: new URL('https://example.com'),
         })
+
+        instance.persistence!.props['$surveys'] = undefined
     })
 
     describe('when enabled by decide', () => {
@@ -261,13 +264,19 @@ describe('surveys', () => {
 
         it('getSurveys returns empty array if surveys are disabled', () => {
             instance.config.disable_surveys = true
-            instance.surveys.getSurveys((data) => {
+            instance._send_request.mockClear()
+            const disabledSurveys = new PostHogSurveys(instance)
+            disabledSurveys.getSurveys((data) => {
                 expect(data).toEqual([])
             })
             expect(instance._send_request).not.toHaveBeenCalled()
         })
 
         describe('getActiveMatchingSurveys', () => {
+            beforeEach(() => {
+                instance.persistence!.props['$surveys'] = undefined
+            })
+
             const draftSurvey: Survey = {
                 name: 'draft survey',
                 description: 'draft survey description',

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -250,6 +250,9 @@ describe('surveys', () => {
         })
 
         it('getSurveys returns empty array if surveys are undefined', () => {
+            // need to be sure that set-up didn't populate surveys
+            instance.persistence?.clear()
+
             surveysResponse = { status: 0 }
             instance.surveys.getSurveys((data) => {
                 expect(data).toEqual([])

--- a/src/entrypoints/surveys.ts
+++ b/src/entrypoints/surveys.ts
@@ -1,9 +1,12 @@
 import { generateSurveys } from '../extensions/surveys'
+import { SurveyEventReceiver } from '../extensions/surveys/survey-event-receiver'
 
 import { window } from '../utils/globals'
 
 if (window) {
+    ;(window as any).__PosthogExtensions__ = (window as any).__Posthog__ || {}
     ;(window as any).extendPostHogWithSurveys = generateSurveys
+    ;(window as any).__PosthogExtensions__.SurveysEventReceiver = SurveyEventReceiver
 }
 
 export default generateSurveys

--- a/src/entrypoints/surveys.ts
+++ b/src/entrypoints/surveys.ts
@@ -1,6 +1,6 @@
 import { generateSurveys } from '../extensions/surveys'
 import { SurveyEventReceiver } from '../extensions/surveys/survey-event-receiver'
-import { canActivateRepeatedly, hasEvents } from './extensions/surveys/surveys-utils'
+import { canActivateRepeatedly, hasEvents } from '../extensions/surveys/surveys-utils'
 
 import { window } from '../utils/globals'
 

--- a/src/entrypoints/surveys.ts
+++ b/src/entrypoints/surveys.ts
@@ -1,5 +1,6 @@
 import { generateSurveys } from '../extensions/surveys'
 import { SurveyEventReceiver } from '../extensions/surveys/survey-event-receiver'
+import { canActivateRepeatedly, hasEvents } from './extensions/surveys/surveys-utils'
 
 import { window } from '../utils/globals'
 
@@ -7,6 +8,8 @@ if (window) {
     ;(window as any).__PosthogExtensions__ = (window as any).__Posthog__ || {}
     ;(window as any).extendPostHogWithSurveys = generateSurveys
     ;(window as any).__PosthogExtensions__.SurveysEventReceiver = SurveyEventReceiver
+    ;(window as any).__PosthogExtensions__.canActivateRepeatedly = canActivateRepeatedly
+    ;(window as any).__PosthogExtensions__.hasEvents = hasEvents
 }
 
 export default generateSurveys

--- a/src/entrypoints/surveys.ts
+++ b/src/entrypoints/surveys.ts
@@ -1,5 +1,4 @@
 import { generateSurveys } from '../extensions/surveys'
-import { SurveyEventReceiver } from '../extensions/surveys/survey-event-receiver'
 import { canActivateRepeatedly, hasEvents } from '../extensions/surveys/surveys-utils'
 
 import { window } from '../utils/globals'
@@ -7,7 +6,6 @@ import { window } from '../utils/globals'
 if (window) {
     ;(window as any).__PosthogExtensions__ = (window as any).__Posthog__ || {}
     ;(window as any).extendPostHogWithSurveys = generateSurveys
-    ;(window as any).__PosthogExtensions__.SurveysEventReceiver = SurveyEventReceiver
     ;(window as any).__PosthogExtensions__.canActivateRepeatedly = canActivateRepeatedly
     ;(window as any).__PosthogExtensions__.hasEvents = hasEvents
 }

--- a/src/extensions/surveys/survey-event-receiver.test.ts
+++ b/src/extensions/surveys/survey-event-receiver.test.ts
@@ -4,7 +4,7 @@ import { SurveyType, SurveyQuestionType, Survey } from '../../posthog-surveys-ty
 import { PostHogPersistence } from '../../posthog-persistence'
 import { PostHog } from '../../posthog-core'
 import { PostHogConfig } from '../../types'
-import { SurveyEventReceiver } from '../../utils/survey-event-receiver'
+import { SurveyEventReceiver } from './survey-event-receiver'
 
 describe('survey-event-receiver', () => {
     let config: PostHogConfig

--- a/src/extensions/surveys/survey-event-receiver.ts
+++ b/src/extensions/surveys/survey-event-receiver.ts
@@ -1,11 +1,11 @@
 import { Survey } from '../../posthog-surveys-types'
 import { PostHogPersistence } from '../../posthog-persistence'
 import { SURVEYS_ACTIVATED } from '../../constants'
-import { CaptureResult } from '../../types'
+import { CaptureResult, IReceiveSurveyEvents } from '../../types'
 
-export class SurveyEventReceiver {
-    private readonly eventRegistry: Map<string, string[]>
-    private readonly persistence?: PostHogPersistence
+export class SurveyEventReceiver implements IReceiveSurveyEvents {
+    readonly eventRegistry: Map<string, string[]>
+    readonly persistence?: PostHogPersistence
     private static SURVEY_SHOWN_EVENT_NAME = 'survey shown'
 
     constructor(persistence?: PostHogPersistence) {
@@ -66,7 +66,7 @@ export class SurveyEventReceiver {
         return this.eventRegistry
     }
 
-    private _saveSurveysToStorage(surveys: string[]): void {
+    _saveSurveysToStorage(surveys: string[]): void {
         // we use a new Set here to remove duplicates.
         this.persistence?.register({
             [SURVEYS_ACTIVATED]: [...new Set(surveys)],

--- a/src/extensions/surveys/survey-event-receiver.ts
+++ b/src/extensions/surveys/survey-event-receiver.ts
@@ -1,7 +1,7 @@
-import { Survey } from '../posthog-surveys-types'
-import { PostHogPersistence } from '../posthog-persistence'
-import { SURVEYS_ACTIVATED } from '../constants'
-import { CaptureResult } from '../types'
+import { Survey } from '../../posthog-surveys-types'
+import { PostHogPersistence } from '../../posthog-persistence'
+import { SURVEYS_ACTIVATED } from '../../constants'
+import { CaptureResult } from '../../types'
 
 export class SurveyEventReceiver {
     private readonly eventRegistry: Map<string, string[]>

--- a/src/extensions/surveys/survey-event-receiver.ts
+++ b/src/extensions/surveys/survey-event-receiver.ts
@@ -1,15 +1,13 @@
 import { Survey } from '../../posthog-surveys-types'
 import { PostHogPersistence } from '../../posthog-persistence'
 import { SURVEYS_ACTIVATED } from '../../constants'
-import { CaptureResult, IReceiveSurveyEvents } from '../../types'
+import { CaptureResult } from '../../types'
 
-export class SurveyEventReceiver implements IReceiveSurveyEvents {
-    readonly eventRegistry: Map<string, string[]>
-    readonly persistence?: PostHogPersistence
+export class SurveyEventReceiver {
+    private readonly eventRegistry: Map<string, string[]>
     private static SURVEY_SHOWN_EVENT_NAME = 'survey shown'
 
-    constructor(persistence?: PostHogPersistence) {
-        this.persistence = persistence
+    constructor(private readonly persistence?: PostHogPersistence) {
         this.eventRegistry = new Map<string, string[]>()
     }
 
@@ -66,7 +64,7 @@ export class SurveyEventReceiver implements IReceiveSurveyEvents {
         return this.eventRegistry
     }
 
-    _saveSurveysToStorage(surveys: string[]): void {
+    private _saveSurveysToStorage(surveys: string[]): void {
         // we use a new Set here to remove duplicates.
         this.persistence?.register({
             [SURVEYS_ACTIVATED]: [...new Set(surveys)],

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -133,7 +133,7 @@ export class PostHogSurveys {
         }
     }
 
-    getActiveMatchingSurveys = (callback: SurveyCallback, forceReload = false) => {
+    getActiveMatchingSurveys(callback: SurveyCallback, forceReload = false) {
         this.getSurveys((surveys) => {
             const activeSurveys = surveys.filter((survey) => {
                 return !!(survey.start_date && !survey.end_date)

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -49,7 +49,6 @@ function getRatingBucketForResponseValue(responseValue: number, scale: number) {
 }
 
 export class PostHogSurveys {
-    instance: PostHog
     private _decideServerResponse?: boolean
     public _surveyEventReceiver: IReceiveSurveyEvents | null
 

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -8,7 +8,7 @@ import {
     SurveyUrlMatchType,
 } from './posthog-surveys-types'
 import { isUrlMatchingRegex } from './utils/request-utils'
-import { SurveyEventReceiver } from './utils/survey-event-receiver'
+import { SurveyEventReceiver } from './extensions/surveys/survey-event-receiver'
 import { assignableWindow, document, window } from './utils/globals'
 import { CaptureResult, DecideResponse } from './types'
 import { logger } from './utils/logger'

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -66,11 +66,12 @@ export class PostHogSurveys {
 
     loadIfEnabled() {
         const surveysGenerator = assignableWindow?.extendPostHogWithSurveys
-        if (this._surveyEventReceiver == null) {
-            this._surveyEventReceiver = new SurveyEventReceiver(this.instance.persistence)
-        }
 
         if (!this.instance.config.disable_surveys && this._decideServerResponse && !surveysGenerator) {
+            if (this._surveyEventReceiver == null) {
+                this._surveyEventReceiver = new SurveyEventReceiver(this.instance.persistence)
+            }
+
             this.instance.requestRouter.loadScript('/static/surveys.js', (err) => {
                 if (err) {
                     return logger.error(`Could not load surveys script`, err)

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -63,7 +63,7 @@ export class PostHogSurveys {
         this.loadIfEnabled()
     }
 
-    loadIfEnabled = () => {
+    loadIfEnabled() {
         const surveysGenerator = assignableWindow?.extendPostHogWithSurveys
 
         if (!this.instance.config.disable_surveys && this._decideServerResponse && !surveysGenerator) {

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -12,7 +12,6 @@ import { assignableWindow, document, window } from './utils/globals'
 import { CaptureResult, DecideResponse, IReceiveSurveyEvents } from './types'
 import { logger } from './utils/logger'
 import { isUndefined } from './utils/type-utils'
-import { canActivateRepeatedly, hasEvents } from './extensions/surveys/surveys-utils'
 
 export const surveyUrlValidationMap: Record<SurveyUrlMatchType, (conditionsUrl: string) => boolean> = {
     icontains: (conditionsUrl) =>
@@ -169,9 +168,12 @@ export class PostHogSurveys {
                     ? this.instance.featureFlags.isFeatureEnabled(survey.targeting_flag_key)
                     : true
 
-                const eventBasedTargetingFlagCheck = hasEvents(survey) ? activatedSurveys?.includes(survey.id) : true
+                const eventBasedTargetingFlagCheck = assignableWindow.__PosthogExtensions__.hasEvents(survey)
+                    ? activatedSurveys?.includes(survey.id)
+                    : true
 
-                const overrideInternalTargetingFlagCheck = canActivateRepeatedly(survey)
+                const overrideInternalTargetingFlagCheck =
+                    assignableWindow.__PosthogExtensions__.canActivateRepeatedly(survey)
                 const internalTargetingFlagCheck =
                     survey.internal_targeting_flag_key && !overrideInternalTargetingFlagCheck
                         ? this.instance.featureFlags.isFeatureEnabled(survey.internal_targeting_flag_key)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 import type { MaskInputOptions, SlimDOMOptions } from 'rrweb-snapshot'
 import { PostHog } from './posthog-core'
 import type { SegmentAnalytics } from './extensions/segment-integration'
+import { PostHogPersistence } from './posthog-persistence'
+import { Survey } from './posthog-surveys-types'
 
 export type Property = any
 export type Properties = Record<string, Property>
@@ -515,4 +517,19 @@ export interface ErrorProperties {
 export interface ErrorConversions {
     errorToProperties: (args: ErrorEventArgs) => ErrorProperties
     unhandledRejectionToProperties: (args: [ev: PromiseRejectionEvent]) => ErrorProperties
+}
+
+export interface IReceiveSurveyEvents {
+    eventRegistry: Map<string, string[]>
+    persistence?: PostHogPersistence
+
+    register(surveys: Survey[]): void
+
+    on(event: string, eventPayload?: CaptureResult): void
+
+    getSurveys(): string[]
+
+    getEventRegistry(): Map<string, string[]>
+
+    _saveSurveysToStorage(surveys: string[]): void
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,6 @@
 import type { MaskInputOptions, SlimDOMOptions } from 'rrweb-snapshot'
 import { PostHog } from './posthog-core'
 import type { SegmentAnalytics } from './extensions/segment-integration'
-import { PostHogPersistence } from './posthog-persistence'
-import { Survey } from './posthog-surveys-types'
 
 export type Property = any
 export type Properties = Record<string, Property>
@@ -517,19 +515,4 @@ export interface ErrorProperties {
 export interface ErrorConversions {
     errorToProperties: (args: ErrorEventArgs) => ErrorProperties
     unhandledRejectionToProperties: (args: [ev: PromiseRejectionEvent]) => ErrorProperties
-}
-
-export interface IReceiveSurveyEvents {
-    eventRegistry: Map<string, string[]>
-    persistence?: PostHogPersistence
-
-    register(surveys: Survey[]): void
-
-    on(event: string, eventPayload?: CaptureResult): void
-
-    getSurveys(): string[]
-
-    getEventRegistry(): Map<string, string[]>
-
-    _saveSurveysToStorage(surveys: string[]): void
 }


### PR DESCRIPTION
## Changes

This change allows us to lazy load the SurveyEventReciever type only when Surveys are enabled for an application.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
