### PR TITLE
chore: refactor towards dead clicks autocapture

### DIFF
--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -37,6 +37,202 @@ function limitText(length: number, text: string): string {
     return text
 }
 
+export function getAugmentPropertiesFromElement(elem: Element): Properties {
+    const shouldCaptureEl = shouldCaptureElement(elem)
+    if (!shouldCaptureEl) {
+        return {}
+    }
+
+    const props: Properties = {}
+
+    each(elem.attributes, function (attr: Attr) {
+        if (attr.name && attr.name.indexOf('data-ph-capture-attribute') === 0) {
+            const propertyKey = attr.name.replace('data-ph-capture-attribute-', '')
+            const propertyValue = attr.value
+            if (propertyKey && propertyValue && shouldCaptureValue(propertyValue)) {
+                props[propertyKey] = propertyValue
+            }
+        }
+    })
+
+    return props
+}
+
+export function previousElementSibling(el: Element): Element | null {
+    if (el.previousElementSibling) {
+        return el.previousElementSibling
+    }
+    let _el: Element | null = el
+    do {
+        _el = _el.previousSibling as Element | null // resolves to ChildNode->Node, which is Element's parent class
+    } while (_el && !isElementNode(_el))
+    return _el
+}
+
+export function getDefaultProperties(eventType: string): Properties {
+    return {
+        $event_type: eventType,
+        $ce_version: 1,
+    }
+}
+
+export function getPropertiesFromElement(
+    elem: Element,
+    maskAllAttributes: boolean,
+    maskText: boolean,
+    elementAttributeIgnorelist: string[] | undefined
+): Properties {
+    const tag_name = elem.tagName.toLowerCase()
+    const props: Properties = {
+        tag_name: tag_name,
+    }
+    if (autocaptureCompatibleElements.indexOf(tag_name) > -1 && !maskText) {
+        if (tag_name.toLowerCase() === 'a' || tag_name.toLowerCase() === 'button') {
+            props['$el_text'] = limitText(1024, getDirectAndNestedSpanText(elem))
+        } else {
+            props['$el_text'] = limitText(1024, getSafeText(elem))
+        }
+    }
+
+    const classes = getClassNames(elem)
+    if (classes.length > 0)
+        props['classes'] = classes.filter(function (c) {
+            return c !== ''
+        })
+
+    // capture the deny list here because this not-a-class class makes it tricky to use this.config in the function below
+    each(elem.attributes, function (attr: Attr) {
+        // Only capture attributes we know are safe
+        if (isSensitiveElement(elem) && ['name', 'id', 'class', 'aria-label'].indexOf(attr.name) === -1) return
+
+        if (elementAttributeIgnorelist?.includes(attr.name)) return
+
+        if (!maskAllAttributes && shouldCaptureValue(attr.value) && !isAngularStyleAttr(attr.name)) {
+            let value = attr.value
+            if (attr.name === 'class') {
+                // html attributes can _technically_ contain linebreaks,
+                // but we're very intolerant of them in the class string,
+                // so we strip them.
+                value = splitClassString(value).join(' ')
+            }
+            props['attr__' + attr.name] = limitText(1024, value)
+        }
+    })
+
+    let nthChild = 1
+    let nthOfType = 1
+    let currentElem: Element | null = elem
+    while ((currentElem = previousElementSibling(currentElem))) {
+        // eslint-disable-line no-cond-assign
+        nthChild++
+        if (currentElem.tagName === elem.tagName) {
+            nthOfType++
+        }
+    }
+    props['nth_child'] = nthChild
+    props['nth_of_type'] = nthOfType
+
+    return props
+}
+
+export function autocapturePropertiesForElement(
+    target: Element,
+    {
+        e,
+        maskAllElementAttributes,
+        maskAllText,
+        elementAttributeIgnoreList,
+        elementsChainAsString,
+    }: {
+        e: Event
+        maskAllElementAttributes: boolean
+        maskAllText: boolean
+        elementAttributeIgnoreList?: string[] | undefined
+        elementsChainAsString: boolean
+    }
+): { props: Properties; explicitNoCapture?: boolean } {
+    const targetElementList = [target]
+    let curEl = target
+    while (curEl.parentNode && !isTag(curEl, 'body')) {
+        if (isDocumentFragment(curEl.parentNode)) {
+            targetElementList.push((curEl.parentNode as any).host)
+            curEl = (curEl.parentNode as any).host
+            continue
+        }
+        targetElementList.push(curEl.parentNode as Element)
+        curEl = curEl.parentNode as Element
+    }
+
+    const elementsJson: Properties[] = []
+    const autocaptureAugmentProperties: Properties = {}
+    let href: string | false = false
+    let explicitNoCapture = false
+
+    each(targetElementList, (el) => {
+        const shouldCaptureEl = shouldCaptureElement(el)
+
+        // if the element or a parent element is an anchor tag
+        // include the href as a property
+        if (el.tagName.toLowerCase() === 'a') {
+            href = el.getAttribute('href')
+            href = shouldCaptureEl && href && shouldCaptureValue(href) && href
+        }
+
+        // allow users to programmatically prevent capturing of elements by adding class 'ph-no-capture'
+        const classes = getClassNames(el)
+        if (includes(classes, 'ph-no-capture')) {
+            explicitNoCapture = true
+        }
+
+        elementsJson.push(
+            getPropertiesFromElement(el, maskAllElementAttributes, maskAllText, elementAttributeIgnoreList)
+        )
+
+        const augmentProperties = getAugmentPropertiesFromElement(el)
+        extend(autocaptureAugmentProperties, augmentProperties)
+    })
+
+    if (explicitNoCapture) {
+        return { props: {}, explicitNoCapture }
+    }
+
+    if (!maskAllText) {
+        // if the element is a button or anchor tag get the span text from any
+        // children and include it as/with the text property on the parent element
+        if (target.tagName.toLowerCase() === 'a' || target.tagName.toLowerCase() === 'button') {
+            elementsJson[0]['$el_text'] = getDirectAndNestedSpanText(target)
+        } else {
+            elementsJson[0]['$el_text'] = getSafeText(target)
+        }
+    }
+
+    let externalHref: string | undefined
+    if (href) {
+        elementsJson[0]['attr__href'] = href
+        const hrefHost = convertToURL(href)?.host
+        const locationHost = window?.location?.host
+        if (hrefHost && locationHost && hrefHost !== locationHost) {
+            externalHref = href
+        }
+    }
+
+    const props = extend(
+        getDefaultProperties(e.type),
+        elementsChainAsString
+            ? {
+                  $elements_chain: getElementsChainString(elementsJson),
+              }
+            : {
+                  $elements: elementsJson,
+              },
+        elementsJson[0]?.['$el_text'] ? { $el_text: elementsJson[0]?.['$el_text'] } : {},
+        externalHref && e.type === 'click' ? { $external_click_url: externalHref } : {},
+        autocaptureAugmentProperties
+    )
+
+    return { props }
+}
+
 export class Autocapture {
     instance: PostHog
     _initialized: boolean = false
@@ -150,100 +346,6 @@ export class Autocapture {
         return !disabledClient && !disabledServer
     }
 
-    private _previousElementSibling(el: Element): Element | null {
-        if (el.previousElementSibling) {
-            return el.previousElementSibling
-        }
-        let _el: Element | null = el
-        do {
-            _el = _el.previousSibling as Element | null // resolves to ChildNode->Node, which is Element's parent class
-        } while (_el && !isElementNode(_el))
-        return _el
-    }
-
-    private _getAugmentPropertiesFromElement(elem: Element): Properties {
-        const shouldCaptureEl = shouldCaptureElement(elem)
-        if (!shouldCaptureEl) {
-            return {}
-        }
-
-        const props: Properties = {}
-
-        each(elem.attributes, function (attr: Attr) {
-            if (attr.name && attr.name.indexOf('data-ph-capture-attribute') === 0) {
-                const propertyKey = attr.name.replace('data-ph-capture-attribute-', '')
-                const propertyValue = attr.value
-                if (propertyKey && propertyValue && shouldCaptureValue(propertyValue)) {
-                    props[propertyKey] = propertyValue
-                }
-            }
-        })
-
-        return props
-    }
-
-    private _getPropertiesFromElement(elem: Element, maskInputs: boolean, maskText: boolean): Properties {
-        const tag_name = elem.tagName.toLowerCase()
-        const props: Properties = {
-            tag_name: tag_name,
-        }
-        if (autocaptureCompatibleElements.indexOf(tag_name) > -1 && !maskText) {
-            if (tag_name.toLowerCase() === 'a' || tag_name.toLowerCase() === 'button') {
-                props['$el_text'] = limitText(1024, getDirectAndNestedSpanText(elem))
-            } else {
-                props['$el_text'] = limitText(1024, getSafeText(elem))
-            }
-        }
-
-        const classes = getClassNames(elem)
-        if (classes.length > 0)
-            props['classes'] = classes.filter(function (c) {
-                return c !== ''
-            })
-
-        // capture the deny list here because this not-a-class class makes it tricky to use this.config in the function below
-        const elementAttributeIgnorelist = this.config?.element_attribute_ignorelist
-        each(elem.attributes, function (attr: Attr) {
-            // Only capture attributes we know are safe
-            if (isSensitiveElement(elem) && ['name', 'id', 'class', 'aria-label'].indexOf(attr.name) === -1) return
-
-            if (elementAttributeIgnorelist?.includes(attr.name)) return
-
-            if (!maskInputs && shouldCaptureValue(attr.value) && !isAngularStyleAttr(attr.name)) {
-                let value = attr.value
-                if (attr.name === 'class') {
-                    // html attributes can _technically_ contain linebreaks,
-                    // but we're very intolerant of them in the class string,
-                    // so we strip them.
-                    value = splitClassString(value).join(' ')
-                }
-                props['attr__' + attr.name] = limitText(1024, value)
-            }
-        })
-
-        let nthChild = 1
-        let nthOfType = 1
-        let currentElem: Element | null = elem
-        while ((currentElem = this._previousElementSibling(currentElem))) {
-            // eslint-disable-line no-cond-assign
-            nthChild++
-            if (currentElem.tagName === elem.tagName) {
-                nthOfType++
-            }
-        }
-        props['nth_child'] = nthChild
-        props['nth_of_type'] = nthOfType
-
-        return props
-    }
-
-    private _getDefaultProperties(eventType: string): Properties {
-        return {
-            $event_type: eventType,
-            $ce_version: 1,
-        }
-    }
-
     private _captureEvent(e: Event, eventName = '$autocapture'): boolean | void {
         if (!this.isEnabled) {
             return
@@ -280,88 +382,17 @@ export class Autocapture {
                 isCopyAutocapture ? ['copy', 'cut'] : undefined
             )
         ) {
-            const targetElementList = [target]
-            let curEl = target
-            while (curEl.parentNode && !isTag(curEl, 'body')) {
-                if (isDocumentFragment(curEl.parentNode)) {
-                    targetElementList.push((curEl.parentNode as any).host)
-                    curEl = (curEl.parentNode as any).host
-                    continue
-                }
-                targetElementList.push(curEl.parentNode as Element)
-                curEl = curEl.parentNode as Element
-            }
-
-            const elementsJson: Properties[] = []
-            const autocaptureAugmentProperties: Properties = {}
-            let href,
-                explicitNoCapture = false
-
-            each(targetElementList, (el) => {
-                const shouldCaptureEl = shouldCaptureElement(el)
-
-                // if the element or a parent element is an anchor tag
-                // include the href as a property
-                if (el.tagName.toLowerCase() === 'a') {
-                    href = el.getAttribute('href')
-                    href = shouldCaptureEl && shouldCaptureValue(href) && href
-                }
-
-                // allow users to programmatically prevent capturing of elements by adding class 'ph-no-capture'
-                const classes = getClassNames(el)
-                if (includes(classes, 'ph-no-capture')) {
-                    explicitNoCapture = true
-                }
-
-                elementsJson.push(
-                    this._getPropertiesFromElement(
-                        el,
-                        this.instance.config.mask_all_element_attributes,
-                        this.instance.config.mask_all_text
-                    )
-                )
-
-                const augmentProperties = this._getAugmentPropertiesFromElement(el)
-                extend(autocaptureAugmentProperties, augmentProperties)
+            const { props, explicitNoCapture } = autocapturePropertiesForElement(target, {
+                e,
+                maskAllElementAttributes: this.instance.config.mask_all_element_attributes,
+                maskAllText: this.instance.config.mask_all_text,
+                elementAttributeIgnoreList: this.config.element_attribute_ignorelist,
+                elementsChainAsString: this._elementsChainAsString,
             })
-
-            if (!this.instance.config.mask_all_text) {
-                // if the element is a button or anchor tag get the span text from any
-                // children and include it as/with the text property on the parent element
-                if (target.tagName.toLowerCase() === 'a' || target.tagName.toLowerCase() === 'button') {
-                    elementsJson[0]['$el_text'] = getDirectAndNestedSpanText(target)
-                } else {
-                    elementsJson[0]['$el_text'] = getSafeText(target)
-                }
-            }
-
-            let externalHref: string | undefined
-            if (href) {
-                elementsJson[0]['attr__href'] = href
-                const hrefHost = convertToURL(href)?.host
-                const locationHost = window?.location?.host
-                if (hrefHost && locationHost && hrefHost !== locationHost) {
-                    externalHref = href
-                }
-            }
 
             if (explicitNoCapture) {
                 return false
             }
-
-            const props = extend(
-                this._getDefaultProperties(e.type),
-                this._elementsChainAsString
-                    ? {
-                          $elements_chain: getElementsChainString(elementsJson),
-                      }
-                    : {
-                          $elements: elementsJson,
-                      },
-                elementsJson[0]?.['$el_text'] ? { $el_text: elementsJson[0]?.['$el_text'] } : {},
-                externalHref && e.type === 'click' ? { $external_click_url: externalHref } : {},
-                autocaptureAugmentProperties
-            )
 
             const elementSelectors = this.getElementSelectors(target)
             if (elementSelectors && elementSelectors.length > 0) {

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -5,9 +5,10 @@ import { PostHog } from './posthog-core'
 
 import { document, window } from './utils/globals'
 import { getEventTarget, getParentElement, isElementNode, isTag } from './autocapture-utils'
-import { HEATMAPS_ENABLED_SERVER_SIDE, TOOLBAR_ID } from './constants'
+import { HEATMAPS_ENABLED_SERVER_SIDE } from './constants'
 import { isEmptyObject, isObject, isUndefined } from './utils/type-utils'
 import { logger } from './utils/logger'
+import { isElementInToolbar } from './utils/element-utils'
 
 const DEFAULT_FLUSH_INTERVAL = 5000
 const HEATMAPS = 'heatmaps'
@@ -35,11 +36,6 @@ function elementOrParentPositionMatches(el: Element | null, matches: string[], b
     }
 
     return false
-}
-
-function elementInToolbar(el: Element): boolean {
-    // NOTE: .closest is not supported in IE11 hence the operator check
-    return el.id === TOOLBAR_ID || !!el.closest?.('#' + TOOLBAR_ID)
 }
 
 export class Heatmaps {
@@ -150,7 +146,7 @@ export class Heatmaps {
     }
 
     private _onClick(e: MouseEvent): void {
-        if (elementInToolbar(e.target as Element)) {
+        if (isElementInToolbar(e.target as Element)) {
             return
         }
         const properties = this._getProperties(e, 'click')
@@ -162,13 +158,11 @@ export class Heatmaps {
             })
         }
 
-        // TODO: Detect deadclicks
-
         this._capture(properties)
     }
 
     private _onMouseMove(e: Event): void {
-        if (elementInToolbar(e.target as Element)) {
+        if (isElementInToolbar(e.target as Element)) {
             return
         }
         clearTimeout(this._mouseMoveTimeout)

--- a/src/utils/element-utils.ts
+++ b/src/utils/element-utils.ts
@@ -1,0 +1,6 @@
+import { TOOLBAR_ID } from '../constants'
+
+export function isElementInToolbar(el: Element): boolean {
+    // NOTE: .closest is not supported in IE11 hence the operator check
+    return el.id === TOOLBAR_ID || !!el.closest?.('#' + TOOLBAR_ID)
+}


### PR DESCRIPTION
Lifts a set of refactors out of https://github.com/PostHog/posthog-js/pull/1463/

That PR Introduces dead clicks autocapture but has a consistent failing cypress test for surveys which should not have been impacted