### PR TITLE
feat: Treat self referrals as direct

### DIFF
--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -126,22 +126,27 @@ export const Info = {
 
     deviceType: detectDeviceType,
 
+    referrerInfo: function (): Record<string, any> {
+        const referrer = document?.referrer
+        const referring_domain = referrer ? convertToURL(referrer)?.host : undefined
+        if (!referrer || !referring_domain || referring_domain === location?.host) {
+            return {
+                $referrer: '$direct',
+                $referring_domain: '$direct',
+            }
+        }
+        return {
+            $referrer: referrer,
+            $referring_domain: referring_domain,
+        }
+    },
+
     referrer: function (): string {
-        return document?.referrer || '$direct'
+        return this.referrerInfo().$referrer
     },
 
     referringDomain: function (): string {
-        if (!document?.referrer) {
-            return '$direct'
-        }
-        return convertToURL(document.referrer)?.host || '$direct'
-    },
-
-    referrerInfo: function (): Record<string, any> {
-        return {
-            $referrer: this.referrer(),
-            $referring_domain: this.referringDomain(),
-        }
+        return this.referrerInfo().$referring_domain
     },
 
     initialPersonInfo: function (): Record<string, any> {


### PR DESCRIPTION
## Changes
We handle the `$referrer` property in a potentially confusing way when an internal link is clicked. The latest example is https://posthog.slack.com/archives/C03C60FT1J7/p1726670676997629.

This happens because we use `document.referrer` directly, and this can be self-referential in the following example
1. User is on `https://referrer.com`
2. User clicks a link to `https://tracked.com`
3. Referrer is `referrer.com`
4. User is inactive long enough for the session to expire
5. User clicks an internal link to `https://tracked.com`
6. Referrer is `tracked.com`

This PR changes this, so that the referrer in 6) would be `$direct`

To be clear about this: it is a *breaking change*, however I believe it's more in line with what the expected behaviour would be. One might argue that the original behaviour is a bug

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
