### PR TITLE
feat(flags): give users the ability to suppress override warning logs, if desired

### DIFF
--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -293,22 +293,25 @@ export class PostHogFeatureFlags {
     }
 
     /*
-     * Override feature flags for debugging.
+     * Override feature flags on the client-side.  Useful for setting non-persistent feature flags, or for testing/debugging
+     * feature flags in the PostHog app.
      *
      * ### Usage:
      *
      *     - posthog.feature_flags.override(false)
      *     - posthog.feature_flags.override(['beta-feature'])
-     *     - posthog.feature_flags.override({'beta-feature': 'variant', 'other-feature': True})
+     *     - posthog.feature_flags.override({'beta-feature': 'variant', 'other-feature': true})
+     *     - posthog.feature_flags.override({'beta-feature': 'variant'}, true) // Suppress warning log
      *
      * @param {Object|Array|String} flags Flags to override with.
+     * @param {boolean} [suppressWarning=false] Optional parameter to suppress the override warning.
      */
-    override(flags: boolean | string[] | Record<string, string | boolean>): void {
+    override(flags: boolean | string[] | Record<string, string | boolean>, suppressWarning: boolean = false): void {
         if (!this.instance.__loaded || !this.instance.persistence) {
             return logger.uninitializedWarning('posthog.feature_flags.override')
         }
 
-        this._override_warning = false
+        this._override_warning = suppressWarning
 
         if (flags === false) {
             this.instance.persistence.unregister(PERSISTENCE_OVERRIDE_FEATURE_FLAGS)


### PR DESCRIPTION
## Changes

We've supported manually overriding feature flag values in the client for years (and our toolbar [natively supports it](https://posthog.com/docs/toolbar/override-feature-flags)), but since this override doesn't persist to the backend, we've historically always just treated this feature as a debug feature only.  However, there's been a influx of support requests (on both Twitter and in our support inbox) that are asking about this feature, and one user explicitly mentioned that the feature [would be perfect for his use case if it weren't for the debug warning and logs](https://posthoghelp.zendesk.com/agent/tickets/15724).  I started a [discussion about this in Slack](https://posthog.slack.com/archives/C034XD440RK/p1722281920032039), and if we decide that it's safe to give users the ability to remove these logs, this PR enables it.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
