### PR TITLE
chore: set platform on stack frame

### DIFF
--- a/src/extensions/exception-autocapture/stack-trace.ts
+++ b/src/extensions/exception-autocapture/stack-trace.ts
@@ -33,6 +33,7 @@ export type StackLineParserFn = (line: string) => StackFrame | undefined
 export type StackLineParser = [number, StackLineParserFn]
 
 export interface StackFrame {
+    lang: string
     filename?: string
     function?: string
     module?: string
@@ -63,6 +64,7 @@ const GECKO_PRIORITY = 50
 
 function createFrame(filename: string, func: string, lineno?: number, colno?: number): StackFrame {
     const frame: StackFrame = {
+        lang: 'javascript',
         filename,
         function: func === '<anonymous>' ? UNKNOWN_FUNCTION : func,
         in_app: true, // All browser frames are considered in_app

--- a/src/extensions/exception-autocapture/stack-trace.ts
+++ b/src/extensions/exception-autocapture/stack-trace.ts
@@ -33,11 +33,10 @@ export type StackLineParserFn = (line: string) => StackFrame | undefined
 export type StackLineParser = [number, StackLineParserFn]
 
 export interface StackFrame {
-    lang: string
+    platform: string
     filename?: string
     function?: string
     module?: string
-    platform?: string
     lineno?: number
     colno?: number
     abs_path?: string
@@ -64,7 +63,7 @@ const GECKO_PRIORITY = 50
 
 function createFrame(filename: string, func: string, lineno?: number, colno?: number): StackFrame {
     const frame: StackFrame = {
-        lang: 'javascript',
+        platform: 'javascript',
         filename,
         function: func === '<anonymous>' ? UNKNOWN_FUNCTION : func,
         in_app: true, // All browser frames are considered in_app


### PR DESCRIPTION
## Changes

We need to know what language an individual frame is so that we can avoid an untagged enum switching as part of the Rust service.

For now this assumes all stacks in the JS SDK are `javascript`