### PR TITLE
fix(surveys): style the link button with black text

### DIFF
--- a/src/extensions/surveys/components/PostHogLogo.tsx
+++ b/src/extensions/surveys/components/PostHogLogo.tsx
@@ -1,8 +1,17 @@
 import { IconPosthogLogo } from '../icons'
+// import { getContrastingTextColor } from '../surveys-utils'
 
 export function PostHogLogo() {
+    // const textColor = getContrastingTextColor(backgroundColor)
+
     return (
-        <a href="https://posthog.com" target="_blank" rel="noopener" className="footer-branding">
+        <a
+            href="https://posthog.com"
+            target="_blank"
+            rel="noopener"
+            // style={{ backgroundColor: backgroundColor, color: textColor }}
+            className="footer-branding"
+        >
             Survey by {IconPosthogLogo}
         </a>
     )

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -133,6 +133,8 @@ export const style = (appearance: SurveyAppearance | null) => {
               font-weight: 500;
               background: ${appearance?.backgroundColor || '#eeeded'};
               text-decoration: none;
+              backgroundColor: ${appearance?.backgroundColor || '#eeeded'};
+              color: ${getContrastingTextColor(appearance?.backgroundColor || '#eeeded')};
           }
           .survey-question {
               font-weight: 500;


### PR DESCRIPTION
## Changes

We accidentally reverted the link text styling [with this change](https://github.com/PostHog/posthog-js/pull/1324/files#diff-84b57d5feee425d7e792147602981722b4b81e77179589037baa80f219d421daL8-L15), and it led to a link [that looked bad](https://posthog.slack.com/archives/C034XD440RK/p1722876370834339)

![image](https://github.com/user-attachments/assets/85aa3b06-00a8-49e7-b8d4-c6a19663eee3)

this change moves the styling into the CSS itself (rather than as part of a component), and that seemed to fix it

app

<img width="358" alt="image" src="https://github.com/user-attachments/assets/096d3c83-2887-43cb-976e-83783f5795d3">

popup

<img width="322" alt="image" src="https://github.com/user-attachments/assets/c82b8dda-26ba-4c31-a06a-02c9d331e684">

