### PR TITLE
fix: add web vitals to array full

### DIFF
--- a/src/entrypoints/array.full.ts
+++ b/src/entrypoints/array.full.ts
@@ -4,6 +4,7 @@ import './recorder'
 import './surveys'
 import './exception-autocapture'
 import './tracing-headers'
+import './web-vitals'
 
 import { init_from_snippet } from '../posthog-core'
 


### PR DESCRIPTION
I missed this when adding web vitals
If you have web vitals enabled and used array full we'd still load an external script...

well, not any more