### PR TITLE
revert: "fix: pass original fetch args along"

### DIFF
--- a/src/entrypoints/recorder.ts
+++ b/src/entrypoints/recorder.ts
@@ -507,7 +507,7 @@ function initFetchObserver(
                 }
 
                 after = win.performance.now()
-                res = await originalFetch(url, init)
+                res = await originalFetch(req)
                 before = win.performance.now()
 
                 const responseHeaders: Headers = {}


### PR DESCRIPTION
Reverts PostHog/posthog-js#1351

we've seen multiple reports of fetch wrapping causing errors, it would be amazing if it wasn't this change causing it.

it's safe to revert if it's not this change and important to revert if it is...