### PR TITLE
fix(flags): set default state values in feature flag hooks

### DIFF
--- a/react/src/hooks/useActiveFeatureFlags.ts
+++ b/react/src/hooks/useActiveFeatureFlags.ts
@@ -6,7 +6,11 @@ export function useActiveFeatureFlags(): string[] | undefined {
 
     const [featureFlags, setFeatureFlags] = useState<string[] | undefined>()
     // would be nice to have a default value above however it's not possible due
-    // to a hydration error when using nextjs
+    // to a hydration error when using nextjs. Instead, we set default value with useEffect
+    // which is only run on the client
+    useEffect(() => {
+        setFeatureFlags(client.featureFlags)
+    }, [])
 
     useEffect(() => {
         return client.onFeatureFlags((flags) => {

--- a/react/src/hooks/useFeatureFlagEnabled.ts
+++ b/react/src/hooks/useFeatureFlagEnabled.ts
@@ -6,7 +6,11 @@ export function useFeatureFlagEnabled(flag: string): boolean | undefined {
 
     const [featureEnabled, setFeatureEnabled] = useState<boolean | undefined>()
     // would be nice to have a default value above however it's not possible due
-    // to a hydration error when using nextjs
+    // to a hydration error when using nextjs. Instead, we set default value with useEffect
+    // which is only run on the client
+    useEffect(() => {
+        setFeatureEnabled(client.isFeatureEnabled(flag))
+    }, [])
 
     useEffect(() => {
         return client.onFeatureFlags(() => {

--- a/react/src/hooks/useFeatureFlagPayload.ts
+++ b/react/src/hooks/useFeatureFlagPayload.ts
@@ -7,7 +7,11 @@ export function useFeatureFlagPayload(flag: string): JsonType | undefined {
 
     const [featureFlagPayload, setFeatureFlagPayload] = useState<JsonType>()
     // would be nice to have a default value above however it's not possible due
-    // to a hydration error when using nextjs
+    // to a hydration error when using nextjs. Instead, we set default value with useEffect
+    // which is only run on the client
+    useEffect(() => {
+        setFeatureFlagPayload(client.getFeatureFlagPayload(flag))
+    }, [])
 
     useEffect(() => {
         return client.onFeatureFlags(() => {

--- a/react/src/hooks/useFeatureFlagVariantKey.ts
+++ b/react/src/hooks/useFeatureFlagVariantKey.ts
@@ -6,7 +6,11 @@ export function useFeatureFlagVariantKey(flag: string): string | boolean | undef
 
     const [featureFlagVariantKey, setFeatureFlagVariantKey] = useState<string | boolean>()
     // would be nice to have a default value above however it's not possible due
-    // to a hydration error when using nextjs
+    // to a hydration error when using nextjs. Instead, we set default value with useEffect
+    // which is only run on the client
+    useEffect(() => {
+        setFeatureFlagVariantKey(client.getFeatureFlag(flag))
+    }, [])
 
     useEffect(() => {
         return client.onFeatureFlags(() => {


### PR DESCRIPTION
## Changes
 Thread for context, although it is explained below: https://posthog.slack.com/archives/C07F4BF6WLT/p1738270875752869

**The problem:** For PostHog users who block their app from rendering until `onFeatureFlags` has been called, having no default value in our `useFeatureFlagEnabled` and related hooks means that on first render, `useFeatureFlagEnabled` will return its `useState`'s default value of `undefined`. Successive renders will get the correct value, but PostHog users would expect the hook to return the correct flag value if it has already been fetched on first render.

**The reason we can't use default value:** Since `posthog` client uses browser-only APIs like local storage, it can't be used in the `useState(<defaultValue)`. 

**The fix:** Instead, we can set the default values separately in a useEffect. 
This is documented clearly in NextJS: https://nextjs.org/docs/messages/react-hydration-error#solution-1-using-useeffect-to-run-on-the-client-only

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
