### PR TITLE
chore: build against lowest and current version of TS

### DIFF
--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -13,7 +13,7 @@ jobs:
         strategy:
           matrix:
             node-version: [ 18, 20 ]
-            typescript-version: [ '5.5.4' ]
+            typescript-version: [ '4.7.2', '5.5.4' ]
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
@@ -32,11 +32,12 @@ jobs:
             - name: Install dependencies
               run: pnpm install
 
-            - name: Override TypeScript version
-              run: pnpm add typescript@${{ matrix.typescript-version }} --save-dev
-
             - name: Build project
               run: pnpm run build
+
+            # once its built we can see if we can use it on the forced version
+            - name: Override TypeScript version
+              run: pnpm add typescript@${{ matrix.typescript-version }} --save-dev
 
             - name: Test TypeScript Import
               run: |

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -13,7 +13,7 @@ jobs:
         strategy:
           matrix:
             node-version: [ 18, 20 ]
-            typescript-version: [ '4.7.2', '5.5.4' ]
+            typescript-version: ['4.5.2', '4.7.2', '5.5.4' ]
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -13,7 +13,7 @@ jobs:
         strategy:
           matrix:
             node-version: [ 16, 18, 20 ]
-            typescript-version: [ '4.7.2', '5.5.4' ]
+            typescript-version: [ '4.7.3', '5.5.4' ]
         steps:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -12,8 +12,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            node-version: [ 16, 18, 20 ]
-            typescript-version: [ '4.7.3', '5.5.4' ]
+            node-version: [ 18, 20 ]
+            typescript-version: [ '5.5.4' ]
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -13,7 +13,7 @@ jobs:
         strategy:
           matrix:
             node-version: [ 16, 18, 20, 22, 23 ]
-            typescript-version: ['4.7.2', '5.5.4' ]
+            typescript-version: ['4.7.2', '5.5.4', 'latest' ]
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            node-version: [ 16, 18, 20, 22, 23, 24 ]
+            node-version: [ 16, 18, 20, 22, 23 ]
             typescript-version: ['4.7.2', '5.5.4' ]
         steps:
             - name: Checkout repository

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -25,5 +25,5 @@ jobs:
                 cache: 'pnpm'
             - run: pnpm install
             #Override TypeScript version
-            - run: npm install typescript@${{ matrix.typescript-version }}
+            - run: pnpm install typescript@${{ matrix.typescript-version }}
             - run: pnpm tsc -b

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -12,8 +12,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            node-version: [ 18, 20 ]
-            typescript-version: ['4.5.2', '4.7.2', '5.5.4' ]
+            node-version: [ 16, 18, 20, 22, 23, 24 ]
+            typescript-version: ['4.7.2', '5.5.4' ]
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -1,0 +1,29 @@
+name: Library checks
+
+on:
+    pull_request:
+    push:
+        branches:
+            - main
+
+jobs:
+    unit:
+        name: Check minimum TS version
+        runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            node-version: [ 16, 18, 20 ]
+            typescript-version: [ '4.7.0', '5.5.4' ] # Add your TypeScript versions here
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+              with:
+                version: 8.x.x
+            - uses: actions/setup-node@v4
+              with:
+                node-version: ${{ matrix.node-version }}
+                cache: 'pnpm'
+            - run: pnpm install
+            #Override TypeScript version
+            - run: npm install typescript@${{ matrix.typescript-version }}
+            - run: pnpm tsc -b

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -13,7 +13,7 @@ jobs:
         strategy:
           matrix:
             node-version: [ 16, 18, 20 ]
-            typescript-version: [ '4.7.0', '5.5.4' ] # Add your TypeScript versions here
+            typescript-version: [ '4.7.2', '5.5.4' ]
         steps:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -15,15 +15,31 @@ jobs:
             node-version: [ 16, 18, 20 ]
             typescript-version: [ '4.7.3', '5.5.4' ]
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
               with:
                 version: 8.x.x
-            - uses: actions/setup-node@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
               with:
                 node-version: ${{ matrix.node-version }}
                 cache: 'pnpm'
-            - run: pnpm install
-            #Override TypeScript version
-            - run: pnpm install typescript@${{ matrix.typescript-version }}
-            - run: pnpm tsc -b
+
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Override TypeScript version
+              run: pnpm add typescript@${{ matrix.typescript-version }} --save-dev
+
+            - name: Build project
+              run: pnpm run build
+
+            - name: Test TypeScript Import
+              run: |
+                rm test.ts || true
+                echo "import { posthog } from './dist/module'; console.log(posthog);" > test.ts
+                pnpm exec tsc test.ts --strict --target es2017 --module commonjs --moduleResolution node --noEmit --skipLibCheck

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ we use pnpm.
 it's best to install using `npm install -g pnpm@latest-8`
 and then `pnpm` commands as usual
 
+## 
+
 ## Testing
 
 Unit tests: run `pnpm test`.


### PR DESCRIPTION
i advised a customer to upgrade and they couldn't because we had an implicit minimum TS version, luckily they could upgrade without a major TS verson upgrade the friday before xmas by applying a minor update

let's test that discovered minimum so we know if we break it in future

we discovered you can't run tsc in a project lower than TS 4.7.2 that imports posthog
(for the benefit of folk coming across this issue - this doesn't affect JS projects or the HTML snippet)

---

this builds the library under different node versions and then imports it into a file and runs tsc on that file

here's that failing using the customer's too low version

<img width="627" alt="Screenshot 2024-12-19 at 21 37 20" src="https://github.com/user-attachments/assets/3869ef80-c592-42ec-8f8e-7b1ee856a73d" />
