### PR TITLE
chore: add type to Sentry exception

### DIFF
--- a/cypress/e2e/error-tracking.cy.ts
+++ b/cypress/e2e/error-tracking.cy.ts
@@ -50,6 +50,7 @@ describe('Exception capture', () => {
             cy.phCaptures({ full: true }).then((captures) => {
                 expect(captures.map((c) => c.event)).to.deep.equal(['$pageview', '$autocapture', '$exception'])
                 expect(captures[2].event).to.be.eql('$exception')
+                expect(captures[2].properties.$exception_list[0].stacktrace.type).to.be.eq('raw')
                 expect(captures[2].properties.$exception_list[0].stacktrace.frames.length).to.be.eq(1)
                 expect(captures[2].properties.$exception_list[0].stacktrace.frames[0].function).to.be.eq(
                     'HTMLButtonElement.onclick'

--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -34,6 +34,7 @@ import { SeverityLevel } from '../types'
 // Uncomment the above and comment the below to get type checking for development
 
 type _SentryEvent = any
+type _SentryException = any
 type _SentryEventProcessor = any
 type _SentryHub = any
 
@@ -90,7 +91,13 @@ export function createEventProcessor(
             event.tags['PostHog Recording URL'] = _posthog.get_session_replay_url({ withTimestamp: true })
         }
 
-        const exceptions = event.exception?.values || []
+        const exceptions: _SentryException[] = event.exception?.values || []
+
+        exceptions.map((exception) => {
+            if (exception.stacktrace) {
+                exception.stacktrace.type = 'raw'
+            }
+        })
 
         const data: SentryExceptionProperties & {
             // two properties added to match any exception auto-capture


### PR DESCRIPTION
## Changes

Sentry exceptions should also have the `type` on stacktraces
