### PR TITLE
feat(cdp): allow disabling site destinations

### DIFF
--- a/playground/nextjs/src/posthog.ts
+++ b/playground/nextjs/src/posthog.ts
@@ -60,6 +60,7 @@ if (typeof window !== 'undefined') {
         persistence_name: `${process.env.NEXT_PUBLIC_POSTHOG_KEY}_nextjs`,
         ...configForConsent(),
     })
+
     // Help with debugging(window as any).posthog = posthog
 }
 

--- a/playground/nextjs/src/posthog.ts
+++ b/playground/nextjs/src/posthog.ts
@@ -60,7 +60,7 @@ if (typeof window !== 'undefined') {
         persistence_name: `${process.env.NEXT_PUBLIC_POSTHOG_KEY}_nextjs`,
         ...configForConsent(),
     })
-
+    ;(window as any).posthog = posthog
     // Help with debugging(window as any).posthog = posthog
 }
 

--- a/playground/nextjs/src/posthog.ts
+++ b/playground/nextjs/src/posthog.ts
@@ -28,7 +28,6 @@ export const configForConsent = (): Partial<PostHogConfig> => {
     return {
         persistence: consentGiven ? 'localStorage+cookie' : 'memory',
         disable_surveys: !consentGiven,
-        disable_site_apps_destinations: !consentGiven,
         autocapture: consentGiven,
         disable_session_recording: !consentGiven,
     }
@@ -37,8 +36,10 @@ export const configForConsent = (): Partial<PostHogConfig> => {
 export const updatePostHogConsent = (consentGiven: boolean) => {
     if (consentGiven) {
         localStorage.setItem('cookie_consent', 'true')
+        posthog.opt_in_capturing()
     } else {
         localStorage.removeItem('cookie_consent')
+        posthog.opt_out_capturing()
     }
 
     posthog.set_config(configForConsent())

--- a/playground/nextjs/src/posthog.ts
+++ b/playground/nextjs/src/posthog.ts
@@ -28,6 +28,7 @@ export const configForConsent = (): Partial<PostHogConfig> => {
     return {
         persistence: consentGiven ? 'localStorage+cookie' : 'memory',
         disable_surveys: !consentGiven,
+        disable_site_apps_destinations: !consentGiven,
         autocapture: consentGiven,
         disable_session_recording: !consentGiven,
     }
@@ -49,6 +50,7 @@ if (typeof window !== 'undefined') {
         session_recording: {
             recordCrossOriginIframes: true,
         },
+        opt_in_site_apps: true,
         debug: true,
         disable_web_experiments: false,
         scroll_root_selector: ['#scroll_element', 'html'],

--- a/playground/nextjs/src/posthog.ts
+++ b/playground/nextjs/src/posthog.ts
@@ -60,7 +60,6 @@ if (typeof window !== 'undefined') {
         persistence_name: `${process.env.NEXT_PUBLIC_POSTHOG_KEY}_nextjs`,
         ...configForConsent(),
     })
-    ;(window as any).posthog = posthog
     // Help with debugging(window as any).posthog = posthog
 }
 

--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -250,7 +250,7 @@ describe('SiteApps', () => {
 
             siteAppsInstance.afterDecideResponse(response)
 
-            expect(assignableWindow['__$$ph_site_app_8_posthog']).toBe(posthog)
+            expect(assignableWindow['__$$ph_site_app_8']).toBe(posthog)
             expect(typeof assignableWindow['__$$ph_site_app_8_missed_invocations']).toBe('function')
             expect(typeof assignableWindow['__$$ph_site_app_8_callback']).toBe('function')
             expect(assignableWindow.__PosthogExtensions__?.loadSiteApp).toHaveBeenCalledWith(

--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -200,7 +200,7 @@ describe('SiteApps', () => {
             siteAppsInstance.afterDecideResponse(response)
 
             expect(siteAppsInstance.loaded).toBe(true)
-            expect(siteAppsInstance._decideServerResponse.length).toBe(0)
+            expect(siteAppsInstance._decideServerSiteAppsResponse.length).toBe(0)
         })
 
         it('loads site apps when enabled and opt_in_site_apps is true', (done) => {

--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -95,8 +95,16 @@ describe('SiteApps', () => {
     })
 
     describe('eventCollector', () => {
-        it('does nothing if enabled is false', () => {
+        it('does nothing if opt_in_site_apps is false', () => {
             posthog.config.opt_in_site_apps = false
+            siteAppsInstance.eventCollector('event_name', {} as CaptureResult)
+
+            expect(siteAppsInstance.missedInvocations.length).toBe(0)
+        })
+
+        it('does nothing if decide is disabled', () => {
+            posthog.config.opt_in_site_apps = true
+            posthog.config.advanced_disable_decide = true
             siteAppsInstance.eventCollector('event_name', {} as CaptureResult)
 
             expect(siteAppsInstance.missedInvocations.length).toBe(0)

--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -313,5 +313,25 @@ describe('SiteApps', () => {
             expect(typeof assignableWindow['__$$ph_site_app_5_callback']).toBe('function')
             expect(typeof assignableWindow['__$$ph_site_app_6_callback']).toBe('undefined')
         })
+
+        it('load site destinations if consent is given at a later time', () => {
+            posthog.config.opt_in_site_apps = true
+            posthog.consent.isOptedOut = () => true
+            const response = {
+                siteApps: [
+                    { id: '5', type: 'site_app', url: '/site_app/5' },
+                    { id: '6', type: 'site_destination', url: '/site_app/6' },
+                ],
+            } as DecideResponse
+
+            siteAppsInstance.afterDecideResponse(response)
+
+            posthog.consent.isOptedOut = () => false
+
+            siteAppsInstance.loadIfEnabled()
+
+            expect(typeof assignableWindow['__$$ph_site_app_5_callback']).toBe('function')
+            expect(typeof assignableWindow['__$$ph_site_app_6_callback']).toBe('function')
+        })
     })
 })

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -814,6 +814,12 @@ export class PostHog {
         if (this.config.store_google) {
             this.sessionPersistence.update_campaign_params()
         }
+        if (this.config.save_referrer) {
+            this.sessionPersistence.update_referrer_info()
+        }
+        if (this.config.store_google || this.config.save_referrer) {
+            this.persistence.set_initial_person_info()
+        }
 
         if (this.consent.isOptedOut()) {
             return
@@ -840,16 +846,6 @@ export class PostHog {
 
         // update persistence
         this.sessionPersistence.update_search_keyword()
-
-        // The initial campaign/referrer props need to be stored in the regular persistence, as they are there to mimic
-        // the person-initial props. The non-initial versions are stored in the sessionPersistence, as they are sent
-        // with every event and used by the session table to create session-initial props.
-        if (this.config.save_referrer) {
-            this.sessionPersistence.update_referrer_info()
-        }
-        if (this.config.store_google || this.config.save_referrer) {
-            this.persistence.set_initial_person_info()
-        }
 
         const systemTime = new Date()
         const timestamp = options?.timestamp || systemTime

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -145,6 +145,7 @@ export const defaultConfig = (): PostHogConfig => ({
     disable_persistence: false,
     disable_web_experiments: true, // disabled in beta.
     disable_surveys: false,
+    disable_site_apps_destinations: false,
     enable_recording_console_log: undefined, // When undefined, it falls back to the server-side setting
     secure_cookie: window?.location?.protocol === 'https:',
     ip: true,
@@ -308,6 +309,7 @@ export class PostHog {
         this.scrollManager = new ScrollManager(this)
         this.pageViewManager = new PageViewManager(this)
         this.surveys = new PostHogSurveys(this)
+        this.siteApps = new SiteApps(this)
         this.experiments = new WebExperiments(this)
         this.exceptions = new PostHogExceptions(this)
         this.rateLimiter = new RateLimiter(this)
@@ -434,7 +436,6 @@ export class PostHog {
 
         new TracingHeaders(this).startIfEnabledOrStop()
 
-        this.siteApps = new SiteApps(this)
         this.siteApps?.init()
 
         this.sessionRecording = new SessionRecording(this)
@@ -1828,6 +1829,7 @@ export class PostHog {
             this.autocapture?.startIfEnabled()
             this.heatmaps?.startIfEnabled()
             this.surveys.loadIfEnabled()
+            this.siteApps?.loadIfEnabled()
             this._sync_opt_out_with_persistence()
         }
     }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1828,7 +1828,7 @@ export class PostHog {
             this.autocapture?.startIfEnabled()
             this.heatmaps?.startIfEnabled()
             this.surveys.loadIfEnabled()
-            this.siteApps?.loadIfEnabled()
+            // this.siteApps?.loadIfEnabled()
             this._sync_opt_out_with_persistence()
         }
     }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1828,7 +1828,7 @@ export class PostHog {
             this.autocapture?.startIfEnabled()
             this.heatmaps?.startIfEnabled()
             this.surveys.loadIfEnabled()
-            // this.siteApps?.loadIfEnabled()
+            this.siteApps?.loadIfEnabled()
             this._sync_opt_out_with_persistence()
         }
     }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -145,7 +145,6 @@ export const defaultConfig = (): PostHogConfig => ({
     disable_persistence: false,
     disable_web_experiments: true, // disabled in beta.
     disable_surveys: false,
-    disable_site_apps_destinations: false,
     enable_recording_console_log: undefined, // When undefined, it falls back to the server-side setting
     secure_cookie: window?.location?.protocol === 'https:',
     ip: true,

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -808,6 +808,13 @@ export class PostHog {
             return
         }
 
+        // The initial campaign/referrer props need to be stored in the regular persistence, as they are there to mimic
+        // the person-initial props. The non-initial versions are stored in the sessionPersistence, as they are sent
+        // with every event and used by the session table to create session-initial props.
+        if (this.config.store_google) {
+            this.sessionPersistence.update_campaign_params()
+        }
+
         if (this.consent.isOptedOut()) {
             return
         }
@@ -837,9 +844,6 @@ export class PostHog {
         // The initial campaign/referrer props need to be stored in the regular persistence, as they are there to mimic
         // the person-initial props. The non-initial versions are stored in the sessionPersistence, as they are sent
         // with every event and used by the session table to create session-initial props.
-        if (this.config.store_google) {
-            this.sessionPersistence.update_campaign_params()
-        }
         if (this.config.save_referrer) {
             this.sessionPersistence.update_referrer_info()
         }

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -85,10 +85,7 @@ export class SiteApps {
                     // Stop collecting events once all site apps are loaded
                     if (this.appsLoading.size === 0) {
                         this.loaded = true
-                        // only clear missedInvocations after site_destinations have been loaded
-                        if (!this.instance.consent.isOptedOut()) {
-                            this.missedInvocations = []
-                        }
+                        this.missedInvocations = []
                     }
                 }
                 for (const { id, type, url } of this._decideServerSiteAppsResponse) {
@@ -118,6 +115,8 @@ export class SiteApps {
             } else {
                 this.loaded = true
             }
+        } else {
+            this.loaded = true
         }
     }
 

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -2,7 +2,7 @@ import { PostHog } from './posthog-core'
 import { CaptureResult, DecideResponse } from './types'
 import { assignableWindow } from './utils/globals'
 import { logger } from './utils/logger'
-import { isArray } from './utils/type-utils'
+import { isArray, isUndefined } from './utils/type-utils'
 
 export class SiteApps {
     private _decideServerResponse?: DecideResponse['siteApps']
@@ -89,10 +89,10 @@ export class SiteApps {
                     }
                 }
                 for (const { id, type, url } of this._decideServerResponse) {
+                    // if consent isn't given, skip site destinations
                     if (this.instance.consent.isOptedOut() && type === 'site_destination') continue
                     // if the site app is already loaded, skip it
-                    // eslint-disable-next-line no-restricted-globals
-                    if (`__$$ph_site_app_${id}_posthog` in window) continue
+                    if (!isUndefined(assignableWindow[`__$$ph_site_app_${id}_posthog`])) continue
                     this.appsLoading.add(id)
                     assignableWindow[`__$$ph_site_app_${id}_posthog`] = this.instance
                     assignableWindow[`__$$ph_site_app_${id}_missed_invocations`] = () => this.missedInvocations

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -90,15 +90,9 @@ export class SiteApps {
                 }
                 for (const { id, type, url } of this._decideServerSiteAppsResponse) {
                     // if consent isn't given, skip site destinations
-                    if (this.instance.consent.isOptedOut() && type === 'site_destination') {
-                        checkIfAllLoaded()
-                        continue
-                    }
+                    if (this.instance.consent.isOptedOut() && type === 'site_destination') continue
                     // if the site app is already loaded, skip it
-                    if (!isUndefined(assignableWindow[`__$$ph_site_app_${id}_posthog`])) {
-                        checkIfAllLoaded()
-                        continue
-                    }
+                    if (!isUndefined(assignableWindow[`__$$ph_site_app_${id}_posthog`])) continue
                     this.appsLoading.add(id)
                     assignableWindow[`__$$ph_site_app_${id}_posthog`] = this.instance
                     assignableWindow[`__$$ph_site_app_${id}_missed_invocations`] = () => this.missedInvocations
@@ -114,6 +108,7 @@ export class SiteApps {
                         }
                     })
                 }
+                checkIfAllLoaded()
             } else if (this._decideServerSiteAppsResponse.length > 0) {
                 logger.error('PostHog site apps are disabled. Enable the "opt_in_site_apps" config to proceed.')
                 this.loaded = true

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -85,7 +85,10 @@ export class SiteApps {
                     // Stop collecting events once all site apps are loaded
                     if (this.appsLoading.size === 0) {
                         this.loaded = true
-                        this.missedInvocations = []
+                        // only clear missedInvocations after site_destinations have been loaded
+                        if (!this.instance.consent.isOptedOut()) {
+                            this.missedInvocations = []
+                        }
                     }
                 }
                 for (const { id, type, url } of this._decideServerSiteAppsResponse) {
@@ -115,8 +118,6 @@ export class SiteApps {
             } else {
                 this.loaded = true
             }
-        } else {
-            this.loaded = true
         }
     }
 

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -89,7 +89,7 @@ export class SiteApps {
                     }
                 }
                 for (const { id, type, url } of this._decideServerResponse) {
-                    if (this.instance.config.disable_site_apps_destinations && type === 'site_destination') continue
+                    if (this.instance.consent.isOptedOut() && type === 'site_destination') continue
                     // if the site app is already loaded, skip it
                     // eslint-disable-next-line no-restricted-globals
                     if (`__$$ph_site_app_${id}_posthog` in window) continue

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -92,7 +92,7 @@ export class SiteApps {
                     // if consent isn't given, skip site destinations
                     if (this.instance.consent.isOptedOut() && type === 'site_destination') continue
                     // if the site app is already loaded, skip it
-                    if (!isUndefined(assignableWindow[`__$$ph_site_app_${id}_posthog`])) continue
+                    if (!isUndefined(assignableWindow[`__$$ph_site_app_${id}`])) continue
                     this.appsLoading.add(id)
                     assignableWindow[`__$$ph_site_app_${id}`] = this.instance
                     assignableWindow[`__$$ph_site_app_${id}_missed_invocations`] = () => this.missedInvocations

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -5,7 +5,7 @@ import { logger } from './utils/logger'
 import { isArray, isUndefined } from './utils/type-utils'
 
 export class SiteApps {
-    private _decideServerResponse?: DecideResponse['siteApps']
+    _decideServerResponse?: DecideResponse['siteApps']
     missedInvocations: Record<string, any>[]
     loaded: boolean
     appsLoading: Set<string>
@@ -90,9 +90,15 @@ export class SiteApps {
                 }
                 for (const { id, type, url } of this._decideServerResponse) {
                     // if consent isn't given, skip site destinations
-                    if (this.instance.consent.isOptedOut() && type === 'site_destination') continue
+                    if (this.instance.consent.isOptedOut() && type === 'site_destination') {
+                        checkIfAllLoaded()
+                        continue
+                    }
                     // if the site app is already loaded, skip it
-                    if (!isUndefined(assignableWindow[`__$$ph_site_app_${id}_posthog`])) continue
+                    if (!isUndefined(assignableWindow[`__$$ph_site_app_${id}_posthog`])) {
+                        checkIfAllLoaded()
+                        continue
+                    }
                     this.appsLoading.add(id)
                     assignableWindow[`__$$ph_site_app_${id}_posthog`] = this.instance
                     assignableWindow[`__$$ph_site_app_${id}_missed_invocations`] = () => this.missedInvocations

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -94,7 +94,7 @@ export class SiteApps {
                     // if the site app is already loaded, skip it
                     if (!isUndefined(assignableWindow[`__$$ph_site_app_${id}_posthog`])) continue
                     this.appsLoading.add(id)
-                    assignableWindow[`__$$ph_site_app_${id}_posthog`] = this.instance
+                    assignableWindow[`__$$ph_site_app_${id}`] = this.instance
                     assignableWindow[`__$$ph_site_app_${id}_missed_invocations`] = () => this.missedInvocations
                     assignableWindow[`__$$ph_site_app_${id}_callback`] = () => {
                         this.appsLoading.delete(id)

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -5,7 +5,7 @@ import { logger } from './utils/logger'
 import { isArray, isUndefined } from './utils/type-utils'
 
 export class SiteApps {
-    _decideServerResponse?: DecideResponse['siteApps']
+    _decideServerSiteAppsResponse?: DecideResponse['siteApps']
     missedInvocations: Record<string, any>[]
     loaded: boolean
     appsLoading: Set<string>
@@ -74,9 +74,9 @@ export class SiteApps {
 
     loadIfEnabled() {
         if (
-            this._decideServerResponse &&
-            isArray(this._decideServerResponse) &&
-            this._decideServerResponse.length > 0
+            this._decideServerSiteAppsResponse &&
+            isArray(this._decideServerSiteAppsResponse) &&
+            this._decideServerSiteAppsResponse.length > 0
         ) {
             // can't use if site apps are disabled, or if we're not asking /decide for site apps
             const enabled = this.instance.config.opt_in_site_apps && !this.instance.config.advanced_disable_decide
@@ -88,7 +88,7 @@ export class SiteApps {
                         this.missedInvocations = []
                     }
                 }
-                for (const { id, type, url } of this._decideServerResponse) {
+                for (const { id, type, url } of this._decideServerSiteAppsResponse) {
                     // if consent isn't given, skip site destinations
                     if (this.instance.consent.isOptedOut() && type === 'site_destination') {
                         checkIfAllLoaded()
@@ -114,7 +114,7 @@ export class SiteApps {
                         }
                     })
                 }
-            } else if (this._decideServerResponse.length > 0) {
+            } else if (this._decideServerSiteAppsResponse.length > 0) {
                 logger.error('PostHog site apps are disabled. Enable the "opt_in_site_apps" config to proceed.')
                 this.loaded = true
             } else {
@@ -126,7 +126,7 @@ export class SiteApps {
     }
 
     afterDecideResponse(response: DecideResponse): void {
-        this._decideServerResponse = response['siteApps']
+        this._decideServerSiteAppsResponse = response['siteApps']
         this.loadIfEnabled()
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,6 +248,7 @@ export interface PostHogConfig {
     /** @deprecated - use `disable_persistence` instead  */
     disable_cookie?: boolean
     disable_surveys: boolean
+    disable_site_apps_destinations: boolean
     disable_web_experiments: boolean
     /** If set, posthog-js will never load external scripts such as those needed for Session Replay or Surveys. */
     disable_external_dependency_loading?: boolean
@@ -523,7 +524,7 @@ export interface DecideResponse {
     editorParams?: ToolbarParams /** @deprecated, renamed to toolbarParams, still present on older API responses */
     toolbarVersion: 'toolbar' /** @deprecated, moved to toolbarParams */
     isAuthenticated: boolean
-    siteApps: { id: string; url: string }[]
+    siteApps: { id: string; type: string; url: string }[]
     heatmaps?: boolean
     defaultIdentifiedOnly?: boolean
     captureDeadClicks?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,7 +248,6 @@ export interface PostHogConfig {
     /** @deprecated - use `disable_persistence` instead  */
     disable_cookie?: boolean
     disable_surveys: boolean
-    disable_site_apps_destinations: boolean
     disable_web_experiments: boolean
     /** If set, posthog-js will never load external scripts such as those needed for Session Replay or Surveys. */
     disable_external_dependency_loading?: boolean


### PR DESCRIPTION
## Changes

- Only load `site_destination`'s if `isOptedOut` is false
- site destinations will be loaded if `.opt_in_capturing()` is being called at a later point.
- Updated the nextjs example to call `opt_in_capturing` & `opt_out_capturing` based on the cookie banner ([link](https://github.com/PostHog/posthog-js/blob/site-apps-consent/playground/nextjs/src/posthog.ts))

![2024-11-27 at 15 18 40](https://github.com/user-attachments/assets/a46ed96d-e506-45a9-abc0-11f07ad5d75f)

TODOs:
- [x] add tests

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
