### PR TITLE
feat: Added better sub logging utils

### DIFF
--- a/functional_tests/feature-flags.test.ts
+++ b/functional_tests/feature-flags.test.ts
@@ -1,4 +1,4 @@
-import './helpers/mock-logger'
+import '../src/__tests__/helpers/mock-logger'
 
 import { createPosthogInstance } from '../src/__tests__/helpers/posthog-instance'
 import { waitFor } from '@testing-library/dom'

--- a/functional_tests/feature-flags.test.ts
+++ b/functional_tests/feature-flags.test.ts
@@ -1,3 +1,5 @@
+import './helpers/mock-logger'
+
 import { createPosthogInstance } from '../src/__tests__/helpers/posthog-instance'
 import { waitFor } from '@testing-library/dom'
 import { getRequests, resetRequests } from './mock-server'

--- a/functional_tests/identify.test.ts
+++ b/functional_tests/identify.test.ts
@@ -1,4 +1,4 @@
-import './helpers/mock-logger'
+import '../src/__tests__/helpers/mock-logger'
 
 import 'regenerator-runtime/runtime'
 import { waitFor } from '@testing-library/dom'

--- a/functional_tests/identify.test.ts
+++ b/functional_tests/identify.test.ts
@@ -1,3 +1,5 @@
+import './helpers/mock-logger'
+
 import 'regenerator-runtime/runtime'
 import { waitFor } from '@testing-library/dom'
 import { getRequests } from './mock-server'
@@ -5,7 +7,6 @@ import { createPosthogInstance } from '../src/__tests__/helpers/posthog-instance
 import { logger } from '../src/utils/logger'
 import { uuidv7 } from '../src/uuidv7'
 import { PostHog } from '../src/posthog-core'
