### PR TITLE
fix(segment): Allow overriding user id in Segment integration

### DIFF
--- a/src/extensions/segment-integration.test.ts
+++ b/src/extensions/segment-integration.test.ts
@@ -1,0 +1,128 @@
+import { SegmentAnalytics, SegmentUser, setupSegmentIntegration } from './segment-integration'
+import { PostHog } from '../posthog-core'
+import { afterEach, beforeEach } from '@jest/globals'
+import { PostHogConfig, Properties } from '../types'
+import { PostHogPersistence } from '../posthog-persistence'
+import { USER_STATE } from '../constants'
+
+describe('segment-integration', () => {
+    let config: PostHogConfig
+    let posthog: PostHog
+    let persistence: PostHogPersistence
+
+    const segment: SegmentAnalytics = <SegmentAnalytics>{
+        user: function (): SegmentUser {
+            return <SegmentUser>{
+                id: function (): string | undefined {
+                    return 'phani'
+                },
+                anonymousId: function (): string | undefined {
+                    return 'phani'
+                },
+            }
+        },
+        // eslint-disable-next-line compat/compat
+        register: jest.fn(() => Promise.resolve()),
+    }
+
+    beforeEach(() => {
+        config = {
+            token: 'testtoken',
+            api_host: 'https://app.posthog.com',
+            persistence: 'memory',
+            segment: segment,
+        } as unknown as PostHogConfig
+        persistence = new PostHogPersistence(config)
+        posthog = {
+            config: config,
+            segment_config: {
+                user_id: 'phani raj',
+            },
+            register: (properties: Properties, days?: number) => {
+                posthog.persistence?.register(properties, days)
+            },
+            persistence: persistence,
+            _addCaptureHook: jest.fn(),
+        } as unknown as PostHog
+    })
+
+    afterEach(() => {
+        posthog.persistence?.clear()
+    })
+
+    describe('#setupPostHogFromSegment', () => {
+        it('sets userId from segment user', async () => {
+            setupSegmentIntegration(posthog, () => {
+                expect(posthog.persistence?.get_property(USER_STATE)).toEqual('identified')
+            })
+        })
+
+        it('sets userId from segment config', () => {
+            segment.user = function (): SegmentUser {
+                return <SegmentUser>{
+                    id: function (): string | undefined {
+                        return undefined
+                    },
+                    anonymousId: function (): string | undefined {
+                        return 'anonymous segment user'
+                    },
+                }
+            }
+
+            posthog.config.segment_config = {
+                user_id: 'custom segment user',
+            }
+
+            setupSegmentIntegration(posthog, () => {
+                expect(posthog.persistence?.properties().distinct_id).toEqual('custom segment user')
+                expect(posthog.persistence?.properties().$device_id).toEqual('anonymous segment user')
+                expect(posthog.persistence?.get_property(USER_STATE)).toEqual('identified')
+            })
+        })
+
+        it('checks userId to set user_state', () => {
+            segment.user = function (): SegmentUser {
+                return <SegmentUser>{
+                    id: function (): string | undefined {
+                        return undefined
+                    },
+                    anonymousId: function (): string | undefined {
+                        return 'anonymous segment user'
+                    },
+                }
+            }
+
+            posthog.config.segment = segment
+            posthog.persistence = new PostHogPersistence(config)
+            posthog.config.segment_config = undefined
+
+            setupSegmentIntegration(posthog, () => {
+                expect(posthog.persistence?.properties().distinct_id).toBeUndefined()
+                expect(posthog.persistence?.properties().$device_id).toBeUndefined()
+            })
+        })
+
+        it('picks segment user.id over segment_config.user_id', () => {
+            segment.user = function (): SegmentUser {
+                return <SegmentUser>{
+                    id: function (): string | undefined {
+                        return 'segment user id'
+                    },
+                    anonymousId: function (): string | undefined {
+                        return 'anonymous segment user'
+                    },
+                }
+            }
+
+            posthog.config.segment_config = {
+                user_id: 'custom segment user',
+            }
+
+            setupSegmentIntegration(posthog, () => {
+                expect(posthog.persistence?.properties().distinct_id).toEqual('segment user id')
+                expect(posthog.persistence?.properties().$device_id).toEqual('anonymous segment user')
+                expect(posthog.persistence?.get_property(USER_STATE)).toEqual('identified')
+            })
+        })
+    })
+})

--- a/src/extensions/segment-integration.ts
+++ b/src/extensions/segment-integration.ts
@@ -111,11 +111,13 @@ function setupPostHogFromSegment(posthog: PostHog, done: () => void) {
         // Use segments anonymousId instead
         const getSegmentAnonymousId = () => user.anonymousId() || uuidv7()
         posthog.config.get_device_id = getSegmentAnonymousId
+        const userId = user.id() || posthog.config.segment_config?.user_id
 
         // If a segment user ID exists, set it as the distinct_id
-        if (user.id()) {
+        // If the caller explicitly asked to use the anonymous ID as the distinct ID, use that instead
+        if (userId) {
             posthog.register({
-                distinct_id: user.id(),
+                distinct_id: userId,
                 $device_id: getSegmentAnonymousId(),
             })
             posthog.persistence!.set_property(USER_STATE, 'identified')

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,9 @@ export interface PostHogConfig {
     advanced_disable_toolbar_metrics: boolean
     feature_flag_request_timeout_ms: number
     get_device_id: (uuid: string) => string
+    segment_config?: {
+        user_id?: string
+    }
     name: string
     _onCapture: (eventName: string, eventData: CaptureResult) => void
     capture_performance?: boolean | PerformanceCaptureConfig


### PR DESCRIPTION
## Changes

This PR changes the way we identify users in the Segment Integration for PostHog.
https://github.com/PostHog/posthog-js/blob/d5889f0d97a68d9a6b964a24207d631e0834e46e/src/extensions/segment-integration.ts#L119-L126

As we can see in the above block, we set the `USER_STATE` to `identified` ONLY if the user is identified by Segment. 
This can cause issues for feature flags since they're not persisted if the USER_STATE is `anonymous` causing all sorts of confusing behavior for our customers.

This PR makes a change to the Segment integration to allow us to set the `USER_STATE` to `identified` even if the segment user is unidentified, callers can explicitly set the `user_id` used by segment without identifying the user in segment

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
