### PR TITLE
feat: Add initial person info to cookie when using localPlusCookieStore

### DIFF
--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -3,6 +3,7 @@ import { uuidv7 } from '../uuidv7'
 import { logger } from '../utils/logger'
 import { INITIAL_CAMPAIGN_PARAMS, INITIAL_REFERRER_INFO } from '../constants'
 import { DecideResponse } from '../types'
+import { window } from '../utils/globals'
 
 jest.mock('../utils/logger')
 
@@ -244,6 +245,75 @@ describe('person processing', () => {
             expect(eventS1[0].$set_once).toEqual(undefined)
 
             expect(eventS2Before[0].$set_once).toEqual(undefined)
+
+            expect(eventS2Identify[0].event).toEqual('$identify')
+            expect(eventS2Identify[0].$set_once).toEqual({
+                ...INITIAL_CAMPAIGN_PARAMS_NULL,
+                $initial_current_url: 'https://example1.com/pathname1?utm_source=foo1',
+                $initial_host: 'example1.com',
+                $initial_pathname: '/pathname1',
+                $initial_referrer: 'https://referrer1.com',
+                $initial_referring_domain: 'referrer1.com',
+                $initial_utm_source: 'foo1',
+            })
+
+            expect(eventS2After[0].event).toEqual('event s2 after identify')
+            expect(eventS2After[0].$set_once).toEqual({
+                ...INITIAL_CAMPAIGN_PARAMS_NULL,
+                $initial_current_url: 'https://example1.com/pathname1?utm_source=foo1',
+                $initial_host: 'example1.com',
+                $initial_pathname: '/pathname1',
+                $initial_referrer: 'https://referrer1.com',
+                $initial_referring_domain: 'referrer1.com',
+                $initial_utm_source: 'foo1',
+            })
+        })
+
+        it('should preserve initial referrer info across subdomain', async () => {
+            const persistenceName = uuidv7()
+
+            // arrange
+            const { posthog: posthog1, beforeSendMock: beforeSendMock1 } = await setup(
+                'identified_only',
+                undefined,
+                persistenceName
+            )
+            mockReferrerGetter.mockReturnValue('https://referrer1.com')
+            mockURLGetter.mockReturnValue('https://example1.com/pathname1?utm_source=foo1')
+
+            // act
+            // subdomain 1
+            posthog1.register({ testProp: 'foo' })
+            posthog1.capture('event s1')
+
+            // clear localstorage, but not cookies, to simulate changing subdomain
+            window.localStorage.clear()
+
+            // subdomain 2
+            const { posthog: posthog2, beforeSendMock: beforeSendMock2 } = await setup(
+                'identified_only',
+                undefined,
+                persistenceName
+            )
+
+            mockReferrerGetter.mockReturnValue('https://referrer2.com')
+            mockURLGetter.mockReturnValue('https://example2.com/pathname2?utm_source=foo2')
+            posthog2.capture('event s2 before identify')
+            posthog2.identify(distinctId)
+            posthog2.capture('event s2 after identify')
+
+            // assert
+            const eventS1 = beforeSendMock1.mock.calls[0]
+            const eventS2Before = beforeSendMock2.mock.calls[0]
+            const eventS2Identify = beforeSendMock2.mock.calls[1]
+            const eventS2After = beforeSendMock2.mock.calls[2]
+
+            expect(eventS1[0].$set_once).toEqual(undefined)
+            expect(eventS1[0].properties.testProp).toEqual('foo')
+
+            expect(eventS2Before[0].$set_once).toEqual(undefined)
+            // most properties are lost across subdomain, that's intentional as we don't want to save too many things in cookies
+            expect(eventS2Before[0].properties.testProp).toEqual(undefined)
 
             expect(eventS2Identify[0].event).toEqual('$identify')
             expect(eventS2Identify[0].$set_once).toEqual({

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -3,7 +3,6 @@ import { uuidv7 } from '../uuidv7'
 import { logger } from '../utils/logger'
 import { INITIAL_CAMPAIGN_PARAMS, INITIAL_REFERRER_INFO } from '../constants'
 import { DecideResponse } from '../types'
-import { window } from '../utils/globals'
 
 jest.mock('../utils/logger')
 
@@ -38,6 +37,7 @@ jest.mock('../utils/globals', () => {
     const orig = jest.requireActual('../utils/globals')
     const mockURLGetter = jest.fn()
     const mockReferrerGetter = jest.fn()
+    let mockedCookieVal = ''
     return {
         ...orig,
         mockURLGetter,
@@ -51,6 +51,12 @@ jest.mock('../utils/globals', () => {
             get URL() {
                 return mockURLGetter()
             },
+            get cookie() {
+                return mockedCookieVal
+            },
+            set cookie(value: string) {
+                mockedCookieVal = value
+            },
         },
         get location() {
             const url = mockURLGetter()
@@ -63,7 +69,7 @@ jest.mock('../utils/globals', () => {
 })
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { mockURLGetter, mockReferrerGetter } = require('../utils/globals')
+const { mockURLGetter, mockReferrerGetter, document } = require('../utils/globals')
 
 describe('person processing', () => {
     const distinctId = '123'
@@ -71,6 +77,7 @@ describe('person processing', () => {
         console.error = jest.fn()
         mockReferrerGetter.mockReturnValue('https://referrer.com')
         mockURLGetter.mockReturnValue('https://example.com?utm_source=foo')
+        document.cookie = ''
     })
 
     const setup = async (

--- a/src/__tests__/posthog-persistence.test.ts
+++ b/src/__tests__/posthog-persistence.test.ts
@@ -1,6 +1,6 @@
 /// <reference lib="dom" />
 import { PostHogPersistence } from '../posthog-persistence'
-import { SESSION_ID, USER_STATE } from '../constants'
+import { INITIAL_PERSON_INFO, SESSION_ID, USER_STATE } from '../constants'
 import { PostHogConfig } from '../types'
 import Mock = jest.Mock
 import { PostHog } from '../posthog-core'
@@ -160,6 +160,15 @@ describe('persistence', () => {
                 })}`
             )
 
+            lib.register({ [INITIAL_PERSON_INFO]: { u: 'https://www.example.com', r: 'https://www.referrer.com' } })
+            expect(document.cookie).toContain(
+                `ph__posthog=${encode({
+                    distinct_id: 'test',
+                    $sesid: [1000, 'sid', 2000],
+                    $initial_person_info: { u: 'https://www.example.com', r: 'https://www.referrer.com' },
+                })}`
+            )
+
             // Clear localstorage to simulate being on a different domain
             localStorage.clear()
 
@@ -168,6 +177,7 @@ describe('persistence', () => {
             expect(newLib.props).toEqual({
                 distinct_id: 'test',
                 $sesid: [1000, 'sid', 2000],
+                $initial_person_info: { u: 'https://www.example.com', r: 'https://www.referrer.com' },
             })
         })
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,12 @@
 import { extend } from './utils'
 import { PersistentStore, Properties } from './types'
-import { DISTINCT_ID, ENABLE_PERSON_PROCESSING, SESSION_ID, SESSION_RECORDING_IS_SAMPLED } from './constants'
+import {
+    DISTINCT_ID,
+    ENABLE_PERSON_PROCESSING,
+    INITIAL_PERSON_INFO,
+    SESSION_ID,
+    SESSION_RECORDING_IS_SAMPLED,
+} from './constants'
 
 import { isNull, isUndefined } from './utils/type-utils'
 import { logger } from './utils/logger'
@@ -248,7 +254,13 @@ export const localStore: PersistentStore = {
 // Use localstorage for most data but still use cookie for COOKIE_PERSISTED_PROPERTIES
 // This solves issues with cookies having too much data in them causing headers too large
 // Also makes sure we don't have to send a ton of data to the server
-const COOKIE_PERSISTED_PROPERTIES = [DISTINCT_ID, SESSION_ID, SESSION_RECORDING_IS_SAMPLED, ENABLE_PERSON_PROCESSING]
+const COOKIE_PERSISTED_PROPERTIES = [
+    DISTINCT_ID,
+    SESSION_ID,
+    SESSION_RECORDING_IS_SAMPLED,
+    ENABLE_PERSON_PROCESSING,
+    INITIAL_PERSON_INFO,
+]
 
 export const localPlusCookieStore: PersistentStore = {
     ...localStore,

--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -164,8 +164,8 @@ export const Info = {
     initialPersonInfo: function (): Record<string, any> {
         // we're being a bit more economical with bytes here because this is stored in the cookie
         return {
-            r: this.referrer().substring(1000),
-            u: location?.href.substring(1000),
+            r: this.referrer().substring(0, 1000),
+            u: location?.href.substring(0, 1000),
         }
     },
 

--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -164,8 +164,8 @@ export const Info = {
     initialPersonInfo: function (): Record<string, any> {
         // we're being a bit more economical with bytes here because this is stored in the cookie
         return {
-            r: this.referrer(),
-            u: location?.href,
+            r: this.referrer().substring(1000),
+            u: location?.href.substring(1000),
         }
     },
 


### PR DESCRIPTION
## Changes

Fixes https://github.com/PostHog/posthog-js/issues/1524 by moving the initial person info to the cookie

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
