### PR TITLE
fix: empty query param when calling external dependency toolbar.js

### DIFF
--- a/src/__tests__/utils/external-scripts-loader.test.ts
+++ b/src/__tests__/utils/external-scripts-loader.test.ts
@@ -59,9 +59,7 @@ describe('external-scripts-loader', () => {
             assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'toolbar', callback)
             const scripts = document!.getElementsByTagName('script')
             const new_script = scripts[0]
-            expect(new_script.src).toMatchInlineSnapshot(
-                `"https://us-assets.i.posthog.com/static/toolbar.js?v=1.0.0?&=1726067100000"`
-            )
+            expect(new_script.src).toBe('https://us-assets.i.posthog.com/static/toolbar.js?v=1.0.0&t=1726067100000')
         })
     })
 })

--- a/src/entrypoints/external-scripts-loader.ts
+++ b/src/entrypoints/external-scripts-loader.ts
@@ -49,7 +49,7 @@ assignableWindow.__PosthogExtensions__.loadExternalDependency = (
         // this ensures that we bust the cache periodically
         const timestampToNearestFiveMinutes = Math.floor(Date.now() / fiveMinutesInMillis) * fiveMinutesInMillis
 
-        scriptUrlToLoad = `${scriptUrlToLoad}?&=${timestampToNearestFiveMinutes}`
+        scriptUrlToLoad = `${scriptUrlToLoad}&t=${timestampToNearestFiveMinutes}`
     }
     const url = posthog.requestRouter.endpointFor('assets', scriptUrlToLoad)
 


### PR DESCRIPTION
## Changes

Changed the URL to use `t=<num>` as query param instead of empty/undefined param name (`v=161.1&=<num>`).


## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)

## Backstory

We use posthog in a nextjs application and use nextjs's rewrites as a proxy for better tracking. We noticed that the toolbar does not work on our site. when checking the logs we noticed that the rewrites did not work for the toolbar:

![image](https://github.com/user-attachments/assets/79341337-9595-492c-bf0c-3ba20d6014e8)

```
 code: 'ERR_INVALID_URL',
  input: 'https__ESC_COLON_//eu-assets.i.posthog.com/static/__ESC_COLON_path*'
```

But the `web-vitals.js` loaded without a problem...

![image](https://github.com/user-attachments/assets/2c370995-0ebd-4ca7-bf65-01fe6dea0ab3)


Further investigation lead to the empty query param for the `toolbar.js` rotating token to bust  the cdn cache.

`?v=1.166.1?&=1728316200000`

The current stable version of next.js (`14.2.14`) has a "bug" that can't handle empty query params correctly in rewrites. The most recent canary version of nextjs seems to not have this bug anymore.

But still I think its better when posthog does not use an empty query param as this seems like something that was not intentional in the first place and secondly can result in unexpected behavior in frameworks like nextjs

