### PR TITLE
chore: very small change to IE11 bundling

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,9 +22,7 @@ const plugins = (es5) => [
             [
                 '@babel/preset-env',
                 {
-                    targets: es5
-                        ? '>0.5%, last 2 versions, Firefox ESR, not dead, IE 11'
-                        : '>0.5%, last 2 versions, Firefox ESR, not dead',
+                    targets: es5 ? 'defaults, IE 11' : '>0.5%, last 2 versions, Firefox ESR, not dead',
                 },
             ],
         ],


### PR DESCRIPTION
IE 11 tests are freezing in https://github.com/PostHog/posthog-js/pull/1525 which shouldn't have changed IE11 bundle at all

This pulls small changes from that PR that are safe to make in an attempt to identify the problem