### PR TITLE
feat: Allow users to customize `fetch` behavior

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -663,6 +663,10 @@ export class PostHog {
         }
         options.compression = options.compression === 'best-available' ? this.compression : options.compression
 
+        // Specially useful if you're doing SSR with NextJS
+        // Users must be careful when tweaking `cache` because they might get out-of-date feature flags
+        options.fetchOptions = options.fetchOptions || this.config.fetch_options
+
         request({
             ...options,
             callback: (response) => {

--- a/src/request.ts
+++ b/src/request.ts
@@ -165,6 +165,7 @@ const _fetch = (options: RequestOptions) => {
         keepalive: options.method === 'POST' && (estimatedSize || 0) < KEEP_ALIVE_THRESHOLD,
         body,
         signal: aborter?.signal,
+        ...options.fetchOptions,
     })
         .then((response) => {
             return response.text().then((responseText) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -333,6 +333,15 @@ export interface PostHogConfig {
         events_burst_limit?: number
     }
 
+    /** Used when sending data via `fetch`, use with care, this is intentionally meant to be used with NextJS `fetch`
+     *  Incorrect usage may cause out-of-date data for feature flags, actions tracking, etc.
+     *  See https://nextjs.org/docs/app/api-reference/functions/fetch#fetchurl-options
+     */
+    fetch_options?: {
+        cache?: RequestInit['cache']
+        next_options?: NextOptions
+    }
+
     /**
      * PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION
      * whether to wrap fetch and add tracing headers to the request
@@ -440,6 +449,9 @@ export interface RequestResponse {
 
 export type RequestCallback = (response: RequestResponse) => void
 
+// See https://nextjs.org/docs/app/api-reference/functions/fetch#fetchurl-options
+type NextOptions = { revalidate: false | 0 | number; tags: string[] }
+
 export interface RequestOptions {
     url: string
     // Data can be a single object or an array of objects when batched
@@ -452,6 +464,10 @@ export interface RequestOptions {
     timeout?: number
     noRetries?: boolean
     compression?: Compression | 'best-available'
+    fetchOptions?: {
+        cache?: RequestInit['cache']
+        next?: NextOptions
+    }
 }
 
 // Queued request types - the same as a request but with additional queueing information


### PR DESCRIPTION
NextJS SSR v15.1+ will not cache `fetch` requests by default, but some users might want that, specially in development mode. We're now allowing them to customize our `fetch` requests by setting the new `fetch_options` setting when calling `posthog.init`

This needs to be used carefully, but it should be extremely powerful and useful for NextJS users. We'll add documentation about it on `posthog.com` soon.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
