### PR TITLE
fix: only add to window when it exists

### DIFF
--- a/src/entrypoints/exception-autocapture.ts
+++ b/src/entrypoints/exception-autocapture.ts
@@ -48,6 +48,9 @@ const posthogErrorWrappingFunctions = {
     wrapOnError,
     wrapUnhandledRejection,
 }
-;(window as any).posthogErrorWrappingFunctions = posthogErrorWrappingFunctions
+
+if (window) {
+    ;(window as any).posthogErrorWrappingFunctions = posthogErrorWrappingFunctions
+}
 
 export default posthogErrorWrappingFunctions


### PR DESCRIPTION
We add error functions to window even when it is undefined... let's copy the other entrypoints and check first

(should) fixes #1349 