### PR TITLE
fix: session idle timestamp correction

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -74,6 +74,14 @@ interface QueuedRRWebEvent {
     enqueuedAt: number
 }
 
+interface SessionIdlePayload {
+    eventTimestamp: number
+    lastActivityTimestamp: number
+    threshold: number
+    bufferLength: number
+    bufferSize: number
+}
+
 const newQueuedEvent = (rrwebMethod: () => void): QueuedRRWebEvent => ({
     rrwebMethod,
     enqueuedAt: Date.now(),
@@ -550,6 +558,7 @@ export class SessionRecording {
                 this.isIdle = true
                 // don't take full snapshots while idle
                 clearInterval(this._fullSnapshotTimer)
+                // need to override the timestamp on the session idle events so they appear at the point we last saw activity, not this new point in time
                 this._tryAddCustomEvent('sessionIdle', {
                     eventTimestamp: event.timestamp,
                     lastActivityTimestamp: this._lastActivityTimestamp,
@@ -797,6 +806,18 @@ export class SessionRecording {
         // but we allow custom events even when idle
         if (this.isIdle && event.type !== EventType.Custom) {
             return
+        }
+
+        if (event.type === EventType.Custom && event.data.tag === 'sessionIdle') {
+            // session idle events have a timestamp when rrweb sees them
+            // which can artificially lengthen a session
+            // we know when we detected it based on the payload and can correct the timestamp
+            const payload = event.data.payload as SessionIdlePayload
+            if (payload) {
+                const lastActivity = payload.lastActivityTimestamp
+                const threshold = payload.threshold
+                event.timestamp = lastActivity + threshold
+            }
         }
 
         const properties = {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -558,7 +558,6 @@ export class SessionRecording {
                 this.isIdle = true
                 // don't take full snapshots while idle
                 clearInterval(this._fullSnapshotTimer)
-                // need to override the timestamp on the session idle events so they appear at the point we last saw activity, not this new point in time
                 this._tryAddCustomEvent('sessionIdle', {
                     eventTimestamp: event.timestamp,
                     lastActivityTimestamp: this._lastActivityTimestamp,


### PR DESCRIPTION
In https://posthoghelp.zendesk.com/agent/tickets/16379 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/29949) we see a session that emits zero events for > 10hrs and so doesn't trigger idle detection

when the session returns we correctly flushed only the session idle event and started a new session

but!

the session idle event has as its timestamp the point it was detected making for an 10hr+ session with 10 hours of inactivity

Since we know the threshold and the time of last activity we can correct the timestamp of the event before emitting it

----

tested locally and can see sessionIdle not being emitted at the time it was captured

<img width="965" alt="Screenshot 2024-09-23 at 09 50 38" src="https://github.com/user-attachments/assets/38d554ec-aa4e-4ce1-bce3-c1cc33d3bf73">
