### PR TITLE
feat: default to gzip compression instead of base64

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -390,7 +390,7 @@ export class PostHog {
             logger.error('[posthog] on_xhr_error is deprecated. Use on_request_error instead')
         }
 
-        this.compression = config.disable_compression ? undefined : Compression.Base64
+        this.compression = config.disable_compression ? undefined : Compression.GZipJS
 
         this.persistence = new PostHogPersistence(this.config)
         this.sessionPersistence =


### PR DESCRIPTION

## Changes
it's weird that we do our first requests before the decide response with base64 "compression", as

1. we've supported gzip for literally years, so there's basically zero risk of somehow hitting an endpoint that doesn't support it
2. base64 is not compression, it increases the payload size compared to if we did nothing at all
3. rust capture does not support base64

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
