### PR TITLE
feat(surveys): added a customizable submit button text color

### DIFF
--- a/src/extensions/surveys/components/BottomSection.tsx
+++ b/src/extensions/surveys/components/BottomSection.tsx
@@ -20,7 +20,9 @@ export function BottomSection({
     link?: string | null
 }) {
     const { isPreviewMode, isPopup } = useContext(SurveyContext)
-    const textColor = getContrastingTextColor(appearance.submitButtonColor || defaultSurveyAppearance.submitButtonColor)
+    const textColor =
+        appearance.submitButtonTextColor ||
+        getContrastingTextColor(appearance.submitButtonColor || defaultSurveyAppearance.submitButtonColor)
     return (
         <div className="bottom-section">
             <div className="buttons">

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -499,6 +499,7 @@ export function getTextColor(el: HTMLElement) {
 export const defaultSurveyAppearance: SurveyAppearance = {
     backgroundColor: '#eeeded',
     submitButtonColor: 'black',
+    submitButtonTextColor: 'white',
     ratingButtonColor: 'white',
     ratingButtonActiveColor: 'black',
     borderColor: '#c9c6c6',

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -12,6 +12,7 @@ export interface SurveyAppearance {
     textColor?: string
     // deprecate submit button text eventually
     submitButtonText?: string
+    submitButtonTextColor?: string
     descriptionTextColor?: string
     ratingButtonColor?: string
     ratingButtonActiveColor?: string


### PR DESCRIPTION
## Changes

[Hospitable asked for this](https://posthog.slack.com/archives/C074A08LP1B/p1722508627577449), and it was super easy to do.  Feels worth it.

Ships with the UI controls here: https://github.com/PostHog/posthog/pull/24170
