### PR TITLE
fix: zone detection

### DIFF
--- a/patches/@rrweb__record@2.0.0-alpha.17.patch
+++ b/patches/@rrweb__record@2.0.0-alpha.17.patch
@@ -1,45 +1,32 @@
 diff --git a/dist/record.js b/dist/record.js
-index 46ec389fefb698243008b39db65470dbdf0a3857..6c62dab78676066344afb27976dd7d83a7e17c58 100644
+index 46ec389fefb698243008b39db65470dbdf0a3857..efc65d8c393de8d0ad35083cba315aef91a04c2c 100644
 --- a/dist/record.js
 +++ b/dist/record.js
-@@ -26,6 +26,27 @@ const testableMethods$1 = {
+@@ -26,6 +26,14 @@ const testableMethods$1 = {
    Element: [],
    MutationObserver: ["constructor"]
  };
-+const isFunction = (x) => typeof x === 'function';
-+const isAngularZonePatchedFunction = (x) => {
++
++const isAngularZonePresent = () => {
 +  try {
-+    if (!isFunction(x)) {
-+        return false;
-+    }
-+    // if Angular has a zone, then whatever this is could be tainted
-+    if (globalThis.Zone) {
-+      return true
-+    }
-+    for (const key of Object.getOwnPropertyNames(x || {})) {
-+        if (key.indexOf('__zone') !== -1) {
-+            return true;
-+        }
-+    }
-+    return false
++    return !!globalThis.Zone
 +  } catch {
-+    // we've seen some intermittent problems in Safari since introducing this check
 +    return false
 +  }
 +}
  const untaintedBasePrototype$1 = {};
  function getUntaintedPrototype$1(key) {
    if (untaintedBasePrototype$1[key])
-@@ -54,7 +75,7 @@ function getUntaintedPrototype$1(key) {
+@@ -54,7 +62,7 @@ function getUntaintedPrototype$1(key) {
        }
      )
    );
 -  if (isUntaintedAccessors && isUntaintedMethods) {
-+  if (isUntaintedAccessors && isUntaintedMethods && !isAngularZonePatchedFunction(defaultObj)) {
++  if (isUntaintedAccessors && isUntaintedMethods && !isAngularZonePresent()) {
      untaintedBasePrototype$1[key] = defaultObj.prototype;
      return defaultObj.prototype;
    }
-@@ -65,10 +86,10 @@ function getUntaintedPrototype$1(key) {
+@@ -65,10 +73,10 @@ function getUntaintedPrototype$1(key) {
      if (!win) return defaultObj.prototype;
      const untaintedObject = win[key].prototype;
      document.body.removeChild(iframeEl);
@@ -52,7 +39,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..6c62dab78676066344afb27976dd7d83
    }
  }
  const untaintedAccessorCache$1 = {};
-@@ -246,6 +267,9 @@ function isCSSImportRule(rule2) {
+@@ -246,6 +254,9 @@ function isCSSImportRule(rule2) {
  function isCSSStyleRule(rule2) {
    return "selectorText" in rule2;
  }
@@ -62,7 +49,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..6c62dab78676066344afb27976dd7d83
  class Mirror {
    constructor() {
      __publicField$1(this, "idNodeMap", /* @__PURE__ */ new Map());
-@@ -809,9 +833,14 @@ function serializeElementNode(n2, options) {
+@@ -809,9 +820,14 @@ function serializeElementNode(n2, options) {
      }
    }
    if (tagName === "link" && inlineStylesheet) {
@@ -80,7 +67,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..6c62dab78676066344afb27976dd7d83
      let cssText = null;
      if (stylesheet) {
        cssText = stringifyStylesheet(stylesheet);
-@@ -855,7 +884,15 @@ function serializeElementNode(n2, options) {
+@@ -855,7 +871,15 @@ function serializeElementNode(n2, options) {
      }
    }
    if (tagName === "dialog" && n2.open) {
@@ -97,7 +84,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..6c62dab78676066344afb27976dd7d83
    }
    if (tagName === "canvas" && recordCanvas) {
      if (n2.__context === "2d") {
-@@ -1116,7300 +1153,227 @@ function serializeNodeWithId(n2, options) {
+@@ -1116,7300 +1140,227 @@ function serializeNodeWithId(n2, options) {
        keepIframeSrcFn
      };
      if (serializedNode.type === NodeType$2.Element && serializedNode.tagName === "textarea" && serializedNode.attributes.value !== void 0) ;
@@ -7607,7 +7594,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..6c62dab78676066344afb27976dd7d83
  class BaseRRNode {
    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
    constructor(..._args) {
-@@ -8507,7 +1471,7 @@ function getUntaintedPrototype(key) {
+@@ -8507,7 +1458,7 @@ function getUntaintedPrototype(key) {
        }
      )
    );
@@ -7616,7 +7603,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..6c62dab78676066344afb27976dd7d83
      untaintedBasePrototype[key] = defaultObj.prototype;
      return defaultObj.prototype;
    }
-@@ -11382,11 +4346,19 @@ class CanvasManager {
+@@ -11382,11 +4333,19 @@ class CanvasManager {
      let rafId;
      const getCanvas = () => {
        const matchedCanvas = [];
@@ -7641,7 +7628,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..6c62dab78676066344afb27976dd7d83
        return matchedCanvas;
      };
      const takeCanvasSnapshots = (timestamp) => {
-@@ -11407,13 +4379,20 @@ class CanvasManager {
+@@ -11407,13 +4366,20 @@ class CanvasManager {
              context.clear(context.COLOR_BUFFER_BIT);
            }
          }

--- a/patches/@rrweb__record@2.0.0-alpha.17.patch
+++ b/patches/@rrweb__record@2.0.0-alpha.17.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/record.js b/dist/record.js
-index 46ec389fefb698243008b39db65470dbdf0a3857..efc65d8c393de8d0ad35083cba315aef91a04c2c 100644
+index 46ec389fefb698243008b39db65470dbdf0a3857..a18724d8b6ba43a30935daf257127fbb0c898541 100644
 --- a/dist/record.js
 +++ b/dist/record.js
 @@ -26,6 +26,14 @@ const testableMethods$1 = {
@@ -7599,7 +7599,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..efc65d8c393de8d0ad35083cba315aef
      )
    );
 -  if (isUntaintedAccessors && isUntaintedMethods) {
-+  if (isUntaintedAccessors && isUntaintedMethods && !isAngularZonePatchedFunction(defaultObj)) {
++  if (isUntaintedAccessors && isUntaintedMethods && !isAngularZonePresent()) {
      untaintedBasePrototype[key] = defaultObj.prototype;
      return defaultObj.prototype;
    }

--- a/patches/@rrweb__record@2.0.0-alpha.17.patch
+++ b/patches/@rrweb__record@2.0.0-alpha.17.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/record.js b/dist/record.js
-index 46ec389fefb698243008b39db65470dbdf0a3857..f62e24ecbcde20bad874188da64970945c41484e 100644
+index 46ec389fefb698243008b39db65470dbdf0a3857..610c1f4cb3d208eb9a4736958176ad78cf85ead7 100644
 --- a/dist/record.js
 +++ b/dist/record.js
-@@ -26,6 +26,24 @@ const testableMethods$1 = {
+@@ -26,6 +26,23 @@ const testableMethods$1 = {
    Element: [],
    MutationObserver: ["constructor"]
  };
@@ -12,7 +12,6 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..f62e24ecbcde20bad874188da6497094
 +    if (!isFunction(x)) {
 +        return false;
 +    }
-+    const prototypeKeys = Object.getOwnPropertyNames(x.prototype || {});
 +    for (const key of Object.getOwnPropertyNames(x.prototype || {})) {
 +        if (key.indexOf('__zone') !== -1) {
 +            return true;
@@ -27,7 +26,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..f62e24ecbcde20bad874188da6497094
  const untaintedBasePrototype$1 = {};
  function getUntaintedPrototype$1(key) {
    if (untaintedBasePrototype$1[key])
-@@ -54,7 +72,7 @@ function getUntaintedPrototype$1(key) {
+@@ -54,7 +71,7 @@ function getUntaintedPrototype$1(key) {
        }
      )
    );
@@ -36,7 +35,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..f62e24ecbcde20bad874188da6497094
      untaintedBasePrototype$1[key] = defaultObj.prototype;
      return defaultObj.prototype;
    }
-@@ -65,10 +83,10 @@ function getUntaintedPrototype$1(key) {
+@@ -65,10 +82,10 @@ function getUntaintedPrototype$1(key) {
      if (!win) return defaultObj.prototype;
      const untaintedObject = win[key].prototype;
      document.body.removeChild(iframeEl);
@@ -49,7 +48,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..f62e24ecbcde20bad874188da6497094
    }
  }
  const untaintedAccessorCache$1 = {};
-@@ -246,6 +264,9 @@ function isCSSImportRule(rule2) {
+@@ -246,6 +263,9 @@ function isCSSImportRule(rule2) {
  function isCSSStyleRule(rule2) {
    return "selectorText" in rule2;
  }
@@ -59,7 +58,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..f62e24ecbcde20bad874188da6497094
  class Mirror {
    constructor() {
      __publicField$1(this, "idNodeMap", /* @__PURE__ */ new Map());
-@@ -809,9 +830,14 @@ function serializeElementNode(n2, options) {
+@@ -809,9 +829,14 @@ function serializeElementNode(n2, options) {
      }
    }
    if (tagName === "link" && inlineStylesheet) {
@@ -77,7 +76,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..f62e24ecbcde20bad874188da6497094
      let cssText = null;
      if (stylesheet) {
        cssText = stringifyStylesheet(stylesheet);
-@@ -855,7 +881,15 @@ function serializeElementNode(n2, options) {
+@@ -855,7 +880,15 @@ function serializeElementNode(n2, options) {
      }
    }
    if (tagName === "dialog" && n2.open) {
@@ -94,7 +93,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..f62e24ecbcde20bad874188da6497094
    }
    if (tagName === "canvas" && recordCanvas) {
      if (n2.__context === "2d") {
-@@ -1116,7300 +1150,227 @@ function serializeNodeWithId(n2, options) {
+@@ -1116,7300 +1149,227 @@ function serializeNodeWithId(n2, options) {
        keepIframeSrcFn
      };
      if (serializedNode.type === NodeType$2.Element && serializedNode.tagName === "textarea" && serializedNode.attributes.value !== void 0) ;
@@ -7604,7 +7603,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..f62e24ecbcde20bad874188da6497094
  class BaseRRNode {
    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
    constructor(..._args) {
-@@ -8507,7 +1468,7 @@ function getUntaintedPrototype(key) {
+@@ -8507,7 +1467,7 @@ function getUntaintedPrototype(key) {
        }
      )
    );
@@ -7613,7 +7612,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..f62e24ecbcde20bad874188da6497094
      untaintedBasePrototype[key] = defaultObj.prototype;
      return defaultObj.prototype;
    }
-@@ -11382,11 +4343,19 @@ class CanvasManager {
+@@ -11382,11 +4342,19 @@ class CanvasManager {
      let rafId;
      const getCanvas = () => {
        const matchedCanvas = [];
@@ -7638,7 +7637,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..f62e24ecbcde20bad874188da6497094
        return matchedCanvas;
      };
      const takeCanvasSnapshots = (timestamp) => {
-@@ -11407,13 +4376,20 @@ class CanvasManager {
+@@ -11407,13 +4375,20 @@ class CanvasManager {
              context.clear(context.COLOR_BUFFER_BIT);
            }
          }

--- a/patches/@rrweb__record@2.0.0-alpha.17.patch
+++ b/patches/@rrweb__record@2.0.0-alpha.17.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/record.js b/dist/record.js
-index 46ec389fefb698243008b39db65470dbdf0a3857..70db907755d68b08232e25e1b255a974f56f3c65 100644
+index 46ec389fefb698243008b39db65470dbdf0a3857..f62e24ecbcde20bad874188da64970945c41484e 100644
 --- a/dist/record.js
 +++ b/dist/record.js
-@@ -26,6 +26,19 @@ const testableMethods$1 = {
+@@ -26,6 +26,24 @@ const testableMethods$1 = {
    Element: [],
    MutationObserver: ["constructor"]
  };
@@ -13,7 +13,12 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..70db907755d68b08232e25e1b255a974
 +        return false;
 +    }
 +    const prototypeKeys = Object.getOwnPropertyNames(x.prototype || {});
-+    return prototypeKeys.some((key) => key.indexOf('__zone'));
++    for (const key of Object.getOwnPropertyNames(x.prototype || {})) {
++        if (key.indexOf('__zone') !== -1) {
++            return true;
++        }
++    }
++    return false
 +  } catch {
 +    // we've seen some intermittent problems in Safari since introducing this check
 +    return false
@@ -22,7 +27,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..70db907755d68b08232e25e1b255a974
  const untaintedBasePrototype$1 = {};
  function getUntaintedPrototype$1(key) {
    if (untaintedBasePrototype$1[key])
-@@ -54,7 +67,7 @@ function getUntaintedPrototype$1(key) {
+@@ -54,7 +72,7 @@ function getUntaintedPrototype$1(key) {
        }
      )
    );
@@ -31,7 +36,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..70db907755d68b08232e25e1b255a974
      untaintedBasePrototype$1[key] = defaultObj.prototype;
      return defaultObj.prototype;
    }
-@@ -65,10 +78,10 @@ function getUntaintedPrototype$1(key) {
+@@ -65,10 +83,10 @@ function getUntaintedPrototype$1(key) {
      if (!win) return defaultObj.prototype;
      const untaintedObject = win[key].prototype;
      document.body.removeChild(iframeEl);
@@ -44,7 +49,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..70db907755d68b08232e25e1b255a974
    }
  }
  const untaintedAccessorCache$1 = {};
-@@ -246,6 +259,9 @@ function isCSSImportRule(rule2) {
+@@ -246,6 +264,9 @@ function isCSSImportRule(rule2) {
  function isCSSStyleRule(rule2) {
    return "selectorText" in rule2;
  }
@@ -54,7 +59,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..70db907755d68b08232e25e1b255a974
  class Mirror {
    constructor() {
      __publicField$1(this, "idNodeMap", /* @__PURE__ */ new Map());
-@@ -809,9 +825,14 @@ function serializeElementNode(n2, options) {
+@@ -809,9 +830,14 @@ function serializeElementNode(n2, options) {
      }
    }
    if (tagName === "link" && inlineStylesheet) {
@@ -72,7 +77,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..70db907755d68b08232e25e1b255a974
      let cssText = null;
      if (stylesheet) {
        cssText = stringifyStylesheet(stylesheet);
-@@ -855,7 +876,15 @@ function serializeElementNode(n2, options) {
+@@ -855,7 +881,15 @@ function serializeElementNode(n2, options) {
      }
    }
    if (tagName === "dialog" && n2.open) {
@@ -89,7 +94,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..70db907755d68b08232e25e1b255a974
    }
    if (tagName === "canvas" && recordCanvas) {
      if (n2.__context === "2d") {
-@@ -1116,7300 +1145,227 @@ function serializeNodeWithId(n2, options) {
+@@ -1116,7300 +1150,227 @@ function serializeNodeWithId(n2, options) {
        keepIframeSrcFn
      };
      if (serializedNode.type === NodeType$2.Element && serializedNode.tagName === "textarea" && serializedNode.attributes.value !== void 0) ;
@@ -7599,7 +7604,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..70db907755d68b08232e25e1b255a974
  class BaseRRNode {
    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
    constructor(..._args) {
-@@ -8507,7 +1463,7 @@ function getUntaintedPrototype(key) {
+@@ -8507,7 +1468,7 @@ function getUntaintedPrototype(key) {
        }
      )
    );
@@ -7608,7 +7613,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..70db907755d68b08232e25e1b255a974
      untaintedBasePrototype[key] = defaultObj.prototype;
      return defaultObj.prototype;
    }
-@@ -11382,11 +4338,19 @@ class CanvasManager {
+@@ -11382,11 +4343,19 @@ class CanvasManager {
      let rafId;
      const getCanvas = () => {
        const matchedCanvas = [];
@@ -7633,7 +7638,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..70db907755d68b08232e25e1b255a974
        return matchedCanvas;
      };
      const takeCanvasSnapshots = (timestamp) => {
-@@ -11407,13 +4371,20 @@ class CanvasManager {
+@@ -11407,13 +4376,20 @@ class CanvasManager {
              context.clear(context.COLOR_BUFFER_BIT);
            }
          }

--- a/patches/@rrweb__record@2.0.0-alpha.17.patch
+++ b/patches/@rrweb__record@2.0.0-alpha.17.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/record.js b/dist/record.js
-index 46ec389fefb698243008b39db65470dbdf0a3857..610c1f4cb3d208eb9a4736958176ad78cf85ead7 100644
+index 46ec389fefb698243008b39db65470dbdf0a3857..6c62dab78676066344afb27976dd7d83a7e17c58 100644
 --- a/dist/record.js
 +++ b/dist/record.js
-@@ -26,6 +26,23 @@ const testableMethods$1 = {
+@@ -26,6 +26,27 @@ const testableMethods$1 = {
    Element: [],
    MutationObserver: ["constructor"]
  };
@@ -12,7 +12,11 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..610c1f4cb3d208eb9a4736958176ad78
 +    if (!isFunction(x)) {
 +        return false;
 +    }
-+    for (const key of Object.getOwnPropertyNames(x.prototype || {})) {
++    // if Angular has a zone, then whatever this is could be tainted
++    if (globalThis.Zone) {
++      return true
++    }
++    for (const key of Object.getOwnPropertyNames(x || {})) {
 +        if (key.indexOf('__zone') !== -1) {
 +            return true;
 +        }
@@ -26,7 +30,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..610c1f4cb3d208eb9a4736958176ad78
  const untaintedBasePrototype$1 = {};
  function getUntaintedPrototype$1(key) {
    if (untaintedBasePrototype$1[key])
-@@ -54,7 +71,7 @@ function getUntaintedPrototype$1(key) {
+@@ -54,7 +75,7 @@ function getUntaintedPrototype$1(key) {
        }
      )
    );
@@ -35,7 +39,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..610c1f4cb3d208eb9a4736958176ad78
      untaintedBasePrototype$1[key] = defaultObj.prototype;
      return defaultObj.prototype;
    }
-@@ -65,10 +82,10 @@ function getUntaintedPrototype$1(key) {
+@@ -65,10 +86,10 @@ function getUntaintedPrototype$1(key) {
      if (!win) return defaultObj.prototype;
      const untaintedObject = win[key].prototype;
      document.body.removeChild(iframeEl);
@@ -48,7 +52,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..610c1f4cb3d208eb9a4736958176ad78
    }
  }
  const untaintedAccessorCache$1 = {};
-@@ -246,6 +263,9 @@ function isCSSImportRule(rule2) {
+@@ -246,6 +267,9 @@ function isCSSImportRule(rule2) {
  function isCSSStyleRule(rule2) {
    return "selectorText" in rule2;
  }
@@ -58,7 +62,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..610c1f4cb3d208eb9a4736958176ad78
  class Mirror {
    constructor() {
      __publicField$1(this, "idNodeMap", /* @__PURE__ */ new Map());
-@@ -809,9 +829,14 @@ function serializeElementNode(n2, options) {
+@@ -809,9 +833,14 @@ function serializeElementNode(n2, options) {
      }
    }
    if (tagName === "link" && inlineStylesheet) {
@@ -76,7 +80,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..610c1f4cb3d208eb9a4736958176ad78
      let cssText = null;
      if (stylesheet) {
        cssText = stringifyStylesheet(stylesheet);
-@@ -855,7 +880,15 @@ function serializeElementNode(n2, options) {
+@@ -855,7 +884,15 @@ function serializeElementNode(n2, options) {
      }
    }
    if (tagName === "dialog" && n2.open) {
@@ -93,7 +97,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..610c1f4cb3d208eb9a4736958176ad78
    }
    if (tagName === "canvas" && recordCanvas) {
      if (n2.__context === "2d") {
-@@ -1116,7300 +1149,227 @@ function serializeNodeWithId(n2, options) {
+@@ -1116,7300 +1153,227 @@ function serializeNodeWithId(n2, options) {
        keepIframeSrcFn
      };
      if (serializedNode.type === NodeType$2.Element && serializedNode.tagName === "textarea" && serializedNode.attributes.value !== void 0) ;
@@ -7603,7 +7607,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..610c1f4cb3d208eb9a4736958176ad78
  class BaseRRNode {
    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
    constructor(..._args) {
-@@ -8507,7 +1467,7 @@ function getUntaintedPrototype(key) {
+@@ -8507,7 +1471,7 @@ function getUntaintedPrototype(key) {
        }
      )
    );
@@ -7612,7 +7616,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..610c1f4cb3d208eb9a4736958176ad78
      untaintedBasePrototype[key] = defaultObj.prototype;
      return defaultObj.prototype;
    }
-@@ -11382,11 +4342,19 @@ class CanvasManager {
+@@ -11382,11 +4346,19 @@ class CanvasManager {
      let rafId;
      const getCanvas = () => {
        const matchedCanvas = [];
@@ -7637,7 +7641,7 @@ index 46ec389fefb698243008b39db65470dbdf0a3857..610c1f4cb3d208eb9a4736958176ad78
        return matchedCanvas;
      };
      const takeCanvasSnapshots = (timestamp) => {
-@@ -11407,13 +4375,20 @@ class CanvasManager {
+@@ -11407,13 +4379,20 @@ class CanvasManager {
              context.clear(context.COLOR_BUFFER_BIT);
            }
          }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@rrweb/record@2.0.0-alpha.17':
-    hash: nrscfm4vgic7ua6pjpvsibukl4
+    hash: b2wlmgtfu75ftypjejqj7owubq
     path: patches/@rrweb__record@2.0.0-alpha.17.patch
   '@rrweb/rrweb-plugin-console-record@2.0.0-alpha.17':
     hash: ytsspyi7p3hvqcq64vqb7wb6bu
@@ -74,7 +74,7 @@ devDependencies:
     version: 12.1.1(rollup@4.24.0)(tslib@2.5.0)(typescript@5.5.4)
   '@rrweb/record':
     specifier: 2.0.0-alpha.17
-    version: 2.0.0-alpha.17(patch_hash=nrscfm4vgic7ua6pjpvsibukl4)
+    version: 2.0.0-alpha.17(patch_hash=b2wlmgtfu75ftypjejqj7owubq)
   '@rrweb/rrweb-plugin-console-record':
     specifier: 2.0.0-alpha.17
     version: 2.0.0-alpha.17(patch_hash=ytsspyi7p3hvqcq64vqb7wb6bu)(rrweb@2.0.0-alpha.17)
@@ -2870,7 +2870,7 @@ packages:
     dev: true
     optional: true
 
-  /@rrweb/record@2.0.0-alpha.17(patch_hash=nrscfm4vgic7ua6pjpvsibukl4):
+  /@rrweb/record@2.0.0-alpha.17(patch_hash=b2wlmgtfu75ftypjejqj7owubq):
     resolution: {integrity: sha512-Je+lzjeWMF8/I0IDoXFzkGPKT8j7AkaBup5YcwUHlkp18VhLVze416MvI6915teE27uUA2ScXMXzG0Yiu5VTIw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@rrweb/record@2.0.0-alpha.17':
-    hash: f5yybcx26kdc7g5kmthu63z7dm
+    hash: ytun2qdrmzlebdo6gj5mz7wdxi
     path: patches/@rrweb__record@2.0.0-alpha.17.patch
   '@rrweb/rrweb-plugin-console-record@2.0.0-alpha.17':
     hash: ytsspyi7p3hvqcq64vqb7wb6bu
@@ -74,7 +74,7 @@ devDependencies:
     version: 12.1.1(rollup@4.24.0)(tslib@2.5.0)(typescript@5.5.4)
   '@rrweb/record':
     specifier: 2.0.0-alpha.17
-    version: 2.0.0-alpha.17(patch_hash=f5yybcx26kdc7g5kmthu63z7dm)
+    version: 2.0.0-alpha.17(patch_hash=ytun2qdrmzlebdo6gj5mz7wdxi)
   '@rrweb/rrweb-plugin-console-record':
     specifier: 2.0.0-alpha.17
     version: 2.0.0-alpha.17(patch_hash=ytsspyi7p3hvqcq64vqb7wb6bu)(rrweb@2.0.0-alpha.17)
@@ -2870,7 +2870,7 @@ packages:
     dev: true
     optional: true
 
-  /@rrweb/record@2.0.0-alpha.17(patch_hash=f5yybcx26kdc7g5kmthu63z7dm):
+  /@rrweb/record@2.0.0-alpha.17(patch_hash=ytun2qdrmzlebdo6gj5mz7wdxi):
     resolution: {integrity: sha512-Je+lzjeWMF8/I0IDoXFzkGPKT8j7AkaBup5YcwUHlkp18VhLVze416MvI6915teE27uUA2ScXMXzG0Yiu5VTIw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@rrweb/record@2.0.0-alpha.17':
-    hash: viz5vmxcmz5nggemb4cjgrd3iy
+    hash: f5yybcx26kdc7g5kmthu63z7dm
     path: patches/@rrweb__record@2.0.0-alpha.17.patch
   '@rrweb/rrweb-plugin-console-record@2.0.0-alpha.17':
     hash: ytsspyi7p3hvqcq64vqb7wb6bu
@@ -74,7 +74,7 @@ devDependencies:
     version: 12.1.1(rollup@4.24.0)(tslib@2.5.0)(typescript@5.5.4)
   '@rrweb/record':
     specifier: 2.0.0-alpha.17
-    version: 2.0.0-alpha.17(patch_hash=viz5vmxcmz5nggemb4cjgrd3iy)
+    version: 2.0.0-alpha.17(patch_hash=f5yybcx26kdc7g5kmthu63z7dm)
   '@rrweb/rrweb-plugin-console-record':
     specifier: 2.0.0-alpha.17
     version: 2.0.0-alpha.17(patch_hash=ytsspyi7p3hvqcq64vqb7wb6bu)(rrweb@2.0.0-alpha.17)
@@ -2870,7 +2870,7 @@ packages:
     dev: true
     optional: true
 
-  /@rrweb/record@2.0.0-alpha.17(patch_hash=viz5vmxcmz5nggemb4cjgrd3iy):
+  /@rrweb/record@2.0.0-alpha.17(patch_hash=f5yybcx26kdc7g5kmthu63z7dm):
     resolution: {integrity: sha512-Je+lzjeWMF8/I0IDoXFzkGPKT8j7AkaBup5YcwUHlkp18VhLVze416MvI6915teE27uUA2ScXMXzG0Yiu5VTIw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@rrweb/record@2.0.0-alpha.17':
-    hash: ytun2qdrmzlebdo6gj5mz7wdxi
+    hash: nrscfm4vgic7ua6pjpvsibukl4
     path: patches/@rrweb__record@2.0.0-alpha.17.patch
   '@rrweb/rrweb-plugin-console-record@2.0.0-alpha.17':
     hash: ytsspyi7p3hvqcq64vqb7wb6bu
@@ -74,7 +74,7 @@ devDependencies:
     version: 12.1.1(rollup@4.24.0)(tslib@2.5.0)(typescript@5.5.4)
   '@rrweb/record':
     specifier: 2.0.0-alpha.17
-    version: 2.0.0-alpha.17(patch_hash=ytun2qdrmzlebdo6gj5mz7wdxi)
+    version: 2.0.0-alpha.17(patch_hash=nrscfm4vgic7ua6pjpvsibukl4)
   '@rrweb/rrweb-plugin-console-record':
     specifier: 2.0.0-alpha.17
     version: 2.0.0-alpha.17(patch_hash=ytsspyi7p3hvqcq64vqb7wb6bu)(rrweb@2.0.0-alpha.17)
@@ -2870,7 +2870,7 @@ packages:
     dev: true
     optional: true
 
-  /@rrweb/record@2.0.0-alpha.17(patch_hash=ytun2qdrmzlebdo6gj5mz7wdxi):
+  /@rrweb/record@2.0.0-alpha.17(patch_hash=nrscfm4vgic7ua6pjpvsibukl4):
     resolution: {integrity: sha512-Je+lzjeWMF8/I0IDoXFzkGPKT8j7AkaBup5YcwUHlkp18VhLVze416MvI6915teE27uUA2ScXMXzG0Yiu5VTIw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@rrweb/record@2.0.0-alpha.17':
-    hash: b2wlmgtfu75ftypjejqj7owubq
+    hash: wvznj3762vyf2y3azxobt3dlz4
     path: patches/@rrweb__record@2.0.0-alpha.17.patch
   '@rrweb/rrweb-plugin-console-record@2.0.0-alpha.17':
     hash: ytsspyi7p3hvqcq64vqb7wb6bu
@@ -74,7 +74,7 @@ devDependencies:
     version: 12.1.1(rollup@4.24.0)(tslib@2.5.0)(typescript@5.5.4)
   '@rrweb/record':
     specifier: 2.0.0-alpha.17
-    version: 2.0.0-alpha.17(patch_hash=b2wlmgtfu75ftypjejqj7owubq)
+    version: 2.0.0-alpha.17(patch_hash=wvznj3762vyf2y3azxobt3dlz4)
   '@rrweb/rrweb-plugin-console-record':
     specifier: 2.0.0-alpha.17
     version: 2.0.0-alpha.17(patch_hash=ytsspyi7p3hvqcq64vqb7wb6bu)(rrweb@2.0.0-alpha.17)
@@ -2870,7 +2870,7 @@ packages:
     dev: true
     optional: true
 
-  /@rrweb/record@2.0.0-alpha.17(patch_hash=b2wlmgtfu75ftypjejqj7owubq):
+  /@rrweb/record@2.0.0-alpha.17(patch_hash=wvznj3762vyf2y3azxobt3dlz4):
     resolution: {integrity: sha512-Je+lzjeWMF8/I0IDoXFzkGPKT8j7AkaBup5YcwUHlkp18VhLVze416MvI6915teE27uUA2ScXMXzG0Yiu5VTIw==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.17

--- a/src/utils/prototype-utils.ts
+++ b/src/utils/prototype-utils.ts
@@ -5,7 +5,7 @@
  */
 
 import { AssignableWindow } from './globals'
-import { isAngularZonePatchedFunction, isFunction, isNativeFunction } from './type-utils'
+import { isAngularZonePresent, isFunction, isNativeFunction } from './type-utils'
 import { logger } from './logger'
 
 interface NativeImplementationsCache {
@@ -25,7 +25,7 @@ export function getNativeImplementation<T extends keyof NativeImplementationsCac
 
     let impl = assignableWindow[name] as NativeImplementationsCache[T]
 
-    if (isNativeFunction(impl) && !isAngularZonePatchedFunction(impl)) {
+    if (isNativeFunction(impl) && !isAngularZonePresent()) {
         return (cachedImplementations[name] = impl.bind(assignableWindow) as NativeImplementationsCache[T])
     }
 

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -1,4 +1,5 @@
 import { includes } from '.'
+import { window } from './globals'
 import { knownUnsafeEditableEvent, KnownUnsafeEditableEvent } from '../types'
 
 // eslint-disable-next-line posthog-js/no-direct-array-check
@@ -24,13 +25,9 @@ export const isFunction = (x: unknown): x is (...args: any[]) => any => {
 export const isNativeFunction = (x: unknown): x is (...args: any[]) => any =>
     isFunction(x) && x.toString().indexOf('[native code]') !== -1
 
-// When angular patches functions they pass the above `isNativeFunction` check
-export const isAngularZonePatchedFunction = (x: unknown): boolean => {
-    if (!isFunction(x)) {
-        return false
-    }
-    const prototypeKeys = Object.getOwnPropertyNames(x.prototype || {})
-    return prototypeKeys.some((key) => key.indexOf('__zone'))
+// When angular patches functions they pass the above `isNativeFunction` check (at least the MutationObserver)
+export const isAngularZonePresent = (): boolean => {
+    return !!(window as any).Zone
 }
 
 // Underscore Addons


### PR DESCRIPTION
mutation observer setup is _sometimes_ failing in Safari

I think that the underlying problem is we can't reliably get the mutation observer from an iframe

but we are at least _always_ trying to get it from an iframe instead of only when angular has monkeyed around with it

let's reduce the number of people affected by checking correctly

i've tested locally that this doesn't freeze the test angular app that would freeze if this didn't work

and i've tested locally that i can record safari (as much as i can, it wasn't _always_ failing)