### PR TITLE
fix: payload host deny list

### DIFF
--- a/src/__tests__/extensions/replay/config.test.ts
+++ b/src/__tests__/extensions/replay/config.test.ts
@@ -210,13 +210,26 @@ describe('config', () => {
         describe('payloadHostDenyList', () => {
             it('uses a default when none provided', () => {
                 const networkOptions = buildNetworkRequestOptions(defaultConfig(), {})
-                expect(networkOptions.payloadHostDenyList).toEqual(['.lr-ingest.io', '.ingest.sentry.io'])
+                expect(networkOptions.payloadHostDenyList).toEqual([
+                    '.lr-ingest.io',
+                    '.ingest.sentry.io',
+                    '.clarity.ms',
+                    'analytics.google.com',
+                ])
             })
+
             it('adds to the default when deny list is provided', () => {
                 const networkOptions = buildNetworkRequestOptions(defaultConfig(), {
                     payloadHostDenyList: ['wat', 'huh'],
                 })
-                expect(networkOptions.payloadHostDenyList).toEqual(['wat', 'huh', '.lr-ingest.io', '.ingest.sentry.io'])
+                expect(networkOptions.payloadHostDenyList).toEqual([
+                    'wat',
+                    'huh',
+                    '.lr-ingest.io',
+                    '.ingest.sentry.io',
+                    '.clarity.ms',
+                    'analytics.google.com',
+                ])
             })
         })
     })

--- a/src/extensions/replay/config.ts
+++ b/src/extensions/replay/config.ts
@@ -48,7 +48,13 @@ export const defaultNetworkOptions: Required<NetworkRecordOptions> = {
         'resource',
     ],
     payloadSizeLimitBytes: 1000000,
-    payloadHostDenyList: ['.lr-ingest.io', '.ingest.sentry.io'],
+    payloadHostDenyList: [
+        '.lr-ingest.io',
+        '.ingest.sentry.io',
+        '.clarity.ms',
+        // NB no leading dot here
+        'analytics.google.com',
+    ],
 }
 
 const HEADER_DENY_LIST = [


### PR DESCRIPTION
noticed while investigating something else
if you have payload capture on then we're capturing payloads for ms clarity and google analytics. that's silly and unnecessary data load