### PR TITLE
fix: sanitize set_once properties

### DIFF
--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -500,6 +500,24 @@ describe('posthog core', () => {
             })
         })
 
+        it('calls sanitize_properties for $set_once', () => {
+            posthog = posthogWith(
+                {
+                    api_host: 'https://custom.posthog.com',
+                    sanitize_properties: (props, event_name) => ({ token: props.token, event_name, ...props }),
+                },
+                overrides
+            )
+
+            posthog.persistence.get_initial_props = () => ({ initial: 'prop' })
+            expect(posthog._calculate_set_once_properties({ key: 'prop' })).toEqual({
+                event_name: '$set_once',
+                token: undefined,
+                initial: 'prop',
+                key: 'prop',
+            })
+        })
+
         it('saves $snapshot data and token for $snapshot events', () => {
             posthog = posthogWith({}, overrides)
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -988,7 +988,11 @@ export class PostHog {
             return dataSetOnce
         }
         // if we're an identified person, send initial params with every event
-        const setOnceProperties = extend({}, this.persistence.get_initial_props(), dataSetOnce || {})
+        let setOnceProperties = extend({}, this.persistence.get_initial_props(), dataSetOnce || {})
+        const sanitize_properties = this.config.sanitize_properties
+        if (sanitize_properties) {
+            setOnceProperties = sanitize_properties(setOnceProperties, '$set_once')
+        }
         if (isEmptyObject(setOnceProperties)) {
             return undefined
         }


### PR DESCRIPTION
## Changes

- `sanitize_properties` was not being run on the properties gathered for `$set_once`. Now it is
- Resolves https://posthoghelp.zendesk.com/agent/tickets/16580 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/22642)

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
