### PR TITLE
fix: ignore ridonculously large web vitals values

### DIFF
--- a/src/__tests__/extensions/web-vitals.test.ts
+++ b/src/__tests__/extensions/web-vitals.test.ts
@@ -1,11 +1,11 @@
-import { createPosthogInstance } from './helpers/posthog-instance'
-import { uuidv7 } from '../uuidv7'
-import { PostHog } from '../posthog-core'
-import { DecideResponse } from '../types'
-import { assignableWindow } from '../utils/globals'
-import { FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS } from '../extensions/web-vitals'
+import { createPosthogInstance } from '../helpers/posthog-instance'
+import { uuidv7 } from '../../uuidv7'
+import { PostHog } from '../../posthog-core'
+import { DecideResponse } from '../../types'
+import { assignableWindow } from '../../utils/globals'
+import { FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS, ONE_HOUR_IN_MILLIS } from '../../extensions/web-vitals'
 
-jest.mock('../utils/logger')
+jest.mock('../../utils/logger')
 jest.useFakeTimers()
 
 describe('web vitals', () => {
@@ -49,6 +49,8 @@ describe('web vitals', () => {
             posthog = await createPosthogInstance(uuidv7(), {
                 _onCapture: onCapture,
                 capture_performance: { web_vitals: true },
+                // sometimes pageviews sneak in and make asserting on mock capture tricky
+                capture_pageview: false,
             })
 
             loadScriptMock.mockImplementation((_path, callback) => {
@@ -120,6 +122,27 @@ describe('web vitals', () => {
                     },
                 },
             ])
+        })
+
+        it('should ignore a ridiculous value', async () => {
+            randomlyAddAMetric('LCP', ONE_HOUR_IN_MILLIS, { extra: 'property' })
+
+            expect(onCapture).toBeCalledTimes(0)
+
+            jest.advanceTimersByTime(FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS + 1)
+
+            expect(onCapture).toBeCalledTimes(0)
+        })
+
+        it('can be configured not to ignore a ridiculous value', async () => {
+            posthog.config.capture_performance = { __apply_web_vitals_max_limit: false }
+            randomlyAddAMetric('LCP', ONE_HOUR_IN_MILLIS, { extra: 'property' })
+
+            expect(onCapture).toBeCalledTimes(0)
+
+            jest.advanceTimersByTime(FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS + 1)
+
+            expect(onCapture).toBeCalledTimes(1)
         })
     })
 

--- a/src/__tests__/extensions/web-vitals.test.ts
+++ b/src/__tests__/extensions/web-vitals.test.ts
@@ -3,7 +3,7 @@ import { uuidv7 } from '../../uuidv7'
 import { PostHog } from '../../posthog-core'
 import { DecideResponse } from '../../types'
 import { assignableWindow } from '../../utils/globals'
-import { FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS, ONE_HOUR_IN_MILLIS } from '../../extensions/web-vitals'
+import { FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS, FIFTEEN_MINUTES_IN_MILLIS } from '../../extensions/web-vitals'
 
 jest.mock('../../utils/logger')
 jest.useFakeTimers()
@@ -125,7 +125,7 @@ describe('web vitals', () => {
         })
 
         it('should ignore a ridiculous value', async () => {
-            randomlyAddAMetric('LCP', ONE_HOUR_IN_MILLIS, { extra: 'property' })
+            randomlyAddAMetric('LCP', FIFTEEN_MINUTES_IN_MILLIS, { extra: 'property' })
 
             expect(onCapture).toBeCalledTimes(0)
 
@@ -135,8 +135,8 @@ describe('web vitals', () => {
         })
 
         it('can be configured not to ignore a ridiculous value', async () => {
-            posthog.config.capture_performance = { __apply_web_vitals_max_limit: false }
-            randomlyAddAMetric('LCP', ONE_HOUR_IN_MILLIS, { extra: 'property' })
+            posthog.config.capture_performance = { __web_vitals_max_value: 0 }
+            randomlyAddAMetric('LCP', FIFTEEN_MINUTES_IN_MILLIS, { extra: 'property' })
 
             expect(onCapture).toBeCalledTimes(0)
 

--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -7,7 +7,9 @@ import { assignableWindow, window } from '../../utils/globals'
 import Config from '../../config'
 
 export const FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS = 8000
-export const FIFTEEN_MINUTES_IN_MILLIS = 15 * 60 * 1000
+const ONE_MINUTE_IN_MILLIS = 60 * 1000
+export const FIFTEEN_MINUTES_IN_MILLIS = 15 * ONE_MINUTE_IN_MILLIS
+
 const LOGGER_PREFIX = '[Web Vitals]'
 type WebVitalsEventBuffer = { url: string | undefined; metrics: any[]; firstMetricTimestamp: number | undefined }
 
@@ -24,10 +26,14 @@ export class WebVitalsAutocapture {
     }
 
     public get _maxAllowedValue(): number {
-        return isObject(this.instance.config.capture_performance) &&
+        const configured =
+            isObject(this.instance.config.capture_performance) &&
             isNumber(this.instance.config.capture_performance.__web_vitals_max_value)
-            ? this.instance.config.capture_performance.__web_vitals_max_value
-            : FIFTEEN_MINUTES_IN_MILLIS
+                ? this.instance.config.capture_performance.__web_vitals_max_value
+                : FIFTEEN_MINUTES_IN_MILLIS
+        // you can set to 0 to disable the check or any value over ten seconds
+        // 1 milli to 1 minute will be set to 15 minutes, cos that would be a silly low maximum
+        return 0 < configured && configured <= ONE_MINUTE_IN_MILLIS ? FIFTEEN_MINUTES_IN_MILLIS : configured
     }
 
     public get isEnabled(): boolean {

--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -127,7 +127,7 @@ export class WebVitalsAutocapture {
         // we observe some very large values sometimes, we'll ignore them
         // since the likelihood of LCP > 1 hour being correct is very low
         if (this._applyMaxLimit && metric.value >= ONE_HOUR_IN_MILLIS) {
-            logger.error(LOGGER_PREFIX + 'Ignoring metric with value > 1 hour', metric)
+            logger.error(LOGGER_PREFIX + 'Ignoring metric with value >= 1 hour', metric)
             return
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,9 +101,10 @@ export interface PerformanceCaptureConfig {
     /**
      * We observe very large values reported by the Chrome web vitals library
      * These outliers are likely not real, useful values, and we exclude them
-     * You can set this to false in order to include them, NB this is not recommended
+     * You can set this to 0 in order to include all values, NB this is not recommended
+     * if not set this defaults to 15 minutes
      */
-    __apply_web_vitals_max_limit?: boolean
+    __web_vitals_max_value?: number
 }
 
 export interface HeatmapConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,12 @@ export interface PerformanceCaptureConfig {
     network_timing?: boolean
     /** works as a passenger event to use chrome's web vitals library to wrap fetch and capture web vitals */
     web_vitals?: boolean
+    /**
+     * We observe very large values reported by the Chrome web vitals library
+     * These outliers are likely not real, useful values, and we exclude them
+     * You can set this to false in order to include them, NB this is not recommended
+     */
+    __apply_web_vitals_max_limit?: boolean
 }
 
 export interface HeatmapConfig {


### PR DESCRIPTION
We see web vitals captured with values many times greater than one hour.

This is 99.999999% definitely a bug in the web vitals library or browsers.

Certainly it's not useful to know you have outliers where someone's FCP was 2 days.

Let's limit ourselves to a max of one hour, but let people override that if they really, really want to