### PR TITLE
Add e-commerce test page to nextjs playground

### DIFF
--- a/playground/nextjs/pages/_app.tsx
+++ b/playground/nextjs/pages/_app.tsx
@@ -12,6 +12,8 @@ import { PageHeader } from '@/src/Header'
 import { useUser } from '@/src/auth'
 import { posthogHelpers } from '@/src/posthog'
 
+const CDP_DOMAINS = ['https://*.redditstatic.com', 'https://*.reddit.com'].join(' ')
+
 export default function App({ Component, pageProps }: AppProps) {
     const router = useRouter()
 
@@ -54,10 +56,10 @@ export default function App({ Component, pageProps }: AppProps) {
                     httpEquiv="Content-Security-Policy"
                     content={`
                     default-src 'self';
-                    connect-src 'self' ${localhostDomain} https://*.posthog.com https://lottie.host;
-                    script-src 'self' 'unsafe-eval' 'unsafe-inline' ${localhostDomain} https://*.posthog.com;
+                    connect-src 'self' ${localhostDomain} https://*.posthog.com https://lottie.host ${CDP_DOMAINS};
+                    script-src 'self' 'unsafe-eval' 'unsafe-inline' ${localhostDomain} https://*.posthog.com ${CDP_DOMAINS};
                     style-src 'self' 'unsafe-inline' ${localhostDomain} https://*.posthog.com;
-                    img-src 'self' ${localhostDomain} https://*.posthog.com https://lottie.host;
+                    img-src 'self' ${localhostDomain} https://*.posthog.com https://lottie.host ${CDP_DOMAINS};
                 `}
                 />
             </Head>

--- a/playground/nextjs/pages/ecommerce.tsx
+++ b/playground/nextjs/pages/ecommerce.tsx
@@ -1,0 +1,80 @@
+import { usePostHog } from 'posthog-js/react'
+
+const events = [
+    {
+        name: 'Product Added',
+        properties: {
+            product_id: 'SomeProductID',
+            name: 'SomeProductName',
+            price: 42,
+            quantity: 1,
+        },
+    },
+    {
+        name: 'Products Searched',
+        properties: {
+            products: [
+                {
+                    product_id: 'SomeProductID',
+                    name: 'SomeProductName',
+                    price: 42,
+                },
+                {
+                    product_id: 'OtherProductID',
+                    name: 'OtherProductName',
+                    price: 43,
+                },
+            ],
+        },
+    },
+    {
+        name: 'Product Added to Wishlist',
+        properties: {
+            product_id: 'SomeProductID',
+            name: 'SomeProductName',
+            price: 42,
+            quantity: 1,
+            wishlist_id: 'SomeWishlistID',
+            wishlist_name: 'SomeWishlistName',
+        },
+    },
+    {
+        name: 'Order Completed',
+        properties: {
+            products: [
+                {
+                    product_id: 'SomeProductID',
+                    name: 'SomeProductName',
+                    price: 42,
+                },
+                {
+                    product_id: 'OtherProductID',
+                    name: 'OtherProductName',
+                    price: 43,
+                },
+            ],
+            total: 83,
+            currency: 'USD',
+        },
+    },
+    {
+        name: 'Custom Event',
+        properties: {
+            foo: 'bar',
+        },
+    },
+]
+
+export default function SurveyForm() {
+    const posthog = usePostHog()
+
+    return (
+        <div className="flex items-center gap-2 flex-wrap">
+            {events.map((event) => (
+                <button key={event.name} onClick={() => posthog.capture(event.name, event.properties)}>
+                    {event.name}
+                </button>
+            ))}
+        </div>
+    )
+}

--- a/playground/nextjs/src/Header.tsx
+++ b/playground/nextjs/src/Header.tsx
@@ -25,6 +25,7 @@ export const PageHeader = () => {
                         <Link href="/replay-examples/canvas">Canvas</Link>
                         <Link href="/replay-examples/media">Media</Link>
                         <Link href="/replay-examples/long">Long</Link>
+                        <Link href="/ecommerce">E-commerce</Link>
                     </div>
 
                     <div>

--- a/playground/nextjs/src/posthog.ts
+++ b/playground/nextjs/src/posthog.ts
@@ -4,7 +4,7 @@
 // import 'posthog-js/dist/exception-autocapture'
 // import 'posthog-js/dist/tracing-headers'
 
-import posthogJS, { PostHogConfig } from 'posthog-js'
+import posthogJS, { PostHog, PostHogConfig } from 'posthog-js'
 import { User } from './auth'
 
 export const PERSON_PROCESSING_MODE: 'always' | 'identified_only' | 'never' =
@@ -12,7 +12,7 @@ export const PERSON_PROCESSING_MODE: 'always' | 'identified_only' | 'never' =
 
 export const POSTHOG_USE_SNIPPET: boolean = (process.env.NEXT_PUBLIC_POSTHOG_USE_SNIPPET as any) || false
 
-export const posthog = POSTHOG_USE_SNIPPET
+export const posthog: PostHog = POSTHOG_USE_SNIPPET
     ? typeof window !== 'undefined'
         ? (window as any).posthog
         : null
@@ -64,6 +64,7 @@ if (typeof window !== 'undefined') {
         persistence_name: `${process.env.NEXT_PUBLIC_POSTHOG_KEY}_nextjs`,
         opt_in_site_apps: true,
         __preview_remote_config: true,
+        __preview_experimental_cookieless_mode: false,
         ...configForConsent(),
     })
     // Help with debugging


### PR DESCRIPTION
## Changes

I wanted to add a page to test out these specific events manually, may as well commit it

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
