### PR TITLE
fix: manage capture pageview hook lifecycle

### DIFF
--- a/cypress/e2e/session-recording.cy.ts
+++ b/cypress/e2e/session-recording.cy.ts
@@ -397,10 +397,18 @@ describe('Session recording', () => {
                     // a meta and then a full snapshot
                     expect(captures[1]['properties']['$snapshot_data'][0].type).to.equal(4) // meta
                     expect(captures[1]['properties']['$snapshot_data'][1].type).to.equal(2) // full_snapshot
-                    expect(captures[1]['properties']['$snapshot_data'][2].type).to.equal(5) // custom event with options
-                    expect(captures[1]['properties']['$snapshot_data'][3].type).to.equal(5) // custom event with posthog config
+
+                    expect(captures[1]['properties']['$snapshot_data'][2].type).to.equal(5)
+                    expect(captures[1]['properties']['$snapshot_data'][2].data.tag).to.equal('$pageview')
+
+                    expect(captures[1]['properties']['$snapshot_data'][3].type).to.equal(5) // custom event with options
+                    expect(captures[1]['properties']['$snapshot_data'][3].data.tag).to.equal('$session_options')
+
+                    expect(captures[1]['properties']['$snapshot_data'][4].type).to.equal(5) // custom event with posthog config
+                    expect(captures[1]['properties']['$snapshot_data'][4].data.tag).to.equal('$posthog_config') // custom event with posthog config
+
                     const xPositions = []
-                    for (let i = 4; i < captures[1]['properties']['$snapshot_data'].length; i++) {
+                    for (let i = 5; i < captures[1]['properties']['$snapshot_data'].length; i++) {
                         expect(captures[1]['properties']['$snapshot_data'][i].type).to.equal(3)
                         expect(captures[1]['properties']['$snapshot_data'][i].data.source).to.equal(
                             6,

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -312,8 +312,11 @@ describe('SessionRecording', () => {
         })
 
         it('sets the pageview capture hook once', () => {
+            expect(sessionRecording['_removePageViewCaptureHook']).toBeUndefined()
+
             sessionRecording.startIfEnabledOrStop()
-            expect(sessionRecording['_pageviewCaptureHook']).not.toBeNull()
+
+            expect(sessionRecording['_removePageViewCaptureHook']).not.toBeUndefined()
             expect(posthog._addCaptureHook).toHaveBeenCalledTimes(1)
 
             // calling a second time doesn't add another capture hook

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -332,6 +332,7 @@ export class SessionRecording {
             clearInterval(this._fullSnapshotTimer)
 
             this._removePageViewCaptureHook?.()
+            this._removePageViewCaptureHook = undefined
 
             logger.info(LOGGER_PREFIX + ' stopped')
         }

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -116,6 +116,7 @@ export class SessionRecording {
 
     private _fullSnapshotTimer?: ReturnType<typeof setInterval>
 
+    private _removePageViewCaptureHook: (() => void) | undefined = undefined
     // if pageview capture is disabled
     // then we can manually track href changes
     private _lastHref?: string
@@ -284,16 +285,35 @@ export class SessionRecording {
         if (this.isRecordingEnabled) {
             this._startCapture()
 
+            // calling addEventListener multiple times is safe and will not add duplicates
             window?.addEventListener('beforeunload', this._onBeforeUnload)
             window?.addEventListener('offline', this._onOffline)
             window?.addEventListener('online', this._onOnline)
             window?.addEventListener('visibilitychange', this._onVisibilityChange)
 
+            if (isNullish(this._removePageViewCaptureHook)) {
+                // :TRICKY: rrweb does not capture navigation within SPA-s, so hook into our $pageview events to get access to all events.
+                //   Dropping the initial event is fine (it's always captured by rrweb).
+                this._removePageViewCaptureHook = this.instance._addCaptureHook((eventName) => {
+                    // If anything could go wrong here it has the potential to block the main loop,
+                    // so we catch all errors.
+                    try {
+                        if (eventName === '$pageview') {
+                            const href = window ? this._maskUrl(window.location.href) : ''
+                            if (!href) {
+                                return
+                            }
+                            this._tryAddCustomEvent('$pageview', { href })
+                        }
+                    } catch (e) {
+                        logger.error('Could not add $pageview to rrweb session', e)
+                    }
+                })
+            }
+
             logger.info(LOGGER_PREFIX + ' started')
         } else {
             this.stopRecording()
-            this.clearBuffer()
-            clearInterval(this._fullSnapshotTimer)
         }
     }
 
@@ -307,6 +327,11 @@ export class SessionRecording {
             window?.removeEventListener('offline', this._onOffline)
             window?.removeEventListener('online', this._onOnline)
             window?.removeEventListener('visibilitychange', this._onVisibilityChange)
+
+            this.clearBuffer()
+            clearInterval(this._fullSnapshotTimer)
+
+            this._removePageViewCaptureHook?.()
 
             logger.info(LOGGER_PREFIX + ' stopped')
         }
@@ -659,24 +684,6 @@ export class SessionRecording {
             },
             plugins: activePlugins,
             ...sessionRecordingOptions,
-        })
-
-        // :TRICKY: rrweb does not capture navigation within SPA-s, so hook into our $pageview events to get access to all events.
-        //   Dropping the initial event is fine (it's always captured by rrweb).
-        this.instance._addCaptureHook((eventName) => {
-            // If anything could go wrong here it has the potential to block the main loop,
-            // so we catch all errors.
-            try {
-                if (eventName === '$pageview') {
-                    const href = window ? this._maskUrl(window.location.href) : ''
-                    if (!href) {
-                        return
-                    }
-                    this._tryAddCustomEvent('$pageview', { href })
-                }
-            } catch (e) {
-                logger.error('Could not add $pageview to rrweb session', e)
-            }
         })
 
         // We reset the last activity timestamp, resetting the idle timer

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -864,8 +864,8 @@ export class PostHog {
         return data
     }
 
-    _addCaptureHook(callback: (eventName: string, eventPayload?: CaptureResult) => void): void {
-        this.on('eventCaptured', (data) => callback(data.event, data))
+    _addCaptureHook(callback: (eventName: string, eventPayload?: CaptureResult) => void): () => void {
+        return this.on('eventCaptured', (data) => callback(data.event, data))
     }
 
     _calculate_event_properties(event_name: string, event_properties: Properties, timestamp?: Date): Properties {


### PR DESCRIPTION
Taking small steps to reorganise this.

First step is to increase the safety of calling start and stop multiple times

I have seen recordings with a surprising number of apparently duplicate custom pageview events

We _always_ register a pageview callback when starting, instead of registering one when we don't have one

So, this:

* changes `_addCaptureHook` to return the unsubscribe function
* calls the unsubscribe when stopping
* and only adds a listener if we don't already have one