### PR TITLE
fix: angular change detection mutation observer

### DIFF
--- a/eslint-rules/no-direct-mutation-observer.js
+++ b/eslint-rules/no-direct-mutation-observer.js
@@ -1,0 +1,58 @@
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Disallow direct use of MutationObserver and enforce importing NativeMutationObserver from global.ts',
+            category: 'Best Practices',
+            recommended: false,
+        },
+        schema: [],
+        messages: {
+            noDirectMutationObserver:
+                'Direct use of MutationObserver is not allowed. Use NativeMutationObserver from global.ts instead.',
+            missingNativeMutationObserver:
+                'You must import NativeMutationObserver from global.ts to use MutationObserver functionality.',
+        },
+    },
+    create(context) {
+        let importedNativeMutationObserver = false
+        const targetFileName = 'utils/global'
+
+        return {
+            ImportDeclaration(node) {
+                // Check if 'NativeMutationObserver' is imported from 'global.ts'
+                if (node.source.value.includes(targetFileName)) {
+                    const importedSpecifiers = node.specifiers.map(
+                        (specifier) => specifier.imported && specifier.imported.name
+                    )
+                    if (importedSpecifiers.includes('NativeMutationObserver')) {
+                        importedNativeMutationObserver = true
+                    }
+                }
+            },
+            NewExpression(node) {
+                // Check if `MutationObserver` is used
+                if (node.callee.type === 'Identifier' && node.callee.name === 'MutationObserver') {
+                    if (!importedNativeMutationObserver) {
+                        context.report({
+                            node,
+                            messageId: 'noDirectMutationObserver',
+                        })
+                    }
+                }
+            },
+            Identifier(node) {
+                // Warn if `MutationObserver` is directly referenced outside of a `new` expression (rare cases)
+                if (node.name === 'MutationObserver' && node.parent.type !== 'NewExpression') {
+                    if (!importedNativeMutationObserver) {
+                        context.report({
+                            node,
+                            messageId: 'missingNativeMutationObserver',
+                        })
+                    }
+                }
+            },
+        }
+    },
+}

