### PR TITLE
feat: Add pageview and prev pageview tracking

### DIFF
--- a/src/__tests__/page-view.test.ts
+++ b/src/__tests__/page-view.test.ts
@@ -14,6 +14,8 @@ describe('PageView ID manager', () => {
     const firstTimestamp = new Date()
     const duration = 42
     const secondTimestamp = new Date(firstTimestamp.getTime() + duration * 1000)
+    const pageviewId1 = 'pageview-id-1'
+    const pageviewId2 = 'pageview-id-2'
 
     describe('doPageView', () => {
         let instance: PostHog
@@ -55,12 +57,12 @@ describe('PageView ID manager', () => {
                 },
             })
 
-            pageViewIdManager.doPageView(firstTimestamp)
+            pageViewIdManager.doPageView(firstTimestamp, pageviewId1)
 
             // force the manager to update the scroll data by calling an internal method
             instance.scrollManager['_updateScrollData']()
 
-            const secondPageView = pageViewIdManager.doPageView(secondTimestamp)
+            const secondPageView = pageViewIdManager.doPageView(secondTimestamp, pageviewId2)
             expect(secondPageView.$prev_pageview_last_scroll).toEqual(2000)
             expect(secondPageView.$prev_pageview_last_scroll_percentage).toBeCloseTo(2 / 3)
             expect(secondPageView.$prev_pageview_max_scroll).toEqual(2000)
@@ -70,6 +72,8 @@ describe('PageView ID manager', () => {
             expect(secondPageView.$prev_pageview_max_content).toEqual(3000)
             expect(secondPageView.$prev_pageview_max_content_percentage).toBeCloseTo(3 / 4)
             expect(secondPageView.$prev_pageview_duration).toEqual(duration)
+            expect(secondPageView.$prev_pageview_id).toEqual(pageviewId1)
+            expect(secondPageView.$pageview_id).toEqual(pageviewId2)
         })
 
         it('includes scroll position properties for a short page', () => {
@@ -86,12 +90,12 @@ describe('PageView ID manager', () => {
                 },
             })
 
-            pageViewIdManager.doPageView(firstTimestamp)
+            pageViewIdManager.doPageView(firstTimestamp, pageviewId1)
 
             // force the manager to update the scroll data by calling an internal method
             instance.scrollManager['_updateScrollData']()
 
-            const secondPageView = pageViewIdManager.doPageView(secondTimestamp)
+            const secondPageView = pageViewIdManager.doPageView(secondTimestamp, pageviewId2)
             expect(secondPageView.$prev_pageview_last_scroll).toEqual(0)
             expect(secondPageView.$prev_pageview_last_scroll_percentage).toEqual(1)
             expect(secondPageView.$prev_pageview_max_scroll).toEqual(0)
@@ -101,22 +105,24 @@ describe('PageView ID manager', () => {
             expect(secondPageView.$prev_pageview_max_content).toEqual(1000)
             expect(secondPageView.$prev_pageview_max_content_percentage).toEqual(1)
             expect(secondPageView.$prev_pageview_duration).toEqual(duration)
+            expect(secondPageView.$prev_pageview_id).toEqual(pageviewId1)
+            expect(secondPageView.$pageview_id).toEqual(pageviewId2)
         })
 
         it('can handle scroll updates before doPageView is called', () => {
             instance.scrollManager['_updateScrollData']()
-            const firstPageView = pageViewIdManager.doPageView(firstTimestamp)
+            const firstPageView = pageViewIdManager.doPageView(firstTimestamp, pageviewId1)
             expect(firstPageView.$prev_pageview_last_scroll).toBeUndefined()
 
-            const secondPageView = pageViewIdManager.doPageView(secondTimestamp)
+            const secondPageView = pageViewIdManager.doPageView(secondTimestamp, pageviewId2)
             expect(secondPageView.$prev_pageview_last_scroll).toBeDefined()
         })
 
         it('should include the pathname', () => {
             instance.scrollManager['_updateScrollData']()
-            const firstPageView = pageViewIdManager.doPageView(firstTimestamp)
+            const firstPageView = pageViewIdManager.doPageView(firstTimestamp, pageviewId1)
             expect(firstPageView.$prev_pageview_pathname).toBeUndefined()
-            const secondPageView = pageViewIdManager.doPageView(secondTimestamp)
+            const secondPageView = pageViewIdManager.doPageView(secondTimestamp, pageviewId2)
             expect(secondPageView.$prev_pageview_pathname).toEqual('/pathname')
         })
     })

--- a/src/page-view.ts
+++ b/src/page-view.ts
@@ -19,6 +19,15 @@ interface PageViewEventProperties {
     $prev_pageview_max_content_percentage?: number
 }
 
+// This keeps track of the PageView state (such as the previous PageView's path, timestamp, id, and scroll properties).
+// We store the state in memory, which means that for non-SPA sites, the state will be lost on page reload. This means
+// that non-SPA sites should always send a $pageleave event on any navigation, before the page unloads. For SPA sites,
+// they only need to send a $pageleave event when the user navigates away from the site, as the information is not lost
+// on an internal navigation, and is included as the $prev_pageview_ properties in the next $pageview event.
+
+// Practically, this means that to find the scroll properties for a given pageview, you need to find the event where
+// event name is $pageview or $pageleave and where $prev_pageview_id matches the original pageview event's id.
+
 export class PageViewManager {
     _currentPageview?: { timestamp: Date; pageViewId: string | undefined; pathname: string | undefined }
     _instance: PostHog

--- a/src/page-view.ts
+++ b/src/page-view.ts
@@ -68,7 +68,7 @@ export class PageViewManager {
 
         const scrollContext = this._instance.scrollManager.getContext()
 
-        if (scrollContext) {
+        if (scrollContext && !this._instance.config.disable_scroll_properties) {
             let { maxScrollHeight, lastScrollY, maxScrollY, maxContentHeight, lastContentY, maxContentY } =
                 scrollContext
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -2245,6 +2245,10 @@ export class PostHog {
         }
         return beforeSendResult
     }
+
+    public getPageViewId(): string | undefined {
+        return this.pageViewManager._currentPageview?.pageViewId
+    }
 }
 
 safewrapClass(PostHog, ['identify'])

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -986,17 +986,15 @@ export class PostHog {
             properties = extend(properties, sessionProps)
         }
 
-        if (!this.config.disable_scroll_properties) {
-            let performanceProperties: Record<string, any> = {}
-            if (event_name === '$pageview') {
-                performanceProperties = this.pageViewManager.doPageView(timestamp, uuid)
-            } else if (event_name === '$pageleave') {
-                performanceProperties = this.pageViewManager.doPageLeave(timestamp)
-            } else {
-                performanceProperties = this.pageViewManager.doEvent()
-            }
-            properties = extend(properties, performanceProperties)
+        let pageviewProperties: Record<string, any>
+        if (event_name === '$pageview') {
+            pageviewProperties = this.pageViewManager.doPageView(timestamp, uuid)
+        } else if (event_name === '$pageleave') {
+            pageviewProperties = this.pageViewManager.doPageLeave(timestamp)
+        } else {
+            pageviewProperties = this.pageViewManager.doEvent()
         }
+        properties = extend(properties, pageviewProperties)
 
         if (event_name === '$pageview' && document) {
             properties['title'] = document.title


### PR DESCRIPTION
## Changes
* Keep track of the last pagview event id
* Send the pageview event id with every event

This came from a discussion with @orian who wanted to be able to associate all of the query completed events that were triggered by the same pageview

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
