### PR TITLE
chore: fix error tests listener registration

### DIFF
--- a/cypress/e2e/error-tracking.cy.ts
+++ b/cypress/e2e/error-tracking.cy.ts
@@ -2,17 +2,18 @@ import { start } from '../support/setup'
 
 describe('Exception autocapture', () => {
     beforeEach(() => {
+        cy.on('uncaught:exception', () => {
+            // otherwise the exception we throw on purpose causes the test to fail
+            return false
+        })
+
         start({
             decideResponseOverrides: {
                 autocaptureExceptions: true,
             },
             url: './playground/cypress',
         })
-
-        cy.on('uncaught:exception', () => {
-            // otherwise the exception we throw on purpose causes the test to fail
-            return false
-        })
+        cy.wait('@exception-autocapture-script')
     })
 
     it('captures exceptions', () => {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -32,7 +32,7 @@ beforeEach(() => {
 
     cy.readFile('dist/recorder.js').then((body) => {
         cy.intercept('/static/recorder.js*', { body }).as('recorder')
-        cy.intercept('/static/recorder-v2.js*', { body }).as('recorder')
+        cy.intercept('/static/recorder-v2.js*', { body }).as('recorderv2')
     })
 
     cy.readFile('dist/recorder.js.map').then((body) => {
@@ -48,7 +48,7 @@ beforeEach(() => {
     })
 
     cy.readFile('dist/exception-autocapture.js').then((body) => {
-        cy.intercept('/static/exception-autocapture.js*', { body })
+        cy.intercept('/static/exception-autocapture.js*', { body }).as('exception-autocapture-script')
     })
 
     cy.readFile('dist/exception-autocapture.js.map').then((body) => {


### PR DESCRIPTION
I can't consistently make this happen locally

But I did once notice that I don't always get

```
possible EventEmitter memory leak detected
```

i only noticed after the fact but if we didn't register an event listener then the tests wouldn't pass 

i've checked console logs in prod for our team and don't see this so it's safe to patch in tests (🙈)