### PR TITLE
fix: check url match twice because of potential race condition

### DIFF
--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -12,6 +12,7 @@ import {
 
 import * as Preact from 'preact'
 import { useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { addEventListener } from '../utils'
 import { document as _document, window as _window } from '../utils/globals'
 import { createLogger } from '../utils/logger'
 import { isNull, isNumber } from '../utils/type-utils'
@@ -35,7 +36,6 @@ import {
     style,
     SurveyContext,
 } from './surveys/surveys-utils'
-import { addEventListener } from '../utils'
 const logger = createLogger('[Surveys]')
 
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
@@ -76,6 +76,10 @@ export class SurveyManager {
             if (diffDaysFromToday < surveyWaitPeriodInDays) {
                 return
             }
+        }
+        // Adding this duplicate check to see if there's some sort of race-condition between getActiveMatchingSurveys and actual URL changes, as sometimes Surveys are shown up when they shouldn't be
+        if (!doesSurveyUrlMatch(survey)) {
+            return
         }
 
         const surveySeen = getSurveySeen(survey)

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -77,10 +77,6 @@ export class SurveyManager {
                 return
             }
         }
-        // Adding this duplicate check to see if there's some sort of race-condition between getActiveMatchingSurveys and actual URL changes, as sometimes Surveys are shown up when they shouldn't be
-        if (!doesSurveyUrlMatch(survey)) {
-            return
-        }
 
         const surveySeen = getSurveySeen(survey)
         if (!surveySeen) {
@@ -230,6 +226,10 @@ export class SurveyManager {
             nonAPISurveyQueue.forEach((survey) => {
                 // We only evaluate the display logic for one survey at a time
                 if (!isNull(this.surveyInFocus)) {
+                    return
+                }
+                // Adding this duplicate check to see if there's some sort of race-condition between getActiveMatchingSurveys and actual URL changes, as sometimes Surveys are shown up when they shouldn't be
+                if (!doesSurveyUrlMatch(survey)) {
                     return
                 }
                 if (survey.type === SurveyType.Widget) {


### PR DESCRIPTION
## Changes

Also checks if the URL condition is matching before actually rendering it.

This is to test wether or not there's some sort of race condition where the survey is rendered on the correct URL, but the URL changes, and before we process that, the survey is already rendered.

[Instance event where it happened](https://us.posthog.com/project/55348/person/6f932fa8c52e49cd8a581c7aa6a42487#activeTab=events). Survey is set to not sohw up in this event, but it did.

...

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
