### PR TITLE
feat: Only set missing campaign params to null if there is at least one non-null

### DIFF
--- a/src/__tests__/posthog-core.test.ts
+++ b/src/__tests__/posthog-core.test.ts
@@ -212,5 +212,41 @@ describe('posthog core', () => {
                 expect(properties['$referring_domain']).toBe('$direct')
             })
         })
+
+        describe('campaign params', () => {
+            it('should not send campaign params as null if there are no non-null ones', () => {
+                // arrange
+                const token = uuidv7()
+                mockURLGetter.mockReturnValue('https://www.example.com/some/path')
+                const { posthog, onCapture } = setup({
+                    token,
+                    persistence_name: token,
+                })
+
+                // act
+                posthog.capture('$pageview')
+
+                //assert
+                expect(onCapture.mock.calls[0][1].properties).not.toHaveProperty('utm_source')
+                expect(onCapture.mock.calls[0][1].properties).not.toHaveProperty('utm_medium')
+            })
+
+            it('should send present campaign params, and nulls for others', () => {
+                // arrange
+                const token = uuidv7()
+                mockURLGetter.mockReturnValue('https://www.example.com/some/path?utm_source=source')
+                const { posthog, onCapture } = setup({
+                    token,
+                    persistence_name: token,
+                })
+
+                // act
+                posthog.capture('$pageview')
+
+                //assert
+                expect(onCapture.mock.calls[0][1].properties.utm_source).toBe('source')
+                expect(onCapture.mock.calls[0][1].properties.utm_medium).toBe(null)
+            })
+        })
     })
 })

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -12,7 +12,7 @@ import {
     PERSISTENCE_RESERVED_PROPERTIES,
 } from './constants'
 
-import { isObject, isUndefined } from './utils/type-utils'
+import { isEmptyObject, isObject, isUndefined } from './utils/type-utils'
 import { Info } from './utils/event-utils'
 import { logger } from './utils/logger'
 
@@ -221,7 +221,11 @@ export class PostHogPersistence {
 
     update_campaign_params(): void {
         if (!this.campaign_params_saved) {
-            this.register(Info.campaignParams(this.config.custom_campaign_params))
+            const campaignParams = Info.campaignParams(this.config.custom_campaign_params)
+            // only save campaign params if there were any
+            if (!isEmptyObject(stripEmptyProperties(campaignParams))) {
+                this.register(Info.campaignParams(this.config.custom_campaign_params))
+            }
             this.campaign_params_saved = true
         }
     }


### PR DESCRIPTION
## Changes

See this ticket https://posthoghelp.zendesk.com/agent/tickets/19698 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/21794)

We definitely want to keep something similar to the changed logic. i.e. if one session has utm_source = source, and the next session has utm_medium = medium.

However, we could prevent overwriting the campaign params if there are none set.

Had a discussion with @neilkakkar about it here https://posthog.slack.com/archives/C05LJK1N3CP/p1729764244044729

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
