### PR TITLE
fix(flags): store setOnce properties in locally persisted feature flag props

### DIFF
--- a/src/__tests__/posthog-core.identify.test.ts
+++ b/src/__tests__/posthog-core.identify.test.ts
@@ -269,7 +269,7 @@ describe('identify()', () => {
             expect(instance.featureFlags.setAnonymousDistinctId).not.toHaveBeenCalled()
             expect(instance.featureFlags.reloadFeatureFlags).not.toHaveBeenCalled()
             expect(instance.featureFlags.setPersonPropertiesForFlags).toHaveBeenCalledWith(
-                { email: 'john@example.com' },
+                { email: 'john@example.com', howOftenAmISet: 'once!' },
                 true
             )
         })
@@ -280,7 +280,7 @@ describe('identify()', () => {
             expect(instance.featureFlags.setAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
             expect(instance.featureFlags.reloadFeatureFlags).toHaveBeenCalled()
             expect(instance.featureFlags.setPersonPropertiesForFlags).toHaveBeenCalledWith(
-                { email: 'john@example.com' },
+                { email: 'john@example.com', howOftenAmISet: 'once!' },
                 false
             )
         })

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1427,7 +1427,10 @@ export class PostHog {
             this.persistence.set_property(USER_STATE, 'identified')
 
             // Update current user properties
-            this.setPersonPropertiesForFlags(userPropertiesToSet || {}, false)
+            this.setPersonPropertiesForFlags(
+                { ...(userPropertiesToSetOnce || {}), ...(userPropertiesToSet || {}) },
+                false
+            )
 
             this.capture(
                 '$identify',
@@ -1484,7 +1487,7 @@ export class PostHog {
         }
 
         // Update current user properties
-        this.setPersonPropertiesForFlags(userPropertiesToSet || {})
+        this.setPersonPropertiesForFlags({ ...(userPropertiesToSetOnce || {}), ...(userPropertiesToSet || {}) })
 
         // if exactly this $set call has been sent before, don't send it again - determine based on hash of properties
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1366,7 +1366,8 @@ export class PostHog {
      * If you want to merge two identified users, you can call posthog.alias
      *
      * @param {String} [new_distinct_id] A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.
-     * @param {Object} [userPropertiesToSet] Optional: An associative array of properties to store about the user
+     * @param {Object} [userPropertiesToSet] Optional: An associative array of properties to store about the user. Note: For feature flag evaluations, if the same key is present in the userPropertiesToSetOnce,
+     *  it will be overwritten by the value in userPropertiesToSet.
      * @param {Object} [userPropertiesToSetOnce] Optional: An associative array of properties to store about the user. If property is previously set, this does not override that value.
      */
     identify(new_distinct_id?: string, userPropertiesToSet?: Properties, userPropertiesToSetOnce?: Properties): void {
@@ -1474,7 +1475,8 @@ export class PostHog {
      * identified_only, and a Person profile has not been created yet, this will create one.
      *
      *
-     * @param {Object} [userPropertiesToSet] Optional: An associative array of properties to store about the user
+     * @param {Object} [userPropertiesToSet] Optional: An associative array of properties to store about the user. Note: For feature flag evaluations, if the same key is present in the userPropertiesToSetOnce,
+     *  it will be overwritten by the value in userPropertiesToSet.
      * @param {Object} [userPropertiesToSetOnce] Optional: An associative array of properties to store about the user. If property is previously set, this does not override that value.
      */
     setPersonProperties(userPropertiesToSet?: Properties, userPropertiesToSetOnce?: Properties): void {


### PR DESCRIPTION
## Changes

Context: https://posthoghelp.zendesk.com/agent/tickets/24489 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26418)

Include `setOnce` properties in the locally persisted feature flag person properties: https://posthog.com/docs/feature-flags/adding-feature-flag-code#automatic-overrides

These are stored in local storage, but only used by feature flags for passing into the `/decide` call. This means that we should be safe from `setOnce` properties inadvertently overwriting previous property values.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
