### PR TITLE
feat: Deprecate `sanitize_properties`

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1036,6 +1036,7 @@ export class PostHog {
 
         const sanitize_properties = this.config.sanitize_properties
         if (sanitize_properties) {
+            logger.error('sanitize_properties is deprecated. Use before_send instead')
             properties = sanitize_properties(properties, event_name)
         }
 
@@ -1058,6 +1059,7 @@ export class PostHog {
         let setOnceProperties = extend({}, this.persistence.get_initial_props(), dataSetOnce || {})
         const sanitize_properties = this.config.sanitize_properties
         if (sanitize_properties) {
+            logger.error('sanitize_properties is deprecated. Use before_send instead')
             setOnceProperties = sanitize_properties(setOnceProperties, '$set_once')
         }
         if (isEmptyObject(setOnceProperties)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,7 +278,6 @@ export interface PostHogConfig {
     inapp_protocol: string
     inapp_link_new_window: boolean
     request_batching: boolean
-    sanitize_properties: ((properties: Properties, event_name: string) => Properties) | null
     properties_string_max_length: number
     session_recording: SessionRecordingOptions
     session_idle_timeout_seconds: number
@@ -291,6 +290,13 @@ export interface PostHogConfig {
     feature_flag_request_timeout_ms: number
     get_device_id: (uuid: string) => string
     name: string
+
+    /**
+     * This function is called when collecting properties for an event.
+     * It allows you to edit data before it is sent
+     * @deprecated - use `before_send` instead
+     */
+    sanitize_properties: ((properties: Properties, event_name: string) => Properties) | null
     /**
      * this is a read-only function that can be used to react to event capture
      * @deprecated - use `before_send` instead - NB before_send is not read only
@@ -527,11 +533,7 @@ export interface RemoteConfig {
     }
     elementsChainAsString?: boolean
     // this is currently in development and may have breaking changes without a major version bump
-    autocaptureExceptions?:
-        | boolean
-        | {
-              endpoint?: string
-          }
+    autocaptureExceptions?: boolean | { endpoint?: string }
     sessionRecording?: SessionRecordingCanvasOptions & {
         endpoint?: string
         consoleLogRecordingEnabled?: boolean


### PR DESCRIPTION
## Changes

We can achieve the exact same outcome we achieve with `sanitize_properties` by using `before_send` which is a much more compreheensive function, with better usability and ergonomics.

We can't remove this function without a major, so let's deprecate it and issue a console warning when it's used.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
