### PR TITLE
feat(llm-observability): metric and feedback methods

### DIFF
--- a/src/__tests__/ai.test.ts
+++ b/src/__tests__/ai.test.ts
@@ -53,13 +53,13 @@ describe('ai', () => {
     })
 
     describe('captureTraceFeedback()', () => {
-        it('should capture metric', () => {
+        it('should capture feedback', () => {
             const { posthog, beforeSendMock } = setup()
 
             posthog.captureTraceFeedback('123', 'feedback')
 
             const { event, properties } = beforeSendMock.mock.calls[0][0]
-            expect(event).toBe('$ai_metric')
+            expect(event).toBe('$ai_feedback')
             expect(properties['$ai_trace_id']).toBe('123')
             expect(properties['$ai_feedback_text']).toBe('feedback')
         })
@@ -70,7 +70,7 @@ describe('ai', () => {
             posthog.captureTraceFeedback(123, 'feedback')
 
             const { event, properties } = beforeSendMock.mock.calls[0][0]
-            expect(event).toBe('$ai_metric')
+            expect(event).toBe('$ai_feedback')
             expect(properties['$ai_trace_id']).toBe('123')
             expect(properties['$ai_feedback_text']).toBe('feedback')
         })

--- a/src/__tests__/ai.test.ts
+++ b/src/__tests__/ai.test.ts
@@ -1,0 +1,78 @@
+import { defaultPostHog } from './helpers/posthog-instance'
+import type { PostHogConfig } from '../types'
+import { uuidv7 } from '../uuidv7'
+
+describe('ai', () => {
+    beforeEach(() => {
+        console.error = jest.fn()
+    })
+
+    const setup = (config: Partial<PostHogConfig> = {}, token: string = uuidv7()) => {
+        const beforeSendMock = jest.fn().mockImplementation((e) => e)
+        const posthog = defaultPostHog().init(token, { ...config, before_send: beforeSendMock }, token)!
+        posthog.debug()
+        return { posthog, beforeSendMock }
+    }
+
+    describe('captureTraceMetric()', () => {
+        it('should capture metric', () => {
+            const { posthog, beforeSendMock } = setup()
+
+            posthog.captureTraceMetric('123', 'test', 'test')
+
+            const { event, properties } = beforeSendMock.mock.calls[0][0]
+            expect(event).toBe('$ai_metric')
+            expect(properties['$ai_trace_id']).toBe('123')
+            expect(properties['$ai_metric_name']).toBe('test')
+            expect(properties['$ai_metric_value']).toBe('test')
+        })
+
+        it('should convert numeric values', () => {
+            const { posthog, beforeSendMock } = setup()
+
+            posthog.captureTraceMetric(123, 'test', 1)
+
+            const { event, properties } = beforeSendMock.mock.calls[0][0]
+            expect(event).toBe('$ai_metric')
+            expect(properties['$ai_trace_id']).toBe('123')
+            expect(properties['$ai_metric_name']).toBe('test')
+            expect(properties['$ai_metric_value']).toBe('1')
+        })
+
+        it('should convert boolean metric_value', () => {
+            const { posthog, beforeSendMock } = setup()
+
+            posthog.captureTraceMetric('test', 'test', false)
+
+            const { event, properties } = beforeSendMock.mock.calls[0][0]
+            expect(event).toBe('$ai_metric')
+            expect(properties['$ai_trace_id']).toBe('test')
+            expect(properties['$ai_metric_name']).toBe('test')
+            expect(properties['$ai_metric_value']).toBe('false')
+        })
+    })
+
+    describe('captureTraceFeedback()', () => {
+        it('should capture metric', () => {
+            const { posthog, beforeSendMock } = setup()
+
+            posthog.captureTraceFeedback('123', 'feedback')
+
+            const { event, properties } = beforeSendMock.mock.calls[0][0]
+            expect(event).toBe('$ai_metric')
+            expect(properties['$ai_trace_id']).toBe('123')
+            expect(properties['$ai_feedback_text']).toBe('feedback')
+        })
+
+        it('should convert numeric values', () => {
+            const { posthog, beforeSendMock } = setup()
+
+            posthog.captureTraceFeedback(123, 'feedback')
+
+            const { event, properties } = beforeSendMock.mock.calls[0][0]
+            expect(event).toBe('$ai_metric')
+            expect(properties['$ai_trace_id']).toBe('123')
+            expect(properties['$ai_feedback_text']).toBe('feedback')
+        })
+    })
+})

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -2137,7 +2137,7 @@ export class PostHog {
      * @param userFeedback The feedback to capture.
      */
     captureTraceFeedback(traceId: string | number, userFeedback: string) {
-        this.capture('$ai_metric', {
+        this.capture('$ai_feedback', {
             $ai_trace_id: String(traceId),
             $ai_feedback_text: userFeedback,
         })

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -2130,6 +2130,32 @@ export class PostHog {
     public getPageViewId(): string | undefined {
         return this.pageViewManager._currentPageview?.pageViewId
     }
+
+    /**
+     * Capture written user feedback for a LLM trace. Numeric values are converted to strings.
+     * @param traceId The trace ID to capture feedback for.
+     * @param userFeedback The feedback to capture.
+     */
+    captureTraceFeedback(traceId: string | number, userFeedback: string) {
+        this.capture('$ai_metric', {
+            $ai_trace_id: String(traceId),
+            $ai_feedback_text: userFeedback,
+        })
+    }
+
+    /**
+     * Capture a metric for a LLM trace. Numeric values are converted to strings.
+     * @param traceId The trace ID to capture the metric for.
+     * @param metricName The name of the metric to capture.
+     * @param metricValue The value of the metric to capture.
+     */
+    captureTraceMetric(traceId: string | number, metricName: string, metricValue: string | number | boolean) {
+        this.capture('$ai_metric', {
+            $ai_trace_id: String(traceId),
+            $ai_metric_name: metricName,
+            $ai_metric_value: String(metricValue),
+        })
+    }
 }
 
 safewrapClass(PostHog, ['identify'])


### PR DESCRIPTION
## Problem

It should be straightforward to capture a LLM metric or feedback. Mirrors https://github.com/PostHog/posthog-js-lite/pull/365.

## Changes

- Add methods to capture user feedback and metrics.
- Convert values like numbers and booleans to strings to unify the property type.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
