### PR TITLE
revert: remove x-posthog-token header

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -629,7 +629,6 @@ export class PostHog {
         })
         options.headers = {
             ...this.config.request_headers,
-            'x-posthog-token': this.config.token,
         }
         options.compression = options.compression === 'best-available' ? this.compression : options.compression
 


### PR DESCRIPTION
## Changes

this header causes lots of preflight requests so probably isn't worth it in the end. Not in use yet so no risk to remove (just added in https://github.com/PostHog/posthog-js/pull/1347)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
