### PR TITLE
feat: Start tracking timezone offset and language prefix

### DIFF
--- a/src/__tests__/utils/event-utils.test.ts
+++ b/src/__tests__/utils/event-utils.test.ts
@@ -344,4 +344,35 @@ describe(`event-utils`, () => {
             }
         })
     })
+
+    describe('timezones', () => {
+        it('should compute timezone', () => {
+            const timezone = Info.timezone()
+            expect(typeof timezone).toBe('string')
+        })
+
+        it('should compute timezone offset as a number', () => {
+            const offset = Info.timezoneOffset()
+            expect(typeof offset).toBe('number')
+        })
+    })
+
+    describe('browser language', () => {
+        let languageGetter: jest.SpyInstance
+
+        beforeEach(() => {
+            languageGetter = jest.spyOn(window.navigator, 'language', 'get')
+            languageGetter.mockReturnValue('pt-BR')
+        })
+
+        it('should compute browser language', () => {
+            const language = Info.browserLanguage()
+            expect(language).toBe('pt-BR')
+        })
+
+        it('should compute browser language prefix', () => {
+            const languagePrefix = Info.browserLanguagePrefix()
+            expect(languagePrefix).toBe('pt')
+        })
+    })
 })

--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -130,11 +130,16 @@ export const Info = {
      */
     browserVersion: detectBrowserVersion,
 
-    browserLanguage: function (): string {
+    browserLanguage: function (): string | undefined {
         return (
             navigator.language || // Any modern browser
             (navigator as Record<string, any>).userLanguage // IE11
         )
+    },
+
+    browserLanguagePrefix: function (): string | undefined {
+        const browserLanguage = this.browserLanguage()
+        return typeof browserLanguage === 'string' ? browserLanguage.split('-')[0] : undefined
     },
 
     os: detectOS,
@@ -209,6 +214,14 @@ export const Info = {
         }
     },
 
+    timezoneOffset: function (): number | undefined {
+        try {
+            return new Date().getTimezoneOffset()
+        } catch {
+            return undefined
+        }
+    },
+
     properties: function (): Properties {
         if (!userAgent) {
             return {}
@@ -222,6 +235,7 @@ export const Info = {
                 $device: Info.device(userAgent),
                 $device_type: Info.deviceType(userAgent),
                 $timezone: Info.timezone(),
+                $timezone_offset: Info.timezoneOffset(),
             }),
             {
                 $current_url: location?.href,
@@ -230,6 +244,7 @@ export const Info = {
                 $raw_user_agent: userAgent.length > 1000 ? userAgent.substring(0, 997) + '...' : userAgent,
                 $browser_version: Info.browserVersion(userAgent, navigator.vendor),
                 $browser_language: Info.browserLanguage(),
+                $browser_language_prefix: Info.browserLanguagePrefix(),
                 $screen_height: window?.screen.height,
                 $screen_width: window?.screen.width,
                 $viewport_height: window?.innerHeight,


### PR DESCRIPTION
## Changes

We've recently launched a new feature on Web Analytics where you can filter views/visitors by timezone/language. Even though that was possible to do already, it is not as fast as it could be. We'll start feeding this information into the database directly from the SDK, this will allow us to, in the future, update our logic to use these properties directly, ditching the slow code.


## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
