### PR TITLE
chore: package json browserslist as source of truth

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,9 +122,11 @@
             "eslint cypress --fix"
         ]
     },
-    "browserslist": [
-        "> 0.5%, last 2 versions, Firefox ESR, not dead, IE 11"
-    ],
+    "browserslist": {
+        "production": [
+            "> 0.5%, last 2 versions, Firefox ESR, not dead, IE 11"
+        ]
+    },
     "pnpm": {
         "patchedDependencies": {
             "@rrweb/rrweb-plugin-console-record@2.0.0-alpha.17": "patches/@rrweb__rrweb-plugin-console-record@2.0.0-alpha.17.patch",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ import { visualizer } from 'rollup-plugin-visualizer'
 import commonjs from '@rollup/plugin-commonjs'
 import fs from 'fs'
 import path from 'path'
+import { browserslist } from './package.json'
 
 const plugins = (es5) => [
     json(),
@@ -26,7 +27,7 @@ const plugins = (es5) => [
             [
                 '@babel/preset-env',
                 {
-                    targets: es5 ? 'defaults, IE 11' : '>0.5%, last 2 versions, Firefox ESR, not dead',
+                    targets: es5 ? '>0.5%, last 2 versions, Firefox ESR, not dead, IE 11' : browserslist.production,
                 },
             ],
         ],


### PR DESCRIPTION
pulling small changes out of #1525 because IE 11 tests are freezing in that PR and it's really hard to figure out why

this grabs the browserslist setting from package.json