-jest.mock('../src/utils/logger')
 
 describe('FunctionalTests / Identify', () => {
     let token: string

--- a/src/__tests__/consent.test.ts
+++ b/src/__tests__/consent.test.ts
@@ -1,3 +1,5 @@
+import './helpers/mock-logger'
+
 import { PostHog } from '../posthog-core'
 import { defaultPostHog } from './helpers/posthog-instance'
 import { uuidv7 } from '../uuidv7'

--- a/src/__tests__/decide.ts
+++ b/src/__tests__/decide.ts
@@ -212,7 +212,10 @@ describe('Decide', () => {
             subject(undefined as unknown as DecideResponse)
 
             expect(posthog.featureFlags.receivedFeatureFlags).toHaveBeenCalledWith({}, true)
-            expect(console.error).toHaveBeenCalledWith('[PostHog.js]', 'Failed to fetch feature flags from PostHog.')
+            expect(console.error).toHaveBeenCalledWith(
+                '[PostHog.js] [Decide]',
+                'Failed to fetch feature flags from PostHog.'
+            )
         })
 
         it('Make sure receivedFeatureFlags is not called if advanced_disable_feature_flags_on_first_load is set', () => {

--- a/src/__tests__/extensions/web-vitals.test.ts
+++ b/src/__tests__/extensions/web-vitals.test.ts
@@ -1,3 +1,5 @@
+import '../helpers/mock-logger'
+
 import { createPosthogInstance } from '../helpers/posthog-instance'
 import { uuidv7 } from '../../uuidv7'
 import { PostHog } from '../../posthog-core'
@@ -5,7 +7,6 @@ import { DecideResponse, PerformanceCaptureConfig, SupportedWebVitalsMetrics } f
 import { assignableWindow } from '../../utils/globals'
 import { DEFAULT_FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS, FIFTEEN_MINUTES_IN_MILLIS } from '../../extensions/web-vitals'
 
-jest.mock('../../utils/logger')
 jest.useFakeTimers()
 
 describe('web vitals', () => {

--- a/src/__tests__/featureflags.ts
+++ b/src/__tests__/featureflags.ts
@@ -87,7 +87,7 @@ describe('featureflags', () => {
         expect(featureFlags.getFlags()).toEqual([])
         expect(featureFlags.isFeatureEnabled('beta-feature')).toEqual(undefined)
         expect(window.console.warn).toHaveBeenCalledWith(
-            '[PostHog.js]',
+            '[PostHog.js] [FeatureFlags]',
             'isFeatureEnabled for key "beta-feature" failed. Feature flags didn\'t load in time.'
         )
 
@@ -95,7 +95,7 @@ describe('featureflags', () => {
 
         expect(featureFlags.getFeatureFlag('beta-feature')).toEqual(undefined)
         expect(window.console.warn).toHaveBeenCalledWith(
-            '[PostHog.js]',
+            '[PostHog.js] [FeatureFlags]',
             'getFeatureFlag for key "beta-feature" failed. Feature flags didn\'t load in time.'
         )
     })
@@ -246,7 +246,7 @@ describe('featureflags', () => {
             'alpha-feature-2': true,
         })
         expect(window.console.warn).toHaveBeenCalledWith(
-            '[PostHog.js]',
+            '[PostHog.js] [FeatureFlags]',
             ' Overriding feature flags!',
             expect.any(Object)
         )

--- a/src/__tests__/heatmaps.test.ts
+++ b/src/__tests__/heatmaps.test.ts
@@ -1,3 +1,5 @@
+import './helpers/mock-logger'
+
 import { createPosthogInstance } from './helpers/posthog-instance'
 import { uuidv7 } from '../uuidv7'
 import { PostHog } from '../posthog-core'
@@ -7,7 +9,6 @@ import { beforeEach, expect } from '@jest/globals'
 import { HEATMAPS_ENABLED_SERVER_SIDE } from '../constants'
 import { Heatmaps } from '../heatmaps'
 
-jest.mock('../utils/logger')
 jest.useFakeTimers()
 
 describe('heatmaps', () => {

--- a/src/__tests__/helpers/mock-logger.ts
+++ b/src/__tests__/helpers/mock-logger.ts
@@ -1,0 +1,32 @@
+import { Logger } from '../../utils/logger'
+
+jest.mock('../../utils/logger', () => {
+    const mockLogger: Logger = {
+        _log: jest.fn(),
+        critical: jest.fn(),
+        uninitializedWarning: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        createLogger: () => {
+            return mockLogger
+        },
+    }
+    return {
+        logger: mockLogger,
+        createLogger: mockLogger.createLogger,
+    }
+})
+
+import { logger } from '../../utils/logger'
+import { isFunction } from '../../utils/type-utils'
+
+export const clearLoggerMocks = () => {
+    Object.values(logger).forEach((mock: any) => {
+        if (isFunction(mock.mockClear)) {
+            mock.mockClear()
+        }
+    })
+}
+
+export const mockLogger: jest.Mocked<Logger> = logger as any

--- a/src/__tests__/identify.test.ts
+++ b/src/__tests__/identify.test.ts
@@ -1,7 +1,7 @@
+import { mockLogger } from './helpers/mock-logger'
+
 import { createPosthogInstance } from './helpers/posthog-instance'
-import { logger } from '../utils/logger'
 import { uuidv7 } from '../uuidv7'
-jest.mock('../utils/logger')
 
 describe('identify', () => {
     // Note that there are other tests for identify in posthog-core.identify.js
@@ -19,8 +19,8 @@ describe('identify', () => {
 
         // assert
         expect(posthog.persistence!.properties()['$user_id']).toEqual(distinctId)
-        expect(jest.mocked(logger).error).toBeCalledTimes(0)
-        expect(jest.mocked(logger).warn).toBeCalledTimes(0)
+        expect(mockLogger.error).toBeCalledTimes(0)
+        expect(mockLogger.warn).toBeCalledTimes(0)
     })
 
     it('should convert a numeric distinct_id to a string', async () => {
@@ -35,8 +35,8 @@ describe('identify', () => {
 
         // assert
         expect(posthog.persistence!.properties()['$user_id']).toEqual(distinctIdString)
-        expect(jest.mocked(logger).error).toBeCalledTimes(0)
-        expect(jest.mocked(logger).warn).toBeCalledTimes(1)
+        expect(mockLogger.error).toBeCalledTimes(0)
+        expect(mockLogger.warn).toBeCalledTimes(1)
     })
 
     it('should send $is_identified = true with the identify event and following events', async () => {

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -1,10 +1,9 @@
+import { mockLogger } from './helpers/mock-logger'
+
 import { createPosthogInstance } from './helpers/posthog-instance'
 import { uuidv7 } from '../uuidv7'
-import { logger } from '../utils/logger'
 import { INITIAL_CAMPAIGN_PARAMS, INITIAL_REFERRER_INFO } from '../constants'
 import { RemoteConfig } from '../types'
-
-jest.mock('../utils/logger')
 
 const INITIAL_CAMPAIGN_PARAMS_NULL = {
     $initial_current_url: null,
@@ -156,8 +155,8 @@ describe('person processing', () => {
             posthog.identify(distinctId)
 
             // assert
-            expect(jest.mocked(logger).error).toBeCalledTimes(1)
-            expect(jest.mocked(logger).error).toHaveBeenCalledWith(
+            expect(mockLogger.error).toBeCalledTimes(1)
+            expect(mockLogger.error).toHaveBeenCalledWith(
                 'posthog.identify was called, but process_person is set to "never". This call will be ignored.'
             )
             expect(beforeSendMock).toBeCalledTimes(0)
@@ -172,7 +171,7 @@ describe('person processing', () => {
             posthog.identify(distinctId)
             posthog.capture('custom event after identify')
             // assert
-            expect(jest.mocked(logger).error).toBeCalledTimes(0)
+            expect(mockLogger.error).toBeCalledTimes(0)
             const eventBeforeIdentify = beforeSendMock.mock.calls[0]
             expect(eventBeforeIdentify[0].properties.$process_person_profile).toEqual(false)
             const identifyCall = beforeSendMock.mock.calls[1]
@@ -191,7 +190,7 @@ describe('person processing', () => {
             posthog.identify(distinctId)
             posthog.capture('custom event after identify')
             // assert
-            expect(jest.mocked(logger).error).toBeCalledTimes(0)
+            expect(mockLogger.error).toBeCalledTimes(0)
             const eventBeforeIdentify = beforeSendMock.mock.calls[0]
             expect(eventBeforeIdentify[0].properties.$process_person_profile).toEqual(true)
             const identifyCall = beforeSendMock.mock.calls[1]
@@ -503,8 +502,8 @@ describe('person processing', () => {
             posthog.capture('custom event after group')
 
             // assert
-            expect(jest.mocked(logger).error).toBeCalledTimes(1)
-            expect(jest.mocked(logger).error).toHaveBeenCalledWith(
+            expect(mockLogger.error).toBeCalledTimes(1)
+            expect(mockLogger.error).toHaveBeenCalledWith(
                 'posthog.group was called, but process_person is set to "never". This call will be ignored.'
             )
 
@@ -526,8 +525,8 @@ describe('person processing', () => {
 
             // assert
             expect(beforeSendMock).toBeCalledTimes(0)
-            expect(jest.mocked(logger).error).toBeCalledTimes(1)
-            expect(jest.mocked(logger).error).toHaveBeenCalledWith(
+            expect(mockLogger.error).toBeCalledTimes(1)
+            expect(mockLogger.error).toHaveBeenCalledWith(
                 'posthog.setPersonProperties was called, but process_person is set to "never". This call will be ignored.'
             )
         })
@@ -593,8 +592,8 @@ describe('person processing', () => {
 
             // assert
             expect(beforeSendMock).toBeCalledTimes(0)
-            expect(jest.mocked(logger).error).toBeCalledTimes(1)
-            expect(jest.mocked(logger).error).toHaveBeenCalledWith(
+            expect(mockLogger.error).toBeCalledTimes(1)
+            expect(mockLogger.error).toHaveBeenCalledWith(
                 'posthog.alias was called, but process_person is set to "never". This call will be ignored.'
             )
         })
@@ -644,7 +643,7 @@ describe('person processing', () => {
 
             // assert
             expect(beforeSendMock).toBeCalledTimes(0)
-            expect(jest.mocked(logger).error).toBeCalledTimes(0)
+            expect(mockLogger.error).toBeCalledTimes(0)
         })
     })
 

--- a/src/__tests__/posthog-core.beforeSend.test.ts
+++ b/src/__tests__/posthog-core.beforeSend.test.ts
@@ -1,10 +1,9 @@
+import { mockLogger } from './helpers/mock-logger'
+
 import { uuidv7 } from '../uuidv7'
 import { defaultPostHog } from './helpers/posthog-instance'
-import { logger } from '../utils/logger'
 import { CaptureResult, knownUnsafeEditableEvent, PostHogConfig } from '../types'
 import { PostHog } from '../posthog-core'
-
-jest.mock('../utils/logger')
 
 const rejectingEventFn = () => {
     return null
@@ -53,9 +52,7 @@ describe('posthog core - before send', () => {
 
         expect(capturedData).toBeUndefined()
         expect(posthog._send_request).not.toHaveBeenCalled()
-        expect(jest.mocked(logger).info).toHaveBeenCalledWith(
-            `Event '${eventName}' was rejected in beforeSend function`
-        )
+        expect(mockLogger.info).toHaveBeenCalledWith(`Event '${eventName}' was rejected in beforeSend function`)
     })
 
     it('can edit an event', () => {
@@ -156,7 +153,7 @@ describe('posthog core - before send', () => {
             method: 'POST',
             url: 'https://us.i.posthog.com/e/',
         })
-        expect(jest.mocked(logger).warn).toHaveBeenCalledWith(
+        expect(mockLogger.warn).toHaveBeenCalledWith(
             `Event '${eventName}' has no properties after beforeSend function, this is likely an error.`
         )
     })
@@ -172,7 +169,7 @@ describe('posthog core - before send', () => {
 
         posthog.capture(randomUnsafeEditableEvent, {}, {})
 
-        expect(jest.mocked(logger).warn).toHaveBeenCalledWith(
+        expect(mockLogger.warn).toHaveBeenCalledWith(
             `Event '${randomUnsafeEditableEvent}' was rejected in beforeSend function. This can cause unexpected behavior.`
         )
     })

--- a/src/__tests__/rate-limiter.test.ts
+++ b/src/__tests__/rate-limiter.test.ts
@@ -1,8 +1,6 @@
+import { clearLoggerMocks, mockLogger } from './helpers/mock-logger'
 import { window } from '../../src/utils/globals'
 import { RateLimiter } from '../rate-limiter'
-import { logger } from '../utils/logger'
-
-jest.mock('../../src/utils/logger')
 
 describe('Rate Limiter', () => {
     let rateLimiter: RateLimiter
@@ -44,6 +42,8 @@ describe('Rate Limiter', () => {
         }
 
         rateLimiter = new RateLimiter(mockPostHog as any)
+
+        clearLoggerMocks()
     })
 
     describe('client side', () => {
@@ -270,7 +270,7 @@ describe('Rate Limiter', () => {
                 text: '',
             })
 
-            expect(jest.mocked(logger).error).not.toHaveBeenCalled()
+            expect(mockLogger.error).not.toHaveBeenCalled()
         })
     })
 })

--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -1,18 +1,13 @@
+import { mockLogger } from './helpers/mock-logger'
+
 import { SiteApps } from '../site-apps'
 import { PostHogPersistence } from '../posthog-persistence'
 import { RequestRouter } from '../utils/request-router'
 import { PostHog } from '../posthog-core'
 import { DecideResponse, PostHogConfig, Properties, CaptureResult } from '../types'
 import { assignableWindow } from '../utils/globals'
-import { logger } from '../utils/logger'
 import '../entrypoints/external-scripts-loader'
 import { isFunction } from '../utils/type-utils'
-
-jest.mock('../utils/logger', () => ({
-    logger: {
-        error: jest.fn(),
-    },
-}))
 
 describe('SiteApps', () => {
     let posthog: PostHog
@@ -314,8 +309,8 @@ describe('SiteApps', () => {
 
             siteAppsInstance.onRemoteConfig(response)
 
-            expect(logger.error).toHaveBeenCalledWith(
-                'PostHog site apps are disabled. Enable the "opt_in_site_apps" config to proceed.'
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                'Site apps exist but "opt_in_site_apps" is not set so they are not loaded.'
             )
             expect(siteAppsInstance.loaded).toBe(true)
         })

--- a/src/__tests__/utils/number-utils.test.ts
+++ b/src/__tests__/utils/number-utils.test.ts
@@ -1,11 +1,6 @@
-import { clampToRange } from '../../utils/number-utils'
-import { logger } from '../../utils/logger'
+import { mockLogger } from '../helpers/mock-logger'
 
-jest.mock('../../utils/logger', () => ({
-    logger: {
-        warn: jest.fn(),
-    },
-}))
+import { clampToRange } from '../../utils/number-utils'
 
 describe('number-utils', () => {
     describe('clampToRange', () => {
@@ -87,7 +82,7 @@ describe('number-utils', () => {
 
         it('logs a warning when min is greater than max', () => {
             expect(clampToRange(50, 100, 10, 'Test Label')).toBe(10)
-            expect(logger.warn).toHaveBeenCalledWith('min cannot be greater than max.')
+            expect(mockLogger.warn).toHaveBeenCalledWith('min cannot be greater than max.')
         })
     })
 })

--- a/src/autocapture-utils.ts
+++ b/src/autocapture-utils.ts
@@ -417,7 +417,7 @@ export function getNestedSpanText(target: Element): string {
                         text = `${text} ${getNestedSpanText(child)}`.trim()
                     }
                 } catch (e) {
-                    logger.error(e)
+                    logger.error('[AutoCapture]', e)
                 }
             }
         })

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -20,10 +20,12 @@ import { PostHog } from './posthog-core'
 import { AUTOCAPTURE_DISABLED_SERVER_SIDE } from './constants'
 
 import { isBoolean, isFunction, isNull, isObject } from './utils/type-utils'
-import { logger } from './utils/logger'
+import { createLogger } from './utils/logger'
 import { document, window } from './utils/globals'
 import { convertToURL } from './utils/request-utils'
 import { isDocumentFragment, isElementNode, isTag, isTextNode } from './utils/element-utils'
+
+const logger = createLogger('[AutoCapture]')
 
 function limitText(length: number, text: string): string {
     if (text.length > length) {

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -2,8 +2,10 @@ import { PostHog } from './posthog-core'
 import { Compression, DecideResponse, RemoteConfig } from './types'
 import { STORED_GROUP_PROPERTIES_KEY, STORED_PERSON_PROPERTIES_KEY } from './constants'
 
-import { logger } from './utils/logger'
+import { createLogger } from './utils/logger'
 import { assignableWindow, document } from './utils/globals'
+
+const logger = createLogger('[Decide]')
 
 export class Decide {
     constructor(private readonly instance: PostHog) {

--- a/src/entrypoints/exception-autocapture.ts
+++ b/src/entrypoints/exception-autocapture.ts
@@ -1,7 +1,9 @@
 import { errorToProperties, unhandledRejectionToProperties } from '../extensions/exception-autocapture/error-conversion'
 import { assignableWindow, window } from '../utils/globals'
 import { ErrorEventArgs, Properties } from '../types'
-import { logger } from '../utils/logger'
+import { createLogger } from '../utils/logger'
+
+const logger = createLogger('[ExceptionAutocapture]')
 
 const wrapOnError = (captureFn: (props: Properties) => void) => {
     const win = window as any

--- a/src/entrypoints/external-scripts-loader.ts
+++ b/src/entrypoints/external-scripts-loader.ts
@@ -1,6 +1,8 @@
 import type { PostHog } from '../posthog-core'
 import { assignableWindow, document, PostHogExtensionKind } from '../utils/globals'
-import { logger } from '../utils/logger'
+import { createLogger } from '../utils/logger'
+
+const logger = createLogger('[ExternalScriptsLoader]')
 
 const loadScript = (posthog: PostHog, url: string, callback: (error?: string | Event, event?: Event) => void) => {
     if (posthog.config.disable_external_dependency_loading) {

--- a/src/entrypoints/recorder.ts
+++ b/src/entrypoints/recorder.ts
@@ -22,12 +22,14 @@ import {
     isString,
     isUndefined,
 } from '../utils/type-utils'
-import { logger } from '../utils/logger'
+import { createLogger } from '../utils/logger'
 import { assignableWindow } from '../utils/globals'
 import { defaultNetworkOptions } from '../extensions/replay/config'
 import { formDataToQuery } from '../utils/request-utils'
 import { patch } from '../extensions/replay/rrweb-plugins/patch'
 import { isHostOnDenyList } from '../extensions/replay/external/denylist'
+
+const logger = createLogger('[Recorder]')
 
 export type NetworkData = {
     requests: CapturedNetworkRequest[]

--- a/src/extensions/dead-clicks-autocapture.ts
+++ b/src/extensions/dead-clicks-autocapture.ts
@@ -2,10 +2,10 @@ import { PostHog } from '../posthog-core'
 import { DEAD_CLICKS_ENABLED_SERVER_SIDE } from '../constants'
 import { isBoolean, isObject } from '../utils/type-utils'
 import { assignableWindow, document, LazyLoadedDeadClicksAutocaptureInterface } from '../utils/globals'
-import { logger } from '../utils/logger'
+import { createLogger } from '../utils/logger'
 import { DeadClicksAutoCaptureConfig, RemoteConfig } from '../types'
 
-const LOGGER_PREFIX = '[Dead Clicks]'
+const logger = createLogger('[Dead Clicks]')
 
 export const isDeadClicksEnabledForHeatmaps = () => {
     return true
@@ -58,7 +58,7 @@ export class DeadClicksAutocapture {
             'dead-clicks-autocapture',
             (err) => {
                 if (err) {
-                    logger.error(LOGGER_PREFIX + ' failed to load script', err)
+                    logger.error('failed to load script', err)
                     return
                 }
                 cb()
@@ -68,7 +68,7 @@ export class DeadClicksAutocapture {
 
     private start() {
         if (!document) {
-            logger.error(LOGGER_PREFIX + ' `document` not found. Cannot start.')
+            logger.error('`document` not found. Cannot start.')
             return
         }
 
@@ -86,7 +86,7 @@ export class DeadClicksAutocapture {
                 config
             )
             this._lazyLoadedDeadClicksAutocapture.start(document)
-            logger.info(`${LOGGER_PREFIX} starting...`)
+            logger.info(`starting...`)
         }
     }
 
@@ -94,7 +94,7 @@ export class DeadClicksAutocapture {
         if (this._lazyLoadedDeadClicksAutocapture) {
             this._lazyLoadedDeadClicksAutocapture.stop()
             this._lazyLoadedDeadClicksAutocapture = undefined
-            logger.info(`${LOGGER_PREFIX} stopping...`)
+            logger.info(`stopping...`)
         }
     }
 }

--- a/src/extensions/exception-autocapture/index.ts
+++ b/src/extensions/exception-autocapture/index.ts
@@ -2,10 +2,10 @@ import { assignableWindow, window } from '../../utils/globals'
 import { PostHog } from '../../posthog-core'
 import { Properties, RemoteConfig } from '../../types'
 
-import { logger } from '../../utils/logger'
+import { createLogger } from '../../utils/logger'
 import { EXCEPTION_CAPTURE_ENABLED_SERVER_SIDE } from '../../constants'
 
-const LOGGER_PREFIX = '[Exception Autocapture]'
+const logger = createLogger('[ExceptionAutocapture]')
 
 export class ExceptionObserver {
     instance: PostHog
@@ -35,7 +35,7 @@ export class ExceptionObserver {
 
     startIfEnabled(): void {
         if (this.isEnabled && !this.isCapturing) {
-            logger.info(LOGGER_PREFIX + ' enabled, starting...')
+            logger.info('enabled, starting...')
             this.loadScript(this.startCapturing)
         }
     }
@@ -51,7 +51,7 @@ export class ExceptionObserver {
             'exception-autocapture',
             (err) => {
                 if (err) {
-                    return logger.error(LOGGER_PREFIX + ' failed to load script', err)
+                    return logger.error('failed to load script', err)
                 }
                 cb()
             }
@@ -68,7 +68,7 @@ export class ExceptionObserver {
             assignableWindow.__PosthogExtensions__?.errorWrappingFunctions?.wrapUnhandledRejection
 
         if (!wrapOnError || !wrapUnhandledRejection) {
-            logger.error(LOGGER_PREFIX + ' failed to load error wrapping functions - cannot start')
+            logger.error('failed to load error wrapping functions - cannot start')
             return
         }
 
@@ -76,7 +76,7 @@ export class ExceptionObserver {
             this.unwrapOnError = wrapOnError(this.captureException.bind(this))
             this.unwrapUnhandledRejection = wrapUnhandledRejection(this.captureException.bind(this))
         } catch (e) {
-            logger.error(LOGGER_PREFIX + ' failed to start', e)
+            logger.error('failed to start', e)
             this.stopCapturing()
         }
     }

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -6,6 +6,7 @@ import { shouldCaptureValue } from '../../autocapture-utils'
 import { each } from '../../utils'
 
 const LOGGER_PREFIX = '[SessionRecording]'
+
 const REDACTED = 'redacted'
 
 export const defaultNetworkOptions: Required<NetworkRecordOptions> = {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -38,7 +38,7 @@ import {
 } from '@rrweb/types'
 
 import { isBoolean, isFunction, isNullish, isNumber, isObject, isString, isUndefined } from '../../utils/type-utils'
-import { logger } from '../../utils/logger'
+import { createLogger } from '../../utils/logger'
 import { assignableWindow, document, PostHogExtensionKind, window } from '../../utils/globals'
 import { buildNetworkRequestOptions } from './config'
 import { isLocalhost } from '../../utils/request-utils'
@@ -46,6 +46,9 @@ import { MutationRateLimiter } from './mutation-rate-limiter'
 import { gzipSync, strFromU8, strToU8 } from 'fflate'
 import { clampToRange } from '../../utils/number-utils'
 import { includes } from '../../utils'
+
+const LOGGER_PREFIX = '[SessionRecording]'
+const logger = createLogger(LOGGER_PREFIX)
 
 type SessionStartReason =
     | 'sampling_overridden'
@@ -118,8 +121,6 @@ const newQueuedEvent = (rrwebMethod: () => void): QueuedRRWebEvent => ({
     enqueuedAt: Date.now(),
     attempt: 1,
 })
-
-const LOGGER_PREFIX = '[SessionRecording]'
 
 type compressedFullSnapshotEvent = {
     type: EventType.FullSnapshot
@@ -207,7 +208,7 @@ function compressEvent(event: eventWithTime): eventWithTime | compressedEventWit
             }
         }
     } catch (e) {
-        logger.error(LOGGER_PREFIX + ' could not compress event - will use uncompressed event', e)
+        logger.error('could not compress event - will use uncompressed event', e)
     }
     return event
 }
@@ -445,7 +446,7 @@ export class SessionRecording {
         this.receivedDecide = false
 
         if (!this.instance.sessionManager) {
-            logger.error(LOGGER_PREFIX + ' started without valid sessionManager')
+            logger.error('started without valid sessionManager')
             throw new Error(LOGGER_PREFIX + ' started without valid sessionManager. This is a bug.')
         }
 
@@ -458,8 +459,7 @@ export class SessionRecording {
 
         if (this.sessionIdleThresholdMilliseconds >= this.sessionManager.sessionTimeoutMs) {
             logger.warn(
-                LOGGER_PREFIX +
-                    ` session_idle_threshold_ms (${this.sessionIdleThresholdMilliseconds}) is greater than the session timeout (${this.sessionManager.sessionTimeoutMs}). Session will never be detected as idle`
+                `session_idle_threshold_ms (${this.sessionIdleThresholdMilliseconds}) is greater than the session timeout (${this.sessionManager.sessionTimeoutMs}). Session will never be detected as idle`
             )
         }
     }
@@ -559,7 +559,7 @@ export class SessionRecording {
             this._samplingSessionListener?.()
             this._samplingSessionListener = undefined
 
-            logger.info(LOGGER_PREFIX + ' stopped')
+            logger.info('stopped')
         }
     }
 
@@ -601,8 +601,7 @@ export class SessionRecording {
                 this._reportStarted('sampled')
             } else {
                 logger.warn(
-                    LOGGER_PREFIX +
-                        ` Sample rate (${currentSampleRate}) has determined that this sessionId (${sessionId}) will not be sent to the server.`
+                    `Sample rate (${currentSampleRate}) has determined that this sessionId (${sessionId}) will not be sent to the server.`
                 )
             }
 
@@ -756,7 +755,7 @@ export class SessionRecording {
         if (!this.rrwebRecord) {
             assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, this.scriptName, (err) => {
                 if (err) {
-                    return logger.error(LOGGER_PREFIX + ` could not load recorder`, err)
+                    return logger.error('could not load recorder', err)
                 }
 
                 this._onScriptLoaded()
@@ -765,7 +764,7 @@ export class SessionRecording {
             this._onScriptLoaded()
         }
 
-        logger.info(LOGGER_PREFIX + ' starting')
+        logger.info('starting')
         if (this.status === 'active') {
             this._reportStarted(startReason || 'recording_initialized')
         }
@@ -868,7 +867,7 @@ export class SessionRecording {
                     rrwebMethod: queuedRRWebEvent.rrwebMethod,
                 })
             } else {
-                logger.warn(LOGGER_PREFIX + ' could not emit queued rrweb event.', e, queuedRRWebEvent)
+                logger.warn('could not emit queued rrweb event.', e, queuedRRWebEvent)
             }
 
             return false
@@ -926,8 +925,7 @@ export class SessionRecording {
 
         if (!this.rrwebRecord) {
             logger.error(
-                LOGGER_PREFIX +
-                    'onScriptLoaded was called but rrwebRecord is not available. This indicates something has gone wrong.'
+                'onScriptLoaded was called but rrwebRecord is not available. This indicates something has gone wrong.'
             )
             return
         }
@@ -1006,7 +1004,7 @@ export class SessionRecording {
                     networkPlugin(buildNetworkRequestOptions(this.instance.config, this.networkPayloadCapture))
                 )
             } else {
-                logger.info(LOGGER_PREFIX + ' NetworkCapture not started because we are on localhost.')
+                logger.info('NetworkCapture not started because we are on localhost.')
             }
         }
 
@@ -1276,7 +1274,7 @@ export class SessionRecording {
             this._flushBuffer()
         }, 100)
 
-        logger.info(LOGGER_PREFIX + ' recording paused due to URL blocker')
+        logger.info('recording paused due to URL blocker')
         this._tryAddCustomEvent('recording paused', { reason: 'url blocker' })
     }
 
@@ -1292,7 +1290,7 @@ export class SessionRecording {
         this._scheduleFullSnapshot()
 
         this._tryAddCustomEvent('recording resumed', { reason: 'left blocked url' })
-        logger.info(LOGGER_PREFIX + ' recording resumed')
+        logger.info('recording resumed')
     }
 
     private _addEventTriggerListener() {
@@ -1308,7 +1306,7 @@ export class SessionRecording {
                     this._activateTrigger('event')
                 }
             } catch (e) {
-                logger.error(LOGGER_PREFIX + 'Could not activate event trigger', e)
+                logger.error('Could not activate event trigger', e)
             }
         })
     }
@@ -1352,7 +1350,7 @@ export class SessionRecording {
         this.instance.register_for_session({
             $session_recording_start_reason: startReason,
         })
-        logger.info(LOGGER_PREFIX + ' ' + startReason.replace('_', ' '), tagPayload)
+        logger.info(startReason.replace('_', ' '), tagPayload)
         if (!includes(['recording_initialized', 'session_id_changed'], startReason)) {
             this._tryAddCustomEvent(startReason, tagPayload)
         }

--- a/src/extensions/segment-integration.ts
+++ b/src/extensions/segment-integration.ts
@@ -17,11 +17,13 @@
  *  ```
  */
 import { PostHog } from '../posthog-core'
-import { logger } from '../utils/logger'
+import { createLogger } from '../utils/logger'
 
 import { uuidv7 } from '../uuidv7'
 import { isFunction } from '../utils/type-utils'
 import { USER_STATE } from '../constants'
+
+const logger = createLogger('[SegmentIntegration]')
 
 export type SegmentUser = {
     anonymousId(): string | undefined
@@ -72,11 +74,11 @@ const createSegmentIntegration = (posthog: PostHog): SegmentPlugin => {
         }
         if (!ctx.event.userId && ctx.event.anonymousId !== posthog.get_distinct_id()) {
             // This is our only way of detecting that segment's analytics.reset() has been called so we also call it
-            logger.info('Segment integration does not have a userId set, resetting PostHog')
+            logger.info('No userId set, resetting PostHog')
             posthog.reset()
         }
         if (ctx.event.userId && ctx.event.userId !== posthog.get_distinct_id()) {
-            logger.info('Segment integration has a userId set, identifying with PostHog')
+            logger.info('UserId set, identifying with PostHog')
             posthog.identify(ctx.event.userId)
         }
 

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -32,8 +32,9 @@ import {
     RatingQuestion,
     MultipleChoiceQuestion,
 } from './surveys/components/QuestionTypes'
-import { logger } from '../utils/logger'
 import { Cancel } from './surveys/components/QuestionHeader'
+import { createLogger } from '../utils/logger'
+const logger = createLogger('[Surveys]')
 
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const window = _window as Window & typeof globalThis

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -160,7 +160,7 @@ export class Toolbar {
 
             assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, 'toolbar', (err) => {
                 if (err) {
-                    logger.error('Failed to load toolbar', err)
+                    logger.error('[Toolbar] Failed to load', err)
                     this.setToolbarState(ToolbarState.UNINITIALIZED)
                     return
                 }

--- a/src/extensions/tracing-headers.ts
+++ b/src/extensions/tracing-headers.ts
@@ -1,9 +1,9 @@
 import { PostHog } from '../posthog-core'
 import { assignableWindow } from '../utils/globals'
-import { logger } from '../utils/logger'
+import { createLogger } from '../utils/logger'
 import { isUndefined } from '../utils/type-utils'
 
-const LOGGER_PREFIX = '[TRACING-HEADERS]'
+const logger = createLogger('[TracingHeaders]')
 
 export class TracingHeaders {
     private _restoreXHRPatch: (() => void) | undefined = undefined
@@ -19,7 +19,7 @@ export class TracingHeaders {
 
         assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, 'tracing-headers', (err) => {
             if (err) {
-                return logger.error(LOGGER_PREFIX + ' failed to load script', err)
+                return logger.error('failed to load script', err)
             }
             cb()
         })

--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -13,7 +13,6 @@ export const DEFAULT_FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS = 5000
 const ONE_MINUTE_IN_MILLIS = 60 * 1000
 export const FIFTEEN_MINUTES_IN_MILLIS = 15 * ONE_MINUTE_IN_MILLIS
 
-const LOGGER_PREFIX = '[Web Vitals]'
 type WebVitalsEventBuffer = { url: string | undefined; metrics: any[]; firstMetricTimestamp: number | undefined }
 
 export class WebVitalsAutocapture {

--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -1,9 +1,11 @@
 import { PostHog } from '../../posthog-core'
 import { RemoteConfig, SupportedWebVitalsMetrics } from '../../types'
-import { logger } from '../../utils/logger'
+import { createLogger } from '../../utils/logger'
 import { isBoolean, isNullish, isNumber, isObject, isUndefined } from '../../utils/type-utils'
 import { WEB_VITALS_ALLOWED_METRICS, WEB_VITALS_ENABLED_SERVER_SIDE } from '../../constants'
 import { assignableWindow, window } from '../../utils/globals'
+
+const logger = createLogger('[Web Vitals]')
 
 type WebVitalsMetricCallback = (metric: any) => void
 
@@ -65,7 +67,7 @@ export class WebVitalsAutocapture {
 
     public startIfEnabled(): void {
         if (this.isEnabled && !this._initialized) {
-            logger.info(LOGGER_PREFIX + ' enabled, starting...')
+            logger.info('enabled, starting...')
             this.loadScript(this._startCapturing)
         }
     }
@@ -99,7 +101,7 @@ export class WebVitalsAutocapture {
         }
         assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, 'web-vitals', (err) => {
             if (err) {
-                logger.error(LOGGER_PREFIX + ' failed to load script', err)
+                logger.error('failed to load script', err)
                 return
             }
             cb()
@@ -110,7 +112,7 @@ export class WebVitalsAutocapture {
         // TODO you should be able to mask the URL here
         const href = window ? window.location.href : undefined
         if (!href) {
-            logger.error(LOGGER_PREFIX + 'Could not determine current URL')
+            logger.error('Could not determine current URL')
         }
         return href
     }
@@ -139,7 +141,7 @@ export class WebVitalsAutocapture {
     private _addToBuffer = (metric: any) => {
         const sessionIds = this.instance.sessionManager?.checkAndGetSessionAndWindowId(true)
         if (isUndefined(sessionIds)) {
-            logger.error(LOGGER_PREFIX + 'Could not read session ID. Dropping metrics!')
+            logger.error('Could not read session ID. Dropping metrics!')
             return
         }
 
@@ -151,14 +153,14 @@ export class WebVitalsAutocapture {
         }
 
         if (isNullish(metric?.name) || isNullish(metric?.value)) {
-            logger.error(LOGGER_PREFIX + 'Invalid metric received', metric)
+            logger.error('Invalid metric received', metric)
             return
         }
 
         // we observe some very large values sometimes, we'll ignore them
         // since the likelihood of LCP > 1 hour being correct is very low
         if (this._maxAllowedValue && metric.value >= this._maxAllowedValue) {
-            logger.error(LOGGER_PREFIX + 'Ignoring metric with value >= ' + this._maxAllowedValue, metric)
+            logger.error('Ignoring metric with value >= ' + this._maxAllowedValue, metric)
             return
         }
 
@@ -215,7 +217,7 @@ export class WebVitalsAutocapture {
         }
 
         if (!onLCP || !onCLS || !onFCP || !onINP) {
-            logger.error(LOGGER_PREFIX + 'web vitals callbacks not loaded - not starting')
+            logger.error('web vitals callbacks not loaded - not starting')
             return
         }
 

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -7,13 +7,13 @@ import { document, window } from './utils/globals'
 import { getEventTarget, getParentElement } from './autocapture-utils'
 import { HEATMAPS_ENABLED_SERVER_SIDE } from './constants'
 import { isEmptyObject, isObject, isUndefined } from './utils/type-utils'
-import { logger } from './utils/logger'
+import { createLogger } from './utils/logger'
 import { isElementInToolbar, isElementNode, isTag } from './utils/element-utils'
 import { DeadClicksAutocapture, isDeadClicksEnabledForHeatmaps } from './extensions/dead-clicks-autocapture'
 
 const DEFAULT_FLUSH_INTERVAL = 5000
-const HEATMAPS = 'heatmaps'
-const LOGGER_PREFIX = '[' + HEATMAPS + ']'
+
+const logger = createLogger('[heatmaps')
 
 type HeatmapEventBuffer =
     | {
@@ -89,7 +89,7 @@ export class Heatmaps {
             if (this._initialized) {
                 return
             }
-            logger.info(LOGGER_PREFIX + ' starting...')
+            logger.info('starting...')
             this._setupListeners()
             this._flushInterval = setInterval(this.flush.bind(this), this.flushIntervalMilliseconds)
         } else {

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -13,7 +13,7 @@ import { DeadClicksAutocapture, isDeadClicksEnabledForHeatmaps } from './extensi
 
 const DEFAULT_FLUSH_INTERVAL = 5000
 
-const logger = createLogger('[heatmaps')
+const logger = createLogger('[Heatmaps]')
 
 type HeatmapEventBuffer =
     | {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -410,7 +410,7 @@ export class PostHog {
         )
 
         if (this.config.on_xhr_error) {
-            logger.error('[posthog] on_xhr_error is deprecated. Use on_request_error instead')
+            logger.error('on_xhr_error is deprecated. Use on_request_error instead')
         }
 
         this.compression = config.disable_compression ? undefined : Compression.GZipJS

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -20,7 +20,9 @@ import {
 } from './constants'
 
 import { isArray } from './utils/type-utils'
-import { logger } from './utils/logger'
+import { createLogger } from './utils/logger'
+
+const logger = createLogger('[FeatureFlags]')
 
 const PERSISTENCE_ACTIVE_FEATURE_FLAGS = '$active_feature_flags'
 const PERSISTENCE_OVERRIDE_FEATURE_FLAGS = '$override_feature_flags'

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -11,11 +11,11 @@ import { isUrlMatchingRegex } from './utils/request-utils'
 import { SurveyEventReceiver } from './utils/survey-event-receiver'
 import { assignableWindow, document, window } from './utils/globals'
 import { RemoteConfig } from './types'
-import { logger } from './utils/logger'
+import { createLogger } from './utils/logger'
 import { isNullish } from './utils/type-utils'
 import { getSurveySeenStorageKeys } from './extensions/surveys/surveys-utils'
 
-const LOGGER_PREFIX = '[Surveys]'
+const logger = createLogger('[Surveys]')
 
 export const surveyUrlValidationMap: Record<SurveyUrlMatchType, (conditionsUrl: string) => boolean> = {
     icontains: (conditionsUrl) =>
@@ -90,7 +90,7 @@ export class PostHogSurveys {
 
             assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, 'surveys', (err) => {
                 if (err) {
-                    return logger.error(LOGGER_PREFIX, 'Could not load surveys script', err)
+                    return logger.error('Could not load surveys script', err)
                 }
 
                 this._surveyManager = assignableWindow.__PosthogExtensions__?.generateSurveys?.(this.instance)
@@ -295,14 +295,14 @@ export class PostHogSurveys {
             return nextQuestionIndex
         }
 
-        logger.warn(LOGGER_PREFIX, 'Falling back to next question index due to unexpected branching type')
+        logger.warn('Falling back to next question index due to unexpected branching type')
         return nextQuestionIndex
     }
 
     // this method is lazily loaded onto the window to avoid loading preact and other dependencies if surveys is not enabled
     private _canActivateRepeatedly(survey: Survey) {
         if (isNullish(assignableWindow.__PosthogExtensions__?.canActivateRepeatedly)) {
-            logger.warn(LOGGER_PREFIX, 'canActivateRepeatedly is not defined, must init before calling')
+            logger.warn('init was not called')
             return false // TODO does it make sense to have a default here?
         }
         return assignableWindow.__PosthogExtensions__.canActivateRepeatedly(survey)
@@ -310,7 +310,7 @@ export class PostHogSurveys {
 
     canRenderSurvey(surveyId: string) {
         if (isNullish(this._surveyManager)) {
-            logger.warn(LOGGER_PREFIX, 'canActivateRepeatedly is not defined, must init before calling')
+            logger.warn('init was not called')
             return
         }
         this.getSurveys((surveys) => {
@@ -321,7 +321,7 @@ export class PostHogSurveys {
 
     renderSurvey(surveyId: string, selector: string) {
         if (isNullish(this._surveyManager)) {
-            logger.warn(LOGGER_PREFIX, 'canActivateRepeatedly is not defined, must init before calling')
+            logger.warn('init was not called')
             return
         }
         this.getSurveys((surveys) => {

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,7 +1,9 @@
 import { CAPTURE_RATE_LIMIT } from './constants'
 import type { PostHog } from './posthog-core'
 import { RequestResponse } from './types'
-import { logger } from './utils/logger'
+import { createLogger } from './utils/logger'
+
+const logger = createLogger('[RateLimiter]')
 
 const ONE_MINUTE_IN_MILLISECONDS = 60 * 1000
 const RATE_LIMIT_EVENT = '$$client_ingestion_warning'
@@ -96,11 +98,11 @@ export class RateLimiter {
             const response: CaptureResponse = JSON.parse(text)
             const quotaLimitedProducts = response.quota_limited || []
             quotaLimitedProducts.forEach((batchKey) => {
-                logger.info(`[RateLimiter] ${batchKey || 'events'} is quota limited.`)
+                logger.info(`${batchKey || 'events'} is quota limited.`)
                 this.serverLimits[batchKey] = new Date().getTime() + ONE_MINUTE_IN_MILLISECONDS
             })
         } catch (e: any) {
-            logger.warn(`[RateLimiter] could not rate limit - continuing. Error: "${e?.message}"`, { text })
+            logger.warn(`could not rate limit - continuing. Error: "${e?.message}"`, { text })
             return
         }
     }

--- a/src/sessionid.ts
+++ b/src/sessionid.ts
@@ -6,10 +6,12 @@ import { uuid7ToTimestampMs, uuidv7 } from './uuidv7'
 import { window } from './utils/globals'
 
 import { isArray, isNumber, isUndefined } from './utils/type-utils'
-import { logger } from './utils/logger'
+import { createLogger } from './utils/logger'
 
 import { clampToRange } from './utils/number-utils'
 import { PostHog } from './posthog-core'
+
+const logger = createLogger('[SessionId]')
 
 export const DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS = 30 * 60 // 30 minutes
 export const MAX_SESSION_IDLE_TIMEOUT_SECONDS = 10 * 60 * 60 // 10 hours
@@ -230,7 +232,7 @@ export class SessionIdManager {
         if (noSessionId || activityTimeout || sessionPastMaximumLength) {
             sessionId = this._sessionIdGenerator()
             windowId = this._windowIdGenerator()
-            logger.info('[SessionId] new session ID generated', {
+            logger.info('new session ID generated', {
                 sessionId,
                 windowId,
                 changeReason: { noSessionId, activityTimeout, sessionPastMaximumLength },

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -1,8 +1,10 @@
 import { PostHog } from './posthog-core'
 import { CaptureResult, RemoteConfig } from './types'
 import { assignableWindow } from './utils/globals'
-import { logger } from './utils/logger'
+import { createLogger } from './utils/logger'
 import { isArray } from './utils/type-utils'
+
+const logger = createLogger('[SiteApps]')
 
 export class SiteApps {
     instance: PostHog
@@ -102,7 +104,7 @@ export class SiteApps {
                     })
                 }
             } else if (response['siteApps'].length > 0) {
-                logger.error('PostHog site apps are disabled. Enable the "opt_in_site_apps" config to proceed.')
+                logger.error('Site apps exist but "opt_in_site_apps" is not set so they are not loaded.')
                 this.loaded = true
             } else {
                 this.loaded = true

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,44 +2,62 @@ import Config from '../config'
 import { isUndefined } from './type-utils'
 import { assignableWindow, window } from './globals'
 
-const LOGGER_PREFIX = '[PostHog.js]'
-export const logger = {
-    _log: (level: 'log' | 'warn' | 'error', ...args: any[]) => {
-        if (
-            window &&
-            (Config.DEBUG || assignableWindow.POSTHOG_DEBUG) &&
-            !isUndefined(window.console) &&
-            window.console
-        ) {
-            const consoleLog =
-                '__rrweb_original__' in window.console[level]
-                    ? (window.console[level] as any)['__rrweb_original__']
-                    : window.console[level]
-
-            // eslint-disable-next-line no-console
-            consoleLog(LOGGER_PREFIX, ...args)
-        }
-    },
-
-    info: (...args: any[]) => {
-        logger._log('log', ...args)
-    },
-
-    warn: (...args: any[]) => {
-        logger._log('warn', ...args)
-    },
-
-    error: (...args: any[]) => {
-        logger._log('error', ...args)
-    },
-
-    critical: (...args: any[]) => {
-        // Critical errors are always logged to the console
-        // eslint-disable-next-line no-console
-        console.error(LOGGER_PREFIX, ...args)
-    },
-
-    uninitializedWarning: (methodName: string) => {
-        logger.error(`You must initialize PostHog before calling ${methodName}`)
-    },
+export type Logger = {
+    _log: (level: 'log' | 'warn' | 'error', ...args: any[]) => void
+    info: (...args: any[]) => void
+    warn: (...args: any[]) => void
+    error: (...args: any[]) => void
+    critical: (...args: any[]) => void
+    uninitializedWarning: (methodName: string) => void
+    createLogger: (prefix: string) => Logger
 }
+
+const _createLogger = (prefix: string): Logger => {
+    const logger: Logger = {
+        _log: (level: 'log' | 'warn' | 'error', ...args: any[]) => {
+            if (
+                window &&
+                (Config.DEBUG || assignableWindow.POSTHOG_DEBUG) &&
+                !isUndefined(window.console) &&
+                window.console
+            ) {
+                const consoleLog =
+                    '__rrweb_original__' in window.console[level]
+                        ? (window.console[level] as any)['__rrweb_original__']
+                        : window.console[level]
+
+                // eslint-disable-next-line no-console
+                consoleLog(prefix, ...args)
+            }
+        },
+
+        info: (...args: any[]) => {
+            logger._log('log', ...args)
+        },
+
+        warn: (...args: any[]) => {
+            logger._log('warn', ...args)
+        },
+
+        error: (...args: any[]) => {
+            logger._log('error', ...args)
+        },
+
+        critical: (...args: any[]) => {
+            // Critical errors are always logged to the console
+            // eslint-disable-next-line no-console
+            console.error(prefix, ...args)
+        },
+
+        uninitializedWarning: (methodName: string) => {
+            logger.error(`You must initialize PostHog before calling ${methodName}`)
+        },
+
+        createLogger: (additionalPrefix: string) => _createLogger(`${prefix} ${additionalPrefix}`),
+    }
+    return logger
+}
+
+export const logger = _createLogger('[PostHog.js]')
+
+export const createLogger = logger.createLogger


### PR DESCRIPTION
## Changes

Adds a `createLogger` function to help standardise some of our log patterns that includes the sub name

Also added a better helper as the various mocking things were a bit messy.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
