### PR TITLE
feat: Add timezone to events

### DIFF
--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -182,6 +182,14 @@ export const Info = {
         return props
     },
 
+    timezone: function (): string | undefined {
+        try {
+            return Intl.DateTimeFormat().resolvedOptions().timeZone
+        } catch {
+            return undefined
+        }
+    },
+
     properties: function (): Properties {
         if (!userAgent) {
             return {}
@@ -194,6 +202,7 @@ export const Info = {
                 $browser: Info.browser(userAgent, navigator.vendor),
                 $device: Info.device(userAgent),
                 $device_type: Info.deviceType(userAgent),
+                $timezone: Info.timezone(),
             }),
             {
                 $current_url: location?.href,


### PR DESCRIPTION
## Changes

Add timezone to events (timezone looks like Europe/London).

In older browsers that don't support Intl, this property won't be sent.

This is useful for a couple of things:
* I want to add a time of day query, which shows you how active your site is at different times of day, and it'd be cool to have a toggle to show it by the user's timezone (so you could see that e.g. around the world your app is always popular at 8am)
* I can use this for the cookieless rotating salt, to figure out which day's salt to use

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
