### PR TITLE
fix: Don't track hash params by default

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -38,6 +38,7 @@ import { assignableWindow, document, window } from '../../utils/globals'
 import { buildNetworkRequestOptions } from './config'
 import { isLocalhost } from '../../utils/request-utils'
 import { MutationRateLimiter } from './mutation-rate-limiter'
+import { Info } from '../../utils/event-utils'
 
 const BASE_ENDPOINT = '/s/'
 
@@ -667,7 +668,8 @@ export class SessionRecording {
             // so we catch all errors.
             try {
                 if (eventName === '$pageview') {
-                    const href = window ? this._maskUrl(window.location.href) : ''
+                    let href = Info.location().href
+                    href = href ? this._maskUrl(href) : ''
                     if (!href) {
                         return
                     }

--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -5,6 +5,7 @@ import { isBoolean, isNullish, isNumber, isObject, isUndefined } from '../../uti
 import { WEB_VITALS_ENABLED_SERVER_SIDE } from '../../constants'
 import { assignableWindow, window } from '../../utils/globals'
 import Config from '../../config'
+import { Info } from '../../utils/event-utils'
 
 export const FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS = 8000
 const ONE_MINUTE_IN_MILLIS = 60 * 1000
@@ -81,7 +82,7 @@ export class WebVitalsAutocapture {
 
     private _currentURL(): string | undefined {
         // TODO you should be able to mask the URL here
-        const href = window ? window.location.href : undefined
+        const href = Info.location().href
         if (!href) {
             logger.error(LOGGER_PREFIX + 'Could not determine current URL')
         }

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -8,6 +8,7 @@ import { getParentElement, isTag } from './autocapture-utils'
 import { HEATMAPS_ENABLED_SERVER_SIDE, TOOLBAR_ID } from './constants'
 import { isEmptyObject, isObject, isUndefined } from './utils/type-utils'
 import { logger } from './utils/logger'
+import { Info } from './utils/event-utils'
 
 const DEFAULT_FLUSH_INTERVAL = 5000
 const HEATMAPS = 'heatmaps'
@@ -179,12 +180,12 @@ export class Heatmaps {
     }
 
     private _capture(properties: Properties): void {
-        if (!window) {
+        // TODO we should be able to mask this
+        const url = Info.location().href
+
+        if (!url) {
             return
         }
-
-        // TODO we should be able to mask this
-        const url = window.location.href
 
         this.buffer = this.buffer || {}
 

--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -34,6 +34,7 @@ export const CAMPAIGN_PARAMS = [
 export const Info = {
     location: function (): { href?: string; hrefIncludingHash?: string; host?: string; pathname?: string } {
         return {
+            // NOTE: Hash params are typically sensitive and not designed to be sent to servers so we exclude them here by default
             href: location?.href?.split('#')[0],
             hrefIncludingHash: location?.href,
             host: location?.host,

--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -32,6 +32,15 @@ export const CAMPAIGN_PARAMS = [
 ]
 
 export const Info = {
+    location: function (): { href?: string; hrefIncludingHash?: string; host?: string; pathname?: string } {
+        return {
+            href: location?.href?.split('#')[0],
+            hrefIncludingHash: location?.href,
+            host: location?.host,
+            pathname: location?.pathname,
+        }
+    },
+
     campaignParams: function (customParams?: string[]): Record<string, string> {
         if (!document) {
             return {}
@@ -148,7 +157,7 @@ export const Info = {
         // we're being a bit more economical with bytes here because this is stored in the cookie
         return {
             r: this.referrer(),
-            u: location?.href,
+            u: Info.location().href,
         }
     },
 
@@ -198,9 +207,9 @@ export const Info = {
                 $device_type: Info.deviceType(userAgent),
             }),
             {
-                $current_url: location?.href,
-                $host: location?.host,
-                $pathname: location?.pathname,
+                $current_url: Info.location().href,
+                $host: Info.location().host,
+                $pathname: Info.location().pathname,
                 $raw_user_agent: userAgent.length > 1000 ? userAgent.substring(0, 997) + '...' : userAgent,
                 $browser_version: Info.browserVersion(userAgent, navigator.vendor),
                 $browser_language: Info.browserLanguage(),


### PR DESCRIPTION
## Changes

Hash params are typically not necessary to be tracked and often even undeseriable as they can be used for storing tokens etc. that never leave the browser.

I don't think we should track these by default. This is technically a breaking change so a little hard to guage but I strongly feel like the default should be not to track

We probably want to offer a config option to allow this...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
