### PR TITLE
feat: Add the ability to mask some PII-containing URL parameters

### DIFF
--- a/src/__tests__/request-utils.test.ts
+++ b/src/__tests__/request-utils.test.ts
@@ -106,13 +106,13 @@ describe('request utils', () => {
                 'https://www.example.com/?foo=1#query=2',
             ],
             [
-                "does not add a hash when the isn't one",
+                "does not add a hash when there isn't one",
                 'https://www.example.com/?foo=1',
                 ['query'],
                 'https://www.example.com/?foo=1',
             ],
             [
-                "does not add a query when the isn't one",
+                "does not add a query when there isn't one",
                 'https://www.example.com',
                 ['query'],
                 'https://www.example.com',

--- a/src/__tests__/request-utils.test.ts
+++ b/src/__tests__/request-utils.test.ts
@@ -1,4 +1,4 @@
-import { getQueryParam, formDataToQuery, isUrlMatchingRegex } from '../utils/request-utils'
+import { getQueryParam, formDataToQuery, isUrlMatchingRegex, maskQueryParams } from '../utils/request-utils'
 
 describe('request utils', () => {
     describe('_HTTPBuildQuery', () => {
@@ -45,6 +45,81 @@ describe('request utils', () => {
             ['gets param when no match and there are params with trailing slash', '/?test=123', 'name', ''],
         ])('%s', (_name, url, param, expected) => {
             expect(getQueryParam(`https://example.com${url}`, param)).toEqual(expected)
+        })
+    })
+
+    describe('maskQueryParams', () => {
+        test.each([
+            [
+                'passes through when no params to mask',
+                'https://www.example.com/?query=1#hash',
+                [],
+                'https://www.example.com/?query=1#hash',
+            ],
+            ['passes through empty string', '', [], ''],
+            [
+                'masks a query param',
+                'https://www.example.com/?query=1#hash',
+                ['query'],
+                'https://www.example.com/?query=<masked>#hash',
+            ],
+            [
+                'masks a query param with no value',
+                'https://www.example.com/?query=#hash',
+                ['query'],
+                'https://www.example.com/?query=<masked>#hash',
+            ],
+            [
+                'masks a query param with no value or equals',
+                'https://www.example.com/?query#hash',
+                ['query'],
+                'https://www.example.com/?query=<masked>#hash',
+            ],
+            [
+                'masks a query param multiple times',
+                'https://www.example.com/?query=1&query=2',
+                ['query'],
+                'https://www.example.com/?query=<masked>&query=<masked>',
+            ],
+            [
+                'does not mask other query params',
+                'https://www.example.com/?query=1&other=2#hash',
+                ['query'],
+                'https://www.example.com/?query=<masked>&other=2#hash',
+            ],
+            [
+                'does not mask in the pathname',
+                'https://www.example.com/query=1/?query=1#hash',
+                ['query'],
+                'https://www.example.com/query=1/?query=<masked>#hash',
+            ],
+            [
+                'does not modify malformed query params',
+                'https://www.example.com/?other%=%',
+                ['query'],
+                'https://www.example.com/?other%=%',
+            ],
+            [
+                'does not mask in the hash',
+                'https://www.example.com/?foo=1#query=2',
+                ['query'],
+                'https://www.example.com/?foo=1#query=2',
+            ],
+            [
+                "does not add a hash when the isn't one",
+                'https://www.example.com/?foo=1',
+                ['query'],
+                'https://www.example.com/?foo=1',
+            ],
+            [
+                "does not add a query when the isn't one",
+                'https://www.example.com',
+                ['query'],
+                'https://www.example.com',
+            ],
+            ['works without domain too', 'pathname/?query=1#hash', ['query'], 'pathname/?query=<masked>#hash'],
+        ])('%s', (_name, url, params, expected) => {
+            expect(maskQueryParams(url, params, '<masked>')).toEqual(expected)
         })
     })
 

--- a/src/__tests__/request-utils.test.ts
+++ b/src/__tests__/request-utils.test.ts
@@ -118,6 +118,12 @@ describe('request utils', () => {
                 'https://www.example.com',
             ],
             ['works without domain too', 'pathname/?query=1#hash', ['query'], 'pathname/?query=<masked>#hash'],
+            [
+                'can mask multiple query params',
+                'pathname/?gclid=1&fbclid=2',
+                ['gclid', 'fbclid'],
+                'pathname/?gclid=<masked>&fbclid=<masked>',
+            ],
         ])('%s', (_name, url, params, expected) => {
             expect(maskQueryParams(url, params, '<masked>')).toEqual(expected)
         })

--- a/src/__tests__/session-props.test.ts
+++ b/src/__tests__/session-props.test.ts
@@ -1,6 +1,7 @@
 import { SessionPropsManager } from '../session-props'
 import { SessionIdManager } from '../sessionid'
 import { PostHogPersistence } from '../posthog-persistence'
+import { PostHog } from '../posthog-core'
 
 describe('Session Props Manager', () => {
     const createSessionPropsManager = () => {
@@ -14,7 +15,13 @@ describe('Session Props Manager', () => {
             register: persistenceRegister,
             props: {},
         } as unknown as PostHogPersistence
-        const sessionPropsManager = new SessionPropsManager(sessionIdManager, persistence, generateProps)
+        const posthog = {
+            sessionManager: sessionIdManager,
+            persistence,
+            config: {},
+        } as unknown as PostHog
+
+        const sessionPropsManager = new SessionPropsManager(posthog, sessionIdManager, persistence, generateProps)
 
         return {
             onSessionId,

--- a/src/__tests__/utils/event-utils.test.ts
+++ b/src/__tests__/utils/event-utils.test.ts
@@ -32,6 +32,23 @@ describe(`event-utils`, () => {
             expect(properties['$raw_user_agent'].length).toBe(1000)
             expect(properties['$raw_user_agent'].substring(995)).toBe('aa...')
         })
+
+        it('should mask out personal data from URL', () => {
+            // @ts-expect-error ok to set global in test
+            globals.location = { href: 'https://www.example.com/path?gclid=12345&other=true' }
+            const properties = Info.properties({ maskPersonalDataProperties: true })
+            expect(properties['$current_url']).toEqual('https://www.example.com/path?gclid=<masked>&other=true')
+        })
+
+        it('should mask out custom personal data', () => {
+            // @ts-expect-error ok to set global in test
+            globals.location = { href: 'https://www.example.com/path?gclid=12345&other=true' }
+            const properties = Info.properties({
+                maskPersonalDataProperties: true,
+                customPersonalDataProperties: ['other'],
+            })
+            expect(properties['$current_url']).toEqual('https://www.example.com/path?gclid=<masked>&other=<masked>')
+        })
     })
 
     describe('user agent', () => {

--- a/src/customizations/setAllPersonProfilePropertiesAsPersonPropertiesForFlags.ts
+++ b/src/customizations/setAllPersonProfilePropertiesAsPersonPropertiesForFlags.ts
@@ -4,7 +4,19 @@ import { each, extend } from '../utils'
 import { includes } from '../utils/string-utils'
 
 export const setAllPersonProfilePropertiesAsPersonPropertiesForFlags = (posthog: PostHog): void => {
-    const allProperties = extend({}, Info.properties(), Info.campaignParams(), Info.referrerInfo())
+    const allProperties = extend(
+        {},
+        Info.properties({
+            maskPersonalDataProperties: posthog.config.mask_personal_data_properties,
+            customPersonalDataProperties: posthog.config.custom_personal_data_properties,
+        }),
+        Info.campaignParams({
+            customTrackedParams: posthog.config.custom_campaign_params,
+            maskPersonalDataProperties: posthog.config.mask_personal_data_properties,
+            customPersonalDataProperties: posthog.config.custom_personal_data_properties,
+        }),
+        Info.referrerInfo()
+    )
     const personProperties: Record<string, string> = {}
     each(allProperties, function (v, k: string) {
         if (includes(CAMPAIGN_PARAMS, k) || includes(EVENT_TO_PERSON_PROPERTIES, k)) {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -963,10 +963,10 @@ export class PostHog {
             return properties
         }
 
-        const infoProperties = Info.properties(
-            this.config.mask_personal_data_properties,
-            this.config.custom_personal_data_properties
-        )
+        const infoProperties = Info.properties({
+            maskPersonalDataProperties: this.config.mask_personal_data_properties,
+            customPersonalDataProperties: this.config.custom_personal_data_properties,
+        })
 
         if (this.sessionManager) {
             const { sessionId, windowId } = this.sessionManager.checkAndGetSessionAndWindowId()

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -166,6 +166,8 @@ export const defaultConfig = (): PostHogConfig => ({
     session_recording: {},
     mask_all_element_attributes: false,
     mask_all_text: false,
+    mask_personal_data_properties: false,
+    custom_personal_data_properties: [],
     advanced_disable_decide: false,
     advanced_disable_feature_flags: false,
     advanced_disable_feature_flags_on_first_load: false,
@@ -435,7 +437,7 @@ export class PostHog {
 
         if (!this.config.__preview_experimental_cookieless_mode) {
             this.sessionManager = new SessionIdManager(this)
-            this.sessionPropsManager = new SessionPropsManager(this.sessionManager, this.persistence)
+            this.sessionPropsManager = new SessionPropsManager(this, this.sessionManager, this.persistence)
         }
 
         new TracingHeaders(this).startIfEnabledOrStop()
@@ -961,7 +963,10 @@ export class PostHog {
             return properties
         }
 
-        const infoProperties = Info.properties()
+        const infoProperties = Info.properties(
+            this.config.mask_personal_data_properties,
+            this.config.custom_personal_data_properties
+        )
 
         if (this.sessionManager) {
             const { sessionId, windowId } = this.sessionManager.checkAndGetSessionAndWindowId()

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -222,7 +222,11 @@ export class PostHogPersistence {
 
     update_campaign_params(): void {
         if (!this.campaign_params_saved) {
-            const campaignParams = Info.campaignParams(this.config.custom_campaign_params)
+            const campaignParams = Info.campaignParams(
+                this.config.custom_campaign_params,
+                this.config.mask_personal_data_properties,
+                this.config.custom_personal_data_properties
+            )
             // only save campaign params if there were any
             if (!isEmptyObject(stripEmptyProperties(campaignParams))) {
                 this.register(campaignParams)

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -222,11 +222,11 @@ export class PostHogPersistence {
 
     update_campaign_params(): void {
         if (!this.campaign_params_saved) {
-            const campaignParams = Info.campaignParams(
-                this.config.custom_campaign_params,
-                this.config.mask_personal_data_properties,
-                this.config.custom_personal_data_properties
-            )
+            const campaignParams = Info.campaignParams({
+                customTrackedParams: this.config.custom_campaign_params,
+                maskPersonalDataProperties: this.config.mask_personal_data_properties,
+                customPersonalDataProperties: this.config.custom_personal_data_properties,
+            })
             // only save campaign params if there were any
             if (!isEmptyObject(stripEmptyProperties(campaignParams))) {
                 this.register(campaignParams)

--- a/src/session-props.ts
+++ b/src/session-props.ts
@@ -33,11 +33,11 @@ const generateSessionSourceParams = (instance?: PostHog): SessionSourceProps => 
     return {
         initialPathName: location?.pathname || '',
         referringDomain: Info.referringDomain(),
-        ...Info.campaignParams(
-            config?.custom_campaign_params,
-            config?.mask_personal_data_properties,
-            config?.custom_personal_data_properties
-        ),
+        ...Info.campaignParams({
+            customTrackedParams: config?.custom_campaign_params,
+            maskPersonalDataProperties: config?.mask_personal_data_properties,
+            customPersonalDataProperties: config?.custom_personal_data_properties,
+        }),
     }
 }
 

--- a/src/session-props.ts
+++ b/src/session-props.ts
@@ -8,9 +8,10 @@
  */
 import { location } from './utils/globals'
 import { Info } from './utils/event-utils'
-import { SessionIdManager } from './sessionid'
-import { PostHogPersistence } from './posthog-persistence'
+import type { SessionIdManager } from './sessionid'
+import type { PostHogPersistence } from './posthog-persistence'
 import { CLIENT_SESSION_PROPS } from './constants'
+import type { PostHog } from './posthog-core'
 
 interface SessionSourceProps {
     initialPathName: string
@@ -27,24 +28,32 @@ interface StoredSessionSourceProps {
     props: SessionSourceProps
 }
 
-const generateSessionSourceParams = (): SessionSourceProps => {
+const generateSessionSourceParams = (instance?: PostHog): SessionSourceProps => {
+    const config = instance?.config
     return {
         initialPathName: location?.pathname || '',
         referringDomain: Info.referringDomain(),
-        ...Info.campaignParams(),
+        ...Info.campaignParams(
+            config?.custom_campaign_params,
+            config?.mask_personal_data_properties,
+            config?.custom_personal_data_properties
+        ),
     }
 }
 
 export class SessionPropsManager {
+    private readonly instance: PostHog
     private readonly _sessionIdManager: SessionIdManager
     private readonly _persistence: PostHogPersistence
-    private readonly _sessionSourceParamGenerator: () => SessionSourceProps
+    private readonly _sessionSourceParamGenerator: (instance?: PostHog) => SessionSourceProps
 
     constructor(
+        instance: PostHog,
         sessionIdManager: SessionIdManager,
         persistence: PostHogPersistence,
-        sessionSourceParamGenerator?: () => SessionSourceProps
+        sessionSourceParamGenerator?: (instance?: PostHog) => SessionSourceProps
     ) {
+        this.instance = instance
         this._sessionIdManager = sessionIdManager
         this._persistence = persistence
         this._sessionSourceParamGenerator = sessionSourceParamGenerator || generateSessionSourceParams
@@ -64,7 +73,7 @@ export class SessionPropsManager {
 
         const newProps: StoredSessionSourceProps = {
             sessionId,
-            props: this._sessionSourceParamGenerator(),
+            props: this._sessionSourceParamGenerator(this.instance),
         }
         this._persistence.register({ [CLIENT_SESSION_PROPS]: newProps })
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,8 +283,8 @@ export interface PostHogConfig {
     session_idle_timeout_seconds: number
     mask_all_element_attributes: boolean
     mask_all_text: boolean
-    mask_pii_properties?: boolean
-    custom_pii_properties?: string[]
+    mask_personal_data_properties: boolean
+    custom_personal_data_properties: string[]
     advanced_disable_decide: boolean
     advanced_disable_feature_flags: boolean
     advanced_disable_feature_flags_on_first_load: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,6 +283,8 @@ export interface PostHogConfig {
     session_idle_timeout_seconds: number
     mask_all_element_attributes: boolean
     mask_all_text: boolean
+    mask_pii_properties?: boolean
+    custom_pii_properties?: string[]
     advanced_disable_decide: boolean
     advanced_disable_feature_flags: boolean
     advanced_disable_feature_flags_on_first_load: boolean

--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -31,16 +31,18 @@ export const PERSONAL_DATA_CAMPAIGN_PARAMS = [
     '_kx', // klaviyo
 ]
 
-export const CAMPAIGN_PARAMS = [
-    'utm_source',
-    'utm_medium',
-    'utm_campaign',
-    'utm_content',
-    'utm_term',
-    'gad_source', // google ads source
-    'mc_cid', // mailchimp campaign id
-    ...PERSONAL_DATA_CAMPAIGN_PARAMS,
-]
+export const CAMPAIGN_PARAMS = extendArray(
+    [
+        'utm_source',
+        'utm_medium',
+        'utm_campaign',
+        'utm_content',
+        'utm_term',
+        'gad_source', // google ads source
+        'mc_cid', // mailchimp campaign id
+    ],
+    PERSONAL_DATA_CAMPAIGN_PARAMS
+)
 
 export const EVENT_TO_PERSON_PROPERTIES = [
     // mobile params

--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -9,15 +9,13 @@ import { stripLeadingDollar } from './string-utils'
 
 const URL_REGEX_PREFIX = 'https?://(.*)'
 
-// Should be kept in sync with https://github.com/PostHog/posthog/blob/master/plugin-server/src/utils/db/utils.ts#L60
-export const CAMPAIGN_PARAMS = [
-    'utm_source',
-    'utm_medium',
-    'utm_campaign',
-    'utm_content',
-    'utm_term',
+// CAMPAIGN_PARAMS and EVENT_TO_PERSON_PROPERTIES should be kept in sync with
+// https://github.com/PostHog/posthog/blob/master/plugin-server/src/utils/db/utils.ts#L60
+
+// The list of campaign parameters that could be considered personal data under e.g. GDPR.
+// These can be masked in URLs and properties before being sent to posthog.
+export const PERSONAL_DATA_CAMPAIGN_PARAMS = [
     'gclid', // google ads
-    'gad_source', // google ads
     'gclsrc', // google ads 360
     'dclid', // google display ads
     'gbraid', // google ads, web to app
@@ -26,12 +24,22 @@ export const CAMPAIGN_PARAMS = [
     'msclkid', // microsoft
     'twclid', // twitter
     'li_fat_id', // linkedin
-    'mc_cid', // mailchimp campaign id
     'igshid', // instagram
     'ttclid', // tiktok
     'rdt_cid', // reddit
     'irclid', // impact
     '_kx', // klaviyo
+]
+
+export const CAMPAIGN_PARAMS = [
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_content',
+    'utm_term',
+    'gad_source', // google ads source
+    'mc_cid', // mailchimp campaign id
+    ...PERSONAL_DATA_CAMPAIGN_PARAMS,
 ]
 
 export const EVENT_TO_PERSON_PROPERTIES = [

--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -64,11 +64,15 @@ export const EVENT_TO_PERSON_PROPERTIES = [
 export const MASKED = '<masked>'
 
 export const Info = {
-    campaignParams: function (
-        customTrackedParams?: string[],
-        maskPersonalDataProperties?: boolean,
+    campaignParams: function ({
+        customTrackedParams,
+        maskPersonalDataProperties,
+        customPersonalDataProperties,
+    }: {
+        customTrackedParams?: string[]
+        maskPersonalDataProperties?: boolean
         customPersonalDataProperties?: string[] | undefined
-    ): Record<string, string> {
+    } = {}): Record<string, string> {
         if (!document) {
             return {}
         }
@@ -244,10 +248,13 @@ export const Info = {
         }
     },
 
-    properties: function (
-        maskPersonalDataProperties: boolean,
-        customPersonalDataProperties: string[] | undefined
-    ): Properties {
+    properties: function ({
+        maskPersonalDataProperties,
+        customPersonalDataProperties,
+    }: {
+        maskPersonalDataProperties?: boolean
+        customPersonalDataProperties?: string[]
+    } = {}): Properties {
         if (!userAgent) {
             return {}
         }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -63,6 +63,15 @@ export const extend = function (obj: Record<string, any>, ...args: Record<string
     return obj
 }
 
+export const extendArray = function <T>(obj: T[], ...args: T[][]): T[] {
+    eachArray(args, function (source) {
+        eachArray(source, function (item) {
+            obj.push(item)
+        })
+    })
+    return obj
+}
+
 export const include = function (
     obj: null | string | Array<any> | Record<string, any>,
     target: any

--- a/src/utils/request-utils.ts
+++ b/src/utils/request-utils.ts
@@ -74,6 +74,47 @@ export const getQueryParam = function (url: string, param: string): string {
     }
 }
 
+// replace any query params in the url with the provided mask value. Tries to keep the URL as instant as possible,
+// including preserving malformed text in most cases
+export const maskQueryParams = function (url: string, maskedParams: string[] | undefined, mask: string): string {
+    if (!maskedParams || !maskedParams.length) {
+        return url
+    }
+
+    const splitHash = url.split('#')
+    const withoutHash: string = splitHash[0] || ''
+    const hash = splitHash[1]
+
+    const splitQuery: string[] = withoutHash.split('?')
+    const queryString: string = splitQuery[1]
+    const urlWithoutQueryAndHash: string = splitQuery[0]
+    const queryParts = (queryString || '').split('&')
+
+    // use an array of strings rather than an object to preserve ordering and duplicates
+    const paramStrings: string[] = []
+
+    for (let i = 0; i < queryParts.length; i++) {
+        const keyValuePair = queryParts[i].split('=')
+        if (!isArray(keyValuePair)) {
+            continue
+        } else if (maskedParams.includes(keyValuePair[0])) {
+            paramStrings.push(keyValuePair[0] + '=' + mask)
+        } else {
+            paramStrings.push(queryParts[i])
+        }
+    }
+
+    let result = urlWithoutQueryAndHash
+    if (queryString != null) {
+        result += '?' + paramStrings.join('&')
+    }
+    if (hash != null) {
+        result += '#' + hash
+    }
+
+    return result
+}
+
 export const _getHashParam = function (hash: string, param: string): string | null {
     const matches = hash.match(new RegExp(param + '=([^&]*)'))
     return matches ? matches[1] : null

--- a/src/utils/request-utils.ts
+++ b/src/utils/request-utils.ts
@@ -76,9 +76,13 @@ export const getQueryParam = function (url: string, param: string): string {
 
 // replace any query params in the url with the provided mask value. Tries to keep the URL as instant as possible,
 // including preserving malformed text in most cases
-export const maskQueryParams = function (url: string, maskedParams: string[] | undefined, mask: string): string {
-    if (!maskedParams || !maskedParams.length) {
-        return url
+export const maskQueryParams = function <T extends string | undefined>(
+    url: T,
+    maskedParams: string[] | undefined,
+    mask: string
+): T extends string ? string : undefined {
+    if (!url || !maskedParams || !maskedParams.length) {
+        return url as any
     }
 
     const splitHash = url.split('#')
@@ -112,7 +116,7 @@ export const maskQueryParams = function (url: string, maskedParams: string[] | u
         result += '#' + hash
     }
 
-    return result
+    return result as any
 }
 
 export const _getHashParam = function (hash: string, param: string): string | null {


### PR DESCRIPTION
## Changes

Add a config option to mask URL parameters. This will also mask any properties that are derived from them.

Why: We want to add a cookieless mode, allowing users to be tracked before consent is given. To do this, we need to not capture any PII-containing properties (such as ad IDs like `gclid`), as consent would be needed for those.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
