### PR TITLE
fix: expose getNextSurveyStep to use in posthog

### DIFF
--- a/src/entrypoints/surveys-preview.es.ts
+++ b/src/entrypoints/surveys-preview.es.ts
@@ -1,1 +1,2 @@
-export { renderSurveysPreview, renderFeedbackWidgetPreview } from '../extensions/surveys'
+export { renderFeedbackWidgetPreview, renderSurveysPreview } from '../extensions/surveys'
+export { getNextSurveyStep } from '../posthog-surveys'


### PR DESCRIPTION
## Changes

No functional changes.

Exposes `getNextSurveyStep` to the exported functions so we don't need to duplicate that logic on `posthog/posthog` for survey previewing purposes

## Checklist
- [x] Tests for new code (no code changes, just exposing a function)
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
