### PR TITLE
feat: Support for client-assigned feature flags

### DIFF
--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -810,6 +810,33 @@ describe('posthog core', () => {
         })
     })
 
+    describe('client assigned feature flags', () => {
+        it('onFeatureFlags should be called immediately if client assigned feature flags are defined', () => {
+            let called = false
+            const posthog = posthogWith({
+                bootstrap: {
+                    clientAssignedFeatureFlags: [{ key: 'test-flag', variants: { test: 0.5, control: 0.5 } }],
+                },
+            })
+
+            posthog.featureFlags.onFeatureFlags(() => (called = true))
+            expect(called).toEqual(true)
+        })
+
+        it('onFeatureFlags should not be called immediately if client assigned feature flags bootstrap is empty', () => {
+            let called = false
+
+            const posthog = posthogWith({
+                bootstrap: {
+                    clientAssignedFeatureFlags: [],
+                },
+            })
+
+            posthog.featureFlags.onFeatureFlags(() => (called = true))
+            expect(called).toEqual(false)
+        })
+    })
+
     describe('init()', () => {
         jest.spyOn(window, 'window', 'get')
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -478,6 +478,26 @@ export class PostHog {
             })
         }
 
+        if (this._hasClientAssignedFeatureFlags()) {
+            const clientAssignedFeatureFlags: Record<string, string | boolean> = {}
+            const clientAssignedFeatureFlagPayloads: Record<string, JsonType> = {}
+
+            for (const flag of this.config.bootstrap?.clientAssignedFeatureFlags || []) {
+                const variant = this.featureFlags._getMatchingVariant(flag)
+                if (variant) {
+                    clientAssignedFeatureFlags[flag.key] = variant
+                    if (flag.payload) {
+                        clientAssignedFeatureFlagPayloads[flag.key] = flag.payload
+                    }
+                }
+            }
+
+            this.featureFlags.receivedFeatureFlags({
+                featureFlags: clientAssignedFeatureFlags,
+                featureFlagPayloads: clientAssignedFeatureFlagPayloads,
+            })
+        }
+
         if (this._hasBootstrappedFeatureFlags()) {
             const activeFlags = Object.keys(config.bootstrap?.featureFlags || {})
                 .filter((flag) => !!config.bootstrap?.featureFlags?.[flag])
@@ -744,6 +764,14 @@ export class PostHog {
         execute(alias_calls, this)
         execute(other_calls, this)
         execute(capturing_calls, this)
+    }
+
+    _hasClientAssignedFeatureFlags(): boolean {
+        return (
+            (this.config.bootstrap?.clientAssignedFeatureFlags &&
+                Object.keys(this.config.bootstrap?.clientAssignedFeatureFlags).length > 0) ||
+            false
+        )
     }
 
     _hasBootstrappedFeatureFlags(): boolean {

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -8,6 +8,7 @@ import {
     Properties,
     JsonType,
     Compression,
+    ClientAssignedFeatureFlag,
 } from './types'
 import { PostHogPersistence } from './posthog-persistence'
 
@@ -482,5 +483,119 @@ export class PostHogFeatureFlags {
         } else {
             this.instance.unregister(STORED_GROUP_PROPERTIES_KEY)
         }
+    }
+
+    _getMatchingVariant(featureFlag: ClientAssignedFeatureFlag): string | null {
+        const lookupTable = this._variantLookupTable(featureFlag.variants)
+        const hash = this._get_hash(featureFlag.key, this.instance.get_distinct_id(), 'variant')
+
+        for (const variant of lookupTable) {
+            if (hash >= variant.value_min && hash < variant.value_max) {
+                return variant.key
+            }
+        }
+        return null
+    }
+
+    // TODO how should this behave for erroneous values?
+    _variantLookupTable(variants: Record<string, number>): { value_min: number; value_max: number; key: string }[] {
+        const lookupTable: { value_min: number; value_max: number; key: string }[] = []
+        let valueMin = 0
+
+        for (const [variant, percentage] of Object.entries(variants)) {
+            const valueMax = valueMin + percentage
+            lookupTable.push({
+                value_min: valueMin,
+                value_max: valueMax,
+                key: variant,
+            })
+            valueMin = valueMax
+        }
+        return lookupTable
+    }
+
+    _get_hash(featureFlagKey: string, distinctId: string, salt: string = ''): number {
+        const hashKey = `${featureFlagKey}.${distinctId}${salt}`
+        const hashHex = this._hash(hashKey)
+        // TODO do we care about IE11 support for BigInt?
+        const hashInt = BigInt(`0x${hashHex}`)
+        const LONG_SCALE = BigInt('0xFFFFFFFFFFFFFFF')
+        return Number(hashInt) / Number(LONG_SCALE) // Normalize the hash to a value between 0 and 1
+    }
+
+    // TODO how much do we trust sonnet to write a hashing function?
+    _hash(input: string): string {
+        function rotateLeft(n: number, s: number): number {
+            return ((n << s) | (n >>> (32 - s))) >>> 0
+        }
+
+        let H0 = 0x67452301
+        let H1 = 0xefcdab89
+        let H2 = 0x98badcfe
+        let H3 = 0x10325476
+        let H4 = 0xc3d2e1f0
+
+        // Convert string to byte array
+        const bytes: number[] = []
+        for (let i = 0; i < input.length; i++) {
+            const char = input.charCodeAt(i)
+            bytes.push(char & 0xff)
+        }
+
+        // Add padding
+        bytes.push(0x80)
+        while ((bytes.length * 8) % 512 !== 448) {
+            bytes.push(0)
+        }
+
+        const bitLen = input.length * 8
+        bytes.push(0, 0, 0, 0) // JavaScript bitwise ops are 32-bit
+        bytes.push((bitLen >>> 24) & 0xff)
+        bytes.push((bitLen >>> 16) & 0xff)
+        bytes.push((bitLen >>> 8) & 0xff)
+        bytes.push(bitLen & 0xff)
+
+        // Process blocks
+        for (let i = 0; i < bytes.length; i += 64) {
+            const w = new Array(80)
+            for (let j = 0; j < 16; j++) {
+                w[j] =
+                    (bytes[i + j * 4] << 24) |
+                    (bytes[i + j * 4 + 1] << 16) |
+                    (bytes[i + j * 4 + 2] << 8) |
+                    bytes[i + j * 4 + 3]
+            }
+
+            for (let j = 16; j < 80; j++) {
+                w[j] = rotateLeft(w[j - 3] ^ w[j - 8] ^ w[j - 14] ^ w[j - 16], 1)
+            }
+
+            let [a, b, c, d, e] = [H0, H1, H2, H3, H4]
+
+            for (let j = 0; j < 80; j++) {
+                const f =
+                    j < 20 ? (b & c) | (~b & d) : j < 40 ? b ^ c ^ d : j < 60 ? (b & c) | (b & d) | (c & d) : b ^ c ^ d
+
+                const k = j < 20 ? 0x5a827999 : j < 40 ? 0x6ed9eba1 : j < 60 ? 0x8f1bbcdc : 0xca62c1d6
+
+                const temp = (rotateLeft(a, 5) + f + e + k + w[j]) >>> 0
+                e = d
+                d = c
+                c = rotateLeft(b, 30)
+                b = a
+                a = temp
+            }
+
+            H0 = (H0 + a) >>> 0
+            H1 = (H1 + b) >>> 0
+            H2 = (H2 + c) >>> 0
+            H3 = (H3 + d) >>> 0
+            H4 = (H4 + e) >>> 0
+        }
+
+        return [H0, H1, H2, H3, H4]
+            .map((n) => n.toString(16).padStart(8, '0'))
+            .join('')
+            .slice(0, 15)
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,10 +77,16 @@ export interface AutocaptureConfig {
 
     capture_copied_text?: boolean
 }
+export type ClientAssignedFeatureFlag = {
+    key: string
+    variants: Record<string, number>
+    payload?: JsonType
+}
 
 export interface BootstrapConfig {
     distinctID?: string
     isIdentifiedID?: boolean
+    clientAssignedFeatureFlags?: ClientAssignedFeatureFlag[]
     featureFlags?: Record<string, boolean | string>
     featureFlagPayloads?: Record<string, JsonType>
     /**


### PR DESCRIPTION
## Changes

Adds support for client-assigned feature flags. When `bootstrap.clientAssignedFeatureFlags` is provided, the specified feature flags will be assigned with values based on the PostHog backend's allocation strategy.

```js
posthog.init('<ph_project_api_key>', {
    bootstrap: {
        clientAssignedFeatureFlags: [
            {
                key: 'my-awesome-experiment-flag',
                variants: {
                    test: 0.5,
                    control: 0.5,
                },
            },
        ],
    },
})
```

Related https://github.com/PostHog/posthog/pull/26145

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
