### PR TITLE
chore: Rename cklsh constants to cookieless

### DIFF
--- a/src/__tests__/cookieless.test.ts
+++ b/src/__tests__/cookieless.test.ts
@@ -24,12 +24,12 @@ describe('cookieless', () => {
         posthog.capture(eventName, eventProperties)
         expect(beforeSendMock).toBeCalledTimes(1)
         let event = beforeSendMock.mock.calls[0][0]
-        expect(event.properties.distinct_id).toBe('$posthog_cklsh')
+        expect(event.properties.distinct_id).toBe('$posthog_cookieless')
         expect(event.properties.$anon_distinct_id).toBe(undefined)
         expect(event.properties.$device_id).toBe(null)
         expect(event.properties.$session_id).toBe(undefined)
         expect(event.properties.$window_id).toBe(undefined)
-        expect(event.properties.$cklsh_mode).toEqual(true)
+        expect(event.properties.$cookieless_mode).toEqual(true)
         expect(document.cookie).toBe('')
 
         // simulate user giving cookie consent
@@ -39,12 +39,12 @@ describe('cookieless', () => {
         posthog.capture(eventName, eventProperties)
         expect(beforeSendMock).toBeCalledTimes(2)
         event = beforeSendMock.mock.calls[1][0]
-        expect(event.properties.distinct_id).toBe('$posthog_cklsh')
+        expect(event.properties.distinct_id).toBe('$posthog_cookieless')
         expect(event.properties.$anon_distinct_id).toBe(undefined)
         expect(event.properties.$device_id).toBe(null)
         expect(event.properties.$session_id).toBe(undefined)
         expect(event.properties.$window_id).toBe(undefined)
-        expect(event.properties.$cklsh_mode).toEqual(true)
+        expect(event.properties.$cookieless_mode).toEqual(true)
         expect(document.cookie).not.toBe('')
 
         // a user identifying
@@ -52,11 +52,11 @@ describe('cookieless', () => {
         expect(beforeSendMock).toBeCalledTimes(3)
         event = beforeSendMock.mock.calls[2][0]
         expect(event.properties.distinct_id).toBe(identifiedDistinctId)
-        expect(event.properties.$anon_distinct_id).toBe('$posthog_cklsh')
+        expect(event.properties.$anon_distinct_id).toBe('$posthog_cookieless')
         expect(event.properties.$device_id).toBe(null)
         expect(event.properties.$session_id).toBe(undefined)
         expect(event.properties.$window_id).toBe(undefined)
-        expect(event.properties.$cklsh_mode).toEqual(true)
+        expect(event.properties.$cookieless_mode).toEqual(true)
 
         // an event after identifying
         posthog.capture(eventName, eventProperties)
@@ -67,7 +67,7 @@ describe('cookieless', () => {
         expect(event.properties.$device_id).toBe(null)
         expect(event.properties.$session_id).toBe(undefined)
         expect(event.properties.$window_id).toBe(undefined)
-        expect(event.properties.$cklsh_mode).toEqual(true)
+        expect(event.properties.$cookieless_mode).toEqual(true)
 
         // reset
         posthog.reset()
@@ -77,12 +77,12 @@ describe('cookieless', () => {
         posthog.capture(eventName, eventProperties)
         expect(beforeSendMock).toBeCalledTimes(5)
         event = beforeSendMock.mock.calls[4][0]
-        expect(event.properties.distinct_id).toBe('$posthog_cklsh')
+        expect(event.properties.distinct_id).toBe('$posthog_cookieless')
         expect(event.properties.$anon_distinct_id).toBe(undefined)
         expect(event.properties.$device_id).toBe(null)
         expect(event.properties.$session_id).toBe(undefined)
         expect(event.properties.$window_id).toBe(undefined)
-        expect(event.properties.$cklsh_mode).toEqual(true)
+        expect(event.properties.$cookieless_mode).toEqual(true)
         expect(document.cookie).toBe('')
     })
 })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,8 +53,8 @@ export const TOOLBAR_CONTAINER_CLASS = 'toolbar-global-fade-container'
  * PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION
  * Sentinel value for distinct id, device id, session id. Signals that the server should generate the value
  * */
-export const COOKIELESS_SENTINEL_VALUE = '$posthog_cklsh'
-export const COOKIELESS_MODE_FLAG_PROPERTY = '$cklsh_mode'
+export const COOKIELESS_SENTINEL_VALUE = '$posthog_cookieless'
+export const COOKIELESS_MODE_FLAG_PROPERTY = '$cookieless_mode'
 
 export const WEB_EXPERIMENTS = '$web_experiments'
 


### PR DESCRIPTION
## Changes

Renaming some constants, for more obvious naming for somebody reading through some logs.

Not used in production yet, so doesn't affect version compatibility.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
