### PR TITLE
feat: allow configuring request queue interval

### DIFF
--- a/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -467,6 +467,15 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"undefined\\",
     \\"{ cache?: RequestCache | undefined; next_options?: NextOptions | undefined; }\\"
   ],
+  \\"request_queue_config\\": [
+    \\"undefined\\",
+    {
+      \\"flush_interval_ms\\": [
+        \\"undefined\\",
+        \\"number\\"
+      ]
+    }
+  ],
   \\"__add_tracing_headers\\": [
     \\"undefined\\",
     \\"false\\",

--- a/src/__tests__/request-queue.test.ts
+++ b/src/__tests__/request-queue.test.ts
@@ -1,131 +1,171 @@
-import { RequestQueue } from '../request-queue'
-import { QueuedRequestOptions } from '../types'
+import { DEFAULT_FLUSH_INTERVAL_MS, RequestQueue } from '../request-queue'
+import { QueuedRequestWithOptions } from '../types'
+import { createPosthogInstance } from './helpers/posthog-instance'
 
 const EPOCH = 1_600_000_000
 
 describe('RequestQueue', () => {
-    let sendRequest: (options: QueuedRequestOptions) => void
-    let queue: RequestQueue
-
-    beforeEach(() => {
-        sendRequest = jest.fn()
-        queue = new RequestQueue(sendRequest)
-        jest.useFakeTimers()
-        jest.setSystemTime(EPOCH - 3000) // Running the timers will add 3 seconds
-        jest.spyOn(console, 'warn').mockImplementation(() => {})
-    })
-
-    it('handles poll after enqueueing requests', () => {
-        queue.enqueue({
-            data: { event: 'foo', timestamp: EPOCH - 3000 },
-            transport: 'XHR',
-            url: '/e',
-        })
-        queue.enqueue({
-            data: { event: '$identify', timestamp: EPOCH - 2000 },
-            url: '/identify',
-        })
-        queue.enqueue({
-            data: { event: 'bar', timestamp: EPOCH - 1000 },
-            url: '/e',
-        })
-        queue.enqueue({
-            data: { event: 'zeta', timestamp: EPOCH },
-            url: '/e',
-            batchKey: 'sessionRecording',
+    describe('setting flush timeout', () => {
+        it('can override the flush timeout', () => {
+            const queue = new RequestQueue(jest.fn(), { flush_interval_ms: 1000 })
+            expect(queue['flushTimeoutMs']).toEqual(1000)
         })
 
-        queue.enable()
-
-        expect(sendRequest).toHaveBeenCalledTimes(0)
-
-        jest.runOnlyPendingTimers()
-
-        expect(sendRequest).toHaveBeenCalledTimes(3)
-        expect(jest.mocked(sendRequest).mock.calls).toEqual([
-            [
-                {
-                    url: '/e',
-                    data: [
-                        { event: 'foo', offset: 3000 },
-                        { event: 'bar', offset: 1000 },
-                    ],
-                    transport: 'XHR',
-                },
-            ],
-            [
-                {
-                    url: '/identify',
-                    data: [{ event: '$identify', offset: 2000 }],
-                },
-            ],
-            [
-                {
-                    url: '/e',
-                    data: [{ event: 'zeta', offset: 0 }],
-                    batchKey: 'sessionRecording',
-                },
-            ],
-        ])
-    })
-
-    it('handles unload', () => {
-        queue.enqueue({ url: '/s', data: { recording_payload: 'example' } })
-        queue.enqueue({ url: '/e', data: { event: 'foo', timestamp: 1_610_000_000 } })
-        queue.enqueue({ url: '/identify', data: { event: '$identify', timestamp: 1_620_000_000 } })
-        queue.enqueue({ url: '/e', data: { event: 'bar', timestamp: 1_630_000_000 } })
-        queue.unload()
-
-        expect(sendRequest).toHaveBeenCalledTimes(3)
-        expect(sendRequest).toHaveBeenNthCalledWith(1, {
-            url: '/e',
-            data: [
-                { event: 'foo', timestamp: 1_610_000_000 },
-                { event: 'bar', timestamp: 1_630_000_000 },
-            ],
-            transport: 'sendBeacon',
+        it('defaults to 3000 when not configured', () => {
+            const queue = new RequestQueue(jest.fn(), {})
+            expect(queue['flushTimeoutMs']).toEqual(DEFAULT_FLUSH_INTERVAL_MS)
         })
 
-        expect(sendRequest).toHaveBeenNthCalledWith(2, {
-            url: '/s',
-            data: [{ recording_payload: 'example' }],
-            transport: 'sendBeacon',
+        it('defaults to 3000 when no config', () => {
+            const queue = new RequestQueue(jest.fn())
+            expect(queue['flushTimeoutMs']).toEqual(DEFAULT_FLUSH_INTERVAL_MS)
         })
-        expect(sendRequest).toHaveBeenNthCalledWith(3, {
-            url: '/identify',
-            data: [{ event: '$identify', timestamp: 1_620_000_000 }],
-            transport: 'sendBeacon',
+
+        it('cannot set below 250', () => {
+            const queue = new RequestQueue(jest.fn(), { flush_interval_ms: 249 })
+            expect(queue['flushTimeoutMs']).toEqual(250)
+        })
+
+        it('cannot set above 5000', () => {
+            const queue = new RequestQueue(jest.fn(), { flush_interval_ms: 5001 })
+            expect(queue['flushTimeoutMs']).toEqual(5000)
+        })
+
+        it('can be passed in from posthog config', async () => {
+            const posthog = await createPosthogInstance('token', { request_queue_config: { flush_interval_ms: 1000 } })
+            expect(posthog.config.request_queue_config.flush_interval_ms).toEqual(1000)
+            expect(posthog['_requestQueue']['flushTimeoutMs']).toEqual(1000)
         })
     })
 
-    it('handles unload with batchKeys', () => {
-        queue.enqueue({ url: '/e', data: { event: 'foo', timestamp: 1_610_000_000 }, transport: 'XHR' })
-        queue.enqueue({ url: '/identify', data: { event: '$identify', timestamp: 1_620_000_000 } })
-        queue.enqueue({ url: '/e', data: { event: 'bar', timestamp: 1_630_000_000 } })
-        queue.enqueue({ url: '/e', data: { event: 'zeta', timestamp: 1_640_000_000 }, batchKey: 'sessionRecording' })
+    describe('with default config', () => {
+        let sendRequest: (options: QueuedRequestWithOptions) => void
+        let queue: RequestQueue
 
-        queue.unload()
-
-        expect(sendRequest).toHaveBeenCalledTimes(3)
-
-        expect(sendRequest).toHaveBeenNthCalledWith(1, {
-            data: [
-                { event: 'foo', timestamp: 1610000000 },
-                { event: 'bar', timestamp: 1630000000 },
-            ],
-            transport: 'sendBeacon',
-            url: '/e',
+        beforeEach(() => {
+            sendRequest = jest.fn()
+            queue = new RequestQueue(sendRequest, {})
+            jest.useFakeTimers()
+            jest.setSystemTime(EPOCH - 3000) // Running the timers will add 3 seconds
+            jest.spyOn(console, 'warn').mockImplementation(() => {})
         })
-        expect(sendRequest).toHaveBeenNthCalledWith(2, {
-            batchKey: 'sessionRecording',
-            data: [{ event: 'zeta', timestamp: 1640000000 }],
-            transport: 'sendBeacon',
-            url: '/e',
+
+        it('handles poll after enqueueing requests', () => {
+            queue.enqueue({
+                data: { event: 'foo', timestamp: EPOCH - 3000 },
+                transport: 'XHR',
+                url: '/e',
+            })
+            queue.enqueue({
+                data: { event: '$identify', timestamp: EPOCH - 2000 },
+                url: '/identify',
+            })
+            queue.enqueue({
+                data: { event: 'bar', timestamp: EPOCH - 1000 },
+                url: '/e',
+            })
+            queue.enqueue({
+                data: { event: 'zeta', timestamp: EPOCH },
+                url: '/e',
+                batchKey: 'sessionRecording',
+            })
+
+            queue.enable()
+
+            expect(sendRequest).toHaveBeenCalledTimes(0)
+
+            jest.runOnlyPendingTimers()
+
+            expect(sendRequest).toHaveBeenCalledTimes(3)
+            expect(jest.mocked(sendRequest).mock.calls).toEqual([
+                [
+                    {
+                        url: '/e',
+                        data: [
+                            { event: 'foo', offset: 3000 },
+                            { event: 'bar', offset: 1000 },
+                        ],
+                        transport: 'XHR',
+                    },
+                ],
+                [
+                    {
+                        url: '/identify',
+                        data: [{ event: '$identify', offset: 2000 }],
+                    },
+                ],
+                [
+                    {
+                        url: '/e',
+                        data: [{ event: 'zeta', offset: 0 }],
+                        batchKey: 'sessionRecording',
+                    },
+                ],
+            ])
         })
-        expect(sendRequest).toHaveBeenNthCalledWith(3, {
-            data: [{ event: '$identify', timestamp: 1620000000 }],
-            transport: 'sendBeacon',
-            url: '/identify',
+
+        it('handles unload', () => {
+            queue.enqueue({ url: '/s', data: { recording_payload: 'example' } })
+            queue.enqueue({ url: '/e', data: { event: 'foo', timestamp: 1_610_000_000 } })
+            queue.enqueue({ url: '/identify', data: { event: '$identify', timestamp: 1_620_000_000 } })
+            queue.enqueue({ url: '/e', data: { event: 'bar', timestamp: 1_630_000_000 } })
+            queue.unload()
+
+            expect(sendRequest).toHaveBeenCalledTimes(3)
+            expect(sendRequest).toHaveBeenNthCalledWith(1, {
+                url: '/e',
+                data: [
+                    { event: 'foo', timestamp: 1_610_000_000 },
+                    { event: 'bar', timestamp: 1_630_000_000 },
+                ],
+                transport: 'sendBeacon',
+            })
+
+            expect(sendRequest).toHaveBeenNthCalledWith(2, {
+                url: '/s',
+                data: [{ recording_payload: 'example' }],
+                transport: 'sendBeacon',
+            })
+            expect(sendRequest).toHaveBeenNthCalledWith(3, {
+                url: '/identify',
+                data: [{ event: '$identify', timestamp: 1_620_000_000 }],
+                transport: 'sendBeacon',
+            })
+        })
+
+        it('handles unload with batchKeys', () => {
+            queue.enqueue({ url: '/e', data: { event: 'foo', timestamp: 1_610_000_000 }, transport: 'XHR' })
+            queue.enqueue({ url: '/identify', data: { event: '$identify', timestamp: 1_620_000_000 } })
+            queue.enqueue({ url: '/e', data: { event: 'bar', timestamp: 1_630_000_000 } })
+            queue.enqueue({
+                url: '/e',
+                data: { event: 'zeta', timestamp: 1_640_000_000 },
+                batchKey: 'sessionRecording',
+            })
+
+            queue.unload()
+
+            expect(sendRequest).toHaveBeenCalledTimes(3)
+
+            expect(sendRequest).toHaveBeenNthCalledWith(1, {
+                data: [
+                    { event: 'foo', timestamp: 1610000000 },
+                    { event: 'bar', timestamp: 1630000000 },
+                ],
+                transport: 'sendBeacon',
+                url: '/e',
+            })
+            expect(sendRequest).toHaveBeenNthCalledWith(2, {
+                batchKey: 'sessionRecording',
+                data: [{ event: 'zeta', timestamp: 1640000000 }],
+                transport: 'sendBeacon',
+                url: '/e',
+            })
+            expect(sendRequest).toHaveBeenNthCalledWith(3, {
+                data: [{ event: '$identify', timestamp: 1620000000 }],
+                transport: 'sendBeacon',
+                url: '/identify',
+            })
         })
     })
 })

--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -2,7 +2,7 @@
 /// <reference lib="dom" />
 
 import { extendURLParams, request } from '../request'
-import { Compression, RequestOptions } from '../types'
+import { Compression, RequestWithOptions } from '../types'
 
 jest.mock('../utils/globals', () => ({
     ...jest.requireActual('../utils/globals'),
@@ -51,8 +51,8 @@ describe('request', () => {
     const now = 1700000000000
 
     const mockCallback = jest.fn()
-    let createRequest: (overrides?: Partial<RequestOptions>) => RequestOptions
-    let transport: RequestOptions['transport']
+    let createRequest: (overrides?: Partial<RequestWithOptions>) => RequestWithOptions
+    let transport: RequestWithOptions['transport']
 
     beforeEach(() => {
         mockedXHR.open.mockClear()

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,6 +1,6 @@
 import { each, find } from './utils'
 import Config from './config'
-import { Compression, RequestOptions, RequestResponse } from './types'
+import { Compression, RequestWithOptions, RequestResponse } from './types'
 import { formDataToQuery } from './utils/request-utils'
 
 import { logger } from './utils/logger'
@@ -56,7 +56,7 @@ const encodeToDataString = (data: string | Record<string, any>): string => {
     return 'data=' + encodeURIComponent(typeof data === 'string' ? data : jsonStringify(data))
 }
 
-const encodePostData = ({ data, compression }: RequestOptions): EncodedBody | undefined => {
+const encodePostData = ({ data, compression }: RequestWithOptions): EncodedBody | undefined => {
     if (!data) {
         return
     }
@@ -90,7 +90,7 @@ const encodePostData = ({ data, compression }: RequestOptions): EncodedBody | un
     }
 }
 
-const xhr = (options: RequestOptions) => {
+const xhr = (options: RequestWithOptions) => {
     const req = new XMLHttpRequest!()
     req.open(options.method || 'GET', options.url, true)
     const { contentType, body } = encodePostData(options) ?? {}
@@ -130,7 +130,7 @@ const xhr = (options: RequestOptions) => {
     req.send(body)
 }
 
-const _fetch = (options: RequestOptions) => {
+const _fetch = (options: RequestWithOptions) => {
     const { contentType, body, estimatedSize } = encodePostData(options) ?? {}
 
     // eslint-disable-next-line compat/compat
@@ -196,7 +196,7 @@ const _fetch = (options: RequestOptions) => {
     return
 }
 
-const _sendBeacon = (options: RequestOptions) => {
+const _sendBeacon = (options: RequestWithOptions) => {
     // beacon documentation https://w3c.github.io/beacon/
     // beacons format the message and use the type property
 
@@ -215,7 +215,10 @@ const _sendBeacon = (options: RequestOptions) => {
     }
 }
 
-const AVAILABLE_TRANSPORTS: { transport: RequestOptions['transport']; method: (options: RequestOptions) => void }[] = []
+const AVAILABLE_TRANSPORTS: {
+    transport: RequestWithOptions['transport']
+    method: (options: RequestWithOptions) => void
+}[] = []
 
 // We add the transports in order of preference
 if (fetch) {
@@ -240,7 +243,7 @@ if (navigator?.sendBeacon) {
 }
 
 // This is the entrypoint. It takes care of sanitizing the options and then calls the appropriate request method.
-export const request = (_options: RequestOptions) => {
+export const request = (_options: RequestWithOptions) => {
     // Clone the options so we don't modify the original object
     const options = { ..._options }
     options.timeout = options.timeout || 60000

--- a/src/retry-queue.ts
+++ b/src/retry-queue.ts
@@ -1,4 +1,4 @@
-import { RetriableRequestOptions } from './types'
+import { RetriableRequestWithOptions } from './types'
 
 import { isNumber, isUndefined } from './utils/type-utils'
 import { logger } from './utils/logger'
@@ -30,7 +30,7 @@ export function pickNextRetryDelay(retriesPerformedSoFar: number): number {
 
 interface RetryQueueElement {
     retryAt: number
-    requestOptions: RetriableRequestOptions
+    requestOptions: RetriableRequestWithOptions
 }
 
 export class RetryQueue {
@@ -58,7 +58,7 @@ export class RetryQueue {
         }
     }
 
-    retriableRequest({ retriesPerformedSoFar, ...options }: RetriableRequestOptions): void {
+    retriableRequest({ retriesPerformedSoFar, ...options }: RetriableRequestWithOptions): void {
         if (isNumber(retriesPerformedSoFar) && retriesPerformedSoFar > 0) {
             options.url = extendURLParams(options.url, { retry_count: retriesPerformedSoFar })
         }
@@ -81,7 +81,7 @@ export class RetryQueue {
         })
     }
 
-    private enqueue(requestOptions: RetriableRequestOptions): void {
+    private enqueue(requestOptions: RetriableRequestWithOptions): void {
         const retriesPerformedSoFar = requestOptions.retriesPerformedSoFar || 0
         requestOptions.retriesPerformedSoFar = retriesPerformedSoFar + 1
 


### PR DESCRIPTION
the request queue has a fixed interval where it sends events, this allows us to batch events to reduce load on ingestion and reduce network calls on client devices

but for customers where they may have short page visits or automated page redirects this means relying on the unload mechanism which browsers don't guarantee

let's allow configuring that interval between 250 and 5000ms