### PR TITLE
fix: web vitals delayed capture

### DIFF
--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -7,7 +7,7 @@ import { assignableWindow, window } from '../../utils/globals'
 
 type WebVitalsMetricCallback = (metric: any) => void
 
-export const FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS = 8000
+export const DEFAULT_FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS = 5000
 const ONE_MINUTE_IN_MILLIS = 60 * 1000
 export const FIFTEEN_MINUTES_IN_MILLIS = 15 * ONE_MINUTE_IN_MILLIS
 
@@ -36,6 +36,13 @@ export class WebVitalsAutocapture {
         return !isUndefined(clientConfigMetricAllowList)
             ? clientConfigMetricAllowList
             : this.instance.persistence?.props[WEB_VITALS_ALLOWED_METRICS] || ['CLS', 'FCP', 'INP', 'LCP']
+    }
+
+    public get flushToCaptureTimeoutMs(): number {
+        const clientConfig: number | undefined = isObject(this.instance.config.capture_performance)
+            ? this.instance.config.capture_performance.web_vitals_delayed_flush_ms
+            : undefined
+        return clientConfig || DEFAULT_FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS
     }
 
     public get _maxAllowedValue(): number {
@@ -163,7 +170,7 @@ export class WebVitalsAutocapture {
             // poor performance is >4s, we wait twice that time to send
             // this is in case we haven't received all metrics
             // we'll at least gather some
-            this._delayedFlushTimer = setTimeout(this._flushToCapture, FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS)
+            this._delayedFlushTimer = setTimeout(this._flushToCapture, this.flushToCaptureTimeoutMs)
         }
 
         if (isUndefined(this.buffer.url)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,12 @@ export interface PerformanceCaptureConfig {
      * NB setting this does not override whether the capture is enabled
      */
     web_vitals_allowed_metrics?: SupportedWebVitalsMetrics[]
+    /**
+     * we delay flushing web vitals metrics to reduce the number of events we send
+     * this is the maximum time we will wait before sending the metrics
+     * if not set it defaults to 5 seconds
+     */
+    web_vitals_delayed_flush_ms?: number
 }
 
 export interface HeatmapConfig {


### PR DESCRIPTION
We delay capturing web vitals metrics to try and avoid charging too much for collection

But this might be leading some sites to missing the metrics

Let's reduce that timeout and make it configurable so we can test it