### PR TITLE
fix: no keep alive for large payloads

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -133,7 +133,9 @@ const _fetch = (options: RequestOptions) => {
     fetch!(url, {
         method: options?.method || 'GET',
         headers,
-        keepalive: options.method === 'POST',
+        // if body is greater than 64kb, then fetch with keepalive will error
+        // see 8:10:5 at https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+        keepalive: false,
         body,
         signal: aborter?.signal,
     })

--- a/src/request.ts
+++ b/src/request.ts
@@ -4,7 +4,7 @@ import { Compression, RequestOptions, RequestResponse } from './types'
 import { formDataToQuery } from './utils/request-utils'
 
 import { logger } from './utils/logger'
-import { fetch, XMLHttpRequest, AbortController, navigator } from './utils/globals'
+import { AbortController, fetch, navigator, XMLHttpRequest } from './utils/globals'
 import { gzipSync, strToU8 } from 'fflate'
 
 // eslint-disable-next-line compat/compat


### PR DESCRIPTION
we set keepalive to true for any request that is a POST

the fetch spec at https://fetch.spec.whatwg.org/#http-network-or-cache-fetch says

> If contentLength is non-null and httpRequest’s [keepalive](https://fetch.spec.whatwg.org/#request-keepalive-flag) is true, then:
> If the sum of contentLength and inflightKeepaliveBytes is greater than 64 kibibytes, then return a [network error](https://fetch.spec.whatwg.org/#concept-network-error).

read more at e.g. https://javascript.info/fetch-api#:~:text=But%20the%20keepalive%20option%20tells,for%20keepalive%20requests%20is%2064KB.

it is likely that a replay payload would be >64kb compressed

not all browsers obey this spec equally (of course) so it won't always fail, so it's not broken consistently enough to stand out.

but locally I can see network requests failing for this reason

fetch keepalive is intended for situations including those like analytics (👋 posthog) where you might want to allow a request to finish even though the page is navigating so we don't want to turn it off completely

lets estimate body size and set keepalive when its safe (which it should be for most analytics events)