### PR TITLE
feat(surveys): Make entire cancel button area clickable

### DIFF
--- a/src/extensions/surveys/components/QuestionHeader.tsx
+++ b/src/extensions/surveys/components/QuestionHeader.tsx
@@ -35,7 +35,7 @@ export function Cancel({ onClick }: { onClick: () => void }) {
     const { isPreviewMode } = useContext(SurveyContext)
 
     return (
-        <div className="cancel-btn-wrapper">
+        <div className="cancel-btn-wrapper" onClick={onClick} disabled={isPreviewMode}>
             <button className="form-cancel" onClick={onClick} disabled={isPreviewMode}>
                 {cancelSVG}
             </button>


### PR DESCRIPTION
## Changes

Resolves https://github.com/PostHog/posthog/issues/25594
The Cancel button on a survey right now attaches the click handler to the tiny `X` in the close button. 
This PR makes the entire Circle and the X inside it clickable.

![image](https://github.com/user-attachments/assets/88b359c8-5be9-482c-8a70-1f51e9e52828)


## Checklist
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
