### PR TITLE
fix: never send when not sampled

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -2437,5 +2437,19 @@ describe('SessionRecording', () => {
             // even though still waiting for URL to trigger
             expect(sessionRecording['status']).toBe('active')
         })
+
+        it('ANDS with Sampling', async () => {
+            sessionRecording.onRemoteConfig(
+                makeDecideResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                        eventTriggers: ['$exception'],
+                        sampleRate: '0.00', // i.e. never send recording
+                    },
+                })
+            )
+
+            expect(sessionRecording['status']).toBe('disabled')
+        })
     })
 })

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -2438,7 +2438,7 @@ describe('SessionRecording', () => {
             expect(sessionRecording['status']).toBe('active')
         })
 
-        it('ANDS with Sampling', async () => {
+        it('disables recording when sampling rate is 0 regardless of event triggers', async () => {
             sessionRecording.onRemoteConfig(
                 makeDecideResponse({
                     sessionRecording: {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -397,6 +397,12 @@ export class SessionRecording {
             return 'disabled'
         }
 
+        // if sampling is set and the session is already decided to not be sampled
+        // then we should never be active
+        if (this.isSampled === false) {
+            return 'disabled'
+        }
+
         if (this._urlBlocked) {
             return 'paused'
         }


### PR DESCRIPTION
see: https://posthoghelp.zendesk.com/agent/tickets/24373 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26227)

If a sampling decision has been made and a session should not be recorded

but event or URL triggers are defined 

the trigger pending status takes precedence and we build up a buffer

when the trigger is seen we send that buffer

and then the sampling status can assert itself and the recording immediately stops

this lifts the check for `sampled is False` higher in the status check to avoid this happening