### PR TITLE
fix: Fix the referrer changing mid-session

### DIFF
--- a/src/__tests__/posthog-core.test.ts
+++ b/src/__tests__/posthog-core.test.ts
@@ -108,7 +108,6 @@ describe('posthog core', () => {
                 // arrange
                 const token = uuidv7()
                 mockReferrerGetter.mockReturnValue('https://referrer.example.com/some/path')
-                mockURLGetter.mockReturnValue('')
                 const { posthog, onCapture } = setup({
                     token,
                     persistence_name: token,
@@ -129,7 +128,6 @@ describe('posthog core', () => {
                 // arrange
                 const token = uuidv7()
                 mockReferrerGetter.mockReturnValue('https://referrer1.example.com/some/path')
-                mockURLGetter.mockReturnValue('')
                 const { posthog: posthog1 } = setup({
                     token,
                     persistence_name: token,
@@ -160,7 +158,6 @@ describe('posthog core', () => {
                 // arrange
                 const token = uuidv7()
                 mockReferrerGetter.mockReturnValue('https://referrer1.example.com/some/path')
-                mockURLGetter.mockReturnValue('')
                 const { posthog: posthog1 } = setup({
                     token,
                     persistence_name: token,
@@ -185,6 +182,26 @@ describe('posthog core', () => {
                 expect($set_once['$initial_referring_domain']).toBe('referrer1.example.com')
                 expect(properties['$referrer']).toBe('https://referrer2.example.com/some/path')
                 expect(properties['$referring_domain']).toBe('referrer2.example.com')
+            })
+
+            it('should use $direct when there is no referrer', () => {
+                // arrange
+                const token = uuidv7()
+                mockReferrerGetter.mockReturnValue('')
+                const { posthog, onCapture } = setup({
+                    token,
+                    persistence_name: token,
+                })
+
+                // act
+                posthog.capture(eventName, eventProperties)
+
+                // assert
+                const { $set_once, properties } = onCapture.mock.calls[0][1]
+                expect($set_once['$initial_referrer']).toBe('$direct')
+                expect($set_once['$initial_referring_domain']).toBe('$direct')
+                expect(properties['$referrer']).toBe('$direct')
+                expect(properties['$referring_domain']).toBe('$direct')
             })
         })
     })

--- a/src/__tests__/posthog-core.test.ts
+++ b/src/__tests__/posthog-core.test.ts
@@ -1,16 +1,48 @@
-import { PostHogConfig } from '../types'
-import { uuidv7 } from '../uuidv7'
 import { defaultPostHog } from './helpers/posthog-instance'
+import type { PostHogConfig } from '../types'
+import { uuidv7 } from '../uuidv7'
+
+const mockReferrerGetter = jest.fn()
+const mockURLGetter = jest.fn()
+jest.mock('../utils/globals', () => {
+    const orig = jest.requireActual('../utils/globals')
+    return {
+        ...orig,
+        document: {
+            ...orig.document,
+            createElement: (...args: any[]) => orig.document.createElement(...args),
+            get referrer() {
+                return mockReferrerGetter?.()
+            },
+            get URL() {
+                return mockURLGetter?.()
+            },
+        },
+        get location() {
+            const url = mockURLGetter?.()
+            return {
+                href: url,
+                toString: () => url,
+            }
+        },
+    }
+})
 
 describe('posthog core', () => {
+    beforeEach(() => {
+        mockReferrerGetter.mockReturnValue('https://referrer.com')
+        mockURLGetter.mockReturnValue('https://example.com')
+        console.error = jest.fn()
+    })
+
     describe('capture()', () => {
         const eventName = 'custom_event'
-        const properties = {
+        const eventProperties = {
             event: 'prop',
         }
-        const setup = (config: Partial<PostHogConfig> = {}) => {
+        const setup = (config: Partial<PostHogConfig> = {}, token: string = uuidv7()) => {
             const onCapture = jest.fn()
-            const posthog = defaultPostHog().init('testtoken', { ...config, _onCapture: onCapture }, uuidv7())!
+            const posthog = defaultPostHog().init(token, { ...config, _onCapture: onCapture }, token)!
             posthog.debug()
             return { posthog, onCapture }
         }
@@ -23,7 +55,7 @@ describe('posthog core', () => {
             })
 
             // act
-            const actual = posthog._calculate_event_properties(eventName, properties)
+            const actual = posthog._calculate_event_properties(eventName, eventProperties)
 
             // assert
             expect(actual['event']).toBe('prop')
@@ -37,7 +69,7 @@ describe('posthog core', () => {
             it('includes information about remaining rate limit', () => {
                 const { posthog, onCapture } = setup()
 
-                posthog.capture(eventName, properties)
+                posthog.capture(eventName, eventProperties)
 
                 expect(onCapture.mock.calls[0][1]).toMatchObject({
                     properties: {
@@ -52,20 +84,107 @@ describe('posthog core', () => {
 
                 console.error = jest.fn()
                 const { posthog, onCapture } = setup()
-
                 for (let i = 0; i < 100; i++) {
-                    posthog.capture(eventName, properties)
+                    posthog.capture(eventName, eventProperties)
                 }
                 expect(onCapture).toHaveBeenCalledTimes(100)
                 onCapture.mockClear()
                 ;(console.error as any).mockClear()
-                posthog.capture(eventName, properties)
-                expect(onCapture.mock.calls).toEqual([])
-                expect(console.error).toHaveBeenCalledTimes(1)
+                for (let i = 0; i < 50; i++) {
+                    posthog.capture(eventName, eventProperties)
+                }
+                expect(onCapture).toHaveBeenCalledTimes(1)
+                expect(onCapture.mock.calls[0][0]).toBe('$$client_ingestion_warning')
+                expect(console.error).toHaveBeenCalledTimes(50)
                 expect(console.error).toHaveBeenCalledWith(
                     '[PostHog.js]',
                     'This capture call is ignored due to client rate limiting.'
                 )
+            })
+        })
+
+        describe('referrer', () => {
+            it("should send referrer info with the event's properties", () => {
+                // arrange
+                const token = uuidv7()
+                mockReferrerGetter.mockReturnValue('https://referrer.example.com/some/path')
+                mockURLGetter.mockReturnValue('')
+                const { posthog, onCapture } = setup({
+                    token,
+                    persistence_name: token,
+                })
+
+                // act
+                posthog.capture(eventName, eventProperties)
+
+                // assert
+                const { $set_once, properties } = onCapture.mock.calls[0][1]
+                expect($set_once['$initial_referrer']).toBe('https://referrer.example.com/some/path')
+                expect($set_once['$initial_referring_domain']).toBe('referrer.example.com')
+                expect(properties['$referrer']).toBe('https://referrer.example.com/some/path')
+                expect(properties['$referring_domain']).toBe('referrer.example.com')
+            })
+
+            it('should not update the referrer within the same session', () => {
+                // arrange
+                const token = uuidv7()
+                mockReferrerGetter.mockReturnValue('https://referrer1.example.com/some/path')
+                mockURLGetter.mockReturnValue('')
+                const { posthog: posthog1 } = setup({
+                    token,
+                    persistence_name: token,
+                })
+                posthog1.capture(eventName, eventProperties)
+                mockReferrerGetter.mockReturnValue('https://referrer2.example.com/some/path')
+                const { posthog: posthog2, onCapture: onCapture2 } = setup({
+                    token,
+                    persistence_name: token,
+                })
+
+                // act
+                posthog2.capture(eventName, eventProperties)
+
+                // assert
+                expect(posthog2.persistence!.props.$initial_person_info.r).toEqual(
+                    'https://referrer1.example.com/some/path'
+                )
+                expect(posthog2.sessionPersistence!.props.$referrer).toEqual('https://referrer1.example.com/some/path')
+                const { $set_once, properties } = onCapture2.mock.calls[0][1]
+                expect($set_once['$initial_referrer']).toBe('https://referrer1.example.com/some/path')
+                expect($set_once['$initial_referring_domain']).toBe('referrer1.example.com')
+                expect(properties['$referrer']).toBe('https://referrer1.example.com/some/path')
+                expect(properties['$referring_domain']).toBe('referrer1.example.com')
+            })
+
+            it('should use the new referrer in a new session', () => {
+                // arrange
+                const token = uuidv7()
+                mockReferrerGetter.mockReturnValue('https://referrer1.example.com/some/path')
+                mockURLGetter.mockReturnValue('')
+                const { posthog: posthog1 } = setup({
+                    token,
+                    persistence_name: token,
+                })
+                posthog1.capture(eventName, eventProperties)
+                mockReferrerGetter.mockReturnValue('https://referrer2.example.com/some/path')
+                const { posthog: posthog2, onCapture: onCapture2 } = setup({
+                    token,
+                    persistence_name: token,
+                })
+                posthog2.sessionPersistence!.clear() // simulate a new session
+
+                // act
+                posthog2.capture(eventName, eventProperties)
+
+                // assert
+                expect(posthog2.persistence!.props.$initial_person_info.r).toEqual(
+                    'https://referrer1.example.com/some/path'
+                )
+                const { $set_once, properties } = onCapture2.mock.calls[0][1]
+                expect($set_once['$initial_referrer']).toBe('https://referrer1.example.com/some/path')
+                expect($set_once['$initial_referring_domain']).toBe('referrer1.example.com')
+                expect(properties['$referrer']).toBe('https://referrer2.example.com/some/path')
+                expect(properties['$referring_domain']).toBe('referrer2.example.com')
             })
         })
     })

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -227,7 +227,7 @@ export class PostHogPersistence {
     }
 
     update_referrer_info(): void {
-        this.register(Info.referrerInfo())
+        this.register_once(Info.referrerInfo(), undefined)
     }
 
     set_initial_person_info(): void {


### PR DESCRIPTION
## Changes

As part of the personless event changes, we accidentally introduced a bug where the referrer could change mid-session. This shouldn't happen, and led to some annoying situation where e.g. if a payments workflow navigated people to checkout.stripe.com and then back to the original site, the referrer would switch to stripe, which meant that any events after that couldn't be attributed to the original referrer.

This fixes that bug, and adds some tests.

(P.S. I realised how this was broken when working on https://github.com/PostHog/posthog-js/pull/1313, IMO with this fix merged that PR becomes a lot less useful)

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
