### PR TITLE
fix: survey URL targeting should re-evaluate after the URL changes

### DIFF
--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -1,4 +1,5 @@
 import { PostHog } from '../posthog-core'
+import { surveyUrlValidationMap } from '../posthog-surveys'
 import {
     Survey,
     SurveyAppearance,
@@ -8,12 +9,13 @@ import {
     SurveyRenderReason,
     SurveyType,
 } from '../posthog-surveys-types'
+import { CaptureResult } from '../types'
 
 import * as Preact from 'preact'
 import { useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { document as _document, window as _window } from '../utils/globals'
 import { createLogger } from '../utils/logger'
-import { isNull, isNumber } from '../utils/type-utils'
+import { isArray, isNull, isNumber } from '../utils/type-utils'
 import { createWidgetShadow, createWidgetStyle } from './surveys-widget'
 import { ConfirmationMessage } from './surveys/components/ConfirmationMessage'
 import { Cancel } from './surveys/components/QuestionHeader'
@@ -482,6 +484,70 @@ export function SurveyPopup({
     )
     const shouldShowConfirmation = isSurveySent || previewPageIndex === survey.questions.length
     const confirmationBoxLeftStyle = style?.left && isNumber(style?.left) ? { left: style.left - 40 } : {}
+
+    // Add URL change listener to hide survey when URL no longer matches
+    useEffect(() => {
+        if (isPreviewMode || !survey.conditions?.url || !posthog) {
+            return
+        }
+
+        const checkUrlMatch = () => {
+            const urlMatchType = survey.conditions?.urlMatchType ?? 'icontains'
+            const url = survey.conditions?.url
+            if (!url) {
+                return
+            }
+            const urlCheck = surveyUrlValidationMap[urlMatchType](url)
+            if (!urlCheck) {
+                setIsPopupVisible(false)
+                removeSurveyFromFocus(survey.id)
+            }
+        }
+
+        // Listen for navigation events
+        const handleUrlChange = () => {
+            checkUrlMatch()
+        }
+
+        // Listen for browser back/forward
+        window.addEventListener('popstate', handleUrlChange)
+
+        // Create our before_send handler
+        const surveyBeforeSend = (eventData: CaptureResult | null) => {
+            if (eventData?.event === '$pageview' || eventData?.event === '$pageleave') {
+                handleUrlChange()
+            }
+            return eventData
+        }
+
+        // Add our handler to the existing before_send configuration
+        const originalBeforeSend = posthog.config.before_send
+        if (isArray(originalBeforeSend)) {
+            posthog.config.before_send = [...originalBeforeSend, surveyBeforeSend]
+        } else if (originalBeforeSend) {
+            posthog.config.before_send = [originalBeforeSend, surveyBeforeSend]
+        } else {
+            posthog.config.before_send = surveyBeforeSend
+        }
+
+        return () => {
+            window.removeEventListener('popstate', handleUrlChange)
+            // Remove our handler from the before_send configuration
+            if (isArray(posthog.config.before_send)) {
+                posthog.config.before_send = posthog.config.before_send.filter((fn) => fn !== surveyBeforeSend)
+                // If there's only one handler left, convert back to a single function
+                if (posthog.config.before_send.length === 1) {
+                    posthog.config.before_send = posthog.config.before_send[0]
+                }
+                // If there are no handlers left, restore to original state
+                else if (posthog.config.before_send.length === 0) {
+                    posthog.config.before_send = undefined
+                }
+            } else if (posthog.config.before_send === surveyBeforeSend) {
+                posthog.config.before_send = undefined
+            }
+        }
+    }, [isPreviewMode, survey, removeSurveyFromFocus, posthog])
 
     if (isPreviewMode) {
         style = style || {}

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -1,5 +1,5 @@
 import { PostHog } from '../posthog-core'
-import { surveyUrlValidationMap } from '../posthog-surveys'
+import { doesSurveyUrlMatch } from '../posthog-surveys'
 import {
     Survey,
     SurveyAppearance,
@@ -452,20 +452,17 @@ export function usePopupVisibility(
         }
 
         const checkUrlMatch = () => {
-            const urlMatchType = survey.conditions?.urlMatchType ?? 'icontains'
-            const url = survey.conditions?.url
-            if (!url) {
-                return
-            }
-            const urlCheck = surveyUrlValidationMap[urlMatchType](url)
+            const urlCheck = doesSurveyUrlMatch(survey)
             if (!urlCheck) {
                 setIsPopupVisible(false)
                 removeSurveyFromFocus(survey.id)
             }
         }
 
-        // Listen for browser back/forward and hash changes (for hash-based routing)
+        // Listen for browser back/forward browser history changes
         window.addEventListener('popstate', checkUrlMatch)
+        // Listen for hash changes, for SPA frameworks that use hash-based routing
+        // The hashchange event is fired when the fragment identifier of the URL has changed (the part of the URL beginning with and following the # symbol).
         window.addEventListener('hashchange', checkUrlMatch)
 
         // Listen for SPA navigation

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -447,7 +447,7 @@ export function usePopupVisibility(
 
     // Add URL change listener to hide survey when URL no longer matches
     useEffect(() => {
-        if (isPreviewMode || !survey.conditions?.url || !posthog) {
+        if (isPreviewMode || !survey.conditions?.url) {
             return
         }
 
@@ -485,7 +485,7 @@ export function usePopupVisibility(
             window.history.pushState = originalPushState
             window.history.replaceState = originalReplaceState
         }
-    }, [isPreviewMode, survey, removeSurveyFromFocus, posthog])
+    }, [isPreviewMode, survey, removeSurveyFromFocus])
 
     return { isPopupVisible, isSurveySent, setIsPopupVisible }
 }

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -131,6 +131,7 @@ export function getNextSurveyStep(
     return nextQuestionIndex
 }
 
+// use urlMatchType to validate url condition, fallback to contains for backwards compatibility
 export function doesSurveyUrlMatch(survey: Survey): boolean {
     if (!survey.conditions?.url) {
         return true

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -131,6 +131,14 @@ export function getNextSurveyStep(
     return nextQuestionIndex
 }
 
+export function doesSurveyUrlMatch(survey: Survey): boolean {
+    if (!survey.conditions?.url) {
+        return true
+    }
+
+    return surveyUrlValidationMap[survey.conditions?.urlMatchType ?? 'icontains'](survey.conditions.url)
+}
+
 export class PostHogSurveys {
     private _decideServerResponse?: boolean
     public _surveyEventReceiver: SurveyEventReceiver | null
@@ -271,10 +279,7 @@ export class PostHogSurveys {
                     return true
                 }
 
-                // use urlMatchType to validate url condition, fallback to contains for backwards compatibility
-                const urlCheck = survey.conditions?.url
-                    ? surveyUrlValidationMap[survey.conditions?.urlMatchType ?? 'icontains'](survey.conditions.url)
-                    : true
+                const urlCheck = doesSurveyUrlMatch(survey)
                 const selectorCheck = survey.conditions?.selector
                     ? document?.querySelector(survey.conditions.selector)
                     : true


### PR DESCRIPTION
## Changes

Adds a new effect to `SurveyPopup` to continuously check if the URL has changed to display a survey or not.

Right now, if you add a URL filter, go there, and then change the page, the survey is still persisted on the UI.

But, to match the filter properly, it should instead be hidden, as that survey is only supposed to show on a specific URL.

@dmarticus tagged you as reviewer because maybe there's some historical reason as why it was made to work like that instead of hiding it once the URL changes

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
