### PR TITLE
fix: flushing the buffer for debug signal while idle extends session activity

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -37,6 +37,7 @@ import {
     EventType,
     eventWithTime,
     fullSnapshotEvent,
+    incrementalData,
     incrementalSnapshotEvent,
     IncrementalSource,
     metaEvent,
@@ -84,7 +85,7 @@ const createIncrementalSnapshot = (event = {}): incrementalSnapshotEvent => ({
     type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
     data: {
         source: 1,
-    },
+    } as Partial<incrementalData> as incrementalData,
     ...event,
 })
 
@@ -1032,6 +1033,7 @@ describe('SessionRecording', () => {
                 // we always take a full snapshot when there hasn't been one
                 // and use _fullSnapshotTimer to track that
                 // we want to avoid that behavior here, so we set it to any value
+                // @ts-expect-error -- detected as Timeout because the test is picking up `NodeJS.Timeout` as the type not `number` as in the browser
                 sessionRecording['_fullSnapshotTimer'] = 1
 
                 sessionIdGeneratorMock.mockImplementation(() => 'old-session-id')

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -1362,7 +1362,7 @@ describe('SessionRecording', () => {
             })
         })
 
-        it('emits custom events even when idle', () => {
+        it('emits custom events even only when returning from idle', () => {
             // force idle state
             sessionRecording['isIdle'] = true
             // buffer is empty
@@ -1389,6 +1389,10 @@ describe('SessionRecording', () => {
                 size: 47,
                 windowId: 'windowId',
             })
+            emitInactiveEvent(startingTimestamp + 100, true)
+            expect(posthog.capture).not.toHaveBeenCalled()
+
+            expect(sessionRecording['flushBufferTimer']).toBeUndefined()
         })
 
         it('drops full snapshots when idle - so we must make sure not to take them while idle!', () => {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -902,7 +902,7 @@ export class SessionRecording {
         this.buffer.size += properties.$snapshot_bytes
         this.buffer.data.push(properties.$snapshot_data)
 
-        if (!this.flushBufferTimer) {
+        if (!this.flushBufferTimer && !this.isIdle) {
             this.flushBufferTimer = setTimeout(() => {
                 this._flushBuffer()
             }, RECORDING_BUFFER_TIMEOUT)

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -893,8 +893,9 @@ export class SessionRecording {
     private _captureSnapshotBuffered(properties: Properties) {
         const additionalBytes = 2 + (this.buffer?.data.length || 0) // 2 bytes for the array brackets and 1 byte for each comma
         if (
-            this.buffer.size + properties.$snapshot_bytes + additionalBytes > RECORDING_MAX_EVENT_SIZE ||
-            this.buffer.sessionId !== this.sessionId
+            !this.isIdle && // we never want to flush when idle
+            (this.buffer.size + properties.$snapshot_bytes + additionalBytes > RECORDING_MAX_EVENT_SIZE ||
+                this.buffer.sessionId !== this.sessionId)
         ) {
             this.buffer = this._flushBuffer()
         }


### PR DESCRIPTION
In stepping through what we do around idleness in the recorder 

* we only check and extend session if it’s an interactive event
* i.e. if the user is not idle
* Reading the code of `checkAndGetSessionAndWindowId` you must check and extend session in order to check idle timeout 
* So you can’t have an idle timeout in recording unless you return from idle 🤯
* While idle we only allow custom events  they go into the in-memory buffer  when that happens…
* the buffer is flushed if the session id has changed or if the buffer holds > 0.9MBish  and if not we set a two second timer which will flush the buffer  
* when flushing the buffer so long as the buffer is not empty we capture a snapshot with the buffer contents 
* that calls capture on the posthog instance  
* which among other things makes a non-readonly check of the session id and window id 
* which might cause the session id to change generally 
* _and_ for the message being captured **overwriting the data being sent with the new session and window id** 
* and checking the session/window id extends the activity timer
* so if a session has frequent enough custom events while idle it would never idle timeout

This PR ensures we don't flush the buffer when idle but still allows buffering (allowed) snapshot data while idle