### PR TITLE
chore: Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,9 @@
 
 ...
 
+<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
+<!-- Closes #ISSUE_ID -->
+
 ## Checklist
 - [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
 - [ ] Accounted for the impact of any changes across different browsers


### PR DESCRIPTION
Adds a new line on the GitHub PR template to reference an open issue to close it automatically when the PR is merged.

## Changes

...

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
