### PR TITLE
feat: Use token scoped remote config

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -9,7 +9,7 @@ Cypress.on('window:before:load', (win) => {
     cy.spy(win.console, 'debug')
 
     // NOTE: Temporary change whilst testing remote config
-    ;(win as any)._POSTHOG_CONFIG = {}
+    ;(win as any)._POSTHOG_REMOTE_CONFIG = {}
 })
 
 beforeEach(() => {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -9,7 +9,12 @@ Cypress.on('window:before:load', (win) => {
     cy.spy(win.console, 'debug')
 
     // NOTE: Temporary change whilst testing remote config
-    ;(win as any)._POSTHOG_REMOTE_CONFIG = {}
+    ;(win as any)._POSTHOG_REMOTE_CONFIG = {
+        test_token: {
+            config: {},
+            siteApps: [],
+        },
+    }
 })
 
 beforeEach(() => {

--- a/src/__tests__/helpers/posthog-instance.ts
+++ b/src/__tests__/helpers/posthog-instance.ts
@@ -16,7 +16,12 @@ export const createPosthogInstance = async (
     const posthog = new PostHog()
 
     // NOTE: Temporary change whilst testing remote config
-    assignableWindow._POSTHOG_CONFIG = {} as any
+    assignableWindow._POSTHOG_REMOTE_CONFIG = {
+        [token]: {
+            config: {},
+            siteApps: [],
+        },
+    } as any
 
     // eslint-disable-next-line compat/compat
     return await new Promise<PostHog>((resolve) =>

--- a/src/__tests__/loader.test.ts
+++ b/src/__tests__/loader.test.ts
@@ -16,7 +16,12 @@ describe(`Module-based loader in Node env`, () => {
 
     beforeEach(() => {
         // NOTE: Temporary change whilst testing remote config
-        assignableWindow._POSTHOG_CONFIG = {} as any
+        assignableWindow._POSTHOG_REMOTE_CONFIG = {
+            'test-token': {
+                config: {},
+                siteApps: [],
+            },
+        } as any
 
         jest.useFakeTimers()
         jest.spyOn(posthog, '_send_request').mockReturnValue()
@@ -61,7 +66,7 @@ describe(`Module-based loader in Node env`, () => {
         console.warn = jest.fn()
         expect(posthog.init(`my-test`, undefined, 'sdk-1')).toBeInstanceOf(PostHog)
         expect(posthog.init(``, undefined, 'sdk-2')).toBeInstanceOf(PostHog)
-        expect(console.error).toHaveBeenCalledTimes(1)
+        expect(console.error).toHaveBeenCalledTimes(2)
         expect(console.error).toHaveBeenCalledWith(
             '[PostHog.js]',
             'PostHog was initialized without a token. This likely indicates a misconfiguration. Please check the first argument passed to posthog.init()'

--- a/src/__tests__/posthog-core.identify.test.ts
+++ b/src/__tests__/posthog-core.identify.test.ts
@@ -10,16 +10,22 @@ describe('identify()', () => {
 
     beforeEach(() => {
         beforeSendMock = jest.fn().mockImplementation((e) => e)
+        const token = uuidv7()
         // NOTE: Temporary change whilst testing remote config
-        assignableWindow._POSTHOG_CONFIG = {} as any
+        assignableWindow._POSTHOG_REMOTE_CONFIG = {
+            [token]: {
+                config: {},
+                siteApps: [],
+            },
+        } as any
 
         const posthog = defaultPostHog().init(
-            uuidv7(),
+            token,
             {
                 api_host: 'https://test.com',
                 before_send: beforeSendMock,
             },
-            uuidv7()
+            token
         )
 
         instance = Object.assign(posthog, {

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -24,13 +24,19 @@ describe('posthog core', () => {
     }
 
     const posthogWith = (config: Partial<PostHogConfig>, overrides?: Partial<PostHog>): PostHog => {
-        const posthog = defaultPostHog().init('testtoken', config, uuidv7())
+        // NOTE: Temporary change whilst testing remote config
+        const token = config.token || 'testtoken'
+        globals.assignableWindow._POSTHOG_REMOTE_CONFIG = {
+            [token]: {
+                config: {},
+                siteApps: [],
+            },
+        } as any
+        const posthog = defaultPostHog().init(token, config, uuidv7())
         return Object.assign(posthog, overrides || {})
     }
 
     beforeEach(() => {
-        // NOTE: Temporary change whilst testing remote config
-        globals.assignableWindow._POSTHOG_CONFIG = {} as any
         jest.useFakeTimers().setSystemTime(baseUTCDateTime)
     })
 

--- a/src/__tests__/segment.test.ts
+++ b/src/__tests__/segment.test.ts
@@ -22,7 +22,12 @@ describe(`Segment integration`, () => {
     jest.setTimeout(500)
 
     beforeEach(() => {
-        assignableWindow._POSTHOG_CONFIG = {} as any
+        assignableWindow._POSTHOG_REMOTE_CONFIG = {
+            'test-token': {
+                config: {},
+                siteApps: [],
+            },
+        } as any
 
         // Create something that looks like the Segment Analytics 2.0 API. We
         // could use the actual client, but it's a little more tricky and we'd

--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -15,8 +15,10 @@ describe('SiteApps', () => {
     let emitCaptureEvent: ((eventName: string, eventPayload: CaptureResult) => void) | undefined
     let removeCaptureHook = jest.fn()
 
+    const token = 'testtoken'
+
     const defaultConfig: Partial<PostHogConfig> = {
-        token: 'testtoken',
+        token: token,
         api_host: 'https://test.com',
         persistence: 'memory',
     }
@@ -40,7 +42,7 @@ describe('SiteApps', () => {
             }),
         }
 
-        delete assignableWindow._POSTHOG_JS_APPS
+        delete assignableWindow._POSTHOG_REMOTE_CONFIG
         delete assignableWindow.POSTHOG_DEBUG
 
         removeCaptureHook = jest.fn()
@@ -249,7 +251,12 @@ describe('SiteApps', () => {
         })
 
         it('does not load site apps if new global loader exists', () => {
-            assignableWindow._POSTHOG_JS_APPS = []
+            assignableWindow._POSTHOG_REMOTE_CONFIG = {
+                [token]: {
+                    config: {},
+                    siteApps: [],
+                },
+            } as any
             siteAppsInstance.onRemoteConfig({
                 siteApps: [{ id: '1', url: '/site_app/1' }],
             } as RemoteConfig)
@@ -289,26 +296,31 @@ describe('SiteApps', () => {
 
         beforeEach(() => {
             appConfigs = []
-            assignableWindow._POSTHOG_JS_APPS = [
-                {
-                    id: '1',
-                    init: jest.fn((config) => {
-                        appConfigs.push(config)
-                        return {
-                            processEvent: jest.fn(),
-                        }
-                    }),
+            assignableWindow._POSTHOG_REMOTE_CONFIG = {
+                [token]: {
+                    config: {},
+                    siteApps: [
+                        {
+                            id: '1',
+                            init: jest.fn((config) => {
+                                appConfigs.push(config)
+                                return {
+                                    processEvent: jest.fn(),
+                                }
+                            }),
+                        },
+                        {
+                            id: '2',
+                            init: jest.fn((config) => {
+                                appConfigs.push(config)
+                                return {
+                                    processEvent: jest.fn(),
+                                }
+                            }),
+                        },
+                    ],
                 },
-                {
-                    id: '2',
-                    init: jest.fn((config) => {
-                        appConfigs.push(config)
-                        return {
-                            processEvent: jest.fn(),
-                        }
-                    }),
-                },
-            ]
+            } as any
 
             siteAppsInstance.init()
         })
@@ -319,7 +331,12 @@ describe('SiteApps', () => {
         })
 
         it('does not sets up the eventCaptured listener if no site apps', () => {
-            assignableWindow._POSTHOG_JS_APPS = []
+            assignableWindow._POSTHOG_REMOTE_CONFIG = {
+                [token]: {
+                    config: {},
+                    siteApps: [],
+                },
+            } as any
             siteAppsInstance.onRemoteConfig({} as RemoteConfig)
             expect(posthog.on).not.toHaveBeenCalled()
         })

--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -254,7 +254,16 @@ describe('SiteApps', () => {
             assignableWindow._POSTHOG_REMOTE_CONFIG = {
                 [token]: {
                     config: {},
-                    siteApps: [],
+                    siteApps: [
+                        {
+                            id: '1',
+                            init: jest.fn(() => {
+                                return {
+                                    processEvent: jest.fn(),
+                                }
+                            }),
+                        },
+                    ],
                 },
             } as any
             siteAppsInstance.onRemoteConfig({

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -146,7 +146,7 @@ export class SiteApps {
     }
 
     onRemoteConfig(response: RemoteConfig): void {
-        if (this.siteAppLoaders) {
+        if (this.siteAppLoaders?.length) {
             if (!this.isEnabled) {
                 logger.error(`PostHog site apps are disabled. Enable the "opt_in_site_apps" config to proceed.`)
                 return
@@ -156,12 +156,8 @@ export class SiteApps {
                 this.setupSiteApp(app)
             }
 
-            if (!this.siteAppLoaders.length) {
-                this.stopBuffering?.()
-            } else {
-                // NOTE: We could improve this to only fire if we actually have listeners for the event
-                this.instance.on('eventCaptured', (event) => this.onCapturedEvent(event))
-            }
+            // NOTE: We could improve this to only fire if we actually have listeners for the event
+            this.instance.on('eventCaptured', (event) => this.onCapturedEvent(event))
 
             return
         }

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -33,6 +33,10 @@ export class SiteApps {
         }
     }
 
+    get siteAppLoaders(): SiteAppLoader[] | undefined {
+        return assignableWindow._POSTHOG_REMOTE_CONFIG?.[this.instance.config.token]?.siteApps
+    }
+
     init() {
         if (this.isEnabled) {
             const stop = this.instance._addCaptureHook(this.eventCollector.bind(this))
@@ -142,17 +146,17 @@ export class SiteApps {
     }
 
     onRemoteConfig(response: RemoteConfig): void {
-        if (isArray(assignableWindow._POSTHOG_JS_APPS)) {
+        if (this.siteAppLoaders) {
             if (!this.isEnabled) {
                 logger.error(`PostHog site apps are disabled. Enable the "opt_in_site_apps" config to proceed.`)
                 return
             }
 
-            for (const app of assignableWindow._POSTHOG_JS_APPS) {
+            for (const app of this.siteAppLoaders) {
                 this.setupSiteApp(app)
             }
 
-            if (!assignableWindow._POSTHOG_JS_APPS.length) {
+            if (!this.siteAppLoaders.length) {
                 this.stopBuffering?.()
             } else {
                 // NOTE: We could improve this to only fire if we actually have listeners for the event

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -2,7 +2,6 @@ import { PostHog } from './posthog-core'
 import { CaptureResult, Properties, RemoteConfig, SiteApp, SiteAppGlobals, SiteAppLoader } from './types'
 import { assignableWindow } from './utils/globals'
 import { createLogger } from './utils/logger'
-import { isArray } from './utils/type-utils'
 
 const logger = createLogger('[SiteApps]')
 

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -27,8 +27,14 @@ export type AssignableWindow = Window &
     typeof globalThis &
     Record<string, any> & {
         __PosthogExtensions__?: PostHogExtensions
-        _POSTHOG_CONFIG?: RemoteConfig
-        _POSTHOG_JS_APPS?: SiteAppLoader[]
+
+        _POSTHOG_REMOTE_CONFIG?: Record<
+            string,
+            {
+                config: RemoteConfig
+                siteApps: SiteAppLoader[]
+            }
+        >
     }
 
 /**


### PR DESCRIPTION
## Changes

Related to https://github.com/PostHog/posthog/pull/26964

Use the scoped version of the config loader

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
