### PR TITLE
feat: lazy load session recording

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -48,6 +48,7 @@ import LazyLoadedSessionRecording, {
     RECORDING_IDLE_THRESHOLD_MS,
     RECORDING_MAX_EVENT_SIZE,
 } from '../../../entrypoints/session-recorder'
+import SessionRecorder from '../../../entrypoints/session-recorder'
 
 // Type and source defined here designate a non-user-generated recording event
 
@@ -1967,23 +1968,24 @@ describe('SessionRecording', () => {
             loadScriptMock.mockImplementation((_ph, _path, callback) => {
                 callback()
             })
-            sessionRecording = new LazyLoadedSessionRecording(posthog)
+            sessionRecording = new SessionRecorder(posthog)
 
             sessionRecording.onRemoteConfig(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
             sessionRecording.start()
             expect(loadScriptMock).toHaveBeenCalled()
 
-            expect(sessionRecording['queuedRRWebEvents']).toHaveLength(0)
+            // called with `recording_initialized` event
+            expect(sessionRecording['queuedRRWebEvents']).toHaveLength(1)
 
             sessionRecording['_tryAddCustomEvent']('test', { test: 'test' })
         })
 
         it('queues events', () => {
-            expect(sessionRecording['queuedRRWebEvents']).toHaveLength(1)
+            expect(sessionRecording['queuedRRWebEvents']).toHaveLength(2)
         })
 
         it('limits the queue of events', () => {
-            expect(sessionRecording['queuedRRWebEvents']).toHaveLength(1)
+            expect(sessionRecording['queuedRRWebEvents']).toHaveLength(2)
 
             for (let i = 0; i < 100; i++) {
                 sessionRecording['_tryAddCustomEvent']('test', { test: 'test' })

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -31,7 +31,7 @@ import {
     RECORDING_IDLE_THRESHOLD_MS,
     RECORDING_MAX_EVENT_SIZE,
     SessionRecording,
-} from '../../../extensions/replay/sessionrecording'
+} from '../../../entrypoints/sessionrecording'
 import { assignableWindow, window } from '../../../utils/globals'
 import { RequestRouter } from '../../../utils/request-router'
 import {

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -11,7 +11,7 @@ import { PostHog } from '../posthog-core'
 import { PostHogPersistence } from '../posthog-persistence'
 import { SessionIdManager } from '../sessionid'
 import { RequestQueue } from '../request-queue'
-import { SessionRecording } from '../extensions/replay/sessionrecording'
+import { SessionRecording } from '../entrypoints/sessionrecording'
 import { PostHogFeatureFlags } from '../posthog-featureflags'
 
 describe('posthog core', () => {

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -7,12 +7,12 @@ import * as globals from '../utils/globals'
 import { ENABLE_PERSON_PROCESSING, USER_STATE } from '../constants'
 import { createPosthogInstance, defaultPostHog } from './helpers/posthog-instance'
 import { PostHogConfig, RemoteConfig } from '../types'
-import { PostHog } from '../posthog-core'
+import { OnlyValidKeys, PostHog } from '../posthog-core'
 import { PostHogPersistence } from '../posthog-persistence'
 import { SessionIdManager } from '../sessionid'
 import { RequestQueue } from '../request-queue'
-import { SessionRecording } from '../entrypoints/sessionrecording'
 import { PostHogFeatureFlags } from '../posthog-featureflags'
+import { SessionRecordingLoader } from '../extensions/replay/session-recording-loader'
 
 describe('posthog core', () => {
     const baseUTCDateTime = new Date(Date.UTC(2020, 0, 1, 0, 0, 0))
@@ -825,7 +825,10 @@ describe('posthog core', () => {
             posthog.sessionRecording = {
                 afterDecideResponse: jest.fn(),
                 startIfEnabledOrStop: jest.fn(),
-            } as unknown as SessionRecording
+            } as OnlyValidKeys<
+                Partial<SessionRecordingLoader>,
+                Partial<SessionRecordingLoader>
+            > as SessionRecordingLoader
             posthog.persistence = {
                 register: jest.fn(),
                 update_config: jest.fn(),
@@ -1136,7 +1139,7 @@ describe('posthog core', () => {
                 instance._send_request = jest.fn()
                 instance._loaded()
 
-                expect(instance._send_request.mock.calls[0][0]).toMatchObject({
+                expect(jest.mocked(instance._send_request).mock.calls[0][0]).toMatchObject({
                     url: 'http://localhost/decide/?v=3',
                 })
                 expect(instance.featureFlags.setReloadingPaused).toHaveBeenCalledWith(true)

--- a/src/__tests__/sessionid.test.ts
+++ b/src/__tests__/sessionid.test.ts
@@ -43,6 +43,7 @@ describe('Session ID manager', () => {
             disabled: false,
         }
         ;(sessionStore.is_supported as jest.Mock).mockReturnValue(true)
+        // @ts-expect-error - typescript gets confused about type of Date here
         jest.spyOn(global, 'Date').mockImplementation(() => new originalDate(now))
         ;(uuidv7 as jest.Mock).mockReturnValue('newUUID')
         ;(uuid7ToTimestampMs as jest.Mock).mockReturnValue(timestamp)

--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -3,7 +3,7 @@ import { mockLogger } from './helpers/mock-logger'
 import { SiteApps } from '../site-apps'
 import { PostHogPersistence } from '../posthog-persistence'
 import { RequestRouter } from '../utils/request-router'
-import { PostHog } from '../posthog-core'
+import { OnlyValidKeys, PostHog } from '../posthog-core'
 import { DecideResponse, PostHogConfig, Properties, CaptureResult } from '../types'
 import { assignableWindow } from '../utils/globals'
 import '../entrypoints/external-scripts-loader'
@@ -131,7 +131,10 @@ describe('SiteApps', () => {
             siteAppsInstance.enabled = true
             siteAppsInstance.loaded = false
 
-            const eventPayload = { event: 'test_event', properties: { prop1: 'value1' } } as CaptureResult
+            const eventPayload = { event: 'test_event', properties: { prop1: 'value1' } } as OnlyValidKeys<
+                Partial<CaptureResult>,
+                Partial<CaptureResult>
+            > as CaptureResult
 
             jest.spyOn(siteAppsInstance, 'globalsForEvent').mockReturnValue({ some: 'globals' })
 
@@ -147,7 +150,10 @@ describe('SiteApps', () => {
 
             siteAppsInstance.missedInvocations = new Array(1000).fill({})
 
-            const eventPayload = { event: 'test_event', properties: { prop1: 'value1' } } as CaptureResult
+            const eventPayload = { event: 'test_event', properties: { prop1: 'value1' } } as OnlyValidKeys<
+                Partial<CaptureResult>,
+                Partial<CaptureResult>
+            > as CaptureResult
 
             jest.spyOn(siteAppsInstance, 'globalsForEvent').mockReturnValue({ some: 'globals' })
 

--- a/src/entrypoints/session-recorder.ts
+++ b/src/entrypoints/session-recorder.ts
@@ -29,6 +29,7 @@ import {
     SessionRecordingStatus,
     SessionRecordingUrlTrigger,
     SessionStartReason,
+    SnapshotBuffer,
     TriggerType,
 } from '../types'
 import {
@@ -83,13 +84,6 @@ const ACTIVE_SOURCES = [
 ]
 
 type TriggerStatus = 'trigger_activated' | 'trigger_pending' | 'trigger_disabled'
-
-export interface SnapshotBuffer {
-    size: number
-    data: any[]
-    sessionId: string
-    windowId: string
-}
 
 interface QueuedRRWebEvent {
     rrwebMethod: () => void

--- a/src/extensions/replay/session-recording-loader.ts
+++ b/src/extensions/replay/session-recording-loader.ts
@@ -1,0 +1,75 @@
+import { assignableWindow, document, LazyLoadedSessionRecordingInterface, window } from '../../utils/globals'
+import { PostHog } from '../../posthog-core'
+import { RemoteConfig } from '../../types'
+import { createLogger } from '../../utils/logger'
+import { SESSION_RECORDING_ENABLED_SERVER_SIDE } from '../../constants'
+
+const logger = createLogger('[Session-Recording-Loader]')
+
+export const isSessionRecordingEnabled = (loader: SessionRecordingLoader) => {
+    const enabled_server_side = !!loader.instance.get_property(SESSION_RECORDING_ENABLED_SERVER_SIDE)
+    const enabled_client_side = !loader.instance.config.disable_session_recording
+    return !!window && enabled_server_side && enabled_client_side
+}
+
+export class SessionRecordingLoader {
+    get lazyLoaded(): LazyLoadedSessionRecordingInterface | undefined {
+        return this._lazyLoadedSessionRecording
+    }
+
+    private _lazyLoadedSessionRecording: LazyLoadedSessionRecordingInterface | undefined
+
+    constructor(readonly instance: PostHog, readonly isEnabled: (srl: SessionRecordingLoader) => boolean) {
+        this.startIfEnabled()
+    }
+
+    public onRemoteConfig(response: RemoteConfig) {
+        if (this.instance.persistence) {
+            this._lazyLoadedSessionRecording?.onRemoteConfig(response)
+        }
+        this.startIfEnabled()
+    }
+
+    public startIfEnabled() {
+        if (this.isEnabled(this)) {
+            this.loadScript(() => {
+                this.start()
+            })
+        }
+    }
+
+    private loadScript(cb: () => void): void {
+        if (assignableWindow.__PosthogExtensions__?.initSessionRecording) {
+            // already loaded
+            cb()
+        }
+        assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this.instance, 'session-recording', (err) => {
+            if (err) {
+                logger.error('failed to load script', err)
+                return
+            }
+            cb()
+        })
+    }
+
+    private start() {
+        if (!document) {
+            logger.error('`document` not found. Cannot start.')
+            return
+        }
+
+        if (!this._lazyLoadedSessionRecording && assignableWindow.__PosthogExtensions__?.initSessionRecording) {
+            this._lazyLoadedSessionRecording = assignableWindow.__PosthogExtensions__.initSessionRecording(
+                this.instance
+            )
+            this._lazyLoadedSessionRecording.start()
+        }
+    }
+
+    stop() {
+        if (this._lazyLoadedSessionRecording) {
+            this._lazyLoadedSessionRecording.stop()
+            this._lazyLoadedSessionRecording = undefined
+        }
+    }
+}

--- a/src/extensions/replay/sessionrecording-utils.ts
+++ b/src/extensions/replay/sessionrecording-utils.ts
@@ -2,7 +2,7 @@ import type { eventWithTime, listenerHandler, pluginEvent } from '@rrweb/types'
 import type { record } from '@rrweb/record'
 
 import { isObject } from '../../utils/type-utils'
-import { SnapshotBuffer } from './sessionrecording'
+import { SnapshotBuffer } from '../../entrypoints/sessionrecording'
 
 // taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#circular_references
 export function circularReferenceReplacer() {

--- a/src/extensions/replay/sessionrecording-utils.ts
+++ b/src/extensions/replay/sessionrecording-utils.ts
@@ -2,7 +2,7 @@ import type { eventWithTime, listenerHandler, pluginEvent } from '@rrweb/types'
 import type { record } from '@rrweb/record'
 
 import { isObject } from '../../utils/type-utils'
-import { SnapshotBuffer } from '../../entrypoints/sessionrecording'
+import { SnapshotBuffer } from '../../types'
 
 // taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#circular_references
 export function circularReferenceReplacer() {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -101,7 +101,11 @@ Globals should be all caps
  * That's a really tricky mistake to spot.
  * The OnlyValidKeys type ensures that only keys that are valid in the PostHogConfig type are allowed.
  */
-type OnlyValidKeys<T, Shape> = T extends Shape ? (Exclude<keyof T, keyof Shape> extends never ? T : never) : never
+export type OnlyValidKeys<T, Shape> = T extends Shape
+    ? Exclude<keyof T, keyof Shape> extends never
+        ? T
+        : never
+    : never
 
 const instances: Record<string, PostHog> = {}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -384,31 +384,42 @@ export interface SessionRecordingOptions {
     maskNetworkRequestFn?: ((data: NetworkRequest) => NetworkRequest | null | undefined) | null
     /** Modify the network request before it is captured. Returning null or undefined stops it being captured */
     maskCapturedNetworkRequestFn?: ((data: CapturedNetworkRequest) => CapturedNetworkRequest | null | undefined) | null
-    // our settings here only support a subset of those proposed for rrweb's network capture plugin
+    /**
+     * our settings here only support a subset of those proposed for rrweb's network capture plugin
+     */
     recordHeaders?: boolean
     recordBody?: boolean
-    // ADVANCED: while a user is active we take a full snapshot of the browser every interval. For very few sites playback performance might be better with different interval. Set to 0 to disable
+    /**
+     * ADVANCED: while a user is active we take a full snapshot of the browser every interval. For very few sites playback performance might be better with different interval. Set to 0 to disable
+     */
     full_snapshot_interval_millis?: number
-    /*
+    /**
      ADVANCED: whether to partially compress rrweb events before sending them to the server,
      defaults to true, can be set to false to disable partial compression
      NB requests are still compressed when sent to the server regardless of this setting
     */
     compress_events?: boolean
-    /*
+    /**
      ADVANCED: alters the threshold before a recording considers a user has become idle.
      Normally only altered alongside changes to session_idle_timeout_ms.
      Default is 5 minutes.
     */
     session_idle_threshold_ms?: number
-    /*
+    /**
+     * ADVANCED: allow capture of network performance and payload data when running on localhost
+     * (still requires other config to enable). This is disabled by default for performance reasons.
+     * Normally only useful for debugging and development. But can be necessary for some frameworks
+     * such as capacitor that run on localhost.
+     */
+    _forceAllowLocalhostNetworkCapture?: boolean
+    /**
      ADVANCED: alters the refill rate for the token bucket mutation throttling
      Normally only altered alongside posthog support guidance.
      Accepts values between 0 and 100
      Default is 10.
     */
     __mutationRateLimiterRefillRate?: number
-    /*
+    /**
      ADVANCED: alters the bucket size for the token bucket mutation throttling
      Normally only altered alongside posthog support guidance.
      Accepts values between 0 and 100

--- a/src/types.ts
+++ b/src/types.ts
@@ -443,6 +443,13 @@ export type SessionRecordingStatus = 'disabled' | 'sampled' | 'active' | 'buffer
 
 export type TriggerType = 'url' | 'event'
 
+export interface SnapshotBuffer {
+    size: number
+    data: any[]
+    sessionId: string
+    windowId: string
+}
+
 export enum Compression {
     GZipJS = 'gzip-js',
     Base64 = 'base64',

--- a/src/types.ts
+++ b/src/types.ts
@@ -423,6 +423,26 @@ export type SessionIdChangedCallback = (
     changeReason?: { noSessionId: boolean; activityTimeout: boolean; sessionPastMaximumLength: boolean }
 ) => void
 
+export type SessionStartReason =
+    | 'recording_initialized'
+    | 'sampling_overridden'
+    | 'linked_flag_matched'
+    | 'linked_flag_overridden'
+    | 'sampled'
+    | 'session_id_changed'
+    | 'url_trigger_matched'
+    | 'event_trigger_matched'
+
+/**
+ * Session recording starts in buffering mode while waiting for decide response
+ * Once the response is received it might be disabled, active or sampled
+ * When sampled that means a sample rate is set and the last time the session id was rotated
+ * the sample rate determined this session should be sent to the server.
+ */
+export type SessionRecordingStatus = 'disabled' | 'sampled' | 'active' | 'buffering' | 'paused'
+
+export type TriggerType = 'url' | 'event'
+
 export enum Compression {
     GZipJS = 'gzip-js',
     Base64 = 'base64',

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -42,7 +42,7 @@ export type PostHogExtensionKind =
     | 'toolbar'
     | 'exception-autocapture'
     | 'web-vitals'
-    | 'session-recording'
+    | 'session-recorder'
     | 'recorder'
     | 'tracing-headers'
     | 'surveys'

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -1,7 +1,16 @@
 import { ErrorProperties } from '../extensions/exception-autocapture/error-conversion'
 import type { PostHog } from '../posthog-core'
 import { SessionIdManager } from '../sessionid'
-import { DeadClicksAutoCaptureConfig, ErrorEventArgs, ErrorMetadata, Properties, RemoteConfig } from '../types'
+import {
+    DeadClicksAutoCaptureConfig,
+    ErrorEventArgs,
+    ErrorMetadata,
+    Properties,
+    RemoteConfig,
+    SessionRecordingStatus,
+    SessionStartReason,
+    TriggerType,
+} from '../types'
 
 /*
  * Global helpers to protect access to browser globals in a way that is safer for different targets
@@ -33,11 +42,23 @@ export type PostHogExtensionKind =
     | 'toolbar'
     | 'exception-autocapture'
     | 'web-vitals'
+    | 'session-recording'
     | 'recorder'
     | 'tracing-headers'
     | 'surveys'
     | 'dead-clicks-autocapture'
     | 'remote-config'
+
+export interface LazyLoadedSessionRecordingInterface {
+    start: (startReason?: SessionStartReason) => void
+    stop: () => void
+    onRemoteConfig(response: RemoteConfig): void
+    get status(): SessionRecordingStatus
+    overrideTrigger: (triggerType: TriggerType) => void
+    overrideSampling: () => void
+    overrideLinkedFlag: () => void
+    get started(): boolean
+}
 
 export interface LazyLoadedDeadClicksAutocaptureInterface {
     start: (observerTarget: Node) => void
@@ -79,6 +100,7 @@ interface PostHogExtensions {
         ph: PostHog,
         config: DeadClicksAutoCaptureConfig
     ) => LazyLoadedDeadClicksAutocaptureInterface
+    initSessionRecording?: (ph: PostHog) => LazyLoadedSessionRecordingInterface
 }
 
 const global: typeof globalThis | undefined = typeof globalThis !== 'undefined' ? globalThis : win


### PR DESCRIPTION
move session recording entirely to lazy loaded not just the rrweb portions

tested locally and can still record

still need to figure out how to safely release this since it will be published to NPM before the new lazy bundle is available on the CDN