### PR TITLE
feat: compress replay data

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -1988,6 +1988,13 @@ describe('SessionRecording', () => {
     })
 
     describe('when compression is active', () => {
+        const captureOptions = {
+            _batchKey: 'recordings',
+            _noTruncate: true,
+            _url: 'https://test.com/s/',
+            skip_client_rate_limiting: true,
+        }
+
         beforeEach(() => {
             posthog.config.session_recording.compress_events = true
             sessionRecording.afterDecideResponse(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
@@ -2004,6 +2011,7 @@ describe('SessionRecording', () => {
                     $snapshot_data: [
                         {
                             data: expect.any(String),
+                            cv: '2024-10',
                             type: 2,
                         },
                     ],
@@ -2011,12 +2019,7 @@ describe('SessionRecording', () => {
                     $snapshot_bytes: expect.any(Number),
                     $window_id: 'windowId',
                 },
-                {
-                    _batchKey: 'recordings',
-                    _noTruncate: true,
-                    _url: 'https://test.com/s/',
-                    skip_client_rate_limiting: true,
-                }
+                captureOptions
             )
         })
 
@@ -2029,6 +2032,7 @@ describe('SessionRecording', () => {
                 {
                     $snapshot_data: [
                         {
+                            cv: '2024-10',
                             data: {
                                 adds: expect.any(String),
                                 texts: expect.any(String),
@@ -2044,12 +2048,7 @@ describe('SessionRecording', () => {
                     $snapshot_bytes: expect.any(Number),
                     $window_id: 'windowId',
                 },
-                {
-                    _batchKey: 'recordings',
-                    _noTruncate: true,
-                    _url: 'https://test.com/s/',
-                    skip_client_rate_limiting: true,
-                }
+                captureOptions
             )
         })
 
@@ -2071,6 +2070,7 @@ describe('SessionRecording', () => {
                                 source: 8,
                                 styleId: 1,
                             },
+                            cv: '2024-10',
                             type: 3,
                         },
                     ],
@@ -2078,12 +2078,7 @@ describe('SessionRecording', () => {
                     $snapshot_bytes: expect.any(Number),
                     $window_id: 'windowId',
                 },
-                {
-                    _batchKey: 'recordings',
-                    _noTruncate: true,
-                    _url: 'https://test.com/s/',
-                    skip_client_rate_limiting: true,
-                }
+                captureOptions
             )
         })
 
@@ -2100,12 +2095,7 @@ describe('SessionRecording', () => {
                     $snapshot_bytes: 86,
                     $window_id: 'windowId',
                 },
-                {
-                    _batchKey: 'recordings',
-                    _noTruncate: true,
-                    _url: 'https://test.com/s/',
-                    skip_client_rate_limiting: true,
-                }
+                captureOptions
             )
         })
 
@@ -2129,12 +2119,7 @@ describe('SessionRecording', () => {
                     $snapshot_bytes: 58,
                     $window_id: 'windowId',
                 },
-                {
-                    _batchKey: 'recordings',
-                    _noTruncate: true,
-                    _url: 'https://test.com/s/',
-                    skip_client_rate_limiting: true,
-                }
+                captureOptions
             )
         })
 
@@ -2157,12 +2142,7 @@ describe('SessionRecording', () => {
                     $snapshot_bytes: 69,
                     $window_id: 'windowId',
                 },
-                {
-                    _batchKey: 'recordings',
-                    _noTruncate: true,
-                    _url: 'https://test.com/s/',
-                    skip_client_rate_limiting: true,
-                }
+                captureOptions
             )
         })
     })

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -89,11 +89,60 @@ const createIncrementalSnapshot = (event = {}): incrementalSnapshotEvent => ({
     ...event,
 })
 
