### PR TITLE
feat: Add prev pageview duration

### DIFF
--- a/src/__tests__/page-view.test.ts
+++ b/src/__tests__/page-view.test.ts
@@ -11,6 +11,10 @@ jest.mock('../utils/globals', () => ({
 }))
 
 describe('PageView ID manager', () => {
+    const firstTimestamp = new Date()
+    const duration = 42
+    const secondTimestamp = new Date(firstTimestamp.getTime() + duration * 1000)
+
     describe('doPageView', () => {
         let instance: PostHog
         let pageViewIdManager: PageViewManager
@@ -51,12 +55,12 @@ describe('PageView ID manager', () => {
                 },
             })
 
-            pageViewIdManager.doPageView()
+            pageViewIdManager.doPageView(firstTimestamp)
 
             // force the manager to update the scroll data by calling an internal method
             instance.scrollManager['_updateScrollData']()
 
-            const secondPageView = pageViewIdManager.doPageView()
+            const secondPageView = pageViewIdManager.doPageView(secondTimestamp)
             expect(secondPageView.$prev_pageview_last_scroll).toEqual(2000)
             expect(secondPageView.$prev_pageview_last_scroll_percentage).toBeCloseTo(2 / 3)
             expect(secondPageView.$prev_pageview_max_scroll).toEqual(2000)
@@ -65,6 +69,7 @@ describe('PageView ID manager', () => {
             expect(secondPageView.$prev_pageview_last_content_percentage).toBeCloseTo(3 / 4)
             expect(secondPageView.$prev_pageview_max_content).toEqual(3000)
             expect(secondPageView.$prev_pageview_max_content_percentage).toBeCloseTo(3 / 4)
+            expect(secondPageView.$prev_pageview_duration).toEqual(duration)
         })
 
         it('includes scroll position properties for a short page', () => {
@@ -81,12 +86,12 @@ describe('PageView ID manager', () => {
                 },
             })
 
-            pageViewIdManager.doPageView()
+            pageViewIdManager.doPageView(firstTimestamp)
 
             // force the manager to update the scroll data by calling an internal method
             instance.scrollManager['_updateScrollData']()
 
-            const secondPageView = pageViewIdManager.doPageView()
+            const secondPageView = pageViewIdManager.doPageView(secondTimestamp)
             expect(secondPageView.$prev_pageview_last_scroll).toEqual(0)
             expect(secondPageView.$prev_pageview_last_scroll_percentage).toEqual(1)
             expect(secondPageView.$prev_pageview_max_scroll).toEqual(0)
@@ -95,22 +100,23 @@ describe('PageView ID manager', () => {
             expect(secondPageView.$prev_pageview_last_content_percentage).toEqual(1)
             expect(secondPageView.$prev_pageview_max_content).toEqual(1000)
             expect(secondPageView.$prev_pageview_max_content_percentage).toEqual(1)
+            expect(secondPageView.$prev_pageview_duration).toEqual(duration)
         })
 
         it('can handle scroll updates before doPageView is called', () => {
             instance.scrollManager['_updateScrollData']()
-            const firstPageView = pageViewIdManager.doPageView()
+            const firstPageView = pageViewIdManager.doPageView(firstTimestamp)
             expect(firstPageView.$prev_pageview_last_scroll).toBeUndefined()
 
-            const secondPageView = pageViewIdManager.doPageView()
+            const secondPageView = pageViewIdManager.doPageView(secondTimestamp)
             expect(secondPageView.$prev_pageview_last_scroll).toBeDefined()
         })
 
         it('should include the pathname', () => {
             instance.scrollManager['_updateScrollData']()
-            const firstPageView = pageViewIdManager.doPageView()
+            const firstPageView = pageViewIdManager.doPageView(firstTimestamp)
             expect(firstPageView.$prev_pageview_pathname).toBeUndefined()
-            const secondPageView = pageViewIdManager.doPageView()
+            const secondPageView = pageViewIdManager.doPageView(secondTimestamp)
             expect(secondPageView.$prev_pageview_pathname).toEqual('/pathname')
         })
     })

--- a/src/extensions/segment-integration.ts
+++ b/src/extensions/segment-integration.ts
@@ -81,7 +81,11 @@ const createSegmentIntegration = (posthog: PostHog): SegmentPlugin => {
             posthog.reloadFeatureFlags()
         }
 
-        const additionalProperties = posthog._calculate_event_properties(eventName, ctx.event.properties ?? {})
+        const additionalProperties = posthog._calculate_event_properties(
+            eventName,
+            ctx.event.properties ?? {},
+            new Date()
+        )
         ctx.event.properties = Object.assign({}, additionalProperties, ctx.event.properties)
         return ctx
     }

--- a/src/page-view.ts
+++ b/src/page-view.ts
@@ -44,6 +44,11 @@ export class PageViewManager {
         const previousTimestamp = this._prevPageviewTimestamp
         const scrollContext = this._instance.scrollManager.getContext()
 
+        if (!previousTimestamp) {
+            // this means there was no previous pageview
+            return {}
+        }
+
         let properties: PageViewEventProperties = {}
         if (scrollContext) {
             let { maxScrollHeight, lastScrollY, maxScrollY, maxContentHeight, lastContentY, maxContentY } =

--- a/src/page-view.ts
+++ b/src/page-view.ts
@@ -4,6 +4,7 @@ import { isUndefined } from './utils/type-utils'
 
 interface PageViewEventProperties {
     $prev_pageview_pathname?: string
+    $prev_pageview_duration?: number // seconds
     $prev_pageview_last_scroll?: number
     $prev_pageview_last_scroll_percentage?: number
     $prev_pageview_max_scroll?: number
@@ -16,72 +17,82 @@ interface PageViewEventProperties {
 
 export class PageViewManager {
     _currentPath?: string
+    _prevPageviewTimestamp?: Date
     _instance: PostHog
 
     constructor(instance: PostHog) {
         this._instance = instance
     }
 
-    doPageView(): PageViewEventProperties {
-        const response = this._previousScrollProperties()
+    doPageView(timestamp: Date): PageViewEventProperties {
+        const response = this._previousPageViewProperties(timestamp)
 
         // On a pageview we reset the contexts
         this._currentPath = window?.location.pathname ?? ''
         this._instance.scrollManager.resetContext()
+        this._prevPageviewTimestamp = timestamp
 
         return response
     }
 
-    doPageLeave(): PageViewEventProperties {
-        return this._previousScrollProperties()
+    doPageLeave(timestamp: Date): PageViewEventProperties {
+        return this._previousPageViewProperties(timestamp)
     }
 
-    private _previousScrollProperties(): PageViewEventProperties {
+    private _previousPageViewProperties(timestamp: Date): PageViewEventProperties {
         const previousPath = this._currentPath
+        const previousTimestamp = this._prevPageviewTimestamp
         const scrollContext = this._instance.scrollManager.getContext()
 
-        if (!previousPath || !scrollContext) {
-            return {}
+        let properties: PageViewEventProperties = {}
+        if (scrollContext) {
+            let { maxScrollHeight, lastScrollY, maxScrollY, maxContentHeight, lastContentY, maxContentY } =
+                scrollContext
+
+            if (
+                !isUndefined(maxScrollHeight) &&
+                !isUndefined(lastScrollY) &&
+                !isUndefined(maxScrollY) &&
+                !isUndefined(maxContentHeight) &&
+                !isUndefined(lastContentY) &&
+                !isUndefined(maxContentY)
+            ) {
+                // Use ceil, so that e.g. scrolling 999.5px of a 1000px page is considered 100% scrolled
+                maxScrollHeight = Math.ceil(maxScrollHeight)
+                lastScrollY = Math.ceil(lastScrollY)
+                maxScrollY = Math.ceil(maxScrollY)
+                maxContentHeight = Math.ceil(maxContentHeight)
+                lastContentY = Math.ceil(lastContentY)
+                maxContentY = Math.ceil(maxContentY)
+
+                // if the maximum scroll height is near 0, then the percentage is 1
+                const lastScrollPercentage = maxScrollHeight <= 1 ? 1 : clamp(lastScrollY / maxScrollHeight, 0, 1)
+                const maxScrollPercentage = maxScrollHeight <= 1 ? 1 : clamp(maxScrollY / maxScrollHeight, 0, 1)
+                const lastContentPercentage = maxContentHeight <= 1 ? 1 : clamp(lastContentY / maxContentHeight, 0, 1)
+                const maxContentPercentage = maxContentHeight <= 1 ? 1 : clamp(maxContentY / maxContentHeight, 0, 1)
+
+                properties = {
+                    $prev_pageview_last_scroll: lastScrollY,
+                    $prev_pageview_last_scroll_percentage: lastScrollPercentage,
+                    $prev_pageview_max_scroll: maxScrollY,
+                    $prev_pageview_max_scroll_percentage: maxScrollPercentage,
+                    $prev_pageview_last_content: lastContentY,
+                    $prev_pageview_last_content_percentage: lastContentPercentage,
+                    $prev_pageview_max_content: maxContentY,
+                    $prev_pageview_max_content_percentage: maxContentPercentage,
+                }
+            }
         }
 
-        let { maxScrollHeight, lastScrollY, maxScrollY, maxContentHeight, lastContentY, maxContentY } = scrollContext
-
-        if (
-            isUndefined(maxScrollHeight) ||
-            isUndefined(lastScrollY) ||
-            isUndefined(maxScrollY) ||
-            isUndefined(maxContentHeight) ||
-            isUndefined(lastContentY) ||
-            isUndefined(maxContentY)
-        ) {
-            return {}
+        if (previousPath) {
+            properties.$prev_pageview_pathname = previousPath
+        }
+        if (previousTimestamp) {
+            // Use seconds, for consistency with our other duration-related properties like $duration
+            properties.$prev_pageview_duration = (timestamp.getTime() - previousTimestamp.getTime()) / 1000
         }
 
-        // Use ceil, so that e.g. scrolling 999.5px of a 1000px page is considered 100% scrolled
-        maxScrollHeight = Math.ceil(maxScrollHeight)
-        lastScrollY = Math.ceil(lastScrollY)
-        maxScrollY = Math.ceil(maxScrollY)
-        maxContentHeight = Math.ceil(maxContentHeight)
-        lastContentY = Math.ceil(lastContentY)
-        maxContentY = Math.ceil(maxContentY)
-
-        // if the maximum scroll height is near 0, then the percentage is 1
-        const lastScrollPercentage = maxScrollHeight <= 1 ? 1 : clamp(lastScrollY / maxScrollHeight, 0, 1)
-        const maxScrollPercentage = maxScrollHeight <= 1 ? 1 : clamp(maxScrollY / maxScrollHeight, 0, 1)
-        const lastContentPercentage = maxContentHeight <= 1 ? 1 : clamp(lastContentY / maxContentHeight, 0, 1)
-        const maxContentPercentage = maxContentHeight <= 1 ? 1 : clamp(maxContentY / maxContentHeight, 0, 1)
-
-        return {
-            $prev_pageview_pathname: previousPath,
-            $prev_pageview_last_scroll: lastScrollY,
-            $prev_pageview_last_scroll_percentage: lastScrollPercentage,
-            $prev_pageview_max_scroll: maxScrollY,
-            $prev_pageview_max_scroll_percentage: maxScrollPercentage,
-            $prev_pageview_last_content: lastContentY,
-            $prev_pageview_last_content_percentage: lastContentPercentage,
-            $prev_pageview_max_content: maxContentY,
-            $prev_pageview_max_content_percentage: maxContentPercentage,
-        }
+        return properties
     }
 }
 


### PR DESCRIPTION
## Changes

Add prev pageview duration, for a customer, inspired by this slack thread https://posthog.slack.com/archives/C05LJK1N3CP/p1723144788366199

We already do have some logic for measuring the time between the same event (that gets stored in storage rather than in memory), but that doesn't add e.g. pageview duration to a pageleave event, and doesn't match up with the other prev_pageview props like prev_pageview_pathname, which the paths view on web analytics already uses.


## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
