### PR TITLE
fix: make feedback tab survey display responsive

### DIFF
--- a/playwright/surveys/feedback-widget.spec.ts
+++ b/playwright/surveys/feedback-widget.spec.ts
@@ -90,6 +90,41 @@ test.describe('surveys - feedback widget', () => {
         await pollUntilEventCaptured(page, 'survey sent')
     })
 
+    test('displays feedback tab in a responsive manner ', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: '123',
+                            name: 'Test survey',
+                            type: 'widget',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [
+                                { type: 'open', question: 'Feedback for us?', description: 'tab feedback widget' },
+                            ],
+                            appearance: {
+                                widgetLabel: 'Feedback',
+                                widgetType: 'tab',
+                                displayThankYouMessage: true,
+                                thankyouMessageHeader: 'Thanks!',
+                                thankyouMessageBody: 'We appreciate your feedback.',
+                            },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(startOptions, page, context)
+        await surveysAPICall
+
+        await page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab').click()
+        await page.setViewportSize({ width: 375, height: 667 })
+
+        await expect(page.locator('.PostHogWidget123').locator('.survey-form')).toBeInViewport()
+    })
+
     test('widgetType is custom selector', async ({ page, context }) => {
         const surveysAPICall = page.route('**/surveys/**', async (route) => {
             await route.fulfill({

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -14,7 +14,7 @@ import {
 import { addEventListener } from '../utils'
 
 import * as Preact from 'preact'
-import { useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { useContext, useEffect, useMemo, useState } from 'preact/hooks'
 import { document as _document, window as _window } from '../utils/globals'
 import { doesSurveyUrlMatch, SURVEY_LOGGER as logger } from '../utils/survey-utils'
 import { isNull, isNumber } from '../utils/type-utils'
@@ -1008,7 +1008,6 @@ export function FeedbackWidget({
     const [isFeedbackButtonVisible, setIsFeedbackButtonVisible] = useState(true)
     const [showSurvey, setShowSurvey] = useState(false)
     const [styleOverrides, setStyleOverrides] = useState<React.CSSProperties>({})
-    const widgetRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
         if (!posthog) {
@@ -1020,15 +1019,12 @@ export function FeedbackWidget({
         }
 
         if (survey.appearance?.widgetType === 'tab') {
-            if (widgetRef.current) {
-                const widgetPos = widgetRef.current.getBoundingClientRect()
-                setStyleOverrides({
-                    top: '50%',
-                    bottom: 'auto',
-                    borderRadius: 10,
-                    borderBottom: `1.5px solid ${survey.appearance?.borderColor || '#c9c6c6'}`,
-                })
-            }
+            setStyleOverrides({
+                top: '50%',
+                bottom: 'auto',
+                borderRadius: 10,
+                borderBottom: `1.5px solid ${survey.appearance?.borderColor || '#c9c6c6'}`,
+            })
         }
         const handleShowSurvey = (event: Event) => {
             const customEvent = event as CustomEvent
@@ -1074,7 +1070,6 @@ export function FeedbackWidget({
             {survey.appearance?.widgetType === 'tab' && (
                 <div
                     className="ph-survey-widget-tab"
-                    ref={widgetRef}
                     onClick={() => !readOnly && setShowSurvey(!showSurvey)}
                     style={{ color: getContrastingTextColor(survey.appearance.widgetColor) }}
                 >

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -1024,7 +1024,6 @@ export function FeedbackWidget({
                 const widgetPos = widgetRef.current.getBoundingClientRect()
                 setStyleOverrides({
                     top: '50%',
-                    left: parseInt(`${widgetPos.right - 360}`),
                     bottom: 'auto',
                     borderRadius: 10,
                     borderBottom: `1.5px solid ${survey.appearance?.borderColor || '#c9c6c6'}`,

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -35,7 +35,7 @@ export function getSurveyResponseKey(questionId: string) {
 export const style = (appearance: SurveyAppearance | null) => {
     const positions = {
         [SurveyPosition.Left]: 'left: 30px;',
-        [SurveyPosition.Right]: 'right: 30px;',
+        [SurveyPosition.Right]: 'right: 60px;',
         [SurveyPosition.Center]: `
             left: 50%;
             transform: translateX(-50%);


### PR DESCRIPTION
## Changes

Closes  posthog/posthog#27982

Before
![before](https://github.com/user-attachments/assets/5481d45f-fa4d-4054-9526-91eab8fb1d8b)

After
![after](https://github.com/user-attachments/assets/3a837090-5b92-4f16-9b4c-47ec766462ad)

## Discussion

Ultimately the issue here is that there are some styles in `src/extensions/surveys.tsx` that override the ones in `src/extensions/surveys/surveys-utils.tsx`. So this was just a matter of removing the override causing the problem.

In addition to the lack of responsive behavior, this same style was causing some positioning to be off on some device widths. Here's an example of that with the `center` position:

![center_bug](https://github.com/user-attachments/assets/9b483e2f-8fb1-42f8-af4b-30722275d77e)

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
  - Added a playwright test for responsive behavior
- [ ] Accounted for the impact of any changes across different browsers
- ⚠️ I did not do this. I'm not sure how to account for this. I'd love some assistance with that if possible.
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
  - This change should be backward compatible