### PR TITLE
feat: deadclicks in heatmaps

### DIFF
--- a/src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts
+++ b/src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts
@@ -386,14 +386,19 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
 
     it('can have alternative behaviour for onCapture', () => {
         jest.setSystemTime(0)
+        const replacementCapture = jest.fn()
+
+        lazyLoadedDeadClicksAutocapture = new LazyLoadedDeadClicksAutocapture(fakeInstance, {
+            __onCapture: replacementCapture,
+        })
+        lazyLoadedDeadClicksAutocapture.start(document)
+
         lazyLoadedDeadClicksAutocapture['_clicks'].push({
             node: document.body,
             originalEvent: { type: 'click' } as MouseEvent,
             timestamp: 900,
         })
         lazyLoadedDeadClicksAutocapture['_lastMutation'] = undefined
-        const replacementCapture = jest.fn()
-        lazyLoadedDeadClicksAutocapture.onCapture = replacementCapture
 
         jest.setSystemTime(3001 + 900)
         lazyLoadedDeadClicksAutocapture['_checkClicks']()

--- a/src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts
+++ b/src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts
@@ -383,4 +383,23 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
             expect(fakeInstance.capture).not.toHaveBeenCalled()
         })
     })
+
+    it('can have alternative behaviour for onCapture', () => {
+        jest.setSystemTime(0)
+        lazyLoadedDeadClicksAutocapture['_clicks'].push({
+            node: document.body,
+            originalEvent: { type: 'click' } as Event,
+            timestamp: 900,
+        })
+        lazyLoadedDeadClicksAutocapture['_lastMutation'] = undefined
+        const replacementCapture = jest.fn()
+        lazyLoadedDeadClicksAutocapture.onCapture = replacementCapture
+
+        jest.setSystemTime(3001 + 900)
+        lazyLoadedDeadClicksAutocapture['_checkClicks']()
+
+        expect(lazyLoadedDeadClicksAutocapture['_clicks']).toHaveLength(0)
+        expect(fakeInstance.capture).not.toHaveBeenCalled()
+        expect(replacementCapture).toHaveBeenCalled()
+    })
 })

