### PR TITLE
chore: add page title to custom events

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -303,7 +303,7 @@ export class SessionRecording {
                             if (!href) {
                                 return
                             }
-                            this._tryAddCustomEvent('$pageview', { href })
+                            this._tryAddCustomEvent('$pageview', { href, title: this._documentTitle() })
                         }
                     } catch (e) {
                         logger.error('Could not add $pageview to rrweb session', e)
@@ -807,9 +807,13 @@ export class SessionRecording {
         }
         const currentUrl = this._maskUrl(window.location.href)
         if (this._lastHref !== currentUrl) {
-            this._tryAddCustomEvent('$url_changed', { href: currentUrl })
+            this._tryAddCustomEvent('$url_changed', { href: currentUrl, title: this._documentTitle() })
             this._lastHref = currentUrl
         }
+    }
+
+    private _documentTitle() {
+        return document?.title || null
     }
 
     private _processQueuedEvents() {


### PR DESCRIPTION
## Changes

In working through some of the design changes proposed in https://github.com/PostHog/posthog/issues/24561 we are looking to track the title of a given page in the playback tabs

<img width="669" alt="Screenshot 2024-09-10 at 20 26 01" src="https://github.com/user-attachments/assets/cd398d08-2062-4a46-8a3d-9fca6837a134">

Given we don't want to rely on `$pageview` events where possible in Replay because we can't always guarantee a customer uses events, it seems like the only alternative is to add the title to the custom rrweb events.

Open to pushback here. Other options include:
1) Never showing the title during playback and just relying on the url
2) Only enhancing the tab with the title if a customer collects events

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
