### PR TITLE
feat: add url_ignorelist for autocapture config

### DIFF
--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -1112,6 +1112,27 @@ describe('Autocapture system', () => {
             expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(false)
         })
 
+        it('not capture urls which match the url regex ignorelist', () => {
+            const main_el = document.createElement('some-element')
+            const button = document.createElement('a')
+            button.innerHTML = 'bla'
+            main_el.appendChild(button)
+            const e = makeMouseEvent({
+                target: main_el,
+                composedPath: () => [button, main_el],
+            })
+            const autocapture_config = {
+                url_ignorelist: ['https://posthog.com/test/*'],
+            }
+
+            window!.location = new URL('https://posthog.com/test/captured') as unknown as Location
+
+            expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(false)
+
+            window!.location = new URL('https://posthog.com/docs/not-captured') as unknown as Location
+            expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(true)
+        })
+
         it('an empty url regex allowlist does not match any url', () => {
             const main_el = document.createElement('some-element')
             const button = document.createElement('a')

--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -1104,11 +1104,11 @@ describe('Autocapture system', () => {
                 url_allowlist: ['https://posthog.com/test/*'],
             }
 
-            window!.location = new URL('https://posthog.com/test/captured') as unknown as Location
+            window!.location = new URL('https://posthog.com/test/matching') as unknown as Location
 
             expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(true)
 
-            window!.location = new URL('https://posthog.com/docs/not-captured') as unknown as Location
+            window!.location = new URL('https://posthog.com/docs/not-matching') as unknown as Location
             expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(false)
         })
 
@@ -1125,11 +1125,11 @@ describe('Autocapture system', () => {
                 url_ignorelist: ['https://posthog.com/test/*'],
             }
 
-            window!.location = new URL('https://posthog.com/test/captured') as unknown as Location
+            window!.location = new URL('https://posthog.com/test/matching') as unknown as Location
 
             expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(false)
 
-            window!.location = new URL('https://posthog.com/docs/not-captured') as unknown as Location
+            window!.location = new URL('https://posthog.com/docs/not-matching') as unknown as Location
             expect(shouldCaptureDomEvent(button, e, autocapture_config)).toBe(true)
         })
 

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -9,6 +9,15 @@ export function splitClassString(s: string): string[] {
     return s ? trim(s).split(/\s+/) : []
 }
 
