### PR TITLE
fix: specify transport in fewer places to let config control

### DIFF
--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -433,7 +433,6 @@ export class PostHogFeatureFlags {
 
         if (!existing_early_access_features || force_reload) {
             this.instance._send_request({
-                transport: 'fetch',
                 url: this.instance.requestRouter.endpointFor(
                     'api',
                     `/api/early_access_features/?token=${this.instance.config.token}`

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -118,7 +118,6 @@ export class PostHogSurveys {
                     `/api/surveys/?token=${this.instance.config.token}`
                 ),
                 method: 'GET',
-                transport: 'fetch',
                 callback: (response) => {
                     if (response.statusCode !== 200 || !response.json) {
                         return callback([])

--- a/src/web-experiments.ts
+++ b/src/web-experiments.ts
@@ -151,7 +151,6 @@ export class WebExperiments {
                 `/api/web_experiments/?token=${this.instance.config.token}`
             ),
             method: 'GET',
-            transport: 'fetch',
             callback: (response) => {
                 if (response.statusCode !== 200 || !response.json) {
                     return callback([])


### PR DESCRIPTION
let's only specify a non-default transport if it matters