-const createCustomSnapshot = (event = {}): customEvent => ({
+const createIncrementalMouseEvent = () => {
+    return createIncrementalSnapshot({
+        data: {
+            source: 2,
+            positions: [
+                {
+                    id: 1,
+                    x: 100,
+                    y: 200,
+                    timeOffset: 100,
+                },
+            ],
+        },
+    })
+}
+
+const createIncrementalMutationEvent = () => {
+    const mutationData = {
+        texts: [],
+        attributes: [],
+        removes: [],
+        adds: [],
+        isAttachIframe: true,
+    }
+    return createIncrementalSnapshot({
+        data: {
+            source: 0,
+            ...mutationData,
+        },
+    })
+}
+
+const createIncrementalStyleSheetEvent = () => {
+    return createIncrementalSnapshot({
+        data: {
+            // doesn't need to be a valid style sheet event
+            source: 8,
+            id: 1,
+            styleId: 1,
+            removes: [],
+            adds: [],
+            replace: 'something',
+            replaceSync: 'something',
+        },
+    })
+}
+
+const createCustomSnapshot = (event = {}, payload = {}): customEvent => ({
     type: EventType.Custom,
     data: {
         tag: 'custom',
-        payload: {},
+        payload: {
+            ...payload,
+        },
     },
     ...event,
 })
@@ -1935,6 +1984,186 @@ describe('SessionRecording', () => {
             _emit(createIncrementalSnapshot({ type: 3 }))
 
             expect((sessionRecording as any)['_tryAddCustomEvent']).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('when compression is active', () => {
+        beforeEach(() => {
+            posthog.config.session_recording.compress_events = true
+            sessionRecording.afterDecideResponse(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
+            sessionRecording.startIfEnabledOrStop()
+        })
+
+        it('compresses full snapshot data', () => {
+            _emit(createFullSnapshot())
+            sessionRecording['_flushBuffer']()
+
+            expect(posthog.capture).toHaveBeenCalledWith(
+                '$snapshot',
+                {
+                    $snapshot_data: [
+                        {
+                            data: expect.any(String),
+                            type: 2,
+                        },
+                    ],
+                    $session_id: sessionId,
+                    $snapshot_bytes: expect.any(Number),
+                    $window_id: 'windowId',
+                },
+                {
+                    _batchKey: 'recordings',
+                    _noTruncate: true,
+                    _url: 'https://test.com/s/',
+                    skip_client_rate_limiting: true,
+                }
+            )
+        })
+
+        it('compresses incremental snapshot mutation data', () => {
+            _emit(createIncrementalMutationEvent())
+            sessionRecording['_flushBuffer']()
+
+            expect(posthog.capture).toHaveBeenCalledWith(
+                '$snapshot',
+                {
+                    $snapshot_data: [
+                        {
+                            data: {
+                                adds: expect.any(String),
+                                texts: expect.any(String),
+                                removes: expect.any(String),
+                                attributes: expect.any(String),
+                                isAttachIframe: true,
+                                source: 0,
+                            },
+                            type: 3,
+                        },
+                    ],
+                    $session_id: sessionId,
+                    $snapshot_bytes: expect.any(Number),
+                    $window_id: 'windowId',
+                },
+                {
+                    _batchKey: 'recordings',
+                    _noTruncate: true,
+                    _url: 'https://test.com/s/',
+                    skip_client_rate_limiting: true,
+                }
+            )
+        })
+
+        it('compresses incremental snapshot style data', () => {
+            _emit(createIncrementalStyleSheetEvent())
+            sessionRecording['_flushBuffer']()
+
+            expect(posthog.capture).toHaveBeenCalledWith(
+                '$snapshot',
+                {
+                    $snapshot_data: [
+                        {
+                            data: {
+                                adds: expect.any(String),
+                                id: 1,
+                                removes: expect.any(String),
+                                replace: 'something',
+                                replaceSync: 'something',
+                                source: 8,
+                                styleId: 1,
+                            },
+                            type: 3,
+                        },
+                    ],
+                    $session_id: sessionId,
+                    $snapshot_bytes: expect.any(Number),
+                    $window_id: 'windowId',
+                },
+                {
+                    _batchKey: 'recordings',
+                    _noTruncate: true,
+                    _url: 'https://test.com/s/',
+                    skip_client_rate_limiting: true,
+                }
+            )
+        })
+
+        it('does not compress incremental snapshot non full data', () => {
+            const mouseEvent = createIncrementalMouseEvent()
+            _emit(mouseEvent)
+            sessionRecording['_flushBuffer']()
+
+            expect(posthog.capture).toHaveBeenCalledWith(
+                '$snapshot',
+                {
+                    $snapshot_data: [mouseEvent],
+                    $session_id: sessionId,
+                    $snapshot_bytes: 86,
+                    $window_id: 'windowId',
+                },
+                {
+                    _batchKey: 'recordings',
+                    _noTruncate: true,
+                    _url: 'https://test.com/s/',
+                    skip_client_rate_limiting: true,
+                }
+            )
+        })
+
+        it('does not compress custom events', () => {
+            _emit(createCustomSnapshot(undefined, { tag: 'wat' }))
+            sessionRecording['_flushBuffer']()
+
+            expect(posthog.capture).toHaveBeenCalledWith(
+                '$snapshot',
+                {
+                    $snapshot_data: [
+                        {
+                            data: {
+                                payload: { tag: 'wat' },
+                                tag: 'custom',
+                            },
+                            type: 5,
+                        },
+                    ],
+                    $session_id: sessionId,
+                    $snapshot_bytes: 58,
+                    $window_id: 'windowId',
+                },
+                {
+                    _batchKey: 'recordings',
+                    _noTruncate: true,
+                    _url: 'https://test.com/s/',
+                    skip_client_rate_limiting: true,
+                }
+            )
+        })
+
+        it('does not compress meta events', () => {
+            _emit(createMetaSnapshot())
+            sessionRecording['_flushBuffer']()
+
+            expect(posthog.capture).toHaveBeenCalledWith(
+                '$snapshot',
+                {
+                    $snapshot_data: [
+                        {
+                            type: META_EVENT_TYPE,
+                            data: {
+                                href: 'https://has-to-be-present-or-invalid.com',
+                            },
+                        },
+                    ],
+                    $session_id: sessionId,
+                    $snapshot_bytes: 69,
+                    $window_id: 'windowId',
+                },
+                {
+                    _batchKey: 'recordings',
+                    _noTruncate: true,
+                    _url: 'https://test.com/s/',
+                    skip_client_rate_limiting: true,
+                }
+            )
         })
     })
 })

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -125,10 +125,12 @@ export type compressedEvent =
 export type compressedEventWithTime = compressedEvent & {
     timestamp: number
     delay?: number
+    // marker for compression version
+    cv: '2024-10'
 }
 
 function gzipToString(data: unknown): string {
-    return strFromU8(gzipSync(strToU8(JSON.stringify(data))))
+    return strFromU8(gzipSync(strToU8(JSON.stringify(data))), true)
 }
 
 // rrweb's packer takes an event and returns a string or the reverse on unpact,
@@ -140,11 +142,13 @@ function compressEvent(event: eventWithTime, ph: PostHog): eventWithTime | compr
             return {
                 ...event,
                 data: gzipToString(event.data),
+                cv: '2024-10',
             }
         }
         if (event.type === EventType.IncrementalSnapshot && event.data.source === IncrementalSource.Mutation) {
             return {
                 ...event,
+                cv: '2024-10',
                 data: {
                     ...event.data,
                     texts: gzipToString(event.data.texts),
@@ -157,6 +161,7 @@ function compressEvent(event: eventWithTime, ph: PostHog): eventWithTime | compr
         if (event.type === EventType.IncrementalSnapshot && event.data.source === IncrementalSource.StyleSheetRule) {
             return {
                 ...event,
+                cv: '2024-10',
                 data: {
                     ...event.data,
                     adds: gzipToString(event.data.adds),

--- a/src/types.ts
+++ b/src/types.ts
@@ -277,6 +277,8 @@ export interface SessionRecordingOptions {
     recordBody?: boolean
     // ADVANCED: while a user is active we take a full snapshot of the browser every interval. For very few sites playback performance might be better with different interval. Set to 0 to disable
     full_snapshot_interval_millis?: number
+    // PREVIEW: whether to compress part of the events before sending them to the server, this is a preview feature and may change without notice
+    compress_events?: boolean
 }
 
 export type SessionIdChangedCallback = (


### PR DESCRIPTION
We want to compress replay payloads since they're sometimes massive and very compressible

We do compress the entire payload when it is travelling over the network and when in storage, but at points in processing it is not compressed and we can leave some data compressed to make life easier on our infra

But blob ingestion needs to read some metadata from some events so we don't want to just compress everything

So, we now support posthog-js partially compressing selected payloads 

This only compresses when it is enabled so we can test this ourselves to see what the what

pairs with https://github.com/PostHog/posthog/pull/25183