### PR TITLE
fix: sentry integration fields

### DIFF
--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -87,9 +87,13 @@ export function createEventProcessor(
 
         const exceptions: _SentryException[] = event.exception?.values || []
 
-        exceptions.map((exception) => {
+        exceptions.forEach((exception) => {
             if (exception.stacktrace) {
                 exception.stacktrace.type = 'raw'
+
+                exception.stacktrace.frames.forEach((frame: any) => {
+                    frame.platform = 'web:javascript'
+                })
             }
         })
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1952,13 +1952,16 @@ export class PostHog {
     captureException(error: Error, additionalProperties?: Properties): void {
         const syntheticException = new Error('PostHog syntheticException')
         const properties: Properties = isFunction(assignableWindow.__PosthogExtensions__?.parseErrorAsProperties)
-            ? assignableWindow.__PosthogExtensions__.parseErrorAsProperties(
-                  [error.message, undefined, undefined, undefined, error],
-                  // create synthetic error to get stack in cases where user input does not contain one
-                  // creating the exceptionas soon into our code as possible means we should only have to
-                  // remove a single frame (this 'captureException' method) from the resultant stack
-                  { syntheticException }
-              )
+            ? {
+                  ...assignableWindow.__PosthogExtensions__.parseErrorAsProperties(
+                      [error.message, undefined, undefined, undefined, error],
+                      // create synthetic error to get stack in cases where user input does not contain one
+                      // creating the exceptions soon into our code as possible means we should only have to
+                      // remove a single frame (this 'captureException' method) from the resultant stack
+                      { syntheticException }
+                  ),
+                  ...additionalProperties,
+              }
             : {
                   $exception_level: 'error',
                   $exception_list: [


### PR DESCRIPTION
## Changes

Cymbal is throwing some errors on exceptions because not all the correct fields are set:

```
serde error: missing field `platform` at line 1 column 14449
```

- Adds the platform field
- Also fixes a bug where additional properties were not being set in the case where an exception was manually captured but `parseErrorAsProperties` didn't exist (e.g. exception auto capture wasn't enabled)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
