### PR TITLE
fix: network capture tests should fail if we exhaust the body

### DIFF
--- a/cypress/e2e/session-recording.cy.ts
+++ b/cypress/e2e/session-recording.cy.ts
@@ -3,6 +3,7 @@
 import { isNull } from '../../src/utils/type-utils'
 import { start } from '../support/setup'
 import { assertWhetherPostHogRequestsWereCalled, pollPhCaptures } from '../support/assertions'
+import { patch } from '../../src/extensions/replay/rrweb-plugins/patch'
 
 function ensureRecordingIsStopped() {
     cy.resetPhCaptures()
@@ -82,60 +83,310 @@ describe('Session recording', () => {
         })
     })
 
-    describe('with network capture', () => {
-        beforeEach(() => {
-            start({
-                decideResponseOverrides: {
-                    isAuthenticated: false,
-                    sessionRecording: {
-                        endpoint: '/ses/',
-                        networkPayloadCapture: { recordBody: true },
+    describe('network capture', () => {
+        let originalFetch: typeof fetch | null = null
+
+        afterEach(() => {
+            if (originalFetch) {
+                cy.window().then((win) => {
+                    console.log('replacing original fetch')
+                    win.fetch = originalFetch
+                    originalFetch = null
+                })
+            }
+        })
+        describe('with safe wrapped network capture', () => {
+            beforeEach(() => {
+                start({
+                    decideResponseOverrides: {
+                        isAuthenticated: false,
+                        sessionRecording: {
+                            endpoint: '/ses/',
+                            networkPayloadCapture: { recordBody: true },
+                        },
+                        capturePerformance: true,
+                        autocapture_opt_out: true,
                     },
-                    capturePerformance: true,
-                    autocapture_opt_out: true,
-                },
-                url: './playground/cypress',
-                options: {
-                    loaded: (ph) => {
-                        ph.sessionRecording._forceAllowLocalhostNetworkCapture = true
+                    url: './playground/cypress',
+                    options: {
+                        loaded: (ph) => {
+                            ph.sessionRecording._forceAllowLocalhostNetworkCapture = true
+                        },
                     },
-                },
+                })
+
+                cy.wait('@recorder')
+
+                // wrap fetch to log the body of the request
+                // this simulates various libraries that require
+                // being able to read the request
+                // and possibly alter it
+                // see: https://github.com/PostHog/posthog/issues/24471
+                // for the catastrophic but hard to detect impact of
+                // interfering with that with our wrapper
+                cy.window().then((win) => {
+                    originalFetch = win.fetch
+                    win.fetch = async function (requestOrURL: URL | RequestInfo, init?: RequestInit | undefined) {
+                        try {
+                            console.log('in the fetch wrapper')
+
+                            const req = new Request(requestOrURL, init)
+                            const body =
+                                typeof requestOrURL !== 'string' && 'body' in requestOrURL
+                                    ? requestOrURL.body
+                                    : init?.body
+                            if (body) {
+                                // read the body out of the request, this uses up the request object
+                                // and won't work on a used up request object
+                                // eslint-disable-next-line no-console
+                                console.log('Request body:', body)
+                            }
+
+                            const res = await originalFetch(req)
+                            // also read the body
+
+                            const reader = res.clone().body.getReader()
+                            // eslint-disable-next-line compat/compat
+                            const decoder = new TextDecoder()
+                            let result = ''
+
+                            function readStream() {
+                                return reader.read().then(({ done, value }) => {
+                                    if (done) {
+                                        // Stream is fully read
+                                        return result
+                                    }
+
+                                    // Decode the current chunk and append it to the result
+                                    result += decoder.decode(value, { stream: true })
+
+                                    // Read the next chunk
+                                    return readStream()
+                                })
+                            }
+
+                            // we read the body to exhaust it
+                            await readStream()
+
+                            return res
+                        } catch (e) {
+                            console.error('fetch wrapper error', e)
+                            throw e
+                        } finally {
+                            console.log('fetch wrapper finally')
+                        }
+                    }
+                })
             })
 
-            cy.wait('@recorder')
-        })
+            it('it sends network payloads', () => {
+                cy.intercept({url: 'https://example.com', times: 1 }, (req) => {
+                    req.reply({
+                        statusCode: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                        body: {
+                            message: 'This is a JSON response',
+                        },
+                    })
+                }).as('example.com')
 
-        it('it sends network payloads', () => {
-            cy.intercept('https://example.com', 'success').as('example.com')
-            cy.get('[data-cy-network-call-button]').click()
-            cy.wait('@example.com')
-            cy.wait('@session-recording')
-            cy.phCaptures({ full: true }).then((captures) => {
-                const snapshots = captures.filter((c) => c.event === '$snapshot')
+                cy.get('[data-cy-network-call-button]').click()
+                cy.wait('@example.com')
+                cy.wait('@session-recording')
+                cy.phCaptures({ full: true }).then((captures) => {
+                    const snapshots = captures.filter((c) => c.event === '$snapshot')
 
-                const capturedRequests: Record<string, any>[] = []
-                for (const snapshot of snapshots) {
-                    for (const snapshotData of snapshot.properties['$snapshot_data']) {
-                        if (snapshotData.type === 6) {
-                            for (const req of snapshotData.data.payload.requests) {
-                                capturedRequests.push(req)
+                    const capturedRequests: Record<string, any>[] = []
+                    for (const snapshot of snapshots) {
+                        for (const snapshotData of snapshot.properties['$snapshot_data']) {
+                            if (snapshotData.type === 6) {
+                                for (const req of snapshotData.data.payload.requests) {
+                                    capturedRequests.push(req)
+                                }
                             }
                         }
                     }
-                }
 
-                // yay, includes type 6 network data
-                expect(capturedRequests).to.have.length.above(0)
+                    const expectedCaptureds: [RegExp, string][] = [
+                        [/http:\/\/localhost:\d+\/playground\/cypress\//, 'navigation'],
+                        [/http:\/\/localhost:\d+\/static\/array.js/, 'script'],
+                        [
+                            /http:\/\/localhost:\d+\/decide\/\?v=3&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
+                            'xmlhttprequest',
+                        ],
+                        [/http:\/\/localhost:\d+\/static\/recorder.js\?v=1\.\d\d\d\.\d+/, 'script'],
+                        [/https:\/\/example.com/, 'fetch'],
+                    ]
 
-                // the HTML file that cypress is operating on (playground/cypress/index.html)
-                // when the button for this test is click makes a post to https://example.com
-                const capturedFetchRequest = capturedRequests.find((cr) => cr.name === 'https://example.com/')
+                    // yay, includes expected type 6 network data
+                    expect(capturedRequests.length).to.equal(expectedCaptureds.length)
+                    expectedCaptureds.forEach(([url, initiatorType], index) => {
+                        expect(capturedRequests[index].name).to.match(url)
+                        expect(capturedRequests[index].initiatorType).to.equal(initiatorType)
+                    })
 
-                expect(capturedFetchRequest.fetchStart).to.be.greaterThan(0) // proxy for including network timing info
+                    // the HTML file that cypress is operating on (playground/cypress/index.html)
+                    // when the button for this test is click makes a post to https://example.com
+                    const capturedFetchRequest = capturedRequests.find((cr) => cr.name === 'https://example.com/')
+                    expect(capturedFetchRequest).to.not.be.undefined
 
-                expect(capturedFetchRequest.initiatorType).to.eql('fetch')
-                expect(capturedFetchRequest.isInitial).to.be.undefined
-                expect(capturedFetchRequest.requestBody).to.eq('i am the fetch body')
+                    expect(capturedFetchRequest.fetchStart).to.be.greaterThan(0) // proxy for including network timing info
+
+                    expect(capturedFetchRequest.initiatorType).to.eql('fetch')
+                    expect(capturedFetchRequest.isInitial).to.be.undefined
+                    expect(capturedFetchRequest.requestBody).to.eq('i am the fetch body')
+
+                    expect(capturedFetchRequest.responseBody).to.eq(
+                        JSON.stringify({
+                            message: 'This is a JSON response',
+                        })
+                    )
+                })
+            })
+        })
+
+        describe('with badly wrapped network capture', () => {
+            beforeEach(() => {
+                start({
+                    decideResponseOverrides: {
+                        isAuthenticated: false,
+                        sessionRecording: {
+                            endpoint: '/ses/',
+                            networkPayloadCapture: { recordBody: true },
+                        },
+                        capturePerformance: true,
+                        autocapture_opt_out: true,
+                    },
+                    url: './playground/cypress',
+                    options: {
+                        loaded: (ph) => {
+                            ph.sessionRecording._forceAllowLocalhostNetworkCapture = true
+                        },
+                    },
+                })
+
+                cy.wait('@recorder')
+
+                // wrap fetch to log the body of the request
+                // this simulates various libraries that require
+                // being able to read the request
+                // and possibly alter it
+                // see: https://github.com/PostHog/posthog/issues/24471
+                // for the catastrophic but hard to detect impact of
+                // interfering with that with our wrapper
+                cy.window().then((win) => {
+                    originalFetch = win.fetch
+                    win.fetch = async function (requestOrURL: URL | RequestInfo, init?: RequestInit | undefined) {
+                        try {
+                            console.log('in the fetch wrapper')
+
+                            const body =
+                                typeof requestOrURL !== 'string' && 'body' in requestOrURL
+                                    ? requestOrURL.body
+                                    : init?.body
+                            if (body) {
+                                // read the body out of the request, this uses up the request object
+                                // and won't work on a used up request object
+                                // eslint-disable-next-line no-console
+                                console.log('Request body:', body)
+                            }
+
+                            const res = await originalFetch(requestOrURL, init)
+                            // also read the body
+
+                            const reader = res.body.getReader()
+                            // eslint-disable-next-line compat/compat
+                            const decoder = new TextDecoder()
+                            let result = ''
+
+                            function readStream() {
+                                return reader.read().then(({ done, value }) => {
+                                    if (done) {
+                                        // Stream is fully read
+                                        return result
+                                    }
+
+                                    // Decode the current chunk and append it to the result
+                                    result += decoder.decode(value, { stream: true })
+
+                                    // Read the next chunk
+                                    return readStream()
+                                })
+                            }
+
+                            // we read the body to exhaust it
+                            await readStream()
+
+                            return res
+                        } catch (e) {
+                            console.error('fetch wrapper error', e)
+                            throw e
+                        } finally {
+                            console.log('fetch wrapper finally')
+                        }
+                    }
+                })
+            })
+
+            it('it sends network payloads', () => {
+                cy.intercept({url: 'https://example.com', times: 1 }, (req) => {
+                    req.reply({
+                        statusCode: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                        body: {
+                            message: 'This is a JSON response',
+                        },
+                    })
+                }).as('example.com')
+
+                cy.get('[data-cy-network-call-button]').click()
+                cy.wait('@example.com')
+                cy.wait('@session-recording')
+                cy.phCaptures({ full: true }).then((captures) => {
+                    const snapshots = captures.filter((c) => c.event === '$snapshot')
+
+                    const capturedRequests: Record<string, any>[] = []
+                    for (const snapshot of snapshots) {
+                        for (const snapshotData of snapshot.properties['$snapshot_data']) {
+                            if (snapshotData.type === 6) {
+                                for (const req of snapshotData.data.payload.requests) {
+                                    capturedRequests.push(req)
+                                }
+                            }
+                        }
+                    }
+
+                    const expectedCaptureds: [RegExp, string][] = [
+                        [/http:\/\/localhost:\d+\/playground\/cypress\//, 'navigation'],
+                        [/http:\/\/localhost:\d+\/static\/array.js/, 'script'],
+                        [
+                            /http:\/\/localhost:\d+\/decide\/\?v=3&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
+                            'xmlhttprequest',
+                        ],
+                        [/http:\/\/localhost:\d+\/static\/recorder.js\?v=1\.\d\d\d\.\d+/, 'script'],
+                        [/https:\/\/example.com/, 'fetch'],
+                    ]
+
+                    // yay, includes expected type 6 network data
+                    expect(capturedRequests.length).to.equal(expectedCaptureds.length)
+                    expectedCaptureds.forEach(([url, initiatorType], index) => {
+                        expect(capturedRequests[index].name).to.match(url)
+                        expect(capturedRequests[index].initiatorType).to.equal(initiatorType)
+                    })
+
+                    // the HTML file that cypress is operating on (playground/cypress/index.html)
+                    // when the button for this test is click makes a post to https://example.com
+                    const capturedFetchRequest = capturedRequests.find((cr) => cr.name === 'https://example.com/')
+                    expect(capturedFetchRequest).to.not.be.undefined
+
+                    expect(capturedFetchRequest.fetchStart).to.be.greaterThan(0) // proxy for including network timing info
+
+                    expect(capturedFetchRequest.initiatorType).to.eql('fetch')
+                    expect(capturedFetchRequest.isInitial).to.be.undefined
+                    expect(capturedFetchRequest.requestBody).to.eq('i am the fetch body')
+
+                    expect(capturedFetchRequest.responseBody).to.eq('[SessionReplay] Failed to read body')
+                })
             })
         })
     })

--- a/cypress/e2e/session-recording.cy.ts
+++ b/cypress/e2e/session-recording.cy.ts
@@ -129,53 +129,43 @@ describe('Session recording', () => {
                 })
         })
     })
+    ;[true, false].forEach((isBadlyBehavedWrapper) => {
+        describe(`network capture - when fetch wrapper ${
+            isBadlyBehavedWrapper ? 'is' : 'is not'
+        } badly behaved`, () => {
+            let originalFetch: typeof fetch | null = null
 
-    describe('network capture', () => {
-        let originalFetch: typeof fetch | null = null
-
-        beforeEach(() => {
-            start({
-                decideResponseOverrides: {
-                    isAuthenticated: false,
-                    sessionRecording: {
-                        endpoint: '/ses/',
-                        networkPayloadCapture: { recordBody: true },
-                    },
-                    capturePerformance: true,
-                    autocapture_opt_out: true,
-                },
-                url: './playground/cypress',
-                options: {
-                    loaded: (ph) => {
-                        ph.sessionRecording._forceAllowLocalhostNetworkCapture = true
-                    },
-                },
-            })
-
-            cy.wait('@recorder')
-
-            cy.intercept({ url: 'https://example.com', times: 1 }, (req) => {
-                req.reply({
-                    statusCode: 200,
-                    headers: { 'Content-Type': 'application/json' },
-                    body: {
-                        message: 'This is a JSON response',
-                    },
-                })
-            }).as('example.com')
-        })
-
-        afterEach(() => {
-            if (originalFetch) {
-                cy.window().then((win) => {
-                    win.fetch = originalFetch
-                    originalFetch = null
-                })
-            }
-        })
-
-        describe('with safe wrapped network capture', () => {
             beforeEach(() => {
+                start({
+                    decideResponseOverrides: {
+                        isAuthenticated: false,
+                        sessionRecording: {
+                            endpoint: '/ses/',
+                            networkPayloadCapture: { recordBody: true },
+                        },
+                        capturePerformance: true,
+                        autocapture_opt_out: true,
+                    },
+                    url: './playground/cypress',
+                    options: {
+                        loaded: (ph) => {
+                            ph.sessionRecording._forceAllowLocalhostNetworkCapture = true
+                        },
+                    },
+                })
+
+                cy.wait('@recorder')
+
+                cy.intercept({ url: 'https://example.com', times: 1 }, (req) => {
+                    req.reply({
+                        statusCode: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                        body: {
+                            message: 'This is a JSON response',
+                        },
+                    })
+                }).as('example.com')
+
                 // wrap fetch to log the body of the request
                 // this simulates various libraries that require
                 // being able to read the request
@@ -185,8 +175,17 @@ describe('Session recording', () => {
                 // interfering with that with our wrapper
                 cy.window().then((win) => {
                     originalFetch = win.fetch
-                    win.fetch = wrapFetchInCypress({ originalFetch })
+                    win.fetch = wrapFetchInCypress({ originalFetch, badlyBehaved: isBadlyBehavedWrapper })
                 })
+            })
+
+            afterEach(() => {
+                if (originalFetch) {
+                    cy.window().then((win) => {
+                        win.fetch = originalFetch
+                        originalFetch = null
+                    })
+                }
             })
 
             it('it sends network payloads', () => {
@@ -237,77 +236,12 @@ describe('Session recording', () => {
                     expect(capturedFetchRequest.requestBody).to.eq('i am the fetch body')
 
                     expect(capturedFetchRequest.responseBody).to.eq(
-                        JSON.stringify({
-                            message: 'This is a JSON response',
-                        })
+                        isBadlyBehavedWrapper
+                            ? '[SessionReplay] Failed to read body'
+                            : JSON.stringify({
+                                  message: 'This is a JSON response',
+                              })
                     )
-                })
-            })
-        })
-
-        describe('with badly wrapped network capture', () => {
-            beforeEach(() => {
-                // wrap fetch to log the body of the request
-                // this simulates various libraries that require
-                // being able to read the request
-                // and possibly alter it
-                // see: https://github.com/PostHog/posthog/issues/24471
-                // for the catastrophic but hard to detect impact of
-                // interfering with that with our wrapper
-                cy.window().then((win) => {
-                    originalFetch = win.fetch
-                    win.fetch = wrapFetchInCypress({ originalFetch, badlyBehaved: true })
-                })
-            })
-
-            it('it sends network payloads', () => {
-                cy.get('[data-cy-network-call-button]').click()
-                cy.wait('@example.com')
-                cy.wait('@session-recording')
-                cy.phCaptures({ full: true }).then((captures) => {
-                    const snapshots = captures.filter((c) => c.event === '$snapshot')
-
-                    const capturedRequests: Record<string, any>[] = []
-                    for (const snapshot of snapshots) {
-                        for (const snapshotData of snapshot.properties['$snapshot_data']) {
-                            if (snapshotData.type === 6) {
-                                for (const req of snapshotData.data.payload.requests) {
-                                    capturedRequests.push(req)
-                                }
-                            }
-                        }
-                    }
-
-                    const expectedCaptureds: [RegExp, string][] = [
-                        [/http:\/\/localhost:\d+\/playground\/cypress\//, 'navigation'],
-                        [/http:\/\/localhost:\d+\/static\/array.js/, 'script'],
-                        [
-                            /http:\/\/localhost:\d+\/decide\/\?v=3&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
-                            'xmlhttprequest',
-                        ],
-                        [/http:\/\/localhost:\d+\/static\/recorder.js\?v=1\.\d\d\d\.\d+/, 'script'],
-                        [/https:\/\/example.com/, 'fetch'],
-                    ]
-
-                    // yay, includes expected type 6 network data
-                    expect(capturedRequests.length).to.equal(expectedCaptureds.length)
-                    expectedCaptureds.forEach(([url, initiatorType], index) => {
-                        expect(capturedRequests[index].name).to.match(url)
-                        expect(capturedRequests[index].initiatorType).to.equal(initiatorType)
-                    })
-
-                    // the HTML file that cypress is operating on (playground/cypress/index.html)
-                    // when the button for this test is click makes a post to https://example.com
-                    const capturedFetchRequest = capturedRequests.find((cr) => cr.name === 'https://example.com/')
-                    expect(capturedFetchRequest).to.not.be.undefined
-
-                    expect(capturedFetchRequest.fetchStart).to.be.greaterThan(0) // proxy for including network timing info
-
-                    expect(capturedFetchRequest.initiatorType).to.eql('fetch')
-                    expect(capturedFetchRequest.isInitial).to.be.undefined
-                    expect(capturedFetchRequest.requestBody).to.eq('i am the fetch body')
-
-                    expect(capturedFetchRequest.responseBody).to.eq('[SessionReplay] Failed to read body')
                 })
             })
         })

--- a/src/entrypoints/recorder.ts
+++ b/src/entrypoints/recorder.ts
@@ -220,8 +220,6 @@ function initXhrObserver(cb: networkCallback, win: IWindow, options: Required<Ne
     const recordRequestHeaders = shouldRecordHeaders('request', options.recordHeaders)
     const recordResponseHeaders = shouldRecordHeaders('response', options.recordHeaders)
 
-    logger.info('initialising xhr observer', { recordRequestHeaders, recordResponseHeaders })
-
     const restorePatch = patch(
         win.XMLHttpRequest.prototype,
         'open',

--- a/src/entrypoints/recorder.ts
+++ b/src/entrypoints/recorder.ts
@@ -513,7 +513,7 @@ function initFetchObserver(
                 }
 
                 after = win.performance.now()
-                res = await originalFetch(url, init)
+                res = await originalFetch(req)
                 before = win.performance.now()
 
                 const responseHeaders: Headers = {}

--- a/src/entrypoints/recorder.ts
+++ b/src/entrypoints/recorder.ts
@@ -513,7 +513,7 @@ function initFetchObserver(
                 }
 
                 after = win.performance.now()
-                res = await originalFetch(req)
+                res = await originalFetch(url, init)
                 before = win.performance.now()
 
                 const responseHeaders: Headers = {}

--- a/src/entrypoints/recorder.ts
+++ b/src/entrypoints/recorder.ts
@@ -430,7 +430,7 @@ function _tryReadBody(r: Request | Response): Promise<string> {
                     (reason) => reject(reason)
                 )
                 .finally(() => clearTimeout(timeout))
-        } catch (e) {
+        } catch {
             clearTimeout(timeout)
             resolve('[SessionReplay] Failed to read body')
         }
@@ -483,9 +483,6 @@ function initFetchObserver(
     }
     const recordRequestHeaders = shouldRecordHeaders('request', options.recordHeaders)
     const recordResponseHeaders = shouldRecordHeaders('response', options.recordHeaders)
-
-    // eslint-disable-next-line no-console
-    console.log('initialising fetch observer', { recordRequestHeaders, recordResponseHeaders })
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/src/extensions/replay/rrweb-plugins/patch.ts
+++ b/src/extensions/replay/rrweb-plugins/patch.ts
@@ -20,23 +20,37 @@ export function patch(
 
         // Make sure it's a function first, as we need to attach an empty prototype for `defineProperties` to work
         // otherwise it'll throw "TypeError: Object.defineProperties called on non-object"
-        if (isFunction(wrapped)) {
+        if (isFunction(wrapped) && !(wrapped as any).__posthog_wrapped__) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             wrapped.prototype = wrapped.prototype || {}
+
             Object.defineProperties(wrapped, {
                 __posthog_wrapped__: {
                     enumerable: false,
                     value: true,
                 },
             })
+
+            console.log('wrapping something!')
+            console.log('wrapped', wrapped)
+            console.log('wrapped __p', (wrapped as any).__posthog_wrapped__)
         }
 
         source[name] = wrapped
 
+        console.log('wat', {
+            winFetch: source.fetch,
+            wrapped,
+            source,
+            name,
+            wat: source[name],
+        })
+
         return () => {
             source[name] = original
         }
-    } catch {
+    } catch (ex) {
+        console.error('Error in patching:', ex)
         return () => {
             //
         }

--- a/src/extensions/replay/rrweb-plugins/patch.ts
+++ b/src/extensions/replay/rrweb-plugins/patch.ts
@@ -20,10 +20,9 @@ export function patch(
 
         // Make sure it's a function first, as we need to attach an empty prototype for `defineProperties` to work
         // otherwise it'll throw "TypeError: Object.defineProperties called on non-object"
-        if (isFunction(wrapped) && !(wrapped as any).__posthog_wrapped__) {
+        if (isFunction(wrapped)) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             wrapped.prototype = wrapped.prototype || {}
-
             Object.defineProperties(wrapped, {
                 __posthog_wrapped__: {
                     enumerable: false,

--- a/src/extensions/replay/rrweb-plugins/patch.ts
+++ b/src/extensions/replay/rrweb-plugins/patch.ts
@@ -30,27 +30,14 @@ export function patch(
                     value: true,
                 },
             })
-
-            console.log('wrapping something!')
-            console.log('wrapped', wrapped)
-            console.log('wrapped __p', (wrapped as any).__posthog_wrapped__)
         }
 
         source[name] = wrapped
 
-        console.log('wat', {
-            winFetch: source.fetch,
-            wrapped,
-            source,
-            name,
-            wat: source[name],
-        })
-
         return () => {
             source[name] = original
         }
-    } catch (ex) {
-        console.error('Error in patching:', ex)
+    } catch {
         return () => {
             //
         }


### PR DESCRIPTION
part of responding to https://github.com/PostHog/posthog/issues/24471 due to the unexpected consequences of https://github.com/PostHog/posthog-js/pull/1351

it is _very_ hard to test for all unexpected consequences of changes to code 🙈 

but we do at least _now_ know for sure that that we cannot rely on request/response objects being readable and that we should not read them and then pass them on

![Screenshot 2024-08-30 at 10 03 11](https://github.com/user-attachments/assets/86767b18-a5a9-4e3f-ad83-30a6efc9d495)

Here's the test failing in CI and showing we would have avoided all of the painful impact for folk

```
  1 failing
  1) Session recording
       network capture - when fetch wrapper is not badly behaved
         it sends network payloads:
     TypeError: The following error originated from your test code, not from Cypress. It was caused by an unhandled promise rejection.
  > Failed to execute 'fetch' on 'Window': Cannot construct a Request with a Request object that has already been used.
```