### PR TITLE
feat: Annotate our `scroll` events as `passive`

### DIFF
--- a/src/entrypoints/dead-clicks-autocapture.ts
+++ b/src/entrypoints/dead-clicks-autocapture.ts
@@ -87,7 +87,7 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
         this._mutationObserver?.disconnect()
         this._mutationObserver = undefined
         assignableWindow.removeEventListener('click', this._onClick)
-        assignableWindow.removeEventListener('scroll', this._onScroll, true)
+        assignableWindow.removeEventListener('scroll', this._onScroll, { capture: true })
         assignableWindow.removeEventListener('selectionchange', this._onSelectionChange)
     }
 
@@ -114,11 +114,15 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
         }
     }
 
+    // `capture: true` is required to get scroll events for other scrollable elements
+    // on the page, not just the window
+    // see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#usecapture
+    //
+    // `passive: true` is used to tell the browser that the scroll event handler will not call `preventDefault()`
+    // This allows the browser to optimize scrolling performance by not waiting for our handling of the scroll event
+    // see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive
     private _startScrollObserver() {
-        // setting the third argument to `true` means that we will receive scroll events for other scrollable elements
-        // on the page, not just the window
-        // see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#usecapture
-        assignableWindow.addEventListener('scroll', this._onScroll, true)
+        assignableWindow.addEventListener('scroll', this._onScroll, { capture: true, passive: true })
     }
 
     private _onScroll = (): void => {

--- a/src/extensions/rageclick.ts
+++ b/src/extensions/rageclick.ts
@@ -1,4 +1,4 @@
-// Naive rage click implementation: If mouse has not moved than RAGE_CLICK_THRESHOLD_PX
+// Naive rage click implementation: If mouse has not moved further than RAGE_CLICK_THRESHOLD_PX
 // over RAGE_CLICK_CLICK_COUNT clicks with max RAGE_CLICK_TIMEOUT_MS between clicks, it's
 // counted as a rage click
 

--- a/src/scroll-manager.ts
+++ b/src/scroll-manager.ts
@@ -56,13 +56,17 @@ export class ScrollManager {
         this.context.maxContentHeight = Math.max(contentHeight, this.context.maxContentHeight ?? 0)
     }
 
+    // `capture: true` is required to get scroll events for other scrollable elements
+    // on the page, not just the window
+    // see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#usecapture
+    //
+    // `passive: true` is used to tell the browser that the scroll event handler will not call `preventDefault()`
+    // This allows the browser to optimize scrolling performance by not waiting for our handling of the scroll event
+    // see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive
     startMeasuringScrollPosition() {
-        // setting the third argument to `true` means that we will receive scroll events for other scrollable elements
-        // on the page, not just the window
-        // see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#usecapture
-        window?.addEventListener('scroll', this._updateScrollData, true)
-        window?.addEventListener('scrollend', this._updateScrollData, true)
-        window?.addEventListener('resize', this._updateScrollData)
+        window?.addEventListener('scroll', this._updateScrollData, { capture: true, passive: true })
+        window?.addEventListener('scrollend', this._updateScrollData, { capture: true, passive: true })
+        window?.addEventListener('resize', this._updateScrollData, { passive: true })
     }
 
     public scrollElement(): Element | undefined {


### PR DESCRIPTION
Browsers need to process all events before they can do the default behavior. This is usually not a problem for most events because what we're doing is important and we can spend ~10ms processing an event, but this is a bigger problem when we're processing `scroll` events.

`scroll` events trigger hundreds of times per second, and if you spend 10ms processing it, scrolling becomes very slow. Luckily, browsers provide us a way to tell it: hey, I'm not going to call `preventDefault`, just scroll away! That's done by adding `passive: true` when calling `addEventListener`. This tells the browser we won't call it, and that if we do call it, it's ok, we're wrong and shouldn't have called it, you don't need to respect our call.

We are tracking scroll in two different places (should probably do only one, to be honest?) - dead clicks autocapture AND heatmaps (via `scrollManager`), so I've added it to both places!

It's hard to see performance improvements in my super power mega blaster M3 but it should be helpful for lower-end devices.