### PR TITLE
feat: Add better npm import, and script entrypoint for customizations

### DIFF
--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -2,7 +2,7 @@
 import { useActiveFeatureFlags, usePostHog } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
 import { cookieConsentGiven, PERSON_PROCESSING_MODE } from '@/src/posthog'
-import { setAllPersonProfilePropertiesAsPersonPropertiesForFlags } from 'posthog-js/lib/src/customizations/setAllPersonProfilePropertiesAsPersonPropertiesForFlags'
+import { setAllPersonProfilePropertiesAsPersonPropertiesForFlags } from 'posthog-js/lib/customizations'
 import { STORED_PERSON_PROPERTIES_KEY } from '../../../src/constants'
 
 export default function Home() {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -106,7 +106,7 @@ const entrypointTargets = entrypoints.map((file) => {
 const typeTargets = entrypoints
     .filter((file) => file.endsWith('.es.ts'))
     .map((file) => {
-        const source = `./lib/src/entrypoints/${file.replace('.ts', '.d.ts')}`
+        const source = `./lib/entrypoints/${file.replace('.ts', '.d.ts')}`
         /** @type {import('rollup').RollupOptions} */
         return {
             input: source,

--- a/src/customizations/index.ts
+++ b/src/customizations/index.ts
@@ -1,0 +1,2 @@
+export * from './setAllPersonProfilePropertiesAsPersonPropertiesForFlags'
+export * from './before-send'

--- a/src/entrypoints/customizations.full.ts
+++ b/src/entrypoints/customizations.full.ts
@@ -1,0 +1,7 @@
+// this file is called customizations.full.ts because it includes all customizations
+// this naming scheme allows us to create a lighter version in the future with only the most popular customizations
+// without breaking backwards compatibility
+
+import * as customizations from '../customizations'
+import { assignableWindow } from '../utils/globals'
+assignableWindow.posthogCustomizations = customizations

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -224,7 +224,7 @@ export class PostHogPersistence {
             const campaignParams = Info.campaignParams(this.config.custom_campaign_params)
             // only save campaign params if there were any
             if (!isEmptyObject(stripEmptyProperties(campaignParams))) {
-                this.register(Info.campaignParams(this.config.custom_campaign_params))
+                this.register(campaignParams)
             }
             this.campaign_params_saved = true
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "rootDir": "./src",
         "outDir": "./lib",
         "target": "ES5",
         "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
## Changes

Add a script entrypoint, `cutomizations.full.js` for adding all of the cutomizations for posthog-js.

Right now this is the sampling functions and the setAllPersonPropertiesAsPropertiesForFlags function.

I've also added a central import for npm users who want to use customizations, so now they can do `import { sampleByDistinctId } from 'posthog-js/lib/customizations'`

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
