### PR TITLE
chore: deduplicate subsequent identify calls

### DIFF
--- a/src/__tests__/posthog-core.identify.test.ts
+++ b/src/__tests__/posthog-core.identify.test.ts
@@ -208,6 +208,22 @@ describe('identify()', () => {
             )
             expect(instance.featureFlags.setAnonymousDistinctId).not.toHaveBeenCalled()
         })
+
+        it('does not call $set when duplicate properties are passed', () => {
+            instance.identify('a-new-id', { email: 'john@example.com' }, { howOftenAmISet: 'once!' })
+            instance.identify('a-new-id', { email: 'john@example.com' }, { howOftenAmISet: 'once!' })
+
+            expect(beforeSendMock).toHaveBeenCalledTimes(1)
+            expect(instance.featureFlags.setAnonymousDistinctId).not.toHaveBeenCalled()
+        })
+
+        it('calls $set when different properties are passed with the same distinct_id', () => {
+            instance.identify('a-new-id', { email: 'john@example.com' }, { howOftenAmISet: 'once!' })
+            instance.identify('a-new-id', { email: 'john@example.com' }, { howOftenAmISet: 'twice!' })
+
+            expect(beforeSendMock).toHaveBeenCalledTimes(2)
+            expect(instance.featureFlags.setAnonymousDistinctId).not.toHaveBeenCalled()
+        })
     })
 
     describe('invalid id passed', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1431,6 +1431,12 @@ export class PostHog {
             // let the reload feature flag request know to send this previous distinct id
             // for flag consistency
             this.featureFlags.setAnonymousDistinctId(previous_distinct_id)
+
+            this._cachedIdentify = PostHog._getIdentifyHash(
+                new_distinct_id,
+                userPropertiesToSet,
+                userPropertiesToSetOnce
+            )
         } else if (userPropertiesToSet || userPropertiesToSetOnce) {
             if (
                 this._cachedIdentify !==

--- a/src/utils/identify-utils.ts
+++ b/src/utils/identify-utils.ts
@@ -1,0 +1,10 @@
+import { jsonStringify } from '../request'
+import type { Properties } from '../types'
+
+export function getIdentifyHash(
+    distinct_id: string,
+    userPropertiesToSet?: Properties,
+    userPropertiesToSetOnce?: Properties
+): string {
+    return jsonStringify({ distinct_id, userPropertiesToSet, userPropertiesToSetOnce })
+}


### PR DESCRIPTION
Often duplicate $identify calls are made due to the SDK being incorrectly setup in the app, or due to re-rendering of providers.

The current behaviour is to only deduplicate $identify calls with no properties, but most $identify calls include properties like email, so they are not deduplicated. This PR extends deduplication to calls with properties.

Note: this is my first contribution to js sdk so would appreciate a thorough review.
...

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
