### PR TITLE
feat: Add debug logic for set_config

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1733,6 +1733,11 @@ export class PostHog {
             }
             if (this.config.debug) {
                 Config.DEBUG = true
+                logger.info('set_config', {
+                    config,
+                    oldConfig,
+                    newConfig: { ...this.config },
+                })
             }
 
             this.sessionRecording?.startIfEnabledOrStop()

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -430,8 +430,10 @@ export class PostHog {
         // global debug to be true
         Config.DEBUG = Config.DEBUG || this.config.debug
         if (Config.DEBUG) {
-            // eslint-disable-next-line no-console
-            console.log('[PostHog.js] Starting in debug mode', this)
+            logger.info('Starting in debug mode', {
+                this: this,
+                config: { ...this.config },
+            })
         }
 
         this._sync_opt_out_with_persistence()

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -60,6 +60,9 @@ export class PostHogPersistence {
         this.name = parseName(config)
         this.storage = this.buildStorage(config)
         this.load()
+        if (config.debug) {
+            logger.info('Persistence loaded', this.props)
+        }
         this.update_config(config, config)
         this.save()
     }


### PR DESCRIPTION
## Changes

I'm trying to help a customer debug a problem with their setup, and it's hard to do remotely without access to their source code. I figured this might help me.

## Checklist
~Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))~ n/a as long as existing tests pass
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
