### PR TITLE
chore: add recorder to es5 bundle

### DIFF
--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -27,12 +27,16 @@ jobs:
         include:
           - browser: 'chrome:headless'
             name: Chrome
+            cli: ''
           - browser: 'firefox:headless'
             name: Firefox
+            cli: ''
           - browser: 'browserstack:ie'
             name: IE11
+            cli: '--skip-js-errors'
           - browser: 'browserstack:safari'
             name: Safari
+            cli: ''
 
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +62,7 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
           RUN_ID: ${{ github.run_id }}
           BROWSER: ${{ matrix.browser }}
-        run: pnpm testcafe ${{ matrix.browser }} --stop-on-first-fail
+        run: pnpm testcafe ${{ matrix.browser }} --stop-on-first-fail ${{ matrix.cli }}
 
       - name: Check ${{ matrix.name }} events
         run: pnpm check-testcafe-results

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,34 +9,37 @@ import commonjs from '@rollup/plugin-commonjs'
 import fs from 'fs'
 import path from 'path'
 
-const plugins = (es5) => [
-    json(),
-    resolve({ browser: true }),
-    typescript({ sourceMap: true, outDir: './dist' }),
-    commonjs(),
-    babel({
-        extensions: ['.js', '.jsx', '.ts', '.tsx'],
-        babelHelpers: 'bundled',
-        plugins: ['@babel/plugin-transform-nullish-coalescing-operator'],
-        presets: [
-            [
-                '@babel/preset-env',
-                {
-                    targets: es5
-                        ? '>0.5%, last 2 versions, Firefox ESR, not dead, IE 11'
-                        : '>0.5%, last 2 versions, Firefox ESR, not dead',
-                },
-            ],
-        ],
-    }),
-    terser({
-        toplevel: true,
-        compress: {
-            // 5 is the default if unspecified
-            ecma: es5 ? 5 : 6,
-        },
-    }),
-]
+const plugins = (es5) => {
+    const babelOptions = {
+        targets: es5
+            ? '>0.5%, last 2 versions, Firefox ESR, not dead, IE 11'
+            : '>0.5%, last 2 versions, Firefox ESR, not dead',
+    }
+    if (es5) {
+        babelOptions.useBuiltIns = 'usage'
+        babelOptions.corejs = 3
+    }
+
+    return [
+        json(),
+        resolve({ browser: true }),
+        typescript({ sourceMap: true, outDir: './dist' }),
+        commonjs(),
+        babel({
+            extensions: ['.js', '.jsx', '.ts', '.tsx'],
+            babelHelpers: 'bundled',
+            plugins: ['@babel/plugin-transform-nullish-coalescing-operator'],
+            presets: [['@babel/preset-env', babelOptions]],
+        }),
+        terser({
+            toplevel: true,
+            compress: {
+                // 5 is the default if unspecified
+                ecma: es5 ? 5 : 6,
+            },
+        }),
+    ]
+}
 
 const entrypoints = fs.readdirSync('./src/entrypoints')
 

--- a/src/entrypoints/array.full.es5.ts
+++ b/src/entrypoints/array.full.es5.ts
@@ -2,10 +2,10 @@
 // but will have different config when passed through rollup
 // to allow es5/IE11 support
 
-// it doesn't include recorder which doesn't support IE11,
-// and it doesn't include web-vitals which doesn't support IE11
+// but it doesn't include web-vitals which doesn't support IE11
 
 import './surveys'
 import './exception-autocapture'
 import './tracing-headers'
+import './recorder'
 import './array.no-external'


### PR DESCRIPTION
we've had a customer request to support replay in the ES5 bundle so they can try replay in IE11

rrweb doesn't officially support IE11, so 🤞 