### PR TITLE
feat: swap the default to identified_only

### DIFF
--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -55,7 +55,7 @@ describe('person processing', () => {
     }
 
     describe('init', () => {
-        it("should default to 'always' person_profiles", async () => {
+        it("should default to 'identified_only' person_profiles", async () => {
             // arrange
             const token = uuidv7()
 
@@ -65,7 +65,7 @@ describe('person processing', () => {
             })
 
             // assert
-            expect(posthog.config.person_profiles).toEqual('always')
+            expect(posthog.config.person_profiles).toEqual('identified_only')
         })
         it('should read person_profiles from init config', async () => {
             // arrange

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -628,5 +628,23 @@ describe('person processing', () => {
             expect(onCapture.mock.calls[0][1].properties.$process_person_profile).toEqual(false)
             expect(onCapture.mock.calls[1][1].properties.$process_person_profile).toEqual(false)
         })
+
+        it('should persist when the default person mode is overridden by decide', async () => {
+            // arrange
+            const persistenceName = uuidv7()
+            const { posthog: posthog1, onCapture: onCapture1 } = await setup(undefined, undefined, persistenceName)
+
+            // act
+            posthog1._afterDecideResponse({ defaultIdentifiedOnly: false } as DecideResponse)
+            posthog1.capture('custom event 1')
+            const { posthog: posthog2, onCapture: onCapture2 } = await setup(undefined, undefined, persistenceName)
+            posthog2.capture('custom event 2')
+
+            // assert
+            expect(onCapture1.mock.calls.length).toEqual(1)
+            expect(onCapture2.mock.calls.length).toEqual(1)
+            expect(onCapture1.mock.calls[0][1].properties.$process_person_profile).toEqual(true)
+            expect(onCapture2.mock.calls[0][1].properties.$process_person_profile).toEqual(true)
+        })
     })
 })

--- a/src/__tests__/posthog-core.test.ts
+++ b/src/__tests__/posthog-core.test.ts
@@ -115,6 +115,7 @@ describe('posthog core', () => {
                 const { posthog, onCapture } = setup({
                     token,
                     persistence_name: token,
+                    person_profiles: 'always',
                 })
 
                 // act
@@ -135,6 +136,7 @@ describe('posthog core', () => {
                 const { posthog: posthog1 } = setup({
                     token,
                     persistence_name: token,
+                    person_profiles: 'always',
                 })
                 posthog1.capture(eventName, eventProperties)
                 mockReferrerGetter.mockReturnValue('https://referrer2.example.com/some/path')
@@ -165,6 +167,7 @@ describe('posthog core', () => {
                 const { posthog: posthog1 } = setup({
                     token,
                     persistence_name: token,
+                    person_profiles: 'always',
                 })
                 posthog1.capture(eventName, eventProperties)
                 mockReferrerGetter.mockReturnValue('https://referrer2.example.com/some/path')
@@ -195,6 +198,7 @@ describe('posthog core', () => {
                 const { posthog, onCapture } = setup({
                     token,
                     persistence_name: token,
+                    person_profiles: 'always',
                 })
 
                 // act

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -345,6 +345,20 @@ describe('posthog core', () => {
 
             expect(posthog.compression).toEqual('gzip-js')
         })
+        it('uses defaultIdentifiedOnly from decide response', () => {
+            const posthog = posthogWith({})
+
+            posthog._afterDecideResponse({ defaultIdentifiedOnly: true } as DecideResponse)
+            expect(posthog.config.person_profiles).toEqual('identified_only')
+
+            posthog._afterDecideResponse({ defaultIdentifiedOnly: false } as DecideResponse)
+            expect(posthog.config.person_profiles).toEqual('always')
+        })
+        it('defaultIdentifiedOnly does not override person_profiles if already set', () => {
+            const posthog = posthogWith({ person_profiles: 'always' })
+            posthog._afterDecideResponse({ defaultIdentifiedOnly: true } as DecideResponse)
+            expect(posthog.config.person_profiles).toEqual('always')
+        })
 
         it('enables compression from decide response when only one received', () => {
             const posthog = posthogWith({})

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -387,6 +387,7 @@ describe('posthog core', () => {
                 properties: () => ({ distinct_id: 'abc', persistent: 'prop', $is_identified: false }),
                 remove_event_timer: jest.fn(),
                 get_property: () => 'anonymous',
+                props: { $groups: {} },
             } as unknown as PostHogPersistence,
             sessionPersistence: {
                 properties: () => ({ distinct_id: 'abc', persistent: 'prop' }),
@@ -425,7 +426,7 @@ describe('posthog core', () => {
                 $window_id: 'windowId',
                 $session_id: 'sessionId',
                 $is_identified: false,
-                $process_person_profile: true,
+                $process_person_profile: false,
             })
         })
 
@@ -447,7 +448,7 @@ describe('posthog core', () => {
                 $session_id: 'sessionId',
                 $lib_custom_api_host: 'https://custom.posthog.com',
                 $is_identified: false,
-                $process_person_profile: true,
+                $process_person_profile: false,
             })
         })
 
@@ -465,7 +466,7 @@ describe('posthog core', () => {
                 posthog._calculate_event_properties('custom_event', { event: 'prop' }, new Date())[
                     '$process_person_profile'
                 ]
-            ).toEqual(true)
+            ).toEqual(false)
         })
 
         it('only adds token and distinct_id if event_name is $snapshot', () => {
@@ -496,7 +497,7 @@ describe('posthog core', () => {
             expect(posthog._calculate_event_properties('custom_event', { event: 'prop' }, new Date())).toEqual({
                 event_name: 'custom_event',
                 token: 'testtoken',
-                $process_person_profile: true,
+                $process_person_profile: false,
             })
         })
 

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -401,7 +401,7 @@ describe('posthog core', () => {
                 properties: () => ({ distinct_id: 'abc', persistent: 'prop', $is_identified: false }),
                 remove_event_timer: jest.fn(),
                 get_property: () => 'anonymous',
-                props: { $groups: {} },
+                props: {},
                 register: jest.fn(),
             } as unknown as PostHogPersistence,
             sessionPersistence: {

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -4,7 +4,7 @@ import { Info } from '../utils/event-utils'
 import { document, window } from '../utils/globals'
 import { uuidv7 } from '../uuidv7'
 import * as globals from '../utils/globals'
-import { USER_STATE } from '../constants'
+import { ENABLE_PERSON_PROCESSING, USER_STATE } from '../constants'
 import { createPosthogInstance, defaultPostHog } from './helpers/posthog-instance'
 import { logger } from '../utils/logger'
 import { DecideResponse, PostHogConfig } from '../types'
@@ -525,6 +525,7 @@ describe('posthog core', () => {
             )
 
             posthog.persistence.get_initial_props = () => ({ initial: 'prop' })
+            posthog.persistence.props[ENABLE_PERSON_PROCESSING] = true // person processing is needed for $set_once
             expect(posthog._calculate_set_once_properties({ key: 'prop' })).toEqual({
                 event_name: '$set_once',
                 token: undefined,

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -402,6 +402,7 @@ describe('posthog core', () => {
                 remove_event_timer: jest.fn(),
                 get_property: () => 'anonymous',
                 props: { $groups: {} },
+                register: jest.fn(),
             } as unknown as PostHogPersistence,
             sessionPersistence: {
                 properties: () => ({ distinct_id: 'abc', persistent: 'prop' }),

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -545,8 +545,12 @@ export class PostHog {
         if (response.analytics?.endpoint) {
             this.analyticsDefaultEndpoint = response.analytics.endpoint
         }
-        this.config.person_profiles =
-            response['defaultIdentifiedOnly'] && !this._initialPersonProfilesConfig ? 'identified_only' : 'always'
+
+        this.config.person_profiles = this._initialPersonProfilesConfig
+            ? this._initialPersonProfilesConfig
+            : response['defaultIdentifiedOnly']
+            ? 'identified_only'
+            : 'always'
 
         this.sessionRecording?.afterDecideResponse(response)
         this.autocapture?.afterDecideResponse(response)

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -179,7 +179,7 @@ export const defaultConfig = (): PostHogConfig => ({
     bootstrap: {},
     disable_compression: false,
     session_idle_timeout_seconds: 30 * 60, // 30 minutes
-    person_profiles: 'always',
+    person_profiles: 'identified_only',
     __add_tracing_headers: false,
 })
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -991,7 +991,7 @@ export class PostHog {
             properties = sanitize_properties(properties, event_name)
         }
 
-        // add person processing flag as very last step, so it cannot be overridden. process_person=true is default
+        // add person processing flag as very last step, so it cannot be overridden
         properties['$process_person_profile'] = this._hasPersonProcessing()
 
         return properties

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -546,11 +546,13 @@ export class PostHog {
             this.analyticsDefaultEndpoint = response.analytics.endpoint
         }
 
-        this.config.person_profiles = this._initialPersonProfilesConfig
-            ? this._initialPersonProfilesConfig
-            : response['defaultIdentifiedOnly']
-            ? 'identified_only'
-            : 'always'
+        this.set_config({
+            person_profiles: this._initialPersonProfilesConfig
+                ? this._initialPersonProfilesConfig
+                : response['defaultIdentifiedOnly']
+                ? 'identified_only'
+                : 'always',
+        })
 
         this.sessionRecording?.afterDecideResponse(response)
         this.autocapture?.afterDecideResponse(response)

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -992,7 +992,12 @@ export class PostHog {
         }
 
         // add person processing flag as very last step, so it cannot be overridden
-        properties['$process_person_profile'] = this._hasPersonProcessing()
+        const hasPersonProcessing = this._hasPersonProcessing()
+        properties['$process_person_profile'] = hasPersonProcessing
+        // if the event has person processing, ensure that all future events will too, even if the setting changes
+        if (hasPersonProcessing) {
+            this._requirePersonProcessing('_calculate_event_properties')
+        }
 
         return properties
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -398,6 +398,7 @@ export interface DecideResponse {
     isAuthenticated: boolean
     siteApps: { id: number; url: string }[]
     heatmaps?: boolean
+    defaultIdentifiedOnly?: boolean
 }
 
 export type FeatureFlagsCallback = (


### PR DESCRIPTION
> [!warning]
> This should only be merged after we support the field response from /decide.

## Changes

We want to make the `person_profiles: identified_only` config the default for everyone. It will save everyone money - even if they don't change their config - and is better for our customers and our pipeline. 

Instead of just pushing out a change to posthog-js for this, we want to be able to control the behavior and roll it out slowly, just in case there are any problems. 

So, this PR changes the default, but also listens to a field from decide that will say if we should be defaulting people into `identified_only`, or using the old default `always`. If someone has set their config manually, then we will continue using that setting.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
