### PR TITLE
feat: add payload host denylist

### DIFF
--- a/src/__tests__/extensions/replay/config.test.ts
+++ b/src/__tests__/extensions/replay/config.test.ts
@@ -183,6 +183,18 @@ describe('config', () => {
                 })
             })
         })
+        describe('payloadHostDenyList', () => {
+            it('uses a default when none provided', () => {
+                const networkOptions = buildNetworkRequestOptions(defaultConfig(), {})
+                expect(networkOptions.payloadHostDenyList).toEqual(['.lr-ingest.io', '.ingest.sentry.io'])
+            })
+            it('adds to the default when deny list is provided', () => {
+                const networkOptions = buildNetworkRequestOptions(defaultConfig(), {
+                    payloadHostDenyList: ['wat', 'huh'],
+                })
+                expect(networkOptions.payloadHostDenyList).toEqual(['wat', 'huh', '.lr-ingest.io', '.ingest.sentry.io'])
+            })
+        })
     })
 
     describe('masking/privacy', () => {

--- a/src/__tests__/extensions/replay/external/denylist.test.ts
+++ b/src/__tests__/extensions/replay/external/denylist.test.ts
@@ -1,0 +1,26 @@
+import { expect } from '@jest/globals'
+import { NetworkRecordOptions } from '../../../../types'
+import { isHostOnDenyList } from '../../../../extensions/replay/external/denylist'
+
+describe('network host denylist', () => {
+    const testCases = [
+        { url: 'https://www.google.com', denyList: ['.google.com'], isDenied: true, expectedHost: 'www.google.com' },
+        {
+            url: 'https://www.google.com',
+            denyList: ['.ask.jeeves.com'],
+            isDenied: false,
+            expectedHost: 'www.google.com',
+        },
+        { url: 'google.com', denyList: ['.google.com'], isDenied: false, expectedHost: null },
+    ]
+    it.each(testCases)(
+        '$url when denylist is $denyList should have denied as $isDenied',
+        ({ url, denyList, isDenied, expectedHost }) => {
+            const { hostname, isHostDenied } = isHostOnDenyList(url, {
+                payloadHostDenyList: denyList,
+            } as unknown as NetworkRecordOptions)
+            expect(hostname).toBe(expectedHost)
+            expect(isHostDenied).toBe(isDenied)
+        }
+    )
+})

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -8,7 +8,7 @@ import { each } from '../../utils'
 const LOGGER_PREFIX = '[SessionRecording]'
 const REDACTED = 'redacted'
 
-export const defaultNetworkOptions: NetworkRecordOptions = {
+export const defaultNetworkOptions: Required<NetworkRecordOptions> = {
     initiatorTypes: [
         'audio',
         'beacon',
@@ -47,6 +47,7 @@ export const defaultNetworkOptions: NetworkRecordOptions = {
         'resource',
     ],
     payloadSizeLimitBytes: 1000000,
+    payloadHostDenyList: ['.lr-ingest.io', '.ingest.sentry.io'],
 }
 
 const HEADER_DENY_LIST = [
@@ -186,11 +187,18 @@ function scrubPayloads(capturedRequest: CapturedNetworkRequest | undefined): Cap
  */
 export const buildNetworkRequestOptions = (
     instanceConfig: PostHogConfig,
-    remoteNetworkOptions: Pick<NetworkRecordOptions, 'recordHeaders' | 'recordBody' | 'recordPerformance'>
+    remoteNetworkOptions: Pick<
+        NetworkRecordOptions,
+        'recordHeaders' | 'recordBody' | 'recordPerformance' | 'payloadHostDenyList'
+    >
 ): NetworkRecordOptions => {
     const config: NetworkRecordOptions = {
         payloadSizeLimitBytes: defaultNetworkOptions.payloadSizeLimitBytes,
         performanceEntryTypeToObserve: [...defaultNetworkOptions.performanceEntryTypeToObserve],
+        payloadHostDenyList: [
+            ...(remoteNetworkOptions.payloadHostDenyList || []),
+            ...defaultNetworkOptions.payloadHostDenyList,
+        ],
     }
     // client can always disable despite remote options
     const canRecordHeaders =

--- a/src/extensions/replay/external/README.md
+++ b/src/extensions/replay/external/README.md
@@ -1,0 +1,5 @@
+files in here are intended for the lazy loaded portion of replay
+
+you aren't supposed to import them from outside the entrypoint file
+
+they could cause an increase in bundle size

--- a/src/extensions/replay/external/denylist.ts
+++ b/src/extensions/replay/external/denylist.ts
@@ -1,0 +1,32 @@
+import { NetworkRecordOptions } from '../../../types'
+
+function hostnameFromURL(url: string | URL | RequestInfo): string | null {
+    try {
+        if (typeof url === 'string') {
+            return new URL(url).hostname
+        }
+        if ('url' in url) {
+            return new URL(url.url).hostname
+        }
+        return url.hostname
+    } catch {
+        return null
+    }
+}
+
+export function isHostOnDenyList(url: string | URL | Request, options: NetworkRecordOptions) {
+    const hostname = hostnameFromURL(url)
+    const defaultNotDenied = { hostname, isHostDenied: false }
+
+    if (!options.payloadHostDenyList?.length || !hostname?.trim().length) {
+        return defaultNotDenied
+    }
+
+    for (const deny of options.payloadHostDenyList) {
+        if (hostname.endsWith(deny)) {
+            return { hostname, isHostDenied: true }
+        }
+    }
+
+    return defaultNotDenied
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -451,6 +451,14 @@ export type NetworkRecordOptions = {
      * NB this will be at most 1MB even if set larger
      */
     payloadSizeLimitBytes: number
+    /**
+     * some domains we should never record the payload
+     * for example other companies session replay ingestion payloads aren't super useful but are gigantic
+     * if this isn't provided we use a default list
+     * if this is provided - we add the provided list to the default list
+     * i.e. we never record the payloads on the default deny list
+     */
+    payloadHostDenyList?: string[]
 }
 
 /** @deprecated - use CapturedNetworkRequest instead  */


### PR DESCRIPTION
We've seen replay message be rejected for being too large
And on inspection they contain many megabytes of replay data _for other vendors_
There's no point capturing those payloads 🙈 

* adds a default deny list
* adds a hook that we could use to start overriding it via decide response
* ...