### PR TITLE
fix(surveys): 7-point likert scale didn't work with branching logic

### DIFF
--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -892,6 +892,32 @@ describe('surveys', () => {
             expect(surveys.getNextSurveyStep(survey, 0, 5)).toEqual(3)
         })
 
+        // Response-based branching, scale 1-7
+        it('should branch out the negative/neutral/positive respondents correctly (scale 1-7)', () => {
+            survey.questions = [
+                {
+                    question: 'How satisfied are you?',
+                    type: SurveyQuestionType.Rating,
+                    scale: 7,
+                    branching: {
+                        type: SurveyQuestionBranchingType.ResponseBased,
+                        responseValues: { negative: 1, neutral: 2, positive: 3 },
+                    },
+                },
+                { type: SurveyQuestionType.Open, question: 'We apologize for your experience. Can you tell us more?' },
+                { type: SurveyQuestionType.Open, question: 'What could we do to improve your experience?' },
+                { type: SurveyQuestionType.Open, question: 'Great! What did you enjoy the most?' },
+            ] as unknown as SurveyQuestion[]
+
+            expect(surveys.getNextSurveyStep(survey, 0, 1)).toEqual(1)
+            expect(surveys.getNextSurveyStep(survey, 0, 2)).toEqual(1)
+            expect(surveys.getNextSurveyStep(survey, 0, 3)).toEqual(1)
+            expect(surveys.getNextSurveyStep(survey, 0, 4)).toEqual(2)
+            expect(surveys.getNextSurveyStep(survey, 0, 5)).toEqual(3)
+            expect(surveys.getNextSurveyStep(survey, 0, 6)).toEqual(3)
+            expect(surveys.getNextSurveyStep(survey, 0, 7)).toEqual(3)
+        })
+
         // Response-based branching, scale 0-10 (NPS)
         it('should branch out detractors/passives/promoters correctly', () => {
             survey.questions = [

--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -1088,7 +1088,7 @@ describe('surveys', () => {
                 { type: SurveyQuestionType.Open, question: 'Seems you are not completely happy. Tell us more!' },
                 { type: SurveyQuestionType.Open, question: 'Glad to hear that. Tell us more!' },
             ] as unknown as SurveyQuestion[]
-            expect(() => surveys.getNextSurveyStep(survey, 0, 1)).toThrow('The scale must be one of: 3, 5, 10')
+            expect(() => surveys.getNextSurveyStep(survey, 0, 1)).toThrow('The scale must be one of: 3, 5, 7, 10')
         })
 
         it('should throw an error for a response value out of the valid range', () => {
@@ -1109,6 +1109,8 @@ describe('surveys', () => {
             expect(() => surveys.getNextSurveyStep(survey, 0, 20)).toThrow('The response must be in range 1-3')
             ;(survey.questions[0] as RatingSurveyQuestion).scale = 5
             expect(() => surveys.getNextSurveyStep(survey, 0, 20)).toThrow('The response must be in range 1-5')
+            ;(survey.questions[0] as RatingSurveyQuestion).scale = 7
+            expect(() => surveys.getNextSurveyStep(survey, 0, 20)).toThrow('The response must be in range 1-7')
             ;(survey.questions[0] as RatingSurveyQuestion).scale = 10
             expect(() => surveys.getNextSurveyStep(survey, 0, 20)).toThrow('The response must be in range 0-10')
         })

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -40,6 +40,12 @@ function getRatingBucketForResponseValue(responseValue: number, scale: number) {
         }
 
         return responseValue <= 2 ? 'negative' : responseValue === 3 ? 'neutral' : 'positive'
+    } else if (scale === 7) {
+        if (responseValue < 1 || responseValue > 7) {
+            throw new Error('The response must be in range 1-7')
+        }
+
+        return responseValue <= 3 ? 'negative' : responseValue === 4 ? 'neutral' : 'positive'
     } else if (scale === 10) {
         if (responseValue < 0 || responseValue > 10) {
             throw new Error('The response must be in range 0-10')
@@ -48,7 +54,7 @@ function getRatingBucketForResponseValue(responseValue: number, scale: number) {
         return responseValue <= 6 ? 'detractors' : responseValue <= 8 ? 'passives' : 'promoters'
     }
 
-    throw new Error('The scale must be one of: 3, 5, 10')
+    throw new Error('The scale must be one of: 3, 5, 7, 10')
 }
 
 export class PostHogSurveys {


### PR DESCRIPTION
## Changes

A [user reported](https://posthoghelp.zendesk.com/agent/tickets/18314) that our 7-point likert scales didn't support branching logic in the PostHog UI, which is good, because `posthog-js` didn't support them either and would've thrown a runtime error if users tried it.

This change supports handling 7-point scales for our branching logic.  Will ship with the [PostHog UI changes](https://github.com/PostHog/posthog/pull/25059), but this change should go in first so that we don't have users hitting runtime errors.

Demo of it all working: https://www.loom.com/share/e22de74e2bea4b7cb66fe34343e68916

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
