### PR TITLE
feat: Add debug logging for the initial props that posthog was started with

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -397,8 +397,8 @@ export class PostHog {
             this.config.persistence === 'sessionStorage'
                 ? this.persistence
                 : new PostHogPersistence({ ...this.config, persistence: 'sessionStorage' })
-        const initialPersistenceProps = this.persistence.props
-        const initialSessionProps = this.sessionPersistence.props
+        const initialPersistenceProps = { ...this.persistence.props }
+        const initialSessionProps = { ...this.sessionPersistence.props }
 
         this._requestQueue = new RequestQueue((req) => this._send_retriable_request(req))
         this._retryQueue = new RetryQueue(this)

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -397,6 +397,8 @@ export class PostHog {
             this.config.persistence === 'sessionStorage'
                 ? this.persistence
                 : new PostHogPersistence({ ...this.config, persistence: 'sessionStorage' })
+        const initialPersistenceProps = this.persistence.props
+        const initialSessionProps = this.sessionPersistence.props
 
         this._requestQueue = new RequestQueue((req) => this._send_retriable_request(req))
         this._retryQueue = new RetryQueue(this)
@@ -432,7 +434,10 @@ export class PostHog {
         if (Config.DEBUG) {
             logger.info('Starting in debug mode', {
                 this: this,
-                config: { ...this.config },
+                config,
+                thisC: { ...this.config },
+                p: initialPersistenceProps,
+                s: initialSessionProps,
             })
         }
 

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -61,7 +61,7 @@ export class PostHogPersistence {
         this.storage = this.buildStorage(config)
         this.load()
         if (config.debug) {
-            logger.info('Persistence loaded', this.props)
+            logger.info('Persistence loaded', config['persistence'], this.props)
         }
         this.update_config(config, config)
         this.save()

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -61,7 +61,7 @@ export class PostHogPersistence {
         this.storage = this.buildStorage(config)
         this.load()
         if (config.debug) {
-            logger.info('Persistence loaded', config['persistence'], this.props)
+            logger.info('Persistence loaded', config['persistence'], { ...this.props })
         }
         this.update_config(config, config)
         this.save()


### PR DESCRIPTION
## Changes

I'm debugging things for this customer: https://posthog.slack.com/archives/C05LJK1N3CP/p1720719062387739

I've established that the cross domain cookie is being successfully read from on the second site, but that we are ignoring the values. I'm hoping this extra debugging will help

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
