### PR TITLE
fix: warn when on xhr error used

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -386,6 +386,10 @@ export class PostHog {
             })
         )
 
+        if (this.config.on_xhr_error) {
+            logger.error('[posthog] on_xhr_error is deprecated. Use on_request_error instead')
+        }
+
         this.compression = config.disable_compression ? undefined : Compression.Base64
 
         this.persistence = new PostHogPersistence(this.config)


### PR DESCRIPTION
see https://github.com/PostHog/posthog-js/issues/1193

we can't go back in time to make that right... but we can at least maybe help the future traveller