### PR TITLE
chore: snapshot types that we want to not accidentally deprecate or remove

### DIFF
--- a/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -206,43 +206,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"blockClass\\": [
       \\"undefined\\",
       \\"string\\",
-      {
-        \\"exec\\": \\"(string: string) => RegExpExecArray | null\\",
-        \\"test\\": \\"(string: string) => boolean\\",
-        \\"source\\": \\"string\\",
-        \\"global\\": [
-          \\"false\\",
-          \\"true\\"
-        ],
-        \\"ignoreCase\\": [
-          \\"false\\",
-          \\"true\\"
-        ],
-        \\"multiline\\": [
-          \\"false\\",
-          \\"true\\"
-        ],
-        \\"lastIndex\\": \\"number\\",
-        \\"compile\\": \\"(pattern: string, flags?: string | undefined) => RegExp\\",
-        \\"flags\\": \\"string\\",
-        \\"sticky\\": [
-          \\"false\\",
-          \\"true\\"
-        ],
-        \\"unicode\\": [
-          \\"false\\",
-          \\"true\\"
-        ],
-        \\"dotAll\\": [
-          \\"false\\",
-          \\"true\\"
-        ],
-        \\"__@match@355\\": \\"(string: string) => RegExpMatchArray | null\\",
-        \\"__@replace@357\\": \\"{ (string: string, replaceValue: string): string; (string: string, replacer: (substring: string, ...args: any[]) => string): string; }\\",
-        \\"__@search@360\\": \\"(string: string) => number\\",
-        \\"__@split@362\\": \\"(string: string, limit?: number | undefined) => string[]\\",
-        \\"__@matchAll@364\\": \\"(str: string) => IterableIterator<RegExpMatchArray>\\"
-      }
+      \\"RegExp\\"
     ],
     \\"blockSelector\\": [
       \\"undefined\\",
@@ -256,43 +220,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"maskTextClass\\": [
       \\"undefined\\",
       \\"string\\",
-      {
-        \\"exec\\": \\"(string: string) => RegExpExecArray | null\\",
-        \\"test\\": \\"(string: string) => boolean\\",
-        \\"source\\": \\"string\\",
-        \\"global\\": [
-          \\"false\\",
-          \\"true\\"
-        ],
-        \\"ignoreCase\\": [
-          \\"false\\",
-          \\"true\\"
-        ],
-        \\"multiline\\": [
-          \\"false\\",
-          \\"true\\"
-        ],
-        \\"lastIndex\\": \\"number\\",
-        \\"compile\\": \\"(pattern: string, flags?: string | undefined) => RegExp\\",
-        \\"flags\\": \\"string\\",
-        \\"sticky\\": [
-          \\"false\\",
-          \\"true\\"
-        ],
-        \\"unicode\\": [
-          \\"false\\",
-          \\"true\\"
-        ],
-        \\"dotAll\\": [
-          \\"false\\",
-          \\"true\\"
-        ],
-        \\"__@match@355\\": \\"(string: string) => RegExpMatchArray | null\\",
-        \\"__@replace@357\\": \\"{ (string: string, replaceValue: string): string; (string: string, replacer: (substring: string, ...args: any[]) => string): string; }\\",
-        \\"__@search@360\\": \\"(string: string) => number\\",
-        \\"__@split@362\\": \\"(string: string, limit?: number | undefined) => string[]\\",
-        \\"__@matchAll@364\\": \\"(str: string) => IterableIterator<RegExpMatchArray>\\"
-      }
+      \\"RegExp\\"
     ],
     \\"maskTextSelector\\": [
       \\"undefined\\",

--- a/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -1,0 +1,697 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`config snapshot for AutocaptureConfig 1`] = `
+"{
+  \\"url_allowlist\\": \\"(string | RegExp)[]\\",
+  \\"url_ignorelist\\": \\"(string | RegExp)[]\\",
+  \\"dom_event_allowlist\\": \\"DomAutocaptureEvents[]\\",
+  \\"element_allowlist\\": \\"AutocaptureCompatibleElement[]\\",
+  \\"css_selector_allowlist\\": \\"string[]\\",
+  \\"element_attribute_ignorelist\\": \\"string[]\\",
+  \\"capture_copied_text\\": [
+    \\"false\\",
+    \\"true\\"
+  ]
+}"
+`;
+
+exports[`config snapshot for PostHogConfig 1`] = `
+"{
+  \\"api_host\\": \\"string\\",
+  \\"ui_host\\": \\"string\\",
+  \\"api_transport\\": [
+    \\"\\\\\\"XHR\\\\\\"\\",
+    \\"\\\\\\"fetch\\\\\\"\\"
+  ],
+  \\"token\\": \\"string\\",
+  \\"name\\": \\"string\\",
+  \\"autocapture\\": [
+    \\"false\\",
+    \\"true\\",
+    \\"AutocaptureConfig\\"
+  ],
+  \\"rageclick\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"cross_subdomain_cookie\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"persistence\\": [
+    \\"\\\\\\"localStorage\\\\\\"\\",
+    \\"\\\\\\"cookie\\\\\\"\\",
+    \\"\\\\\\"memory\\\\\\"\\",
+    \\"\\\\\\"localStorage+cookie\\\\\\"\\",
+    \\"\\\\\\"sessionStorage\\\\\\"\\"
+  ],
+  \\"persistence_name\\": \\"string\\",
+  \\"cookie_name\\": \\"string\\",
+  \\"loaded\\": \\"(posthog_instance: PostHog) => void\\",
+  \\"save_referrer\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"save_campaign_params\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"store_google\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"custom_campaign_params\\": \\"string[]\\",
+  \\"custom_blocked_useragents\\": \\"string[]\\",
+  \\"debug\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"verbose\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"capture_pageview\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"capture_pageleave\\": [
+    \\"false\\",
+    \\"true\\",
+    \\"\\\\\\"if_capture_pageview\\\\\\"\\"
+  ],
+  \\"cookie_expiration\\": \\"number\\",
+  \\"upgrade\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"disable_session_recording\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"disable_persistence\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"disable_cookie\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"disable_surveys\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"disable_web_experiments\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"disable_external_dependency_loading\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"prepare_external_dependency_script\\": \\"(script: HTMLScriptElement) => HTMLScriptElement\\",
+  \\"enable_recording_console_log\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"secure_cookie\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"ip\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"opt_out_capturing_by_default\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"opt_out_capturing_persistence_type\\": [
+    \\"\\\\\\"localStorage\\\\\\"\\",
+    \\"\\\\\\"cookie\\\\\\"\\"
+  ],
+  \\"opt_out_persistence_by_default\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"opt_out_useragent_filter\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"opt_out_capturing_cookie_prefix\\": \\"string\\",
+  \\"opt_in_site_apps\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"respect_dnt\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"property_denylist\\": \\"string[]\\",
+  \\"property_blacklist\\": \\"string[]\\",
+  \\"request_headers\\": \\"{ [header_name: string]: string; }\\",
+  \\"xhr_headers\\": \\"{ [header_name: string]: string; }\\",
+  \\"on_request_error\\": \\"(error: RequestResponse) => void\\",
+  \\"on_xhr_error\\": \\"(failedRequest: XMLHttpRequest) => void\\",
+  \\"request_batching\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"properties_string_max_length\\": \\"number\\",
+  \\"session_recording\\": {
+    \\"blockClass\\": [
+      \\"string\\",
+      \\"RegExp\\"
+    ],
+    \\"blockSelector\\": \\"string\\",
+    \\"ignoreClass\\": \\"string\\",
+    \\"maskTextClass\\": [
+      \\"string\\",
+      \\"RegExp\\"
+    ],
+    \\"maskTextSelector\\": \\"string\\",
+    \\"maskTextFn\\": \\"(text: string, element?: HTMLElement) => string\\",
+    \\"maskAllInputs\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"maskInputOptions\\": \\"Partial<{ color: boolean; date: boolean; 'datetime-local': boolean; email: boolean; month: boolean; number: boolean; range: boolean; search: boolean; tel: boolean; text: boolean; time: boolean; url: boolean; week: boolean; textarea: boolean; select: boolean; password: boolean; }>\\",
+    \\"maskInputFn\\": \\"(text: string, element?: HTMLElement) => string\\",
+    \\"slimDOMOptions\\": [
+      \\"true\\",
+      \\"\\\\\\"all\\\\\\"\\",
+      \\"Partial<{ script: boolean; comment: boolean; headFavicon: boolean; headWhitespace: boolean; headMetaDescKeywords: boolean; headMetaSocial: boolean; headMetaRobots: boolean; headMetaHttpEquiv: boolean; headMetaAuthorship: boolean; headMetaVerification: boolean; headTitleMutations: boolean; }>\\"
+    ],
+    \\"collectFonts\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"inlineStylesheet\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"recordCrossOriginIframes\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"recordHeaders\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"recordBody\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"captureCanvas\\": \\"SessionRecordingCanvasOptions\\",
+    \\"maskCapturedNetworkRequestFn\\": \\"(data: CapturedNetworkRequest) => CapturedNetworkRequest\\",
+    \\"maskNetworkRequestFn\\": \\"(data: NetworkRequest) => NetworkRequest\\",
+    \\"full_snapshot_interval_millis\\": \\"number\\",
+    \\"compress_events\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"session_idle_threshold_ms\\": \\"number\\",
+    \\"__mutationRateLimiterRefillRate\\": \\"number\\",
+    \\"__mutationRateLimiterBucketSize\\": \\"number\\"
+  },
+  \\"session_idle_timeout_seconds\\": \\"number\\",
+  \\"mask_all_element_attributes\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"mask_all_text\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"mask_personal_data_properties\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"custom_personal_data_properties\\": \\"string[]\\",
+  \\"advanced_disable_decide\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"advanced_disable_feature_flags\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"advanced_disable_feature_flags_on_first_load\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"advanced_disable_toolbar_metrics\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"feature_flag_request_timeout_ms\\": \\"number\\",
+  \\"get_device_id\\": \\"(uuid: string) => string\\",
+  \\"before_send\\": [
+    \\"BeforeSendFn\\",
+    \\"BeforeSendFn[]\\"
+  ],
+  \\"sanitize_properties\\": \\"(properties: Properties, event_name: string) => Properties\\",
+  \\"_onCapture\\": \\"(eventName: string, eventData: CaptureResult) => void\\",
+  \\"capture_performance\\": [
+    \\"false\\",
+    \\"true\\",
+    \\"PerformanceCaptureConfig\\"
+  ],
+  \\"disable_compression\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"bootstrap\\": {
+    \\"distinctID\\": \\"string\\",
+    \\"isIdentifiedID\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"featureFlags\\": \\"Record<string, string | boolean>\\",
+    \\"featureFlagPayloads\\": \\"Record<string, JsonType>\\",
+    \\"sessionID\\": \\"string\\"
+  },
+  \\"segment\\": \\"SegmentAnalytics\\",
+  \\"capture_heatmaps\\": [
+    \\"false\\",
+    \\"true\\",
+    \\"HeatmapConfig\\"
+  ],
+  \\"enable_heatmaps\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"capture_dead_clicks\\": [
+    \\"false\\",
+    \\"true\\",
+    \\"DeadClicksAutoCaptureConfig\\"
+  ],
+  \\"disable_scroll_properties\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"scroll_root_selector\\": [
+    \\"string\\",
+    \\"string[]\\"
+  ],
+  \\"person_profiles\\": [
+    \\"\\\\\\"always\\\\\\"\\",
+    \\"\\\\\\"never\\\\\\"\\",
+    \\"\\\\\\"identified_only\\\\\\"\\"
+  ],
+  \\"process_person\\": [
+    \\"\\\\\\"always\\\\\\"\\",
+    \\"\\\\\\"never\\\\\\"\\",
+    \\"\\\\\\"identified_only\\\\\\"\\"
+  ],
+  \\"rate_limiting\\": \\"{ events_per_second?: number; events_burst_limit?: number; }\\",
+  \\"fetch_options\\": \\"{ cache?: RequestCache; next_options?: NextOptions; }\\",
+  \\"__add_tracing_headers\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"__preview_remote_config\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"__preview_experimental_cookieless_mode\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"api_method\\": \\"string\\",
+  \\"inapp_protocol\\": \\"string\\",
+  \\"inapp_link_new_window\\": [
+    \\"false\\",
+    \\"true\\"
+  ]
+}"
+`;
+
+exports[`config snapshot for SessionRecordingOptions 1`] = `
+"{
+  \\"blockClass\\": [
+    \\"string\\",
+    \\"RegExp\\"
+  ],
+  \\"blockSelector\\": \\"string\\",
+  \\"ignoreClass\\": \\"string\\",
+  \\"maskTextClass\\": [
+    \\"string\\",
+    \\"RegExp\\"
+  ],
+  \\"maskTextSelector\\": \\"string\\",
+  \\"maskTextFn\\": \\"(text: string, element?: HTMLElement) => string\\",
+  \\"maskAllInputs\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"maskInputOptions\\": \\"Partial<{ color: boolean; date: boolean; 'datetime-local': boolean; email: boolean; month: boolean; number: boolean; range: boolean; search: boolean; tel: boolean; text: boolean; time: boolean; url: boolean; week: boolean; textarea: boolean; select: boolean; password: boolean; }>\\",
+  \\"maskInputFn\\": \\"(text: string, element?: HTMLElement) => string\\",
+  \\"slimDOMOptions\\": [
+    \\"true\\",
+    \\"\\\\\\"all\\\\\\"\\",
+    \\"Partial<{ script: boolean; comment: boolean; headFavicon: boolean; headWhitespace: boolean; headMetaDescKeywords: boolean; headMetaSocial: boolean; headMetaRobots: boolean; headMetaHttpEquiv: boolean; headMetaAuthorship: boolean; headMetaVerification: boolean; headTitleMutations: boolean; }>\\"
+  ],
+  \\"collectFonts\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"inlineStylesheet\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"recordCrossOriginIframes\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"recordHeaders\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"recordBody\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"captureCanvas\\": \\"SessionRecordingCanvasOptions\\",
+  \\"maskCapturedNetworkRequestFn\\": \\"(data: CapturedNetworkRequest) => CapturedNetworkRequest\\",
+  \\"maskNetworkRequestFn\\": \\"(data: NetworkRequest) => NetworkRequest\\",
+  \\"full_snapshot_interval_millis\\": \\"number\\",
+  \\"compress_events\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"session_idle_threshold_ms\\": \\"number\\",
+  \\"__mutationRateLimiterRefillRate\\": \\"number\\",
+  \\"__mutationRateLimiterBucketSize\\": \\"number\\"
+}"
+`;
+
+exports[`config snapshot should match the snapshot 1`] = `
+"{
+  \\"api_host\\": \\"string\\",
+  \\"ui_host\\": \\"string\\",
+  \\"api_transport\\": [
+    \\"\\\\\\"XHR\\\\\\"\\",
+    \\"\\\\\\"fetch\\\\\\"\\"
+  ],
+  \\"token\\": \\"string\\",
+  \\"name\\": \\"string\\",
+  \\"autocapture\\": [
+    \\"false\\",
+    \\"true\\",
+    \\"AutocaptureConfig\\"
+  ],
+  \\"rageclick\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"cross_subdomain_cookie\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"persistence\\": [
+    \\"\\\\\\"localStorage\\\\\\"\\",
+    \\"\\\\\\"cookie\\\\\\"\\",
+    \\"\\\\\\"memory\\\\\\"\\",
+    \\"\\\\\\"localStorage+cookie\\\\\\"\\",
+    \\"\\\\\\"sessionStorage\\\\\\"\\"
+  ],
+  \\"persistence_name\\": \\"string\\",
+  \\"cookie_name\\": \\"string\\",
+  \\"loaded\\": \\"(posthog_instance: PostHog) => void\\",
+  \\"save_referrer\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"save_campaign_params\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"store_google\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"custom_campaign_params\\": \\"string[]\\",
+  \\"custom_blocked_useragents\\": \\"string[]\\",
+  \\"debug\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"verbose\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"capture_pageview\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"capture_pageleave\\": [
+    \\"false\\",
+    \\"true\\",
+    \\"\\\\\\"if_capture_pageview\\\\\\"\\"
+  ],
+  \\"cookie_expiration\\": \\"number\\",
+  \\"upgrade\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"disable_session_recording\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"disable_persistence\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"disable_cookie\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"disable_surveys\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"disable_web_experiments\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"disable_external_dependency_loading\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"prepare_external_dependency_script\\": \\"(script: HTMLScriptElement) => HTMLScriptElement\\",
+  \\"enable_recording_console_log\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"secure_cookie\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"ip\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"opt_out_capturing_by_default\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"opt_out_capturing_persistence_type\\": [
+    \\"\\\\\\"localStorage\\\\\\"\\",
+    \\"\\\\\\"cookie\\\\\\"\\"
+  ],
+  \\"opt_out_persistence_by_default\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"opt_out_useragent_filter\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"opt_out_capturing_cookie_prefix\\": \\"string\\",
+  \\"opt_in_site_apps\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"respect_dnt\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"property_denylist\\": \\"string[]\\",
+  \\"property_blacklist\\": \\"string[]\\",
+  \\"request_headers\\": \\"{ [header_name: string]: string; }\\",
+  \\"xhr_headers\\": \\"{ [header_name: string]: string; }\\",
+  \\"on_request_error\\": \\"(error: RequestResponse) => void\\",
+  \\"on_xhr_error\\": \\"(failedRequest: XMLHttpRequest) => void\\",
+  \\"request_batching\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"properties_string_max_length\\": \\"number\\",
+  \\"session_recording\\": {
+    \\"blockClass\\": [
+      \\"string\\",
+      \\"RegExp\\"
+    ],
+    \\"blockSelector\\": \\"string\\",
+    \\"ignoreClass\\": \\"string\\",
+    \\"maskTextClass\\": [
+      \\"string\\",
+      \\"RegExp\\"
+    ],
+    \\"maskTextSelector\\": \\"string\\",
+    \\"maskTextFn\\": \\"(text: string, element?: HTMLElement) => string\\",
+    \\"maskAllInputs\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"maskInputOptions\\": \\"Partial<{ color: boolean; date: boolean; 'datetime-local': boolean; email: boolean; month: boolean; number: boolean; range: boolean; search: boolean; tel: boolean; text: boolean; time: boolean; url: boolean; week: boolean; textarea: boolean; select: boolean; password: boolean; }>\\",
+    \\"maskInputFn\\": \\"(text: string, element?: HTMLElement) => string\\",
+    \\"slimDOMOptions\\": [
+      \\"true\\",
+      \\"\\\\\\"all\\\\\\"\\",
+      \\"Partial<{ script: boolean; comment: boolean; headFavicon: boolean; headWhitespace: boolean; headMetaDescKeywords: boolean; headMetaSocial: boolean; headMetaRobots: boolean; headMetaHttpEquiv: boolean; headMetaAuthorship: boolean; headMetaVerification: boolean; headTitleMutations: boolean; }>\\"
+    ],
+    \\"collectFonts\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"inlineStylesheet\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"recordCrossOriginIframes\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"recordHeaders\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"recordBody\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"captureCanvas\\": \\"SessionRecordingCanvasOptions\\",
+    \\"maskCapturedNetworkRequestFn\\": \\"(data: CapturedNetworkRequest) => CapturedNetworkRequest\\",
+    \\"maskNetworkRequestFn\\": \\"(data: NetworkRequest) => NetworkRequest\\",
+    \\"full_snapshot_interval_millis\\": \\"number\\",
+    \\"compress_events\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"session_idle_threshold_ms\\": \\"number\\",
+    \\"__mutationRateLimiterRefillRate\\": \\"number\\",
+    \\"__mutationRateLimiterBucketSize\\": \\"number\\"
+  },
+  \\"session_idle_timeout_seconds\\": \\"number\\",
+  \\"mask_all_element_attributes\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"mask_all_text\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"mask_personal_data_properties\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"custom_personal_data_properties\\": \\"string[]\\",
+  \\"advanced_disable_decide\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"advanced_disable_feature_flags\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"advanced_disable_feature_flags_on_first_load\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"advanced_disable_toolbar_metrics\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"feature_flag_request_timeout_ms\\": \\"number\\",
+  \\"get_device_id\\": \\"(uuid: string) => string\\",
+  \\"before_send\\": [
+    \\"BeforeSendFn\\",
+    \\"BeforeSendFn[]\\"
+  ],
+  \\"sanitize_properties\\": \\"(properties: Properties, event_name: string) => Properties\\",
+  \\"_onCapture\\": \\"(eventName: string, eventData: CaptureResult) => void\\",
+  \\"capture_performance\\": [
+    \\"false\\",
+    \\"true\\",
+    \\"PerformanceCaptureConfig\\"
+  ],
+  \\"disable_compression\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"bootstrap\\": {
+    \\"distinctID\\": \\"string\\",
+    \\"isIdentifiedID\\": [
+      \\"false\\",
+      \\"true\\"
+    ],
+    \\"featureFlags\\": \\"Record<string, string | boolean>\\",
+    \\"featureFlagPayloads\\": \\"Record<string, JsonType>\\",
+    \\"sessionID\\": \\"string\\"
+  },
+  \\"segment\\": \\"SegmentAnalytics\\",
+  \\"capture_heatmaps\\": [
+    \\"false\\",
+    \\"true\\",
+    \\"HeatmapConfig\\"
+  ],
+  \\"enable_heatmaps\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"capture_dead_clicks\\": [
+    \\"false\\",
+    \\"true\\",
+    \\"DeadClicksAutoCaptureConfig\\"
+  ],
+  \\"disable_scroll_properties\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"scroll_root_selector\\": [
+    \\"string\\",
+    \\"string[]\\"
+  ],
+  \\"person_profiles\\": [
+    \\"\\\\\\"always\\\\\\"\\",
+    \\"\\\\\\"never\\\\\\"\\",
+    \\"\\\\\\"identified_only\\\\\\"\\"
+  ],
+  \\"process_person\\": [
+    \\"\\\\\\"always\\\\\\"\\",
+    \\"\\\\\\"never\\\\\\"\\",
+    \\"\\\\\\"identified_only\\\\\\"\\"
+  ],
+  \\"rate_limiting\\": \\"{ events_per_second?: number; events_burst_limit?: number; }\\",
+  \\"fetch_options\\": \\"{ cache?: RequestCache; next_options?: NextOptions; }\\",
+  \\"__add_tracing_headers\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"__preview_remote_config\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"__preview_experimental_cookieless_mode\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"api_method\\": \\"string\\",
+  \\"inapp_protocol\\": \\"string\\",
+  \\"inapp_link_new_window\\": [
+    \\"false\\",
+    \\"true\\"
+  ]
+}"
+`;

--- a/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -3,8 +3,12 @@
 exports[`config snapshot for PostHogConfig 1`] = `
 "{
   \\"api_host\\": \\"string\\",
-  \\"ui_host\\": \\"string\\",
+  \\"ui_host\\": [
+    \\"null\\",
+    \\"string\\"
+  ],
   \\"api_transport\\": [
+    \\"undefined\\",
     \\"\\\\\\"XHR\\\\\\"\\",
     \\"\\\\\\"fetch\\\\\\"\\"
   ],
@@ -14,13 +18,32 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"false\\",
     \\"true\\",
     {
-      \\"url_allowlist\\": \\"(string | RegExp)[]\\",
-      \\"url_ignorelist\\": \\"(string | RegExp)[]\\",
-      \\"dom_event_allowlist\\": \\"DomAutocaptureEvents[]\\",
-      \\"element_allowlist\\": \\"AutocaptureCompatibleElement[]\\",
-      \\"css_selector_allowlist\\": \\"string[]\\",
-      \\"element_attribute_ignorelist\\": \\"string[]\\",
+      \\"url_allowlist\\": [
+        \\"undefined\\",
+        \\"(string | RegExp)[]\\"
+      ],
+      \\"url_ignorelist\\": [
+        \\"undefined\\",
+        \\"(string | RegExp)[]\\"
+      ],
+      \\"dom_event_allowlist\\": [
+        \\"undefined\\",
+        \\"DomAutocaptureEvents[]\\"
+      ],
+      \\"element_allowlist\\": [
+        \\"undefined\\",
+        \\"AutocaptureCompatibleElement[]\\"
+      ],
+      \\"css_selector_allowlist\\": [
+        \\"undefined\\",
+        \\"string[]\\"
+      ],
+      \\"element_attribute_ignorelist\\": [
+        \\"undefined\\",
+        \\"string[]\\"
+      ],
       \\"capture_copied_text\\": [
+        \\"undefined\\",
         \\"false\\",
         \\"true\\"
       ]
@@ -42,7 +65,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"\\\\\\"sessionStorage\\\\\\"\\"
   ],
   \\"persistence_name\\": \\"string\\",
-  \\"cookie_name\\": \\"string\\",
+  \\"cookie_name\\": [
+    \\"undefined\\",
+    \\"string\\"
+  ],
   \\"loaded\\": \\"(posthog_instance: PostHog) => void\\",
   \\"save_referrer\\": [
     \\"false\\",
@@ -53,6 +79,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"true\\"
   ],
   \\"store_google\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\"
   ],
@@ -63,6 +90,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"true\\"
   ],
   \\"verbose\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\"
   ],
@@ -89,6 +117,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"true\\"
   ],
   \\"disable_cookie\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\"
   ],
@@ -104,8 +133,12 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"false\\",
     \\"true\\"
   ],
-  \\"prepare_external_dependency_script\\": \\"(script: HTMLScriptElement) => HTMLScriptElement\\",
+  \\"prepare_external_dependency_script\\": [
+    \\"undefined\\",
+    \\"(script: HTMLScriptElement) => HTMLScriptElement | null\\"
+  ],
   \\"enable_recording_console_log\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\"
   ],
@@ -126,6 +159,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"\\\\\\"cookie\\\\\\"\\"
   ],
   \\"opt_out_persistence_by_default\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\"
   ],
@@ -133,7 +167,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"false\\",
     \\"true\\"
   ],
-  \\"opt_out_capturing_cookie_prefix\\": \\"string\\",
+  \\"opt_out_capturing_cookie_prefix\\": [
+    \\"null\\",
+    \\"string\\"
+  ],
   \\"opt_in_site_apps\\": [
     \\"false\\",
     \\"true\\"
@@ -143,11 +180,23 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"true\\"
   ],
   \\"property_denylist\\": \\"string[]\\",
-  \\"property_blacklist\\": \\"string[]\\",
+  \\"property_blacklist\\": [
+    \\"undefined\\",
+    \\"string[]\\"
+  ],
   \\"request_headers\\": \\"{ [header_name: string]: string; }\\",
-  \\"xhr_headers\\": \\"{ [header_name: string]: string; }\\",
-  \\"on_request_error\\": \\"(error: RequestResponse) => void\\",
-  \\"on_xhr_error\\": \\"(failedRequest: XMLHttpRequest) => void\\",
+  \\"xhr_headers\\": [
+    \\"undefined\\",
+    \\"{ [header_name: string]: string; }\\"
+  ],
+  \\"on_request_error\\": [
+    \\"undefined\\",
+    \\"(error: RequestResponse) => void\\"
+  ],
+  \\"on_xhr_error\\": [
+    \\"undefined\\",
+    \\"(failedRequest: XMLHttpRequest) => void\\"
+  ],
   \\"request_batching\\": [
     \\"false\\",
     \\"true\\"
@@ -155,9 +204,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
   \\"properties_string_max_length\\": \\"number\\",
   \\"session_recording\\": {
     \\"blockClass\\": [
+      \\"undefined\\",
       \\"string\\",
       {
-        \\"exec\\": \\"(string: string) => RegExpExecArray\\",
+        \\"exec\\": \\"(string: string) => RegExpExecArray | null\\",
         \\"test\\": \\"(string: string) => boolean\\",
         \\"source\\": \\"string\\",
         \\"global\\": [
@@ -173,7 +223,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
           \\"true\\"
         ],
         \\"lastIndex\\": \\"number\\",
-        \\"compile\\": \\"(pattern: string, flags?: string) => RegExp\\",
+        \\"compile\\": \\"(pattern: string, flags?: string | undefined) => RegExp\\",
         \\"flags\\": \\"string\\",
         \\"sticky\\": [
           \\"false\\",
@@ -187,19 +237,27 @@ exports[`config snapshot for PostHogConfig 1`] = `
           \\"false\\",
           \\"true\\"
         ],
