### PR TITLE
fix(): prevent person processing if /decide fails to fetch remote config

### DIFF
--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -750,31 +750,5 @@ describe('person processing', () => {
             expect(beforeSendMock.mock.calls[0][0].properties.$process_person_profile).toEqual(false)
             expect(beforeSendMock.mock.calls[1][0].properties.$process_person_profile).toEqual(false)
         })
-
-        it('should persist when the default person mode is overridden by decide', async () => {
-            // arrange
-            const persistenceName = uuidv7()
-            const { posthog: posthog1, beforeSendMock: beforeSendMock1 } = await setup(
-                undefined,
-                undefined,
-                persistenceName
-            )
-
-            // act
-            posthog1._onRemoteConfig({ defaultIdentifiedOnly: false } as RemoteConfig)
-            posthog1.capture('custom event 1')
-            const { posthog: posthog2, beforeSendMock: beforeSendMock2 } = await setup(
-                undefined,
-                undefined,
-                persistenceName
-            )
-            posthog2.capture('custom event 2')
-
-            // assert
-            expect(beforeSendMock1.mock.calls.length).toEqual(1)
-            expect(beforeSendMock2.mock.calls.length).toEqual(1)
-            expect(beforeSendMock1.mock.calls[0][0].properties.$process_person_profile).toEqual(true)
-            expect(beforeSendMock2.mock.calls[0][0].properties.$process_person_profile).toEqual(true)
-        })
     })
 })

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -721,19 +721,19 @@ describe('person processing', () => {
     })
 
     describe('decide', () => {
-        it('should change the person mode from default when decide response is handled', async () => {
+        it('should default the person mode to identified_only when an incomplete decide response is handled', async () => {
             // arrange
             const { posthog, beforeSendMock } = await setup(undefined)
             posthog.capture('startup page view')
 
             // act
-            posthog._onRemoteConfig({ defaultIdentifiedOnly: false } as RemoteConfig)
+            posthog._onRemoteConfig({} as RemoteConfig)
             posthog.capture('custom event')
 
             // assert
             expect(beforeSendMock.mock.calls.length).toEqual(2)
             expect(beforeSendMock.mock.calls[0][0].properties.$process_person_profile).toEqual(false)
-            expect(beforeSendMock.mock.calls[1][0].properties.$process_person_profile).toEqual(true)
+            expect(beforeSendMock.mock.calls[1][0].properties.$process_person_profile).toEqual(false)
         })
 
         it('should NOT change the person mode from user-defined when decide response is handled', async () => {

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -342,14 +342,17 @@ describe('posthog core', () => {
 
             expect(posthog.compression).toEqual('gzip-js')
         })
-        it('uses defaultIdentifiedOnly from decide response', () => {
+        it('ignores legacy field defaultIdentifiedOnly from decide response', () => {
             const posthog = posthogWith({})
 
             posthog._onRemoteConfig({ defaultIdentifiedOnly: true } as RemoteConfig)
             expect(posthog.config.person_profiles).toEqual('identified_only')
 
             posthog._onRemoteConfig({ defaultIdentifiedOnly: false } as RemoteConfig)
-            expect(posthog.config.person_profiles).toEqual('always')
+            expect(posthog.config.person_profiles).toEqual('identified_only')
+
+            posthog._onRemoteConfig({} as RemoteConfig)
+            expect(posthog.config.person_profiles).toEqual('identified_only')
         })
         it('defaultIdentifiedOnly does not override person_profiles if already set', () => {
             const posthog = posthogWith({ person_profiles: 'always' })

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -587,11 +587,7 @@ export class PostHog {
         }
 
         this.set_config({
-            person_profiles: this._initialPersonProfilesConfig
-                ? this._initialPersonProfilesConfig
-                : config['defaultIdentifiedOnly']
-                  ? 'identified_only'
-                  : 'always',
+            person_profiles: this._initialPersonProfilesConfig ? this._initialPersonProfilesConfig : 'identified_only',
         })
 
         this.siteApps?.onRemoteConfig(config)

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -2047,6 +2047,12 @@ export class PostHog {
     }
 
     _hasPersonProcessing(): boolean {
+        // If the SDK config is not set, we can't determine if we should process the person. Default to false
+        // as later events will have the config set and persons will be processed correctly.
+        if (!this.config || isEmptyObject(this.config)) {
+            return false
+        }
+
         return !(
             this.config.person_profiles === 'never' ||
             (this.config.person_profiles === 'identified_only' &&

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -2043,12 +2043,6 @@ export class PostHog {
     }
 
     _hasPersonProcessing(): boolean {
-        // If the SDK config is not set, we can't determine if we should process the person. Default to false
-        // as later events will have the config set and persons will be processed correctly.
-        if (!this.config || isEmptyObject(this.config)) {
-            return false
-        }
-
         return !(
             this.config.person_profiles === 'never' ||
             (this.config.person_profiles === 'identified_only' &&

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -35,7 +35,7 @@ export const isObject = (x: unknown): x is Record<string, any> => {
     // eslint-disable-next-line posthog-js/no-direct-object-check
     return x === Object(x) && !isArray(x)
 }
-export const isEmptyObject = (x: unknown): x is Record<string, any> => {
+export const isEmptyObject = (x: unknown) => {
     if (isObject(x)) {
         for (const key in x) {
             if (hasOwnProperty.call(x, key)) {


### PR DESCRIPTION
## Changes

Context:
- https://posthoghelp.zendesk.com/agent/tickets/22908 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/28448) 
- https://posthoghelp.zendesk.com/agent/tickets/22134 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/25748)

In digging through the code it appears that there are two cases where this could potentially happen:
1. An event is emitted in between `_init` setting `this.config = {}` ([here](https://github.com/PostHog/posthog-js/blob/main/src/posthog-core.ts#L406)) and it getting re-set to the proper value (this seems like an extremely unlikely race condition but we may as well protect against it in `_hasPersonProcessing`, and while writing unit tests for a potential fix here I discovered that all events would fail to send if `posthog.config` was an empty object anyway)
2. `/decide` fails to return the config values, leaving the SDK to fall back to `person_profiles: 'always'` ([here](https://github.com/PostHog/posthog-js/blob/main/src/posthog-core.ts#L589-L595))

To protect against the second edge case we make the following change: Remove the dependency on the `defaultIdentifiedOnly` field from `/decide`. This is the new default, so we should not need this conditional moving forward anyway.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
