### PR TITLE
chore(dev): Pin pnpm version to be the same as posthog/posthog

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",
     "license": "MIT",
+    "packageManager": "pnpm@8.10.5",
     "scripts": {
         "start": "pnpm build-react && pnpm build-rollup -w",
         "build": "pnpm build-rollup && pnpm build-react",


### PR DESCRIPTION
## Changes

Ensure that the pnpm version used is the same as the one used in [posthog/posthog/package.json#L18](https://github.com/PostHog/posthog/blob/cced38ccd1d0063d9f086d46480ec105d21cde04/package.json#L18.)

Related to https://github.com/PostHog/posthog/issues/22022.