### PR TITLE
fix: Expose version

### DIFF
--- a/src/__tests__/posthog-core.test.ts
+++ b/src/__tests__/posthog-core.test.ts
@@ -35,6 +35,10 @@ describe('posthog core', () => {
         console.error = jest.fn()
     })
 
+    it('exposes the version', () => {
+        expect(defaultPostHog().version).toMatch(/\d+\.\d+\.\d+/)
+    })
+
     describe('capture()', () => {
         const eventName = 'custom_event'
         const eventProperties = {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -264,6 +264,7 @@ export class PostHog {
     __request_queue: QueuedRequestOptions[]
     decideEndpointWasHit: boolean
     analyticsDefaultEndpoint: string
+    version = Config.LIB_VERSION
 
     SentryIntegration: typeof SentryIntegration
     sentryIntegration: (options?: SentryIntegrationOptions) => ReturnType<typeof sentryIntegration>


### PR DESCRIPTION
## Changes

Change to the type causes issue in posthog. Also it wasn't accounted for even in the tests for this repo
Also exposes the version so we don't have to rely on internal methods

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
