### PR TITLE
fix: XHR req method capture

### DIFF
--- a/playground/cypress/index.html
+++ b/playground/cypress/index.html
@@ -19,6 +19,28 @@
         Make network call
     </button>
 
+    <button data-cy-xhr-call-button onclick="makeXHRNetworkPOST()">
+    Make XHR post network call
+</button>
+
+<script>
+    function makeXHRNetworkPOST() {
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', 'https://example.com');
+        xhr.setRequestHeader('Content-Type', 'application/json');
+        xhr.onload = function () {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                console.log('Response:', xhr.responseText);
+            } else {
+                console.error('Request failed with status:', xhr.status);
+            }
+        };
+        xhr.onerror = function () {
+            console.error('Network error');
+        };
+        xhr.send('i am the xhr body');
+    }
+</script>
     <br />
 
     <button data-cy-feature-flag-button onclick="console.log(posthog.isFeatureEnabled('some-feature'))">

--- a/src/entrypoints/recorder.ts
+++ b/src/entrypoints/recorder.ts
@@ -386,7 +386,7 @@ function prepareRequest({
             timeOrigin,
             timestamp,
             method: method,
-            initiatorType: entry ? (entry.initiatorType as InitiatorType) : initiatorType,
+            initiatorType: initiatorType ? initiatorType : entry ? (entry.initiatorType as InitiatorType) : undefined,
             status,
             requestHeaders: networkRequest.requestHeaders,
             requestBody: networkRequest.requestBody,

--- a/src/entrypoints/recorder.ts
+++ b/src/entrypoints/recorder.ts
@@ -309,7 +309,7 @@ function initXhrObserver(cb: networkCallback, win: IWindow, options: Required<Ne
                         .then((entry) => {
                             const requests = prepareRequest({
                                 entry,
-                                method: req.method,
+                                method: method,
                                 status: xhr?.status,
                                 networkRequest,
                                 start,

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -429,7 +429,6 @@ export class SessionRecording {
         return currentTriggerSession === this.sessionId ? 'trigger_activated' : 'trigger_pending'
     }
 
-    /**
     private get triggerStatus(): TriggerStatus {
         const eitherIsActivated =
             this.eventTriggerStatus === 'trigger_activated' || this.urlTriggerStatus === 'trigger_activated'

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -430,10 +430,8 @@ export class SessionRecording {
     }
 
     /**
-     * Any one trigger can activate the session
-     * So, if they are all the same - return that value
-     * If either is disabled return the other's valu
-     * @private
+     * trigger is active if _either_ URL _or_ event trigger is active
+     * and is pending if _either_ URL _or_ event trigger is pending
      */
     private get triggerStatus(): TriggerStatus {
         const eitherIsActivated =

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -430,8 +430,6 @@ export class SessionRecording {
     }
 
     /**
-     * trigger is active if _either_ URL _or_ event trigger is active
-     * and is pending if _either_ URL _or_ event trigger is pending
      */
     private get triggerStatus(): TriggerStatus {
         const eitherIsActivated =

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -430,7 +430,6 @@ export class SessionRecording {
     }
 
     /**
-     */
     private get triggerStatus(): TriggerStatus {
         const eitherIsActivated =
             this.eventTriggerStatus === 'trigger_activated' || this.urlTriggerStatus === 'trigger_activated'


### PR DESCRIPTION
We were using `req.method` _before_ the request was used and so XHR was always captured as "GET"

