### PR TITLE
feat: different default and max idle period

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -235,7 +235,11 @@ describe('SessionRecording', () => {
         const postHogPersistence = new PostHogPersistence(config)
         postHogPersistence.clear()
 
-        sessionManager = new SessionIdManager(config, postHogPersistence, sessionIdGeneratorMock, windowIdGeneratorMock)
+        sessionManager = new SessionIdManager(
+            { config, persistence: postHogPersistence, register: jest.fn() } as unknown as PostHog,
+            sessionIdGeneratorMock,
+            windowIdGeneratorMock
+        )
 
         // add capture hook returns an unsubscribe function
         removeCaptureHookMock = jest.fn()
@@ -1130,7 +1134,11 @@ describe('SessionRecording', () => {
                 let unsubscribeCallback: () => void
 
                 beforeEach(() => {
-                    sessionManager = new SessionIdManager(config, new PostHogPersistence(config))
+                    sessionManager = new SessionIdManager({
+                        config,
+                        persistence: new PostHogPersistence(config),
+                        register: jest.fn(),
+                    } as unknown as PostHog)
                     posthog.sessionManager = sessionManager
 
                     mockCallback = jest.fn()
@@ -1216,7 +1224,11 @@ describe('SessionRecording', () => {
 
             describe('with a real session id manager', () => {
                 beforeEach(() => {
-                    sessionManager = new SessionIdManager(config, new PostHogPersistence(config))
+                    sessionManager = new SessionIdManager({
+                        config,
+                        persistence: new PostHogPersistence(config),
+                        register: jest.fn(),
+                    } as unknown as PostHog)
                     posthog.sessionManager = sessionManager
 
                     sessionRecording.startIfEnabledOrStop()

--- a/src/__tests__/utils/number-utils.test.ts
+++ b/src/__tests__/utils/number-utils.test.ts
@@ -10,14 +10,78 @@ jest.mock('../../utils/logger', () => ({
 describe('number-utils', () => {
     describe('clampToRange', () => {
         it.each([
-            // [value, result, min, max, expected result, test description]
-            ['returns max when value is not a number', null, 10, 100, 100],
-            ['returns max when value is not a number', 'not-a-number', 10, 100, 100],
-            ['returns max when value is greater than max', 150, 10, 100, 100],
-            ['returns min when value is less than min', 5, 10, 100, 10],
-            ['returns the value when it is within the range', 50, 10, 100, 50],
-        ])('%s', (_description, value, min, max, expected) => {
-            const result = clampToRange(value, min, max, 'Test Label')
+            [
+                'returns max when value is not a number',
+                {
+                    value: null,
+                    min: 10,
+                    max: 100,
+                    expected: 100,
+                    fallback: undefined,
+                },
+            ],
+            [
+                'returns max when value is not a number',
+                {
+                    value: 'not-a-number',
+                    min: 10,
+                    max: 100,
+                    expected: 100,
+                    fallback: undefined,
+                },
+            ],
+            [
+                'returns max when value is greater than max',
+                {
+                    value: 150,
+                    min: 10,
+                    max: 100,
+                    expected: 100,
+                    fallback: undefined,
+                },
+            ],
+            [
+                'returns min when value is less than min',
+                {
+                    value: 5,
+                    min: 10,
+                    max: 100,
+                    expected: 10,
+                    fallback: undefined,
+                },
+            ],
+            [
+                'returns the value when it is within the range',
+                {
+                    value: 50,
+                    min: 10,
+                    max: 100,
+                    expected: 50,
+                    fallback: undefined,
+                },
+            ],
+            [
+                'returns the fallback value when provided is not valid',
+                {
+                    value: 'invalid',
+                    min: 10,
+                    max: 100,
+                    expected: 20,
+                    fallback: 20,
+                },
+            ],
+            [
+                'returns the max value when fallback is not valid',
+                {
+                    value: 'invalid',
+                    min: 10,
+                    max: 75,
+                    expected: 75,
+                    fallback: '20',
+                },
+            ],
+        ])('%s', (_description, { value, min, max, expected, fallback }) => {
+            const result = clampToRange(value, min, max, 'Test Label', fallback)
             expect(result).toBe(expected)
         })
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -427,7 +427,7 @@ export class PostHog {
         this._retryQueue = new RetryQueue(this)
         this.__request_queue = []
 
-        this.sessionManager = new SessionIdManager(this.config, this.persistence)
+        this.sessionManager = new SessionIdManager(this)
         this.sessionPropsManager = new SessionPropsManager(this.sessionManager, this.persistence)
 
         new TracingHeaders(this).startIfEnabledOrStop()

--- a/src/sessionid.ts
+++ b/src/sessionid.ts
@@ -10,9 +10,10 @@ import { logger } from './utils/logger'
 
 import { clampToRange } from './utils/number-utils'
 
-const MAX_SESSION_IDLE_TIMEOUT = 30 * 60 // 30 minutes
-const MIN_SESSION_IDLE_TIMEOUT = 60 // 1 minute
-const SESSION_LENGTH_LIMIT = 24 * 3600 * 1000 // 24 hours
+const DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS = 30 * 60 // 30 minutes
+const MAX_SESSION_IDLE_TIMEOUT_SECONDS = 10 * 60 * 60 // 10 hours
+const MIN_SESSION_IDLE_TIMEOUT_SECONDS = 60 // 1 minute
+const SESSION_LENGTH_LIMIT_MILLISECONDS = 24 * 3600 * 1000 // 24 hours
 
 export class SessionIdManager {
     private readonly _sessionIdGenerator: () => string
@@ -46,12 +47,12 @@ export class SessionIdManager {
 
         const persistenceName = config['persistence_name'] || config['token']
 
-        const desiredTimeout = config['session_idle_timeout_seconds'] || MAX_SESSION_IDLE_TIMEOUT
+        const desiredTimeout = config['session_idle_timeout_seconds'] || DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS
         this._sessionTimeoutMs =
             clampToRange(
                 desiredTimeout,
-                MIN_SESSION_IDLE_TIMEOUT,
-                MAX_SESSION_IDLE_TIMEOUT,
+                MIN_SESSION_IDLE_TIMEOUT_SECONDS,
+                MAX_SESSION_IDLE_TIMEOUT_SECONDS,
                 'session_idle_timeout_seconds'
             ) * 1000
 
@@ -218,7 +219,7 @@ export class SessionIdManager {
         const sessionPastMaximumLength =
             isNumber(startTimestamp) &&
             startTimestamp > 0 &&
-            Math.abs(timestamp - startTimestamp) > SESSION_LENGTH_LIMIT
+            Math.abs(timestamp - startTimestamp) > SESSION_LENGTH_LIMIT_MILLISECONDS
 
         let valuesChanged = false
         const noSessionId = !sessionId

--- a/src/sessionid.ts
+++ b/src/sessionid.ts
@@ -9,9 +9,10 @@ import { isArray, isNumber, isUndefined } from './utils/type-utils'
 import { logger } from './utils/logger'
 
 import { clampToRange } from './utils/number-utils'
+import { PostHog } from './posthog-core'
 
-const DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS = 30 * 60 // 30 minutes
-const MAX_SESSION_IDLE_TIMEOUT_SECONDS = 10 * 60 * 60 // 10 hours
+export const DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS = 30 * 60 // 30 minutes
+export const MAX_SESSION_IDLE_TIMEOUT_SECONDS = 10 * 60 * 60 // 10 hours
 const MIN_SESSION_IDLE_TIMEOUT_SECONDS = 60 // 1 minute
 const SESSION_LENGTH_LIMIT_MILLISECONDS = 24 * 3600 * 1000 // 24 hours
 
@@ -30,14 +31,13 @@ export class SessionIdManager {
     private _sessionIdChangedHandlers: SessionIdChangedCallback[] = []
     private readonly _sessionTimeoutMs: number
 
-    constructor(
-        config: Partial<PostHogConfig>,
-        persistence: PostHogPersistence,
-        sessionIdGenerator?: () => string,
-        windowIdGenerator?: () => string
-    ) {
-        this.config = config
-        this.persistence = persistence
+    constructor(instance: PostHog, sessionIdGenerator?: () => string, windowIdGenerator?: () => string) {
+        if (!instance.persistence) {
+            throw new Error('SessionIdManager requires a PostHogPersistence instance')
+        }
+
+        this.config = instance.config
+        this.persistence = instance.persistence
         this._windowId = undefined
         this._sessionId = undefined
         this._sessionStartTimestamp = null
@@ -45,16 +45,19 @@ export class SessionIdManager {
         this._sessionIdGenerator = sessionIdGenerator || uuidv7
         this._windowIdGenerator = windowIdGenerator || uuidv7
 
-        const persistenceName = config['persistence_name'] || config['token']
+        const persistenceName = this.config['persistence_name'] || this.config['token']
 
-        const desiredTimeout = config['session_idle_timeout_seconds'] || DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS
+        const desiredTimeout = this.config['session_idle_timeout_seconds'] || DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS
         this._sessionTimeoutMs =
             clampToRange(
                 desiredTimeout,
                 MIN_SESSION_IDLE_TIMEOUT_SECONDS,
                 MAX_SESSION_IDLE_TIMEOUT_SECONDS,
-                'session_idle_timeout_seconds'
+                'session_idle_timeout_seconds',
+                DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS
             ) * 1000
+
+        instance.register({ $configured_session_timeout_ms: this._sessionTimeoutMs })
 
         this._window_id_storage_key = 'ph_' + persistenceName + '_window_id'
         this._primary_window_exists_storage_key = 'ph_' + persistenceName + '_primary_window_exists'

--- a/src/utils/number-utils.ts
+++ b/src/utils/number-utils.ts
@@ -1,15 +1,26 @@
 import { isNumber } from './type-utils'
 import { logger } from './logger'
 
-export function clampToRange(value: unknown, min: number, max: number, label?: string): number {
+/**
+ * Clamps a value to a range.
+ * @param value the value to clamp
+ * @param min the minimum value
+ * @param max the maximum value
+ * @param label if provided then enables logging and prefixes all logs with labels
+ * @param fallbackValue if provided then returns this value if the value is not a valid number
+ */
+export function clampToRange(value: unknown, min: number, max: number, label?: string, fallbackValue?: number): number {
     if (min > max) {
         logger.warn('min cannot be greater than max.')
         min = max
     }
 
     if (!isNumber(value)) {
-        label && logger.warn(label + ' must be a number. Defaulting to max value:' + max)
-        return max
+        label &&
+            logger.warn(
+                label + ' must be a number. using max or fallback. max: ' + max + ', fallback: ' + fallbackValue
+            )
+        return clampToRange(fallbackValue || max, min, max, label)
     } else if (value > max) {
         label && logger.warn(label + ' cannot be  greater than max: ' + max + '. Using max value instead.')
         return max


### PR DESCRIPTION
allow configuring an idle timeout larger than the default

see https://posthog.slack.com/archives/C07RUA1TBT3/p1732619524510359

the motivation for the user here is that their product might be used by someone before they leave for the day, and then once they return, and those two interactions are logically one session. the second might follow-on from the first.