### PR TITLE
docs: Add missing types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -905,16 +905,32 @@ export interface SessionRecordingOptions {
     /**
      * Derived from `rrweb.record` options
      * @see https://github.com/rrweb-io/rrweb/blob/master/guide.md
-     * @default undefined
      */
     maskTextSelector?: string | null
 
     /**
      * Derived from `rrweb.record` options
      * @see https://github.com/rrweb-io/rrweb/blob/master/guide.md
-     * @default undefined
      */
     maskTextFn?: ((text: string, element?: HTMLElement) => string) | null
+
+    /**
+     * Derived from `rrweb.record` options
+     * @see https://github.com/rrweb-io/rrweb/blob/master/guide.md
+     */
+    maskAllInputs?: boolean
+
+    /**
+     * Derived from `rrweb.record` options
+     * @see https://github.com/rrweb-io/rrweb/blob/master/guide.md
+     */
+    maskInputOptions?: recordOptions['maskInputOptions']
+
+    /**
+     * Derived from `rrweb.record` options
+     * @see https://github.com/rrweb-io/rrweb/blob/master/guide.md
+     */
+    maskInputFn?: ((text: string, element?: HTMLElement) => string) | null
 
     /**
      * Derived from `rrweb.record` options


### PR DESCRIPTION
These were incorrectly removed in 58550b9e853d666be9392668e31c739505d107ce

I could say it was Cursor fault, but I should've paid more attention

Closes #1702
