### PR TITLE
fix(surveys): Process feature_flag_keys on Survey object

### DIFF
--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -149,6 +149,12 @@ export interface Survey {
     name: string
     description: string
     type: SurveyType
+    feature_flag_keys:
+        | {
+              key: string
+              value?: string
+          }[]
+        | null
     linked_flag_key: string | null
     targeting_flag_key: string | null
     internal_targeting_flag_key: string | null


### PR DESCRIPTION
## Changes

As part of adaptive survey collection, we introduced a new feature flag that the surveys component should use to filter out surveys to be shown to people. 
The common pattern has become : 
1. Add a flag to the API
2. Add the same flag as a check to `getActiveMatchingSurveys`

Instead, this PR now uses the `feature_flag_keys` array to find the names of the feature flags to check in the survey component. 
With this change, one can just add a new flag to the `feature_flag_keys` in the Surveys API in posthog.com and the survey component will automatically pick it up. 


## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
