### PR TITLE
chore: clarify that tests are exercising our fetch wrapper

### DIFF
--- a/cypress/e2e/session-recording.cy.ts
+++ b/cypress/e2e/session-recording.cy.ts
@@ -113,14 +113,27 @@ describe('Session recording', () => {
             cy.phCaptures({ full: true }).then((captures) => {
                 const snapshots = captures.filter((c) => c.event === '$snapshot')
 
-                const snapshotTypes: number[] = []
+                const capturedRequests: Record<string, any>[] = []
                 for (const snapshot of snapshots) {
                     for (const snapshotData of snapshot.properties['$snapshot_data']) {
-                        snapshotTypes.push(snapshotData.type)
+                        if (snapshotData.type === 6) {
+                            for (const req of snapshotData.data.payload.requests) {
+                                capturedRequests.push(req)
+                            }
+                        }
                     }
                 }
+
                 // yay, includes type 6 network data
-                expect(snapshotTypes.filter((x) => x === 6)).to.have.length.above(0)
+                expect(capturedRequests).to.have.length.above(0)
+
+                const capturedFetchRequest = capturedRequests.find((cr) => cr.name === 'https://example.com/')
+
+                expect(capturedFetchRequest.fetchStart).to.be.greaterThan(0) // proxy for including network timing info
+
+                expect(capturedFetchRequest.initiatorType).to.eql('fetch')
+                expect(capturedFetchRequest.isInitial).to.be.undefined
+                expect(capturedFetchRequest.requestBody).to.eq('i am the fetch body')
             })
         })
     })

--- a/cypress/e2e/session-recording.cy.ts
+++ b/cypress/e2e/session-recording.cy.ts
@@ -127,7 +127,8 @@ describe('Session recording', () => {
                 // yay, includes type 6 network data
                 expect(capturedRequests).to.have.length.above(0)
 
-                // the HTML file that cypress is operating on-click makes a post to https://example.com
+                // the HTML file that cypress is operating on (playground/cypress/index.html)
+                // when the button for this test is click makes a post to https://example.com
                 const capturedFetchRequest = capturedRequests.find((cr) => cr.name === 'https://example.com/')
 
                 expect(capturedFetchRequest.fetchStart).to.be.greaterThan(0) // proxy for including network timing info

--- a/cypress/e2e/session-recording.cy.ts
+++ b/cypress/e2e/session-recording.cy.ts
@@ -127,6 +127,7 @@ describe('Session recording', () => {
                 // yay, includes type 6 network data
                 expect(capturedRequests).to.have.length.above(0)
 
+                // the HTML file that cypress is operating on-click makes a post to https://example.com
                 const capturedFetchRequest = capturedRequests.find((cr) => cr.name === 'https://example.com/')
 
                 expect(capturedFetchRequest.fetchStart).to.be.greaterThan(0) // proxy for including network timing info

--- a/playground/cypress/index.html
+++ b/playground/cypress/index.html
@@ -15,7 +15,7 @@
         Send custom event
     </button>
 
-        <button data-cy-network-call-button onclick="fetch('https://example.com')">
+        <button data-cy-network-call-button onclick="fetch('https://example.com', {body: 'i am the fetch body', method: 'POST'})">
         Make network call
     </button>
 


### PR DESCRIPTION
part of responding to https://github.com/PostHog/posthog/issues/24471 due to the unexpected consequences of https://github.com/PostHog/posthog-js/pull/1351

The Cypress tests already covered the expected behaviour of the wrapper, but it wasn't clear that was what was happening.

This refactors the test and introduces much clearer assertions

I have checked that the test passes even with the change from https://github.com/PostHog/posthog-js/pull/1351

I believe the issue is if another fetch wrapper reads the body of the request (and potentially other interactions with the request) but will follow-up to this PR with a test to cover that scenario