### PR TITLE
fix: don't load preact until you have to

### DIFF
--- a/src/entrypoints/surveys.ts
+++ b/src/entrypoints/surveys.ts
@@ -1,8 +1,11 @@
 import { generateSurveys } from '../extensions/surveys'
 
 import { window } from '../utils/globals'
+import { canActivateRepeatedly } from '../extensions/surveys/surveys-utils'
 
 if (window) {
+    ;(window as any).__PosthogExtensions__ = (window as any).__PosthogExtensions__ || {}
+    ;(window as any).__PosthogExtensions__.canActivateRepeatedly = canActivateRepeatedly
     ;(window as any).extendPostHogWithSurveys = generateSurveys
 }
 

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -59,7 +59,6 @@ export class PostHogSurveys {
         // we set this to undefined here because we need the persistence storage for this type
         // but that's not initialized until loadIfEnabled is called.
         this._surveyEventReceiver = null
-        this.loadIfEnabled()
     }
 
     afterDecideResponse(response: DecideResponse) {

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -14,6 +14,8 @@ import { DecideResponse } from './types'
 import { logger } from './utils/logger'
 import { canActivateRepeatedly } from './extensions/surveys/surveys-utils'
 
+const LOGGER_PREFIX = '[Surveys]'
+
 export const surveyUrlValidationMap: Record<SurveyUrlMatchType, (conditionsUrl: string) => boolean> = {
     icontains: (conditionsUrl) =>
         !!window && window.location.href.toLowerCase().indexOf(conditionsUrl.toLowerCase()) > -1,
@@ -50,12 +52,10 @@ function getRatingBucketForResponseValue(responseValue: number, scale: number) {
 }
 
 export class PostHogSurveys {
-    instance: PostHog
     private _decideServerResponse?: boolean
     public _surveyEventReceiver: SurveyEventReceiver | null
 
-    constructor(instance: PostHog) {
-        this.instance = instance
+    constructor(private readonly instance: PostHog) {
         // we set this to undefined here because we need the persistence storage for this type
         // but that's not initialized until loadIfEnabled is called.
         this._surveyEventReceiver = null
@@ -75,7 +75,7 @@ export class PostHogSurveys {
             }
             this.instance.requestRouter.loadScript('/static/surveys.js', (err) => {
                 if (err) {
-                    return logger.error(`Could not load surveys script`, err)
+                    return logger.error(LOGGER_PREFIX, 'Could not load surveys script', err)
                 }
 
                 assignableWindow.extendPostHogWithSurveys(this.instance)
@@ -258,7 +258,7 @@ export class PostHogSurveys {
             return nextQuestionIndex
         }
 
-        console.warn('Falling back to next question index due to unexpected branching type') // eslint-disable-line no-console
+        logger.warn(LOGGER_PREFIX, 'Falling back to next question index due to unexpected branching type')
         return nextQuestionIndex
     }
 }


### PR DESCRIPTION
we need to keep the bundle as small as possible, it's already ~3x bigger than when people first start complaining about the size

https://github.com/PostHog/posthog-js/pull/1281/ is in merge hell because we abandoned it

this is another attempt to avoid everyone downloading preact, it reduces bundle size by 6%