### PR TITLE
fix(flags): set default state values in feature flag hooks

### DIFF
--- a/react/src/hooks/__tests__/featureFlags.test.jsx
+++ b/react/src/hooks/__tests__/featureFlags.test.jsx
@@ -5,6 +5,8 @@ import { useFeatureFlagPayload, useFeatureFlagVariantKey, useFeatureFlagEnabled,
 
 jest.useFakeTimers()
 
+const ACTIVE_FEATURE_FLAGS = ['example_feature_true', 'multivariate_feature', 'example_feature_payload']
+
 const FEATURE_FLAG_STATUS = {
     example_feature_true: true,
     example_feature_false: false,
@@ -38,6 +40,9 @@ describe('useFeatureFlagPayload hook', () => {
             }
             callback(activeFlags)
             return () => {}
+        },
+        featureFlags: {
+            getFlags: () => ACTIVE_FEATURE_FLAGS,
         },
     }))
 

--- a/react/src/hooks/useActiveFeatureFlags.ts
+++ b/react/src/hooks/useActiveFeatureFlags.ts
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react'
 import { usePostHog } from './usePostHog'
 
-export function useActiveFeatureFlags(): string[] | undefined {
+export function useActiveFeatureFlags(): string[] {
     const client = usePostHog()
 
-    const [featureFlags, setFeatureFlags] = useState<string[] | undefined>(() => client.featureFlags.getFlags())
+    const [featureFlags, setFeatureFlags] = useState<string[]>(() => client.featureFlags.getFlags())
 
     useEffect(() => {
         return client.onFeatureFlags((flags) => {

--- a/react/src/hooks/useActiveFeatureFlags.ts
+++ b/react/src/hooks/useActiveFeatureFlags.ts
@@ -5,8 +5,6 @@ export function useActiveFeatureFlags(): string[] | undefined {
     const client = usePostHog()
 
     const [featureFlags, setFeatureFlags] = useState<string[] | undefined>(() => client.featureFlags.getFlags())
-    // would be nice to have a default value above however it's not possible due
-    // to a hydration error when using nextjs
 
     useEffect(() => {
         return client.onFeatureFlags((flags) => {

--- a/react/src/hooks/useActiveFeatureFlags.ts
+++ b/react/src/hooks/useActiveFeatureFlags.ts
@@ -1,10 +1,12 @@
+'use client'
+
 import { useEffect, useState } from 'react'
 import { usePostHog } from './usePostHog'
 
 export function useActiveFeatureFlags(): string[] | undefined {
     const client = usePostHog()
 
-    const [featureFlags, setFeatureFlags] = useState<string[] | undefined>()
+    const [featureFlags, setFeatureFlags] = useState<string[] | undefined>(() => client.featureFlags.getFlags())
     // would be nice to have a default value above however it's not possible due
     // to a hydration error when using nextjs
 

--- a/react/src/hooks/useActiveFeatureFlags.ts
+++ b/react/src/hooks/useActiveFeatureFlags.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useEffect, useState } from 'react'
 import { usePostHog } from './usePostHog'
 

--- a/react/src/hooks/useFeatureFlagEnabled.ts
+++ b/react/src/hooks/useFeatureFlagEnabled.ts
@@ -5,8 +5,6 @@ export function useFeatureFlagEnabled(flag: string): boolean | undefined {
     const client = usePostHog()
 
     const [featureEnabled, setFeatureEnabled] = useState<boolean | undefined>(() => client.isFeatureEnabled(flag))
-    // would be nice to have a default value above however it's not possible due
-    // to a hydration error when using nextjs
 
     useEffect(() => {
         return client.onFeatureFlags(() => {

--- a/react/src/hooks/useFeatureFlagEnabled.ts
+++ b/react/src/hooks/useFeatureFlagEnabled.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useEffect, useState } from 'react'
 import { usePostHog } from './usePostHog'
 

--- a/react/src/hooks/useFeatureFlagEnabled.ts
+++ b/react/src/hooks/useFeatureFlagEnabled.ts
@@ -1,10 +1,12 @@
+'use client'
+
 import { useEffect, useState } from 'react'
 import { usePostHog } from './usePostHog'
 
 export function useFeatureFlagEnabled(flag: string): boolean | undefined {
     const client = usePostHog()
 
-    const [featureEnabled, setFeatureEnabled] = useState<boolean | undefined>()
+    const [featureEnabled, setFeatureEnabled] = useState<boolean | undefined>(() => client.isFeatureEnabled(flag))
     // would be nice to have a default value above however it's not possible due
     // to a hydration error when using nextjs
 

--- a/react/src/hooks/useFeatureFlagPayload.ts
+++ b/react/src/hooks/useFeatureFlagPayload.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { JsonType } from 'posthog-js'
 import { usePostHog } from './usePostHog'
 
-export function useFeatureFlagPayload(flag: string): JsonType | undefined {
+export function useFeatureFlagPayload(flag: string): JsonType {
     const client = usePostHog()
 
     const [featureFlagPayload, setFeatureFlagPayload] = useState<JsonType>(() => client.getFeatureFlagPayload(flag))

--- a/react/src/hooks/useFeatureFlagPayload.ts
+++ b/react/src/hooks/useFeatureFlagPayload.ts
@@ -6,8 +6,6 @@ export function useFeatureFlagPayload(flag: string): JsonType | undefined {
     const client = usePostHog()
 
     const [featureFlagPayload, setFeatureFlagPayload] = useState<JsonType>(() => client.getFeatureFlagPayload(flag))
-    // would be nice to have a default value above however it's not possible due
-    // to a hydration error when using nextjs
 
     useEffect(() => {
         return client.onFeatureFlags(() => {

--- a/react/src/hooks/useFeatureFlagPayload.ts
+++ b/react/src/hooks/useFeatureFlagPayload.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect, useState } from 'react'
 import { JsonType } from 'posthog-js'
 import { usePostHog } from './usePostHog'
@@ -5,7 +7,7 @@ import { usePostHog } from './usePostHog'
 export function useFeatureFlagPayload(flag: string): JsonType | undefined {
     const client = usePostHog()
 
-    const [featureFlagPayload, setFeatureFlagPayload] = useState<JsonType>()
+    const [featureFlagPayload, setFeatureFlagPayload] = useState<JsonType>(() => client.getFeatureFlagPayload(flag))
     // would be nice to have a default value above however it's not possible due
     // to a hydration error when using nextjs
 

--- a/react/src/hooks/useFeatureFlagPayload.ts
+++ b/react/src/hooks/useFeatureFlagPayload.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useEffect, useState } from 'react'
 import { JsonType } from 'posthog-js'
 import { usePostHog } from './usePostHog'

--- a/react/src/hooks/useFeatureFlagVariantKey.ts
+++ b/react/src/hooks/useFeatureFlagVariantKey.ts
@@ -1,12 +1,10 @@
-'use client'
-
 import { useEffect, useState } from 'react'
 import { usePostHog } from './usePostHog'
 
 export function useFeatureFlagVariantKey(flag: string): string | boolean | undefined {
     const client = usePostHog()
 
-    const [featureFlagVariantKey, setFeatureFlagVariantKey] = useState<string | boolean>(() =>
+    const [featureFlagVariantKey, setFeatureFlagVariantKey] = useState<string | boolean | undefined>(() =>
         client.getFeatureFlag(flag)
     )
     // would be nice to have a default value above however it's not possible due

--- a/react/src/hooks/useFeatureFlagVariantKey.ts
+++ b/react/src/hooks/useFeatureFlagVariantKey.ts
@@ -1,10 +1,14 @@
+'use client'
+
 import { useEffect, useState } from 'react'
 import { usePostHog } from './usePostHog'
 
 export function useFeatureFlagVariantKey(flag: string): string | boolean | undefined {
     const client = usePostHog()
 
-    const [featureFlagVariantKey, setFeatureFlagVariantKey] = useState<string | boolean>()
+    const [featureFlagVariantKey, setFeatureFlagVariantKey] = useState<string | boolean>(() =>
+        client.getFeatureFlag(flag)
+    )
     // would be nice to have a default value above however it's not possible due
     // to a hydration error when using nextjs
 

--- a/react/src/hooks/useFeatureFlagVariantKey.ts
+++ b/react/src/hooks/useFeatureFlagVariantKey.ts
@@ -7,8 +7,6 @@ export function useFeatureFlagVariantKey(flag: string): string | boolean | undef
     const [featureFlagVariantKey, setFeatureFlagVariantKey] = useState<string | boolean | undefined>(() =>
         client.getFeatureFlag(flag)
     )
-    // would be nice to have a default value above however it's not possible due
-    // to a hydration error when using nextjs
 
     useEffect(() => {
         return client.onFeatureFlags(() => {

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -97,7 +97,7 @@ export class PostHogPersistence {
             // selected storage type wasn't supported, fallback to 'localstorage+cookie' if possible
             store = localPlusCookieStore
         } else {
-            store = cookieStore
+            store = memoryStore
         }
 
         return store

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -97,7 +97,7 @@ export class PostHogPersistence {
             // selected storage type wasn't supported, fallback to 'localstorage+cookie' if possible
             store = localPlusCookieStore
         } else {
-            store = memoryStore
+            store = cookieStore
         }
 
         return store

--- a/src/types.ts
+++ b/src/types.ts
@@ -1389,7 +1389,7 @@ export interface ToolbarParams {
 export type SnippetArrayItem = [method: string, ...args: any[]]
 
 export type JsonRecord = { [key: string]: JsonType }
-export type JsonType = string | number | boolean | null | JsonRecord | Array<JsonType>
+export type JsonType = string | number | boolean | null | undefined | JsonRecord | Array<JsonType>
 
 /** A feature that isn't publicly available yet.*/
 export interface EarlyAccessFeature {


### PR DESCRIPTION
## Changes

Context: https://posthog.slack.com/archives/C07F4BF6WLT/p1738270875752869

TLDR:
To suppress a NextJS hydration error, we were previously forgoing default state values in our feature flags hooks. This was necessary because the `posthog` client methods like `isFeatureEnabled` use browser-only APIs like `localStorage` or `document`, which cannot run in SSR. 

Currently, we "fix" this issue by using solution #1 from the [nextjs docs](https://nextjs.org/docs/messages/react-hydration-error#possible-ways-to-fix-it). However, this results in the first render on the client side returning `undefined` from our feature flag hooks, which is both potentially incorrect (if flags are already loaded) and can cause bugs. Further, this hydration error does not actually apply to anyone using our React library for CSR-only.

However, `posthog-js` does not actually support SSR in any case - `usePosthog` uses the SSR-violating `useContext` hook, and our documentation even requires the `'use client'` [directive to initialize the SDK](https://posthog.com/docs/libraries/next-js#router-specific-instructions).

**Changes in this PR:** apply the default value directly in `useState` in our feature flag hooks. Since the hooks are only meant to be run within CSR anyway, this should not affect any users

Note: You cannot fix a problem like this by setting different default values if running in server vs client: NextJS will exhibit a hydration error if the initial render on the server-side does not match the initial render on the client-side: https://nextjs.org/docs/messages/react-hydration-error#possible-ways-to-fix-it

I've tested this works as expected with the existing (non-SSR) nextjs playground - no more `undefined` on initial render!

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
