### PR TITLE
fix: use previous site-app variables

### DIFF
--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -295,7 +295,7 @@ describe('SiteApps', () => {
 
             siteAppsInstance.afterDecideResponse(response)
 
-            expect(assignableWindow['__$$ph_site_app_1_posthog']).toBe(posthog)
+            expect(assignableWindow['__$$ph_site_app_1']).toBe(posthog)
             expect(typeof assignableWindow['__$$ph_site_app_1_missed_invocations']).toBe('function')
             expect(typeof assignableWindow['__$$ph_site_app_1_callback']).toBe('function')
             expect(assignableWindow.__PosthogExtensions__?.loadSiteApp).toHaveBeenCalledWith(

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -87,7 +87,7 @@ export class SiteApps {
                 for (const { id, url } of response['siteApps']) {
                     // TODO: if we have opted out and "type" is "site_destination", ignore it... but do include "site_app" types
                     this.appsLoading.add(id)
-                    assignableWindow[`__$$ph_site_app_${id}_posthog`] = this.instance
+                    assignableWindow[`__$$ph_site_app_${id}`] = this.instance
                     assignableWindow[`__$$ph_site_app_${id}_missed_invocations`] = () => this.missedInvocations
                     assignableWindow[`__$$ph_site_app_${id}_callback`] = () => {
                         this.appsLoading.delete(id)


### PR DESCRIPTION
## Changes

The existing site apps on cloud expect `__$$ph_site_app_${id}` as the global where they'll find the PostHog-JS library. This changed recently to `__$$ph_site_app_${id}_posthog`. Revert that change.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
