### PR TITLE
chore: fix the rollup bundle visualiser output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ react/dist
 test-result.json
 yarn-error.log
 stats.html
+bundle-stats*.html
 .eslintcache
 cypress/downloads/downloads.html

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,14 +18,14 @@ const plugins = [
         presets: ['@babel/preset-env'],
     }),
     terser({ toplevel: true }),
-    visualizer(),
 ]
 
 /** @type {import('rollup').RollupOptions[]} */
 
 const entrypoints = fs.readdirSync('./src/entrypoints').map((file) => {
     const fileParts = file.split('.')
-    const extension = fileParts.pop()
+    // pop the extension
+    fileParts.pop()
 
     let format = fileParts[fileParts.length - 1]
     // NOTE: Sadly we can't just use the file extensions as tsc won't compile things correctly
@@ -37,6 +37,8 @@ const entrypoints = fs.readdirSync('./src/entrypoints').map((file) => {
 
     const fileName = fileParts.join('.')
 
+    // we're allowed to console log in this file :)
+    // eslint-disable-next-line no-console
     console.log(`Building ${fileName} in ${format} format`)
     return {
         input: `src/entrypoints/${file}`,
@@ -56,7 +58,7 @@ const entrypoints = fs.readdirSync('./src/entrypoints').map((file) => {
                 ...(format === 'cjs' ? { exports: 'auto' } : {}),
             },
         ],
-        plugins: [...plugins],
+        plugins: [...plugins, visualizer({ filename: `bundle-stats-${fileName}.html` })],
     }
 })
 


### PR DESCRIPTION
When we last changed the rollup bundling - I think - we started writing a bundle file for each entrypoint but all with the same name

I think I'm the only person that uses this but I do use it, so this changes to output a file for every bundle with its own name.

We can use this primarily to see what is causing array.js to grow but can also then dig into each of the bundles if we need to