### PR TITLE
feat: send errors one way

### DIFF
--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -18,6 +18,7 @@
 
 import { PostHog } from '../posthog-core'
 import { SeverityLevel } from '../types'
+import { BASE_ERROR_ENDPOINT } from './exception-autocapture'
 
 // NOTE - we can't import from @sentry/types because it changes frequently and causes clashes
 // We only use a small subset of the types, so we can just define the integration overall and use any for the rest
@@ -124,7 +125,12 @@ export function createEventProcessor(
                 '&query=' +
                 event.event_id
         }
-        _posthog.capture('$exception', data)
+
+        // we take the URL from the exception observer
+        // so that when we add error specific URL for ingestion
+        // these errors are sent there too
+        _posthog.capture('$exception', data, { _url: _posthog.exceptionObserver?.endpoint || BASE_ERROR_ENDPOINT })
+
         return event
     }
 }


### PR DESCRIPTION
We are going to start sending errors to their own ingestion endpoint.

This updates the sentry integration to use whatever is the current error endpoint for error autocapture