### PR TITLE
fix: angular change detection clashing

### DIFF
--- a/src/__tests__/heatmaps.test.ts
+++ b/src/__tests__/heatmaps.test.ts
@@ -8,6 +8,15 @@ import { HEATMAPS_ENABLED_SERVER_SIDE } from '../constants'
 import { Heatmaps } from '../heatmaps'
 
 jest.mock('../utils/logger')
+jest.mock('../utils/globals', () => {
+    const og = jest.requireActual('../utils/globals')
+    return {
+        ...og,
+        // because setInterval is wrapped in globals, we need to replace it here so jest's fake timers can affect it
+        setInterval: jest.fn((callback, interval) => global.setInterval(callback, interval)),
+    }
+})
+
 jest.useFakeTimers()
 
 describe('heatmaps', () => {

--- a/src/entrypoints/dead-clicks-autocapture.ts
+++ b/src/entrypoints/dead-clicks-autocapture.ts
@@ -5,6 +5,7 @@ import { autocaptureCompatibleElements, getEventTarget } from '../autocapture-ut
 import { DeadClickCandidate, DeadClicksAutoCaptureConfig, Properties } from '../types'
 import { autocapturePropertiesForElement } from '../autocapture'
 import { isElementInToolbar, isElementNode, isTag } from '../utils/element-utils'
+import { getNativeMutationObserverImplementation } from '../utils/prototype-utils'
 
 function asClick(event: MouseEvent): DeadClickCandidate | null {
     const eventTarget = getEventTarget(event)
@@ -66,7 +67,8 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
 
     private _startMutationObserver(observerTarget: Node) {
         if (!this._mutationObserver) {
-            this._mutationObserver = new MutationObserver((mutations) => {
+            const NativeMutationObserver = getNativeMutationObserverImplementation()
+            this._mutationObserver = new NativeMutationObserver((mutations) => {
                 this.onMutation(mutations)
             })
             this._mutationObserver.observe(observerTarget, {

--- a/src/extensions/replay/mutation-rate-limiter.ts
+++ b/src/extensions/replay/mutation-rate-limiter.ts
@@ -1,6 +1,7 @@
 import type { eventWithTime, mutationCallbackParam } from '@rrweb/types'
 import { INCREMENTAL_SNAPSHOT_EVENT_TYPE, MUTATION_SOURCE_TYPE, rrwebRecord } from './sessionrecording-utils'
 import { clampToRange } from '../../utils/number-utils'
+import { setInterval } from '../../utils/globals'
 
 export class MutationRateLimiter {
     private bucketSize = 100

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -45,6 +45,7 @@ import { MutationRateLimiter } from './mutation-rate-limiter'
 import { gzipSync, strFromU8, strToU8 } from 'fflate'
 import { clampToRange } from '../../utils/number-utils'
 import { includes } from '../../utils'
+import { setInterval, setTimeout, addEventListener } from '../../utils/globals'
 
 type SessionStartReason =
     | 'sampling_overridden'
@@ -487,10 +488,10 @@ export class SessionRecording {
             this._startCapture(startReason)
 
             // calling addEventListener multiple times is safe and will not add duplicates
-            window?.addEventListener('beforeunload', this._onBeforeUnload)
-            window?.addEventListener('offline', this._onOffline)
-            window?.addEventListener('online', this._onOnline)
-            window?.addEventListener('visibilitychange', this._onVisibilityChange)
+            addEventListener('beforeunload', this._onBeforeUnload)
+            addEventListener('offline', this._onOffline)
+            addEventListener('online', this._onOnline)
+            addEventListener('visibilitychange', this._onVisibilityChange)
 
             // on reload there might be an already sampled session that should be continued before decide response,
             // so we call this here _and_ in the decide response

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -10,6 +10,7 @@ import { isEmptyObject, isObject, isUndefined } from './utils/type-utils'
 import { logger } from './utils/logger'
 import { isElementInToolbar, isElementNode, isTag } from './utils/element-utils'
 import { DeadClicksAutocapture, isDeadClicksEnabledForHeatmaps } from './extensions/dead-clicks-autocapture'
+import { setInterval } from './utils/globals'
 
 const DEFAULT_FLUSH_INTERVAL = 5000
 const HEATMAPS = 'heatmaps'
@@ -48,7 +49,7 @@ export class Heatmaps {
 
     // TODO: Periodically flush this if no other event has taken care of it
     private buffer: HeatmapEventBuffer
-    private _flushInterval: ReturnType<typeof setInterval> | null = null
+    private _flushInterval: number | NodeJS.Timeout | null = null
     private deadClicksCapture: DeadClicksAutocapture | undefined
 
     constructor(instance: PostHog) {
@@ -119,6 +120,8 @@ export class Heatmaps {
     }
 
     private _onDeadClick(click: DeadClickCandidate): void {
+        // eslint-disable-next-line no-console
+        console.log('heatmap detected deadclick')
         this._onClick(click.originalEvent, 'deadclick')
     }
 

--- a/src/utils/prototype-utils.ts
+++ b/src/utils/prototype-utils.ts
@@ -9,7 +9,7 @@ import { isFunction, isNativeFunction } from './type-utils'
 import { logger } from './logger'
 
 interface NativeImplementationsCache {
-    mutationObserverCtor: typeof MutationObserver
+    MutationObserver: typeof MutationObserver
 }
 
 const cachedImplementations: Partial<NativeImplementationsCache> = {}
@@ -56,5 +56,5 @@ export function getNativeImplementation<T extends keyof NativeImplementationsCac
 }
 
 export function getNativeMutationObserverImplementation(): typeof MutationObserver {
-    return getNativeImplementation('mutationObserverCtor')
+    return getNativeImplementation('MutationObserver')
 }

--- a/src/utils/prototype-utils.ts
+++ b/src/utils/prototype-utils.ts
@@ -55,11 +55,6 @@ export function getNativeImplementation<T extends keyof NativeImplementationsCac
     return (cachedImplementations[name] = impl.bind(assignableWindow) as NativeImplementationsCache[T])
 }
 
-/** Clear a cached implementation. */
-export function clearCachedImplementation(name: keyof NativeImplementationsCache): void {
-    cachedImplementations[name] = undefined
-}
-
 export function getNativeMutationObserverImplementation(): typeof MutationObserver {
     return getNativeImplementation('mutationObserverCtor')
 }

--- a/src/utils/prototype-utils.ts
+++ b/src/utils/prototype-utils.ts
@@ -1,0 +1,65 @@
+/**
+ * adapted from https://github.com/getsentry/sentry-javascript/blob/72751dacb88c5b970d8bac15052ee8e09b28fd5d/packages/browser-utils/src/getNativeImplementation.ts#L27
+ * and https://github.com/PostHog/rrweb/blob/804380afbb1b9bed70b8792cb5a25d827f5c0cb5/packages/utils/src/index.ts#L31
+ * after a number of performance reports from Angular users
+ */
+
+import { assignableWindow } from './globals'
+import { isFunction, isNativeFunction } from './type-utils'
+import { logger } from './logger'
+
+interface NativeImplementationsCache {
+    mutationObserverCtor: typeof MutationObserver
+}
+
+const cachedImplementations: Partial<NativeImplementationsCache> = {}
+
+export function getNativeImplementation<T extends keyof NativeImplementationsCache>(
+    name: T
+): NativeImplementationsCache[T] {
+    const cached = cachedImplementations[name]
+    if (cached) {
+        return cached
+    }
+
+    let impl = assignableWindow[name] as NativeImplementationsCache[T]
+
+    // Fast path to avoid DOM I/O
+    if (isNativeFunction(impl)) {
+        return (cachedImplementations[name] = impl.bind(assignableWindow) as NativeImplementationsCache[T])
+    }
+
+    const document = assignableWindow.document
+    if (document && isFunction(document.createElement)) {
+        try {
+            const sandbox = document.createElement('iframe')
+            sandbox.hidden = true
+            document.head.appendChild(sandbox)
+            const contentWindow = sandbox.contentWindow
+            if (contentWindow && (contentWindow as any)[name]) {
+                impl = (contentWindow as any)[name] as NativeImplementationsCache[T]
+            }
+            document.head.removeChild(sandbox)
+        } catch (e) {
+            // Could not create sandbox iframe, just use assignableWindow.xxx
+            logger.warn(`Could not create sandbox iframe for ${name} check, bailing to assignableWindow.${name}: `, e)
+        }
+    }
+
+    // Sanity check: This _should_ not happen, but if it does, we just skip caching...
+    // This can happen e.g. in tests where fetch may not be available in the env, or similar.
+    if (!impl) {
+        return impl
+    }
+
+    return (cachedImplementations[name] = impl.bind(assignableWindow) as NativeImplementationsCache[T])
+}
+
+/** Clear a cached implementation. */
+export function clearCachedImplementation(name: keyof NativeImplementationsCache): void {
+    cachedImplementations[name] = undefined
+}
+
+export function getNativeMutationObserverImplementation(): typeof MutationObserver {
+    return getNativeImplementation('mutationObserverCtor')
+}

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -21,7 +21,17 @@ export const isFunction = function (f: any): f is (...args: any[]) => any {
 }
 
 export const isNativeFunction = function (f: any): f is (...args: any[]) => any {
+    // eslint-disable-next-line no-console
+    console.log(f.toString())
     return isFunction(f) && f.toString().includes('[native code]')
+}
+
+export const isAngularZonePatchedFunction = function (f: any): boolean {
+    if (!isFunction(f)) {
+        return false
+    }
+    const prototypeKeys = Object.getOwnPropertyNames(f.prototype || {})
+    return prototypeKeys.some((key) => key.indexOf('__zone'))
 }
 
 // Underscore Addons

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -19,6 +19,11 @@ export const isFunction = function (f: any): f is (...args: any[]) => any {
     // eslint-disable-next-line posthog-js/no-direct-function-check
     return typeof f === 'function'
 }
+
+export const isNativeFunction = function (f: any): f is (...args: any[]) => any {
+    return isFunction(f) && f.toString().includes('[native code]')
+}
+
 // Underscore Addons
 export const isObject = function (x: unknown): x is Record<string, any> {
     // eslint-disable-next-line posthog-js/no-direct-object-check


### PR DESCRIPTION
we get periodic reports of performance issues with angular

angular change detection patches browser methods

we do change detection too

so we fight each other

this grabs methods from an iframe so that we aren't using angular's patched methods
