### PR TITLE
fix(surveys): textarea border box was being set in the preview but not in the surveys rendered on user websites

### DIFF
--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -67,6 +67,7 @@ export const style = (appearance: SurveyAppearance | null) => {
               border-color: ${appearance?.borderColor || '#c9c6c6'};
               margin-top: 14px;
               width: 100%;
+              box-sizing: border-box;
           }
           .survey-box:has(.survey-question:empty):not(:has(.survey-question-description)) textarea {
               margin-top: 0;


### PR DESCRIPTION
## Changes

Issue identified here: https://posthog.slack.com/archives/C074A08LP1B/p1722845257000019?thread_ts=1722508627.577449&cid=C074A08LP1B

This issue came from me trying to fix the textarea size for free response surveys.  My fix made the survey preview rendering work correctly, but it was too wide for the popover rendering (which is more important; that's the thing the end users see!)

Before: 

![image](https://github.com/user-attachments/assets/cef328b0-df5f-4723-a845-279e24f5f885)

and

<img width="351" alt="Screenshot 2024-08-05 at 7 31 55 AM" src="https://github.com/user-attachments/assets/4d7ddd98-1a18-4d99-b21b-1e876e3abb8e">


I fixed this to add an explicit border box into the textarea.  In the preview, it was inheriting a border box already, so this wasn't a problem, but since the rendered survey has a different DOM tree, with different stylings, it didn't work for end users.

This fix should work for both.

After (on page):

<img width="301" alt="Screenshot 2024-08-05 at 7 47 27 AM" src="https://github.com/user-attachments/assets/42149280-dc0c-4d6d-a976-f0e9cd5528a9">

After (in preview section):

<img width="883" alt="image" src="https://github.com/user-attachments/assets/c16da302-8bc7-47be-903a-63837c3d04a6">

