### PR TITLE
feat(cdp): only load site_destinations conditionally

### DIFF
--- a/playground/nextjs/src/posthog.ts
+++ b/playground/nextjs/src/posthog.ts
@@ -43,8 +43,10 @@ export const configForConsent = (): Partial<PostHogConfig> => {
 export const updatePostHogConsent = (consentGiven: boolean) => {
     if (consentGiven) {
         localStorage.setItem('cookie_consent', 'true')
+        posthog.opt_in_capturing()
     } else {
         localStorage.removeItem('cookie_consent')
+        posthog.opt_out_capturing()
     }
 
     posthog.set_config(configForConsent())

--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -44,6 +44,8 @@ describe('SiteApps', () => {
 
         delete assignableWindow._POSTHOG_REMOTE_CONFIG
         delete assignableWindow.POSTHOG_DEBUG
+        delete assignableWindow[`__$$ph_site_app_1`]
+        delete assignableWindow[`__$$ph_site_app_2`]
 
         removeCaptureHook = jest.fn()
 
@@ -58,6 +60,7 @@ describe('SiteApps', () => {
                 emitCaptureEvent = cb
                 return removeCaptureHook
             }),
+            consent: { isOptedOut: jest.fn().mockReturnValue(false) },
             _afterDecideResponse: jest.fn(),
             get_distinct_id: jest.fn().mockImplementation(() => 'distinctid'),
             _send_request: jest.fn().mockImplementation(({ callback }) => callback?.({ config: {} })),
@@ -240,8 +243,8 @@ describe('SiteApps', () => {
             posthog.config.opt_in_site_apps = false
             siteAppsInstance.onRemoteConfig({
                 siteApps: [
-                    { id: '1', url: '/site_app/1' },
-                    { id: '2', url: '/site_app/2' },
+                    { id: '1', type: 'site_destination', url: '/site_app/1' },
+                    { id: '2', type: 'site_destination', url: '/site_app/2' },
                 ],
             } as RemoteConfig)
 
@@ -257,6 +260,7 @@ describe('SiteApps', () => {
                     siteApps: [
                         {
                             id: '1',
+                            type: 'site_destination',
                             init: jest.fn(() => {
                                 return {
                                     processEvent: jest.fn(),
@@ -267,7 +271,7 @@ describe('SiteApps', () => {
                 },
             } as any
             siteAppsInstance.onRemoteConfig({
-                siteApps: [{ id: '1', url: '/site_app/1' }],
+                siteApps: [{ id: '1', type: 'site_destination', url: '/site_app/1' }],
             } as RemoteConfig)
 
             expect(assignableWindow.__PosthogExtensions__?.loadSiteApp).not.toHaveBeenCalled()
@@ -311,6 +315,7 @@ describe('SiteApps', () => {
                     siteApps: [
                         {
                             id: '1',
+                            type: 'site_destination',
                             init: jest.fn((config) => {
                                 appConfigs.push(config)
                                 return {
@@ -320,6 +325,7 @@ describe('SiteApps', () => {
                         },
                         {
                             id: '2',
+                            type: 'site_destination',
                             init: jest.fn((config) => {
                                 appConfigs.push(config)
                                 return {

--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -59,11 +59,11 @@ describe('SiteApps', () => {
         }
 
         posthog = createPostHog(defaultConfig)
-        ;(posthog._addCaptureHook = jest.fn((cb) => {
+        posthog._addCaptureHook = jest.fn((cb) => {
             emitCaptureEvent = cb
             return removeCaptureHook
-        })),
-            (posthog.on = jest.fn())
+        })
+        posthog.on = jest.fn()
         posthog.capture = jest.fn()
         posthog._send_request = jest.fn().mockImplementation(({ callback }) => callback?.({ config: {} }))
         logger.error = jest.fn()

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -2126,6 +2126,8 @@ export class PostHog {
         if (this.config.capture_pageview) {
             this._captureInitialPageview()
         }
+
+        this.set_config({})
     }
 
     /**

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1857,7 +1857,6 @@ export class PostHog {
             this.heatmaps?.startIfEnabled()
             this.surveys.loadIfEnabled()
             this.siteApps?.loadIfEnabled()
-            this.surveys.loadIfEnabled()
             this._sync_opt_out_with_persistence()
         }
     }

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -165,8 +165,8 @@ export class SiteApps {
                 // if consent isn't given, skip site destinations
                 if (this.instance.consent.isOptedOut() && app.type === 'site_destination') continue
                 // if the site app is already loaded, skip it
-                if (!isUndefined(assignableWindow[`__$$ph_site_app_${app.id}_loaded`])) continue
-                assignableWindow[`__$$ph_site_app_${app.id}_loaded`] = 'true'
+                if (!isUndefined(assignableWindow[`__$$ph_site_app_${app.id}`])) continue
+                assignableWindow[`__$$ph_site_app_${app.id}`] = this.instance
                 this.setupSiteApp(app)
             }
             return

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -202,7 +202,7 @@ export class SiteApps {
     onRemoteConfig(response: RemoteConfig): void {
         this._decideServerSiteAppsResponse = response['siteApps']
         // NOTE: We could improve this to only fire if we actually have listeners for the event
-        this.instance.on('eventCaptured', (event) => this.onCapturedEvent(event))
+        if (this.siteAppLoaders?.length) this.instance.on('eventCaptured', (event) => this.onCapturedEvent(event))
         this.loadIfEnabled()
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -549,7 +549,7 @@ export interface RemoteConfig {
     editorParams?: ToolbarParams /** @deprecated, renamed to toolbarParams, still present on older API responses */
     toolbarVersion: 'toolbar' /** @deprecated, moved to toolbarParams */
     isAuthenticated: boolean
-    siteApps: { id: string; url: string }[]
+    siteApps: { id: string; type: string; url: string }[]
     heatmaps?: boolean
     defaultIdentifiedOnly?: boolean
     captureDeadClicks?: boolean
@@ -579,6 +579,7 @@ export type SiteAppGlobals = {
 
 export type SiteAppLoader = {
     id: string
+    type: string
     init: (config: { posthog: PostHog; callback: (success: boolean) => void }) => {
         processEvent?: (globals: SiteAppGlobals) => void
     }


### PR DESCRIPTION
## Changes

requires: https://github.com/PostHog/posthog/pull/27027

- only load site_destinations with consent
- save campaign and referrer properties in memory before consent has been given ([context](https://posthog.slack.com/archives/C02E3BKC78F/p1733229244098949))
- site destinations will be loaded if `.opt_in_capturing()` is being called at a later point
- updated the nextjs example to call opt_in_capturing & opt_out_capturing based on the cookie banner ([link](https://github.com/PostHog/posthog-js/pull/1619/files#diff-0fabc8946739ca6aa9ee3f3993e07f8cd87f7908a74a6b116e25885d45a81d8bR46-R49))
- the `opt_in_capturing()` function will call `posthog.set_config({})`

TODO:
- [x] update tests