### PR TITLE
fix: it's just rude to assign to date now

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -18,7 +18,6 @@ import {
 import { PostHog } from '../../posthog-core'
 import { DecideResponse, FlagVariant, NetworkRecordOptions, NetworkRequest, Properties } from '../../types'
 import { EventType, type eventWithTime, IncrementalSource, type listenerHandler, RecordPlugin } from '@rrweb/types'
-import { timestamp } from '../../utils'
 
 import { isBoolean, isFunction, isNullish, isNumber, isObject, isString, isUndefined } from '../../utils/type-utils'
 import { logger } from '../../utils/logger'
@@ -492,7 +491,7 @@ export class SessionRecording {
                     payload: [JSON.stringify(message)],
                 },
             },
-            timestamp: timestamp(),
+            timestamp: Date.now(),
         })
     }
 

--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -2,7 +2,7 @@ import { getQueryParam, convertToURL } from './request-utils'
 import { isNull } from './type-utils'
 import { Properties } from '../types'
 import Config from '../config'
-import { each, extend, stripEmptyProperties, stripLeadingDollar, timestamp } from './index'
+import { each, extend, stripEmptyProperties, stripLeadingDollar } from './index'
 import { document, location, userAgent, window } from './globals'
 import { detectBrowser, detectBrowserVersion, detectDevice, detectDeviceType, detectOS } from './user-agent-utils'
 
@@ -211,7 +211,7 @@ export const Info = {
                 $lib: 'web',
                 $lib_version: Config.LIB_VERSION,
                 $insert_id: Math.random().toString(36).substring(2, 10) + Math.random().toString(36).substring(2, 10),
-                $time: timestamp() / 1000, // epoch time in seconds
+                $time: Date.now() / 1000, // epoch time in seconds
             }
         )
     },

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -118,12 +118,7 @@ export const isValidRegex = function (str: string): boolean {
 }
 
 export const timestamp = function (): number {
-    Date.now =
-        Date.now ||
-        function () {
-            return +new Date()
-        }
-    return Date.now()
+    return Date.now ? Date.now() : +new Date()
 }
 
 export const trySafe = function <T>(fn: () => T): T | undefined {


### PR DESCRIPTION
We use `Date.now` liberally throughout the SDK

We also have a `timestamp` method used in a couple of places that tries to patch `Date.now` for browsers that don't have it.

That's IE8 and older which we don't aim to support anyway.

That `timestamp` method tries to assign back to Date.now, in some cases this will cause errors.

Since we use `Date.now` liberally elsewhere, let's just remove the offending method