### PR TITLE
feat(Surveys): Add ActionMatcher to match CaptureResult to any known actions

### DIFF
--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -583,6 +583,27 @@ describe('Autocapture system', () => {
             expect(props['$elements'][0]).toHaveProperty('attr__data-props', 'prop'.repeat(256) + '...')
         })
 
+        it('assigns element_selector if htmlelement matches known selectors', () => {
+            const elTarget = document.createElement('img')
+            elTarget.id = 'primary_button'
+            const elParent = document.createElement('span')
+            elParent.appendChild(elTarget)
+            autocapture.setElementSelectors(new Set<string>('#primary_button'))
+            const elGrandparent = document.createElement('a')
+            elGrandparent.setAttribute('href', 'https://test.com')
+            elGrandparent.appendChild(elParent)
+            autocapture['_captureEvent'](
+                makeMouseEvent({
+                    target: elTarget,
+                })
+            )
+
+            const props = captureMock.mock.calls[0][1]
+            expect(props['$element_selectors']).toContain('primary_button')
+            expect(props['$elements'][0]).toHaveProperty('attr__href', 'https://test.com')
+            expect(props['$external_click_url']).toEqual('https://test.com')
+        })
+
         it('gets the href attribute from parent anchor tags', () => {
             const elTarget = document.createElement('img')
             const elParent = document.createElement('span')

--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -588,7 +588,12 @@ describe('Autocapture system', () => {
             elTarget.id = 'primary_button'
             const elParent = document.createElement('span')
             elParent.appendChild(elTarget)
-            autocapture.setElementSelectors(new Set<string>('#primary_button'))
+
+            document.querySelectorAll = function () {
+                return [elTarget] as unknown as NodeListOf<Element>
+            }
+
+            autocapture.setElementSelectors(new Set<string>(['#primary_button']))
             const elGrandparent = document.createElement('a')
             elGrandparent.setAttribute('href', 'https://test.com')
             elGrandparent.appendChild(elParent)
@@ -599,7 +604,7 @@ describe('Autocapture system', () => {
             )
 
             const props = captureMock.mock.calls[0][1]
-            expect(props['$element_selectors']).toContain('primary_button')
+            expect(props['$element_selectors']).toContain('#primary_button')
             expect(props['$elements'][0]).toHaveProperty('attr__href', 'https://test.com')
             expect(props['$external_click_url']).toEqual('https://test.com')
         })

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -116,7 +116,7 @@ export class Autocapture {
     }
 
     public getElementSelectors(element: Element | null): string[] | null {
-        const elementSelectors = ['']
+        const elementSelectors: string[] = []
 
         this._elementSelectors?.forEach((selector) => {
             const matchedElements = document?.querySelectorAll(selector)

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -40,11 +40,13 @@ export class Autocapture {
     instance: PostHog
     _initialized: boolean = false
     _isDisabledServerSide: boolean | null = null
+    _elementSelectors: Set<string> | null
     rageclicks = new RageClick()
     _elementsChainAsString = false
 
     constructor(instance: PostHog) {
         this.instance = instance
+        this._elementSelectors = null
     }
 
     private get config(): AutocaptureConfig {
@@ -109,6 +111,25 @@ export class Autocapture {
         this.startIfEnabled()
     }
 
+    public setElementSelectors(selectors: Set<string>): void {
+        this._elementSelectors = selectors
+    }
+
+    public getElementSelectors(element: Element | null): string[] | null {
+        const elementSelectors = ['']
+
+        this._elementSelectors?.forEach((selector) => {
+            const matchedElements = document?.querySelectorAll(selector)
+            matchedElements?.forEach((matchedElement: Element) => {
+                if (element === matchedElement) {
+                    elementSelectors.push(selector)
+                }
+            })
+        })
+
+        return elementSelectors
+    }
+
     public get isEnabled(): boolean {
         const persistedServerDisabled = this.instance.persistence?.props[AUTOCAPTURE_DISABLED_SERVER_SIDE]
         const memoryDisabled = this._isDisabledServerSide
@@ -155,6 +176,7 @@ export class Autocapture {
                 }
             }
         })
+
         return props
     }
 
@@ -350,6 +372,11 @@ export class Autocapture {
                 externalHref && e.type === 'click' ? { $external_click_url: externalHref } : {},
                 autocaptureAugmentProperties
             )
+
+            const elementSelectors = this.getElementSelectors(target)
+            if (elementSelectors && elementSelectors.length > 0) {
+                props['$element_selectors'] = elementSelectors
+            }
 
             if (eventName === COPY_AUTOCAPTURE_EVENT) {
                 // you can't read the data from the clipboard event,

--- a/src/extensions/surveys/action-matcher.test.ts
+++ b/src/extensions/surveys/action-matcher.test.ts
@@ -1,0 +1,163 @@
+/// <reference lib="dom" />
+
+import { ActionType, ActionStepStringMatching } from '../../posthog-surveys-types'
+import { PostHogPersistence } from '../../posthog-persistence'
+import { PostHog } from '../../posthog-core'
+import { CaptureResult, PostHogConfig } from '../../types'
+import { ActionMatcher } from './action-matcher'
+
+describe('action-matcher', () => {
+    let config: PostHogConfig
+    let instance: PostHog
+
+    beforeEach(() => {
+        config = {
+            token: 'testtoken',
+            api_host: 'https://app.posthog.com',
+            persistence: 'memory',
+        } as unknown as PostHogConfig
+
+        instance = {
+            config: config,
+            persistence: new PostHogPersistence(config),
+            _addCaptureHook: jest.fn(),
+        } as unknown as PostHog
+    })
+
+    afterEach(() => {
+        instance.persistence?.clear()
+    })
+
+    const createCaptureResult = (eventName: string, currentUrl?: string): CaptureResult => {
+        return {
+            $set: undefined,
+            $set_once: undefined,
+            properties: {
+                $current_url: currentUrl,
+            },
+            timestamp: undefined,
+            uuid: '0C984DA5-761F-4F75-9582-D2F95B43B04A',
+            event: eventName,
+        }
+    }
+    const createAction = (
+        id: number,
+        eventName: string,
+        currentUrl?: string,
+        urlMatch?: ActionStepStringMatching
+    ): ActionType => {
+        return {
+            id: id,
+            name: `${eventName || 'user defined '} action`,
+            description: '',
+            post_to_slack: false,
+            slack_message_format: '',
+            steps: [
+                {
+                    event: eventName,
+                    text: null,
+                    text_matching: null,
+                    href: null,
+                    href_matching: null,
+                    url: currentUrl,
+                    url_matching: urlMatch || 'exact',
+                },
+            ],
+            created_at: '2024-06-20T14:39:23.616676Z',
+            deleted: false,
+            is_calculating: false,
+            last_calculated_at: '2024-06-20T14:39:23.616051Z',
+            is_action: true,
+            tags: [],
+        }
+    }
+
+    it('can match action on event name', () => {
+        const pageViewAction = createAction(3, '$mypageview') as unknown as ActionType
+        const actionMatcher = new ActionMatcher(instance)
+        actionMatcher.register([pageViewAction])
+        let pageViewActionMatched = false
+
+        const onAction = (actionName: string) => {
+            if (!pageViewActionMatched) {
+                pageViewActionMatched = actionName === pageViewAction.name
+            }
+        }
+
+        actionMatcher._addActionHook(onAction)
+
+        actionMatcher.on('$match_event_name', createCaptureResult('$mypageview'))
+        expect(pageViewActionMatched).toBeTruthy()
+    })
+
+    it('can match action on current_url exact', () => {
+        const pageViewAction = createAction(2, '$autocapture', 'https://us.posthog.com')
+        const actionMatcher = new ActionMatcher(instance)
+        actionMatcher.register([pageViewAction])
+
+        let pageViewActionMatched = false
+
+        const onAction = (actionName: string) => {
+            if (!pageViewActionMatched) {
+                pageViewActionMatched = actionName === pageViewAction.name
+            }
+        }
+
+        actionMatcher._addActionHook(onAction)
+        actionMatcher.on('$autocapture', createCaptureResult('$autocapture', 'https://eu.posthog.com'))
+        expect(pageViewActionMatched).toBeFalsy()
+
+        actionMatcher.on('$autocapture', createCaptureResult('$autocapture', 'https://us.posthog.com'))
+        expect(pageViewActionMatched).toBeTruthy()
+    })
+
+    it('can match action on current_url regexp', () => {
+        const pageViewAction = createAction(2, '$current_url_regexp', '[a-z][a-z].posthog.*', 'regex')
+        const actionMatcher = new ActionMatcher(instance)
+        actionMatcher.register([pageViewAction])
+
+        let pageViewActionMatched = false
+
+        const onAction = (actionName: string) => {
+            if (!pageViewActionMatched) {
+                pageViewActionMatched = actionName === pageViewAction.name
+            }
+        }
+
+        actionMatcher._addActionHook(onAction)
+        actionMatcher.on('$autocapture', createCaptureResult('$current_url_regexp', 'https://eu.posthog.com'))
+        expect(pageViewActionMatched).toBeTruthy()
+        pageViewActionMatched = false
+
+        actionMatcher.on('$autocapture', createCaptureResult('$current_url_regexp', 'https://us.posthog.com'))
+        expect(pageViewActionMatched).toBeTruthy()
+    })
+
+    it('can match action on html element selector', () => {
+        const buttonClickedAction = createAction(2, '$autocapture')
+        if (buttonClickedAction.steps) {
+            buttonClickedAction.steps[0].selector = '* > #__next .flex > button:nth-child(2)'
+        }
+
+        const actionMatcher = new ActionMatcher(instance)
+        actionMatcher.register([buttonClickedAction])
+        let buttonClickedActionMatched = false
+
+        const onAction = (actionName: string) => {
+            if (!buttonClickedActionMatched) {
+                buttonClickedActionMatched = actionName === buttonClickedAction.name
+            }
+        }
+        actionMatcher._addActionHook(onAction)
+
+        const result = createCaptureResult('$autocapture', 'https://eu.posthog.com')
+        result.properties.$element_selectors = []
+        actionMatcher.on('$autocapture', result)
+        expect(buttonClickedActionMatched).toBeFalsy()
+
+        result.properties.$element_selectors = ['* > #__next .flex > button:nth-child(2)']
+
+        actionMatcher.on('$autocapture', result)
+        expect(buttonClickedActionMatched).toBeTruthy()
+    })
+})

--- a/src/extensions/surveys/action-matcher.test.ts
+++ b/src/extensions/surveys/action-matcher.test.ts
@@ -49,9 +49,6 @@ describe('action-matcher', () => {
         return {
             id: id,
             name: `${eventName || 'user defined '} action`,
-            description: '',
-            post_to_slack: false,
-            slack_message_format: '',
             steps: [
                 {
                     event: eventName,
@@ -65,8 +62,6 @@ describe('action-matcher', () => {
             ],
             created_at: '2024-06-20T14:39:23.616676Z',
             deleted: false,
-            is_calculating: false,
-            last_calculated_at: '2024-06-20T14:39:23.616051Z',
             is_action: true,
             tags: [],
         }

--- a/src/extensions/surveys/action-matcher.ts
+++ b/src/extensions/surveys/action-matcher.ts
@@ -1,0 +1,215 @@
+import { PostHog } from '../../posthog-core'
+import { ActionStepStringMatching, ActionStepType, ActionType, SurveyElement } from '../../posthog-surveys-types'
+import { SimpleEventEmitter } from '../../utils/simple-event-emitter'
+import { CaptureResult } from '../../types'
+import { isUndefined } from '../../utils/type-utils'
+import { window } from '../../utils/globals'
+import { isUrlMatchingRegex } from '../../utils/request-utils'
+
+export class ActionMatcher {
+    private readonly actionRegistry?: Set<ActionType>
+    private readonly instance?: PostHog
+    private readonly actionEvents: Set<string>
+    private _debugEventEmitter = new SimpleEventEmitter()
+
+    constructor(instance?: PostHog) {
+        this.instance = instance
+        this.actionEvents = new Set<string>()
+        this.actionRegistry = new Set<ActionType>()
+    }
+
+    init() {
+        if (!isUndefined(this.instance?._addCaptureHook)) {
+            const matchEventToAction = (eventName: string, eventPayload: any) => {
+                this.on(eventName, eventPayload)
+            }
+            this.instance?._addCaptureHook(matchEventToAction)
+        }
+    }
+
+    register(actions: ActionType[]): void {
+        if (isUndefined(this.instance?._addCaptureHook)) {
+            return
+        }
+
+        actions.forEach((action) => {
+            this.actionRegistry?.add(action)
+            action.steps?.forEach((step) => {
+                this.actionEvents?.add(step?.event || '')
+            })
+        })
+
+        if (this.instance?.autocapture) {
+            const selectorsToWatch: Set<string> = new Set<string>()
+            actions.forEach((action) => {
+                action.steps?.forEach((step) => {
+                    if (step?.selector) {
+                        selectorsToWatch.add(step?.selector)
+                    }
+                })
+            })
+            this.instance?.autocapture.setElementSelectors(selectorsToWatch)
+        }
+
+        // if (eventNames.length > 0) {
+        //     throw new Error(`I know about these events : ${eventNames}`)
+        // }
+    }
+
+    on(eventName: string, eventPayload?: CaptureResult) {
+        if (eventPayload == null || eventName.length == 0) {
+            return
+        }
+
+        if (!this.actionEvents.has(eventName) && !this.actionEvents.has(<string>eventPayload?.event)) {
+            // throw new Error(`unknown event ${eventName}, I only know about : ${JSON.stringify(this.actionEvents.values())}`)
+            return
+        }
+
+        if (this.actionRegistry && this.actionRegistry?.size > 0) {
+            this.actionRegistry.forEach((action) => {
+                if (this.checkAction(eventPayload, action)) {
+                    this._debugEventEmitter.emit('actionCaptured', action.name)
+                }
+            })
+        }
+    }
+
+    _addActionHook(callback: (actionName: string, eventPayload?: any) => void): void {
+        this.onAction('actionCaptured', (data) => callback(data))
+    }
+
+    private checkAction(event?: CaptureResult, action?: ActionType): boolean {
+        if (action?.steps == null) {
+            return false
+        }
+
+        for (const step of action.steps) {
+            if (this.checkStep(event, step)) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    onAction(event: 'actionCaptured', cb: (...args: any[]) => void): () => void {
+        return this._debugEventEmitter.on(event, cb)
+    }
+
+    private checkStep = (event?: CaptureResult, step?: ActionStepType): boolean => {
+        return this.checkStepEvent(event, step) && this.checkStepUrl(event, step) && this.checkStepElement(event, step)
+    }
+
+    private checkStepEvent = (event?: CaptureResult, step?: ActionStepType): boolean => {
+        // CHECK CONDITIONS, OTHERWISE SKIPPED
+        if (step?.event && event?.event !== step?.event) {
+            return false // EVENT NAME IS A MISMATCH
+        }
+        return true
+    }
+
+    private checkStepUrl(event?: CaptureResult, step?: ActionStepType): boolean {
+        // CHECK CONDITIONS, OTHERWISE SKIPPED
+        if (step?.url) {
+            const eventUrl = event?.properties?.$current_url
+            if (!eventUrl || typeof eventUrl !== 'string') {
+                return false // URL IS UNKNOWN
+            }
+            if (!ActionMatcher.matchString(eventUrl, step?.url, step?.url_matching || 'contains')) {
+                return false // URL IS A MISMATCH
+            }
+        }
+        return true
+    }
+
+    private static matchString(url: string, pattern: string, matching: ActionStepStringMatching): boolean {
+        switch (matching) {
+            case 'regex':
+                return !!window && isUrlMatchingRegex(url, pattern)
+            case 'exact':
+                return pattern === url
+            case 'contains':
+                // Simulating SQL LIKE behavior (_ = any single character, % = any zero or more characters)
+                // eslint-disable-next-line no-case-declarations
+                const adjustedRegExpStringPattern = ActionMatcher.escapeStringRegexp(pattern)
+                    .replace(/_/g, '.')
+                    .replace(/%/g, '.*')
+                return isUrlMatchingRegex(url, adjustedRegExpStringPattern)
+
+            default:
+                return false
+        }
+    }
+
+    private static escapeStringRegexp(pattern: string): string {
+        // Escape characters with special meaning either inside or outside character sets.
+        // Use a simple backslash escape when it’s always valid, and a `\xnn` escape when the simpler form would be disallowed by Unicode patterns’ stricter grammar.
+        return pattern.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d')
+    }
+
+    private checkStepElement(event?: CaptureResult, step?: ActionStepType): boolean {
+        // CHECK CONDITIONS, OTHERWISE SKIPPED
+        if (step?.href || step?.tag_name || step?.text) {
+            const elements = this.getElementsList(event)
+            if (
+                !elements.some((element) => {
+                    if (
+                        step?.href &&
+                        !ActionMatcher.matchString(element.href || '', step?.href, step?.href_matching || 'exact')
+                    ) {
+                        return false // ELEMENT HREF IS A MISMATCH
+                    }
+                    if (step?.tag_name && element.tag_name !== step?.tag_name) {
+                        return false // ELEMENT TAG NAME IS A MISMATCH
+                    }
+                    if (
+                        step?.text &&
+                        !(
+                            ActionMatcher.matchString(element.text || '', step?.text, step?.text_matching || 'exact') ||
+                            ActionMatcher.matchString(
+                                element.$el_text || '',
+                                step?.text,
+                                step?.text_matching || 'exact'
+                            )
+                        )
+                    ) {
+                        return false // ELEMENT TEXT IS A MISMATCH
+                    }
+                    return true
+                })
+            ) {
+                // AT LEAST ONE ELEMENT MUST BE A SUBMATCH
+                return false
+            }
+        }
+
+        if (step?.selector) {
+            const elementSelectors = event?.properties?.$element_selectors as unknown as string[]
+            if (!elementSelectors) {
+                return false // SELECTOR IS A MISMATCH
+            }
+            if (!elementSelectors.includes(step?.selector)) {
+                return false // SELECTOR IS A MISMATCH
+            }
+        }
+
+        return true
+    }
+
+    private getElementsList(event?: CaptureResult): SurveyElement[] {
+        if (event?.properties.$elements == null) {
+            return []
+        }
+
+        return event?.properties.$elements as unknown as SurveyElement[]
+    }
+
+    // private mutateCaptureResultWithElementsList(event: CaptureResult: Element[] {
+    //      event.elementsList = event.elementsList.map((element) => ({
+    //     ...element,
+    //     attr_class: element.attributes?.attr__class ?? element.attr_class,
+    //     $el_text: element.text,
+    // }))
+    // }
+}

--- a/src/extensions/surveys/action-matcher.ts
+++ b/src/extensions/surveys/action-matcher.ts
@@ -50,10 +50,6 @@ export class ActionMatcher {
             })
             this.instance?.autocapture.setElementSelectors(selectorsToWatch)
         }
-
-        // if (eventNames.length > 0) {
-        //     throw new Error(`I know about these events : ${eventNames}`)
-        // }
     }
 
     on(eventName: string, eventPayload?: CaptureResult) {
@@ -62,7 +58,6 @@ export class ActionMatcher {
         }
 
         if (!this.actionEvents.has(eventName) && !this.actionEvents.has(<string>eventPayload?.event)) {
-            // throw new Error(`unknown event ${eventName}, I only know about : ${JSON.stringify(this.actionEvents.values())}`)
             return
         }
 
@@ -204,12 +199,4 @@ export class ActionMatcher {
 
         return event?.properties.$elements as unknown as SurveyElement[]
     }
-
-    // private mutateCaptureResultWithElementsList(event: CaptureResult: Element[] {
-    //      event.elementsList = event.elementsList.map((element) => ({
-    //     ...element,
-    //     attr_class: element.attributes?.attr__class ?? element.attr_class,
-    //     $el_text: element.text,
-    // }))
-    // }
 }

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -22,7 +22,6 @@ export interface SurveyAppearance {
     thankYouMessageHeader?: string
     thankYouMessageDescription?: string
     thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType
-    thankYouMessageCloseButtonText?: string
     borderColor?: string
     position?: 'left' | 'right' | 'center'
     placeholder?: string
@@ -123,6 +122,20 @@ export type SurveyCallback = (surveys: Survey[]) => void
 
 export type SurveyUrlMatchType = 'regex' | 'not_regex' | 'exact' | 'is_not' | 'icontains' | 'not_icontains'
 
+export interface SurveyElement {
+    text?: string
+    $el_text?: string
+    tag_name?: string
+    href?: string
+    attr_id?: string
+    attr_class?: string[]
+    nth_child?: number
+    nth_of_type?: number
+    attributes?: Record<string, any>
+    event_id?: number
+    order?: number
+    group_id?: number
+}
 export interface Survey {
     // Sync this with the backend's SurveyAPISerializer!
     id: string
@@ -150,4 +163,110 @@ export interface Survey {
     end_date: string | null
     current_iteration: number | null
     current_iteration_start_date: string | null
+}
+
+export enum PropertyFilterType {
+    /** Event properties */
+    Event = 'event',
+    Element = 'element',
+}
+
+export enum PropertyOperator {
+    Exact = 'exact',
+    IsNot = 'is_not',
+    IContains = 'icontains',
+    NotIContains = 'not_icontains',
+    Regex = 'regex',
+    NotRegex = 'not_regex',
+    GreaterThan = 'gt',
+    GreaterThanOrEqual = 'gte',
+    LessThan = 'lt',
+    LessThanOrEqual = 'lte',
+    IsSet = 'is_set',
+    IsNotSet = 'is_not_set',
+    IsDateExact = 'is_date_exact',
+    IsDateBefore = 'is_date_before',
+    IsDateAfter = 'is_date_after',
+    Between = 'between',
+    NotBetween = 'not_between',
+    Minimum = 'min',
+    Maximum = 'max',
+}
+
+export type PropertyFilterValue = string | number | (string | number)[] | null
+
+/** Sync with plugin-server/src/types.ts */
+interface BasePropertyFilter {
+    key: string
+    value?: PropertyFilterValue
+    label?: string
+    type?: PropertyFilterType
+}
+
+/** Sync with plugin-server/src/types.ts */
+export interface EventPropertyFilter extends BasePropertyFilter {
+    type: PropertyFilterType.Event
+    /** @default 'exact' */
+    operator: PropertyOperator
+}
+
+/** Sync with plugin-server/src/types.ts */
+export interface ElementPropertyFilter extends BasePropertyFilter {
+    type: PropertyFilterType.Element
+    key: 'tag_name' | 'text' | 'href' | 'selector'
+    operator: PropertyOperator
+}
+export type AnyPropertyFilter = EventPropertyFilter | ElementPropertyFilter
+
+export interface ActionType {
+    count?: number
+    created_at: string
+    deleted?: boolean
+    id: number
+    is_calculating?: boolean
+    last_calculated_at?: string
+    last_updated_at?: string // alias for last_calculated_at to achieve event and action parity
+    name: string | null
+    description?: string
+    post_to_slack?: boolean
+    slack_message_format?: string
+    steps?: ActionStepType[]
+    tags?: string[]
+    verified?: boolean
+    is_action?: true
+    action_id?: number // alias of id to make it compatible with event definitions uuid
+    bytecode?: any[]
+    bytecode_error?: string
+}
+
+/** Sync with plugin-server/src/types.ts */
+export type ActionStepStringMatching = 'contains' | 'exact' | 'regex'
+
+export interface ActionStepType {
+    event?: string | null
+    properties?: AnyPropertyFilter[]
+    selector?: string | null
+    /** @deprecated Only `selector` should be used now. */
+    tag_name?: string
+    text?: string | null
+    /** @default StringMatching.Exact */
+    text_matching?: ActionStepStringMatching | null
+    href?: string | null
+    /** @default ActionStepStringMatching.Exact */
+    href_matching?: ActionStepStringMatching | null
+    url?: string | null
+    /** @default StringMatching.Contains */
+    url_matching?: ActionStepStringMatching | null
+}
+
+export interface ElementType {
+    attr_class?: string[]
+    attr_id?: string
+    attributes: Record<string, string>
+    href?: string
+    nth_child?: number
+    nth_of_type?: number
+    order?: number
+    tag_name: string
+    text?: string
 }

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -22,6 +22,7 @@ export interface SurveyAppearance {
     thankYouMessageHeader?: string
     thankYouMessageDescription?: string
     thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType
+    thankYouMessageCloseButtonText?: string
     borderColor?: string
     position?: 'left' | 'right' | 'center'
     placeholder?: string
@@ -165,78 +166,16 @@ export interface Survey {
     current_iteration_start_date: string | null
 }
 
-export enum PropertyFilterType {
-    /** Event properties */
-    Event = 'event',
-    Element = 'element',
-}
-
-export enum PropertyOperator {
-    Exact = 'exact',
-    IsNot = 'is_not',
-    IContains = 'icontains',
-    NotIContains = 'not_icontains',
-    Regex = 'regex',
-    NotRegex = 'not_regex',
-    GreaterThan = 'gt',
-    GreaterThanOrEqual = 'gte',
-    LessThan = 'lt',
-    LessThanOrEqual = 'lte',
-    IsSet = 'is_set',
-    IsNotSet = 'is_not_set',
-    IsDateExact = 'is_date_exact',
-    IsDateBefore = 'is_date_before',
-    IsDateAfter = 'is_date_after',
-    Between = 'between',
-    NotBetween = 'not_between',
-    Minimum = 'min',
-    Maximum = 'max',
-}
-
-export type PropertyFilterValue = string | number | (string | number)[] | null
-
-/** Sync with plugin-server/src/types.ts */
-interface BasePropertyFilter {
-    key: string
-    value?: PropertyFilterValue
-    label?: string
-    type?: PropertyFilterType
-}
-
-/** Sync with plugin-server/src/types.ts */
-export interface EventPropertyFilter extends BasePropertyFilter {
-    type: PropertyFilterType.Event
-    /** @default 'exact' */
-    operator: PropertyOperator
-}
-
-/** Sync with plugin-server/src/types.ts */
-export interface ElementPropertyFilter extends BasePropertyFilter {
-    type: PropertyFilterType.Element
-    key: 'tag_name' | 'text' | 'href' | 'selector'
-    operator: PropertyOperator
-}
-export type AnyPropertyFilter = EventPropertyFilter | ElementPropertyFilter
-
 export interface ActionType {
     count?: number
     created_at: string
     deleted?: boolean
     id: number
-    is_calculating?: boolean
-    last_calculated_at?: string
-    last_updated_at?: string // alias for last_calculated_at to achieve event and action parity
     name: string | null
-    description?: string
-    post_to_slack?: boolean
-    slack_message_format?: string
     steps?: ActionStepType[]
     tags?: string[]
-    verified?: boolean
     is_action?: true
     action_id?: number // alias of id to make it compatible with event definitions uuid
-    bytecode?: any[]
-    bytecode_error?: string
 }
 
 /** Sync with plugin-server/src/types.ts */
@@ -244,7 +183,6 @@ export type ActionStepStringMatching = 'contains' | 'exact' | 'regex'
 
 export interface ActionStepType {
     event?: string | null
-    properties?: AnyPropertyFilter[]
     selector?: string | null
     /** @deprecated Only `selector` should be used now. */
     tag_name?: string
@@ -257,16 +195,4 @@ export interface ActionStepType {
     url?: string | null
     /** @default StringMatching.Contains */
     url_matching?: ActionStepStringMatching | null
-}
-
-export interface ElementType {
-    attr_class?: string[]
-    attr_id?: string
-    attributes: Record<string, string>
-    href?: string
-    nth_child?: number
-    nth_of_type?: number
-    order?: number
-    tag_name: string
-    text?: string
 }


### PR DESCRIPTION
## Changes

_Broken out of #1292 into its own PR for easier reviewing and merging_

This PR allows us to match user activities performed in the browser to any known actions.

### Not supported
1. Matching person properties in Actions,  when matching surveys. We will not implement this as we don't want to download person properties on the client for surveys.
2. Matching event properties in Actions, when matching surveys. We could do this in a follow-up PR because the event properties are available on the client-side.

## Changes

Here are the set of changes I needed to make to implement action matching in posthog-js

### AutoCapture
1. Autocapture can now register a set of html element selectors. 
4. These html selectors, are checked against the target element **that** was captured
5. If there is a match, those element selectors are sent along as `$element_selectors` property for a given event.

### ActionMatcher
This is a pared down version of the action-matcher found in the ingestion pipeline, main differences are : 
1. Uses the `$element_selectors` property introduced in AutoCapture to match events to an action step.
2. Uses the `elementsJson` that is passed along as part of CaptureResult to check other properties like tagname, text, url etc
4. Raises an `actionCaptured` event when a `CaptureResult` matches a known action step.

### Flowchart for matching actions on the client-side.
``` mermaid
flowchart TD
    A[User clicks button] -->|AutoCapture| B(Analyze element)
    B --> |Element matches known selector|C(Set $element_selectors property)
    C -->D[Capture Action]
    B --> |Element does not match known selector|D[Capture Action]
    D --> |Raise eventCaptured with CaptureResult|E[Event Handlers]
    E --> F[Action Matcher]
    F --> |Check Action Step Matches CaptureResult|G[Raise actionCaptured with actionName]
```

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
