### PR TITLE
feat: add recording url blocklist

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -2158,7 +2158,7 @@ describe('SessionRecording', () => {
         })
     })
 
-    describe.only('URL blocking', () => {
+    describe('URL blocking', () => {
         beforeEach(() => {
             sessionRecording.startIfEnabledOrStop()
             sessionRecording.afterDecideResponse(

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -1,5 +1,7 @@
 /// <reference lib="dom" />
 
+import '@testing-library/jest-dom'
+
 import { PostHogPersistence } from '../../../posthog-persistence'
 import {
     CONSOLE_LOG_RECORDING_ENABLED_SERVER_SIDE,
@@ -2184,6 +2186,7 @@ describe('SessionRecording', () => {
             // Simulate URL change to blocked URL
             fakeNavigateTo('https://test.com/blocked')
             _emit(createIncrementalSnapshot({ data: { source: 3 } }))
+            expect(document.body).toHaveClass('ph-no-capture')
 
             await waitFor(() => {
                 // Verify the buffer was flushed with all events including pause
@@ -2213,6 +2216,8 @@ describe('SessionRecording', () => {
 
             // Verify recording resumes with resume event
             _emit(createIncrementalSnapshot({ data: { source: 5 } }))
+
+            expect(document.body).not.toHaveClass('ph-no-capture')
 
             expect(sessionRecording['buffer'].data).toStrictEqual([
                 expect.objectContaining({

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -2199,8 +2199,6 @@ describe('SessionRecording', () => {
                         $snapshot_data: [
                             { type: 3, data: { source: 1 } },
                             { type: 3, data: { source: 2 } },
-                            // This should be in the buffer
-                            // { type: 5, data: { tag: 'recording paused', payload: { reason: 'url blocker' } } },
                         ],
                     },
                     expect.any(Object)
@@ -2227,11 +2225,6 @@ describe('SessionRecording', () => {
                     type: 3,
                     data: { source: 5 },
                 }),
-                // Resume data is not in the buffer?
-                // expect.objectContaining({
-                //     type: 5,
-                //     data: { tag: 'recording paused', payload: { reason: 'url blocker' } },
-                // })
             ])
         })
     })

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -1224,16 +1224,19 @@ export class SessionRecording {
     private _pauseRecording() {
         this._urlBlocked = true
 
-        this._flushBuffer()
-        this.stopRecording()
+        this.clearBuffer()
+        clearInterval(this._fullSnapshotTimer)
         this._tryAddCustomEvent('recording paused', { reason: 'url blocker' })
+
         logger.info(LOGGER_PREFIX + ' recording paused due to URL blocker')
     }
 
     private _resumeRecording() {
         this._urlBlocked = false
 
-        this.startIfEnabledOrStop()
+        this._tryTakeFullSnapshot()
+
+        this._scheduleFullSnapshot()
         this._tryAddCustomEvent('recording resumed', { reason: 'left blocked url' })
         logger.info(LOGGER_PREFIX + ' recording resumed')
     }

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -1226,6 +1226,10 @@ export class SessionRecording {
     }
 
     private _pauseRecording() {
+        if (this.status === 'paused') {
+            return
+        }
+
         this._urlBlocked = true
 
         this.clearBuffer()
@@ -1236,6 +1240,10 @@ export class SessionRecording {
     }
 
     private _resumeRecording() {
+        if (this.status !== 'paused') {
+            return
+        }
+
         this._urlBlocked = false
 
         this._tryTakeFullSnapshot()

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -258,7 +258,7 @@ export class SessionRecording {
     private _lastHref?: string
 
     private _urlTriggers: SessionRecordingUrlTrigger[] = []
-    private _urlBlockList: SessionRecordingUrlTrigger[] = []
+    private _urlBlocklist: SessionRecordingUrlTrigger[] = []
 
     private _urlBlocked: boolean = false
 
@@ -632,8 +632,8 @@ export class SessionRecording {
             this._urlTriggers = response.sessionRecording.urlTriggers
         }
 
-        if (response.sessionRecording?.urlBlockList) {
-            this._urlBlockList = response.sessionRecording.urlBlockList
+        if (response.sessionRecording?.urlBlocklist) {
+            this._urlBlocklist = response.sessionRecording.urlBlocklist
         }
 
         this.receivedDecide = true
@@ -1199,7 +1199,7 @@ export class SessionRecording {
         const url = window.location.href
 
         const wasBlocked = this.status === 'paused'
-        const isNowBlocked = sessionRecordingUrlTriggerMatches(url, this._urlBlockList)
+        const isNowBlocked = sessionRecordingUrlTriggerMatches(url, this._urlBlocklist)
 
         if (isNowBlocked && !wasBlocked) {
             this._pauseRecording()

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -1004,8 +1004,7 @@ export class SessionRecording {
         // Check if the URL matches any trigger patterns
         this._checkTriggerConditions()
 
-        if (this.status === 'paused' || this.status === 'disabled') {
-            this.clearBuffer()
+        if (this.status === 'paused') {
             return
         }
 
@@ -1058,6 +1057,11 @@ export class SessionRecording {
             $snapshot_data: eventToSend,
             $session_id: this.sessionId,
             $window_id: this.windowId,
+        }
+
+        if (this.status === 'disabled') {
+            this.clearBuffer()
+            return
         }
 
         this._captureSnapshotBuffered(properties)

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -1241,6 +1241,7 @@ export class SessionRecording {
         this._tryAddCustomEvent('recording paused', { reason: 'url blocker' })
 
         this._urlBlocked = true
+        document?.body?.classList?.add('ph-no-capture')
 
         // Clear the snapshot timer since we don't want new snapshots while paused
         clearInterval(this._fullSnapshotTimer)
@@ -1257,6 +1258,7 @@ export class SessionRecording {
         }
 
         this._urlBlocked = false
+        document?.body?.classList?.remove('ph-no-capture')
 
         this._tryTakeFullSnapshot()
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -397,7 +397,7 @@ export class SessionRecording {
     }
 
     private get urlTriggerStatus(): TriggerStatus {
-        if (this.receivedDecide && this._urlTriggers.length === 0) {
+        if (this._urlTriggers.length === 0) {
             return 'trigger_disabled'
         }
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -214,6 +214,17 @@ function isSessionIdleEvent(e: eventWithTime): e is eventWithTime & customEvent 
     return e.type === EventType.Custom && e.data.tag === 'sessionIdle'
 }
 
+function sessionRecordingUrlTriggerMatches(url: string, triggers: SessionRecordingUrlTrigger[]) {
+    return triggers.some((trigger) => {
+        switch (trigger.matching) {
+            case 'regex':
+                return new RegExp(trigger.url).test(url)
+            default:
+                return false
+        }
+    })
+}
+
 export class SessionRecording {
     private _endpoint: string
     private flushBufferTimer?: any
@@ -1181,16 +1192,7 @@ export class SessionRecording {
 
         const url = window.location.href
 
-        if (
-            this._urlTriggers.some((trigger) => {
-                switch (trigger.matching) {
-                    case 'regex':
-                        return new RegExp(trigger.url).test(url)
-                    default:
-                        return false
-                }
-            })
-        ) {
+        if (sessionRecordingUrlTriggerMatches(url, this._urlTriggers)) {
             this._activateUrlTrigger()
         }
     }

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -987,6 +987,11 @@ export class SessionRecording {
         // Check if the URL matches any trigger patterns
         this._checkTriggerConditions()
 
+        if (this.status === 'paused' || this.status === 'disabled') {
+            this.clearBuffer()
+            return
+        }
+
         // we're processing a full snapshot, so we should reset the timer
         if (rawEvent.type === EventType.FullSnapshot) {
             this._scheduleFullSnapshot()
@@ -1038,11 +1043,7 @@ export class SessionRecording {
             $window_id: this.windowId,
         }
 
-        if (this.status !== 'disabled') {
-            this._captureSnapshotBuffered(properties)
-        } else {
-            this.clearBuffer()
-        }
+        this._captureSnapshotBuffered(properties)
     }
 
     private _pageViewFallBack() {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -985,7 +985,7 @@ export class SessionRecording {
         }
 
         // Check if the URL matches any trigger patterns
-        this._checkUrlTrigger()
+        this._checkTriggerConditions()
 
         // we're processing a full snapshot, so we should reset the timer
         if (rawEvent.type === EventType.FullSnapshot) {
@@ -1173,7 +1173,7 @@ export class SessionRecording {
         })
     }
 
-    private _checkUrlTrigger() {
+    private _checkTriggerConditions() {
         if (typeof window === 'undefined' || !window.location.href) {
             return
         }

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -260,6 +260,8 @@ export class SessionRecording {
     private _urlTriggers: SessionRecordingUrlTrigger[] = []
     private _urlBlockList: SessionRecordingUrlTrigger[] = []
 
+    private _urlBlocked: boolean = false
+
     // Util to help developers working on this feature manually override
     _forceAllowLocalhostNetworkCapture = false
 
@@ -381,6 +383,10 @@ export class SessionRecording {
 
         if (this.urlTriggerStatus === 'trigger_pending') {
             return 'buffering'
+        }
+
+        if (this._urlBlocked) {
+            return 'paused'
         }
 
         if (isBoolean(this.isSampled)) {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -87,7 +87,7 @@ type TriggerStatus = typeof TRIGGER_STATUSES[number]
  * When sampled that means a sample rate is set and the last time the session id was rotated
  * the sample rate determined this session should be sent to the server.
  */
-type SessionRecordingStatus = 'disabled' | 'sampled' | 'active' | 'buffering'
+type SessionRecordingStatus = 'disabled' | 'sampled' | 'active' | 'buffering' | 'paused'
 
 export interface SnapshotBuffer {
     size: number
@@ -247,6 +247,7 @@ export class SessionRecording {
     private _lastHref?: string
 
     private _urlTriggers: SessionRecordingUrlTrigger[] = []
+    private _urlBlockList: SessionRecordingUrlTrigger[] = []
 
     // Util to help developers working on this feature manually override
     _forceAllowLocalhostNetworkCapture = false
@@ -612,6 +613,10 @@ export class SessionRecording {
 
         if (response.sessionRecording?.urlTriggers) {
             this._urlTriggers = response.sessionRecording.urlTriggers
+        }
+
+        if (response.sessionRecording?.urlBlockList) {
+            this._urlBlockList = response.sessionRecording.urlBlockList
         }
 
         this.receivedDecide = true

--- a/src/types.ts
+++ b/src/types.ts
@@ -397,6 +397,7 @@ export interface DecideResponse {
         linkedFlag?: string | FlagVariant | null
         networkPayloadCapture?: Pick<NetworkRecordOptions, 'recordBody' | 'recordHeaders'>
         urlTriggers?: SessionRecordingUrlTrigger[]
+        urlBlockList?: SessionRecordingUrlTrigger[]
     }
     surveys?: boolean
     toolbarParams: ToolbarParams
@@ -614,6 +615,7 @@ export interface ErrorConversions {
 }
 
 export interface SessionRecordingUrlTrigger {
+    urlBlockList?: SessionRecordingUrlTrigger[]
     url: string
     matching: 'regex'
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -397,7 +397,7 @@ export interface DecideResponse {
         linkedFlag?: string | FlagVariant | null
         networkPayloadCapture?: Pick<NetworkRecordOptions, 'recordBody' | 'recordHeaders'>
         urlTriggers?: SessionRecordingUrlTrigger[]
-        urlBlockList?: SessionRecordingUrlTrigger[]
+        urlBlocklist?: SessionRecordingUrlTrigger[]
     }
     surveys?: boolean
     toolbarParams: ToolbarParams


### PR DESCRIPTION
## Changes


Client for https://github.com/PostHog/posthog/pull/25845 
Enables pausing the recording when certain urls are visited.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
