### PR TITLE
fix: only take scheduled full snapshots

### DIFF
--- a/cypress/e2e/error-tracking.cy.ts
+++ b/cypress/e2e/error-tracking.cy.ts
@@ -19,7 +19,7 @@ describe('Exception autocapture', () => {
         cy.get('[data-cy-button-throws-error]').click()
 
         // ugh
-        cy.wait(500)
+        cy.wait(1500)
 
         cy.phCaptures({ full: true }).then((captures) => {
             expect(captures.map((c) => c.event)).to.deep.equal(['$pageview', '$autocapture', '$exception'])

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -679,7 +679,6 @@ export class SessionRecording {
                         return
                     }
                     this._tryAddCustomEvent('$pageview', { href })
-                    this._tryTakeFullSnapshot()
                 }
             } catch (e) {
                 logger.error('Could not add $pageview to rrweb session', e)


### PR DESCRIPTION
We currently take a full snapshot when

(in order of increasing frequency)

* rrweb starts
* when the session id or window id changes
* when returning from idle
* on a timer
* when we see a $pageview event

we also infrequently see reports that playback is inconsistent around $pageviews

let's not take that speculative snapshot