--- a/src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts
+++ b/src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts
@@ -160,7 +160,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
         it('click followed by scroll, not a dead click', () => {
             lazyLoadedDeadClicksAutocapture['_clicks'].push({
                 node: document.body,
-                originalEvent: { type: 'click' } as Event,
+                originalEvent: { type: 'click' } as MouseEvent,
                 timestamp: 900,
                 scrollDelayMs: 99,
             })
@@ -175,7 +175,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
         it('click followed by mutation, not a dead click', () => {
             lazyLoadedDeadClicksAutocapture['_clicks'].push({
                 node: document.body,
-                originalEvent: { type: 'click' } as Event,
+                originalEvent: { type: 'click' } as MouseEvent,
                 timestamp: 900,
             })
             lazyLoadedDeadClicksAutocapture['_lastMutation'] = 1000
@@ -189,7 +189,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
         it('click followed by a selection change, not a dead click', () => {
             lazyLoadedDeadClicksAutocapture['_clicks'].push({
                 node: document.body,
-                originalEvent: { type: 'click' } as Event,
+                originalEvent: { type: 'click' } as MouseEvent,
                 timestamp: 900,
             })
             lazyLoadedDeadClicksAutocapture['_lastSelectionChanged'] = 999
@@ -203,7 +203,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
         it('click followed by a selection change outside of threshold, dead click', () => {
             lazyLoadedDeadClicksAutocapture['_clicks'].push({
                 node: document.body,
-                originalEvent: { type: 'click' } as Event,
+                originalEvent: { type: 'click' } as MouseEvent,
                 timestamp: 900,
             })
             lazyLoadedDeadClicksAutocapture['_lastSelectionChanged'] = 1000
@@ -245,7 +245,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
         it('click followed by a mutation after threshold, dead click', () => {
             lazyLoadedDeadClicksAutocapture['_clicks'].push({
                 node: document.body,
-                originalEvent: { type: 'click' } as Event,
+                originalEvent: { type: 'click' } as MouseEvent,
                 timestamp: 900,
             })
             lazyLoadedDeadClicksAutocapture['_lastMutation'] = 900 + 2501
@@ -287,7 +287,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
         it('click followed by a scroll after threshold, dead click', () => {
             lazyLoadedDeadClicksAutocapture['_clicks'].push({
                 node: document.body,
-                originalEvent: { type: 'click' } as Event,
+                originalEvent: { type: 'click' } as MouseEvent,
                 timestamp: 900,
                 scrollDelayMs: 2501,
             })
@@ -329,7 +329,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
         it('click followed by nothing for too long, dead click', () => {
             lazyLoadedDeadClicksAutocapture['_clicks'].push({
                 node: document.body,
-                originalEvent: { type: 'click' } as Event,
+                originalEvent: { type: 'click' } as MouseEvent,
                 timestamp: 900,
             })
             lazyLoadedDeadClicksAutocapture['_lastMutation'] = undefined
@@ -371,7 +371,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
         it('click not followed by anything within threshold, rescheduled for next check', () => {
             lazyLoadedDeadClicksAutocapture['_clicks'].push({
                 node: document.body,
-                originalEvent: { type: 'click' } as Event,
+                originalEvent: { type: 'click' } as MouseEvent,
                 timestamp: 900,
             })
             lazyLoadedDeadClicksAutocapture['_lastMutation'] = undefined
@@ -388,7 +388,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
         jest.setSystemTime(0)
         lazyLoadedDeadClicksAutocapture['_clicks'].push({
             node: document.body,
-            originalEvent: { type: 'click' } as Event,
+            originalEvent: { type: 'click' } as MouseEvent,
             timestamp: 900,
         })
         lazyLoadedDeadClicksAutocapture['_lastMutation'] = undefined

--- a/src/__tests__/extensions/dead-clicks-autocapture.test.ts
+++ b/src/__tests__/extensions/dead-clicks-autocapture.test.ts
@@ -51,7 +51,7 @@ describe('DeadClicksAutocapture', () => {
         mockLoader.mockClear()
 
         const instance = await createPosthogInstance(uuidv7(), { capture_dead_clicks: true })
-        new DeadClicksAutocapture(instance).startIfEnabled()
+        new DeadClicksAutocapture(instance, () => true).startIfEnabled()
 
         expect(mockLoader).toHaveBeenCalledWith(instance, 'dead-clicks-autocapture', expect.any(Function))
     })
@@ -100,7 +100,7 @@ describe('DeadClicksAutocapture', () => {
                     [DEAD_CLICKS_ENABLED_SERVER_SIDE]: serverSide,
                 })
                 instance.config.capture_dead_clicks = clientSide
-                expect(instance.deadClicksAutocapture.isEnabled).toBe(expected)
+                expect(instance.deadClicksAutocapture.isEnabled(instance.deadClicksAutocapture)).toBe(expected)
             }
         )
     })

--- a/src/__tests__/heatmaps.test.ts
+++ b/src/__tests__/heatmaps.test.ts
@@ -229,6 +229,9 @@ describe('heatmaps', () => {
     it('starts dead clicks autocapture with the correct config', () => {
         const heatmapsDeadClicksInstance = posthog.heatmaps['deadClicksCapture']
         expect(heatmapsDeadClicksInstance.isEnabled(heatmapsDeadClicksInstance)).toBe(true)
-        expect(heatmapsDeadClicksInstance.onCapture).toEqual(posthog.heatmaps['_onDeadClick'].bind(posthog.heatmaps))
+        // this is a little nasty but the binding to this makes the function not directly comparable
+        expect(JSON.stringify(heatmapsDeadClicksInstance.onCapture)).toEqual(
+            JSON.stringify(posthog.heatmaps['_onDeadClick'].bind(posthog.heatmaps))
+        )
     })
 })

--- a/src/__tests__/heatmaps.test.ts
+++ b/src/__tests__/heatmaps.test.ts
@@ -229,6 +229,6 @@ describe('heatmaps', () => {
     it('starts dead clicks autocapture with the correct config', () => {
         const heatmapsDeadClicksInstance = posthog.heatmaps['deadClicksCapture']
         expect(heatmapsDeadClicksInstance.isEnabled(heatmapsDeadClicksInstance)).toBe(true)
-        expect(heatmapsDeadClicksInstance.onCapture).toBe(posthog.heatmaps['_onDeadClick'])
+        expect(heatmapsDeadClicksInstance.onCapture).toEqual(posthog.heatmaps['_onDeadClick'].bind(posthog.heatmaps))
     })
 })

--- a/src/__tests__/heatmaps.test.ts
+++ b/src/__tests__/heatmaps.test.ts
@@ -225,4 +225,10 @@ describe('heatmaps', () => {
             }
         )
     })
+
+    it('starts dead clicks autocapture with the correct config', () => {
+        const heatmapsDeadClicksInstance = posthog.heatmaps['deadClicksCapture']
+        expect(heatmapsDeadClicksInstance.isEnabled(heatmapsDeadClicksInstance)).toBe(true)
+        expect(heatmapsDeadClicksInstance.onCapture).toBe(posthog.heatmaps['_onDeadClick'])
+    })
 })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,6 +45,7 @@ export const INITIAL_REFERRER_INFO = '$initial_referrer_info'
 export const INITIAL_PERSON_INFO = '$initial_person_info'
 export const ENABLE_PERSON_PROCESSING = '$epp'
 export const TOOLBAR_ID = '__POSTHOG_TOOLBAR__'
+export const TOOLBAR_CONTAINER_CLASS = 'toolbar-global-fade-container'
 
 export const WEB_EXPERIMENTS = '$web_experiments'
 

--- a/src/entrypoints/dead-clicks-autocapture.ts
+++ b/src/entrypoints/dead-clicks-autocapture.ts
@@ -55,7 +55,7 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
 
     constructor(readonly instance: PostHog, config?: DeadClicksAutoCaptureConfig) {
         this._config = this.asRequiredConfig(config)
-        this._onCapture = this._captureDeadClick
+        this._onCapture = this._captureDeadClick.bind(this)
     }
 
     start(observerTarget: Node) {

--- a/src/entrypoints/dead-clicks-autocapture.ts
+++ b/src/entrypoints/dead-clicks-autocapture.ts
@@ -262,7 +262,7 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
 }
 
 assignableWindow.__PosthogExtensions__ = assignableWindow.__PosthogExtensions__ || {}
-assignableWindow.__PosthogExtensions__.initDeadClicksAutocapture = (ph, config?: DeadClicksAutoCaptureConfig) =>
+assignableWindow.__PosthogExtensions__.initDeadClicksAutocapture = (ph, config) =>
     new LazyLoadedDeadClicksAutocapture(ph, config)
 
 export default LazyLoadedDeadClicksAutocapture

--- a/src/entrypoints/dead-clicks-autocapture.ts
+++ b/src/entrypoints/dead-clicks-autocapture.ts
@@ -262,6 +262,7 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
 }
 
 assignableWindow.__PosthogExtensions__ = assignableWindow.__PosthogExtensions__ || {}
-assignableWindow.__PosthogExtensions__.initDeadClicksAutocapture = (ph) => new LazyLoadedDeadClicksAutocapture(ph)
+assignableWindow.__PosthogExtensions__.initDeadClicksAutocapture = (ph, config?: DeadClicksAutoCaptureConfig) =>
+    new LazyLoadedDeadClicksAutocapture(ph, config)
 
 export default LazyLoadedDeadClicksAutocapture

--- a/src/extensions/dead-clicks-autocapture.ts
+++ b/src/extensions/dead-clicks-autocapture.ts
@@ -26,7 +26,7 @@ export class DeadClicksAutocapture {
     constructor(
         readonly instance: PostHog,
         readonly isEnabled: (dca: DeadClicksAutocapture) => boolean,
-        readonly onCapture: DeadClicksAutoCaptureConfig['__onCapture']
+        readonly onCapture?: DeadClicksAutoCaptureConfig['__onCapture']
     ) {
         this.startIfEnabled()
     }

--- a/src/extensions/dead-clicks-autocapture.ts
+++ b/src/extensions/dead-clicks-autocapture.ts
@@ -3,23 +3,9 @@ import { DEAD_CLICKS_ENABLED_SERVER_SIDE } from '../constants'
 import { isBoolean, isObject } from '../utils/type-utils'
 import { assignableWindow, document, LazyLoadedDeadClicksAutocaptureInterface } from '../utils/globals'
 import { logger } from '../utils/logger'
-import { DecideResponse, Properties } from '../types'
+import { DecideResponse } from '../types'
 
 const LOGGER_PREFIX = '[Dead Clicks]'
-
-interface DeadClickCandidate {
-    node: Element
-    originalEvent: MouseEvent
-    timestamp: number
-    // time between click and the most recent scroll
-    scrollDelayMs?: number
-    // time between click and the most recent mutation
-    mutationDelayMs?: number
-    // time between click and the most recent selection changed event
-    selectionChangedDelayMs?: number
-    // if neither scroll nor mutation seen before threshold passed
-    absoluteDelayMs?: number
-}
 
 export const isDeadClicksEnabledForHeatmaps = () => {
     return true
@@ -50,12 +36,10 @@ export class DeadClicksAutocapture {
         this.startIfEnabled()
     }
 
-    public startIfEnabled({
-        onCapture,
-    }: { force?: boolean; onCapture?: (click: DeadClickCandidate, properties: Properties) => void } = {}) {
+    public startIfEnabled() {
         if (this.isEnabled(this)) {
             this.loadScript(() => {
-                this.start(onCapture)
+                this.start()
             })
         }
     }
@@ -78,7 +62,7 @@ export class DeadClicksAutocapture {
         )
     }
 
-    private start(onCapture?: (click: DeadClickCandidate, properties: Properties) => void) {
+    private start() {
         if (!document) {
             logger.error(LOGGER_PREFIX + ' `document` not found. Cannot start.')
             return
@@ -94,9 +78,6 @@ export class DeadClicksAutocapture {
                     ? this.instance.config.capture_dead_clicks
                     : undefined
             )
-            if (onCapture) {
-                this._lazyLoadedDeadClicksAutocapture.onCapture = onCapture
-            }
             this._lazyLoadedDeadClicksAutocapture.start(document)
             logger.info(`${LOGGER_PREFIX} starting...`)
         }

--- a/src/extensions/dead-clicks-autocapture.ts
+++ b/src/extensions/dead-clicks-autocapture.ts
@@ -3,9 +3,23 @@ import { DEAD_CLICKS_ENABLED_SERVER_SIDE } from '../constants'
 import { isBoolean, isObject } from '../utils/type-utils'
 import { assignableWindow, document, LazyLoadedDeadClicksAutocaptureInterface } from '../utils/globals'
 import { logger } from '../utils/logger'
-import { DeadClickCandidate, DecideResponse, Properties } from '../types'
+import { DecideResponse, Properties } from '../types'
 
 const LOGGER_PREFIX = '[Dead Clicks]'
+
+interface DeadClickCandidate {
+    node: Element
+    originalEvent: MouseEvent
+    timestamp: number
+    // time between click and the most recent scroll
+    scrollDelayMs?: number
+    // time between click and the most recent mutation
+    mutationDelayMs?: number
+    // time between click and the most recent selection changed event
+    selectionChangedDelayMs?: number
+    // if neither scroll nor mutation seen before threshold passed
+    absoluteDelayMs?: number
+}
 
 export const isDeadClicksEnabledForHeatmaps = () => {
     return true

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -9,7 +9,7 @@ import { HEATMAPS_ENABLED_SERVER_SIDE } from './constants'
 import { isEmptyObject, isObject, isUndefined } from './utils/type-utils'
 import { logger } from './utils/logger'
 import { isElementInToolbar, isElementNode, isTag } from './utils/element-utils'
-import { DeadClicksAutocapture } from './extensions/dead-clicks-autocapture'
+import { DeadClicksAutocapture, isDeadClicksEnabledForHeatmaps } from './extensions/dead-clicks-autocapture'
 
 const DEFAULT_FLUSH_INTERVAL = 5000
 const HEATMAPS = 'heatmaps'
@@ -126,9 +126,8 @@ export class Heatmaps {
         registerEvent(document, 'click', (e) => this._onClick((e || window?.event) as MouseEvent), false, true)
         registerEvent(document, 'mousemove', (e) => this._onMouseMove((e || window?.event) as MouseEvent), false, true)
 
-        this.deadClicksCapture = new DeadClicksAutocapture(this.instance)
+        this.deadClicksCapture = new DeadClicksAutocapture(this.instance, isDeadClicksEnabledForHeatmaps)
         this.deadClicksCapture.startIfEnabled({
-            force: true,
             onCapture: (click) => {
                 this._onClick(click.originalEvent, 'deadclick')
             },

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -1,6 +1,6 @@
 import { includes, registerEvent } from './utils'
 import RageClick from './extensions/rageclick'
-import { DecideResponse, Properties } from './types'
+import { DeadClickCandidate, DecideResponse, Properties } from './types'
 import { PostHog } from './posthog-core'
 
 import { document, window } from './utils/globals'
@@ -118,6 +118,10 @@ export class Heatmaps {
         return buffer
     }
 
+    private _onDeadClick(click: DeadClickCandidate): void {
+        this._onClick(click.originalEvent, 'deadclick')
+    }
+
     private _setupListeners(): void {
         if (!window || !document) {
             return
@@ -126,12 +130,12 @@ export class Heatmaps {
         registerEvent(document, 'click', (e) => this._onClick((e || window?.event) as MouseEvent), false, true)
         registerEvent(document, 'mousemove', (e) => this._onMouseMove((e || window?.event) as MouseEvent), false, true)
 
-        this.deadClicksCapture = new DeadClicksAutocapture(this.instance, isDeadClicksEnabledForHeatmaps)
-        this.deadClicksCapture.startIfEnabled({
-            onCapture: (click) => {
-                this._onClick(click.originalEvent, 'deadclick')
-            },
-        })
+        this.deadClicksCapture = new DeadClicksAutocapture(
+            this.instance,
+            isDeadClicksEnabledForHeatmaps,
+            this._onDeadClick.bind(this)
+        )
+        this.deadClicksCapture.startIfEnabled()
 
         this._initialized = true
     }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -78,7 +78,7 @@ import { ExceptionObserver } from './extensions/exception-autocapture'
 import { WebVitalsAutocapture } from './extensions/web-vitals'
 import { WebExperiments } from './web-experiments'
 import { PostHogExceptions } from './posthog-exceptions'
-import { DeadClicksAutocapture } from './extensions/dead-clicks-autocapture'
+import { DeadClicksAutocapture, isDeadClicksEnabledForAutocapture } from './extensions/dead-clicks-autocapture'
 
 /*
 SIMPLE STYLE GUIDE:
@@ -448,7 +448,7 @@ export class PostHog {
         this.exceptionObserver = new ExceptionObserver(this)
         this.exceptionObserver.startIfEnabled()
 
-        this.deadClicksAutocapture = new DeadClicksAutocapture(this)
+        this.deadClicksAutocapture = new DeadClicksAutocapture(this, isDeadClicksEnabledForAutocapture)
         this.deadClicksAutocapture.startIfEnabled()
 
         // if any instance on the page has debug = true, we set the

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,6 +122,20 @@ export interface PerformanceCaptureConfig {
     web_vitals_delayed_flush_ms?: number
 }
 
+export interface DeadClickCandidate {
+    node: Element
+    originalEvent: MouseEvent
+    timestamp: number
+    // time between click and the most recent scroll
+    scrollDelayMs?: number
+    // time between click and the most recent mutation
+    mutationDelayMs?: number
+    // time between click and the most recent selection changed event
+    selectionChangedDelayMs?: number
+    // if neither scroll nor mutation seen before threshold passed
+    absoluteDelayMs?: number
+}
+
 export type DeadClicksAutoCaptureConfig = {
     // by default if a click is followed by a sroll within 100ms it is not a dead click
     scroll_threshold_ms?: number
@@ -129,6 +143,15 @@ export type DeadClicksAutoCaptureConfig = {
     selection_change_threshold_ms?: number
     // by default if a click is followed by a mutation within 2500ms it is not a dead click
     mutation_threshold_ms?: number
+    /**
+     * Allows setting behavior for when a dead click is captured.
+     * For e.g. to support capture to heatmaps
+     *
+     * If not provided the default behavior is to auto-capture dead click events
+     *
+     * Only intended to be provided by the SDK
+     */
+    __onCapture?: ((click: DeadClickCandidate, properties: Properties) => void) | undefined
 } & Pick<AutocaptureConfig, 'element_attribute_ignorelist'>
 
 export interface HeatmapConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,20 +122,6 @@ export interface PerformanceCaptureConfig {
     web_vitals_delayed_flush_ms?: number
 }
 
-export interface DeadClickCandidate {
-    node: Element
-    originalEvent: MouseEvent
-    timestamp: number
-    // time between click and the most recent scroll
-    scrollDelayMs?: number
-    // time between click and the most recent mutation
-    mutationDelayMs?: number
-    // time between click and the most recent selection changed event
-    selectionChangedDelayMs?: number
-    // if neither scroll nor mutation seen before threshold passed
-    absoluteDelayMs?: number
-}
-
 export type DeadClicksAutoCaptureConfig = {
     // by default if a click is followed by a sroll within 100ms it is not a dead click
     scroll_threshold_ms?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,6 +122,20 @@ export interface PerformanceCaptureConfig {
     web_vitals_delayed_flush_ms?: number
 }
 
+export interface DeadClickCandidate {
+    node: Element
+    originalEvent: MouseEvent
+    timestamp: number
+    // time between click and the most recent scroll
+    scrollDelayMs?: number
+    // time between click and the most recent mutation
+    mutationDelayMs?: number
+    // time between click and the most recent selection changed event
+    selectionChangedDelayMs?: number
+    // if neither scroll nor mutation seen before threshold passed
+    absoluteDelayMs?: number
+}
+
 export type DeadClicksAutoCaptureConfig = {
     // by default if a click is followed by a sroll within 100ms it is not a dead click
     scroll_threshold_ms?: number

--- a/src/utils/element-utils.ts
+++ b/src/utils/element-utils.ts
@@ -1,8 +1,8 @@
-import { TOOLBAR_ID } from '../constants'
+import { TOOLBAR_CONTAINER_CLASS, TOOLBAR_ID } from '../constants'
 
 export function isElementInToolbar(el: Element): boolean {
     // NOTE: .closest is not supported in IE11 hence the operator check
-    return el.id === TOOLBAR_ID || !!el.closest?.('#' + TOOLBAR_ID)
+    return el.id === TOOLBAR_ID || !!el.closest?.('.' + TOOLBAR_CONTAINER_CLASS)
 }
 
 /*

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -68,7 +68,7 @@ interface PostHogExtensions {
     }
     initDeadClicksAutocapture?: (
         ph: PostHog,
-        config?: DeadClicksAutoCaptureConfig
+        config: DeadClicksAutoCaptureConfig
     ) => LazyLoadedDeadClicksAutocaptureInterface
 }
 

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -1,7 +1,7 @@
 import { ErrorProperties } from '../extensions/exception-autocapture/error-conversion'
 import type { PostHog } from '../posthog-core'
 import { SessionIdManager } from '../sessionid'
-import { DeadClicksAutoCaptureConfig, ErrorEventArgs, ErrorMetadata, Properties } from '../types'
+import { DeadClickCandidate, DeadClicksAutoCaptureConfig, ErrorEventArgs, ErrorMetadata, Properties } from '../types'
 
 /*
  * Global helpers to protect access to browser globals in a way that is safer for different targets
@@ -33,6 +33,7 @@ export type PostHogExtensionKind =
 export interface LazyLoadedDeadClicksAutocaptureInterface {
     start: (observerTarget: Node) => void
     stop: () => void
+    set onCapture(value: (click: DeadClickCandidate, properties: Properties) => void)
 }
 
 interface PostHogExtensions {

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -1,7 +1,7 @@
 import { ErrorProperties } from '../extensions/exception-autocapture/error-conversion'
 import type { PostHog } from '../posthog-core'
 import { SessionIdManager } from '../sessionid'
-import { DeadClickCandidate, DeadClicksAutoCaptureConfig, ErrorEventArgs, ErrorMetadata, Properties } from '../types'
+import { DeadClicksAutoCaptureConfig, ErrorEventArgs, ErrorMetadata, Properties } from '../types'
 
 /*
  * Global helpers to protect access to browser globals in a way that is safer for different targets
@@ -33,7 +33,6 @@ export type PostHogExtensionKind =
 export interface LazyLoadedDeadClicksAutocaptureInterface {
     start: (observerTarget: Node) => void
     stop: () => void
-    set onCapture(value: (click: DeadClickCandidate, properties: Properties) => void)
 }
 
 interface PostHogExtensions {


### PR DESCRIPTION
we want to allow deadclicks collection in heatmaps

it gives you less information but doesn't cost money, folk that want more information can turn on standalone deadclicks capture

to keep things loose the heatmap starts its own instance of deadclicks capture, deadclicks was altered to receive varying behviour by constructor injection

---

running locally I can capture deadclicks correctly with both deadclicks and heatmaps enabled or either one enabled