### PR TITLE
fix: Don't crash on bigints

### DIFF
--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -343,6 +343,21 @@ describe('request', () => {
                 'application/x-www-form-urlencoded'
             )
         })
+
+        it('converts bigint properties to string without throwing', () => {
+            request(
+                createRequest({
+                    url: 'https://any.posthog-instance.com/',
+                    method: 'POST',
+                    compression: Compression.Base64,
+                    data: { foo: BigInt('999999999999999999999') },
+                })
+            )
+            expect(mockedXHR.send.mock.calls[0][0]).toMatchInlineSnapshot(
+                `"data=eyJmb28iOiI5OTk5OTk5OTk5OTk5OTk5OTk5OTkifQ%3D%3D"`
+            )
+            expect(mockedXHR.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/x-www-form-urlencoded')
+        })
     })
 
     describe('sendBeacon', () => {


### PR DESCRIPTION
## Changes
Fixes https://github.com/PostHog/posthog-js/issues/1440

I'm a bit wary that there's another root cause we're missing, I would like to hear from those users where the BigInts came from in the first place, but in the mean-time let's not crash

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