+/**
+ * this is used by both an allowlist and an ignore list
+ *
+ * so the expected result can be passed in
+ *
+ * when being used as an allowlist, the expected result is true
+ * when being used as an ignore list, the expected result is false
+ *
+ */
 function whenURLMatches(urlsList: (string | RegExp)[], resultOnMatch: boolean): boolean {
     const url = window?.location.href
     if (url && urlsList && urlsList.some((regex) => url.match(regex))) {

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -9,21 +9,9 @@ export function splitClassString(s: string): string[] {
     return s ? trim(s).split(/\s+/) : []
 }
 
-/**
- * this is used by both an allowlist and an ignore list
- *
- * so the expected result can be passed in
- *
- * when being used as an allowlist, the expected result is true
- * when being used as an ignore list, the expected result is false
- *
- */
-function checkForURLMatches(urlsList: (string | RegExp)[], resultOnMatch: boolean): boolean {
+function checkForURLMatches(urlsList: (string | RegExp)[]): boolean {
     const url = window?.location.href
-    if (url && urlsList && urlsList.some((regex) => url.match(regex))) {
-        return resultOnMatch
-    }
-    return !resultOnMatch
+    return !!(url && urlsList && urlsList.some((regex) => url.match(regex)))
 }
 
 /*
@@ -218,13 +206,15 @@ export function shouldCaptureDomEvent(
     }
 
     if (autocaptureConfig?.url_allowlist) {
-        if (checkForURLMatches(autocaptureConfig.url_allowlist, true) === false) {
+        // if the current URL is not in the allow list, don't capture
+        if (!checkForURLMatches(autocaptureConfig.url_allowlist)) {
             return false
         }
     }
 
     if (autocaptureConfig?.url_ignorelist) {
-        if (checkForURLMatches(autocaptureConfig.url_ignorelist, false) === false) {
+        // if the current URL is in the ignore list, don't capture
+        if (checkForURLMatches(autocaptureConfig.url_ignorelist)) {
             return false
         }
     }

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -18,7 +18,7 @@ export function splitClassString(s: string): string[] {
  * when being used as an ignore list, the expected result is false
  *
  */
-function whenURLMatches(urlsList: (string | RegExp)[], resultOnMatch: boolean): boolean {
+function checkForURLMatches(urlsList: (string | RegExp)[], resultOnMatch: boolean): boolean {
     const url = window?.location.href
     if (url && urlsList && urlsList.some((regex) => url.match(regex))) {
         return resultOnMatch
@@ -218,13 +218,13 @@ export function shouldCaptureDomEvent(
     }
 
     if (autocaptureConfig?.url_allowlist) {
-        if (whenURLMatches(autocaptureConfig.url_allowlist, true) === false) {
+        if (checkForURLMatches(autocaptureConfig.url_allowlist, true) === false) {
             return false
         }
     }
 
     if (autocaptureConfig?.url_ignorelist) {
-        if (whenURLMatches(autocaptureConfig.url_ignorelist, false) === false) {
+        if (checkForURLMatches(autocaptureConfig.url_ignorelist, false) === false) {
             return false
         }
     }

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -9,6 +9,14 @@ export function splitClassString(s: string): string[] {
     return s ? trim(s).split(/\s+/) : []
 }
 
+function whenURLMatches(urlsList: (string | RegExp)[], resultOnMatch: boolean): boolean {
+    const url = window?.location.href
+    if (url && urlsList && urlsList.some((regex) => url.match(regex))) {
+        return resultOnMatch
+    }
+    return !resultOnMatch
+}
+
 /*
  * Get the className of an element, accounting for edge cases where element.className is an object
  *
@@ -201,9 +209,13 @@ export function shouldCaptureDomEvent(
     }
 
     if (autocaptureConfig?.url_allowlist) {
-        const url = window.location.href
-        const allowlist = autocaptureConfig.url_allowlist
-        if (allowlist && !allowlist.some((regex) => url.match(regex))) {
+        if (whenURLMatches(autocaptureConfig.url_allowlist, true) === false) {
+            return false
+        }
+    }
+
+    if (autocaptureConfig?.url_ignorelist) {
+        if (whenURLMatches(autocaptureConfig.url_ignorelist, false) === false) {
             return false
         }
     }

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -53,6 +53,7 @@ export class Autocapture {
         const config = isObject(this.instance.config.autocapture) ? this.instance.config.autocapture : {}
         // precompile the regex
         config.url_allowlist = config.url_allowlist?.map((url) => new RegExp(url))
+        config.url_ignorelist = config.url_ignorelist?.map((url) => new RegExp(url))
         return config
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,8 +25,16 @@ export interface AutocaptureConfig {
     /**
      * List of URLs to allow autocapture on, can be strings to match
      * or regexes e.g. ['https://example.com', 'test.com/.*']
+     * this is useful when you want to autocapture on specific pages only
      */
     url_allowlist?: (string | RegExp)[]
+
+    /**
+     * List of URLs to not allow autocapture on, can be strings to match
+     * or regexes e.g. ['https://example.com', 'test.com/.*']
+     * this is useful when you want to autocapture on most pages but not some specific ones
+     */
+    url_ignorelist?: (string | RegExp)[]
 
     /**
      * List of DOM events to allow autocapture on  e.g. ['click', 'change', 'submit']

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,10 @@ export interface AutocaptureConfig {
      * List of URLs to allow autocapture on, can be strings to match
      * or regexes e.g. ['https://example.com', 'test.com/.*']
      * this is useful when you want to autocapture on specific pages only
+     *
+     * if you set both url_allowlist and url_ignorelist,
+     * we check the allowlist first and then the ignorelist.
+     * the ignorelist can override the allowlist
      */
     url_allowlist?: (string | RegExp)[]
 
@@ -33,6 +37,10 @@ export interface AutocaptureConfig {
      * List of URLs to not allow autocapture on, can be strings to match
      * or regexes e.g. ['https://example.com', 'test.com/.*']
      * this is useful when you want to autocapture on most pages but not some specific ones
+     *
+     * if you set both url_allowlist and url_ignorelist,
+     * we check the allowlist first and then the ignorelist.
+     * the ignorelist can override the allowlist
      */
     url_ignorelist?: (string | RegExp)[]
 


### PR DESCRIPTION
see https://posthog.slack.com/archives/C075D3C5HST/p1720808391615839

and https://posthog.com/questions/url-allowlist-for-exclude

@corywatilo made a totally reasonable assumption about how this works... and it's easy to make it work that way

This PR extends autocapture config so you can pass a url_ignorelist instead of (or as well as) a url_allowlist