### PR TITLE
fix: Load RemoteConfig by default but don't use it

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -7,6 +7,9 @@ Cypress.on('window:before:load', (win) => {
     cy.spy(win.console, 'warn')
     cy.spy(win.console, 'log')
     cy.spy(win.console, 'debug')
+
+    // NOTE: Temporary change whilst testing remote config
+    ;(win as any)._POSTHOG_CONFIG = {}
 })
 
 beforeEach(() => {

--- a/src/__tests__/helpers/posthog-instance.ts
+++ b/src/__tests__/helpers/posthog-instance.ts
@@ -2,6 +2,7 @@
 
 import { PostHog, init_as_module } from '../../posthog-core'
 import { PostHogConfig } from '../../types'
+import { assignableWindow } from '../../utils/globals'
 import { uuidv7 } from '../../uuidv7'
 
 export const createPosthogInstance = async (
@@ -13,6 +14,9 @@ export const createPosthogInstance = async (
     // written, we first create an instance, then call init on it which then
     // creates another instance.
     const posthog = new PostHog()
+
+    // NOTE: Temporary change whilst testing remote config
+    assignableWindow._POSTHOG_CONFIG = {} as any
 
     // eslint-disable-next-line compat/compat
     return await new Promise<PostHog>((resolve) =>

--- a/src/__tests__/loader.test.ts
+++ b/src/__tests__/loader.test.ts
@@ -9,12 +9,15 @@ import { PostHog } from '../posthog-core'
 import { defaultPostHog } from './helpers/posthog-instance'
 
 import sinon from 'sinon'
-import { window } from '../utils/globals'
+import { assignableWindow, window } from '../utils/globals'
 
 describe(`Module-based loader in Node env`, () => {
     const posthog = defaultPostHog()
 
     beforeEach(() => {
+        // NOTE: Temporary change whilst testing remote config
+        assignableWindow._POSTHOG_CONFIG = {} as any
+
         jest.useFakeTimers()
         jest.spyOn(posthog, '_send_request').mockReturnValue()
         jest.spyOn(window!.console, 'log').mockImplementation()

--- a/src/__tests__/posthog-core.identify.test.ts
+++ b/src/__tests__/posthog-core.identify.test.ts
@@ -2,6 +2,7 @@ import { USER_STATE } from '../constants'
 import { uuidv7 } from '../uuidv7'
 import { createPosthogInstance, defaultPostHog } from './helpers/posthog-instance'
 import { PostHog } from '../posthog-core'
+import { assignableWindow } from '../utils/globals'
 
 describe('identify()', () => {
     let instance: PostHog
@@ -9,6 +10,9 @@ describe('identify()', () => {
 
     beforeEach(() => {
         beforeSendMock = jest.fn().mockImplementation((e) => e)
+        // NOTE: Temporary change whilst testing remote config
+        assignableWindow._POSTHOG_CONFIG = {} as any
+
         const posthog = defaultPostHog().init(
             uuidv7(),
             {

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -29,6 +29,8 @@ describe('posthog core', () => {
     }
 
     beforeEach(() => {
+        // NOTE: Temporary change whilst testing remote config
+        globals.assignableWindow._POSTHOG_CONFIG = {} as any
         jest.useFakeTimers().setSystemTime(baseUTCDateTime)
     })
 

--- a/src/__tests__/segment.test.ts
+++ b/src/__tests__/segment.test.ts
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals'
 import { PostHog } from '../posthog-core'
 import { SegmentContext, SegmentPlugin } from '../extensions/segment-integration'
 import { USER_STATE } from '../constants'
+import { assignableWindow } from '../utils/globals'
 
 describe(`Segment integration`, () => {
     let segment: any
@@ -21,6 +22,8 @@ describe(`Segment integration`, () => {
     jest.setTimeout(500)
 
     beforeEach(() => {
+        assignableWindow._POSTHOG_CONFIG = {} as any
+
         // Create something that looks like the Segment Analytics 2.0 API. We
         // could use the actual client, but it's a little more tricky and we'd
         // want to mock out the network requests, for which we don't have a good

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -31,14 +31,6 @@ export class RemoteConfigLoader {
     }
 
     load(): void {
-        // Call decide to get what features are enabled and other settings.
-        // As a reminder, if the /decide endpoint is disabled, feature flags, toolbar, session recording, autocapture,
-        // and compression will not be available.
-
-        if (!this.instance.config.__preview_remote_config) {
-            return
-        }
-
         // Attempt 1 - use the pre-loaded config if it came as part of the token-specific array.js
         if (assignableWindow._POSTHOG_CONFIG) {
             logger.info('Using preloaded remote config', assignableWindow._POSTHOG_CONFIG)
@@ -73,6 +65,12 @@ export class RemoteConfigLoader {
             logger.error('Failed to fetch remote config from PostHog.')
             return
         }
+
+        if (!this.instance.config.__preview_remote_config) {
+            logger.info('__preview_remote_config is disabled. Logging config instead', config)
+            return
+        }
+
         this.instance._onRemoteConfig(config)
 
         // We only need to reload if we haven't already loaded the flags or if the request is in flight


### PR DESCRIPTION
## Changes

Part of the rollout testing. Because this is replacing decide we can't use decide to gradually rollout. Instead I'm turning it on for everyone but only using it if the preview flag is enabled. That way I can poke around implementations and see if its working as well as checking backend metrics

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
