### PR TITLE
chore: update README to include missing steps for running local nextjs playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ You can use the create react app setup in `playground/nextjs` to test posthog-js
 
 1. Run `posthog` locally on port 8000 (`DEBUG=1 TEST=1 ./bin/start`).
 1. Run `python manage.py setup_dev --no-data` on posthog repo, which sets up a demo account.
-1. Copy Project API key found in `http://localhost:8000/project/settings` and save it for the last step
-1. `cd playground/nextjs`
-1. Run `pnpm i` to install dependencies
-1. Run `pnpm run build-posthog-js` to build `posthog-js` locally
-1. Run `NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' NEXT_PUBLIC_POSTHOG_HOST='http://localhost:8000' pnpm dev` to start the application
+1. Copy Project API key found in `http://localhost:8000/project/settings` and save it for the last step.
+1. Run `cd playground/nextjs`.
+1. Run `pnpm i` to install dependencies.
+1. Run `pnpm run build-posthog-js` to build `posthog-js` locally.
+1. Run `NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' NEXT_PUBLIC_POSTHOG_HOST='http://localhost:8000' pnpm dev` to start the application.
 
 ### Tiers of testing
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ After all this, you'll be able to run through the below steps:
 You can use the create react app setup in `playground/nextjs` to test posthog-js as an npm module in a Nextjs application.
 
 1. Run `posthog` locally on port 8000 (`DEBUG=1 TEST=1 ./bin/start`).
-1. Run `DEBUG=1 ./manage.py generate_demo_data` on posthog repo, which sets up a demo account.
+1. Run `python manage.py setup_dev --no-data` on posthog repo, which sets up a demo account.
 1. Copy Project API key found in `http://localhost:8000/project/settings` and save it for the last step
 1. `cd playground/nextjs`
 1. Run `pnpm i` to install dependencies

--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ After all this, you'll be able to run through the below steps:
 You can use the create react app setup in `playground/nextjs` to test posthog-js as an npm module in a Nextjs application.
 
 1. Run `posthog` locally on port 8000 (`DEBUG=1 TEST=1 ./bin/start`).
-2. Run `python manage.py setup_dev --no-data` on posthog repo, which sets up a demo account.
-3. Copy posthog token found in `http://localhost:8000/project/settings` and then
-4. `cd playground/nextjs`and run `NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' pnpm dev`
+1. Run `DEBUG=1 ./manage.py generate_demo_data` on posthog repo, which sets up a demo account.
+1. Copy posthog token found in `http://localhost:8000/project/settings` and save it for the last step
+1. `cd playground/nextjs`
+1. Run `pnpm i` to install dependencies
+1. Run `pnpm run build-posthog-js` to build `posthog-js` locally
+1. Run `NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' NEXT_PUBLIC_POSTHOG_HOST='http://localhost:8000' pnpm dev` to start the application
 
 ### Tiers of testing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can use the create react app setup in `playground/nextjs` to test posthog-js
 
 1. Run `posthog` locally on port 8000 (`DEBUG=1 TEST=1 ./bin/start`).
 1. Run `DEBUG=1 ./manage.py generate_demo_data` on posthog repo, which sets up a demo account.
-1. Copy posthog token found in `http://localhost:8000/project/settings` and save it for the last step
+1. Copy Project API key found in `http://localhost:8000/project/settings` and save it for the last step
 1. `cd playground/nextjs`
 1. Run `pnpm i` to install dependencies
 1. Run `pnpm run build-posthog-js` to build `posthog-js` locally


### PR DESCRIPTION
## Changes

When getting `posthog-js` setup locally and testing with the nextjs playground app, it was noticed that there were a few missing steps.  This PR adds those missing steps to the README for thoroughness sake.

...

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
