### PR TITLE
fix: checking status is too blunt for paused status

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -2301,6 +2301,9 @@ describe('SessionRecording', () => {
     describe('URL blocking', () => {
         beforeEach(() => {
             sessionRecording.startIfEnabledOrStop()
+        })
+
+        it('does not flush buffer and includes pause event when hitting blocked URL', async () => {
             sessionRecording.onRemoteConfig(
                 makeDecideResponse({
                     sessionRecording: {
@@ -2314,9 +2317,7 @@ describe('SessionRecording', () => {
                     },
                 })
             )
-        })
 
-        it('does not flush buffer and includes pause event when hitting blocked URL', async () => {
             // Emit some events before hitting blocked URL
             _emit(createIncrementalSnapshot({ data: { source: 1 } }))
             _emit(createIncrementalSnapshot({ data: { source: 2 } }))
@@ -2373,6 +2374,33 @@ describe('SessionRecording', () => {
                     data: { source: 5 },
                 }),
             ])
+        })
+
+        it('only pauses once when sampling determines session should not record', () => {
+            sessionRecording.onRemoteConfig(
+                makeDecideResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                        sampleRate: '0.00',
+                        urlBlocklist: [
+                            {
+                                matching: 'regex',
+                                url: '/blocked',
+                            },
+                        ],
+                    },
+                })
+            )
+            expect(sessionRecording['status']).toBe('disabled')
+
+            fakeNavigateTo('https://test.com/blocked')
+            expect(posthog.capture).not.toHaveBeenCalled()
+            expect(sessionRecording.status).toBe('disabled')
+            expect(sessionRecording['_urlBlocked']).toBe(true)
+            // can check this._tryAddCustomEvent('recording paused', { reason: 'url blocker' })
+
+            _emit(createIncrementalSnapshot({ data: { source: 1 } }))
+            // can check not this._tryAddCustomEvent('recording paused', { reason: 'url blocker' })
         })
     })
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -1239,7 +1239,7 @@ export class SessionRecording {
 
         const url = window.location.href
 
-        const wasBlocked = this.status === 'paused'
+        const wasBlocked = this._urlBlocked
         const isNowBlocked = sessionRecordingUrlTriggerMatches(url, this._urlBlocklist)
 
         if (isNowBlocked && !wasBlocked) {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -1268,7 +1268,8 @@ export class SessionRecording {
     }
 
     private _pauseRecording() {
-        if (this.status === 'paused') {
+        // we check _urlBlocked not status, since more than one thing can affect status
+        if (this._urlBlocked) {
             return
         }
 
@@ -1286,7 +1287,8 @@ export class SessionRecording {
     }
 
     private _resumeRecording() {
-        if (this.status !== 'paused') {
+        // we check _urlBlocked not status, since more than one thing can affect status
+        if (!this._urlBlocked) {
             return
         }
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -1039,7 +1039,7 @@ export class SessionRecording {
         // Check if the URL matches any trigger patterns
         this._checkUrlTriggerConditions()
 
-        if (this.status === 'paused' && !isRecordingPausedEvent(rawEvent)) {
+        if (this._urlBlocked && !isRecordingPausedEvent(rawEvent)) {
             return
         }
 
@@ -1177,7 +1177,12 @@ export class SessionRecording {
         const isBelowMinimumDuration =
             isNumber(minimumDuration) && isPositiveSessionDuration && sessionDuration < minimumDuration
 
-        if (this.status === 'buffering' || this.status === 'paused' || isBelowMinimumDuration) {
+        if (
+            this.status === 'buffering' ||
+            this.status === 'paused' ||
+            this.status === 'disabled' ||
+            isBelowMinimumDuration
+        ) {
             this.flushBufferTimer = setTimeout(() => {
                 this._flushBuffer()
             }, RECORDING_BUFFER_TIMEOUT)


### PR DESCRIPTION
We're checking if status is paused before pausing..

Makes sense, except we have multiple controls and only one status

So, it's possible to be pausable while sampling has determined you shouldn't be recording at all 🤦 . So if `sampling` had determined we should not record this session then we'd init a pause on every rrweb event... which probably causes rrweb events, and down the spiral to madness

Let's check a paused specific flag instead of the top level status