### PR TITLE
feat: Don't create person profile when setting properties for flags

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1491,9 +1491,6 @@ export class PostHog {
      * to update user properties.
      */
     setPersonPropertiesForFlags(properties: Properties, reloadFeatureFlags = true): void {
-        if (!this._requirePersonProcessing('posthog.setPersonPropertiesForFlags')) {
-            return
-        }
         this.featureFlags.setPersonPropertiesForFlags(properties, reloadFeatureFlags)
     }
 


### PR DESCRIPTION
## Changes
Remove the call to `_requirePersonProcessing` from `setPersonPropertiesForFlags`, as it doesn't need it

More context at https://posthog.slack.com/archives/C01MGUHFH6G/p1733511049244089

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
