### PR TITLE
fix: do not even send heatmap with no x or y

### DIFF
--- a/src/__tests__/heatmaps.test.ts
+++ b/src/__tests__/heatmaps.test.ts
@@ -94,20 +94,7 @@ describe('heatmaps', () => {
 
         jest.advanceTimersByTime(posthog.heatmaps!.flushIntervalMilliseconds + 1)
 
-        expect(beforeSendMock).toBeCalledTimes(1)
-        expect(beforeSendMock.mock.lastCall[0]).toMatchObject({
-            event: '$$heatmap',
-            properties: {
-                $heatmap_data: {
-                    'http://replaced/': [
-                        {
-                            target_fixed: false,
-                            type: 'mousemove',
-                        },
-                    ],
-                },
-            },
-        })
+        expect(beforeSendMock).toBeCalledTimes(0)
     })
 
     it('should send rageclick events in the same area', async () => {

--- a/src/utils/element-utils.ts
+++ b/src/utils/element-utils.ts
@@ -2,7 +2,7 @@ import { TOOLBAR_CONTAINER_CLASS, TOOLBAR_ID } from '../constants'
 
 export function isElementInToolbar(el: EventTarget | null): boolean {
     if (el instanceof Element) {
-        // NOTE: .closest is not supported in IE11 hence the operator check
+        // closest isn't available in IE11, but we'll polyfill when bundling
         return el.id === TOOLBAR_ID || !!el.closest?.('.' + TOOLBAR_CONTAINER_CLASS)
     }
     return false


### PR DESCRIPTION
https://github.com/PostHog/posthog-js/pull/1620/ reminds us that JS can and will let people do whatever they want so we can't be guaranteed that events that trigger event listeners are really valid events

this filters out any event that doesn't have the `clientX` and `clientY` that we rely on

we safely filter these in ingestion, but we may as well just not send them