--- a/eslint-rules/no-direct-mutation-observer.js
+++ b/eslint-rules/no-direct-mutation-observer.js
@@ -11,46 +11,16 @@ module.exports = {
         messages: {
             noDirectMutationObserver:
                 'Direct use of MutationObserver is not allowed. Use NativeMutationObserver from global.ts instead.',
-            missingNativeMutationObserver:
-                'You must import NativeMutationObserver from global.ts to use MutationObserver functionality.',
         },
     },
     create(context) {
-        let importedNativeMutationObserver = false
-        const targetFileName = 'utils/global'
-
         return {
-            ImportDeclaration(node) {
-                // Check if 'NativeMutationObserver' is imported from 'global.ts'
-                if (node.source.value.includes(targetFileName)) {
-                    const importedSpecifiers = node.specifiers.map(
-                        (specifier) => specifier.imported && specifier.imported.name
-                    )
-                    if (importedSpecifiers.includes('NativeMutationObserver')) {
-                        importedNativeMutationObserver = true
-                    }
-                }
-            },
             NewExpression(node) {
-                // Check if `MutationObserver` is used
                 if (node.callee.type === 'Identifier' && node.callee.name === 'MutationObserver') {
-                    if (!importedNativeMutationObserver) {
-                        context.report({
-                            node,
-                            messageId: 'noDirectMutationObserver',
-                        })
-                    }
-                }
-            },
-            Identifier(node) {
-                // Warn if `MutationObserver` is directly referenced outside of a `new` expression (rare cases)
-                if (node.name === 'MutationObserver' && node.parent.type !== 'NewExpression') {
-                    if (!importedNativeMutationObserver) {
-                        context.report({
-                            node,
-                            messageId: 'missingNativeMutationObserver',
-                        })
-                    }
+                    context.report({
+                        node,
+                        messageId: 'noDirectMutationObserver',
+                    })
                 }
             },
         }

--- a/src/entrypoints/dead-clicks-autocapture.ts
+++ b/src/entrypoints/dead-clicks-autocapture.ts
@@ -5,6 +5,7 @@ import { autocaptureCompatibleElements, getEventTarget } from '../autocapture-ut
 import { DeadClickCandidate, DeadClicksAutoCaptureConfig, Properties } from '../types'
 import { autocapturePropertiesForElement } from '../autocapture'
 import { isElementInToolbar, isElementNode, isTag } from '../utils/element-utils'
+import { NativeMutationObserver } from '../utils/globals'
 
 function asClick(event: MouseEvent): DeadClickCandidate | null {
     const eventTarget = getEventTarget(event)
@@ -66,7 +67,7 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
 
     private _startMutationObserver(observerTarget: Node) {
         if (!this._mutationObserver) {
-            this._mutationObserver = new MutationObserver((mutations) => {
+            this._mutationObserver = new NativeMutationObserver((mutations) => {
                 this.onMutation(mutations)
             })
             this._mutationObserver.observe(observerTarget, {
@@ -99,6 +100,8 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
     private _onClick = (event: MouseEvent): void => {
         const click = asClick(event)
         if (!isNull(click) && !this._ignoreClick(click)) {
+            // eslint-disable-next-line no-console
+            console.log('deadclicks detected a click', click)
             this._clicks.push(click)
         }
 
@@ -209,8 +212,24 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
 
             if (hadScroll || hadMutation || hadSelectionChange) {
                 // ignore clicks that had a scroll or mutation
+                // eslint-disable-next-line no-console
+                console.log('not a dead click', {
+                    click,
+                    hadScroll,
+                    hadMutation,
+                    hadSelectionChange,
+                })
                 continue
             }
+
+            // eslint-disable-next-line no-console
+            console.log('dead click?', {
+                isdc: scrollTimeout || mutationTimeout || absoluteTimeout || selectionChangedTimeout,
+                scrollTimeout,
+                mutationTimeout,
+                absoluteTimeout,
+                selectionChangedTimeout,
+            })
 
             if (scrollTimeout || mutationTimeout || absoluteTimeout || selectionChangedTimeout) {
                 this._onCapture(click, {

--- a/src/entrypoints/dead-clicks-autocapture.ts
+++ b/src/entrypoints/dead-clicks-autocapture.ts
@@ -100,8 +100,6 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
     private _onClick = (event: MouseEvent): void => {
         const click = asClick(event)
         if (!isNull(click) && !this._ignoreClick(click)) {
-            // eslint-disable-next-line no-console
-            console.log('deadclicks detected a click', click)
             this._clicks.push(click)
         }
 
@@ -212,24 +210,8 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
 
             if (hadScroll || hadMutation || hadSelectionChange) {
                 // ignore clicks that had a scroll or mutation
-                // eslint-disable-next-line no-console
-                console.log('not a dead click', {
-                    click,
-                    hadScroll,
-                    hadMutation,
-                    hadSelectionChange,
-                })
                 continue
             }
-
-            // eslint-disable-next-line no-console
-            console.log('dead click?', {
-                isdc: scrollTimeout || mutationTimeout || absoluteTimeout || selectionChangedTimeout,
-                scrollTimeout,
-                mutationTimeout,
-                absoluteTimeout,
-                selectionChangedTimeout,
-            })
 
             if (scrollTimeout || mutationTimeout || absoluteTimeout || selectionChangedTimeout) {
                 this._onCapture(click, {

--- a/src/utils/prototype-utils.ts
+++ b/src/utils/prototype-utils.ts
@@ -9,11 +9,7 @@ import { isAngularZonePatchedFunction, isFunction, isNativeFunction } from './ty
 import { logger } from './logger'
 
 interface NativeImplementationsCache {
-    // eslint-disable-next-line posthog-js/no-direct-mutation-observer
     MutationObserver: typeof MutationObserver
-    setTimeout: typeof setTimeout
-    addEventListener: typeof addEventListener
-    setInterval: typeof setInterval
 }
 
 const cachedImplementations: Partial<NativeImplementationsCache> = {}
@@ -30,8 +26,6 @@ export function getNativeImplementation<T extends keyof NativeImplementationsCac
     let impl = assignableWindow[name] as NativeImplementationsCache[T]
 
     if (isNativeFunction(impl) && !isAngularZonePatchedFunction(impl)) {
-        // eslint-disable-next-line no-console
-        console.log(name + ' is a native function, no need to create a sandbox')
         return (cachedImplementations[name] = impl.bind(assignableWindow) as NativeImplementationsCache[T])
     }
 
@@ -61,7 +55,6 @@ export function getNativeImplementation<T extends keyof NativeImplementationsCac
     return (cachedImplementations[name] = impl.bind(assignableWindow) as NativeImplementationsCache[T])
 }
 
-// eslint-disable-next-line posthog-js/no-direct-mutation-observer
 export function getNativeMutationObserverImplementation(assignableWindow: AssignableWindow): typeof MutationObserver {
     return getNativeImplementation('MutationObserver', assignableWindow)
 }

--- a/src/utils/prototype-utils.ts
+++ b/src/utils/prototype-utils.ts
@@ -1,0 +1,67 @@
+/**
+ * adapted from https://github.com/getsentry/sentry-javascript/blob/72751dacb88c5b970d8bac15052ee8e09b28fd5d/packages/browser-utils/src/getNativeImplementation.ts#L27
+ * and https://github.com/PostHog/rrweb/blob/804380afbb1b9bed70b8792cb5a25d827f5c0cb5/packages/utils/src/index.ts#L31
+ * after a number of performance reports from Angular users
+ */
+
+import { AssignableWindow } from './globals'
+import { isAngularZonePatchedFunction, isFunction, isNativeFunction } from './type-utils'
+import { logger } from './logger'
+
+interface NativeImplementationsCache {
+    // eslint-disable-next-line posthog-js/no-direct-mutation-observer
+    MutationObserver: typeof MutationObserver
+    setTimeout: typeof setTimeout
+    addEventListener: typeof addEventListener
+    setInterval: typeof setInterval
+}
+
+const cachedImplementations: Partial<NativeImplementationsCache> = {}
+
+export function getNativeImplementation<T extends keyof NativeImplementationsCache>(
+    name: T,
+    assignableWindow: AssignableWindow
+): NativeImplementationsCache[T] {
+    const cached = cachedImplementations[name]
+    if (cached) {
+        return cached
+    }
+
+    let impl = assignableWindow[name] as NativeImplementationsCache[T]
+
+    if (isNativeFunction(impl) && !isAngularZonePatchedFunction(impl)) {
+        // eslint-disable-next-line no-console
+        console.log(name + ' is a native function, no need to create a sandbox')
+        return (cachedImplementations[name] = impl.bind(assignableWindow) as NativeImplementationsCache[T])
+    }
+
+    const document = assignableWindow.document
+    if (document && isFunction(document.createElement)) {
+        try {
+            const sandbox = document.createElement('iframe')
+            sandbox.hidden = true
+            document.head.appendChild(sandbox)
+            const contentWindow = sandbox.contentWindow
+            if (contentWindow && (contentWindow as any)[name]) {
+                impl = (contentWindow as any)[name] as NativeImplementationsCache[T]
+            }
+            document.head.removeChild(sandbox)
+        } catch (e) {
+            // Could not create sandbox iframe, just use assignableWindow.xxx
+            logger.warn(`Could not create sandbox iframe for ${name} check, bailing to assignableWindow.${name}: `, e)
+        }
+    }
+
+    // Sanity check: This _should_ not happen, but if it does, we just skip caching...
+    // This can happen e.g. in tests where fetch may not be available in the env, or similar.
+    if (!impl || !isFunction(impl)) {
+        return impl
+    }
+
+    return (cachedImplementations[name] = impl.bind(assignableWindow) as NativeImplementationsCache[T])
+}
+
+// eslint-disable-next-line posthog-js/no-direct-mutation-observer
+export function getNativeMutationObserverImplementation(assignableWindow: AssignableWindow): typeof MutationObserver {
+    return getNativeImplementation('MutationObserver', assignableWindow)
+}

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -23,7 +23,7 @@ export const isFunction = function (f: any): f is (...args: any[]) => any {
 export const isNativeFunction = function (f: any): f is (...args: any[]) => any {
     // eslint-disable-next-line no-console
     console.log(f.toString())
-    return isFunction(f) && f.toString().includes('[native code]')
+    return isFunction(f) && f.toString().indexOf('[native code]') !== -1
 }
 
 // When angular patches functions they pass the above `isNativeFunction` check

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -21,8 +21,6 @@ export const isFunction = function (f: any): f is (...args: any[]) => any {
 }
 
 export const isNativeFunction = function (f: any): f is (...args: any[]) => any {
-    // eslint-disable-next-line no-console
-    console.log(f.toString())
     return isFunction(f) && f.toString().indexOf('[native code]') !== -1
 }
 

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -19,6 +19,22 @@ export const isFunction = function (f: any): f is (...args: any[]) => any {
     // eslint-disable-next-line posthog-js/no-direct-function-check
     return typeof f === 'function'
 }
+
+export const isNativeFunction = function (f: any): f is (...args: any[]) => any {
+    // eslint-disable-next-line no-console
+    console.log(f.toString())
+    return isFunction(f) && f.toString().includes('[native code]')
+}
+
+// When angular patches functions they pass the above `isNativeFunction` check
+export const isAngularZonePatchedFunction = function (f: any): boolean {
+    if (!isFunction(f)) {
+        return false
+    }
+    const prototypeKeys = Object.getOwnPropertyNames(f.prototype || {})
+    return prototypeKeys.some((key) => key.indexOf('__zone'))
+}
+
 // Underscore Addons
 export const isObject = function (x: unknown): x is Record<string, any> {
     // eslint-disable-next-line posthog-js/no-direct-object-check

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -15,21 +15,21 @@ export const isUint8Array = function (x: unknown): x is Uint8Array {
 // from a comment on http://dbj.org/dbj/?p=286
 // fails on only one very rare and deliberate custom object:
 // let bomb = { toString : undefined, valueOf: function(o) { return "function BOMBA!"; }};
-export const isFunction = function (f: any): f is (...args: any[]) => any {
+export const isFunction = function (x: unknown): x is (...args: any[]) => any {
     // eslint-disable-next-line posthog-js/no-direct-function-check
-    return typeof f === 'function'
+    return typeof x === 'function'
 }
 
-export const isNativeFunction = function (f: any): f is (...args: any[]) => any {
-    return isFunction(f) && f.toString().indexOf('[native code]') !== -1
+export const isNativeFunction = function (x: unknown): x is (...args: any[]) => any {
+    return isFunction(x) && x.toString().indexOf('[native code]') !== -1
 }
 
 // When angular patches functions they pass the above `isNativeFunction` check
-export const isAngularZonePatchedFunction = function (f: any): boolean {
-    if (!isFunction(f)) {
+export const isAngularZonePatchedFunction = function (x: unknown): boolean {
+    if (!isFunction(x)) {
         return false
     }
-    const prototypeKeys = Object.getOwnPropertyNames(f.prototype || {})
+    const prototypeKeys = Object.getOwnPropertyNames(x.prototype || {})
     return prototypeKeys.some((key) => key.indexOf('__zone'))
 }
 


### PR DESCRIPTION
we get periodic reports of performance issues with angular

angular change detection patches browser methods

we do change detection too

so we fight each other

this 

* grabs MutationObserver from an iframe so that we aren't using angular's patched methods
* fixes detection of whether Angular has patched a method
* adds an eslint rule so we don't use MutationObserver directly in future

### TODO

- [ ] also fix rrweb's detection of whether angular has patched this