### PR TITLE
chore: skip if Array.from is missing

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -610,13 +610,13 @@ export class SessionRecording {
     }
 
     private _startCapture() {
-        if (isUndefined(Object.assign)) {
+        if (isUndefined(Object.assign) || isUndefined(Array.from)) {
             // According to the rrweb docs, rrweb is not supported on IE11 and below:
             // "rrweb does not support IE11 and below because it uses the MutationObserver API which was supported by these browsers."
             // https://github.com/rrweb-io/rrweb/blob/master/guide.md#compatibility-note
             //
             // However, MutationObserver does exist on IE11, it just doesn't work well and does not detect all changes.
-            // Instead, when we load "recorder.js", the first JS error is about "Object.assign" being undefined.
+            // Instead, when we load "recorder.js", the first JS error is about "Object.assign" and "Array.from" being undefined.
             // Thus instead of MutationObserver, we look for this function and block recording if it's undefined.
             return
         }


### PR DESCRIPTION
## Changes

When upgrading rrweb in https://github.com/PostHog/posthog-js/pull/1276 we had some [failing tests on IE11](https://github.com/PostHog/posthog-js/actions/runs/11342401043/job/31542713953?pr=1276):

```
TypeError: Object doesn't support property or method 'from'
```

This is because the `Array.from` method is [not supported on IE11](https://caniuse.com/?search=array%20from) and it seems like rrweb internals have changed such that it is now called as part of our tests when upgrading.

Proposal is to remove it in this PR and then upgrade rrweb in the separate PR linked