### PR TITLE
fix: Array.from override

### DIFF
--- a/patches/rrweb@2.0.0-alpha.13.patch
+++ b/patches/rrweb@2.0.0-alpha.13.patch
@@ -224,9 +224,18 @@ index da2c103fe6b1408a5996f0eb3bf047571e434cc2..f5b060c7e0728a3e2c6cf62b01d97282
                  }, [bitmap]);
              }));
 diff --git a/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js b/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
-index 0fc7d4bcafc9be822347f9437658478fd77d9972..5dcd1dcbd5380567110378269f3bc8d7b7ca6440 100644
+index 0fc7d4bcafc9be822347f9437658478fd77d9972..bb4114b638b7d1173ef50b639a58de7d707c474f 100644
 --- a/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
 +++ b/es/rrweb/packages/rrweb-snapshot/es/rrweb-snapshot.js
+@@ -48,7 +48,7 @@ function stringifyStylesheet(s) {
+     try {
+         const rules = s.rules || s.cssRules;
+         return rules
+-            ? fixBrowserCompatibilityIssuesInCSS(Array.from(rules, stringifyRule).join(''))
++            ? fixBrowserCompatibilityIssuesInCSS(Array.from(rules).map(stringifyRule).join(''))
+             : null;
+     }
+     catch (error) {
 @@ -641,9 +641,18 @@ function serializeElementNode(n, options) {
          }
      }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   rrweb@2.0.0-alpha.13:
-    hash: zfkdpmdytjgvxaxif5jxg5ibpy
+    hash: hd3nuwqin7sbif7quehqsiwvzm
     path: patches/rrweb@2.0.0-alpha.13.patch
 
 dependencies:
@@ -191,7 +191,7 @@ devDependencies:
     version: 5.12.0(rollup@4.9.6)
   rrweb:
     specifier: 2.0.0-alpha.13
-    version: 2.0.0-alpha.13(patch_hash=zfkdpmdytjgvxaxif5jxg5ibpy)
+    version: 2.0.0-alpha.13(patch_hash=hd3nuwqin7sbif7quehqsiwvzm)
   rrweb-snapshot:
     specifier: 2.0.0-alpha.13
     version: 2.0.0-alpha.13
@@ -9319,7 +9319,7 @@ packages:
     resolution: {integrity: sha512-slbhNBCYjxLGCeH95a67ECCy5a22nloXp1F5wF7DCzUNw80FN7tF9Lef1sRGLNo32g3mNqTc2sWLATlKejMxYw==}
     dev: true
 
-  /rrweb@2.0.0-alpha.13(patch_hash=zfkdpmdytjgvxaxif5jxg5ibpy):
+  /rrweb@2.0.0-alpha.13(patch_hash=hd3nuwqin7sbif7quehqsiwvzm):
     resolution: {integrity: sha512-a8GXOCnzWHNaVZPa7hsrLZtNZ3CGjiL+YrkpLo0TfmxGLhjNZbWY2r7pE06p+FcjFNlgUVTmFrSJbK3kO7yxvw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.13


### PR DESCRIPTION
## Changes

Some frameworks override the second argument of `Array.from`. A customer reported an issue where their stylesheets were not correctly parsed because of this. Changing to use `Array.from` with one argument followed by `.map` with the applied function 

This has been fixed in the `alpha-14` release of rrweb: https://github.com/rrweb-io/rrweb/pull/1464. We're currently on `alpha-13` and are blocked on upgrading to `alpha-16` because of some typing issues.
We could upgrade to `alpha-14` but the effort of reapplying all our old patches probably isn't worth it. It's much easier to just add this one

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
