### PR TITLE
chore: build when publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,9 +61,6 @@ jobs:
             - name: Install package.json dependencies with pnpm
               run: pnpm install --frozen-lockfile
 
-            - name: Build the package
-            - run: pnpm build
-
             - name: Publish the package in the npm registry
               run: npm publish --access public
               env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,6 +61,9 @@ jobs:
             - name: Install package.json dependencies with pnpm
               run: pnpm install --frozen-lockfile
 
+            - name: Build the package
+            - run: pnpm build
+
             - name: Publish the package in the npm registry
               run: npm publish --access public
               env:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "lint": "eslint src && eslint cypress",
         "lint:fix": "eslint src --fix && eslint cypress --fix",
         "prettier": "prettier --write src/ functional_tests/",
-        "prepublishOnly": "pnpm lint && pnpm test && pnpm build && pnpm test:react",
+        "prepublishOnly": "pnpm lint && pnpm build && pnpm test && pnpm test:react",
         "test": "pnpm test:unit && pnpm test:custom-eslint-rules && pnpm test:functional",
         "test:unit": "jest src",
         "test:custom-eslint-rules": "jest eslint-rules",


### PR DESCRIPTION
We run tests when publishing that assume the lib was built...

So this should fix it