### PR TITLE
fix: capture when argument is not a string

### DIFF
--- a/playwright/error-tracking.spec.ts
+++ b/playwright/error-tracking.spec.ts
@@ -3,30 +3,44 @@ import { start } from './utils/setup'
 import { pollUntilEventCaptured } from './utils/event-capture-utils'
 
 test.describe('Exception capture', () => {
-    test('manual exception capture', async ({ page, context }) => {
-        await start(
-            {
-                decideResponseOverrides: {
-                    autocaptureExceptions: false,
-                },
-                url: './playground/cypress/index.html',
-            },
-            page,
-            context
-        )
+    test.describe('Exception autocapture enabled', () => {
+        test.beforeEach(async ({ page, context }) => {
+            await start(
+                { decideResponseOverrides: { autocaptureExceptions: false }, url: './playground/cypress/index.html' },
+                page,
+                context
+            )
+        })
 
-        await page.click('[data-cy-exception-button]')
+        test('manual exception capture of error', async ({ page }) => {
+            await page.click('[data-cy-exception-button]')
 
-        await pollUntilEventCaptured(page, '$exception')
+            await pollUntilEventCaptured(page, '$exception')
 
-        const captures = await page.capturedEvents()
-        expect(captures.map((c) => c.event)).toEqual(['$pageview', '$autocapture', '$exception'])
-        expect(captures[2].event).toEqual('$exception')
-        expect(captures[2].properties.extra_prop).toEqual(2)
-        expect(captures[2].properties.$exception_source).toBeUndefined()
-        expect(captures[2].properties.$exception_personURL).toBeUndefined()
-        expect(captures[2].properties.$exception_list[0].value).toEqual('wat even am I')
-        expect(captures[2].properties.$exception_list[0].type).toEqual('Error')
+            const captures = await page.capturedEvents()
+            expect(captures.map((c) => c.event)).toEqual(['$pageview', '$autocapture', '$exception'])
+            expect(captures[2].event).toEqual('$exception')
+            expect(captures[2].properties.extra_prop).toEqual(2)
+            expect(captures[2].properties.$exception_source).toBeUndefined()
+            expect(captures[2].properties.$exception_personURL).toBeUndefined()
+            expect(captures[2].properties.$exception_list[0].value).toEqual('wat even am I')
+            expect(captures[2].properties.$exception_list[0].type).toEqual('Error')
+        })
+
+        test('manual exception capture of string', async ({ page }) => {
+            await page.click('[data-cy-exception-string-button]')
+
+            await pollUntilEventCaptured(page, '$exception')
+
+            const captures = await page.capturedEvents()
+            expect(captures.map((c) => c.event)).toEqual(['$pageview', '$autocapture', '$exception'])
+            expect(captures[2].event).toEqual('$exception')
+            expect(captures[2].properties.extra_prop).toEqual(2)
+            expect(captures[2].properties.$exception_source).toBeUndefined()
+            expect(captures[2].properties.$exception_personURL).toBeUndefined()
+            expect(captures[2].properties.$exception_list[0].value).toEqual('I am a plain old string')
+            expect(captures[2].properties.$exception_list[0].type).toEqual('Error')
+        })
     })
 
     test.describe('Exception autocapture enabled', () => {
@@ -34,9 +48,7 @@ test.describe('Exception capture', () => {
             await page.waitingForNetworkCausedBy(['**/exception-autocapture.js*'], async () => {
                 await start(
                     {
-                        decideResponseOverrides: {
-                            autocaptureExceptions: true,
-                        },
+                        decideResponseOverrides: { autocaptureExceptions: true },
                         url: './playground/cypress/index.html',
                     },
                     page,

--- a/src/__tests__/extensions/exception-autocapture/error-conversion.test.ts
+++ b/src/__tests__/extensions/exception-autocapture/error-conversion.test.ts
@@ -43,7 +43,9 @@ describe('Error conversion', () => {
                 },
             ],
         }
-        expect(errorToProperties(['Uncaught exception: InternalError: but somehow still a string'])).toEqual(expected)
+        expect(errorToProperties({ event: 'Uncaught exception: InternalError: but somehow still a string' })).toEqual(
+            expected
+        )
     })
 
     it('should convert a plain object to an error', () => {
@@ -57,7 +59,7 @@ describe('Error conversion', () => {
                 },
             ],
         }
-        expect(errorToProperties([{ string: 'candidate', foo: 'bar' } as unknown as Event])).toEqual(expected)
+        expect(errorToProperties({ event: { string: 'candidate', foo: 'bar' } as unknown as Event })).toEqual(expected)
     })
 
     it('should convert a plain Event to an error', () => {
@@ -72,13 +74,13 @@ describe('Error conversion', () => {
             ],
         }
         const event = new MouseEvent('click', { bubbles: true, cancelable: true, composed: true })
-        expect(errorToProperties([event])).toEqual(expected)
+        expect(errorToProperties({ event })).toEqual(expected)
     })
 
     it('should convert a plain Error to an error', () => {
         const error = new Error('oh no an error has happened')
 
-        const errorProperties = errorToProperties(['something', undefined, undefined, undefined, error])
+        const errorProperties = errorToProperties({ event: 'something', error })
         if (isNull(errorProperties)) {
             throw new Error("this mustn't be null")
         }
@@ -115,12 +117,12 @@ describe('Error conversion', () => {
             ],
         }
         const event = new FakeDomError('click', 'foo')
-        expect(errorToProperties([event as unknown as Event])).toEqual(expected)
+        expect(errorToProperties({ event: event as unknown as Event })).toEqual(expected)
     })
 
     it('should convert a DOM Exception to an error', () => {
         const event = new DOMException('oh no disaster', 'dom-exception')
-        const errorProperties = errorToProperties([event as unknown as Event])
+        const errorProperties = errorToProperties({ event: event as unknown as Event })
 
         if (isNull(errorProperties)) {
             throw new Error("this mustn't be null")
@@ -140,7 +142,7 @@ describe('Error conversion', () => {
     it('should convert an error event to an error', () => {
         const event = new ErrorEvent('oh no an error event', { error: new Error('the real error is hidden inside') })
 
-        const errorProperties = errorToProperties([event as unknown as Event])
+        const errorProperties = errorToProperties({ event: event as unknown as Event })
         if (isNull(errorProperties)) {
             throw new Error("this mustn't be null")
         }
@@ -155,20 +157,6 @@ describe('Error conversion', () => {
         expect(errorProperties.$exception_list[0].stacktrace.frames[0].filename).toBeDefined()
         expect(errorProperties.$exception_list[0].mechanism.synthetic).toEqual(false)
         expect(errorProperties.$exception_list[0].mechanism.handled).toEqual(true)
-    })
-
-    it('can convert source, lineno, colno', () => {
-        const expected: ErrorProperties = {
-            $exception_level: 'error',
-            $exception_list: [
-                {
-                    type: 'Error',
-                    value: 'string candidate',
-                    mechanism: { synthetic: true, handled: true },
-                },
-            ],
-        }
-        expect(errorToProperties(['string candidate', 'a source', 12, 200])).toEqual(expected)
     })
 
     it('should convert unhandled promise rejection that the browser has messed around with', () => {

--- a/src/entrypoints/exception-autocapture.ts
+++ b/src/entrypoints/exception-autocapture.ts
@@ -12,10 +12,10 @@ const wrapOnError = (captureFn: (props: Properties) => void) => {
     }
     const originalOnError = win.onerror
 
-    win.onerror = function (...args: ErrorEventArgs): boolean {
-        const errorProperties = errorToProperties(args)
+    win.onerror = function (args: ErrorEventArgs): boolean {
+        const errorProperties = errorToProperties({ event: args[0], error: args[4] })
         captureFn(errorProperties)
-        return originalOnError?.(...args) ?? false
+        return originalOnError?.(args) ?? false
     }
     win.onerror.__POSTHOG_INSTRUMENTED__ = true
 

--- a/src/entrypoints/exception-autocapture.ts
+++ b/src/entrypoints/exception-autocapture.ts
@@ -12,10 +12,10 @@ const wrapOnError = (captureFn: (props: Properties) => void) => {
     }
     const originalOnError = win.onerror
 
-    win.onerror = function (args: ErrorEventArgs): boolean {
+    win.onerror = function (...args: ErrorEventArgs): boolean {
         const errorProperties = errorToProperties({ event: args[0], error: args[4] })
         captureFn(errorProperties)
-        return originalOnError?.(args) ?? false
+        return originalOnError?.(...args) ?? false
     }
     win.onerror.__POSTHOG_INSTRUMENTED__ = true
 

--- a/src/extensions/exception-autocapture/error-conversion.ts
+++ b/src/extensions/exception-autocapture/error-conversion.ts
@@ -11,7 +11,7 @@ import {
 import { defaultStackParser, StackFrame } from './stack-trace'
 
 import { isEmptyString, isString, isUndefined } from '../../utils/type-utils'
-import { ErrorEventArgs, ErrorMetadata, SeverityLevel, severityLevels } from '../../types'
+import { ErrorConversionArgs, ErrorEventArgs, ErrorMetadata, SeverityLevel, severityLevels } from '../../types'
 
 export interface ErrorProperties {
     $exception_list: Exception[]
@@ -243,11 +243,7 @@ function errorPropertiesFromObject(candidate: Record<string, unknown>, metadata?
     }
 }
 
-export function errorToProperties(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    [event, _, __, ___, error]: ErrorEventArgs,
-    metadata?: ErrorMetadata
-): ErrorProperties {
+export function errorToProperties({ error, event }: ErrorConversionArgs, metadata?: ErrorMetadata): ErrorProperties {
     let errorProperties: ErrorProperties = { $exception_list: [] }
 
     const candidate = error || event
@@ -312,11 +308,14 @@ export function unhandledRejectionToProperties([ev]: [ev: PromiseRejectionEvent]
         })
     }
 
-    return errorToProperties([error as string | Event], {
-        handled: false,
-        overrideExceptionType: 'UnhandledRejection',
-        defaultExceptionMessage: String(error),
-    })
+    return errorToProperties(
+        { event: error as string | Event },
+        {
+            handled: false,
+            overrideExceptionType: 'UnhandledRejection',
+            defaultExceptionMessage: String(error),
+        }
+    )
 }
 
 function getUnhandledRejectionError(error: unknown): unknown {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1503,6 +1503,11 @@ export type CapturedNetworkRequest = Writable<Omit<PerformanceEntry, 'toJSON'>> 
     isInitial?: boolean
 }
 
+export type ErrorConversionArgs = {
+    event: string | Event
+    error?: Error
+}
+
 export type ErrorEventArgs = [
     event: string | Event,
     source?: string | undefined,

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -3,7 +3,7 @@ import type { PostHog } from '../posthog-core'
 import { SessionIdManager } from '../sessionid'
 import {
     DeadClicksAutoCaptureConfig,
-    ErrorEventArgs,
+    ErrorConversionArgs,
     ErrorMetadata,
     Properties,
     RemoteConfig,
@@ -66,10 +66,7 @@ interface PostHogExtensions {
 
     loadSiteApp?: (posthog: PostHog, appUrl: string, callback: (error?: string | Event, event?: Event) => void) => void
 
-    parseErrorAsProperties?: (
-        [event, source, lineno, colno, error]: ErrorEventArgs,
-        metadata?: ErrorMetadata
-    ) => ErrorProperties
+    parseErrorAsProperties?: ({ error, event }: ErrorConversionArgs, metadata?: ErrorMetadata) => ErrorProperties
     errorWrappingFunctions?: {
         wrapOnError: (captureFn: (props: Properties) => void) => () => void
         wrapUnhandledRejection: (captureFn: (props: Properties) => void) => () => void

--- a/src/utils/type-utils.ts
+++ b/src/utils/type-utils.ts
@@ -90,6 +90,10 @@ export const isFile = (x: unknown): x is File => {
     return x instanceof File
 }
 
+export const isError = (x: unknown): x is Error => {
+    return x instanceof Error
+}
+
 export const isKnownUnsafeEditableEvent = (x: unknown): x is KnownUnsafeEditableEvent => {
     return includes(knownUnsafeEditableEvent as unknown as string[], x)
 }


### PR DESCRIPTION
## Changes

Because you could call `captureException()` with a string it is possible that the type and value would be undefined if autocapture was disabled because of:
```
...
type: error.name,
value: error.message,
...
```

Adds a fix to check for an error type and if not just use the provided value. This is best effort given we don't import the full `exception-conversion` file for this case