### PR TITLE
fix: type error accessing null object and added test case

### DIFF
--- a/src/__tests__/heatmaps.test.ts
+++ b/src/__tests__/heatmaps.test.ts
@@ -89,6 +89,27 @@ describe('heatmaps', () => {
         expect(posthog.heatmaps!.getAndClearBuffer()).toBeDefined()
     })
 
+    it('should handle empty mouse moves', async () => {
+        posthog.heatmaps?.['_onMouseMove']?.(new Event('mousemove'))
+
+        jest.advanceTimersByTime(posthog.heatmaps!.flushIntervalMilliseconds + 1)
+
+        expect(beforeSendMock).toBeCalledTimes(1)
+        expect(beforeSendMock.mock.lastCall[0]).toMatchObject({
+            event: '$$heatmap',
+            properties: {
+                $heatmap_data: {
+                    'http://replaced/': [
+                        {
+                            target_fixed: false,
+                            type: 'mousemove',
+                        },
+                    ],
+                },
+            },
+        })
+    })
+
     it('should send rageclick events in the same area', async () => {
         posthog.heatmaps?.['_onClick']?.(createMockMouseEvent())
         posthog.heatmaps?.['_onClick']?.(createMockMouseEvent())

--- a/src/__tests__/heatmaps.test.ts
+++ b/src/__tests__/heatmaps.test.ts
@@ -144,16 +144,24 @@ describe('heatmaps', () => {
     })
 
     it('should ignore clicks if they come from the toolbar', async () => {
+        const testElementToolbar = document.createElement('div')
+        testElementToolbar.id = '__POSTHOG_TOOLBAR__'
+
         posthog.heatmaps?.['_onClick']?.(
             createMockMouseEvent({
-                target: { id: '__POSTHOG_TOOLBAR__' } as Element,
+                target: testElementToolbar,
             })
         )
         expect(posthog.heatmaps?.['buffer']).toEqual(undefined)
 
+        const testElementClosest = document.createElement('div')
+        testElementClosest.closest = () => {
+            return {}
+        }
+
         posthog.heatmaps?.['_onClick']?.(
             createMockMouseEvent({
-                target: { closest: () => ({}) } as unknown as Element,
+                target: testElementClosest,
             })
         )
         expect(posthog.heatmaps?.['buffer']).toEqual(undefined)

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -177,7 +177,7 @@ export class Heatmaps {
     }
 
     private _onMouseMove(e: Event): void {
-        if (isElementInToolbar(e.target as Element)) {
+        if (isElementInToolbar(e.target)) {
             return
         }
         clearTimeout(this._mouseMoveTimeout)

--- a/src/utils/element-utils.ts
+++ b/src/utils/element-utils.ts
@@ -1,8 +1,11 @@
 import { TOOLBAR_CONTAINER_CLASS, TOOLBAR_ID } from '../constants'
 
-export function isElementInToolbar(el: Element | null): boolean {
-    // NOTE: .closest is not supported in IE11 hence the operator check
-    return el?.id === TOOLBAR_ID || !!el?.closest?.('.' + TOOLBAR_CONTAINER_CLASS)
+export function isElementInToolbar(el: EventTarget | null): boolean {
+    if (el instanceof Element) {
+        // NOTE: .closest is not supported in IE11 hence the operator check
+        return el.id === TOOLBAR_ID || !!el.closest?.('.' + TOOLBAR_CONTAINER_CLASS)
+    }
+    return false
 }
 
 /*

--- a/src/utils/element-utils.ts
+++ b/src/utils/element-utils.ts
@@ -1,8 +1,8 @@
 import { TOOLBAR_CONTAINER_CLASS, TOOLBAR_ID } from '../constants'
 
-export function isElementInToolbar(el: Element): boolean {
+export function isElementInToolbar(el: Element | null): boolean {
     // NOTE: .closest is not supported in IE11 hence the operator check
-    return el.id === TOOLBAR_ID || !!el.closest?.('.' + TOOLBAR_CONTAINER_CLASS)
+    return el?.id === TOOLBAR_ID || !!el?.closest?.('.' + TOOLBAR_CONTAINER_CLASS)
 }
 
 /*


### PR DESCRIPTION
## Changes
We stumbled onto this bug, with rxdb [dispatching mouse events](https://github.com/pubkey/rxdb/blob/e045257ed3bef3e8c01032d5a91e6260ce0b8c2e/src/plugins/replication/replication-helper.ts#L116) without data and thus producing a posthog crash. 

[This typecast](https://github.com/supermar1010/posthog-js/blob/7d11d7f33ecce50367777694172d01d22187314d/src/heatmaps.ts#L180) is why the error wasn't spotted by ts. The type of `e.target` is originally `EventTarget | null`, but looses the `| null` in this cast.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
