### PR TITLE
fix: safari support requires we don't use

### DIFF
--- a/src/extensions/replay/sessionrecording-utils.ts
+++ b/src/extensions/replay/sessionrecording-utils.ts
@@ -11,7 +11,7 @@ export function circularReferenceReplacer() {
         if (isObject(value)) {
             // `this` is the object that value is contained in,
             // i.e., its direct parent.
-            while (ancestors.length > 0 && ancestors.at(-1) !== this) {
+            while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
                 ancestors.pop()
             }
             if (ancestors.includes(value)) {


### PR DESCRIPTION
using `at` in the circular replacer copied from MDN implicitly moves us to safari 15.4+

it's not necessary to use `at` and tbh it's rare enough I can parse this version more easily 

should fix https://github.com/PostHog/posthog-js/issues/1518

