### PR TITLE
fix: improve ES6 bundling

### DIFF
--- a/.github/workflows/es-check.yml
+++ b/.github/workflows/es-check.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ssr:
-    name: Cypress
+    name: Build and check ES5/ES6 support
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/es-check.yml
+++ b/.github/workflows/es-check.yml
@@ -21,3 +21,6 @@ jobs:
 
       - name: Run es-check to check if our ie11 bundle is ES5 compatible
         run: npx es-check@7.2.1 es5 dist/array.full.es5.js
+
+      - name: Run es-check to check if our main bundle is ES6 compatible
+        run: npx es-check@7.2.1 es6 dist/array.full.js

--- a/package.json
+++ b/package.json
@@ -122,9 +122,25 @@
             "eslint cypress --fix"
         ]
     },
-    "browserslist": [
-        "> 0.5%, last 2 versions, Firefox ESR, not dead, IE 11"
-    ],
+    "browserslist": {
+        "production": [
+            "> 0.5%, last 2 versions, Firefox ESR, not dead",
+            "chrome > 62",
+            "firefox > 59",
+            "ios_saf >= 10.3",
+            "opera > 50",
+            "safari > 12"
+        ],
+        "es5": [
+            "> 0.5%, last 2 versions, Firefox ESR, not dead",
+            "chrome > 62",
+            "firefox > 59",
+            "ios_saf >= 10.3",
+            "opera > 50",
+            "safari > 12",
+            "IE 11"
+        ]
+    },
     "pnpm": {
         "patchedDependencies": {
             "@rrweb/rrweb-plugin-console-record@2.0.0-alpha.17": "patches/@rrweb__rrweb-plugin-console-record@2.0.0-alpha.17.patch",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
             "> 0.5%, last 2 versions, Firefox ESR, not dead",
             "chrome > 62",
             "firefox > 59",
-            "ios_saf >= 10.3",
+            "ios_saf >= 6.1",
             "opera > 50",
             "safari > 12",
             "IE 11"

--- a/package.json
+++ b/package.json
@@ -122,25 +122,9 @@
             "eslint cypress --fix"
         ]
     },
