### PR TITLE
fix: cache nested loops

### DIFF
--- a/patches/@rrweb__record@2.0.0-alpha.18.patch
+++ b/patches/@rrweb__record@2.0.0-alpha.18.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/record.js b/dist/record.js
-index d9c57625633fb87da27fc5948c1b15a7c4e4caa5..472c9f1359baf685279614c47426648102479efb 100644
+index d9c57625633fb87da27fc5948c1b15a7c4e4caa5..ff1783439be7fdd6ad947b805324e4c7f8f70851 100644
 --- a/dist/record.js
 +++ b/dist/record.js
 @@ -68,10 +68,10 @@ function getUntaintedPrototype$1(key) {
@@ -25,12 +25,25 @@ index d9c57625633fb87da27fc5948c1b15a7c4e4caa5..472c9f1359baf685279614c474266481
  class Mirror {
    constructor() {
      __publicField$1(this, "idNodeMap", /* @__PURE__ */ new Map());
-@@ -426,23 +429,81 @@ function absolutifyURLs(cssText, href) {
- function normalizeCssString(cssText) {
-   return cssText.replace(/(\/\*[^*]*\*\/)|[\s;]/g, "");
+@@ -423,26 +426,96 @@ function absolutifyURLs(cssText, href) {
+     }
+   );
  }
++// these operations can be slow, let's cache them
++const normalizationCache = new Map();
++const splitCache = new Map();
+ function normalizeCssString(cssText) {
+-  return cssText.replace(/(\/\*[^*]*\*\/)|[\s;]/g, "");
+-}
 -function splitCssText(cssText, style) {
 -  const childNodes2 = Array.from(style.childNodes);
++  if (!normalizationCache.has(cssText)) {
++    const normalized = cssText.replace(/(\/\*[^*]*\*\/)|[\s;]/g, '');
++    normalizationCache.set(cssText, normalized);
++  }
++  // we know that the value is in the cache now
++  return normalizationCache.get(cssText);
++}
 +/**
 + * Maps the output of stringifyStylesheet to individual text nodes of a <style> element
 + * which occurs when javascript is used to append to the style element
@@ -51,6 +64,10 @@ index d9c57625633fb87da27fc5948c1b15a7c4e4caa5..472c9f1359baf685279614c474266481
 -        for (let j = 3; j < textContentNorm.length; j++) {
 +  let iterLimit = 0;
 +  if (childNodes.length > 1 && cssText && typeof cssText === 'string') {
++    if (splitCache.has(cssText)) {
++      // we know there's a result
++      return splitCache.get(cssText)
++    }
 +    let cssTextNorm = normalizeCssString(cssText);
 +    const normFactor = cssTextNorm.length / cssText.length;
 +    for (let i = 1; i < childNodes.length; i++) {
@@ -119,16 +136,17 @@ index d9c57625633fb87da27fc5948c1b15a7c4e4caa5..472c9f1359baf685279614c474266481
                }
              }
              break;
-@@ -451,7 +512,7 @@ function splitCssText(cssText, style) {
+@@ -451,7 +524,8 @@ function splitCssText(cssText, style) {
        }
      }
    }
 -  splits.push(cssText);
 +  splits.push(cssText); // either the full thing if no splits were found, or the last split
++  splitCache.set(cssText, splits);
    return splits;
  }
  function markCssSplits(cssText, style) {
-@@ -841,9 +902,14 @@ function serializeElementNode(n2, options) {
+@@ -841,9 +915,14 @@ function serializeElementNode(n2, options) {
      }
    }
    if (tagName === "link" && inlineStylesheet) {
@@ -146,7 +164,7 @@ index d9c57625633fb87da27fc5948c1b15a7c4e4caa5..472c9f1359baf685279614c474266481
      let cssText = null;
      if (stylesheet) {
        cssText = stringifyStylesheet(stylesheet);
-@@ -889,7 +955,15 @@ function serializeElementNode(n2, options) {
+@@ -889,7 +968,15 @@ function serializeElementNode(n2, options) {
      }
    }
    if (tagName === "dialog" && n2.open) {
@@ -163,7 +181,7 @@ index d9c57625633fb87da27fc5948c1b15a7c4e4caa5..472c9f1359baf685279614c474266481
    }
    if (tagName === "canvas" && recordCanvas) {
      if (n2.__context === "2d") {
-@@ -1112,7344 +1186,249 @@ function serializeNodeWithId(n2, options) {
+@@ -1112,7344 +1199,249 @@ function serializeNodeWithId(n2, options) {
      return null;
    }
    if (onSerialize) {
@@ -7736,7 +7754,7 @@ index d9c57625633fb87da27fc5948c1b15a7c4e4caa5..472c9f1359baf685279614c474266481
  class BaseRRNode {
    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
    constructor(..._args) {
-@@ -11451,11 +4430,19 @@ class CanvasManager {
+@@ -11451,11 +4443,19 @@ class CanvasManager {
      let rafId;
      const getCanvas = () => {
        const matchedCanvas = [];
@@ -7761,7 +7779,7 @@ index d9c57625633fb87da27fc5948c1b15a7c4e4caa5..472c9f1359baf685279614c474266481
        return matchedCanvas;
      };
      const takeCanvasSnapshots = (timestamp) => {
-@@ -11476,13 +4463,20 @@ class CanvasManager {
+@@ -11476,13 +4476,20 @@ class CanvasManager {
              context.clear(context.COLOR_BUFFER_BIT);
            }
          }
@@ -7786,22 +7804,35 @@ index d9c57625633fb87da27fc5948c1b15a7c4e4caa5..472c9f1359baf685279614c474266481
            },
            [bitmap]
 diff --git a/dist/record.umd.cjs b/dist/record.umd.cjs
-index 902c5eca13b2c3e69af25afa682d2e7300372bfc..4da3d8a172b53199f91880229ec5d665bb7d0fd4 100644
+index 902c5eca13b2c3e69af25afa682d2e7300372bfc..23fc9fffa6b815da448311dd31cec52c3abeb44f 100644
 --- a/dist/record.umd.cjs
 +++ b/dist/record.umd.cjs
-@@ -473,23 +473,81 @@ function absolutifyURLs(cssText, href) {
- function normalizeCssString(cssText) {
-   return cssText.replace(/(\/\*[^*]*\*\/)|[\s;]/g, "");
+@@ -470,26 +470,96 @@ function absolutifyURLs(cssText, href) {
+     }
+   );
  }
++// these operations can be slow, let's cache them
++const normalizationCache = new Map();
++const splitCache = new Map();
+ function normalizeCssString(cssText) {
+-  return cssText.replace(/(\/\*[^*]*\*\/)|[\s;]/g, "");
+-}
 -function splitCssText(cssText, style) {
 -  const childNodes2 = Array.from(style.childNodes);
++  if (!normalizationCache.has(cssText)) {
++    const normalized = cssText.replace(/(\/\*[^*]*\*\/)|[\s;]/g, '');
++    normalizationCache.set(cssText, normalized);
++  }
++  // we know that the value is in the cache now
++  return normalizationCache.get(cssText);
++}
 +/**
 + * Maps the output of stringifyStylesheet to individual text nodes of a <style> element
 + * which occurs when javascript is used to append to the style element
 + * and may also occur when browsers opt to break up large text nodes
 + * performance needs to be considered, see e.g. #1603
 + */
-+export function splitCssText(
++function splitCssText(
 +  cssText,
 +  style,
 +) {
@@ -7815,6 +7846,10 @@ index 902c5eca13b2c3e69af25afa682d2e7300372bfc..4da3d8a172b53199f91880229ec5d665
 -        for (let j = 3; j < textContentNorm.length; j++) {
 +  let iterLimit = 0;
 +  if (childNodes.length > 1 && cssText && typeof cssText === 'string') {
++    if (splitCache.has(cssText)) {
++      // we know there's a result
++      return splitCache.get(cssText)
++    }
 +    let cssTextNorm = normalizeCssString(cssText);
 +    const normFactor = cssTextNorm.length / cssText.length;
 +    for (let i = 1; i < childNodes.length; i++) {
@@ -7883,12 +7918,13 @@ index 902c5eca13b2c3e69af25afa682d2e7300372bfc..4da3d8a172b53199f91880229ec5d665
                }
              }
              break;
-@@ -498,7 +556,7 @@ function splitCssText(cssText, style) {
+@@ -498,7 +568,8 @@ function splitCssText(cssText, style) {
        }
      }
    }
 -  splits.push(cssText);
 +  splits.push(cssText); // either the full thing if no splits were found, or the last split
++  splitCache.set(cssText, splits);
    return splits;
  }
  function markCssSplits(cssText, style) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@rrweb/record@2.0.0-alpha.18':
-    hash: 6xz6ew2ae2g5uo3dyjmrcucazm
+    hash: wbich7ix2ke4ynry4xbenxe4tm
     path: patches/@rrweb__record@2.0.0-alpha.18.patch
   '@rrweb/rrweb-plugin-console-record@2.0.0-alpha.18':
     hash: xqev6zvgnatibyueo4tkcc7s5q
@@ -74,7 +74,7 @@ devDependencies:
     version: 12.1.2(rollup@4.28.1)(tslib@2.5.0)(typescript@5.5.4)
   '@rrweb/record':
     specifier: 2.0.0-alpha.18
-    version: 2.0.0-alpha.18(patch_hash=6xz6ew2ae2g5uo3dyjmrcucazm)
+    version: 2.0.0-alpha.18(patch_hash=wbich7ix2ke4ynry4xbenxe4tm)
   '@rrweb/rrweb-plugin-console-record':
     specifier: 2.0.0-alpha.18
     version: 2.0.0-alpha.18(patch_hash=xqev6zvgnatibyueo4tkcc7s5q)(rrweb@2.0.0-alpha.18)
@@ -2857,7 +2857,7 @@ packages:
     dev: true
     optional: true
 
-  /@rrweb/record@2.0.0-alpha.18(patch_hash=6xz6ew2ae2g5uo3dyjmrcucazm):
+  /@rrweb/record@2.0.0-alpha.18(patch_hash=wbich7ix2ke4ynry4xbenxe4tm):
     resolution: {integrity: sha512-WbzcybTEqT+cKkOnzYiyaAYvNzAIxTK9f8qNLNOG9lOqWsmi+qu/W7CEdxHmfjlfgXGw/f7bxGZggAWVaizKqg==}
     dependencies:
       '@rrweb/types': 2.0.0-alpha.18


### PR DESCRIPTION
we're clearly hitting a pathological case in the CSS processing for some folks
my guess is something is repeating the check due to run away mutations or something in a tight loop... or maybe it is just bad at very large strings 🤷 

quoting my old colleague Chris Sewart about peformance

you can do it faster
do it less
or not do it

let's cache our results as we go so that we only run the nested check or the regex replace once per input

you can see the test here https://github.com/PostHog/posthog-rrweb/pull/17

we see results like

```
First execution time: 3.3014169996604323ms
Average execution time for the second execution: 1.8079558699950575ms
```

that second execution will be O(1)
while first execution is O(n)

so where O(n) is large this should be a much bigger improvement 