-        \\"__@match@355\\": \\"(string: string) => RegExpMatchArray\\",
+        \\"__@match@355\\": \\"(string: string) => RegExpMatchArray | null\\",
         \\"__@replace@357\\": \\"{ (string: string, replaceValue: string): string; (string: string, replacer: (substring: string, ...args: any[]) => string): string; }\\",
         \\"__@search@360\\": \\"(string: string) => number\\",
-        \\"__@split@362\\": \\"(string: string, limit?: number) => string[]\\",
+        \\"__@split@362\\": \\"(string: string, limit?: number | undefined) => string[]\\",
         \\"__@matchAll@364\\": \\"(str: string) => IterableIterator<RegExpMatchArray>\\"
       }
     ],
-    \\"blockSelector\\": \\"string\\",
-    \\"ignoreClass\\": \\"string\\",
+    \\"blockSelector\\": [
+      \\"undefined\\",
+      \\"null\\",
+      \\"string\\"
+    ],
+    \\"ignoreClass\\": [
+      \\"undefined\\",
+      \\"string\\"
+    ],
     \\"maskTextClass\\": [
+      \\"undefined\\",
       \\"string\\",
       {
-        \\"exec\\": \\"(string: string) => RegExpExecArray\\",
+        \\"exec\\": \\"(string: string) => RegExpExecArray | null\\",
         \\"test\\": \\"(string: string) => boolean\\",
         \\"source\\": \\"string\\",
         \\"global\\": [
@@ -215,7 +273,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
           \\"true\\"
         ],
         \\"lastIndex\\": \\"number\\",
-        \\"compile\\": \\"(pattern: string, flags?: string) => RegExp\\",
+        \\"compile\\": \\"(pattern: string, flags?: string | undefined) => RegExp\\",
         \\"flags\\": \\"string\\",
         \\"sticky\\": [
           \\"false\\",
@@ -229,57 +287,103 @@ exports[`config snapshot for PostHogConfig 1`] = `
           \\"false\\",
           \\"true\\"
         ],
-        \\"__@match@355\\": \\"(string: string) => RegExpMatchArray\\",
+        \\"__@match@355\\": \\"(string: string) => RegExpMatchArray | null\\",
         \\"__@replace@357\\": \\"{ (string: string, replaceValue: string): string; (string: string, replacer: (substring: string, ...args: any[]) => string): string; }\\",
         \\"__@search@360\\": \\"(string: string) => number\\",
-        \\"__@split@362\\": \\"(string: string, limit?: number) => string[]\\",
+        \\"__@split@362\\": \\"(string: string, limit?: number | undefined) => string[]\\",
         \\"__@matchAll@364\\": \\"(str: string) => IterableIterator<RegExpMatchArray>\\"
       }
     ],
-    \\"maskTextSelector\\": \\"string\\",
-    \\"maskTextFn\\": \\"(text: string, element?: HTMLElement) => string\\",
+    \\"maskTextSelector\\": [
+      \\"undefined\\",
+      \\"null\\",
+      \\"string\\"
+    ],
+    \\"maskTextFn\\": [
+      \\"undefined\\",
+      \\"null\\",
+      \\"(text: string, element?: HTMLElement | undefined) => string\\"
+    ],
     \\"maskAllInputs\\": [
+      \\"undefined\\",
       \\"false\\",
       \\"true\\"
     ],
-    \\"maskInputOptions\\": \\"Partial<{ color: boolean; date: boolean; 'datetime-local': boolean; email: boolean; month: boolean; number: boolean; range: boolean; search: boolean; tel: boolean; text: boolean; time: boolean; url: boolean; week: boolean; textarea: boolean; select: boolean; password: boolean; }>\\",
-    \\"maskInputFn\\": \\"(text: string, element?: HTMLElement) => string\\",
+    \\"maskInputOptions\\": [
+      \\"undefined\\",
+      \\"Partial<{ color: boolean; date: boolean; 'datetime-local': boolean; email: boolean; month: boolean; number: boolean; range: boolean; search: boolean; tel: boolean; text: boolean; time: boolean; url: boolean; week: boolean; textarea: boolean; select: boolean; password: boolean; }>\\"
+    ],
+    \\"maskInputFn\\": [
+      \\"undefined\\",
+      \\"null\\",
+      \\"(text: string, element?: HTMLElement | undefined) => string\\"
+    ],
     \\"slimDOMOptions\\": [
+      \\"undefined\\",
       \\"true\\",
       \\"\\\\\\"all\\\\\\"\\",
       \\"Partial<{ script: boolean; comment: boolean; headFavicon: boolean; headWhitespace: boolean; headMetaDescKeywords: boolean; headMetaSocial: boolean; headMetaRobots: boolean; headMetaHttpEquiv: boolean; headMetaAuthorship: boolean; headMetaVerification: boolean; headTitleMutations: boolean; }>\\"
     ],
     \\"collectFonts\\": [
+      \\"undefined\\",
       \\"false\\",
       \\"true\\"
     ],
     \\"inlineStylesheet\\": [
+      \\"undefined\\",
       \\"false\\",
       \\"true\\"
     ],
     \\"recordCrossOriginIframes\\": [
+      \\"undefined\\",
       \\"false\\",
       \\"true\\"
     ],
     \\"recordHeaders\\": [
+      \\"undefined\\",
       \\"false\\",
       \\"true\\"
     ],
     \\"recordBody\\": [
+      \\"undefined\\",
       \\"false\\",
       \\"true\\"
     ],
-    \\"captureCanvas\\": \\"SessionRecordingCanvasOptions\\",
-    \\"maskCapturedNetworkRequestFn\\": \\"(data: CapturedNetworkRequest) => CapturedNetworkRequest\\",
-    \\"maskNetworkRequestFn\\": \\"(data: NetworkRequest) => NetworkRequest\\",
-    \\"full_snapshot_interval_millis\\": \\"number\\",
+    \\"captureCanvas\\": [
+      \\"undefined\\",
+      \\"SessionRecordingCanvasOptions\\"
+    ],
+    \\"maskCapturedNetworkRequestFn\\": [
+      \\"undefined\\",
+      \\"null\\",
+      \\"(data: CapturedNetworkRequest) => CapturedNetworkRequest | null | undefined\\"
+    ],
+    \\"maskNetworkRequestFn\\": [
+      \\"undefined\\",
+      \\"null\\",
+      \\"(data: NetworkRequest) => NetworkRequest | null | undefined\\"
+    ],
+    \\"full_snapshot_interval_millis\\": [
+      \\"undefined\\",
+      \\"number\\"
+    ],
     \\"compress_events\\": [
+      \\"undefined\\",
       \\"false\\",
       \\"true\\"
     ],
-    \\"session_idle_threshold_ms\\": \\"number\\",
-    \\"__mutationRateLimiterRefillRate\\": \\"number\\",
-    \\"__mutationRateLimiterBucketSize\\": \\"number\\"
+    \\"session_idle_threshold_ms\\": [
+      \\"undefined\\",
+      \\"number\\"
+    ],
+    \\"__mutationRateLimiterRefillRate\\": [
+      \\"undefined\\",
+      \\"number\\"
+    ],
+    \\"__mutationRateLimiterBucketSize\\": [
+      \\"undefined\\",
+      \\"number\\"
+    ]
   },
   \\"session_idle_timeout_seconds\\": \\"number\\",
   \\"mask_all_element_attributes\\": [
@@ -314,26 +418,42 @@ exports[`config snapshot for PostHogConfig 1`] = `
   \\"feature_flag_request_timeout_ms\\": \\"number\\",
   \\"get_device_id\\": \\"(uuid: string) => string\\",
   \\"before_send\\": [
+    \\"undefined\\",
     \\"BeforeSendFn\\",
     \\"BeforeSendFn[]\\"
   ],
-  \\"sanitize_properties\\": \\"(properties: Properties, event_name: string) => Properties\\",
+  \\"sanitize_properties\\": [
+    \\"null\\",
+    \\"(properties: Properties, event_name: string) => Properties\\"
+  ],
   \\"_onCapture\\": \\"(eventName: string, eventData: CaptureResult) => void\\",
   \\"capture_performance\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\",
     {
       \\"network_timing\\": [
+        \\"undefined\\",
         \\"false\\",
         \\"true\\"
       ],
       \\"web_vitals\\": [
+        \\"undefined\\",
         \\"false\\",
         \\"true\\"
       ],
-      \\"__web_vitals_max_value\\": \\"number\\",
-      \\"web_vitals_allowed_metrics\\": \\"SupportedWebVitalsMetrics[]\\",
-      \\"web_vitals_delayed_flush_ms\\": \\"number\\"
+      \\"__web_vitals_max_value\\": [
+        \\"undefined\\",
+        \\"number\\"
+      ],
+      \\"web_vitals_allowed_metrics\\": [
+        \\"undefined\\",
+        \\"SupportedWebVitalsMetrics[]\\"
+      ],
+      \\"web_vitals_delayed_flush_ms\\": [
+        \\"undefined\\",
+        \\"number\\"
+      ]
     }
   ],
   \\"disable_compression\\": [
@@ -341,17 +461,34 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"true\\"
   ],
   \\"bootstrap\\": {
-    \\"distinctID\\": \\"string\\",
+    \\"distinctID\\": [
+      \\"undefined\\",
+      \\"string\\"
+    ],
     \\"isIdentifiedID\\": [
+      \\"undefined\\",
       \\"false\\",
       \\"true\\"
     ],
-    \\"featureFlags\\": \\"Record<string, string | boolean>\\",
-    \\"featureFlagPayloads\\": \\"Record<string, JsonType>\\",
-    \\"sessionID\\": \\"string\\"
+    \\"featureFlags\\": [
+      \\"undefined\\",
+      \\"Record<string, string | boolean>\\"
+    ],
+    \\"featureFlagPayloads\\": [
+      \\"undefined\\",
+      \\"Record<string, JsonType>\\"
+    ],
+    \\"sessionID\\": [
+      \\"undefined\\",
+      \\"string\\"
+    ]
   },
-  \\"segment\\": \\"SegmentAnalytics\\",
+  \\"segment\\": [
+    \\"undefined\\",
+    \\"SegmentAnalytics\\"
+  ],
   \\"capture_heatmaps\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\",
     {
@@ -359,52 +496,74 @@ exports[`config snapshot for PostHogConfig 1`] = `
     }
   ],
   \\"enable_heatmaps\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\"
   ],
   \\"capture_dead_clicks\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\",
     [
-      \\"{ scroll_threshold_ms?: number; selection_change_threshold_ms?: number; mutation_threshold_ms?: number; __onCapture?: (click: DeadClickCandidate, properties: Properties) => void; }\\",
+      \\"{ scroll_threshold_ms?: number | undefined; selection_change_threshold_ms?: number | undefined; mutation_threshold_ms?: number | undefined; __onCapture?: ((click: DeadClickCandidate, properties: Properties) => void) | undefined; }\\",
       \\"Pick<AutocaptureConfig, \\\\\\"element_attribute_ignorelist\\\\\\">\\"
     ]
   ],
   \\"disable_scroll_properties\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\"
   ],
   \\"scroll_root_selector\\": [
+    \\"undefined\\",
     \\"string\\",
     \\"string[]\\"
   ],
   \\"person_profiles\\": [
+    \\"undefined\\",
     \\"\\\\\\"always\\\\\\"\\",
     \\"\\\\\\"never\\\\\\"\\",
     \\"\\\\\\"identified_only\\\\\\"\\"
   ],
   \\"process_person\\": [
+    \\"undefined\\",
     \\"\\\\\\"always\\\\\\"\\",
     \\"\\\\\\"never\\\\\\"\\",
     \\"\\\\\\"identified_only\\\\\\"\\"
   ],
-  \\"rate_limiting\\": \\"{ events_per_second?: number; events_burst_limit?: number; }\\",
-  \\"fetch_options\\": \\"{ cache?: RequestCache; next_options?: NextOptions; }\\",
+  \\"rate_limiting\\": [
+    \\"undefined\\",
+    \\"{ events_per_second?: number | undefined; events_burst_limit?: number | undefined; }\\"
+  ],
+  \\"fetch_options\\": [
+    \\"undefined\\",
+    \\"{ cache?: RequestCache | undefined; next_options?: NextOptions | undefined; }\\"
+  ],
   \\"__add_tracing_headers\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\"
   ],
   \\"__preview_remote_config\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\"
   ],
   \\"__preview_experimental_cookieless_mode\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\"
   ],
-  \\"api_method\\": \\"string\\",
-  \\"inapp_protocol\\": \\"string\\",
+  \\"api_method\\": [
+    \\"undefined\\",
+    \\"string\\"
+  ],
+  \\"inapp_protocol\\": [
+    \\"undefined\\",
+    \\"string\\"
+  ],
   \\"inapp_link_new_window\\": [
+    \\"undefined\\",
     \\"false\\",
     \\"true\\"
   ]

--- a/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -1,20 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`config snapshot for AutocaptureConfig 1`] = `
-"{
-  \\"url_allowlist\\": \\"(string | RegExp)[]\\",
-  \\"url_ignorelist\\": \\"(string | RegExp)[]\\",
-  \\"dom_event_allowlist\\": \\"DomAutocaptureEvents[]\\",
-  \\"element_allowlist\\": \\"AutocaptureCompatibleElement[]\\",
-  \\"css_selector_allowlist\\": \\"string[]\\",
-  \\"element_attribute_ignorelist\\": \\"string[]\\",
-  \\"capture_copied_text\\": [
-    \\"false\\",
-    \\"true\\"
-  ]
-}"
-`;
-
 exports[`config snapshot for PostHogConfig 1`] = `
 "{
   \\"api_host\\": \\"string\\",
@@ -28,7 +13,18 @@ exports[`config snapshot for PostHogConfig 1`] = `
   \\"autocapture\\": [
     \\"false\\",
     \\"true\\",
-    \\"AutocaptureConfig\\"
+    {
+      \\"url_allowlist\\": \\"(string | RegExp)[]\\",
+      \\"url_ignorelist\\": \\"(string | RegExp)[]\\",
+      \\"dom_event_allowlist\\": \\"DomAutocaptureEvents[]\\",
+      \\"element_allowlist\\": \\"AutocaptureCompatibleElement[]\\",
+      \\"css_selector_allowlist\\": \\"string[]\\",
+      \\"element_attribute_ignorelist\\": \\"string[]\\",
+      \\"capture_copied_text\\": [
+        \\"false\\",
+        \\"true\\"
+      ]
+    }
   ],
   \\"rageclick\\": [
     \\"false\\",
@@ -160,13 +156,85 @@ exports[`config snapshot for PostHogConfig 1`] = `
   \\"session_recording\\": {
     \\"blockClass\\": [
       \\"string\\",
-      \\"RegExp\\"
+      {
+        \\"exec\\": \\"(string: string) => RegExpExecArray\\",
+        \\"test\\": \\"(string: string) => boolean\\",
+        \\"source\\": \\"string\\",
+        \\"global\\": [
+          \\"false\\",
+          \\"true\\"
+        ],
+        \\"ignoreCase\\": [
+          \\"false\\",
+          \\"true\\"
+        ],
+        \\"multiline\\": [
+          \\"false\\",
+          \\"true\\"
+        ],
+        \\"lastIndex\\": \\"number\\",
+        \\"compile\\": \\"(pattern: string, flags?: string) => RegExp\\",
+        \\"flags\\": \\"string\\",
+        \\"sticky\\": [
+          \\"false\\",
+          \\"true\\"
+        ],
+        \\"unicode\\": [
+          \\"false\\",
+          \\"true\\"
+        ],
+        \\"dotAll\\": [
+          \\"false\\",
+          \\"true\\"
+        ],
+        \\"__@match@355\\": \\"(string: string) => RegExpMatchArray\\",
+        \\"__@replace@357\\": \\"{ (string: string, replaceValue: string): string; (string: string, replacer: (substring: string, ...args: any[]) => string): string; }\\",
+        \\"__@search@360\\": \\"(string: string) => number\\",
+        \\"__@split@362\\": \\"(string: string, limit?: number) => string[]\\",
+        \\"__@matchAll@364\\": \\"(str: string) => IterableIterator<RegExpMatchArray>\\"
+      }
     ],
     \\"blockSelector\\": \\"string\\",
     \\"ignoreClass\\": \\"string\\",
     \\"maskTextClass\\": [
       \\"string\\",
-      \\"RegExp\\"
+      {
+        \\"exec\\": \\"(string: string) => RegExpExecArray\\",
+        \\"test\\": \\"(string: string) => boolean\\",
+        \\"source\\": \\"string\\",
+        \\"global\\": [
+          \\"false\\",
+          \\"true\\"
+        ],
+        \\"ignoreCase\\": [
+          \\"false\\",
+          \\"true\\"
+        ],
+        \\"multiline\\": [
+          \\"false\\",
+          \\"true\\"
+        ],
+        \\"lastIndex\\": \\"number\\",
+        \\"compile\\": \\"(pattern: string, flags?: string) => RegExp\\",
+        \\"flags\\": \\"string\\",
+        \\"sticky\\": [
+          \\"false\\",
+          \\"true\\"
+        ],
+        \\"unicode\\": [
+          \\"false\\",
+          \\"true\\"
+        ],
+        \\"dotAll\\": [
+          \\"false\\",
+          \\"true\\"
+        ],
+        \\"__@match@355\\": \\"(string: string) => RegExpMatchArray\\",
+        \\"__@replace@357\\": \\"{ (string: string, replaceValue: string): string; (string: string, replacer: (substring: string, ...args: any[]) => string): string; }\\",
+        \\"__@search@360\\": \\"(string: string) => number\\",
+        \\"__@split@362\\": \\"(string: string, limit?: number) => string[]\\",
+        \\"__@matchAll@364\\": \\"(str: string) => IterableIterator<RegExpMatchArray>\\"
+      }
     ],
     \\"maskTextSelector\\": \\"string\\",
     \\"maskTextFn\\": \\"(text: string, element?: HTMLElement) => string\\",
@@ -254,7 +322,19 @@ exports[`config snapshot for PostHogConfig 1`] = `
   \\"capture_performance\\": [
     \\"false\\",
     \\"true\\",
-    \\"PerformanceCaptureConfig\\"
+    {
+      \\"network_timing\\": [
+        \\"false\\",
+        \\"true\\"
+      ],
+      \\"web_vitals\\": [
+        \\"false\\",
+        \\"true\\"
+      ],
+      \\"__web_vitals_max_value\\": \\"number\\",
+      \\"web_vitals_allowed_metrics\\": \\"SupportedWebVitalsMetrics[]\\",
+      \\"web_vitals_delayed_flush_ms\\": \\"number\\"
+    }
   ],
   \\"disable_compression\\": [
     \\"false\\",
@@ -274,7 +354,9 @@ exports[`config snapshot for PostHogConfig 1`] = `
   \\"capture_heatmaps\\": [
     \\"false\\",
     \\"true\\",
-    \\"HeatmapConfig\\"
+    {
+      \\"flush_interval_milliseconds\\": \\"number\\"
+    }
   ],
   \\"enable_heatmaps\\": [
     \\"false\\",
@@ -283,377 +365,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
   \\"capture_dead_clicks\\": [
     \\"false\\",
     \\"true\\",
-    \\"DeadClicksAutoCaptureConfig\\"
-  ],
-  \\"disable_scroll_properties\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"scroll_root_selector\\": [
-    \\"string\\",
-    \\"string[]\\"
-  ],
-  \\"person_profiles\\": [
-    \\"\\\\\\"always\\\\\\"\\",
-    \\"\\\\\\"never\\\\\\"\\",
-    \\"\\\\\\"identified_only\\\\\\"\\"
-  ],
-  \\"process_person\\": [
-    \\"\\\\\\"always\\\\\\"\\",
-    \\"\\\\\\"never\\\\\\"\\",
-    \\"\\\\\\"identified_only\\\\\\"\\"
-  ],
-  \\"rate_limiting\\": \\"{ events_per_second?: number; events_burst_limit?: number; }\\",
-  \\"fetch_options\\": \\"{ cache?: RequestCache; next_options?: NextOptions; }\\",
-  \\"__add_tracing_headers\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"__preview_remote_config\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"__preview_experimental_cookieless_mode\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"api_method\\": \\"string\\",
-  \\"inapp_protocol\\": \\"string\\",
-  \\"inapp_link_new_window\\": [
-    \\"false\\",
-    \\"true\\"
-  ]
-}"
-`;
-
-exports[`config snapshot for SessionRecordingOptions 1`] = `
-"{
-  \\"blockClass\\": [
-    \\"string\\",
-    \\"RegExp\\"
-  ],
-  \\"blockSelector\\": \\"string\\",
-  \\"ignoreClass\\": \\"string\\",
-  \\"maskTextClass\\": [
-    \\"string\\",
-    \\"RegExp\\"
-  ],
-  \\"maskTextSelector\\": \\"string\\",
-  \\"maskTextFn\\": \\"(text: string, element?: HTMLElement) => string\\",
-  \\"maskAllInputs\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"maskInputOptions\\": \\"Partial<{ color: boolean; date: boolean; 'datetime-local': boolean; email: boolean; month: boolean; number: boolean; range: boolean; search: boolean; tel: boolean; text: boolean; time: boolean; url: boolean; week: boolean; textarea: boolean; select: boolean; password: boolean; }>\\",
-  \\"maskInputFn\\": \\"(text: string, element?: HTMLElement) => string\\",
-  \\"slimDOMOptions\\": [
-    \\"true\\",
-    \\"\\\\\\"all\\\\\\"\\",
-    \\"Partial<{ script: boolean; comment: boolean; headFavicon: boolean; headWhitespace: boolean; headMetaDescKeywords: boolean; headMetaSocial: boolean; headMetaRobots: boolean; headMetaHttpEquiv: boolean; headMetaAuthorship: boolean; headMetaVerification: boolean; headTitleMutations: boolean; }>\\"
-  ],
-  \\"collectFonts\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"inlineStylesheet\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"recordCrossOriginIframes\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"recordHeaders\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"recordBody\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"captureCanvas\\": \\"SessionRecordingCanvasOptions\\",
-  \\"maskCapturedNetworkRequestFn\\": \\"(data: CapturedNetworkRequest) => CapturedNetworkRequest\\",
-  \\"maskNetworkRequestFn\\": \\"(data: NetworkRequest) => NetworkRequest\\",
-  \\"full_snapshot_interval_millis\\": \\"number\\",
-  \\"compress_events\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"session_idle_threshold_ms\\": \\"number\\",
-  \\"__mutationRateLimiterRefillRate\\": \\"number\\",
-  \\"__mutationRateLimiterBucketSize\\": \\"number\\"
-}"
-`;
-
-exports[`config snapshot should match the snapshot 1`] = `
-"{
-  \\"api_host\\": \\"string\\",
-  \\"ui_host\\": \\"string\\",
-  \\"api_transport\\": [
-    \\"\\\\\\"XHR\\\\\\"\\",
-    \\"\\\\\\"fetch\\\\\\"\\"
-  ],
-  \\"token\\": \\"string\\",
-  \\"name\\": \\"string\\",
-  \\"autocapture\\": [
-    \\"false\\",
-    \\"true\\",
-    \\"AutocaptureConfig\\"
-  ],
-  \\"rageclick\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"cross_subdomain_cookie\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"persistence\\": [
-    \\"\\\\\\"localStorage\\\\\\"\\",
-    \\"\\\\\\"cookie\\\\\\"\\",
-    \\"\\\\\\"memory\\\\\\"\\",
-    \\"\\\\\\"localStorage+cookie\\\\\\"\\",
-    \\"\\\\\\"sessionStorage\\\\\\"\\"
-  ],
-  \\"persistence_name\\": \\"string\\",
-  \\"cookie_name\\": \\"string\\",
-  \\"loaded\\": \\"(posthog_instance: PostHog) => void\\",
-  \\"save_referrer\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"save_campaign_params\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"store_google\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"custom_campaign_params\\": \\"string[]\\",
-  \\"custom_blocked_useragents\\": \\"string[]\\",
-  \\"debug\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"verbose\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"capture_pageview\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"capture_pageleave\\": [
-    \\"false\\",
-    \\"true\\",
-    \\"\\\\\\"if_capture_pageview\\\\\\"\\"
-  ],
-  \\"cookie_expiration\\": \\"number\\",
-  \\"upgrade\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"disable_session_recording\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"disable_persistence\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"disable_cookie\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"disable_surveys\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"disable_web_experiments\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"disable_external_dependency_loading\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"prepare_external_dependency_script\\": \\"(script: HTMLScriptElement) => HTMLScriptElement\\",
-  \\"enable_recording_console_log\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"secure_cookie\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"ip\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"opt_out_capturing_by_default\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"opt_out_capturing_persistence_type\\": [
-    \\"\\\\\\"localStorage\\\\\\"\\",
-    \\"\\\\\\"cookie\\\\\\"\\"
-  ],
-  \\"opt_out_persistence_by_default\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"opt_out_useragent_filter\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"opt_out_capturing_cookie_prefix\\": \\"string\\",
-  \\"opt_in_site_apps\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"respect_dnt\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"property_denylist\\": \\"string[]\\",
-  \\"property_blacklist\\": \\"string[]\\",
-  \\"request_headers\\": \\"{ [header_name: string]: string; }\\",
-  \\"xhr_headers\\": \\"{ [header_name: string]: string; }\\",
-  \\"on_request_error\\": \\"(error: RequestResponse) => void\\",
-  \\"on_xhr_error\\": \\"(failedRequest: XMLHttpRequest) => void\\",
-  \\"request_batching\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"properties_string_max_length\\": \\"number\\",
-  \\"session_recording\\": {
-    \\"blockClass\\": [
-      \\"string\\",
-      \\"RegExp\\"
-    ],
-    \\"blockSelector\\": \\"string\\",
-    \\"ignoreClass\\": \\"string\\",
-    \\"maskTextClass\\": [
-      \\"string\\",
-      \\"RegExp\\"
-    ],
-    \\"maskTextSelector\\": \\"string\\",
-    \\"maskTextFn\\": \\"(text: string, element?: HTMLElement) => string\\",
-    \\"maskAllInputs\\": [
-      \\"false\\",
-      \\"true\\"
-    ],
-    \\"maskInputOptions\\": \\"Partial<{ color: boolean; date: boolean; 'datetime-local': boolean; email: boolean; month: boolean; number: boolean; range: boolean; search: boolean; tel: boolean; text: boolean; time: boolean; url: boolean; week: boolean; textarea: boolean; select: boolean; password: boolean; }>\\",
-    \\"maskInputFn\\": \\"(text: string, element?: HTMLElement) => string\\",
-    \\"slimDOMOptions\\": [
-      \\"true\\",
-      \\"\\\\\\"all\\\\\\"\\",
-      \\"Partial<{ script: boolean; comment: boolean; headFavicon: boolean; headWhitespace: boolean; headMetaDescKeywords: boolean; headMetaSocial: boolean; headMetaRobots: boolean; headMetaHttpEquiv: boolean; headMetaAuthorship: boolean; headMetaVerification: boolean; headTitleMutations: boolean; }>\\"
-    ],
-    \\"collectFonts\\": [
-      \\"false\\",
-      \\"true\\"
-    ],
-    \\"inlineStylesheet\\": [
-      \\"false\\",
-      \\"true\\"
-    ],
-    \\"recordCrossOriginIframes\\": [
-      \\"false\\",
-      \\"true\\"
-    ],
-    \\"recordHeaders\\": [
-      \\"false\\",
-      \\"true\\"
-    ],
-    \\"recordBody\\": [
-      \\"false\\",
-      \\"true\\"
-    ],
-    \\"captureCanvas\\": \\"SessionRecordingCanvasOptions\\",
-    \\"maskCapturedNetworkRequestFn\\": \\"(data: CapturedNetworkRequest) => CapturedNetworkRequest\\",
-    \\"maskNetworkRequestFn\\": \\"(data: NetworkRequest) => NetworkRequest\\",
-    \\"full_snapshot_interval_millis\\": \\"number\\",
-    \\"compress_events\\": [
-      \\"false\\",
-      \\"true\\"
-    ],
-    \\"session_idle_threshold_ms\\": \\"number\\",
-    \\"__mutationRateLimiterRefillRate\\": \\"number\\",
-    \\"__mutationRateLimiterBucketSize\\": \\"number\\"
-  },
-  \\"session_idle_timeout_seconds\\": \\"number\\",
-  \\"mask_all_element_attributes\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"mask_all_text\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"mask_personal_data_properties\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"custom_personal_data_properties\\": \\"string[]\\",
-  \\"advanced_disable_decide\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"advanced_disable_feature_flags\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"advanced_disable_feature_flags_on_first_load\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"advanced_disable_toolbar_metrics\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"feature_flag_request_timeout_ms\\": \\"number\\",
-  \\"get_device_id\\": \\"(uuid: string) => string\\",
-  \\"before_send\\": [
-    \\"BeforeSendFn\\",
-    \\"BeforeSendFn[]\\"
-  ],
-  \\"sanitize_properties\\": \\"(properties: Properties, event_name: string) => Properties\\",
-  \\"_onCapture\\": \\"(eventName: string, eventData: CaptureResult) => void\\",
-  \\"capture_performance\\": [
-    \\"false\\",
-    \\"true\\",
-    \\"PerformanceCaptureConfig\\"
-  ],
-  \\"disable_compression\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"bootstrap\\": {
-    \\"distinctID\\": \\"string\\",
-    \\"isIdentifiedID\\": [
-      \\"false\\",
-      \\"true\\"
-    ],
-    \\"featureFlags\\": \\"Record<string, string | boolean>\\",
-    \\"featureFlagPayloads\\": \\"Record<string, JsonType>\\",
-    \\"sessionID\\": \\"string\\"
-  },
-  \\"segment\\": \\"SegmentAnalytics\\",
-  \\"capture_heatmaps\\": [
-    \\"false\\",
-    \\"true\\",
-    \\"HeatmapConfig\\"
-  ],
-  \\"enable_heatmaps\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"capture_dead_clicks\\": [
-    \\"false\\",
-    \\"true\\",
-    \\"DeadClicksAutoCaptureConfig\\"
+    [
+      \\"{ scroll_threshold_ms?: number; selection_change_threshold_ms?: number; mutation_threshold_ms?: number; __onCapture?: (click: DeadClickCandidate, properties: Properties) => void; }\\",
+      \\"Pick<AutocaptureConfig, \\\\\\"element_attribute_ignorelist\\\\\\">\\"
+    ]
   ],
   \\"disable_scroll_properties\\": [
     \\"false\\",

--- a/src/__tests__/config-snapshot.test.ts
+++ b/src/__tests__/config-snapshot.test.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript'
+import path from 'path'
 
 function extractTypeInfo(filePath: string, typeName: string): string {
     const program = ts.createProgram([filePath], {})

--- a/src/__tests__/config-snapshot.test.ts
+++ b/src/__tests__/config-snapshot.test.ts
@@ -1,0 +1,54 @@
+import ts from 'typescript'
+
+function extractTypeInfo(filePath: string, typeName: string): string {
+    const program = ts.createProgram([filePath], {})
+    const checker = program.getTypeChecker()
+    const sourceFile = program.getSourceFile(filePath)
+
+    if (!sourceFile) {
+        throw new Error(`File not found: ${filePath}`)
+    }
+
+    function getTypeString(type: ts.Type): string {
+        return checker.typeToString(type)
+    }
+
+    function processType(type: ts.Type): any {
+        if (type.isUnion() || type.isIntersection()) {
+            return type.types.map(getTypeString)
+        } else if (type.isClassOrInterface()) {
+            const result: Record<string, any> = {}
+            type.getProperties().forEach((symbol) => {
+                const propType = checker.getTypeOfSymbol(symbol)
+                result[symbol.getName()] = processType(propType)
+            })
+            return result
+        } else if (type.symbol && type.symbol.valueDeclaration) {
+            return getTypeString(type)
+        }
+        return getTypeString(type)
+    }
+
+    let result: Record<string, any> = {}
+
+    ts.forEachChild(sourceFile, (node) => {
+        if (ts.isInterfaceDeclaration(node) && node.name.text === typeName) {
+            const type = checker.getTypeAtLocation(node)
+            result = processType(type)
+        }
+    })
+
+    return JSON.stringify(result, null, 2)
+}
+
+describe('config snapshot', () => {
+    it('for PostHogConfig', () => {
+        expect(extractTypeInfo('src/types.ts', 'PostHogConfig')).toMatchSnapshot()
+    })
+    it('for AutocaptureConfig', () => {
+        expect(extractTypeInfo('src/types.ts', 'AutocaptureConfig')).toMatchSnapshot()
+    })
+    it('for SessionRecordingOptions', () => {
+        expect(extractTypeInfo('src/types.ts', 'SessionRecordingOptions')).toMatchSnapshot()
+    })
+})

--- a/src/__tests__/config-snapshot.test.ts
+++ b/src/__tests__/config-snapshot.test.ts
@@ -1,6 +1,7 @@
 import ts from 'typescript'
 import path from 'path'
 
+type ProcessedType = string | Record<string, string | string[] | Record<string, any> | any[]> | ProcessedType[]
 function extractTypeInfo(filePath: string, typeName: string): string {
     const program = ts.createProgram([filePath], { noImgplicitAny: true, strictNullChecks: true })
     const checker = program.getTypeChecker()
@@ -14,22 +15,31 @@ function extractTypeInfo(filePath: string, typeName: string): string {
         return checker.typeToString(type)
     }
 
-    function processType(type: ts.Type): any {
+    function processType(type: ts.Type): ProcessedType {
+        // Early detect RegExp type and return its string representation
+        // No need to recursively resolve it
+        if (type.symbol?.name === 'RegExp') {
+            return getTypeString(type)
+        }
+
         if (type.isUnion() || type.isIntersection()) {
             return type.types.map(processType)
-        } else if (type.isClassOrInterface()) {
-            const result: Record<string, any> = {}
+        }
+
+        if (type.isClassOrInterface()) {
+            const result: Record<string, ProcessedType> = {}
             type.getProperties().forEach((symbol) => {
                 const propType = checker.getTypeOfSymbol(symbol)
                 result[symbol.getName()] = processType(propType)
             })
+
             return result
         }
 
         return getTypeString(type)
     }
 
-    let result: Record<string, any> = {}
+    let result: ProcessedType = {}
 
     ts.forEachChild(sourceFile, (node) => {
         if (ts.isInterfaceDeclaration(node) && node.name.text === typeName) {
@@ -41,8 +51,12 @@ function extractTypeInfo(filePath: string, typeName: string): string {
     return JSON.stringify(result, null, 2)
 }
 
+// This guarantees that the config types are stable and won't change
+// or that, at least, we won't ever remove any options from the config
+// and/or change the types of existing options.
 describe('config snapshot', () => {
     it('for PostHogConfig', () => {
-        expect(extractTypeInfo(path.resolve(__dirname, '../types.ts'), 'PostHogConfig')).toMatchSnapshot()
+        const typeInfo = extractTypeInfo(path.resolve(__dirname, '../types.ts'), 'PostHogConfig')
+        expect(typeInfo).toMatchSnapshot()
     })
 })

--- a/src/__tests__/config-snapshot.test.ts
+++ b/src/__tests__/config-snapshot.test.ts
@@ -43,7 +43,7 @@ function extractTypeInfo(filePath: string, typeName: string): string {
 
 describe('config snapshot', () => {
     it('for PostHogConfig', () => {
-        expect(extractTypeInfo('src/types.ts', 'PostHogConfig')).toMatchSnapshot()
+        expect(extractTypeInfo(path.resolve(__dirname, '../types.ts'), 'PostHogConfig')).toMatchSnapshot()
     })
     it('for AutocaptureConfig', () => {
         expect(extractTypeInfo('src/types.ts', 'AutocaptureConfig')).toMatchSnapshot()

--- a/src/__tests__/config-snapshot.test.ts
+++ b/src/__tests__/config-snapshot.test.ts
@@ -15,7 +15,7 @@ function extractTypeInfo(filePath: string, typeName: string): string {
 
     function processType(type: ts.Type): any {
         if (type.isUnion() || type.isIntersection()) {
-            return type.types.map(getTypeString)
+            return type.types.map(processType)
         } else if (type.isClassOrInterface()) {
             const result: Record<string, any> = {}
             type.getProperties().forEach((symbol) => {
@@ -23,9 +23,8 @@ function extractTypeInfo(filePath: string, typeName: string): string {
                 result[symbol.getName()] = processType(propType)
             })
             return result
-        } else if (type.symbol && type.symbol.valueDeclaration) {
-            return getTypeString(type)
         }
+
         return getTypeString(type)
     }
 
@@ -44,11 +43,5 @@ function extractTypeInfo(filePath: string, typeName: string): string {
 describe('config snapshot', () => {
     it('for PostHogConfig', () => {
         expect(extractTypeInfo(path.resolve(__dirname, '../types.ts'), 'PostHogConfig')).toMatchSnapshot()
-    })
-    it('for AutocaptureConfig', () => {
-        expect(extractTypeInfo('src/types.ts', 'AutocaptureConfig')).toMatchSnapshot()
-    })
-    it('for SessionRecordingOptions', () => {
-        expect(extractTypeInfo('src/types.ts', 'SessionRecordingOptions')).toMatchSnapshot()
     })
 })

--- a/src/__tests__/config-snapshot.test.ts
+++ b/src/__tests__/config-snapshot.test.ts
@@ -2,7 +2,7 @@ import ts from 'typescript'
 import path from 'path'
 
 function extractTypeInfo(filePath: string, typeName: string): string {
-    const program = ts.createProgram([filePath], {})
+    const program = ts.createProgram([filePath], { noImgplicitAny: true, strictNullChecks: true })
     const checker = program.getTypeChecker()
     const sourceFile = program.getSourceFile(filePath)
 


### PR DESCRIPTION
we accidentally removed some options from a config in another PR

computers should protect us

this is 99% ChatGPT so review accordingly 🙈 

this converts provided types into a dict and snapshots that

this should let us known when we're accidentally breaking types for consumers