### PR TITLE
chore: add feature name prop to event

### DIFF
--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -8,6 +8,7 @@ import {
     Properties,
     JsonType,
     Compression,
+    EarlyAccessFeature,
 } from './types'
 import { PostHogPersistence } from './posthog-persistence'
 
@@ -349,14 +350,25 @@ export class PostHogFeatureFlags {
     }
 
     updateEarlyAccessFeatureEnrollment(key: string, isEnrolled: boolean): void {
+        const existing_early_access_features: EarlyAccessFeature[] =
+            this.instance.get_property(PERSISTENCE_EARLY_ACCESS_FEATURES) || []
+        const feature = existing_early_access_features.find((f) => f.flagKey === key)
+
         const enrollmentPersonProp = {
             [`$feature_enrollment/${key}`]: isEnrolled,
         }
-        this.instance.capture('$feature_enrollment_update', {
+
+        const properties: Properties = {
             $feature_flag: key,
             $feature_enrollment: isEnrolled,
             $set: enrollmentPersonProp,
-        })
+        }
+
+        if (feature) {
+            properties['$name'] = feature.name
+        }
+
+        this.instance.capture('$feature_enrollment_update', properties)
         this.setPersonPropertiesForFlags(enrollmentPersonProp, false)
 
         const newFlags = { ...this.getFlagVariants(), [key]: isEnrolled }


### PR DESCRIPTION
## Changes

Adds the `$name` prop to an early access enrolment event cc @joethreepwood 

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
