### PR TITLE
fix: endless capturing /s/

### DIFF
--- a/src/__tests__/extensions/replay/config.test.ts
+++ b/src/__tests__/extensions/replay/config.test.ts
@@ -114,8 +114,19 @@ describe('config', () => {
                     undefined,
                     '/ingest',
                 ],
+                [
+                    {
+                        // even an imaginary future world of rust session replay capture
+                        name: 'https://app.posthog.com/ingest/s/?ip=1&ver=123',
+                    },
+                    undefined,
+                    'https://app.posthog.com/ingest',
+                ],
             ])('ignores ingestion paths', (capturedRequest, expected, apiHost?: string) => {
-                const networkOptions = buildNetworkRequestOptions({ ...defaultConfig(), api_host: apiHost }, {})
+                const networkOptions = buildNetworkRequestOptions(
+                    { ...defaultConfig(), api_host: apiHost || 'https://us.posthog.com' },
+                    {}
+                )
                 const x = networkOptions.maskRequestFn!(capturedRequest as CapturedNetworkRequest)
                 expect(x).toEqual(expected)
             })

--- a/src/__tests__/extensions/replay/config.test.ts
+++ b/src/__tests__/extensions/replay/config.test.ts
@@ -108,7 +108,7 @@ describe('config', () => {
                 ],
                 [
                     {
-                        // even an imaginary future world of rust session replay capture
+                        // using a relative path as a reverse proxy api host
                         name: 'https://app.posthog.com/ingest/s/?ip=1&ver=123',
                     },
                     undefined,
@@ -116,7 +116,7 @@ describe('config', () => {
                 ],
                 [
                     {
-                        // even an imaginary future world of rust session replay capture
+                        // using a reverse proxy with a path
                         name: 'https://app.posthog.com/ingest/s/?ip=1&ver=123',
                     },
                     undefined,

--- a/src/__tests__/extensions/replay/config.test.ts
+++ b/src/__tests__/extensions/replay/config.test.ts
@@ -75,11 +75,13 @@ describe('config', () => {
                     {
                         name: 'https://app.posthog.com/api/feature_flag/',
                     },
+                    undefined,
                 ],
                 [
                     {
                         name: 'https://app.posthog.com/s/?ip=1&ver=123',
                     },
+                    undefined,
                     undefined,
                 ],
                 [
@@ -87,11 +89,13 @@ describe('config', () => {
                         name: 'https://app.posthog.com/e/?ip=1&ver=123',
                     },
                     undefined,
+                    undefined,
                 ],
                 [
                     {
                         name: 'https://app.posthog.com/i/v0/e/?ip=1&ver=123',
                     },
+                    undefined,
                     undefined,
                 ],
                 [
@@ -100,9 +104,18 @@ describe('config', () => {
                         name: 'https://app.posthog.com/i/v0/s/?ip=1&ver=123',
                     },
                     undefined,
+                    undefined,
                 ],
-            ])('ignores ingestion paths', (capturedRequest, expected) => {
-                const networkOptions = buildNetworkRequestOptions(defaultConfig(), {})
+                [
+                    {
+                        // even an imaginary future world of rust session replay capture
+                        name: 'https://app.posthog.com/ingest/s/?ip=1&ver=123',
+                    },
+                    undefined,
+                    '/ingest',
+                ],
+            ])('ignores ingestion paths', (capturedRequest, expected, apiHost?: string) => {
+                const networkOptions = buildNetworkRequestOptions({ ...defaultConfig(), api_host: apiHost }, {})
                 const x = networkOptions.maskRequestFn!(capturedRequest as CapturedNetworkRequest)
                 expect(x).toEqual(expected)
             })

--- a/src/__tests__/extensions/replay/config.test.ts
+++ b/src/__tests__/extensions/replay/config.test.ts
@@ -78,26 +78,26 @@ describe('config', () => {
                 ],
                 [
                     {
-                        name: 'https://app.posthog.com/s/',
+                        name: 'https://app.posthog.com/s/?ip=1&ver=123',
                     },
                     undefined,
                 ],
                 [
                     {
-                        name: 'https://app.posthog.com/e/',
+                        name: 'https://app.posthog.com/e/?ip=1&ver=123',
                     },
                     undefined,
                 ],
                 [
                     {
-                        name: 'https://app.posthog.com/i/v0/e/',
+                        name: 'https://app.posthog.com/i/v0/e/?ip=1&ver=123',
                     },
                     undefined,
                 ],
                 [
                     {
                         // even an imaginary future world of rust session replay capture
-                        name: 'https://app.posthog.com/i/v0/s/',
+                        name: 'https://app.posthog.com/i/v0/s/?ip=1&ver=123',
                     },
                     undefined,
                 ],

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -101,7 +101,14 @@ const ignorePostHogPaths = (
     apiHostConfig: PostHogConfig['api_host']
 ): CapturedNetworkRequest | undefined => {
     const url = convertToURL(data.name)
-    const pathname = url?.pathname.replace(apiHostConfig, '')
+
+    // we need to account for api host config as e.g. pathname could be /ingest/s/ and we want to ignore that
+    let replaceValue = apiHostConfig.indexOf('http') === 0 ? convertToURL(apiHostConfig)?.pathname : apiHostConfig
+    if (replaceValue === '/') {
+        replaceValue = ''
+    }
+    const pathname = url?.pathname.replace(replaceValue || '', '')
+
     if (url && pathname && POSTHOG_PATHS_TO_IGNORE.some((path) => pathname.indexOf(path) === 0)) {
         return undefined
     }

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -98,7 +98,15 @@ const POSTHOG_PATHS_TO_IGNORE = ['/s/', '/e/', '/i/']
 // because calls to PostHog would be reported using a call to PostHog which would be reported....
 const ignorePostHogPaths = (data: CapturedNetworkRequest): CapturedNetworkRequest | undefined => {
     const url = convertToURL(data.name)
-    if (url && url.pathname && POSTHOG_PATHS_TO_IGNORE.some((path) => url.pathname.indexOf(path) === 0)) {
+    if (
+        url &&
+        url.pathname &&
+        // matches our `/s/` path but also paths within a reverse proxy like `/ingest/s/`
+        POSTHOG_PATHS_TO_IGNORE.some((path) => url.pathname.indexOf(path) >= 0) &&
+        // since we're matching `/blah/` loosely, also check a couple of the query params we add
+        url.search.indexOf('ver=') >= 0 &&
+        url.search.indexOf('ip=') >= 0
+    ) {
         return undefined
     }
     return data


### PR DESCRIPTION
We check for `/s/`, `/e/`,  and `/i/` in URL's pathname and don't capture network payloads to them

But if you use a reverse proxy then the pathname won't necessarily be `/s/` e.g. some folk use `/ingest/s/` so we need a slightly different check

Otherwise when you visit one of these sites we endlessly send a network payload to ourselves recording that we just sent a network payload to ourselves etc