### PR TITLE
feat: default replay partial compression on

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -476,9 +476,9 @@ describe('SessionRecording', () => {
             const fullSnapshot = createFullSnapshot()
             _emit(fullSnapshot)
             expect(sessionRecording['buffer']).toEqual({
-                data: [fullSnapshot],
+                data: [{ ...fullSnapshot, cv: '2024-10', data: expect.any(String) }],
                 sessionId: sessionId,
-                size: 20,
+                size: 121,
                 windowId: 'windowId',
             })
         })
@@ -1009,6 +1009,7 @@ describe('SessionRecording', () => {
         })
 
         it('can emit when there are circular references', () => {
+            posthog.config.session_recording.compress_events = false
             sessionRecording.afterDecideResponse(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
             sessionRecording.startIfEnabledOrStop()
 
@@ -1271,6 +1272,10 @@ describe('SessionRecording', () => {
                 type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
                 data: {
                     source: 0,
+                    adds: [],
+                    attributes: [],
+                    removes: [],
+                    texts: [],
                 },
                 timestamp: activityTimestamp,
             }
@@ -1488,9 +1493,22 @@ describe('SessionRecording', () => {
 
             // the second snapshot remains buffered in memory
             expect(sessionRecording['buffer']).toEqual({
-                data: [firstSnapshotEvent, secondSnapshot],
+                data: [
+                    firstSnapshotEvent,
+                    {
+                        ...secondSnapshot,
+                        cv: '2024-10',
+                        data: {
+                            ...secondSnapshot.data,
+                            adds: expect.any(String),
+                            texts: expect.any(String),
+                            attributes: expect.any(String),
+                            removes: expect.any(String),
+                        },
+                    },
+                ],
                 sessionId: firstSessionId,
-                size: 136,
+                size: 549,
                 windowId: expect.any(String),
             })
 
@@ -1512,9 +1530,22 @@ describe('SessionRecording', () => {
             expect(posthog.capture).toHaveBeenCalledWith(
                 '$snapshot',
                 {
-                    $snapshot_data: [firstSnapshotEvent, secondSnapshot],
+                    $snapshot_data: [
+                        firstSnapshotEvent,
+                        {
+                            ...secondSnapshot,
+                            cv: '2024-10',
+                            data: {
+                                ...secondSnapshot.data,
+                                adds: expect.any(String),
+                                texts: expect.any(String),
+                                attributes: expect.any(String),
+                                removes: expect.any(String),
+                            },
+                        },
+                    ],
                     $session_id: firstSessionId,
-                    $snapshot_bytes: 136,
+                    $snapshot_bytes: 549,
                     $window_id: expect.any(String),
                 },
                 {
@@ -1574,9 +1605,22 @@ describe('SessionRecording', () => {
 
             // the second snapshot remains buffered in memory
             expect(sessionRecording['buffer']).toEqual({
-                data: [firstSnapshotEvent, secondSnapshot],
+                data: [
+                    firstSnapshotEvent,
+                    {
+                        ...secondSnapshot,
+                        cv: '2024-10',
+                        data: {
+                            ...secondSnapshot.data,
+                            adds: expect.any(String),
+                            texts: expect.any(String),
+                            attributes: expect.any(String),
+                            removes: expect.any(String),
+                        },
+                    },
+                ],
                 sessionId: firstSessionId,
-                size: 136,
+                size: 549,
                 windowId: expect.any(String),
             })
 
@@ -1602,9 +1646,22 @@ describe('SessionRecording', () => {
             expect(posthog.capture).toHaveBeenCalledWith(
                 '$snapshot',
                 {
-                    $snapshot_data: [firstSnapshotEvent, secondSnapshot],
+                    $snapshot_data: [
+                        firstSnapshotEvent,
+                        {
+                            ...secondSnapshot,
+                            cv: '2024-10',
+                            data: {
+                                ...secondSnapshot.data,
+                                adds: expect.any(String),
+                                texts: expect.any(String),
+                                attributes: expect.any(String),
+                                removes: expect.any(String),
+                            },
+                        },
+                    ],
                     $session_id: firstSessionId,
-                    $snapshot_bytes: 136,
+                    $snapshot_bytes: 549,
                     $window_id: expect.any(String),
                 },
                 {
@@ -1628,9 +1685,22 @@ describe('SessionRecording', () => {
             expect(posthog.capture).toHaveBeenCalledWith(
                 '$snapshot',
                 {
-                    $snapshot_data: [firstSnapshotEvent, secondSnapshot],
+                    $snapshot_data: [
+                        firstSnapshotEvent,
+                        {
+                            ...secondSnapshot,
+                            cv: '2024-10',
+                            data: {
+                                ...secondSnapshot.data,
+                                adds: expect.any(String),
+                                texts: expect.any(String),
+                                attributes: expect.any(String),
+                                removes: expect.any(String),
+                            },
+                        },
+                    ],
                     $session_id: firstSessionId,
-                    $snapshot_bytes: 136,
+                    $snapshot_bytes: 549,
                     $window_id: expect.any(String),
                 },
                 {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -39,7 +39,9 @@ const BASE_ENDPOINT = '/s/'
 const FIVE_MINUTES = 1000 * 60 * 5
 const TWO_SECONDS = 2000
 export const RECORDING_IDLE_THRESHOLD_MS = FIVE_MINUTES
-export const RECORDING_MAX_EVENT_SIZE = 1024 * 1024 * 0.9 // ~1mb (with some wiggle room)
+const ONE_KB = 1024
+const PARTIAL_COMPRESSION_THRESHOLD = ONE_KB
+export const RECORDING_MAX_EVENT_SIZE = ONE_KB * ONE_KB * 0.9 // ~1mb (with some wiggle room)
 export const RECORDING_BUFFER_TIMEOUT = 2000 // 2 seconds
 export const SESSION_RECORDING_BATCH_KEY = 'recordings'
 
@@ -144,6 +146,11 @@ function gzipToString(data: unknown): string {
 // but we want to be able to inspect metadata during ingestion, and don't want to compress the entire event
 // so we have a custom packer that only compresses part of some events
 function compressEvent(event: eventWithTime, ph: PostHog): eventWithTime | compressedEventWithTime {
+    const originalSize = estimateSize(event)
+    if (originalSize < PARTIAL_COMPRESSION_THRESHOLD) {
+        return event
+    }
+
     try {
         if (event.type === EventType.FullSnapshot) {
             return {
@@ -940,6 +947,7 @@ export class SessionRecording {
         const eventToSend =
             this.instance.config.session_recording.compress_events ?? true ? compressEvent(event, this.instance) : event
         const size = estimateSize(eventToSend)
+
         const properties = {
             $snapshot_bytes: size,
             $snapshot_data: eventToSend,

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -937,9 +937,8 @@ export class SessionRecording {
             }
         }
 
-        const eventToSend = this.instance.config.session_recording.compress_events
-            ? compressEvent(event, this.instance)
-            : event
+        const eventToSend =
+            this.instance.config.session_recording.compress_events ?? true ? compressEvent(event, this.instance) : event
         const size = estimateSize(eventToSend)
         const properties = {
             $snapshot_bytes: size,

--- a/src/types.ts
+++ b/src/types.ts
@@ -277,7 +277,11 @@ export interface SessionRecordingOptions {
     recordBody?: boolean
     // ADVANCED: while a user is active we take a full snapshot of the browser every interval. For very few sites playback performance might be better with different interval. Set to 0 to disable
     full_snapshot_interval_millis?: number
-    // PREVIEW: whether to compress part of the events before sending them to the server, this is a preview feature and may change without notice
+    /*
+     ADVANCED: whether to partially compress rrweb events before sending them to the server,
+     defaults to true, can be set to false to disable partial compression
+     NB requests are still compressed when sent to the server regardless of this setting
+    */
     compress_events?: boolean
     /*
      ADVANCED: alters the threshold before a recording considers a user has become idle.


### PR DESCRIPTION
Partial compression of large rrweb events will make them more reliably ingestable

We've had this on for days now, and some users have tested it

Let's default it on

---

Clicked around in PH app and saved ~1MB in 2 minutes of recording