### PR TITLE
fix: set last reset date as event super property

### DIFF
--- a/src/__tests__/posthog-core.identify.test.ts
+++ b/src/__tests__/posthog-core.identify.test.ts
@@ -1,6 +1,6 @@
 import { USER_STATE } from '../constants'
 import { uuidv7 } from '../uuidv7'
-import { createPosthogInstance, defaultPostHog } from './helpers/posthog-instance'
+import { defaultPostHog } from './helpers/posthog-instance'
 import { PostHog } from '../posthog-core'
 import { assignableWindow } from '../utils/globals'
 
@@ -341,64 +341,6 @@ describe('identify()', () => {
                 })
             )
             expect(instance.featureFlags.setAnonymousDistinctId).not.toHaveBeenCalled()
-        })
-    })
-})
-
-describe('reset()', () => {
-    let instance: PostHog
-
-    beforeEach(async () => {
-        instance = await createPosthogInstance(uuidv7(), {
-            api_host: 'https://test.com',
-            token: 'testtoken',
-        })
-    })
-
-    it('clears persistence', () => {
-        instance.persistence!.register({ $enabled_feature_flags: { flag: 'variant', other: true } })
-        expect(instance.persistence!.props['$enabled_feature_flags']).toEqual({ flag: 'variant', other: true })
-
-        instance.reset()
-
-        expect(instance.persistence!.props['$enabled_feature_flags']).toEqual(undefined)
-    })
-
-    it('resets the session_id and window_id', () => {
-        const initialSessionAndWindowId = instance.sessionManager!.checkAndGetSessionAndWindowId()
-
-        instance.reset()
-
-        const nextSessionAndWindowId = instance.sessionManager!.checkAndGetSessionAndWindowId()
-        expect(initialSessionAndWindowId.sessionId).not.toEqual(nextSessionAndWindowId.sessionId)
-        expect(initialSessionAndWindowId.windowId).not.toEqual(nextSessionAndWindowId.windowId)
-    })
-
-    it('sets the user as anonymous', () => {
-        instance.persistence!.set_property(USER_STATE, 'identified')
-
-        instance.reset()
-
-        expect(instance.persistence!.get_property(USER_STATE)).toEqual('anonymous')
-    })
-
-    it('does not reset the device id', () => {
-        const initialDeviceId = instance.get_property('$device_id')
-
-        instance.reset()
-
-        const nextDeviceId = instance.get_property('$device_id')
-        expect(initialDeviceId).toEqual(nextDeviceId)
-    })
-
-    describe('when calling reset(true)', () => {
-        it('does reset the device id', () => {
-            const initialDeviceId = instance.get_property('$device_id')
-
-            instance.reset(true)
-
-            const nextDeviceId = instance.get_property('$device_id')
-            expect(initialDeviceId).not.toEqual(nextDeviceId)
         })
     })
 })

--- a/src/__tests__/posthog-core.reset.test.ts
+++ b/src/__tests__/posthog-core.reset.test.ts
@@ -1,0 +1,62 @@
+import { PostHog } from '../posthog-core'
+import { createPosthogInstance } from './helpers/posthog-instance'
+import { uuidv7 } from '../uuidv7'
+import { USER_STATE } from '../constants'
+
+describe('reset()', () => {
+    let instance: PostHog
+
+    beforeEach(async () => {
+        instance = await createPosthogInstance(uuidv7(), {
+            api_host: 'https://test.com',
+            token: 'testtoken',
+        })
+    })
+
+    it('clears persistence', () => {
+        instance.persistence!.register({ $enabled_feature_flags: { flag: 'variant', other: true } })
+        expect(instance.persistence!.props['$enabled_feature_flags']).toEqual({ flag: 'variant', other: true })
+
+        instance.reset()
+
+        expect(instance.persistence!.props['$enabled_feature_flags']).toEqual(undefined)
+    })
+
+    it('resets the session_id and window_id', () => {
+        const initialSessionAndWindowId = instance.sessionManager!.checkAndGetSessionAndWindowId()
+
+        instance.reset()
+
+        const nextSessionAndWindowId = instance.sessionManager!.checkAndGetSessionAndWindowId()
+        expect(initialSessionAndWindowId.sessionId).not.toEqual(nextSessionAndWindowId.sessionId)
+        expect(initialSessionAndWindowId.windowId).not.toEqual(nextSessionAndWindowId.windowId)
+    })
+
+    it('sets the user as anonymous', () => {
+        instance.persistence!.set_property(USER_STATE, 'identified')
+
+        instance.reset()
+
+        expect(instance.persistence!.get_property(USER_STATE)).toEqual('anonymous')
+    })
+
+    it('does not reset the device id', () => {
+        const initialDeviceId = instance.get_property('$device_id')
+
+        instance.reset()
+
+        const nextDeviceId = instance.get_property('$device_id')
+        expect(initialDeviceId).toEqual(nextDeviceId)
+    })
+
+    describe('when calling reset(true)', () => {
+        it('does reset the device id', () => {
+            const initialDeviceId = instance.get_property('$device_id')
+
+            instance.reset(true)
+
+            const nextDeviceId = instance.get_property('$device_id')
+            expect(initialDeviceId).not.toEqual(nextDeviceId)
+        })
+    })
+})

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1096,7 +1096,7 @@ export class PostHog {
      *     // Display the properties
      *     console.log(posthog.persistence.properties())
      *
-     * @param {Object} properties An associative array of properties to store about the user
+     * @param {Object} properties properties to store about the user
      * @param {Number} [days] How many days since the user's last visit to store the super properties
      */
     register(properties: Properties, days?: number): void {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1604,6 +1604,13 @@ export class PostHog {
                 ''
             )
         }
+
+        this.register(
+            {
+                $last_posthog_reset: new Date().toISOString(),
+            },
+            1
+        )
     }
 
     /**


### PR DESCRIPTION
i frequently have to diagnose whether a user called reset at an unexpected time and we just have to infer it

Let's set the last reset time on events so we can be more less confused