### PR TITLE
feat: add Better Uptime string to blocked UA

### DIFF
--- a/src/utils/blocked-uas.ts
+++ b/src/utils/blocked-uas.ts
@@ -3,6 +3,7 @@ export const DEFAULT_BLOCKED_UA_STRS = [
     'ahrefssiteaudit',
     'applebot',
     'baiduspider',
+    'better uptime bot',
     'bingbot',
     'bingpreview',
     'bot.htm',


### PR DESCRIPTION
## Changes
added `'better uptime bot'` to `blocked-uas.ts`. The user agent comes from their docs: https://betterstack.com/docs/uptime/frequently-asked-questions/#what-user-agent-does-uptime-use

Let me know if this is the correct way to do this.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
