### PR TITLE
fix: Don't use session storage in memory mode

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -412,7 +412,7 @@ export class PostHog {
 
         this.persistence = new PostHogPersistence(this.config)
         this.sessionPersistence =
-            this.config.persistence === 'sessionStorage'
+            this.config.persistence === 'sessionStorage' || this.config.persistence === 'memory'
                 ? this.persistence
                 : new PostHogPersistence({ ...this.config, persistence: 'sessionStorage' })
 
@@ -1786,7 +1786,7 @@ export class PostHog {
 
             this.persistence?.update_config(this.config, oldConfig)
             this.sessionPersistence =
-                this.config.persistence === 'sessionStorage'
+                this.config.persistence === 'sessionStorage' || this.config.persistence === 'memory'
                     ? this.persistence
                     : new PostHogPersistence({ ...this.config, persistence: 'sessionStorage' })
 


### PR DESCRIPTION
## Changes

We currently use sessionStorage even when the persistence is set to memory. This is a bug, which this PR fixes and adds some tests for.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
