### PR TITLE
feat: sampling that can be shared

### DIFF
--- a/src/customizations/before-send.ts
+++ b/src/customizations/before-send.ts
@@ -1,31 +1,7 @@
 import { clampToRange } from '../utils/number-utils'
 import { BeforeSendFn, CaptureResult, KnownEventName } from '../types'
-import { isArray, isUndefined } from '../utils/type-utils'
 import { includes } from '../utils/string-utils'
-
-function appendArray(currentValue: string[] | undefined, sampleType: string | string[]): string[] {
-    return [...(currentValue ? currentValue : []), ...(isArray(sampleType) ? sampleType : [sampleType])]
-}
-
-function updateThreshold(currentValue: number | undefined, percent: number): number {
-    return (isUndefined(currentValue) ? 1 : currentValue) * percent
-}
-
-function simpleHash(str: string) {
-    let hash = 0
-    for (let i = 0; i < str.length; i++) {
-        hash = (hash << 5) - hash + str.charCodeAt(i) // (hash * 31) + char code
-        hash |= 0 // Convert to 32bit integer
-    }
-    return Math.abs(hash)
-}
-
-/*
- * receives percent as a number between 0 and 1
- */
-function sampleOnProperty(prop: string, percent: number): boolean {
-    return simpleHash(prop) % 100 < clampToRange(percent * 100, 0, 100)
-}
+import { appendArray, sampleOnProperty, updateThreshold } from '../extensions/sampling'
 
 /**
  * Provides an implementation of sampling that samples based on the distinct ID.

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -48,6 +48,7 @@ import { clampToRange } from '../../utils/number-utils'
 import Config from '../../config'
 import { includes } from '../../utils/string-utils'
 import { addEventListener } from '../../utils'
+import { sampleOnProperty } from '../sampling'
 
 const LOGGER_PREFIX = '[SessionRecording]'
 const logger = createLogger(LOGGER_PREFIX)
@@ -592,14 +593,8 @@ export class SessionRecording {
          *
          * Otherwise, we should use the stored decision.
          */
-        let shouldSample: boolean
         const makeDecision = sessionIdChanged || !isBoolean(storedIsSampled)
-        if (makeDecision) {
-            const randomNumber = Math.random()
-            shouldSample = randomNumber < currentSampleRate
-        } else {
-            shouldSample = storedIsSampled
-        }
+        const shouldSample = makeDecision ? sampleOnProperty(sessionId, currentSampleRate) : storedIsSampled
 
         if (makeDecision) {
             if (shouldSample) {

--- a/src/extensions/sampling.ts
+++ b/src/extensions/sampling.ts
@@ -1,0 +1,26 @@
+import { clampToRange } from '../utils/number-utils'
+import { isArray, isUndefined } from '../utils/type-utils'
+
+export function appendArray(currentValue: string[] | undefined, sampleType: string | string[]): string[] {
+    return [...(currentValue ? currentValue : []), ...(isArray(sampleType) ? sampleType : [sampleType])]
+}
+
+export function updateThreshold(currentValue: number | undefined, percent: number): number {
+    return (isUndefined(currentValue) ? 1 : currentValue) * percent
+}
+
+export function simpleHash(str: string) {
+    let hash = 0
+    for (let i = 0; i < str.length; i++) {
+        hash = (hash << 5) - hash + str.charCodeAt(i) // (hash * 31) + char code
+        hash |= 0 // Convert to 32bit integer
+    }
+    return Math.abs(hash)
+}
+
+/*
+ * receives percent as a number between 0 and 1
+ */
+export function sampleOnProperty(prop: string, percent: number): boolean {
+    return simpleHash(prop) % 100 < clampToRange(percent * 100, 0, 100)
+}


### PR DESCRIPTION
the suggested implementation of session id sampling for `before_send` is different to that used in session recording

the one in `before_send` is nicer as its deterministic for each session id

by switching to the `before_send` implementation someone can set a sample rate for session recording, and sample events by session id in `before_send` and only get events for sessions that have recordings 🦾

(suggested by @camerondeleone in slack somewhere)