### PR TITLE
feat: Added domain param to config requests

### DIFF
--- a/src/__tests__/decide.ts
+++ b/src/__tests__/decide.ts
@@ -305,7 +305,7 @@ describe('Decide', () => {
             expect(assignableWindow.__PosthogExtensions__.loadExternalDependency).toHaveBeenCalled()
             expect(posthog._send_request).toHaveBeenCalledWith({
                 method: 'GET',
-                url: 'https://test.com/array/testtoken/config',
+                url: 'https://test.com/array/testtoken/config?domain=localhost',
                 callback: expect.any(Function),
             })
             expect(posthog._onRemoteConfig).toHaveBeenCalledWith(config)

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -27,7 +27,10 @@ export class Decide {
     private _loadRemoteConfigJSON(cb: (config?: RemoteConfig) => void): void {
         this.instance._send_request({
             method: 'GET',
-            url: this.instance.requestRouter.endpointFor('assets', `/array/${this.instance.config.token}/config`),
+            url: this.instance.requestRouter.endpointFor(
+                'assets',
+                `/array/${this.instance.config.token}/config?domain=${assignableWindow.location.hostname}`
+            ),
             callback: (response) => {
                 cb(response.json as RemoteConfig | undefined)
             },

--- a/src/entrypoints/external-scripts-loader.ts
+++ b/src/entrypoints/external-scripts-loader.ts
@@ -46,7 +46,7 @@ assignableWindow.__PosthogExtensions__.loadExternalDependency = (
     let scriptUrlToLoad = `/static/${kind}.js` + `?v=${posthog.version}`
 
     if (kind === 'remote-config') {
-        scriptUrlToLoad = `/array/${posthog.config.token}/config.js`
+        scriptUrlToLoad = `/array/${posthog.config.token}/config.js?domain=${assignableWindow.location.hostname}`
     }
 
     if (kind === 'toolbar') {


### PR DESCRIPTION
## Changes

We need to pass the domain to do some extra validation (we need a query param due to CDN caching)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
