### PR TITLE
fix: catch mutation throttling errors

### DIFF
--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -62,5 +62,5 @@ jobs:
         run: pnpm testcafe ${{ matrix.browser }} --stop-on-first-fail
 
       - name: Check ${{ matrix.name }} events
-        timeout-minutes: 60
+        timeout-minutes: 120
         run: pnpm check-testcafe-results

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -54,7 +54,7 @@ jobs:
         run: pnpm build-rollup
 
       - name: Run ${{ matrix.name }} test
-        timeout-minutes: 10
+        timeout-minutes: 60
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
           RUN_ID: ${{ github.run_id }}
@@ -62,5 +62,5 @@ jobs:
         run: pnpm testcafe ${{ matrix.browser }} --stop-on-first-fail
 
       - name: Check ${{ matrix.name }} events
-        timeout-minutes: 10
+        timeout-minutes: 60
         run: pnpm check-testcafe-results

--- a/src/extensions/replay/mutation-rate-limiter.ts
+++ b/src/extensions/replay/mutation-rate-limiter.ts
@@ -112,7 +112,7 @@ export class MutationRateLimiter {
             }
             return event
         } catch (e) {
-            logger.warn('error throttling mutations', e)
+            logger.warn('[SessionRecording] error throttling mutations', e)
             return event
         }
     }


### PR DESCRIPTION
Am seeing reports of safari recordings not including incremental snapshots. 

This is a code route that incremental snapshots go through that other snapshots don't

I think this is totally a red herring but it is at least a safe change to make