### PR TITLE
feat(web experiments): Emit web_experiment_applied event and do not render experiments for bots

### DIFF
--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -27,10 +27,14 @@ export default function Home() {
         <>
             <p className="italic my-2 text-gray-500">The current time is {time}</p>
 
-            <h2>Trigger posthog events</h2>
+            <h2>
+                Trigger posthog <span>events </span>
+            </h2>
             <div className="flex items-center gap-2 flex-wrap">
                 <button onClick={() => posthog.capture('Clicked button')}>Capture event</button>
-                <button onClick={() => posthog.capture('user_subscribed')}>Subscribe to newsletter</button>
+                <button id="subscribe-user-to-newsletter" onClick={() => posthog.capture('user_subscribed')}>
+                    Subscribe to newsletter
+                </button>
                 <button onClick={() => posthog.capture('user_unsubscribed')}>Unsubscribe from newsletter</button>
                 <button data-attr="autocapture-button">Autocapture buttons</button>
                 <a className="Button" data-attr="autocapture-button" href="#">

--- a/playground/nextjs/src/posthog.ts
+++ b/playground/nextjs/src/posthog.ts
@@ -50,6 +50,7 @@ if (typeof window !== 'undefined') {
             recordCrossOriginIframes: true,
         },
         debug: true,
+        disable_web_experiments: false,
         scroll_root_selector: ['#scroll_element', 'html'],
         persistence: cookieConsentGiven() ? 'localStorage+cookie' : 'memory',
         person_profiles: PERSON_PROCESSING_MODE === 'never' ? 'identified_only' : PERSON_PROCESSING_MODE,

--- a/src/__tests__/web-experiments.test.ts
+++ b/src/__tests__/web-experiments.test.ts
@@ -89,8 +89,17 @@ describe('Web Experimentation', () => {
                     },
                 ],
             },
