### PR TITLE
fix: pass original fetch args along

### DIFF
--- a/src/entrypoints/recorder.ts
+++ b/src/entrypoints/recorder.ts
@@ -507,7 +507,7 @@ function initFetchObserver(
                 }
 
                 after = win.performance.now()
-                res = await originalFetch(req)
+                res = await originalFetch(url, init)
                 before = win.performance.now()
 
                 const responseHeaders: Headers = {}


### PR DESCRIPTION
When wrapping fetch we take a url, init pair and create a request object

When we pass on and call the original fetch method we pass the request object. this is _technically_ equivalent to the original but not literally equivalent which can cause problems if there are further wrappers on fetch

see: https://github.com/PostHog/posthog-js/issues/1326

We actively don't want to alter the fetch details so it should be 100% safe to use the original args when calling the original fetch 🤷 