### PR TITLE
feat: split large replay buffers before sending

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording-utils.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording-utils.test.ts
@@ -5,6 +5,8 @@ import {
     CONSOLE_LOG_PLUGIN_NAME,
     PLUGIN_EVENT_TYPE,
     FULL_SNAPSHOT_EVENT_TYPE,
+    splitBuffer,
+    SEVEN_MEGABYTES,
 } from '../../../extensions/replay/sessionrecording-utils'
 import { largeString, threeMBAudioURI, threeMBImageURI } from '../test_data/sessionrecording-utils-test-data'
 import { eventWithTime } from '@rrweb/types'
@@ -237,6 +239,80 @@ describe(`SessionRecording utility functions`, () => {
                     },
                 },
             })
+        })
+    })
+
+    describe('splitBuffer', () => {
+        it('should return the same buffer if size is less than SEVEN_MEGABYTES', () => {
+            const buffer = {
+                size: 5 * 1024 * 1024,
+                data: new Array(100).fill(0),
+                sessionId: 'session1',
+                windowId: 'window1',
+            }
+
+            const result = splitBuffer(buffer)
+            expect(result).toEqual([buffer])
+        })
+
+        it('should split the buffer into two halves if size is greater than or equal to SEVEN_MEGABYTES', () => {
+            const buffer = {
+                size: 8 * 1024 * 1024,
+                data: new Array(100).fill(0),
+                sessionId: 'session1',
+                windowId: 'window1',
+            }
+
+            const result = splitBuffer(buffer)
+
+            expect(result).toHaveLength(2)
+            expect(result[0].data).toEqual(buffer.data.slice(0, 50))
+            expect(result[1].data).toEqual(buffer.data.slice(50))
+        })
+
+        it('should recursively split the buffer until each part is smaller than SEVEN_MEGABYTES', () => {
+            const largeDataArray = new Array(100).fill('a'.repeat(1024 * 1024))
+            const buffer = {
+                size: 32 * 1024 * 1024,
+                data: largeDataArray,
+                sessionId: 'session1',
+                windowId: 'window1',
+            }
+
+            const result = splitBuffer(buffer)
+
+            expect(result.length).toBe(20)
+            result.forEach((part) => {
+                expect(part.size).toBeLessThan(SEVEN_MEGABYTES)
+            })
+        })
+
+        it('should handle buffer with size exactly SEVEN_MEGABYTES', () => {
+            const buffer = {
+                size: SEVEN_MEGABYTES,
+                data: new Array(100).fill(0),
+                sessionId: 'session1',
+                windowId: 'window1',
+            }
+
+            const result = splitBuffer(buffer)
+
+            expect(result).toHaveLength(2)
+            expect(result[0].data).toEqual(buffer.data.slice(0, 50))
+            expect(result[1].data).toEqual(buffer.data.slice(50))
+        })
+
+        it('should not split buffer if it has only one element', () => {
+            const buffer = {
+                size: 10 * 1024 * 1024,
+                data: [0],
+                sessionId: 'session1',
+                windowId: 'window1',
+            }
+
+            const result = splitBuffer(buffer)
+
+            expect(result).toEqual([buffer])
         })
     })
 })


### PR DESCRIPTION
when we see very large mesages sometimes they are many megabytes of an array of relatvely small items
we can split those arrays down into multiple captured events we are splitting when over _seven megabytes_ so we're still letting this generate pretty large events

this shouldn't amplify the number of events _too_ much
and anyway we're sending this data to capture already just in one large expensive packet

see https://github.com/PostHog/posthog/issues/23703