### PR TITLE
fix: endpoint for is already called inside loadscript

### DIFF
--- a/src/extensions/exception-autocapture/index.ts
+++ b/src/extensions/exception-autocapture/index.ts
@@ -58,18 +58,12 @@ export class ExceptionObserver {
             cb()
         }
 
-        this.instance.requestRouter.loadScript(
-            this.instance.requestRouter.endpointFor(
-                'assets',
-                `/static/exception-autocapture.js?v=${Config.LIB_VERSION}`
-            ),
-            (err) => {
-                if (err) {
-                    return logger.error(LOGGER_PREFIX + ' failed to load script', err)
-                }
-                cb()
+        this.instance.requestRouter.loadScript(`/static/exception-autocapture.js?v=${Config.LIB_VERSION}`, (err) => {
+            if (err) {
+                return logger.error(LOGGER_PREFIX + ' failed to load script', err)
             }
-        )
+            cb()
+        })
     }
 
     private startCapturing = () => {

--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -70,16 +70,13 @@ export class WebVitalsAutocapture {
             cb()
         }
 
-        this.instance.requestRouter.loadScript(
-            this.instance.requestRouter.endpointFor('assets', `/static/web-vitals.js?v=${Config.LIB_VERSION}`),
-            (err) => {
-                if (err) {
-                    logger.error(LOGGER_PREFIX + ' failed to load script', err)
-                    return
-                }
-                cb()
+        this.instance.requestRouter.loadScript(`/static/web-vitals.js?v=${Config.LIB_VERSION}`, (err) => {
+            if (err) {
+                logger.error(LOGGER_PREFIX + ' failed to load script', err)
+                return
             }
-        )
+            cb()
+        })
     }
 
     private _currentURL(): string | undefined {


### PR DESCRIPTION
fixes: #1346 

OP correctly identifies that two scripts are passing the fully resolved endpoint into `loadScript` which then calls `endpointFor`

Calling `endpointFor` twice is not (always) safe
