### PR TITLE
fix(surveys): Accept eventPayload in onEvent handler

### DIFF
--- a/src/__tests__/utils/survey-event-receiver.test.ts
+++ b/src/__tests__/utils/survey-event-receiver.test.ts
@@ -106,19 +106,26 @@ describe('survey-event-receiver', () => {
         it('receiver activates survey on event', () => {
             const surveyEventReceiver = new SurveyEventReceiver(instance)
             surveyEventReceiver.register(surveysWithEvents)
-            surveyEventReceiver.onEvent('billing_changed')
+            const registeredHook = instance._addCaptureHook.mock.calls[0][0]
+            registeredHook('billing_changed')
             const activatedSurveys = surveyEventReceiver.getSurveys()
             expect(activatedSurveys).toContain('first-survey')
         })
 
         it('receiver removes survey from list after its shown', () => {
             const surveyEventReceiver = new SurveyEventReceiver(instance)
+            const firstSurvey = surveysWithEvents[0]
+            if (firstSurvey.conditions && firstSurvey.conditions?.events) {
+                firstSurvey.conditions.events.repeatedActivation = true
+            }
+
             surveyEventReceiver.register(surveysWithEvents)
-            surveyEventReceiver.onEvent('billing_changed')
+            const registeredHook = instance._addCaptureHook.mock.calls[0][0]
+            registeredHook('billing_changed')
             const activatedSurveys = surveyEventReceiver.getSurveys()
             expect(activatedSurveys).toContain('first-survey')
 
-            surveyEventReceiver.onEvent('survey shown', {
+            registeredHook('survey shown', {
                 $set: undefined,
                 $set_once: undefined,
                 event: 'survey shown',
@@ -135,25 +142,28 @@ describe('survey-event-receiver', () => {
         it('receiver activates same survey on multiple event', () => {
             const surveyEventReceiver = new SurveyEventReceiver(instance)
             surveyEventReceiver.register(surveysWithEvents)
-            surveyEventReceiver.onEvent('billing_changed')
+            const registeredHook = instance._addCaptureHook.mock.calls[0][0]
+            registeredHook('billing_changed')
             expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
-            surveyEventReceiver.onEvent('billing_removed')
+            registeredHook('billing_removed')
             expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
         })
 
         it('receiver activates multiple surveys on same event', () => {
             const surveyEventReceiver = new SurveyEventReceiver(instance)
             surveyEventReceiver.register(surveysWithEvents)
-            surveyEventReceiver.onEvent('user_subscribed')
+            const registeredHook = instance._addCaptureHook.mock.calls[0][0]
+            registeredHook('user_subscribed')
             expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey', 'third-survey'])
         })
 
         it('receiver activates multiple surveys on different events', () => {
             const surveyEventReceiver = new SurveyEventReceiver(instance)
             surveyEventReceiver.register(surveysWithEvents)
-            surveyEventReceiver.onEvent('billing_changed')
+            const registeredHook = instance._addCaptureHook.mock.calls[0][0]
+            registeredHook('billing_changed')
             expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey'])
-            surveyEventReceiver.onEvent('address_changed')
+            registeredHook('address_changed')
             expect(surveyEventReceiver.getSurveys()).toEqual(['first-survey', 'third-survey'])
         })
     })

--- a/src/utils/survey-event-receiver.ts
+++ b/src/utils/survey-event-receiver.ts
@@ -88,8 +88,8 @@ export class SurveyEventReceiver {
         }
 
         // match any events to its corresponding survey.
-        const matchEventToSurvey = (eventName: string) => {
-            this.onEvent(eventName)
+        const matchEventToSurvey = (eventName: string, eventPayload?: CaptureResult) => {
+            this.onEvent(eventName, eventPayload)
         }
         this.instance?._addCaptureHook(matchEventToSurvey)
 


### PR DESCRIPTION
## Changes

This is a bug fix for the scenario where we weren't removing a survey from the activated surveys list once the survey is shown.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
