### PR TITLE
fix: some clients need web vitals directly on window

### DIFF
--- a/src/entrypoints/web-vitals.ts
+++ b/src/entrypoints/web-vitals.ts
@@ -12,4 +12,11 @@ const postHogWebVitalsCallbacks = {
 assignableWindow.__PosthogExtensions__ = assignableWindow.__PosthogExtensions__ || {}
 assignableWindow.__PosthogExtensions__.postHogWebVitalsCallbacks = postHogWebVitalsCallbacks
 
+// we used to put posthogWebVitalsCallbacks on window, and now we put it on __PosthogExtensions__
+// but that means that old clients which lazily load this extension are looking in the wrong place
+// yuck,
+// so we also put it directly on the window
+// when 1.161.1 is the older version seen in production we can remove this
+assignableWindow.postHogWebVitalsCallbacks = postHogWebVitalsCallbacks
+
 export default postHogWebVitalsCallbacks

--- a/src/entrypoints/web-vitals.ts
+++ b/src/entrypoints/web-vitals.ts
@@ -16,7 +16,7 @@ assignableWindow.__PosthogExtensions__.postHogWebVitalsCallbacks = postHogWebVit
 // but that means that old clients which lazily load this extension are looking in the wrong place
 // yuck,
 // so we also put it directly on the window
-// when 1.161.1 is the older version seen in production we can remove this
+// when 1.161.1 is the oldest version seen in production we can remove this
 assignableWindow.postHogWebVitalsCallbacks = postHogWebVitalsCallbacks
 
 export default postHogWebVitalsCallbacks


### PR DESCRIPTION
In #1401 we moved the web vitals callbacks onto an object on the window instead of placing them directly on the window... there are more and more extensions being added on to the window - and that is no bueno 

but, existing clients installed with npm may now request web vitals and look for it directly on the window but it isn't there any more - also no bueno

we can't fix this in the main bundle since its only old clients and they won't have that code, so it has to be fixed in the entrypoint file - which is what generates the web vitals file the old clients are lazily loading