### PR TITLE
fix: catch errors detecting dialog state when recording

### DIFF
--- a/patches/@rrweb__record@2.0.0-alpha.17.patch
+++ b/patches/@rrweb__record@2.0.0-alpha.17.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/record.js b/dist/record.js
-index 46ec389fefb698243008b39db65470dbdf0a3857..891e1cf6439630d19e9b745ff428db438943a0b2 100644
+index 46ec389fefb698243008b39db65470dbdf0a3857..bfebdc6a3887a3ddae46b21d21896092d2963fe9 100644
 --- a/dist/record.js
 +++ b/dist/record.js
 @@ -26,6 +26,14 @@ const testableMethods$1 = {
@@ -54,7 +54,24 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..891e1cf6439630d19e9b745ff428db43
      let cssText = null;
      if (stylesheet) {
        cssText = stringifyStylesheet(stylesheet);
-@@ -1116,7300 +1132,227 @@ function serializeNodeWithId(n2, options) {
+@@ -855,7 +871,15 @@ function serializeElementNode(n2, options) {
+     }
+   }
+   if (tagName === "dialog" && n2.open) {
+-    attributes.rr_open_mode = n2.matches("dialog:modal") ? "modal" : "non-modal";
++    try {
++      attributes.rr_open_mode = n2.matches("dialog:modal") ? "modal" : "non-modal";
++    } catch {
++      // likely this is safari not able to deal with the `:modal` selector
++      // we can't detect whether the dialog is modal or non-modal open, so have to guess
++      // hopefully this is only safari 15.4 and 15.5
++      attributes.rr_open_mode = "modal"
++      attributes.ph_rr_could_not_detect_modal = true
++    }
+   }
+   if (tagName === "canvas" && recordCanvas) {
+     if (n2.__context === "2d") {
+@@ -1116,7300 +1140,227 @@ function serializeNodeWithId(n2, options) {
        keepIframeSrcFn
      };
      if (serializedNode.type === NodeType$2.Element && serializedNode.tagName === "textarea" && serializedNode.attributes.value !== void 0) ;
@@ -7564,7 +7581,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..891e1cf6439630d19e9b745ff428db43
  class BaseRRNode {
    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
    constructor(..._args) {
-@@ -8507,7 +1450,7 @@ function getUntaintedPrototype(key) {
+@@ -8507,7 +1458,7 @@ function getUntaintedPrototype(key) {
        }
      )
    );
@@ -7573,7 +7590,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..891e1cf6439630d19e9b745ff428db43
      untaintedBasePrototype[key] = defaultObj.prototype;
      return defaultObj.prototype;
    }
-@@ -11382,11 +4325,19 @@ class CanvasManager {
+@@ -11382,11 +4333,19 @@ class CanvasManager {
      let rafId;
      const getCanvas = () => {
        const matchedCanvas = [];
@@ -7598,7 +7615,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..891e1cf6439630d19e9b745ff428db43
        return matchedCanvas;
      };
      const takeCanvasSnapshots = (timestamp) => {
-@@ -11407,13 +4358,20 @@ class CanvasManager {
+@@ -11407,13 +4366,20 @@ class CanvasManager {
              context.clear(context.COLOR_BUFFER_BIT);
            }
          }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@rrweb/record@2.0.0-alpha.17':
-    hash: vxikte2wlhu3ltbso5lzopaskq
+    hash: c2gbrcq5pbh4ogznn2cbid5ple
     path: patches/@rrweb__record@2.0.0-alpha.17.patch
   '@rrweb/rrweb-plugin-console-record@2.0.0-alpha.17':
     hash: ytsspyi7p3hvqcq64vqb7wb6bu
@@ -74,7 +74,7 @@ devDependencies:
     version: 12.1.1(rollup@4.24.0)(tslib@2.5.0)(typescript@5.5.4)
   '@rrweb/record':
     specifier: 2.0.0-alpha.17
-    version: 2.0.0-alpha.17(patch_hash=vxikte2wlhu3ltbso5lzopaskq)
+    version: 2.0.0-alpha.17(patch_hash=c2gbrcq5pbh4ogznn2cbid5ple)
   '@rrweb/rrweb-plugin-console-record':
     specifier: 2.0.0-alpha.17
     version: 2.0.0-alpha.17(patch_hash=ytsspyi7p3hvqcq64vqb7wb6bu)(rrweb@2.0.0-alpha.17)
@@ -2870,7 +2870,7 @@ packages:
     dev: true
     optional: true
 
-  /@rrweb/record@2.0.0-alpha.17(patch_hash=vxikte2wlhu3ltbso5lzopaskq):
+  /@rrweb/record@2.0.0-alpha.17(patch_hash=c2gbrcq5pbh4ogznn2cbid5ple):
     resolution: {integrity: sha512-Je+lzjeWMF8/I0IDoXFzkGPKT8j7AkaBup5YcwUHlkp18VhLVze416MvI6915teE27uUA2ScXMXzG0Yiu5VTIw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.17


### PR DESCRIPTION
see https://github.com/PostHog/posthog-js/issues/1561 which points at an error in using the `:modal` pseudo selector

it does appear that safari started supporting the dialog element in 15.4 and the `:modal ` selector in 15.6

