### PR TITLE
feat: use gzip compression for decide

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -31,7 +31,7 @@ export class Decide {
             method: 'POST',
             url: this.instance.requestRouter.endpointFor('api', '/decide/?v=3'),
             data,
-            compression: this.instance.config.disable_compression ? undefined : Compression.Base64,
+            compression: this.instance.config.disable_compression ? undefined : Compression.GZipJS,
             timeout: this.instance.config.feature_flag_request_timeout_ms,
             callback: (response) => this.parseDecideResponse(response.json as DecideResponse | undefined),
         })


### PR DESCRIPTION
## Changes

for some reason we use base64 "compression" (it's not) for /decide requests. I'm not sure why as we support gzip will be much more efficient (atm our /decide requests on us.posthog.com are around 4kB, it will likely be <1kB gzipped)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
