### PR TITLE
chore: move test file into __tests__

### DIFF
--- a/src/__tests__/web-experiments.test.ts
+++ b/src/__tests__/web-experiments.test.ts
@@ -1,10 +1,10 @@
-import { WebExperiments } from './web-experiments'
-import { PostHog } from './posthog-core'
-import { DecideResponse, PostHogConfig } from './types'
-import { PostHogPersistence } from './posthog-persistence'
-import { WebExperiment } from './web-experiments-types'
-import { RequestRouter } from './utils/request-router'
-import { ConsentManager } from './consent'
+import { WebExperiments } from '../web-experiments'
+import { PostHog } from '../posthog-core'
+import { DecideResponse, PostHogConfig } from '../types'
+import { PostHogPersistence } from '../posthog-persistence'
+import { WebExperiment } from '../web-experiments-types'
+import { RequestRouter } from '../utils/request-router'
+import { ConsentManager } from '../consent'
 
 describe('Web Experimentation', () => {
     let webExperiment: WebExperiments


### PR DESCRIPTION
I came to my PR and couldn't publish locally because there's a test file outside of the __tests__ folder

i'm too lazy to figure out why we can't support test files in `src` and only `in `src/__tests__`

so i moved it