### PR TITLE
use synthetic stack trace if not originally captured

### DIFF
--- a/cypress/e2e/error-tracking.cy.ts
+++ b/cypress/e2e/error-tracking.cy.ts
@@ -41,6 +41,22 @@ describe('Exception capture', () => {
             cy.wait('@exception-autocapture-script')
         })
 
+        it('adds stacktrace to captured strings', () => {
+            cy.get('[data-cy-exception-string-button]').click()
+
+            // ugh
+            cy.wait(1500)
+
+            cy.phCaptures({ full: true }).then((captures) => {
+                expect(captures.map((c) => c.event)).to.deep.equal(['$pageview', '$autocapture', '$exception'])
+                expect(captures[2].event).to.be.eql('$exception')
+                expect(captures[2].properties.$exception_list[0].stacktrace.frames.length).to.be.eq(1)
+                expect(captures[2].properties.$exception_list[0].stacktrace.frames[0].function).to.be.eq(
+                    'HTMLButtonElement.onclick'
+                )
+            })
+        })
+
         it('autocaptures exceptions', () => {
             cy.get('[data-cy-button-throws-error]').click()
 

--- a/playground/cypress-full/index.html
+++ b/playground/cypress-full/index.html
@@ -40,6 +40,10 @@
         Send an exception
     </button>
 
+    <button data-cy-exception-string-button onclick="posthog.captureException('I am a plain old string', { extra_prop: 2 })">
+        Capture as string
+    </button>
+
     <br />
 
     <script>

--- a/playground/cypress/index.html
+++ b/playground/cypress/index.html
@@ -52,6 +52,10 @@
         Capture an exception
     </button>
 
+    <button data-cy-exception-string-button onclick="posthog.captureException('I am a plain old string', { extra_prop: 2 })">
+        Capture as string
+    </button>
+
     <script>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getSurveys getActiveMatchingSurveys captureException".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     </script>

--- a/src/extensions/exception-autocapture/stack-trace.ts
+++ b/src/extensions/exception-autocapture/stack-trace.ts
@@ -51,7 +51,6 @@ export interface StackFrame {
 }
 
 const WEBPACK_ERROR_REGEXP = /\(error: (.*)\)/
-const STRIP_FRAME_REGEXP = /captureException/
 const STACKTRACE_FRAME_LIMIT = 50
 
 const UNKNOWN_FUNCTION = '?'
@@ -209,14 +208,6 @@ export function reverseAndStripFrames(stack: ReadonlyArray<StackFrame>): StackFr
     const localStack = Array.from(stack)
 
     localStack.reverse()
-
-    if (STRIP_FRAME_REGEXP.test(getLastStackFrame(localStack).function || '')) {
-        localStack.pop()
-
-        if (STRIP_FRAME_REGEXP.test(getLastStackFrame(localStack).function || '')) {
-            localStack.pop()
-        }
-    }
 
     return localStack.slice(0, STACKTRACE_FRAME_LIMIT).map((frame) => ({
         ...frame,

--- a/src/extensions/exception-autocapture/type-checking.ts
+++ b/src/extensions/exception-autocapture/type-checking.ts
@@ -27,6 +27,7 @@ export function isError(candidate: unknown): candidate is Error {
         case '[object Error]':
         case '[object Exception]':
         case '[object DOMException]':
+        case '[object DOMError]':
             return true
         default:
             return isInstanceOf(candidate, Error)

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1826,12 +1826,13 @@ export class PostHog {
 
     /** Capture a caught exception manually */
     captureException(error: Error, additionalProperties?: Properties): void {
+        const syntheticException = new Error('PostHog syntheticException')
         const properties: Properties = isFunction(assignableWindow.__PosthogExtensions__?.parseErrorAsProperties)
             ? assignableWindow.__PosthogExtensions__.parseErrorAsProperties(
                   [error.message, undefined, undefined, undefined, error],
                   // create synthetic error to get stack in cases where user input does not contain one
                   // creating the exception at this level makes it easy to strip the 'captureException' frame
-                  { syntheticException: new Error('PostHog syntheticException') }
+                  { syntheticException }
               )
             : {
                   $exception_level: 'error',

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1827,13 +1827,12 @@ export class PostHog {
     /** Capture a caught exception manually */
     captureException(error: Error, additionalProperties?: Properties): void {
         const properties: Properties = isFunction(assignableWindow.__PosthogExtensions__?.parseErrorAsProperties)
-            ? assignableWindow.__PosthogExtensions__.parseErrorAsProperties([
-                  error.message,
-                  undefined,
-                  undefined,
-                  undefined,
-                  error,
-              ])
+            ? assignableWindow.__PosthogExtensions__.parseErrorAsProperties(
+                  [error.message, undefined, undefined, undefined, error],
+                  // create synthetic error to get stack in cases where user input does not contain one
+                  // creating the exception at this level makes it easy to strip the 'captureException' frame
+                  { syntheticException: new Error('PostHog syntheticException') }
+              )
             : {
                   $exception_level: 'error',
                   $exception_list: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -573,6 +573,7 @@ export type ErrorEventArgs = [
 export type ErrorMetadata = {
     handled?: boolean
     synthetic?: boolean
+    syntheticException?: Error
     overrideExceptionType?: string
     overrideExceptionMessage?: string
     defaultExceptionType?: string


### PR DESCRIPTION
## Changes

Why miss out on a stack trace if you call `captureException` with a string?

This changes things to throw an error to capture the current stack trace and strips the final frame (e.g. inside our `captureException` function)
