### PR TITLE
feat: Remove storage logging and add reset logging

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1467,6 +1467,7 @@ export class PostHog {
      * Useful for clearing data when a user logs out.
      */
     reset(reset_device_id?: boolean): void {
+        logger.info('reset')
         if (!this.__loaded) {
             return logger.uninitializedWarning('posthog.reset')
         }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -124,7 +124,7 @@ export const cookieStore: PersistentStore = {
         return cookie
     },
 
-    set: function (name, value, days, cross_subdomain, is_secure, debug) {
+    set: function (name, value, days, cross_subdomain, is_secure) {
         if (!document) {
             return
         }
@@ -156,10 +156,6 @@ export const cookieStore: PersistentStore = {
             // 4096 bytes is the size at which some browsers (e.g. firefox) will not store a cookie, warn slightly before that
             if (new_cookie_val.length > 4096 * 0.9) {
                 logger.warn('cookieStore warning: large cookie, len=' + new_cookie_val.length)
-            }
-
-            if (debug) {
-                logger.info('cookie set', new_cookie_val)
             }
 
             document.cookie = new_cookie_val
@@ -232,11 +228,8 @@ export const localStore: PersistentStore = {
         return null
     },
 
-    set: function (name, value, _days, _cross_subdomain, _secure, debug) {
+    set: function (name, value) {
         try {
-            if (debug) {
-                logger.info('localStorage set', name, value)
-            }
             window?.localStorage.setItem(name, JSON.stringify(value))
         } catch (err) {
             localStore.error(err)
@@ -383,11 +376,8 @@ export const sessionStore: PersistentStore = {
         return null
     },
 
-    set: function (name, value, _days, _cross_subdomain, _secure, debug) {
+    set: function (name, value) {
         try {
-            if (debug) {
-                logger.info('sessionStorage set', name, value)
-            }
             window?.sessionStorage.setItem(name, JSON.stringify(value))
         } catch (err) {
             sessionStore.error(err)


### PR DESCRIPTION
## Changes
Add the reset logging to help debug things for this customer: https://posthog.slack.com/archives/C05LJK1N3CP/p1722882994008479?thread_ts=1720719062.387739&cid=C05LJK1N3CP

Remove the persistence logging because it's a bit noisy: https://posthog.slack.com/archives/C0113360FFV/p1722615914056199

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
