### PR TITLE
fix: capture network recording type

### DIFF
--- a/src/__tests__/extensions/replay/config.test.ts
+++ b/src/__tests__/extensions/replay/config.test.ts
@@ -216,6 +216,22 @@ describe('config', () => {
             })
         })
 
+        it('can amend the provided object', () => {
+            const posthogConfig = defaultConfig()
+            posthogConfig.session_recording.maskCapturedNetworkRequestFn = (data) => {
+                data.name = 'changed'
+                return data
+            }
+            const networkOptions = buildNetworkRequestOptions(posthogConfig, {})
+
+            const cleaned = networkOptions.maskRequestFn!({
+                name: 'something',
+            } as Partial<CapturedNetworkRequest> as CapturedNetworkRequest)
+            expect(cleaned).toEqual({
+                name: 'changed',
+            })
+        })
+
         it('should remove the Authorization header from requests even when a mask request fn is set', () => {
             const posthogConfig = defaultConfig()
             posthogConfig.session_recording.maskCapturedNetworkRequestFn = (data) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -479,9 +479,8 @@ export type NetworkRequest = {
 // we mirror PerformanceEntry since we read into this type from a PerformanceObserver,
 // but we don't want to inherit its readonly-iness
 type Writable<T> = { -readonly [P in keyof T]: T[P] }
-type CapturedNetworkRequestBase = Writable<Omit<PerformanceEntry, 'toJSON'>>
 
-type CapturedNetworkRequest = CapturedNetworkRequestBase & {
+export type CapturedNetworkRequest = Writable<Omit<PerformanceEntry, 'toJSON'>> & {
     // properties below here are ALPHA, don't rely on them, they may change without notice
     method?: string
     initiatorType?: InitiatorType

--- a/src/types.ts
+++ b/src/types.ts
@@ -280,16 +280,23 @@ export interface RetriableRequestOptions extends QueuedRequestOptions {
 }
 
 export interface CaptureOptions {
-    $set?: Properties /** used with $identify */
-    $set_once?: Properties /** used with $identify */
+    $set?: Properties
+    /** used with $identify */
+    $set_once?: Properties
+    /** used with $identify */
     _url?: string /** Used to override the desired endpoint for the captured event */
     /** Some events are sent as passengers inside other events - e.g. heatmaps and web vitals, not all ingestion routes can process passengers */
     _noHeatmaps?: boolean
-    _batchKey?: string /** key of queue, e.g. 'sessionRecording' vs 'event' */
-    _noTruncate?: boolean /** if set, overrides and disables config.properties_string_max_length */
-    send_instantly?: boolean /** if set skips the batched queue */
-    skip_client_rate_limiting?: boolean /** if set skips the client side rate limiting */
-    transport?: RequestOptions['transport'] /** if set, overrides the desired transport method */
+    _batchKey?: string
+    /** key of queue, e.g. 'sessionRecording' vs 'event' */
+    _noTruncate?: boolean
+    /** if set, overrides and disables config.properties_string_max_length */
+    send_instantly?: boolean
+    /** if set skips the batched queue */
+    skip_client_rate_limiting?: boolean
+    /** if set skips the client side rate limiting */
+    transport?: RequestOptions['transport']
+    /** if set, overrides the desired transport method */
     timestamp?: Date
 }
 
@@ -336,8 +343,10 @@ export interface DecideResponse {
     }
     surveys?: boolean
     toolbarParams: ToolbarParams
-    editorParams?: ToolbarParams /** @deprecated, renamed to toolbarParams, still present on older API responses */
-    toolbarVersion: 'toolbar' /** @deprecated, moved to toolbarParams */
+    editorParams?: ToolbarParams
+    /** @deprecated, renamed to toolbarParams, still present on older API responses */
+    toolbarVersion: 'toolbar'
+    /** @deprecated, moved to toolbarParams */
     isAuthenticated: boolean
     siteApps: { id: number; url: string }[]
     heatmaps?: boolean
@@ -370,8 +379,10 @@ export type ToolbarVersion = 'toolbar'
 
 /* sync with posthog */
 export interface ToolbarParams {
-    token?: string /** public posthog-js token */
-    temporaryToken?: string /** private temporary user token */
+    token?: string
+    /** public posthog-js token */
+    temporaryToken?: string
+    /** private temporary user token */
     actionId?: number
     userIntent?: ToolbarUserIntent
     source?: ToolbarSource
@@ -475,7 +486,12 @@ export type NetworkRequest = {
 //     readonly name: string;
 //     readonly startTime: DOMHighResTimeStamp;
 // NB: properties below here are ALPHA, don't rely on them, they may change without notice
-export type CapturedNetworkRequest = Omit<PerformanceEntry, 'toJSON'> & {
+
+type Writable<T> = { -readonly [P in keyof T]: T[P] }
+
+type CapturedNetworkRequestBase = Writable<Omit<PerformanceEntry, 'toJSON'>>
+
+type CapturedNetworkRequest = CapturedNetworkRequestBase & {
     // properties below here are ALPHA, don't rely on them, they may change without notice
     method?: string
     initiatorType?: InitiatorType

--- a/src/types.ts
+++ b/src/types.ts
@@ -280,23 +280,16 @@ export interface RetriableRequestOptions extends QueuedRequestOptions {
 }
 
 export interface CaptureOptions {
-    $set?: Properties
-    /** used with $identify */
-    $set_once?: Properties
-    /** used with $identify */
+    $set?: Properties /** used with $identify */
+    $set_once?: Properties /** used with $identify */
     _url?: string /** Used to override the desired endpoint for the captured event */
     /** Some events are sent as passengers inside other events - e.g. heatmaps and web vitals, not all ingestion routes can process passengers */
     _noHeatmaps?: boolean
-    _batchKey?: string
-    /** key of queue, e.g. 'sessionRecording' vs 'event' */
-    _noTruncate?: boolean
-    /** if set, overrides and disables config.properties_string_max_length */
-    send_instantly?: boolean
-    /** if set skips the batched queue */
-    skip_client_rate_limiting?: boolean
-    /** if set skips the client side rate limiting */
-    transport?: RequestOptions['transport']
-    /** if set, overrides the desired transport method */
+    _batchKey?: string /** key of queue, e.g. 'sessionRecording' vs 'event' */
+    _noTruncate?: boolean /** if set, overrides and disables config.properties_string_max_length */
+    send_instantly?: boolean /** if set skips the batched queue */
+    skip_client_rate_limiting?: boolean /** if set skips the client side rate limiting */
+    transport?: RequestOptions['transport'] /** if set, overrides the desired transport method */
     timestamp?: Date
 }
 
@@ -343,10 +336,8 @@ export interface DecideResponse {
     }
     surveys?: boolean
     toolbarParams: ToolbarParams
-    editorParams?: ToolbarParams
-    /** @deprecated, renamed to toolbarParams, still present on older API responses */
-    toolbarVersion: 'toolbar'
-    /** @deprecated, moved to toolbarParams */
+    editorParams?: ToolbarParams /** @deprecated, renamed to toolbarParams, still present on older API responses */
+    toolbarVersion: 'toolbar' /** @deprecated, moved to toolbarParams */
     isAuthenticated: boolean
     siteApps: { id: number; url: string }[]
     heatmaps?: boolean
@@ -379,10 +370,8 @@ export type ToolbarVersion = 'toolbar'
 
 /* sync with posthog */
 export interface ToolbarParams {
-    token?: string
-    /** public posthog-js token */
-    temporaryToken?: string
-    /** private temporary user token */
+    token?: string /** public posthog-js token */
+    temporaryToken?: string /** private temporary user token */
     actionId?: number
     userIntent?: ToolbarUserIntent
     source?: ToolbarSource
@@ -487,8 +476,9 @@ export type NetworkRequest = {
 //     readonly startTime: DOMHighResTimeStamp;
 // NB: properties below here are ALPHA, don't rely on them, they may change without notice
 
+// we mirror PerformanceEntry since we read into this type from a PerformanceObserver,
+// but we don't want to inherit its readonly-iness
 type Writable<T> = { -readonly [P in keyof T]: T[P] }
-
 type CapturedNetworkRequestBase = Writable<Omit<PerformanceEntry, 'toJSON'>>
 
 type CapturedNetworkRequest = CapturedNetworkRequestBase & {


### PR DESCRIPTION
see https://posthog.com/questions/hiding-specific-query-parameters-in-session-replay-waterfall-beta-view

allows caller to edit the request, properties being readonly was an unintended consequence of inheriting from PerformanceEntry and never mutating it ourselves