### PR TITLE
fix: warn on unavailable lazy load not throw

### DIFF
--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -267,6 +267,7 @@ export class PostHogSurveys {
     private _canActivateRepeatedly(survey: Survey) {
         if (isNullish(assignableWindow.__PosthogExtensions__?.canActivateRepeatedly)) {
             logger.warn(LOGGER_PREFIX, 'canActivateRepeatedly is not defined, must init before calling')
+            return false // TODO does it make sense to have a default here?
         }
         return assignableWindow.__PosthogExtensions__.canActivateRepeatedly(survey)
     }

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -265,7 +265,7 @@ export class PostHogSurveys {
 
     // this method is lazily loaded onto the window to avoid loading preact and other dependencies if surveys is not enabled
     private _canActivateRepeatedly(survey: Survey) {
-        if (isNullish(assignableWindow.__PosthogExtensions__.canActivateRepeatedly)) {
+        if (isNullish(assignableWindow.__PosthogExtensions__?.canActivateRepeatedly)) {
             logger.warn(LOGGER_PREFIX, 'canActivateRepeatedly is not defined, must init before calling')
         }
         return assignableWindow.__PosthogExtensions__.canActivateRepeatedly(survey)


### PR DESCRIPTION
relates to #1344

we're checking the presence of a method on something that _could_ be undefined

but we don't correctly type all the lazy load stuff, so TS doesn't complain

this at least safely checks the presence and will warn instead 
we're likely calling the method too early (before it has had a chance to be added to the window) this might even be safe, so we definitely shouldn't throw