### PR TITLE
chore: Add test for reset() and anonymous users

### DIFF
--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -529,4 +529,22 @@ describe('person processing', () => {
             expect(jest.mocked(logger).error).toBeCalledTimes(0)
         })
     })
+
+    describe('reset', () => {
+        it('should revert a back to anonymous state in identified_only', async () => {
+            // arrange
+            const { posthog, onCapture } = await setup('identified_only')
+            posthog.identify(distinctId)
+            posthog.capture('custom event before reset')
+
+            // act
+            posthog.reset()
+            posthog.capture('custom event after reset')
+
+            // assert
+            expect(posthog._isIdentified()).toBe(false)
+            expect(onCapture.mock.calls.length).toEqual(3)
+            expect(onCapture.mock.calls[2][1].properties.$process_person_profile).toEqual(false)
+        })
+    })
 })


### PR DESCRIPTION
## Changes
Adds a test for this case, people [here](https://posthog.slack.com/archives/C0351B1DMUY/p1727700456085069?thread_ts=1727278711.749819&cid=C0351B1DMUY) were asking about this behaviour and I wasn't 100% sure so added this, might as well check it in

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
