### PR TITLE
fix: Make legacy property sturdier

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -286,7 +286,7 @@ export class PostHog {
 
     // Legacy property to support existing usage - this isn't technically correct but it's what it has always been - a proxy for flags being loaded
     public get decideEndpointWasHit(): boolean {
-        return this.featureFlags.hasLoadedFlags
+        return this.featureFlags?.hasLoadedFlags ?? false
     }
 
     /** DEPRECATED: We keep this to support existing usage but now one should just call .setPersonProperties */


### PR DESCRIPTION
This property might be accessed/called before we've properly initialized feature flags, so let's make sure we're not breaking anything (we have broken it already, see https://posthog.slack.com/archives/C02E3BKC78F/p1734111258352399)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
  - No tests for now, but we should add it eventually, we need to guarantee this doesn't break anymore 	
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
