### PR TITLE
feat: custom event with remote config

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -1982,21 +1982,26 @@ describe('SessionRecording', () => {
             })
             sessionRecording = new SessionRecording(posthog)
 
-            sessionRecording.onRemoteConfig(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
-            sessionRecording.startIfEnabledOrStop()
-            expect(loadScriptMock).toHaveBeenCalled()
-
             expect(sessionRecording['queuedRRWebEvents']).toHaveLength(0)
 
-            sessionRecording['_tryAddCustomEvent']('test', { test: 'test' })
+            sessionRecording.onRemoteConfig(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
+
+            expect(sessionRecording['queuedRRWebEvents']).toHaveLength(1)
+
+            sessionRecording.startIfEnabledOrStop()
+            expect(loadScriptMock).toHaveBeenCalled()
         })
 
         it('queues events', () => {
-            expect(sessionRecording['queuedRRWebEvents']).toHaveLength(1)
+            sessionRecording['_tryAddCustomEvent']('test', { test: 'test' })
+
+            expect(sessionRecording['queuedRRWebEvents']).toHaveLength(2)
         })
 
         it('limits the queue of events', () => {
-            expect(sessionRecording['queuedRRWebEvents']).toHaveLength(1)
+            sessionRecording['_tryAddCustomEvent']('test', { test: 'test' })
+
+            expect(sessionRecording['queuedRRWebEvents']).toHaveLength(2)
 
             for (let i = 0; i < 100; i++) {
                 sessionRecording['_tryAddCustomEvent']('test', { test: 'test' })

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -709,6 +709,8 @@ export class SessionRecording {
             // in case we see multiple decide responses, we should only listen with the response from the most recent one
             this._persistDecideOnSessionListener?.()
             this._persistDecideOnSessionListener = this.sessionManager.onSessionId(persistResponse)
+
+            this._tryAddCustomEvent('$remote_config_received', response)
         }
     }
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -621,6 +621,7 @@ export class SessionRecording {
     }
 
     onRemoteConfig(response: RemoteConfig) {
+        this._tryAddCustomEvent('$remote_config_received', response)
         this._persistRemoteConfig(response)
 
         this._linkedFlag = response.sessionRecording?.linkedFlag || null
@@ -709,8 +710,6 @@ export class SessionRecording {
             // in case we see multiple decide responses, we should only listen with the response from the most recent one
             this._persistDecideOnSessionListener?.()
             this._persistDecideOnSessionListener = this.sessionManager.onSessionId(persistResponse)
-
-            this._tryAddCustomEvent('$remote_config_received', response)
         }
     }
 


### PR DESCRIPTION
useful when debugging sessions if the customer doesn't have payload capture on

hard to know if a session got the config you'd expect otherwise