### PR TITLE
feat: Bundle option without any external scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "build-rollup": "rm -rf lib && tsc -b && rollup -c --bundleConfigAsCjs",
         "build-react": "cd react; NODE_ENV=dev pnpm i; pnpm build;",
         "lint": "eslint src && eslint cypress",
+        "lint:fix": "eslint src --fix && eslint cypress --fix",
         "prettier": "prettier --write src/ functional_tests/",
         "prepublishOnly": "pnpm lint && pnpm test && pnpm build && pnpm test:react",
         "test": "pnpm test:unit && pnpm test:custom-eslint-rules && pnpm test:functional",

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -67,12 +67,9 @@ export class Decide {
 
         if (response['siteApps']) {
             if (this.instance.config.opt_in_site_apps) {
-                for (const { id, url } of response['siteApps']) {
-                    const scriptUrl = this.instance.requestRouter.endpointFor('api', url)
-
+                for(const { id, url } of response['siteApps']) {
                     assignableWindow[`__$$ph_site_app_${id}`] = this.instance
-
-                    this.instance.requestRouter.loadScript(scriptUrl, (err) => {
+                    assignableWindow.__PosthogExtensions__?.loadSiteApp?.(this.instance, url, (err) => {
                         if (err) {
                             return logger.error(`Error while initializing PostHog app with config id ${id}`, err)
                         }

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -67,7 +67,7 @@ export class Decide {
 
         if (response['siteApps']) {
             if (this.instance.config.opt_in_site_apps) {
-                for(const { id, url } of response['siteApps']) {
+                for (const { id, url } of response['siteApps']) {
                     assignableWindow[`__$$ph_site_app_${id}`] = this.instance
                     assignableWindow.__PosthogExtensions__?.loadSiteApp?.(this.instance, url, (err) => {
                         if (err) {

--- a/src/entrypoints/array.ts
+++ b/src/entrypoints/array.ts
@@ -1,3 +1,4 @@
+import './external-scripts-loader'
 import { init_from_snippet } from '../posthog-core'
 
 init_from_snippet()

--- a/src/entrypoints/external-scripts-loader.ts
+++ b/src/entrypoints/external-scripts-loader.ts
@@ -2,12 +2,7 @@ import type { PostHog } from '../posthog-core'
 import { assignableWindow, document, PostHogExtensionKind } from '../utils/globals'
 import { logger } from '../utils/logger'
 
-
-const loadScript = (
-    posthog: PostHog,
-    url: string,
-    callback: (error?: string | Event, event?: Event) => void
-) => {
+const loadScript = (posthog: PostHog, url: string, callback: (error?: string | Event, event?: Event) => void) => {
     if (posthog.config.disable_external_dependency_loading) {
         logger.warn(`${url} was requested but loading of external scripts is disabled.`)
         return callback('Loading of external scripts is disabled')
@@ -59,16 +54,14 @@ assignableWindow.__PosthogExtensions__.loadExternalDependency = (
     const url = posthog.requestRouter.endpointFor('assets', scriptUrlToLoad)
 
     loadScript(posthog, url, callback)
-
 }
-
 
 assignableWindow.__PosthogExtensions__.loadSiteApp = (
     posthog: PostHog,
     url: string,
     callback: (error?: string | Event, event?: Event) => void
 ): void => {
-    const scriptUrl = posthog.requestRouter.endpointFor('api', url);
+    const scriptUrl = posthog.requestRouter.endpointFor('api', url)
 
     loadScript(posthog, scriptUrl, callback)
 }

--- a/src/entrypoints/external-scripts-loader.ts
+++ b/src/entrypoints/external-scripts-loader.ts
@@ -1,0 +1,74 @@
+import type { PostHog } from '../posthog-core'
+import { assignableWindow, document, PostHogExtensionKind } from '../utils/globals'
+import { logger } from '../utils/logger'
+
+
+const loadScript = (
+    posthog: PostHog,
+    url: string,
+    callback: (error?: string | Event, event?: Event) => void
+) => {
+    if (posthog.config.disable_external_dependency_loading) {
+        logger.warn(`${url} was requested but loading of external scripts is disabled.`)
+        return callback('Loading of external scripts is disabled')
+    }
+
+    const addScript = () => {
+        if (!document) {
+            return callback('document not found')
+        }
+        const scriptTag = document.createElement('script')
+        scriptTag.type = 'text/javascript'
+        scriptTag.src = url
+        scriptTag.onload = (event) => callback(undefined, event)
+        scriptTag.onerror = (error) => callback(error)
+
+        const scripts = document.querySelectorAll('body > script')
+        if (scripts.length > 0) {
+            scripts[0].parentNode?.insertBefore(scriptTag, scripts[0])
+        } else {
+            // In exceptional situations this call might load before the DOM is fully ready.
+            document.body.appendChild(scriptTag)
+        }
+    }
+
+    if (document?.body) {
+        addScript()
+    } else {
+        document?.addEventListener('DOMContentLoaded', addScript)
+    }
+}
+
+assignableWindow.__PosthogExtensions__ = assignableWindow.__PosthogExtensions__ || {}
+assignableWindow.__PosthogExtensions__.loadExternalDependency = (
+    posthog: PostHog,
+    kind: PostHogExtensionKind,
+    callback: (error?: string | Event, event?: Event) => void
+): void => {
+    let scriptUrlToLoad = `/static/${kind}.js` + `?v=${posthog.version}`
+
+    if (kind === 'toolbar') {
+        // toolbar.js is served from the PostHog CDN, this has a TTL of 24 hours.
+        // the toolbar asset includes a rotating "token" that is valid for 5 minutes.
+        const fiveMinutesInMillis = 5 * 60 * 1000
+        // this ensures that we bust the cache periodically
+        const timestampToNearestFiveMinutes = Math.floor(Date.now() / fiveMinutesInMillis) * fiveMinutesInMillis
+
+        scriptUrlToLoad = `${scriptUrlToLoad}?&=${timestampToNearestFiveMinutes}`
+    }
+    const url = posthog.requestRouter.endpointFor('assets', scriptUrlToLoad)
+
+    loadScript(posthog, url, callback)
+
+}
+
+
+assignableWindow.__PosthogExtensions__.loadSiteApp = (
+    posthog: PostHog,
+    url: string,
+    callback: (error?: string | Event, event?: Event) => void
+): void => {
+    const scriptUrl = posthog.requestRouter.endpointFor('api', url);
+
+    loadScript(posthog, scriptUrl, callback)
+}

--- a/src/entrypoints/main.cjs.ts
+++ b/src/entrypoints/main.cjs.ts
@@ -1,4 +1,4 @@
-import "./external-scripts-loader"
+import './external-scripts-loader'
 import { init_as_module } from '../posthog-core'
 export { PostHog } from '../posthog-core'
 export * from '../types'

--- a/src/entrypoints/module.es.ts
+++ b/src/entrypoints/module.es.ts
@@ -1,3 +1,4 @@
+import "./external-scripts-loader"
 import { init_as_module } from '../posthog-core'
 export { PostHog } from '../posthog-core'
 export * from '../types'

--- a/src/entrypoints/module.es.ts
+++ b/src/entrypoints/module.es.ts
@@ -1,4 +1,4 @@
-import "./external-scripts-loader"
+import './external-scripts-loader'
 import { init_as_module } from '../posthog-core'
 export { PostHog } from '../posthog-core'
 export * from '../types'

--- a/src/entrypoints/module.full.es.ts
+++ b/src/entrypoints/module.full.es.ts
@@ -1,4 +1,9 @@
-import "./external-scripts-loader"
+import './recorder'
+import './surveys'
+import './exception-autocapture'
+import './tracing-headers'
+import './web-vitals'
+
 import { init_as_module } from '../posthog-core'
 export { PostHog } from '../posthog-core'
 export * from '../types'

--- a/src/extensions/exception-autocapture/index.ts
+++ b/src/extensions/exception-autocapture/index.ts
@@ -4,7 +4,6 @@ import { DecideResponse, Properties } from '../../types'
 
 import { logger } from '../../utils/logger'
 import { EXCEPTION_CAPTURE_ENABLED_SERVER_SIDE } from '../../constants'
-import Config from '../../config'
 
 const LOGGER_PREFIX = '[Exception Autocapture]'
 
@@ -47,12 +46,16 @@ export class ExceptionObserver {
             cb()
         }
 
-        assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, "exception-autocapture", (err) => {
-            if (err) {
-                return logger.error(LOGGER_PREFIX + ' failed to load script', err)
+        assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(
+            this.instance,
+            'exception-autocapture',
+            (err) => {
+                if (err) {
+                    return logger.error(LOGGER_PREFIX + ' failed to load script', err)
+                }
+                cb()
             }
-            cb()
-        })
+        )
     }
 
     private startCapturing = () => {

--- a/src/extensions/exception-autocapture/index.ts
+++ b/src/extensions/exception-autocapture/index.ts
@@ -47,7 +47,7 @@ export class ExceptionObserver {
             cb()
         }
 
-        this.instance.requestRouter.loadScript(`/static/exception-autocapture.js?v=${Config.LIB_VERSION}`, (err) => {
+        assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, "exception-autocapture", (err) => {
             if (err) {
                 return logger.error(LOGGER_PREFIX + ' failed to load script', err)
             }

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -486,7 +486,7 @@ export class SessionRecording {
         // If recorder.js is already loaded (if array.full.js snippet is used or posthog-js/dist/recorder is
         // imported), don't load script. Otherwise, remotely import recorder.js from cdn since it hasn't been loaded.
         if (!this.rrwebRecord) {
-            this.instance.requestRouter.loadScript(`/static/recorder.js?v=${Config.LIB_VERSION}`, (err) => {
+            assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, "replay", (err) => {
                 if (err) {
                     return logger.error(LOGGER_PREFIX + ` could not load recorder.js`, err)
                 }

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -20,7 +20,6 @@ import {
 import { PostHog } from '../../posthog-core'
 import { DecideResponse, FlagVariant, NetworkRecordOptions, NetworkRequest, Properties } from '../../types'
 import { EventType, type eventWithTime, IncrementalSource, type listenerHandler, RecordPlugin } from '@rrweb/types'
-import Config from '../../config'
 import { timestamp } from '../../utils'
 
 import {
@@ -486,7 +485,7 @@ export class SessionRecording {
         // If recorder.js is already loaded (if array.full.js snippet is used or posthog-js/dist/recorder is
         // imported), don't load script. Otherwise, remotely import recorder.js from cdn since it hasn't been loaded.
         if (!this.rrwebRecord) {
-            assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, "replay", (err) => {
+            assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, 'replay', (err) => {
                 if (err) {
                     return logger.error(LOGGER_PREFIX + ` could not load recorder.js`, err)
                 }

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -158,8 +158,7 @@ export class Toolbar {
             // only load the toolbar once, even if there are multiple instances of PostHogLib
             this.setToolbarState(ToolbarState.LOADING)
 
-            assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, "toolbar", (err) => {
-
+            assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, 'toolbar', (err) => {
                 if (err) {
                     logger.error('Failed to load toolbar', err)
                     this.setToolbarState(ToolbarState.UNINITIALIZED)

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -158,13 +158,8 @@ export class Toolbar {
             // only load the toolbar once, even if there are multiple instances of PostHogLib
             this.setToolbarState(ToolbarState.LOADING)
 
-            // toolbar.js is served from the PostHog CDN, this has a TTL of 24 hours.
-            // the toolbar asset includes a rotating "token" that is valid for 5 minutes.
-            const fiveMinutesInMillis = 5 * 60 * 1000
-            // this ensures that we bust the cache periodically
-            const timestampToNearestFiveMinutes = Math.floor(Date.now() / fiveMinutesInMillis) * fiveMinutesInMillis
+            assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, "toolbar", (err) => {
 
-            this.instance.requestRouter.loadScript(`/static/toolbar.js?t=${timestampToNearestFiveMinutes}`, (err) => {
                 if (err) {
                     logger.error('Failed to load toolbar', err)
                     this.setToolbarState(ToolbarState.UNINITIALIZED)

--- a/src/extensions/tracing-headers.ts
+++ b/src/extensions/tracing-headers.ts
@@ -1,7 +1,6 @@
 import { PostHog } from '../posthog-core'
 import { assignableWindow } from '../utils/globals'
 import { logger } from '../utils/logger'
-import Config from '../config'
 import { isUndefined } from '../utils/type-utils'
 
 const LOGGER_PREFIX = '[TRACING-HEADERS]'
@@ -18,7 +17,7 @@ export class TracingHeaders {
             cb()
         }
 
-        assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, "tracing-headers", (err) => {
+        assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, 'tracing-headers', (err) => {
             if (err) {
                 return logger.error(LOGGER_PREFIX + ' failed to load script', err)
             }

--- a/src/extensions/tracing-headers.ts
+++ b/src/extensions/tracing-headers.ts
@@ -18,7 +18,7 @@ export class TracingHeaders {
             cb()
         }
 
-        this.instance.requestRouter.loadScript(`/static/tracing-headers.js?v=${Config.LIB_VERSION}`, (err) => {
+        assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, "tracing-headers", (err) => {
             if (err) {
                 return logger.error(LOGGER_PREFIX + ' failed to load script', err)
             }

--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -4,7 +4,6 @@ import { logger } from '../../utils/logger'
 import { isBoolean, isNullish, isNumber, isObject, isUndefined } from '../../utils/type-utils'
 import { WEB_VITALS_ALLOWED_METRICS, WEB_VITALS_ENABLED_SERVER_SIDE } from '../../constants'
 import { assignableWindow, window } from '../../utils/globals'
-import Config from '../../config'
 
 type WebVitalsMetricCallback = (metric: any) => void
 
@@ -91,7 +90,7 @@ export class WebVitalsAutocapture {
             // already loaded
             cb()
         }
-        assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, "web-vitals", (err) => {
+        assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, 'web-vitals', (err) => {
             if (err) {
                 logger.error(LOGGER_PREFIX + ' failed to load script', err)
                 return

--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -91,8 +91,7 @@ export class WebVitalsAutocapture {
             // already loaded
             cb()
         }
-
-        this.instance.requestRouter.loadScript(`/static/web-vitals.js?v=${Config.LIB_VERSION}`, (err) => {
+        assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, "web-vitals", (err) => {
             if (err) {
                 logger.error(LOGGER_PREFIX + ' failed to load script', err)
                 return

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -74,7 +74,8 @@ export class PostHogSurveys {
             if (this._surveyEventReceiver == null) {
                 this._surveyEventReceiver = new SurveyEventReceiver(this.instance)
             }
-            this.instance.requestRouter.loadScript('/static/surveys.js', (err) => {
+
+            assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, "surveys", (err) => {
                 if (err) {
                     return logger.error(LOGGER_PREFIX, 'Could not load surveys script', err)
                 }

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -75,7 +75,7 @@ export class PostHogSurveys {
                 this._surveyEventReceiver = new SurveyEventReceiver(this.instance)
             }
 
-            assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, "surveys", (err) => {
+            assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, 'surveys', (err) => {
                 if (err) {
                     return logger.error(LOGGER_PREFIX, 'Could not load surveys script', err)
                 }

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -1,3 +1,4 @@
+import type { PostHog } from '../posthog-core'
 import { SessionIdManager } from '../sessionid'
 import { ErrorEventArgs, ErrorProperties, Properties } from '../types'
 
@@ -14,7 +15,21 @@ import { ErrorEventArgs, ErrorProperties, Properties } from '../types'
 // eslint-disable-next-line no-restricted-globals
 const win: (Window & typeof globalThis) | undefined = typeof window !== 'undefined' ? window : undefined
 
-interface PosthogExtensions {
+export type PostHogExtensionKind = 'toolbar' | 'exception-autocapture' | 'web-vitals' | 'replay' | 'tracing-headers' | "surveys"
+
+interface PostHogExtensions {
+    loadExternalDependency?: (
+        posthog: PostHog,
+        kind: PostHogExtensionKind,
+        callback: (error?: string | Event, event?: Event) => void
+    ) => void
+
+    loadSiteApp?: (
+        posthog: PostHog,
+        appUrl: string,
+        callback: (error?: string | Event, event?: Event) => void
+    ) => void
+
     parseErrorAsProperties?: ([event, source, lineno, colno, error]: ErrorEventArgs) => ErrorProperties
     errorWrappingFunctions?: {
         wrapOnError: (captureFn: (props: Properties) => void) => () => void
@@ -52,7 +67,7 @@ export const userAgent = navigator?.userAgent
 export const assignableWindow: Window &
     typeof globalThis &
     Record<string, any> & {
-        __PosthogExtensions__?: PosthogExtensions
+        __PosthogExtensions__?: PostHogExtensions
     } = win ?? ({} as any)
 
 export { win as window }

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -15,7 +15,13 @@ import { ErrorEventArgs, ErrorProperties, Properties } from '../types'
 // eslint-disable-next-line no-restricted-globals
 const win: (Window & typeof globalThis) | undefined = typeof window !== 'undefined' ? window : undefined
 
-export type PostHogExtensionKind = 'toolbar' | 'exception-autocapture' | 'web-vitals' | 'replay' | 'tracing-headers' | "surveys"
+export type PostHogExtensionKind =
+    | 'toolbar'
+    | 'exception-autocapture'
+    | 'web-vitals'
+    | 'replay'
+    | 'tracing-headers'
+    | 'surveys'
 
 interface PostHogExtensions {
     loadExternalDependency?: (
@@ -24,11 +30,7 @@ interface PostHogExtensions {
         callback: (error?: string | Event, event?: Event) => void
     ) => void
 
-    loadSiteApp?: (
-        posthog: PostHog,
-        appUrl: string,
-        callback: (error?: string | Event, event?: Event) => void
-    ) => void
+    loadSiteApp?: (posthog: PostHog, appUrl: string, callback: (error?: string | Event, event?: Event) => void) => void
 
     parseErrorAsProperties?: ([event, source, lineno, colno, error]: ErrorEventArgs) => ErrorProperties
     errorWrappingFunctions?: {

--- a/src/utils/request-router.ts
+++ b/src/utils/request-router.ts
@@ -1,6 +1,4 @@
 import { PostHog } from '../posthog-core'
-import { document } from '../utils/globals'
-import { logger } from './logger'
 
 /**
  * The request router helps simplify the logic to determine which endpoints should be called for which things
@@ -83,40 +81,6 @@ export class RequestRouter {
                 return `https://${this.region}-assets.${suffix}`
             case 'api':
                 return `https://${this.region}.${suffix}`
-        }
-    }
-
-    loadScript(scriptUrlToLoad: string, callback: (error?: string | Event, event?: Event) => void): void {
-        if (this.instance.config.disable_external_dependency_loading) {
-            logger.warn(`${scriptUrlToLoad} was requested but loading of external scripts is disabled.`)
-            return callback('Loading of external scripts is disabled')
-        }
-
-        const url = scriptUrlToLoad[0] === '/' ? this.endpointFor('assets', scriptUrlToLoad) : scriptUrlToLoad
-
-        const addScript = () => {
-            if (!document) {
-                return callback('document not found')
-            }
-            const scriptTag = document.createElement('script')
-            scriptTag.type = 'text/javascript'
-            scriptTag.src = url
-            scriptTag.onload = (event) => callback(undefined, event)
-            scriptTag.onerror = (error) => callback(error)
-
-            const scripts = document.querySelectorAll('body > script')
-            if (scripts.length > 0) {
-                scripts[0].parentNode?.insertBefore(scriptTag, scripts[0])
-            } else {
-                // In exceptional situations this call might load before the DOM is fully ready.
-                document.body.appendChild(scriptTag)
-            }
-        }
-
-        if (document?.body) {
-            addScript()
-        } else {
-            document?.addEventListener('DOMContentLoaded', addScript)
         }
     }
 }


### PR DESCRIPTION
## Changes

Builds on top of @pauldambra 's great external scripts typing work and makes the external deps loader a separate extension that we can then include depending on the bundle

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
…ut it