### PR TITLE
feat: Implement referring domain denylist

### DIFF
--- a/src/__tests__/posthog-core.test.ts
+++ b/src/__tests__/posthog-core.test.ts
@@ -1,16 +1,48 @@
-import { PostHogConfig } from '../types'
-import { uuidv7 } from '../uuidv7'
 import { defaultPostHog } from './helpers/posthog-instance'
+import type { PostHogConfig } from '../types'
+import { uuidv7 } from '../uuidv7'
+
+const mockReferrerGetter = jest.fn()
+const mockURLGetter = jest.fn()
+jest.mock('../utils/globals', () => {
+    const orig = jest.requireActual('../utils/globals')
+    return {
+        ...orig,
+        document: {
+            ...orig.document,
+            createElement: (...args: any[]) => orig.document.createElement(...args),
+            get referrer() {
+                return mockReferrerGetter?.()
+            },
+            get URL() {
+                return mockURLGetter?.()
+            },
+        },
+        get location() {
+            const url = mockURLGetter?.()
+            return {
+                href: url,
+                toString: () => url,
+            }
+        },
+    }
+})
 
 describe('posthog core', () => {
+    beforeEach(() => {
+        mockReferrerGetter.mockReturnValue('https://referrer.com')
+        mockURLGetter.mockReturnValue('https://example.com')
+        console.error = jest.fn()
+    })
+
     describe('capture()', () => {
         const eventName = 'custom_event'
-        const properties = {
+        const eventProperties = {
             event: 'prop',
         }
-        const setup = (config: Partial<PostHogConfig> = {}) => {
+        const setup = (config: Partial<PostHogConfig> = {}, token: string = uuidv7()) => {
             const onCapture = jest.fn()
-            const posthog = defaultPostHog().init('testtoken', { ...config, _onCapture: onCapture }, uuidv7())!
+            const posthog = defaultPostHog().init(token, { ...config, _onCapture: onCapture }, token)!
             posthog.debug()
             return { posthog, onCapture }
         }
@@ -23,7 +55,7 @@ describe('posthog core', () => {
             })
 
             // act
-            const actual = posthog._calculate_event_properties(eventName, properties)
+            const actual = posthog._calculate_event_properties(eventName, eventProperties)
 
             // assert
             expect(actual['event']).toBe('prop')
@@ -37,7 +69,7 @@ describe('posthog core', () => {
             it('includes information about remaining rate limit', () => {
                 const { posthog, onCapture } = setup()
 
-                posthog.capture(eventName, properties)
+                posthog.capture(eventName, eventProperties)
 
                 expect(onCapture.mock.calls[0][1]).toMatchObject({
                     properties: {
@@ -52,20 +84,112 @@ describe('posthog core', () => {
 
                 console.error = jest.fn()
                 const { posthog, onCapture } = setup()
-
                 for (let i = 0; i < 100; i++) {
-                    posthog.capture(eventName, properties)
+                    posthog.capture(eventName, eventProperties)
                 }
                 expect(onCapture).toHaveBeenCalledTimes(100)
                 onCapture.mockClear()
                 ;(console.error as any).mockClear()
-                posthog.capture(eventName, properties)
-                expect(onCapture.mock.calls).toEqual([])
-                expect(console.error).toHaveBeenCalledTimes(1)
+                for (let i = 0; i < 50; i++) {
+                    posthog.capture(eventName, eventProperties)
+                }
+                expect(onCapture).toHaveBeenCalledTimes(1)
+                expect(onCapture.mock.calls[0][0]).toBe('$$client_ingestion_warning')
+                expect(console.error).toHaveBeenCalledTimes(50)
                 expect(console.error).toHaveBeenCalledWith(
                     '[PostHog.js]',
                     'This capture call is ignored due to client rate limiting.'
                 )
+            })
+        })
+
+        describe('referring domain denylist', () => {
+            it('should not update the referrer if it is in the denylist', () => {
+                // arrange
+                const token = uuidv7()
+                mockReferrerGetter.mockReturnValue('https://referrer.example.com/some/path')
+                mockURLGetter.mockReturnValue('')
+                const { posthog: posthog1 } = setup({
+                    referring_domain_denylist: ['deny.example.com'],
+                    token,
+                    persistence_name: token,
+                })
+                posthog1.capture(eventName, eventProperties)
+                mockReferrerGetter.mockReturnValue('https://deny.example.com/some/path')
+                const { posthog: posthog2, onCapture: onCapture2 } = setup({
+                    referring_domain_denylist: ['deny.example.com'],
+                    token,
+                    persistence_name: token,
+                })
+                // these 2 assertions are to test the test, i.e. did the persistence from posthog1 get passed to posthog2
+                expect(posthog2.persistence.props.$initial_person_info.r).toEqual(
+                    'https://referrer.example.com/some/path'
+                )
+                expect(posthog2.sessionPersistence.props.$referrer).toEqual('https://referrer.example.com/some/path')
+
+                // act
+                posthog2.capture(eventName, eventProperties)
+
+                // assert
+                const { $set_once, properties } = onCapture2.mock.calls[0][1]
+                expect($set_once['$initial_referrer']).toBe('https://referrer.example.com/some/path')
+                expect($set_once['$initial_referring_domain']).toBe('referrer.example.com')
+                expect(properties['$referrer']).toBe('https://referrer.example.com/some/path')
+                expect(properties['$referring_domain']).toBe('referrer.example.com')
+            })
+            it('should send $direct if the initial referrer is in the denylist', () => {
+                mockReferrerGetter.mockReturnValue('https://www.example.com/some/path')
+                mockURLGetter.mockReturnValue('')
+                // arrange
+                const { posthog, onCapture } = setup({
+                    referring_domain_denylist: ['www.example.com'],
+                })
+
+                // act
+                posthog.capture(eventName, eventProperties)
+
+                // assert
+                const { $set_once, properties } = onCapture.mock.calls[0][1]
+                expect($set_once['$initial_referrer']).toBe('$direct')
+                expect($set_once['$initial_referring_domain']).toBe('$direct')
+                expect(properties['$referrer']).toBe('$direct')
+                expect(properties['$referring_domain']).toBe('$direct')
+            })
+            it('should update the referrer if it is not in the denylist', () => {
+                mockReferrerGetter.mockReturnValue('https://www.example.com/some/path')
+                mockURLGetter.mockReturnValue('')
+                // arrange
+                const { posthog, onCapture } = setup({
+                    referring_domain_denylist: ['other.example.com'],
+                })
+
+                // act
+                posthog.capture(eventName, eventProperties)
+
+                // assert
+                const { $set_once, properties } = onCapture.mock.calls[0][1]
+                expect($set_once['$initial_referrer']).toBe('https://www.example.com/some/path')
+                expect($set_once['$initial_referring_domain']).toBe('www.example.com')
+                expect(properties['$referrer']).toBe('https://www.example.com/some/path')
+                expect(properties['$referring_domain']).toBe('www.example.com')
+            })
+            it('should support using a regex in the denylist', () => {
+                mockReferrerGetter.mockReturnValue('https://www.example.com/some/path')
+                mockURLGetter.mockReturnValue('')
+                // arrange
+                const { posthog, onCapture } = setup({
+                    referring_domain_denylist: [/^(.*\.)?example\.com/],
+                })
+
+                // act
+                posthog.capture(eventName, eventProperties)
+
+                // assert
+                const { $set_once, properties } = onCapture.mock.calls[0][1]
+                expect($set_once['$initial_referrer']).toBe('$direct')
+                expect($set_once['$initial_referring_domain']).toBe('$direct')
+                expect(properties['$referrer']).toBe('$direct')
+                expect(properties['$referring_domain']).toBe('$direct')
             })
         })
     })

--- a/src/__tests__/utils/utils.test.ts
+++ b/src/__tests__/utils/utils.test.ts
@@ -1,0 +1,18 @@
+import { some } from '../../utils'
+
+describe('utils/index', () => {
+    describe('some', () => {
+        it('should iterate over an array', () => {
+            expect(some([1, 2, 3], (x) => x === 2)).toBe(true)
+            expect(some([1, 2, 3], (x) => x === 4)).toBe(false)
+        })
+        it('should short circuit when a match is found', () => {
+            const spy = jest.fn()
+            some([1, 2, 3], (x) => {
+                spy()
+                return x === 2
+            })
+            expect(spy).toHaveBeenCalledTimes(2)
+        })
+    })
+})

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -129,6 +129,7 @@ export const defaultConfig = (): PostHogConfig => ({
     custom_campaign_params: [],
     custom_blocked_useragents: [],
     save_referrer: true,
+    referring_domain_denylist: [],
     capture_pageview: true,
     capture_pageleave: 'if_capture_pageview', // We'll only capture pageleave events if capture_pageview is also true
     debug: (location && isString(location?.search) && location.search.indexOf('__posthog_debug=true') !== -1) || false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,7 @@ export interface PostHogConfig {
     // defaults to the empty array
     custom_blocked_useragents: string[]
     save_referrer: boolean
+    referring_domain_denylist: (string | RegExp)[]
     verbose: boolean
     capture_pageview: boolean
     capture_pageleave: boolean | 'if_capture_pageview'

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -16,6 +16,7 @@ const global: typeof globalThis | undefined = typeof globalThis !== 'undefined' 
 export const ArrayProto = Array.prototype
 export const nativeForEach = ArrayProto.forEach
 export const nativeIndexOf = ArrayProto.indexOf
+export const nativeSome = ArrayProto.some
 
 export const navigator = global?.navigator
 export const document = global?.document

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 import { Breaker, EventHandler, Properties } from '../types'
 import { isArray, isFormData, isFunction, isNull, isNullish, isString, hasOwnProperty } from './type-utils'
 import { logger } from './logger'
-import { window, nativeForEach, nativeIndexOf } from './globals'
+import { window, nativeForEach, nativeIndexOf, nativeSome } from './globals'
 
 const breaker: Breaker = {}
 
@@ -56,6 +56,22 @@ export function each(obj: any, iterator: (value: any, key: any) => void | Breake
             }
         }
     }
+}
+
+export function some<T>(obj: T[], f: (value: T, i: number, arr: T[]) => boolean) {
+    if (obj && nativeSome && obj.some === nativeSome) {
+        return obj.some(f)
+    }
+
+    let result = false
+    // @ts-expect-error The iterator function should have a final `return` to stop TS complaining, but that's extra bundle size that serves no actual purpose
+    eachArray(obj, function (value, i) {
+        if (f(value, i, obj)) {
+            result = true
+            return breaker
+        }
+    })
+    return result
 }
 
 export const extend = function (obj: Record<string, any>, ...args: Record<string, any>[]): Record<string, any> {


### PR DESCRIPTION
## Changes
Add a config option where people can pass domains (as string or regex) that posthog will ignore when it comes to setting the referring domain.

When the referrer is an ignored domain, we don't update the stored referrer. When the very first referrer is an ignored domain, we treat it as direct traffic.

For backwards compatibility, the list of ignored domains is empty by default. We may want to consider always adding the current domain to this list, but this is out of scope for this PR.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
