### PR TITLE
feat: support specific endpoint for flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "prepublishOnly": "pnpm lint && pnpm test && pnpm build && pnpm test:react",
         "test": "pnpm test:unit && pnpm test:custom-eslint-rules && pnpm test:functional",
         "test:unit": "jest src",
+        "test:specific": "jest",
         "test:custom-eslint-rules": "jest eslint-rules",
         "test:react": "cd react; pnpm test",
         "test:functional": "jest functional_tests",

--- a/playground/nextjs/src/posthog.ts
+++ b/playground/nextjs/src/posthog.ts
@@ -46,6 +46,7 @@ export const updatePostHogConsent = (consentGiven: boolean) => {
 if (typeof window !== 'undefined') {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || '', {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+        flags_api_host: process.env.NEXT_PUBLIC_POSTHOG_FLAGS_HOST || undefined,
         session_recording: {
             recordCrossOriginIframes: true,
         },

--- a/playground/nuxtjs/plugins/posthog.client.js
+++ b/playground/nuxtjs/plugins/posthog.client.js
@@ -1,17 +1,21 @@
 // plugins/posthog.client.js
 import { defineNuxtPlugin } from '#imports'
 import posthog from 'posthog-js'
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default defineNuxtPlugin((nuxtApp) => {
+    // eslint-disable-next-line no-undef
     const runtimeConfig = useRuntimeConfig()
     const postHogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
-        api_host: runtimeConfig.public.posthogHost || 'https://app.posthog.com',
+        api_host: runtimeConfig.public.posthogHost || 'https://us.i.posthog.com',
+        flags_api_host: runtimeConfig.public.posthogFlagsHost || undefined,
         loaded: (posthog) => {
             if (import.meta.env.MODE === 'development') posthog.debug()
         },
     })
 
     // Make sure that pageviews are captured with each route change
-    const router = useRouter()
+    const router = useRouter() // eslint-disable-line no-undef
     router.afterEach((to) => {
         posthog.capture('$pageview', {
             current_url: to.fullPath,

--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -71,7 +71,7 @@ describe('request-router', () => {
         )
     })
 
-    it('should use the flags_api_host if provided for decide and static/array.js requests', () => {
+    it('should use the flags_api_host if provided for decide requests', () => {
         expect(
             router('https://my.domain.com/', undefined, 'https://my-flag-domain.domain.com').endpointFor(
                 'api',
@@ -85,13 +85,6 @@ describe('request-router', () => {
                 '/decide'
             )
         ).toEqual('https://my-flag-domain.domain.com/decide')
-
-        expect(
-            router('https://us.i.posthog.com/', undefined, 'https://my-flag-domain.domain.com').endpointFor(
-                'api',
-                '/static/array.js'
-            )
-        ).toEqual('https://my-flag-domain.domain.com/static/array.js')
 
         // specifically test undefined flags_api_host
         expect(router('https://us.i.posthog.com/', undefined, undefined).endpointFor('api', '/decide')).toEqual(

--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -71,7 +71,7 @@ describe('request-router', () => {
         )
     })
 
-    it('should use the flags_api_host if provided for decide requests', () => {
+    it('should use the flags_api_host if provided for decide and static/array.js requests', () => {
         expect(
             router('https://my.domain.com/', undefined, 'https://my-flag-domain.domain.com').endpointFor(
                 'api',
@@ -85,6 +85,13 @@ describe('request-router', () => {
                 '/decide'
             )
         ).toEqual('https://my-flag-domain.domain.com/decide')
+
+        expect(
+            router('https://us.i.posthog.com/', undefined, 'https://my-flag-domain.domain.com').endpointFor(
+                'api',
+                '/static/array.js'
+            )
+        ).toEqual('https://my-flag-domain.domain.com/static/array.js')
 
         // specifically test undefined flags_api_host
         expect(router('https://us.i.posthog.com/', undefined, undefined).endpointFor('api', '/decide')).toEqual(

--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -1,10 +1,11 @@
 import { RequestRouter, RequestRouterTarget } from '../../utils/request-router'
 
 describe('request-router', () => {
-    const router = (api_host = 'https://app.posthog.com', ui_host?: string) => {
+    const router = (api_host = 'https://app.posthog.com', ui_host?: string, flags_api_host?: string) => {
         return new RequestRouter({
             config: {
                 api_host,
+                flags_api_host,
                 ui_host,
             },
         } as any)
@@ -68,6 +69,22 @@ describe('request-router', () => {
         expect(router('https://my.domain.com/', 'https://app.posthog.com/').endpointFor('ui')).toEqual(
             'https://us.posthog.com'
         )
+    })
+
+    it('should use the flags_api_host if provided for decide requests', () => {
+        expect(
+            router('https://my.domain.com/', undefined, 'https://my-flag-domain.domain.com').endpointFor(
+                'api',
+                '/decide'
+            )
+        ).toEqual('https://my-flag-domain.domain.com/decide')
+
+        expect(
+            router('https://us.i.posthog.com/', undefined, 'https://my-flag-domain.domain.com').endpointFor(
+                'api',
+                '/decide'
+            )
+        ).toEqual('https://my-flag-domain.domain.com/decide')
     })
 
     it('should react to config changes', () => {

--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -85,6 +85,11 @@ describe('request-router', () => {
                 '/decide'
             )
         ).toEqual('https://my-flag-domain.domain.com/decide')
+
+        // specifically test undefined flags_api_host
+        expect(router('https://us.i.posthog.com/', undefined, undefined).endpointFor('api', '/decide')).toEqual(
+            'https://us.i.posthog.com/decide'
+        )
     })
 
     it('should react to config changes', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -117,6 +117,7 @@ let ENQUEUE_REQUESTS = !SUPPORTS_REQUEST && userAgent?.indexOf('MSIE') === -1 &&
 
 export const defaultConfig = (): PostHogConfig => ({
     api_host: 'https://us.i.posthog.com',
+    flags_api_host: undefined,
     ui_host: null,
     token: '',
     autocapture: true,
@@ -899,6 +900,7 @@ export class PostHog {
 
         if (this.requestRouter.region === RequestRouterRegion.CUSTOM) {
             properties['$lib_custom_api_host'] = this.config.api_host
+            properties['$lib_custom_flags_api_host'] = this.config.flags_api_host
         }
 
         if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,13 @@ export interface HeatmapConfig {
 
 export interface PostHogConfig {
     api_host: string
+    /**
+     * An optional url to use for feature flags requests, to prevent
+     * (incorrect) interference from ad blockers. Most people don't need
+     * this unless you already have a reverse proxy set up and
+     * your tracking URL is being blocked by ad blockers.
+     */
+    flags_api_host?: string
     /** @deprecated - This property is no longer supported */
     api_method?: string
     api_transport?: 'XHR' | 'fetch'

--- a/src/utils/request-router.ts
+++ b/src/utils/request-router.ts
@@ -66,7 +66,7 @@ export class RequestRouter {
             return (this.uiHost || this.apiHost.replace(`.${ingestionDomain}`, '.posthog.com')) + path
         }
 
-        const useFlagsAPIHost = (path.startsWith(flagsPath) || path.startsWith(libPath)) && this.flagsApiHost
+        const useFlagsAPIHost = (path.indexOf(flagsPath) === 0 || path.indexOf(libPath) === 0) && this.flagsApiHost
         if (this.region === RequestRouterRegion.CUSTOM) {
             return useFlagsAPIHost ? this.flagsApiHost + path : this.apiHost + path
         }

--- a/src/utils/request-router.ts
+++ b/src/utils/request-router.ts
@@ -18,7 +18,6 @@ export type RequestRouterTarget = 'api' | 'ui' | 'assets'
 
 const ingestionDomain = 'i.posthog.com'
 const flagsPath = '/decide'
-const libPath = '/static/array'
 
 export class RequestRouter {
     instance: PostHog
@@ -66,7 +65,7 @@ export class RequestRouter {
             return (this.uiHost || this.apiHost.replace(`.${ingestionDomain}`, '.posthog.com')) + path
         }
 
-        const useFlagsAPIHost = (path.indexOf(flagsPath) === 0 || path.indexOf(libPath) === 0) && this.flagsApiHost
+        const useFlagsAPIHost = path.indexOf(flagsPath) === 0 && this.flagsApiHost
         if (this.region === RequestRouterRegion.CUSTOM) {
             return useFlagsAPIHost ? this.flagsApiHost + path : this.apiHost + path
         }

--- a/src/utils/request-router.ts
+++ b/src/utils/request-router.ts
@@ -18,6 +18,7 @@ export type RequestRouterTarget = 'api' | 'ui' | 'assets'
 
 const ingestionDomain = 'i.posthog.com'
 const flagsPath = '/decide'
+const libPath = '/static/array'
 
 export class RequestRouter {
     instance: PostHog
@@ -65,7 +66,7 @@ export class RequestRouter {
             return (this.uiHost || this.apiHost.replace(`.${ingestionDomain}`, '.posthog.com')) + path
         }
 
-        const useFlagsAPIHost = path.startsWith(flagsPath) && this.flagsApiHost
+        const useFlagsAPIHost = (path.startsWith(flagsPath) || path.startsWith(libPath)) && this.flagsApiHost
         if (this.region === RequestRouterRegion.CUSTOM) {
             return useFlagsAPIHost ? this.flagsApiHost + path : this.apiHost + path
         }


### PR DESCRIPTION
## Problem

Ad blocker people go to posthog.com to figure our what our tracking URLs are. If we use the same domain for event tracking and flags, when they determine whatever URL we are using (either default or proxied) and add it to the ad blocker, our website functionality breaks down because flags are blocked.

I think having two domains could solve this. `tracking.whatever-url.com` and `feature-flags-do-not-block.whatever-url.com`. I would honestly consider naming the subdomain exactly that so that it is very clear.

If they end up blocking our tracking URL that is totally fine - that's part of the reason why people use ad blockers in the first place. So this will allow ad blockers to block our default ingestion endpoints, but will _hopefully_ prevent them from blocking decide requests, which are required for website functionality.

## Changes

Adds a new config option `flags_api_host` that is used for any requests that hit `/decide`. If not provided, uses the default `api_host`. 

Also uses this secondary flags_api_host, if set, to get `static/array.js` so we can make the decide calls.

...

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
    - I don't think there should be an impact?
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
    - All existing tests still pass.
