### PR TITLE
feat: allow mutation rate limiter configuration

### DIFF
--- a/src/extensions/replay/mutation-rate-limiter.ts
+++ b/src/extensions/replay/mutation-rate-limiter.ts
@@ -1,5 +1,6 @@
 import type { eventWithTime, mutationCallbackParam } from '@rrweb/types'
 import { INCREMENTAL_SNAPSHOT_EVENT_TYPE, MUTATION_SOURCE_TYPE, rrwebRecord } from './sessionrecording-utils'
+import { clampToRange } from '../../utils/number-utils'
 
 export class MutationRateLimiter {
     private bucketSize = 100
@@ -15,8 +16,18 @@ export class MutationRateLimiter {
             onBlockedNode?: (id: number, node: Node | null) => void
         } = {}
     ) {
-        this.refillRate = this.options.refillRate ?? this.refillRate
-        this.bucketSize = this.options.bucketSize ?? this.bucketSize
+        this.refillRate = clampToRange(
+            this.options.refillRate ?? this.refillRate,
+            0,
+            100,
+            'mutation throttling refill rate'
+        )
+        this.bucketSize = clampToRange(
+            this.options.bucketSize ?? this.bucketSize,
+            0,
+            100,
+            'mutation throttling bucket size'
+        )
         setInterval(() => {
             this.refillBuckets()
         }, 1000)

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -890,6 +890,8 @@ export class SessionRecording {
         this.mutationRateLimiter =
             this.mutationRateLimiter ??
             new MutationRateLimiter(this.rrwebRecord, {
+                refillRate: this.instance.config.session_recording.__mutationRateLimiterRefillRate,
+                bucketSize: this.instance.config.session_recording.__mutationRateLimiterBucketSize,
                 onBlockedNode: (id, node) => {
                     const message = `Too many mutations on node '${id}'. Rate limiting. This could be due to SVG animations or something similar`
                     logger.info(message, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -302,14 +302,14 @@ export interface SessionRecordingOptions {
     /*
      ADVANCED: alters the refill rate for the token bucket mutation throttling
      Normally only altered alongside posthog support guidance.
-     Accepts values between 0 and 1000
+     Accepts values between 0 and 100
      Default is 10.
     */
     __mutationRateLimiterRefillRate?: number
     /*
      ADVANCED: alters the bucket size for the token bucket mutation throttling
      Normally only altered alongside posthog support guidance.
-     Accepts values between 0 and 1000
+     Accepts values between 0 and 100
      Default is 100.
     */
     __mutationRateLimiterBucketSize?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -299,6 +299,20 @@ export interface SessionRecordingOptions {
      Default is 5 minutes.
     */
     session_idle_threshold_ms?: number
+    /*
+     ADVANCED: alters the refill rate for the token bucket mutation throttling
+     Normally only altered alongside posthog support guidance.
+     Accepts values between 0 and 1000
+     Default is 10.
+    */
+    __mutationRateLimiterRefillRate?: number
+    /*
+     ADVANCED: alters the bucket size for the token bucket mutation throttling
+     Normally only altered alongside posthog support guidance.
+     Accepts values between 0 and 1000
+     Default is 100.
+    */
+    __mutationRateLimiterBucketSize?: number
 }
 
 export type SessionIdChangedCallback = (


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/20033 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/22600)

We've rewritten ingestion completely since adding SVG throttling and a customer isn't having a great playback experience because of it.

Let's introduce some configurability... it should be that setting 

```
 {
 	session_recording: {
		__mutationRateLimiterRefillRate: 20 // for moderate decrease in throttling
       // or e.g. __mutationRateLimiterRefillRate: 75 // for significant decrease in throttling
```

this used to have a significant impact on ingestion, but if the customer in the linked ticket is willing to test then we monitor what changes are safe here and maybe even change the defaults