### PR TITLE
feat(surveys): added close button text customization feature

### DIFF
--- a/src/extensions/surveys/components/ConfirmationMessage.tsx
+++ b/src/extensions/surveys/components/ConfirmationMessage.tsx
@@ -39,7 +39,7 @@ export function ConfirmationMessage({
                             style: { color: textColor },
                         })}
                     <BottomSection
-                        text={'Close'}
+                        text={appearance.thankYouMessageCloseButtonText || 'Close'}
                         submitDisabled={false}
                         appearance={appearance}
                         onSubmit={() => onClose()}

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -22,6 +22,7 @@ export interface SurveyAppearance {
     thankYouMessageHeader?: string
     thankYouMessageDescription?: string
     thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType
+    thankYouMessageCloseButtonText?: string
     borderColor?: string
     position?: 'left' | 'right' | 'center'
     placeholder?: string


### PR DESCRIPTION
Ships with https://github.com/PostHog/posthog/pull/23501

## Changes

### Before

Not customizable

<img width="1007" alt="image" src="https://github.com/PostHog/posthog-js/assets/4853149/76ed261e-7c68-40c9-ac66-e9f2776b8605">

### After

![2024-07-05 15 50 11](https://github.com/PostHog/posthog-js/assets/4853149/c8658dae-63c7-4c7b-a418-d6c22bec25bf)

## Checklist

Manually tested it, looks solid.  Low-risk (it's an optional field)/easy change, just needed to make sure that the types lined up.
