### PR TITLE
fix: parse Chrome instead of Android as browser

### DIFF
--- a/src/__tests__/utils/event-utils.test.ts
+++ b/src/__tests__/utils/event-utils.test.ts
@@ -229,11 +229,11 @@ describe(`event-utils`, () => {
                 expectedBrowser: 'Android Mobile',
             },
             {
-                name: 'Android Browser on Galaxy S3',
+                name: 'Chrome Browser on Galaxy S3',
                 userAgent:
                     'Mozilla/5.0 (Linux; Android 4.4.4; en-us; SAMSUNG GT-I9300I Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36',
-                expectedVersion: 4.4,
-                expectedBrowser: 'Android Mobile',
+                expectedVersion: 28.0,
+                expectedBrowser: 'Chrome',
             },
         ]
 

--- a/src/utils/user-agent-utils.ts
+++ b/src/utils/user-agent-utils.ts
@@ -113,10 +113,10 @@ export const detectBrowser = function (user_agent: string, vendor: string | unde
         return CHROME_IOS // why not just Chrome?
     } else if (includes(user_agent, 'CrMo')) {
         return CHROME
-    } else if (includes(user_agent, ANDROID) && includes(user_agent, SAFARI)) {
-        return ANDROID_MOBILE
     } else if (includes(user_agent, CHROME)) {
         return CHROME
+    } else if (includes(user_agent, ANDROID) && includes(user_agent, SAFARI)) {
+        return ANDROID_MOBILE
     } else if (includes(user_agent, 'FxiOS')) {
         return FIREFOX_IOS
     } else if (includes(user_agent.toLowerCase(), KONQUEROR.toLowerCase())) {


### PR DESCRIPTION
## Changes

Based on some Googling it seems like the latter value in this user agent (`Chrome/28.0.1500.94 `) is actually the browser.

_Maybe_ we don't want to make this change because it will affect peoples existing browser attribution but I think it's totally reasonable to ship a fix forward here
