### PR TITLE
fix: Remove posthog error capture from replay

### DIFF
--- a/src/extensions/replay/sessionrecording-utils.ts
+++ b/src/extensions/replay/sessionrecording-utils.ts
@@ -36,7 +36,7 @@ export function circularReferenceReplacer() {
 }
 
 export function estimateSize(sizeable: unknown): number {
-    return JSON.stringify(sizeable, circularReferenceReplacer()).length
+    return JSON.stringify(sizeable, circularReferenceReplacer())?.length || 0
 }
 
 export const replacementImageURI =


### PR DESCRIPTION
We shouldn't be capturing auto posthog errors unless the integration is on... will remove this from replay for now