### PR TITLE
fix(surveys): Reset Survey storage after posthog.reset is called

### DIFF
--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -212,6 +212,16 @@ describe('surveys', () => {
         expect(instance._send_request).toHaveBeenCalledTimes(1)
     })
 
+    it('posthog.reset() removes surveys tracking properties from storage', () => {
+        localStorage.setItem('seenSurvey_XYZ', '1')
+        localStorage.setItem('seenSurvey_ABC', '1')
+        localStorage.setItem('lastSeenSurveyDate', 'some date here')
+        surveys.reset()
+        expect(localStorage.getItem('lastSeenSurveyDate')).toBeNull()
+        expect(localStorage.getItem('seenSurvey_XYZ')).toBeNull()
+        expect(localStorage.getItem('seenSurvey_ABC')).toBeNull()
+    })
+
     it('getSurveys registers the survey event receiver if a survey has events', () => {
         surveysResponse = { surveys: surveysWithEvents }
         surveys.getSurveys((data) => {

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -5,7 +5,7 @@ import { VNode, cloneElement, createContext } from 'preact'
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const window = _window as Window & typeof globalThis
 const document = _document as Document
-
+const SurveySeenPrefix = 'seenSurvey_'
 export const style = (appearance: SurveyAppearance | null) => {
     const positions = {
         left: 'left: 30px;',
@@ -648,12 +648,24 @@ export const getSurveySeen = (survey: Survey): boolean => {
 }
 
 export const getSurveySeenKey = (survey: Survey): string => {
-    let surveySeenKey = `seenSurvey_${survey.id}`
+    let surveySeenKey = `${SurveySeenPrefix}${survey.id}`
     if (survey.current_iteration && survey.current_iteration > 0) {
-        surveySeenKey = `seenSurvey_${survey.id}_${survey.current_iteration}`
+        surveySeenKey = `${SurveySeenPrefix}${survey.id}_${survey.current_iteration}`
     }
 
     return surveySeenKey
+}
+
+export const getSurveySeenStorageKeys = (): string[] => {
+    const surveyKeys = []
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i)
+        if (key?.startsWith(SurveySeenPrefix)) {
+            surveyKeys.push(key)
+        }
+    }
+
+    return surveyKeys
 }
 
 const getSurveyInteractionProperty = (survey: Survey, action: string): string => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1513,6 +1513,7 @@ export class PostHog {
         this.consent.reset()
         this.persistence?.clear()
         this.sessionPersistence?.clear()
+        this.surveys?.reset()
         this.persistence?.set_property(USER_STATE, 'anonymous')
         this.sessionManager?.resetSessionId()
         const uuid = this.config.get_device_id(uuidv7())

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -73,6 +73,18 @@ export class PostHogSurveys {
         this.loadIfEnabled()
     }
 
+    reset(): void {
+        localStorage.removeItem('lastSeenSurveyDate')
+        const surveyKeys = []
+        for (let i = 0; i < localStorage.length; i++) {
+            const key = localStorage.key(i)
+            if (key?.startsWith('seenSurvey_')) {
+                surveyKeys.push(key)
+            }
+        }
+        surveyKeys.forEach((key) => localStorage.removeItem(key))
+    }
+
     loadIfEnabled() {
         const surveysGenerator = assignableWindow?.__PosthogExtensions__?.generateSurveys
 
@@ -287,7 +299,6 @@ export class PostHogSurveys {
         }
         this.getSurveys((surveys) => {
             const survey = surveys.filter((x) => x.id === surveyId)[0]
-
             this._surveyManager.canRenderSurvey(survey)
         })
     }
@@ -299,7 +310,6 @@ export class PostHogSurveys {
         }
         this.getSurveys((surveys) => {
             const survey = surveys.filter((x) => x.id === surveyId)[0]
-
             this._surveyManager.renderSurvey(survey, document?.querySelector(selector))
         })
     }

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -13,6 +13,7 @@ import { assignableWindow, document, window } from './utils/globals'
 import { DecideResponse } from './types'
 import { logger } from './utils/logger'
 import { isNullish } from './utils/type-utils'
+import { getSurveySeenStorageKeys } from './extensions/surveys/surveys-utils'
 
 const LOGGER_PREFIX = '[Surveys]'
 
@@ -75,13 +76,7 @@ export class PostHogSurveys {
 
     reset(): void {
         localStorage.removeItem('lastSeenSurveyDate')
-        const surveyKeys = []
-        for (let i = 0; i < localStorage.length; i++) {
-            const key = localStorage.key(i)
-            if (key?.startsWith('seenSurvey_')) {
-                surveyKeys.push(key)
-            }
-        }
+        const surveyKeys = getSurveySeenStorageKeys()
         surveyKeys.forEach((key) => localStorage.removeItem(key))
     }
 


### PR DESCRIPTION
## Changes

We found through a customer issue that calling `posthog.reset()` doesn't remove the tracking properties added by PostHog Surveys from local storage. This PR adds a `reset` method to posthog surveys and calls it from posthog-core, whenever `posthog.reset()` is called.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
