### PR TITLE
fix: Rotate test distinct id to avoid lagging partition

### DIFF
--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -62,5 +62,5 @@ jobs:
         run: pnpm testcafe ${{ matrix.browser }} --stop-on-first-fail
 
       - name: Check ${{ matrix.name }} events
-        timeout-minutes: 10
+        timeout-minutes: 31
         run: pnpm check-testcafe-results

--- a/testcafe/helpers.js
+++ b/testcafe/helpers.js
@@ -56,7 +56,10 @@ export const initPosthog = (testName, config) => {
         api_host: POSTHOG_API_HOST,
         api_key: POSTHOG_PROJECT_KEY,
         bootstrap: {
-            distinctID: 'automated-tester', // We set this to get around the ingestion delay for new distinctIDs
+            // We set this to get around the ingestion delay for new distinctIDs. It's not ideal, as if we have a
+            // lagging partition on prod then we can be blocked from merging any PRs. Until we run these tests against
+            // a local posthog instance, you can change this ID to change the partition.
+            distinctID: 'automated-tester-2',
             isIdentifiedID: true,
         },
         opt_out_useragent_filter: true,

--- a/testcafe/helpers.js
+++ b/testcafe/helpers.js
@@ -59,7 +59,7 @@ export const initPosthog = (testName, config) => {
             // We set this to get around the ingestion delay for new distinctIDs. It's not ideal, as if we have a
             // lagging partition on prod then we can be blocked from merging any PRs. Until we run these tests against
             // a local posthog instance, you can change this ID to change the partition.
-            distinctID: 'automated-tester-2',
+            distinctID: 'automated-tester-3',
             isIdentifiedID: true,
         },
         opt_out_useragent_filter: true,


### PR DESCRIPTION
## Changes

No code changes, I'm just changing the distinct id that is used in test to avoid the lagging partition.

Obviously this is a quick band aid over a larger problem

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
