### PR TITLE
chore: Remove '$web_experiment_applied' event

### DIFF
--- a/src/__tests__/web-experiments.test.ts
+++ b/src/__tests__/web-experiments.test.ts
@@ -286,13 +286,7 @@ describe('Web Experimentation', () => {
             }
 
             assertElementChanged('Signup', 'innerText', 'Sign me up')
-            expect(posthog.capture).toHaveBeenCalledWith('$web_experiment_applied', {
-                $web_experiment_document_url:
-                    'https://example.com/landing-page?utm_campaign=marketing&utm_medium=mobile',
-                $web_experiment_elements_modified: 1,
-                $web_experiment_name: 'Signup button test',
-                $web_experiment_variant: 'Signup',
-            })
+            expect(posthog.capture).not.toHaveBeenCalled()
         })
 
         it('makes no modifications if control variant', () => {
@@ -300,13 +294,7 @@ describe('Web Experimentation', () => {
                 experiments: [signupButtonWebExperimentWithFeatureFlag],
             }
             assertElementChanged('control', 'innerText', 'original')
-            expect(posthog.capture).toHaveBeenCalledWith('$web_experiment_applied', {
-                $web_experiment_document_url:
-                    'https://example.com/landing-page?utm_campaign=marketing&utm_medium=mobile',
-                $web_experiment_elements_modified: 0,
-                $web_experiment_name: 'Signup button test',
-                $web_experiment_variant: 'control',
-            })
+            expect(posthog.capture).not.toHaveBeenCalled()
         })
 
         it('can render previews based on URL params', () => {
@@ -327,14 +315,7 @@ describe('Web Experimentation', () => {
 
             WebExperiments.getWindowLocation = original
             expect(elParent.innerText).toEqual('Sign me up')
-            expect(posthog.capture).toHaveBeenCalledWith('$web_experiment_applied', {
-                $web_experiment_document_url:
-                    'https://example.com/landing-page?__experiment_id=3&__experiment_variant=Signup',
-                $web_experiment_elements_modified: 1,
-                $web_experiment_name: 'Signup button test',
-                $web_experiment_variant: 'Signup',
-                $web_experiment_preview: true,
-            })
+            expect(posthog.capture).not.toHaveBeenCalled()
         })
 
         it('can set css of Span Element', async () => {

--- a/src/web-experiments.ts
+++ b/src/web-experiments.ts
@@ -170,8 +170,7 @@ export class WebExperiments {
             this.applyTransforms(
                 previewExperiments[0].name,
                 variant,
-                previewExperiments[0].variants[variant].transforms,
-                true
+                previewExperiments[0].variants[variant].transforms
             )
         }
     }
@@ -238,12 +237,7 @@ export class WebExperiments {
         logger.info(`[WebExperiments] ${msg}`, args)
     }
 
-    private applyTransforms(
-        experiment: string,
-        variant: string,
-        transforms: WebExperimentTransform[],
-        isPreview?: boolean
-    ) {
+    private applyTransforms(experiment: string, variant: string, transforms: WebExperimentTransform[]) {
         if (this._is_bot()) {
             WebExperiments.logInfo('Refusing to render web experiment since the viewer is a likely bot')
             return
@@ -251,16 +245,6 @@ export class WebExperiments {
 
         if (variant === 'control') {
             WebExperiments.logInfo('Control variants leave the page unmodified.')
-            if (this.instance && this.instance.capture) {
-                this.instance.capture('$web_experiment_applied', {
-                    $web_experiment_name: experiment,
-                    $web_experiment_preview: isPreview,
-                    $web_experiment_variant: variant,
-                    $web_experiment_document_url: WebExperiments.getWindowLocation()?.href,
-                    $web_experiment_elements_modified: 0,
-                })
-            }
-
             return
         }
 
@@ -271,12 +255,10 @@ export class WebExperiments {
                     transform
                 )
 
-                let elementsModified = 0
                 // eslint-disable-next-line no-restricted-globals
                 const elements = document?.querySelectorAll(transform.selector)
                 elements?.forEach((element) => {
                     const htmlElement = element as HTMLElement
-                    elementsModified += 1
                     if (transform.attributes) {
                         transform.attributes.forEach((attribute) => {
                             switch (attribute.name) {
@@ -314,16 +296,6 @@ export class WebExperiments {
                         htmlElement.setAttribute('style', transform.css)
                     }
                 })
-
-                if (this.instance && this.instance.capture) {
-                    this.instance.capture('$web_experiment_applied', {
-                        $web_experiment_name: experiment,
-                        $web_experiment_variant: variant,
-                        $web_experiment_preview: isPreview,
-                        $web_experiment_document_url: WebExperiments.getWindowLocation()?.href,
-                        $web_experiment_elements_modified: elementsModified,
-                    })
-                }
             }
         })
     }


### PR DESCRIPTION
## Changes

Removes the `$web_experiment_applied`event because it causes many more events than the customer expects.

See https://posthog.slack.com/archives/C07PXH2GTGV/p1736886880767199

Introduced in https://github.com/PostHog/posthog-js/pull/1443

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