-    "browserslist": {
-        "production": [
-            "> 0.5%, last 2 versions, Firefox ESR, not dead",
-            "chrome > 62",
-            "firefox > 59",
-            "ios_saf >= 10.3",
-            "opera > 50",
-            "safari > 12"
-        ],
-        "es5": [
-            "> 0.5%, last 2 versions, Firefox ESR, not dead",
-            "chrome > 62",
-            "firefox > 59",
-            "ios_saf >= 6.1",
-            "opera > 50",
-            "safari > 12",
-            "IE 11"
-        ]
-    },
+    "browserslist": [
+        "> 0.5%, last 2 versions, Firefox ESR, not dead, IE 11"
+    ],
     "pnpm": {
         "patchedDependencies": {
             "@rrweb/rrweb-plugin-console-record@2.0.0-alpha.17": "patches/@rrweb__rrweb-plugin-console-record@2.0.0-alpha.17.patch",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,24 @@ const plugins = (es5) => [
             [
                 '@babel/preset-env',
                 {
-                    browserslistEnv: es5 ? 'es5' : 'production',
+                    targets: es5
+                        ? [
+                              '> 0.5%, last 2 versions, Firefox ESR, not dead',
+                              'chrome > 62',
+                              'firefox > 59',
+                              'ios_saf >= 6.1',
+                              'opera > 50',
+                              'safari > 12',
+                              'IE 11',
+                          ]
+                        : [
+                              '> 0.5%, last 2 versions, Firefox ESR, not dead',
+                              'chrome > 62',
+                              'firefox > 59',
+                              'ios_saf >= 10.3',
+                              'opera > 50',
+                              'safari > 12',
+                          ],
                 },
             ],
         ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ const plugins = (es5) => [
             [
                 '@babel/preset-env',
                 {
-                    targets: es5 ? 'defaults, IE 11' : 'defaults',
+                    browsersListEnv: es5 ? 'es5' : 'production',
                 },
             ],
         ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ const plugins = (es5) => [
             [
                 '@babel/preset-env',
                 {
-                    browsersListEnv: es5 ? 'es5' : 'production',
+                    browserslistEnv: es5 ? 'es5' : 'production',
                 },
             ],
         ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ import { visualizer } from 'rollup-plugin-visualizer'
 import commonjs from '@rollup/plugin-commonjs'
 import fs from 'fs'
 import path from 'path'
+import { browserslist } from './package.json'
 
 const plugins = (es5) => [
     json(),
@@ -26,7 +27,7 @@ const plugins = (es5) => [
             [
                 '@babel/preset-env',
                 {
-                    targets: es5 ? 'defaults, IE 11' : '>0.5%, last 2 versions, Firefox ESR, not dead',
+                    targets: es5 ? browserslist.es5 : browserslist.production,
                 },
             ],
         ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,6 @@ import { visualizer } from 'rollup-plugin-visualizer'
 import commonjs from '@rollup/plugin-commonjs'
 import fs from 'fs'
 import path from 'path'
-import { browserslist } from './package.json'
 
 const plugins = (es5) => [
     json(),
@@ -27,7 +26,7 @@ const plugins = (es5) => [
             [
                 '@babel/preset-env',
                 {
-                    targets: es5 ? 'defaults, IE 11' : browserslist.production,
+                    targets: es5 ? 'defaults, IE 11' : '>0.5%, last 2 versions, Firefox ESR, not dead',
                 },
             ],
         ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ const plugins = (es5) => [
             [
                 '@babel/preset-env',
                 {
-                    targets: es5 ? 'defaults, IE 11' : '>0.5%, last 2 versions, Firefox ESR, not dead',
+                    targets: es5 ? 'defaults, IE 11' : 'defaults',
                 },
             ],
         ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ const plugins = (es5) => [
             [
                 '@babel/preset-env',
                 {
-                    targets: es5 ? browserslist.es5 : browserslist.production,
+                    targets: es5 ? 'defaults, IE 11' : browserslist.production,
                 },
             ],
         ],

--- a/src/__tests__/posthog-core.test.ts
+++ b/src/__tests__/posthog-core.test.ts
@@ -2,36 +2,30 @@ import { defaultPostHog } from './helpers/posthog-instance'
 import type { PostHogConfig } from '../types'
 import { uuidv7 } from '../uuidv7'
 
-const mockReferrerGetter = jest.fn()
-const mockURLGetter = jest.fn()
-jest.mock('../utils/globals', () => {
-    const orig = jest.requireActual('../utils/globals')
-    return {
-        ...orig,
-        document: {
-            ...orig.document,
-            createElement: (...args: any[]) => orig.document.createElement(...args),
-            get referrer() {
-                return mockReferrerGetter?.()
-            },
-            get URL() {
-                return mockURLGetter?.()
-            },
-        },
-        get location() {
-            const url = mockURLGetter?.()
-            return {
-                href: url,
-                toString: () => url,
-            }
-        },
-    }
-})
-
 describe('posthog core', () => {
+    const mockURL = jest.fn()
+    const mockReferrer = jest.fn()
+
+    beforeAll(() => {
+        // Mock getters using Object.defineProperty
+        Object.defineProperty(document, 'URL', {
+            get: mockURL,
+        })
+        Object.defineProperty(document, 'referrer', {
+            get: mockReferrer,
+        })
+        Object.defineProperty(window, 'location', {
+            get: () => ({
+                href: mockURL(),
+                toString: () => mockURL(),
+            }),
+            configurable: true,
+        })
+    })
+
     beforeEach(() => {
-        mockReferrerGetter.mockReturnValue('https://referrer.com')
-        mockURLGetter.mockReturnValue('https://example.com')
+        mockReferrer.mockReturnValue('https://referrer.com')
+        mockURL.mockReturnValue('https://example.com')
         console.error = jest.fn()
     })
 
@@ -111,7 +105,7 @@ describe('posthog core', () => {
             it("should send referrer info with the event's properties", () => {
                 // arrange
                 const token = uuidv7()
-                mockReferrerGetter.mockReturnValue('https://referrer.example.com/some/path')
+                mockReferrer.mockReturnValue('https://referrer.example.com/some/path')
                 const { posthog, beforeSendMock } = setup({
                     token,
                     persistence_name: token,
@@ -132,14 +126,14 @@ describe('posthog core', () => {
             it('should not update the referrer within the same session', () => {
                 // arrange
                 const token = uuidv7()
-                mockReferrerGetter.mockReturnValue('https://referrer1.example.com/some/path')
+                mockReferrer.mockReturnValue('https://referrer1.example.com/some/path')
                 const { posthog: posthog1 } = setup({
                     token,
                     persistence_name: token,
                     person_profiles: 'always',
                 })
                 posthog1.capture(eventName, eventProperties)
-                mockReferrerGetter.mockReturnValue('https://referrer2.example.com/some/path')
+                mockReferrer.mockReturnValue('https://referrer2.example.com/some/path')
                 const { posthog: posthog2, beforeSendMock } = setup({
                     token,
                     persistence_name: token,
@@ -163,14 +157,14 @@ describe('posthog core', () => {
             it('should use the new referrer in a new session', () => {
                 // arrange
                 const token = uuidv7()
-                mockReferrerGetter.mockReturnValue('https://referrer1.example.com/some/path')
+                mockReferrer.mockReturnValue('https://referrer1.example.com/some/path')
                 const { posthog: posthog1 } = setup({
                     token,
                     persistence_name: token,
                     person_profiles: 'always',
                 })
                 posthog1.capture(eventName, eventProperties)
-                mockReferrerGetter.mockReturnValue('https://referrer2.example.com/some/path')
+                mockReferrer.mockReturnValue('https://referrer2.example.com/some/path')
                 const { posthog: posthog2, beforeSendMock: beforeSendMock2 } = setup({
                     token,
                     persistence_name: token,
@@ -194,7 +188,7 @@ describe('posthog core', () => {
             it('should use $direct when there is no referrer', () => {
                 // arrange
                 const token = uuidv7()
-                mockReferrerGetter.mockReturnValue('')
+                mockReferrer.mockReturnValue('')
                 const { posthog, beforeSendMock } = setup({
                     token,
                     persistence_name: token,
@@ -217,7 +211,7 @@ describe('posthog core', () => {
             it('should not send campaign params as null if there are no non-null ones', () => {
                 // arrange
                 const token = uuidv7()
-                mockURLGetter.mockReturnValue('https://www.example.com/some/path')
+                mockURL.mockReturnValue('https://www.example.com/some/path')
                 const { posthog, beforeSendMock } = setup({
                     token,
                     persistence_name: token,
@@ -234,7 +228,7 @@ describe('posthog core', () => {
             it('should send present campaign params, and nulls for others', () => {
                 // arrange
                 const token = uuidv7()
-                mockURLGetter.mockReturnValue('https://www.example.com/some/path?utm_source=source')
+                mockURL.mockReturnValue('https://www.example.com/some/path?utm_source=source')
                 const { posthog, beforeSendMock } = setup({
                     token,
                     persistence_name: token,


### PR DESCRIPTION
#1525 - IE 11 tests are freezing in that PR and it's really hard to figure out why

have pulled many small changes out of that PR but the IE 11 tests still freeze

----

* improves detection/bundling of ES6 support for posthog-js by being more specific with the browser targets that are passed to the bundler
* adds a check that the array.full.js is ES6 compliant in CI

Does not update the browserslist value in package.json, since that is the change that appears to make CI freeze
I'd rather get the benefit of the ES6 compliant bundle in prod before fixing that