### PR TITLE
feat(Surveys): Activate surveys based on actions

### DIFF
--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -583,6 +583,27 @@ describe('Autocapture system', () => {
             expect(props['$elements'][0]).toHaveProperty('attr__data-props', 'prop'.repeat(256) + '...')
         })
 
+        it('assigns element_selector if htmlelement matches known selectors', () => {
+            const elTarget = document.createElement('img')
+            elTarget.id = 'primary_button'
+            const elParent = document.createElement('span')
+            elParent.appendChild(elTarget)
+            autocapture.setElementSelectors(new Set<string>('#primary_button'))
+            const elGrandparent = document.createElement('a')
+            elGrandparent.setAttribute('href', 'https://test.com')
+            elGrandparent.appendChild(elParent)
+            autocapture['_captureEvent'](
+                makeMouseEvent({
+                    target: elTarget,
+                })
+            )
+
+            const props = captureMock.mock.calls[0][1]
+            expect(props['$element_selectors']).toContain('primary_button')
+            expect(props['$elements'][0]).toHaveProperty('attr__href', 'https://test.com')
+            expect(props['$external_click_url']).toEqual('https://test.com')
+        })
+
         it('gets the href attribute from parent anchor tags', () => {
             const elTarget = document.createElement('img')
             const elParent = document.createElement('span')

--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -583,27 +583,6 @@ describe('Autocapture system', () => {
             expect(props['$elements'][0]).toHaveProperty('attr__data-props', 'prop'.repeat(256) + '...')
         })
 
-        it('assigns element_selector if htmlelement matches known selectors', () => {
-            const elTarget = document.createElement('img')
-            elTarget.id = 'primary_button'
-            const elParent = document.createElement('span')
-            elParent.appendChild(elTarget)
-            autocapture.setElementSelectors(new Set<string>('#primary_button'))
-            const elGrandparent = document.createElement('a')
-            elGrandparent.setAttribute('href', 'https://test.com')
-            elGrandparent.appendChild(elParent)
-            autocapture['_captureEvent'](
-                makeMouseEvent({
-                    target: elTarget,
-                })
-            )
-
-            const props = captureMock.mock.calls[0][1]
-            expect(props['$element_selectors']).toContain('primary_button')
-            expect(props['$elements'][0]).toHaveProperty('attr__href', 'https://test.com')
-            expect(props['$external_click_url']).toEqual('https://test.com')
-        })
-
         it('gets the href attribute from parent anchor tags', () => {
             const elTarget = document.createElement('img')
             const elParent = document.createElement('span')

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -195,18 +195,12 @@ describe('surveys', () => {
             expect(data).toEqual(surveysWithEvents)
         }, true)
 
-        const registry = surveys._surveyEventReceiver?.getEventRegistry()
-        expect(registry.has('second-survey')).toBeFalsy()
-        expect(registry.has('first-survey')).toBeTruthy()
-        expect(registry.get('first-survey')).toEqual([
-            'user_subscribed',
-            'user_unsubscribed',
-            'billing_changed',
-            'billing_removed',
-        ])
+        const registry = surveys._surveyEventReceiver?.getEventToSurveys()
+        expect(registry.has('user_subscribed')).toBeTruthy()
+        expect(registry.get('user_subscribed')).toEqual(['first-survey', 'third-survey'])
 
-        expect(registry.has('third-survey')).toBeTruthy()
-        expect(registry.get('third-survey')).toEqual(['user_subscribed', 'user_unsubscribed', 'address_changed'])
+        expect(registry.has('address_changed')).toBeTruthy()
+        expect(registry.get('address_changed')).toEqual(['third-survey'])
     })
 
     it('getSurveys force reloads when called with true', () => {

--- a/src/__tests__/utils/survey-event-receiver.test.ts
+++ b/src/__tests__/utils/survey-event-receiver.test.ts
@@ -1,157 +1,321 @@
 /// <reference lib="dom" />
 
-import { SurveyType, SurveyQuestionType, Survey } from '../../posthog-surveys-types'
+import {
+    SurveyType,
+    SurveyQuestionType,
+    Survey,
+    ActionType,
+    ActionStepStringMatching,
+} from '../../posthog-surveys-types'
 import { PostHogPersistence } from '../../posthog-persistence'
 import { PostHog } from '../../posthog-core'
-import { PostHogConfig } from '../../types'
+import { CaptureResult, PostHogConfig } from '../../types'
 import { SurveyEventReceiver } from '../../utils/survey-event-receiver'
 
 describe('survey-event-receiver', () => {
-    let config: PostHogConfig
-    let instance: PostHog
+    describe('event based surveys', () => {
+        let config: PostHogConfig
+        let instance: PostHog
 
-    const surveysWithEvents: Survey[] = [
-        {
+        const surveysWithEvents: Survey[] = [
+            {
+                name: 'first survey',
+                id: 'first-survey',
+                description: 'first survey description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a bokoblin?' }],
+                conditions: {
+                    events: {
+                        values: [
+                            {
+                                name: 'user_subscribed',
+                            },
+                            {
+                                name: 'user_unsubscribed',
+                            },
+                            {
+                                name: 'billing_changed',
+                            },
+                            {
+                                name: 'billing_removed',
+                            },
+                        ],
+                    },
+                },
+            } as unknown as Survey,
+            {
+                name: 'second survey',
+                id: 'second-survey',
+                description: 'second survey description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a moblin?' }],
+            } as unknown as Survey,
+            {
+                name: 'third survey',
+                id: 'third-survey',
+                description: 'third survey description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a bokoblin?' }],
+                conditions: {
+                    events: {
+                        values: [
+                            {
+                                name: 'user_subscribed',
+                            },
+                            {
+                                name: 'user_unsubscribed',
+                            },
+                            {
+                                name: 'address_changed',
+                            },
+                        ],
+                    },
+                },
+            } as unknown as Survey,
+        ]
+
+        beforeEach(() => {
+            config = {
+                token: 'testtoken',
+                api_host: 'https://app.posthog.com',
+                persistence: 'memory',
+            } as unknown as PostHogConfig
+
+            instance = {
+                config: config,
+                persistence: new PostHogPersistence(config),
+                _addCaptureHook: jest.fn(),
+            } as unknown as PostHog
+        })
+
+        afterEach(() => {
+            instance.persistence?.clear()
+        })
+
+        it('register makes receiver listen for all surveys with events', () => {
+            const surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register(surveysWithEvents)
+            const registry = surveyEventReceiver.getEventToSurveys()
+            expect(registry.has('user_subscribed')).toBeTruthy()
+            expect(registry.get('user_subscribed')).toEqual(['first-survey', 'third-survey'])
+
+            expect(registry.has('address_changed')).toBeTruthy()
+            expect(registry.get('address_changed')).toEqual(['third-survey'])
+        })
+
+        it('receiver activates survey on event', () => {
+            const surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register(surveysWithEvents)
+            surveyEventReceiver.onEvent('billing_changed')
+            const activatedSurveys = surveyEventReceiver.getSurveys()
+            expect(activatedSurveys).toContain('first-survey')
+        })
+
+        it('receiver removes survey from list after its shown', () => {
+            const surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register(surveysWithEvents)
+            surveyEventReceiver.onEvent('billing_changed')
+            const activatedSurveys = surveyEventReceiver.getSurveys()
+            expect(activatedSurveys).toContain('first-survey')
+
+            surveyEventReceiver.onEvent('survey shown', {
+                $set: undefined,
+                $set_once: undefined,
+                event: 'survey shown',
+                timestamp: undefined,
+                uuid: '',
+                properties: {
+                    $survey_id: 'first-survey',
+                },
+            })
+
+            expect(surveyEventReceiver.getSurveys()).toEqual([])
+        })
+
+        it('receiver activates same survey on multiple event', () => {
+            const surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register(surveysWithEvents)
+            surveyEventReceiver.onEvent('billing_changed')
+            expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
+            surveyEventReceiver.onEvent('billing_removed')
+            expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
+        })
+
+        it('receiver activates multiple surveys on same event', () => {
+            const surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register(surveysWithEvents)
+            surveyEventReceiver.onEvent('user_subscribed')
+            expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey', 'third-survey'])
+        })
+
+        it('receiver activates multiple surveys on different events', () => {
+            const surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register(surveysWithEvents)
+            surveyEventReceiver.onEvent('billing_changed')
+            expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
+            surveyEventReceiver.onEvent('address_changed')
+            expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey', 'third-survey'])
+        })
+    })
+
+    describe('action based surveys', () => {
+        let config: PostHogConfig
+        let instance: PostHog
+
+        beforeEach(() => {
+            config = {
+                token: 'testtoken',
+                api_host: 'https://app.posthog.com',
+                persistence: 'memory',
+            } as unknown as PostHogConfig
+
+            instance = {
+                config: config,
+                persistence: new PostHogPersistence(config),
+                _addCaptureHook: jest.fn(),
+            } as unknown as PostHog
+        })
+
+        afterEach(() => {
+            instance.persistence?.clear()
+        })
+
+        const createCaptureResult = (eventName: string, currentUrl?: string): CaptureResult => {
+            return {
+                $set: undefined,
+                $set_once: undefined,
+                properties: {
+                    $current_url: currentUrl,
+                },
+                timestamp: undefined,
+                uuid: '0C984DA5-761F-4F75-9582-D2F95B43B04A',
+                event: eventName,
+            }
+        }
+        const createAction = (
+            id: number,
+            eventName: string,
+            currentUrl?: string,
+            urlMatch?: ActionStepStringMatching
+        ): ActionType => {
+            return {
+                id: id,
+                name: `${eventName || 'user defined '} action`,
+                description: '',
+                post_to_slack: false,
+                slack_message_format: '',
+                steps: [
+                    {
+                        event: eventName,
+                        properties: null,
+                        text: null,
+                        text_matching: null,
+                        href: null,
+                        href_matching: null,
+                        url: currentUrl,
+                        url_matching: urlMatch || 'exact',
+                    },
+                ],
+                created_at: '2024-06-20T14:39:23.616676Z',
+                deleted: false,
+                is_calculating: false,
+                last_calculated_at: '2024-06-20T14:39:23.616051Z',
+                is_action: true,
+                bytecode_error: null,
+                tags: [],
+            }
+        }
+
+        const autoCaptureSurvey = {
             name: 'first survey',
             id: 'first-survey',
             description: 'first survey description',
             type: SurveyType.Popover,
             questions: [{ type: SurveyQuestionType.Open, question: 'what is a bokoblin?' }],
             conditions: {
-                events: {
-                    values: [
-                        {
-                            name: 'user_subscribed',
-                        },
-                        {
-                            name: 'user_unsubscribed',
-                        },
-                        {
-                            name: 'billing_changed',
-                        },
-                        {
-                            name: 'billing_removed',
-                        },
-                    ],
-                },
+                actions: [createAction(2, '$autocapture') as unknown as ActionType],
             },
-        } as unknown as Survey,
-        {
-            name: 'second survey',
-            id: 'second-survey',
-            description: 'second survey description',
-            type: SurveyType.Popover,
-            questions: [{ type: SurveyQuestionType.Open, question: 'what is a moblin?' }],
-        } as unknown as Survey,
-        {
-            name: 'third survey',
-            id: 'third-survey',
-            description: 'third survey description',
+        } as unknown as Survey
+
+        const pageViewSurvey = {
+            name: 'pageview survey',
+            id: 'pageview-survey',
+            description: 'pageview survey description',
             type: SurveyType.Popover,
             questions: [{ type: SurveyQuestionType.Open, question: 'what is a bokoblin?' }],
             conditions: {
-                events: {
-                    values: [
-                        {
-                            name: 'user_subscribed',
-                        },
-                        {
-                            name: 'user_unsubscribed',
-                        },
-                        {
-                            name: 'address_changed',
-                        },
-                    ],
+                actions: [createAction(3, '$pageview') as unknown as ActionType],
+            },
+        } as unknown as Survey
+
+        it('can match action on event name', () => {
+            const myPageViewSurvey = {
+                name: 'my pageview survey',
+                id: 'my-pageview-survey',
+                description: 'pageview survey description',
+                type: SurveyType.Popover,
+                questions: [{ type: SurveyQuestionType.Open, question: 'what is a bokoblin?' }],
+                conditions: {
+                    actions: {
+                        values: [createAction(3, '$mypageview') as unknown as ActionType],
+                    },
                 },
-            },
-        } as unknown as Survey,
-    ]
+            } as unknown as Survey
+            autoCaptureSurvey.conditions.actions.values = [createAction(2, '$match_event_name')]
+            const surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register([autoCaptureSurvey, myPageViewSurvey])
+            surveyEventReceiver._getActionMatcher().on('$match_event_name', createCaptureResult('$match_event_name'))
+            expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
 
-    beforeEach(() => {
-        config = {
-            token: 'testtoken',
-            api_host: 'https://app.posthog.com',
-            persistence: 'memory',
-        } as unknown as PostHogConfig
-
-        instance = {
-            config: config,
-            persistence: new PostHogPersistence(config),
-        } as unknown as PostHog
-    })
-
-    afterEach(() => {
-        instance.persistence?.clear()
-    })
-
-    it('register makes receiver listen for all surveys with events', () => {
-        const surveyEventReceiver = new SurveyEventReceiver(instance.persistence)
-        surveyEventReceiver.register(surveysWithEvents)
-        const registry = surveyEventReceiver.getEventRegistry()
-        expect(registry.has('second-survey')).toBeFalsy()
-        expect(registry.has('first-survey')).toBeTruthy()
-        expect(registry.get('first-survey')).toEqual([
-            'user_subscribed',
-            'user_unsubscribed',
-            'billing_changed',
-            'billing_removed',
-        ])
-
-        expect(registry.has('third-survey')).toBeTruthy()
-        expect(registry.get('third-survey')).toEqual(['user_subscribed', 'user_unsubscribed', 'address_changed'])
-    })
-
-    it('receiver activates survey on event', () => {
-        const surveyEventReceiver = new SurveyEventReceiver(instance.persistence)
-        surveyEventReceiver.register(surveysWithEvents)
-        surveyEventReceiver.on('billing_changed')
-        const activatedSurveys = surveyEventReceiver.getSurveys()
-        expect(activatedSurveys).toContain('first-survey')
-    })
-
-    it('receiver removes survey from list after its shown', () => {
-        const surveyEventReceiver = new SurveyEventReceiver(instance.persistence)
-        surveyEventReceiver.register(surveysWithEvents)
-        surveyEventReceiver.on('billing_changed')
-        const activatedSurveys = surveyEventReceiver.getSurveys()
-        expect(activatedSurveys).toContain('first-survey')
-
-        surveyEventReceiver.on('survey shown', {
-            $set: undefined,
-            $set_once: undefined,
-            event: 'survey shown',
-            timestamp: undefined,
-            uuid: '',
-            properties: {
-                $survey_id: 'first-survey',
-            },
+            surveyEventReceiver
+                ._getActionMatcher()
+                .on('$mypageview', createCaptureResult(myPageViewSurvey.conditions.actions.values[0].steps[0].event))
+            expect(surveyEventReceiver.getSurveys()).toContain('my-pageview-survey')
         })
 
-        expect(surveyEventReceiver.getSurveys()).toEqual([])
-    })
+        it('can match action on current_url exact', () => {
+            autoCaptureSurvey.conditions.actions.values = [createAction(2, '$autocapture', 'https://us.posthog.com')]
+            const surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register([autoCaptureSurvey, pageViewSurvey])
+            surveyEventReceiver
+                ._getActionMatcher()
+                .on('$autocapture', createCaptureResult('$autocapture', 'https://eu.posthog.com'))
+            expect(surveyEventReceiver.getSurveys()).not.toEqual(['first-survey'])
+            surveyEventReceiver
+                ._getActionMatcher()
+                .on('$autocapture', createCaptureResult('$autocapture', 'https://us.posthog.com'))
+            expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
+        })
 
-    it('receiver activates same survey on multiple event', () => {
-        const surveyEventReceiver = new SurveyEventReceiver(instance.persistence)
-        surveyEventReceiver.register(surveysWithEvents)
-        surveyEventReceiver.on('billing_changed')
-        expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
-        surveyEventReceiver.on('billing_removed')
-        expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
-    })
+        it('can match action on current_url regexp', () => {
+            autoCaptureSurvey.conditions.actions.values = [
+                createAction(2, '$current_url_regexp', '[a-z][a-z].posthog.*', 'regex'),
+            ]
+            let surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register([autoCaptureSurvey, pageViewSurvey])
+            surveyEventReceiver
+                ._getActionMatcher()
+                .on('$autocapture', createCaptureResult('$current_url_regexp', 'https://eu.posthog.com'))
+            expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
 
-    it('receiver activates multiple surveys on same event', () => {
-        const surveyEventReceiver = new SurveyEventReceiver(instance.persistence)
-        surveyEventReceiver.register(surveysWithEvents)
-        surveyEventReceiver.on('user_subscribed')
-        expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey', 'third-survey'])
-    })
+            surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register([autoCaptureSurvey, pageViewSurvey])
+            surveyEventReceiver
+                ._getActionMatcher()
+                .on('$autocapture', createCaptureResult('$autocapture', 'https://us.posthog.com'))
+            expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
+        })
 
-    it('receiver activates multiple surveys on different events', () => {
-        const surveyEventReceiver = new SurveyEventReceiver(instance.persistence)
-        surveyEventReceiver.register(surveysWithEvents)
-        surveyEventReceiver.on('billing_changed')
-        expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
-        surveyEventReceiver.on('address_changed')
-        expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey', 'third-survey'])
+        it('can match action on html element selector', () => {
+            const action = createAction(2, '$autocapture')
+            action.steps[0].selector = '* > #__next .flex > button:nth-child(2)'
+            autoCaptureSurvey.conditions.actions.values = [action]
+            const result = createCaptureResult('$autocapture', 'https://eu.posthog.com')
+            result.properties.$element_selectors = ['* > #__next .flex > button:nth-child(2)']
+            const surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register([autoCaptureSurvey, pageViewSurvey])
+            surveyEventReceiver._getActionMatcher().on('$autocapture', result)
+            expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
+        })
     })
 })

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -40,13 +40,11 @@ export class Autocapture {
     instance: PostHog
     _initialized: boolean = false
     _isDisabledServerSide: boolean | null = null
-    _elementSelectors: Set<string> | null
     rageclicks = new RageClick()
     _elementsChainAsString = false
 
     constructor(instance: PostHog) {
         this.instance = instance
-        this._elementSelectors = null
     }
 
     private get config(): AutocaptureConfig {
@@ -111,25 +109,6 @@ export class Autocapture {
         this.startIfEnabled()
     }
 
-    public setElementSelectors(selectors: Set<string>): void {
-        this._elementSelectors = selectors
-    }
-
-    public getElementSelectors(element: Element | null): string[] | null {
-        const elementSelectors = ['']
-
-        this._elementSelectors?.forEach((selector) => {
-            const matchedElements = document?.querySelectorAll(selector)
-            matchedElements?.forEach((matchedElement: Element) => {
-                if (element === matchedElement) {
-                    elementSelectors.push(selector)
-                }
-            })
-        })
-
-        return elementSelectors
-    }
-
     public get isEnabled(): boolean {
         const persistedServerDisabled = this.instance.persistence?.props[AUTOCAPTURE_DISABLED_SERVER_SIDE]
         const memoryDisabled = this._isDisabledServerSide
@@ -176,7 +155,6 @@ export class Autocapture {
                 }
             }
         })
-
         return props
     }
 
@@ -372,11 +350,6 @@ export class Autocapture {
                 externalHref && e.type === 'click' ? { $external_click_url: externalHref } : {},
                 autocaptureAugmentProperties
             )
-
-            const elementSelectors = this.getElementSelectors(target)
-            if (elementSelectors && elementSelectors.length > 0) {
-                props['$element_selectors'] = elementSelectors
-            }
 
             if (eventName === COPY_AUTOCAPTURE_EVENT) {
                 // you can't read the data from the clipboard event,

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -40,11 +40,13 @@ export class Autocapture {
     instance: PostHog
     _initialized: boolean = false
     _isDisabledServerSide: boolean | null = null
+    _elementSelectors: Set<string> | null
     rageclicks = new RageClick()
     _elementsChainAsString = false
 
     constructor(instance: PostHog) {
         this.instance = instance
+        this._elementSelectors = null
     }
 
     private get config(): AutocaptureConfig {
@@ -109,6 +111,25 @@ export class Autocapture {
         this.startIfEnabled()
     }
 
+    public setElementSelectors(selectors: Set<string>): void {
+        this._elementSelectors = selectors
+    }
+
+    public getElementSelectors(element: Element | null): string[] | null {
+        const elementSelectors = ['']
+
+        this._elementSelectors?.forEach((selector) => {
+            const matchedElements = document?.querySelectorAll(selector)
+            matchedElements?.forEach((matchedElement: Element) => {
+                if (element === matchedElement) {
+                    elementSelectors.push(selector)
+                }
+            })
+        })
+
+        return elementSelectors
+    }
+
     public get isEnabled(): boolean {
         const persistedServerDisabled = this.instance.persistence?.props[AUTOCAPTURE_DISABLED_SERVER_SIDE]
         const memoryDisabled = this._isDisabledServerSide
@@ -155,6 +176,7 @@ export class Autocapture {
                 }
             }
         })
+
         return props
     }
 
@@ -350,6 +372,11 @@ export class Autocapture {
                 externalHref && e.type === 'click' ? { $external_click_url: externalHref } : {},
                 autocaptureAugmentProperties
             )
+
+            const elementSelectors = this.getElementSelectors(target)
+            if (elementSelectors && elementSelectors.length > 0) {
+                props['$element_selectors'] = elementSelectors
+            }
 
             if (eventName === COPY_AUTOCAPTURE_EVENT) {
                 // you can't read the data from the clipboard event,

--- a/src/extensions/surveys/action-matcher.test.ts
+++ b/src/extensions/surveys/action-matcher.test.ts
@@ -1,0 +1,163 @@
+/// <reference lib="dom" />
+
+import { ActionType, ActionStepStringMatching } from '../../posthog-surveys-types'
+import { PostHogPersistence } from '../../posthog-persistence'
+import { PostHog } from '../../posthog-core'
+import { CaptureResult, PostHogConfig } from '../../types'
+import { ActionMatcher } from './action-matcher'
+
+describe('action-matcher', () => {
+    let config: PostHogConfig
+    let instance: PostHog
+
+    beforeEach(() => {
+        config = {
+            token: 'testtoken',
+            api_host: 'https://app.posthog.com',
+            persistence: 'memory',
+        } as unknown as PostHogConfig
+
+        instance = {
+            config: config,
+            persistence: new PostHogPersistence(config),
+            _addCaptureHook: jest.fn(),
+        } as unknown as PostHog
+    })
+
+    afterEach(() => {
+        instance.persistence?.clear()
+    })
+
+    const createCaptureResult = (eventName: string, currentUrl?: string): CaptureResult => {
+        return {
+            $set: undefined,
+            $set_once: undefined,
+            properties: {
+                $current_url: currentUrl,
+            },
+            timestamp: undefined,
+            uuid: '0C984DA5-761F-4F75-9582-D2F95B43B04A',
+            event: eventName,
+        }
+    }
+    const createAction = (
+        id: number,
+        eventName: string,
+        currentUrl?: string,
+        urlMatch?: ActionStepStringMatching
+    ): ActionType => {
+        return {
+            id: id,
+            name: `${eventName || 'user defined '} action`,
+            description: '',
+            post_to_slack: false,
+            slack_message_format: '',
+            steps: [
+                {
+                    event: eventName,
+                    text: null,
+                    text_matching: null,
+                    href: null,
+                    href_matching: null,
+                    url: currentUrl,
+                    url_matching: urlMatch || 'exact',
+                },
+            ],
+            created_at: '2024-06-20T14:39:23.616676Z',
+            deleted: false,
+            is_calculating: false,
+            last_calculated_at: '2024-06-20T14:39:23.616051Z',
+            is_action: true,
+            tags: [],
+        }
+    }
+
+    it('can match action on event name', () => {
+        const pageViewAction = createAction(3, '$mypageview') as unknown as ActionType
+        const actionMatcher = new ActionMatcher(instance)
+        actionMatcher.register([pageViewAction])
+        let pageViewActionMatched = false
+
+        const onAction = (actionName: string) => {
+            if (!pageViewActionMatched) {
+                pageViewActionMatched = actionName === pageViewAction.name
+            }
+        }
+
+        actionMatcher._addActionHook(onAction)
+
+        actionMatcher.on('$match_event_name', createCaptureResult('$mypageview'))
+        expect(pageViewActionMatched).toBeTruthy()
+    })
+
+    it('can match action on current_url exact', () => {
+        const pageViewAction = createAction(2, '$autocapture', 'https://us.posthog.com')
+        const actionMatcher = new ActionMatcher(instance)
+        actionMatcher.register([pageViewAction])
+
+        let pageViewActionMatched = false
+
+        const onAction = (actionName: string) => {
+            if (!pageViewActionMatched) {
+                pageViewActionMatched = actionName === pageViewAction.name
+            }
+        }
+
+        actionMatcher._addActionHook(onAction)
+        actionMatcher.on('$autocapture', createCaptureResult('$autocapture', 'https://eu.posthog.com'))
+        expect(pageViewActionMatched).toBeFalsy()
+
+        actionMatcher.on('$autocapture', createCaptureResult('$autocapture', 'https://us.posthog.com'))
+        expect(pageViewActionMatched).toBeTruthy()
+    })
+
+    it('can match action on current_url regexp', () => {
+        const pageViewAction = createAction(2, '$current_url_regexp', '[a-z][a-z].posthog.*', 'regex')
+        const actionMatcher = new ActionMatcher(instance)
+        actionMatcher.register([pageViewAction])
+
+        let pageViewActionMatched = false
+
+        const onAction = (actionName: string) => {
+            if (!pageViewActionMatched) {
+                pageViewActionMatched = actionName === pageViewAction.name
+            }
+        }
+
+        actionMatcher._addActionHook(onAction)
+        actionMatcher.on('$autocapture', createCaptureResult('$current_url_regexp', 'https://eu.posthog.com'))
+        expect(pageViewActionMatched).toBeTruthy()
+        pageViewActionMatched = false
+
+        actionMatcher.on('$autocapture', createCaptureResult('$current_url_regexp', 'https://us.posthog.com'))
+        expect(pageViewActionMatched).toBeTruthy()
+    })
+
+    it('can match action on html element selector', () => {
+        const buttonClickedAction = createAction(2, '$autocapture')
+        if (buttonClickedAction.steps) {
+            buttonClickedAction.steps[0].selector = '* > #__next .flex > button:nth-child(2)'
+        }
+
+        const actionMatcher = new ActionMatcher(instance)
+        actionMatcher.register([buttonClickedAction])
+        let buttonClickedActionMatched = false
+
+        const onAction = (actionName: string) => {
+            if (!buttonClickedActionMatched) {
+                buttonClickedActionMatched = actionName === buttonClickedAction.name
+            }
+        }
+        actionMatcher._addActionHook(onAction)
+
+        const result = createCaptureResult('$autocapture', 'https://eu.posthog.com')
+        result.properties.$element_selectors = []
+        actionMatcher.on('$autocapture', result)
+        expect(buttonClickedActionMatched).toBeFalsy()
+
+        result.properties.$element_selectors = ['* > #__next .flex > button:nth-child(2)']
+
+        actionMatcher.on('$autocapture', result)
+        expect(buttonClickedActionMatched).toBeTruthy()
+    })
+})

--- a/src/extensions/surveys/action-matcher.test.ts
+++ b/src/extensions/surveys/action-matcher.test.ts
@@ -49,9 +49,6 @@ describe('action-matcher', () => {
         return {
             id: id,
             name: `${eventName || 'user defined '} action`,
-            description: '',
-            post_to_slack: false,
-            slack_message_format: '',
             steps: [
                 {
                     event: eventName,
@@ -65,8 +62,6 @@ describe('action-matcher', () => {
             ],
             created_at: '2024-06-20T14:39:23.616676Z',
             deleted: false,
-            is_calculating: false,
-            last_calculated_at: '2024-06-20T14:39:23.616051Z',
             is_action: true,
             tags: [],
         }

--- a/src/extensions/surveys/action-matcher.ts
+++ b/src/extensions/surveys/action-matcher.ts
@@ -1,0 +1,215 @@
+import { PostHog } from '../../posthog-core'
+import { ActionStepStringMatching, ActionStepType, ActionType, SurveyElement } from '../../posthog-surveys-types'
+import { SimpleEventEmitter } from '../../utils/simple-event-emitter'
+import { CaptureResult } from '../../types'
+import { isUndefined } from '../../utils/type-utils'
+import { window } from '../../utils/globals'
+import { isUrlMatchingRegex } from '../../utils/request-utils'
+
+export class ActionMatcher {
+    private readonly actionRegistry?: Set<ActionType>
+    private readonly instance?: PostHog
+    private readonly actionEvents: Set<string>
+    private _debugEventEmitter = new SimpleEventEmitter()
+
+    constructor(instance?: PostHog) {
+        this.instance = instance
+        this.actionEvents = new Set<string>()
+        this.actionRegistry = new Set<ActionType>()
+    }
+
+    init() {
+        if (!isUndefined(this.instance?._addCaptureHook)) {
+            const matchEventToAction = (eventName: string, eventPayload: any) => {
+                this.on(eventName, eventPayload)
+            }
+            this.instance?._addCaptureHook(matchEventToAction)
+        }
+    }
+
+    register(actions: ActionType[]): void {
+        if (isUndefined(this.instance?._addCaptureHook)) {
+            return
+        }
+
+        actions.forEach((action) => {
+            this.actionRegistry?.add(action)
+            action.steps?.forEach((step) => {
+                this.actionEvents?.add(step?.event || '')
+            })
+        })
+
+        if (this.instance?.autocapture) {
+            const selectorsToWatch: Set<string> = new Set<string>()
+            actions.forEach((action) => {
+                action.steps?.forEach((step) => {
+                    if (step?.selector) {
+                        selectorsToWatch.add(step?.selector)
+                    }
+                })
+            })
+            this.instance?.autocapture.setElementSelectors(selectorsToWatch)
+        }
+
+        // if (eventNames.length > 0) {
+        //     throw new Error(`I know about these events : ${eventNames}`)
+        // }
+    }
+
+    on(eventName: string, eventPayload?: CaptureResult) {
+        if (eventPayload == null || eventName.length == 0) {
+            return
+        }
+
+        if (!this.actionEvents.has(eventName) && !this.actionEvents.has(<string>eventPayload?.event)) {
+            // throw new Error(`unknown event ${eventName}, I only know about : ${JSON.stringify(this.actionEvents.values())}`)
+            return
+        }
+
+        if (this.actionRegistry && this.actionRegistry?.size > 0) {
+            this.actionRegistry.forEach((action) => {
+                if (this.checkAction(eventPayload, action)) {
+                    this._debugEventEmitter.emit('actionCaptured', action.name)
+                }
+            })
+        }
+    }
+
+    _addActionHook(callback: (actionName: string, eventPayload?: any) => void): void {
+        this.onAction('actionCaptured', (data) => callback(data))
+    }
+
+    private checkAction(event?: CaptureResult, action?: ActionType): boolean {
+        if (action?.steps == null) {
+            return false
+        }
+
+        for (const step of action.steps) {
+            if (this.checkStep(event, step)) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    onAction(event: 'actionCaptured', cb: (...args: any[]) => void): () => void {
+        return this._debugEventEmitter.on(event, cb)
+    }
+
+    private checkStep = (event?: CaptureResult, step?: ActionStepType): boolean => {
+        return this.checkStepEvent(event, step) && this.checkStepUrl(event, step) && this.checkStepElement(event, step)
+    }
+
+    private checkStepEvent = (event?: CaptureResult, step?: ActionStepType): boolean => {
+        // CHECK CONDITIONS, OTHERWISE SKIPPED
+        if (step?.event && event?.event !== step?.event) {
+            return false // EVENT NAME IS A MISMATCH
+        }
+        return true
+    }
+
+    private checkStepUrl(event?: CaptureResult, step?: ActionStepType): boolean {
+        // CHECK CONDITIONS, OTHERWISE SKIPPED
+        if (step?.url) {
+            const eventUrl = event?.properties?.$current_url
+            if (!eventUrl || typeof eventUrl !== 'string') {
+                return false // URL IS UNKNOWN
+            }
+            if (!ActionMatcher.matchString(eventUrl, step?.url, step?.url_matching || 'contains')) {
+                return false // URL IS A MISMATCH
+            }
+        }
+        return true
+    }
+
+    private static matchString(url: string, pattern: string, matching: ActionStepStringMatching): boolean {
+        switch (matching) {
+            case 'regex':
+                return !!window && isUrlMatchingRegex(url, pattern)
+            case 'exact':
+                return pattern === url
+            case 'contains':
+                // Simulating SQL LIKE behavior (_ = any single character, % = any zero or more characters)
+                // eslint-disable-next-line no-case-declarations
+                const adjustedRegExpStringPattern = ActionMatcher.escapeStringRegexp(pattern)
+                    .replace(/_/g, '.')
+                    .replace(/%/g, '.*')
+                return isUrlMatchingRegex(url, adjustedRegExpStringPattern)
+
+            default:
+                return false
+        }
+    }
+
+    private static escapeStringRegexp(pattern: string): string {
+        // Escape characters with special meaning either inside or outside character sets.
+        // Use a simple backslash escape when it’s always valid, and a `\xnn` escape when the simpler form would be disallowed by Unicode patterns’ stricter grammar.
+        return pattern.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d')
+    }
+
+    private checkStepElement(event?: CaptureResult, step?: ActionStepType): boolean {
+        // CHECK CONDITIONS, OTHERWISE SKIPPED
+        if (step?.href || step?.tag_name || step?.text) {
+            const elements = this.getElementsList(event)
+            if (
+                !elements.some((element) => {
+                    if (
+                        step?.href &&
+                        !ActionMatcher.matchString(element.href || '', step?.href, step?.href_matching || 'exact')
+                    ) {
+                        return false // ELEMENT HREF IS A MISMATCH
+                    }
+                    if (step?.tag_name && element.tag_name !== step?.tag_name) {
+                        return false // ELEMENT TAG NAME IS A MISMATCH
+                    }
+                    if (
+                        step?.text &&
+                        !(
+                            ActionMatcher.matchString(element.text || '', step?.text, step?.text_matching || 'exact') ||
+                            ActionMatcher.matchString(
+                                element.$el_text || '',
+                                step?.text,
+                                step?.text_matching || 'exact'
+                            )
+                        )
+                    ) {
+                        return false // ELEMENT TEXT IS A MISMATCH
+                    }
+                    return true
+                })
+            ) {
+                // AT LEAST ONE ELEMENT MUST BE A SUBMATCH
+                return false
+            }
+        }
+
+        if (step?.selector) {
+            const elementSelectors = event?.properties?.$element_selectors as unknown as string[]
+            if (!elementSelectors) {
+                return false // SELECTOR IS A MISMATCH
+            }
+            if (!elementSelectors.includes(step?.selector)) {
+                return false // SELECTOR IS A MISMATCH
+            }
+        }
+
+        return true
+    }
+
+    private getElementsList(event?: CaptureResult): SurveyElement[] {
+        if (event?.properties.$elements == null) {
+            return []
+        }
+
+        return event?.properties.$elements as unknown as SurveyElement[]
+    }
+
+    // private mutateCaptureResultWithElementsList(event: CaptureResult: Element[] {
+    //      event.elementsList = event.elementsList.map((element) => ({
+    //     ...element,
+    //     attr_class: element.attributes?.attr__class ?? element.attr_class,
+    //     $el_text: element.text,
+    // }))
+    // }
+}

--- a/src/extensions/surveys/action-matcher.ts
+++ b/src/extensions/surveys/action-matcher.ts
@@ -50,10 +50,6 @@ export class ActionMatcher {
             })
             this.instance?.autocapture.setElementSelectors(selectorsToWatch)
         }
-
-        // if (eventNames.length > 0) {
-        //     throw new Error(`I know about these events : ${eventNames}`)
-        // }
     }
 
     on(eventName: string, eventPayload?: CaptureResult) {
@@ -62,7 +58,6 @@ export class ActionMatcher {
         }
 
         if (!this.actionEvents.has(eventName) && !this.actionEvents.has(<string>eventPayload?.event)) {
-            // throw new Error(`unknown event ${eventName}, I only know about : ${JSON.stringify(this.actionEvents.values())}`)
             return
         }
 
@@ -204,12 +199,4 @@ export class ActionMatcher {
 
         return event?.properties.$elements as unknown as SurveyElement[]
     }
-
-    // private mutateCaptureResultWithElementsList(event: CaptureResult: Element[] {
-    //      event.elementsList = event.elementsList.map((element) => ({
-    //     ...element,
-    //     attr_class: element.attributes?.attr__class ?? element.attr_class,
-    //     $el_text: element.text,
-    // }))
-    // }
 }

--- a/src/extensions/surveys/components/ConfirmationMessage.tsx
+++ b/src/extensions/surveys/components/ConfirmationMessage.tsx
@@ -39,7 +39,7 @@ export function ConfirmationMessage({
                             style: { color: textColor },
                         })}
                     <BottomSection
-                        text={'Close'}
+                        text={appearance.thankYouMessageCloseButtonText || 'Close'}
                         submitDisabled={false}
                         appearance={appearance}
                         onSubmit={() => onClose()}

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -159,6 +159,9 @@ export interface Survey {
                 name: string
             }[]
         } | null
+        actions: {
+            values: ActionType[]
+        } | null
     } | null
     start_date: string | null
     end_date: string | null

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -22,6 +22,7 @@ export interface SurveyAppearance {
     thankYouMessageHeader?: string
     thankYouMessageDescription?: string
     thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType
+    thankYouMessageCloseButtonText?: string
     borderColor?: string
     position?: 'left' | 'right' | 'center'
     placeholder?: string

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -22,7 +22,6 @@ export interface SurveyAppearance {
     thankYouMessageHeader?: string
     thankYouMessageDescription?: string
     thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType
-    thankYouMessageCloseButtonText?: string
     borderColor?: string
     position?: 'left' | 'right' | 'center'
     placeholder?: string
@@ -123,6 +122,20 @@ export type SurveyCallback = (surveys: Survey[]) => void
 
 export type SurveyUrlMatchType = 'regex' | 'not_regex' | 'exact' | 'is_not' | 'icontains' | 'not_icontains'
 
+export interface SurveyElement {
+    text?: string
+    $el_text?: string
+    tag_name?: string
+    href?: string
+    attr_id?: string
+    attr_class?: string[]
+    nth_child?: number
+    nth_of_type?: number
+    attributes?: Record<string, any>
+    event_id?: number
+    order?: number
+    group_id?: number
+}
 export interface Survey {
     // Sync this with the backend's SurveyAPISerializer!
     id: string
@@ -150,4 +163,110 @@ export interface Survey {
     end_date: string | null
     current_iteration: number | null
     current_iteration_start_date: string | null
+}
+
+export enum PropertyFilterType {
+    /** Event properties */
+    Event = 'event',
+    Element = 'element',
+}
+
+export enum PropertyOperator {
+    Exact = 'exact',
+    IsNot = 'is_not',
+    IContains = 'icontains',
+    NotIContains = 'not_icontains',
+    Regex = 'regex',
+    NotRegex = 'not_regex',
+    GreaterThan = 'gt',
+    GreaterThanOrEqual = 'gte',
+    LessThan = 'lt',
+    LessThanOrEqual = 'lte',
+    IsSet = 'is_set',
+    IsNotSet = 'is_not_set',
+    IsDateExact = 'is_date_exact',
+    IsDateBefore = 'is_date_before',
+    IsDateAfter = 'is_date_after',
+    Between = 'between',
+    NotBetween = 'not_between',
+    Minimum = 'min',
+    Maximum = 'max',
+}
+
+export type PropertyFilterValue = string | number | (string | number)[] | null
+
+/** Sync with plugin-server/src/types.ts */
+interface BasePropertyFilter {
+    key: string
+    value?: PropertyFilterValue
+    label?: string
+    type?: PropertyFilterType
+}
+
+/** Sync with plugin-server/src/types.ts */
+export interface EventPropertyFilter extends BasePropertyFilter {
+    type: PropertyFilterType.Event
+    /** @default 'exact' */
+    operator: PropertyOperator
+}
+
+/** Sync with plugin-server/src/types.ts */
+export interface ElementPropertyFilter extends BasePropertyFilter {
+    type: PropertyFilterType.Element
+    key: 'tag_name' | 'text' | 'href' | 'selector'
+    operator: PropertyOperator
+}
+export type AnyPropertyFilter = EventPropertyFilter | ElementPropertyFilter
+
+export interface ActionType {
+    count?: number
+    created_at: string
+    deleted?: boolean
+    id: number
+    is_calculating?: boolean
+    last_calculated_at?: string
+    last_updated_at?: string // alias for last_calculated_at to achieve event and action parity
+    name: string | null
+    description?: string
+    post_to_slack?: boolean
+    slack_message_format?: string
+    steps?: ActionStepType[]
+    tags?: string[]
+    verified?: boolean
+    is_action?: true
+    action_id?: number // alias of id to make it compatible with event definitions uuid
+    bytecode?: any[]
+    bytecode_error?: string
+}
+
+/** Sync with plugin-server/src/types.ts */
+export type ActionStepStringMatching = 'contains' | 'exact' | 'regex'
+
+export interface ActionStepType {
+    event?: string | null
+    properties?: AnyPropertyFilter[]
+    selector?: string | null
+    /** @deprecated Only `selector` should be used now. */
+    tag_name?: string
+    text?: string | null
+    /** @default StringMatching.Exact */
+    text_matching?: ActionStepStringMatching | null
+    href?: string | null
+    /** @default ActionStepStringMatching.Exact */
+    href_matching?: ActionStepStringMatching | null
+    url?: string | null
+    /** @default StringMatching.Contains */
+    url_matching?: ActionStepStringMatching | null
+}
+
+export interface ElementType {
+    attr_class?: string[]
+    attr_id?: string
+    attributes: Record<string, string>
+    href?: string
+    nth_child?: number
+    nth_of_type?: number
+    order?: number
+    tag_name: string
+    text?: string
 }

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -22,6 +22,7 @@ export interface SurveyAppearance {
     thankYouMessageHeader?: string
     thankYouMessageDescription?: string
     thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType
+    thankYouMessageCloseButtonText?: string
     borderColor?: string
     position?: 'left' | 'right' | 'center'
     placeholder?: string
@@ -165,78 +166,16 @@ export interface Survey {
     current_iteration_start_date: string | null
 }
 
-export enum PropertyFilterType {
-    /** Event properties */
-    Event = 'event',
-    Element = 'element',
-}
-
-export enum PropertyOperator {
-    Exact = 'exact',
-    IsNot = 'is_not',
-    IContains = 'icontains',
-    NotIContains = 'not_icontains',
-    Regex = 'regex',
-    NotRegex = 'not_regex',
-    GreaterThan = 'gt',
-    GreaterThanOrEqual = 'gte',
-    LessThan = 'lt',
-    LessThanOrEqual = 'lte',
-    IsSet = 'is_set',
-    IsNotSet = 'is_not_set',
-    IsDateExact = 'is_date_exact',
-    IsDateBefore = 'is_date_before',
-    IsDateAfter = 'is_date_after',
-    Between = 'between',
-    NotBetween = 'not_between',
-    Minimum = 'min',
-    Maximum = 'max',
-}
-
-export type PropertyFilterValue = string | number | (string | number)[] | null
-
-/** Sync with plugin-server/src/types.ts */
-interface BasePropertyFilter {
-    key: string
-    value?: PropertyFilterValue
-    label?: string
-    type?: PropertyFilterType
-}
-
-/** Sync with plugin-server/src/types.ts */
-export interface EventPropertyFilter extends BasePropertyFilter {
-    type: PropertyFilterType.Event
-    /** @default 'exact' */
-    operator: PropertyOperator
-}
-
-/** Sync with plugin-server/src/types.ts */
-export interface ElementPropertyFilter extends BasePropertyFilter {
-    type: PropertyFilterType.Element
-    key: 'tag_name' | 'text' | 'href' | 'selector'
-    operator: PropertyOperator
-}
-export type AnyPropertyFilter = EventPropertyFilter | ElementPropertyFilter
-
 export interface ActionType {
     count?: number
     created_at: string
     deleted?: boolean
     id: number
-    is_calculating?: boolean
-    last_calculated_at?: string
-    last_updated_at?: string // alias for last_calculated_at to achieve event and action parity
     name: string | null
-    description?: string
-    post_to_slack?: boolean
-    slack_message_format?: string
     steps?: ActionStepType[]
     tags?: string[]
-    verified?: boolean
     is_action?: true
     action_id?: number // alias of id to make it compatible with event definitions uuid
-    bytecode?: any[]
-    bytecode_error?: string
 }
 
 /** Sync with plugin-server/src/types.ts */
@@ -244,7 +183,6 @@ export type ActionStepStringMatching = 'contains' | 'exact' | 'regex'
 
 export interface ActionStepType {
     event?: string | null
-    properties?: AnyPropertyFilter[]
     selector?: string | null
     /** @deprecated Only `selector` should be used now. */
     tag_name?: string
@@ -257,16 +195,4 @@ export interface ActionStepType {
     url?: string | null
     /** @default StringMatching.Contains */
     url_matching?: ActionStepStringMatching | null
-}
-
-export interface ElementType {
-    attr_class?: string[]
-    attr_id?: string
-    attributes: Record<string, string>
-    href?: string
-    nth_child?: number
-    nth_of_type?: number
-    order?: number
-    tag_name: string
-    text?: string
 }

--- a/src/utils/survey-event-receiver.ts
+++ b/src/utils/survey-event-receiver.ts
@@ -1,37 +1,115 @@
 import { Survey } from '../posthog-surveys-types'
-import { PostHogPersistence } from '../posthog-persistence'
 import { SURVEYS_ACTIVATED } from '../constants'
+
 import { CaptureResult } from '../types'
+import { ActionMatcher } from '../extensions/surveys/action-matcher'
+import { PostHog } from '../posthog-core'
+import { isUndefined } from './type-utils'
 
 export class SurveyEventReceiver {
-    private readonly eventRegistry: Map<string, string[]>
-    private readonly persistence?: PostHogPersistence
+    // eventToSurveys is a mapping of event name to all the surveys that are activated by it
+    private readonly eventToSurveys: Map<string, string[]>
+    // actionToSurveys is a mapping of action name to all the surveys that are activated by it
+    private readonly actionToSurveys: Map<string, string[]>
+    // actionMatcher can look at CaptureResult payloads and match an event to its corresponding action.
+    private actionMatcher?: ActionMatcher | null
+    private readonly instance?: PostHog
     private static SURVEY_SHOWN_EVENT_NAME = 'survey shown'
 
-    constructor(persistence?: PostHogPersistence) {
-        this.persistence = persistence
-        this.eventRegistry = new Map<string, string[]>()
+    constructor(instance: PostHog) {
+        this.instance = instance
+        this.eventToSurveys = new Map<string, string[]>()
+        this.actionToSurveys = new Map<string, string[]>()
     }
 
     register(surveys: Survey[]): void {
-        surveys.forEach((survey) => {
+        if (isUndefined(this.instance?._addCaptureHook)) {
+            return
+        }
+
+        this.setupEventBasedSurveys(surveys)
+        this.setupActionBasedSurveys(surveys)
+    }
+
+    private setupActionBasedSurveys(surveys: Survey[]) {
+        const actionBasedSurveys = surveys.filter(
+            (survey: Survey) => survey.conditions?.actions && survey.conditions?.actions?.values?.length > 0
+        )
+
+        if (actionBasedSurveys.length === 0) {
+            return
+        }
+
+        if (this.actionMatcher == null) {
+            this.actionMatcher = new ActionMatcher(this.instance)
+            this.actionMatcher.init()
+            // match any actions to its corresponding survey.
+            const matchActionToSurvey = (actionName: string) => {
+                this.onAction(actionName)
+            }
+
+            this.actionMatcher._addActionHook(matchActionToSurvey)
+        }
+
+        actionBasedSurveys.forEach((survey) => {
             if (
-                survey.conditions?.events &&
-                survey.conditions?.events?.values &&
-                survey.conditions?.events.values.length > 0
+                survey.conditions &&
+                survey.conditions?.actions &&
+                survey.conditions?.actions?.values &&
+                survey.conditions?.actions?.values?.length > 0
             ) {
-                this.eventRegistry.set(
-                    survey.id,
-                    survey.conditions?.events.values.map((e) => e.name)
-                )
+                // register the known set of actions with
+                // the action-matcher so it can match
+                // events to actions
+                this.actionMatcher?.register(survey.conditions.actions.values)
+
+                // maintain a mapping of (Action1) => [Survey1, Survey2, Survey3]
+                // where Surveys 1-3 are all activated by Action1
+                survey.conditions?.actions?.values?.forEach((action) => {
+                    if (action && action.name) {
+                        const knownSurveys: string[] | undefined = this.actionToSurveys.get(action.name)
+                        if (knownSurveys) {
+                            knownSurveys.push(survey.id)
+                        }
+                        this.actionToSurveys.set(action.name, knownSurveys || [survey.id])
+                    }
+                })
             }
         })
     }
 
-    on(event: string, eventPayload?: CaptureResult): void {
-        const activatedSurveys: string[] = []
-        const existingActivatedSurveys: string[] = this.persistence?.props[SURVEYS_ACTIVATED] || []
+    private setupEventBasedSurveys(surveys: Survey[]) {
+        const eventBasedSurveys = surveys.filter(
+            (survey: Survey) => survey.conditions?.events && survey.conditions?.events?.values?.length > 0
+        )
 
+        if (eventBasedSurveys.length === 0) {
+            return
+        }
+
+        // match any events to its corresponding survey.
+        const matchEventToSurvey = (eventName: string) => {
+            this.onEvent(eventName)
+        }
+        this.instance?._addCaptureHook(matchEventToSurvey)
+
+        surveys.forEach((survey) => {
+            // maintain a mapping of (Event1) => [Survey1, Survey2, Survey3]
+            // where Surveys 1-3 are all activated by Event1
+            survey.conditions?.events?.values?.forEach((event) => {
+                if (event && event.name) {
+                    const knownSurveys: string[] | undefined = this.eventToSurveys.get(event.name)
+                    if (knownSurveys) {
+                        knownSurveys.push(survey.id)
+                    }
+                    this.eventToSurveys.set(event.name, knownSurveys || [survey.id])
+                }
+            })
+        })
+    }
+
+    onEvent(event: string, eventPayload?: CaptureResult): void {
+        const existingActivatedSurveys: string[] = this.instance?.persistence?.props[SURVEYS_ACTIVATED] || []
         if (
             SurveyEventReceiver.SURVEY_SHOWN_EVENT_NAME == event &&
             eventPayload &&
@@ -43,33 +121,40 @@ export class SurveyEventReceiver {
                 const index = existingActivatedSurveys.indexOf(surveyId)
                 if (index >= 0) {
                     existingActivatedSurveys.splice(index, 1)
+                    this._updateActivatedSurveys(existingActivatedSurveys)
                 }
             }
         } else {
-            this.eventRegistry.forEach((events, surveyID) => {
-                if (events.includes(event)) {
-                    activatedSurveys.push(surveyID)
-                }
-            })
+            if (this.eventToSurveys.has(event)) {
+                this._updateActivatedSurveys(existingActivatedSurveys.concat(this.eventToSurveys.get(event) || []))
+            }
         }
+    }
 
-        const updatedSurveys = existingActivatedSurveys.concat(activatedSurveys)
-        this._saveSurveysToStorage(updatedSurveys)
+    onAction(actionName: string): void {
+        const existingActivatedSurveys: string[] = this.instance?.persistence?.props[SURVEYS_ACTIVATED] || []
+        if (this.actionToSurveys.has(actionName)) {
+            this._updateActivatedSurveys(existingActivatedSurveys.concat(this.actionToSurveys.get(actionName) || []))
+        }
+    }
+
+    private _updateActivatedSurveys(activatedSurveys: string[]) {
+        // we use a new Set here to remove duplicates.
+        this.instance?.persistence?.register({
+            [SURVEYS_ACTIVATED]: [...new Set(activatedSurveys)],
+        })
     }
 
     getSurveys(): string[] {
-        const existingActivatedSurveys = this.persistence?.props[SURVEYS_ACTIVATED]
+        const existingActivatedSurveys = this.instance?.persistence?.props[SURVEYS_ACTIVATED]
         return existingActivatedSurveys ? existingActivatedSurveys : []
     }
 
-    getEventRegistry(): Map<string, string[]> {
-        return this.eventRegistry
+    getEventToSurveys(): Map<string, string[]> {
+        return this.eventToSurveys
     }
 
-    private _saveSurveysToStorage(surveys: string[]): void {
-        // we use a new Set here to remove duplicates.
-        this.persistence?.register({
-            [SURVEYS_ACTIVATED]: [...new Set(surveys)],
-        })
+    _getActionMatcher(): ActionMatcher | null | undefined {
+        return this.actionMatcher
     }
 }


### PR DESCRIPTION
_Broken out of #1292 into its own PR for easier reviewing and merging_

This PR allows us to activate surveys if any actions they're configured with are performed in the browser.

## Changes


### Survey Event Receiver
1. Instead of maintaining a map of Survey-ID to its actions or events, we maintain a map of Action/Event to the surveys that are activated by it.
1. We now look for, and register any surveys that are activated by events with the `ActionMatcher`.
2. Changed `on` to be `onEvent` and added a new `onAction` event handler.
3. `onAction` listens on the `actionCaptured` event in `ActionMatcher` described below.

### Flowchart for activating surveys based on actions. 

``` mermaid
flowchart TD
    A[User clicks button] -->|AutoCapture| B(Analyze element)
    B --> |Element matches known selector|C(Set $element_selectors property)
    C -->D[Capture Action]
    B --> |Element does not match known selector|D[Capture Action]
    D --> |Raise eventCaptured with CaptureResult|E[Event Handlers]
    E --> F[Action Matcher]
    F --> |Check Action Step Matches CaptureResult|G[Raise actionCaptured with actionName]
    G --> H[Survey Event Receiver onAction]
    H --> I[Match action name to surveys activated by it]
    I --> |actionName matches a survey's actions|J[Add survey to activatedSurveys]
```

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
