### PR TITLE
refactor: Simplify `Posthog.init()` signature

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -368,7 +368,7 @@ export class PostHog {
         token: string,
         config?: OnlyValidKeys<Partial<PostHogConfig>, Partial<PostHogConfig>>,
         name?: string
-    ): PostHog | undefined {
+    ): PostHog {
         if (!name || name === PRIMARY_INSTANCE_NAME) {
             // This means we are initializing the primary instance (i.e. this)
             return this._init(token, config, name)


### PR DESCRIPTION
In a recent version, we updated the body of this function to always return a `Posthog` instance but we forgot to update the type, let's fix that

This is a slight type-level breaking change at `posthog-core.ts`. This is more serious than the recent changes we did to code that was only present in the React SDK. Should we ship this? I assume you'll have thoughts @pauldambra 

Originally written by https://github.com/thexeos but I couldn't get his PR to pass CI - secrets are not shared with contributors PRs

Closes #1616
Supersedes #1617 
