### PR TITLE
fix: do not capture entire elements in web vitals

### DIFF
--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -181,6 +181,14 @@ export class WebVitalsAutocapture {
             ? Date.now()
             : this.buffer.firstMetricTimestamp
 
+        if (metric.attribution && metric.attribution.interactionTargetElement) {
+            // we don't want to send the entire element
+            // they can be very large
+            // TODO we could run this through autocapture code so that we get elements chain info
+            //  and can display the element in the UI
+            metric.attribution.interactionTargetElement = undefined
+        }
+
         this.buffer.metrics.push({
             ...metric,
             $current_url: $currentUrl,


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/19253 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/21408)

we capture INP attribution to help with debugging but that includes a reference to a DOM element

they can be very large or painful to serialize

we could run through autocapture to get elements chain but until https://github.com/PostHog/posthog-js/pull/1463 that code isn't accessible easily for arbitrary elements

so for now, to resolve the issue, let's just drop the unusable property