### PR TITLE
fix: Fix hitting call stack limit when deep comparing circular objects

### DIFF
--- a/react/src/utils/__tests__/object-utils.test.ts
+++ b/react/src/utils/__tests__/object-utils.test.ts
@@ -30,7 +30,8 @@ describe('object-utils', () => {
             [true, [1, 2, 3], [1, 2, 3]],
             [false, [1, 2, 3], [1, 2, 4]],
             [true, { a: circularArray1 }, { a: circularArray1 }],
-            // [false, { a: circularArray1 }, { a: circularArray2 }], // TODO
+            [true, { a: circularArray1 }, { a: circularArray2 }],
+            [true, circularArray1, [circularArray1]],
             [true, f1, f1],
             [false, f1, f2],
         ])('returns %s for %s and %s', (expected, obj1, obj2) => {

--- a/react/src/utils/object-utils.ts
+++ b/react/src/utils/object-utils.ts
@@ -1,18 +1,31 @@
-export function isDeepEqual(obj1: any, obj2: any): boolean {
-    if (obj1 === obj2) return true
+export function isDeepEqual(obj1: any, obj2: any, visited = new WeakMap()): boolean {
+    if (obj1 === obj2) {
+        return true
+    }
 
     if (typeof obj1 !== 'object' || obj1 === null || typeof obj2 !== 'object' || obj2 === null) {
         return false
     }
 
+    if (visited.has(obj1) && visited.get(obj1) === obj2) {
+        return true
+    }
+    visited.set(obj1, obj2)
+
     const keys1 = Object.keys(obj1)
     const keys2 = Object.keys(obj2)
 
-    if (keys1.length !== keys2.length) return false
+    if (keys1.length !== keys2.length) {
+        return false
+    }
 
     for (const key of keys1) {
-        if (!keys2.includes(key)) return false
-        if (!isDeepEqual(obj1[key], obj2[key])) return false
+        if (!keys2.includes(key)) {
+            return false
+        }
+        if (!isDeepEqual(obj1[key], obj2[key], visited)) {
+            return false
+        }
     }
 
     return true

--- a/react/src/utils/object-utils.ts
+++ b/react/src/utils/object-utils.ts
@@ -1,3 +1,7 @@
+// Deeply compares two objects for equality.
+// Use a WeakMap to keep track of visited objects to avoid infinite recursion.
+// WeakMap is supported in IE11, see https://caniuse.com/?search=JavaScript%20WeakMap
+
 export function isDeepEqual(obj1: any, obj2: any, visited = new WeakMap()): boolean {
     if (obj1 === obj2) {
         return true


### PR DESCRIPTION
## Changes

Incorporates @abhyuditjain's suggestion from https://github.com/PostHog/posthog-js/pull/1686#issuecomment-2612699873

I was surprised that WeakMap was as well-supported as it is, and we can actually use it! https://caniuse.com/?search=JavaScript%20WeakMap

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