-            control: {
+            icontains: {
                 conditions: { url: 'checkout', urlMatchType: 'icontains' },
+                transforms: [
+                    {
+                        selector: '#set-user-properties',
+                        text: 'Sign up',
+                        html: 'Sign up',
+                    },
+                ],
+            },
+            control: {
                 transforms: [
                     {
                         selector: '#set-user-properties',
@@ -265,11 +274,25 @@ describe('Web Experimentation', () => {
                 experiments: [signupButtonWebExperimentWithFeatureFlag],
             }
 
-            assertElementChanged('control', 'innerText', 'Sign up')
+            assertElementChanged('Signup', 'innerText', 'Sign me up')
             expect(posthog.capture).toHaveBeenCalledWith('$web_experiment_applied', {
                 $web_experiment_document_url:
                     'https://example.com/landing-page?utm_campaign=marketing&utm_medium=mobile',
                 $web_experiment_elements_modified: 1,
+                $web_experiment_name: 'Signup button test',
+                $web_experiment_variant: 'Signup',
+            })
+        })
+
+        it('makes no modifications if control variant', () => {
+            experimentsResponse = {
+                experiments: [signupButtonWebExperimentWithFeatureFlag],
+            }
+            assertElementChanged('control', 'innerText', 'original')
+            expect(posthog.capture).toHaveBeenCalledWith('$web_experiment_applied', {
+                $web_experiment_document_url:
+                    'https://example.com/landing-page?utm_campaign=marketing&utm_medium=mobile',
+                $web_experiment_elements_modified: 0,
                 $web_experiment_name: 'Signup button test',
                 $web_experiment_variant: 'control',
             })

--- a/src/__tests__/web-experiments.test.ts
+++ b/src/__tests__/web-experiments.test.ts
@@ -298,6 +298,32 @@ describe('Web Experimentation', () => {
             })
         })
 
+        it('can render previews based on URL params', () => {
+            experimentsResponse = {
+                experiments: [buttonWebExperimentWithUrlConditions],
+            }
+            const webExperiment = new WebExperiments(posthog)
+            const elParent = createTestDocument()
+
+            WebExperiments.getWindowLocation = () => {
+                // eslint-disable-next-line compat/compat
+                return new URL(
+                    'https://example.com/landing-page?__experiment_id=3&__experiment_variant=Signup'
+                ) as unknown as Location
+            }
+
+            webExperiment.previewWebExperiment()
+            expect(elParent.innerText).toEqual('Sign me up')
+            expect(posthog.capture).toHaveBeenCalledWith('$web_experiment_applied', {
+                $web_experiment_document_url:
+                    'https://example.com/landing-page?__experiment_id=3&__experiment_variant=Signup',
+                $web_experiment_elements_modified: 1,
+                $web_experiment_name: 'Signup button test',
+                $web_experiment_variant: 'Signup',
+                $web_experiment_preview: true,
+            })
+        })
+
         it('can set css of Span Element', async () => {
             experimentsResponse = {
                 experiments: [signupButtonWebExperimentWithFeatureFlag],

--- a/src/__tests__/web-experiments.test.ts
+++ b/src/__tests__/web-experiments.test.ts
@@ -304,7 +304,7 @@ describe('Web Experimentation', () => {
             }
             const webExperiment = new WebExperiments(posthog)
             const elParent = createTestDocument()
-
+            const original = WebExperiments.getWindowLocation
             WebExperiments.getWindowLocation = () => {
                 // eslint-disable-next-line compat/compat
                 return new URL(
@@ -313,6 +313,8 @@ describe('Web Experimentation', () => {
             }
 
             webExperiment.previewWebExperiment()
+
+            WebExperiments.getWindowLocation = original
             expect(elParent.innerText).toEqual('Sign me up')
             expect(posthog.capture).toHaveBeenCalledWith('$web_experiment_applied', {
                 $web_experiment_document_url:

--- a/src/web-experiments-types.ts
+++ b/src/web-experiments-types.ts
@@ -8,7 +8,7 @@ export interface WebExperimentTransform {
     text?: string
     html?: string
     imgUrl?: string
-    className?: string
+    css?: string
 }
 
 export type WebExperimentUrlMatchType = 'regex' | 'not_regex' | 'exact' | 'is_not' | 'icontains' | 'not_icontains'

--- a/src/web-experiments.ts
+++ b/src/web-experiments.ts
@@ -83,8 +83,8 @@ export class WebExperiments {
         if (location?.search) {
             const experimentID = getQueryParam(location?.search, '__experiment_id')
             const variant = getQueryParam(location?.search, '__experiment_variant')
-            WebExperiments.logInfo(`previewing web experiments ${experimentID} && ${variant}`)
             if (experimentID && variant) {
+                WebExperiments.logInfo(`previewing web experiments ${experimentID} && ${variant}`)
                 this.getWebExperiments(
                     (webExperiments) => {
                         this.showPreviewWebExperiment(parseInt(experimentID), variant, webExperiments)

--- a/src/web-experiments.ts
+++ b/src/web-experiments.ts
@@ -254,6 +254,20 @@ export class WebExperiments {
             return
         }
 
+        if (variant === 'control') {
+            WebExperiments.logInfo('Control variants leave the page unmodified.')
+            if (this.instance && this.instance.capture) {
+                this.instance.capture('$web_experiment_applied', {
+                    $web_experiment_name: experiment,
+                    $web_experiment_variant: variant,
+                    $web_experiment_document_url: WebExperiments.getWindowLocation()?.href,
+                    $web_experiment_elements_modified: 0,
+                })
+            }
+
+            return
+        }
+
         transforms.forEach((transform) => {
             if (transform.selector) {
                 WebExperiments.logInfo(

--- a/src/web-experiments.ts
+++ b/src/web-experiments.ts
@@ -1,6 +1,6 @@
 import { PostHog } from './posthog-core'
 import { DecideResponse } from './types'
-import { window } from './utils/globals'
+import { location, navigator, window } from './utils/globals'
 import {
     WebExperiment,
     WebExperimentsCallback,
@@ -13,6 +13,7 @@ import { isNullish } from './utils/type-utils'
 import { isUrlMatchingRegex } from './utils/request-utils'
 import { logger } from './utils/logger'
 import { Info } from './utils/event-utils'
+import { isLikelyBot } from './utils/blocked-uas'
 
 export const webExperimentUrlValidationMap: Record<
     WebExperimentUrlMatchType,
@@ -46,17 +47,17 @@ export class WebExperiments {
     }
 
     applyFeatureFlagChanges(flags: string[]) {
-        WebExperiments.logInfo('applying feature flags', flags)
         if (isNullish(this._flagToExperiments) || this.instance.config.disable_web_experiments) {
             return
         }
 
+        WebExperiments.logInfo('applying feature flags', flags)
         flags.forEach((flag) => {
             if (this._flagToExperiments && this._flagToExperiments?.has(flag)) {
                 const selectedVariant = this.instance.getFeatureFlag(flag) as unknown as string
                 const webExperiment = this._flagToExperiments?.get(flag)
                 if (selectedVariant && webExperiment?.variants[selectedVariant]) {
-                    WebExperiments.applyTransforms(
+                    this.applyTransforms(
                         webExperiment.name,
                         selectedVariant,
                         webExperiment.variants[selectedVariant].transforms
@@ -67,9 +68,31 @@ export class WebExperiments {
     }
 
     afterDecideResponse(response: DecideResponse) {
-        this._featureFlags = response.featureFlags
+        if (this._is_bot()) {
+            WebExperiments.logInfo('Refusing to render web experiment since the viewer is a likely bot')
+            return
+        }
 
+        this._featureFlags = response.featureFlags
         this.loadIfEnabled()
+        this.previewWebExperiment()
+    }
+
+    previewWebExperiment() {
+        // eslint-disable-next-line compat/compat
+        const params = new URLSearchParams(location?.search)
+        const experimentID = params.get('__experiment_id')
+        const variant = params.get('__experiment_variant')
+        WebExperiments.logInfo(`previewing web experiments ${experimentID} && ${variant}`)
+        if (experimentID && variant) {
+            this.getWebExperiments(
+                (webExperiments) => {
+                    this.showPreviewWebExperiment(parseInt(experimentID), variant, webExperiments)
+                },
+                false,
+                true
+            )
+        }
     }
 
     loadIfEnabled() {
@@ -84,6 +107,7 @@ export class WebExperiments {
         this.getWebExperiments((webExperiments) => {
             WebExperiments.logInfo(`retrieved web experiments from the server`)
             this._flagToExperiments = new Map<string, WebExperiment>()
+
             webExperiments.forEach((webExperiment) => {
                 if (
                     webExperiment.feature_flag_key &&
@@ -102,7 +126,7 @@ export class WebExperiments {
 
                     const selectedVariant = this._featureFlags[webExperiment.feature_flag_key] as unknown as string
                     if (selectedVariant && webExperiment.variants[selectedVariant]) {
-                        WebExperiments.applyTransforms(
+                        this.applyTransforms(
                             webExperiment.name,
                             selectedVariant,
                             webExperiment.variants[selectedVariant].transforms
@@ -113,7 +137,7 @@ export class WebExperiments {
                         const testVariant = webExperiment.variants[variant]
                         const matchTest = WebExperiments.matchesTestVariant(testVariant)
                         if (matchTest) {
-                            WebExperiments.applyTransforms(webExperiment.name, variant, testVariant.transforms)
+                            this.applyTransforms(webExperiment.name, variant, testVariant.transforms)
                         }
                     }
                 }
@@ -121,8 +145,8 @@ export class WebExperiments {
         }, forceReload)
     }
 
-    public getWebExperiments(callback: WebExperimentsCallback, forceReload: boolean) {
-        if (this.instance.config.disable_web_experiments) {
+    public getWebExperiments(callback: WebExperimentsCallback, forceReload: boolean, previewing?: boolean) {
+        if (this.instance.config.disable_web_experiments && !previewing) {
             return callback([])
         }
 
@@ -148,6 +172,19 @@ export class WebExperiments {
         })
     }
 
+    private showPreviewWebExperiment(experimentID: number, variant: string, webExperiments: WebExperiment[]) {
+        const previewExperiments = webExperiments.filter((exp) => exp.id === experimentID)
+        if (previewExperiments && previewExperiments.length > 0) {
+            WebExperiments.logInfo(
+                `Previewing web experiment [${previewExperiments[0].name}] with variant [${variant}]`
+            )
+            this.applyTransforms(
+                previewExperiments[0].name,
+                variant,
+                previewExperiments[0].variants[variant].transforms
+            )
+        }
+    }
     private static matchesTestVariant(testVariant: WebExperimentVariant) {
         if (isNullish(testVariant.conditions)) {
             return false
@@ -211,17 +248,25 @@ export class WebExperiments {
         logger.info(`[WebExperiments] ${msg}`, args)
     }
 
-    private static applyTransforms(experiment: string, variant: string, transforms: WebExperimentTransform[]) {
+    private applyTransforms(experiment: string, variant: string, transforms: WebExperimentTransform[]) {
+        if (this._is_bot()) {
+            WebExperiments.logInfo('Refusing to render web experiment since the viewer is a likely bot')
+            return
+        }
+
         transforms.forEach((transform) => {
             if (transform.selector) {
                 WebExperiments.logInfo(
                     `applying transform of variant ${variant} for experiment ${experiment} `,
                     transform
                 )
+
+                let elementsModified = 0
                 // eslint-disable-next-line no-restricted-globals
                 const elements = document?.querySelectorAll(transform.selector)
                 elements?.forEach((element) => {
                     const htmlElement = element as HTMLElement
+                    elementsModified += 1
                     if (transform.attributes) {
                         transform.attributes.forEach((attribute) => {
                             switch (attribute.name) {
@@ -248,14 +293,35 @@ export class WebExperiments {
                     }
 
                     if (transform.html) {
-                        htmlElement.innerHTML = transform.html
+                        if (htmlElement.parentElement) {
+                            htmlElement.parentElement.innerHTML = transform.html
+                        } else {
+                            htmlElement.innerHTML = transform.html
+                        }
                     }
 
-                    if (transform.className) {
-                        htmlElement.className = transform.className
+                    if (transform.css) {
+                        htmlElement.setAttribute('style', transform.css)
                     }
                 })
+
+                if (this.instance && this.instance.capture) {
+                    this.instance.capture('$web_experiment_applied', {
+                        $web_experiment_name: experiment,
+                        $web_experiment_variant: variant,
+                        $web_experiment_document_url: WebExperiments.getWindowLocation()?.href,
+                        $web_experiment_elements_modified: elementsModified,
+                    })
+                }
             }
         })
+    }
+
+    _is_bot(): boolean | undefined {
+        if (navigator && this.instance) {
+            return isLikelyBot(navigator, this.instance.config.custom_blocked_useragents)
+        } else {
+            return undefined
+        }
     }
 }


### PR DESCRIPTION
## Changes

1. Replace references to `className` with `css` which assigns the value of this field to the `style` attribute of an HTML element. 
2. Introduce the ability to `preview` an Experiment variant in the browser without deploying the experiment. 
3. Do not render web experiments if the viewer is a bot. 
4. Emit the $web_experiment_applied event so we know if the visual changes actually got applied to a page.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
