### PR TITLE
feat: override exception capture clientside

### DIFF
--- a/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -437,6 +437,11 @@ exports[`config snapshot for PostHogConfig 1`] = `
       \\"Pick<AutocaptureConfig, \\\\\\"element_attribute_ignorelist\\\\\\">\\"
     ]
   ],
+  \\"capture_exceptions\\": [
+    \\"undefined\\",
+    \\"false\\",
+    \\"true\\"
+  ],
   \\"disable_scroll_properties\\": [
     \\"undefined\\",
     \\"false\\",

--- a/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
+++ b/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
@@ -71,7 +71,7 @@ describe('Exception Observer', () => {
         })
 
         it('should instrument handlers when started', () => {
-            expect(exceptionObserver.isCapturing).toBe(true)
+            expect(exceptionObserver.hasHandlers).toBe(true)
             expect(exceptionObserver.isEnabled).toBe(true)
 
             expect((window?.onerror as any).__POSTHOG_INSTRUMENTED__).toBe(true)
@@ -84,7 +84,7 @@ describe('Exception Observer', () => {
             expect((window?.onerror as any)?.__POSTHOG_INSTRUMENTED__).not.toBeDefined()
             expect((window?.onunhandledrejection as any)?.__POSTHOG_INSTRUMENTED__).not.toBeDefined()
 
-            expect(exceptionObserver.isCapturing).toBe(false)
+            expect(exceptionObserver.hasHandlers).toBe(false)
         })
 
         it('captures an event when an error is thrown', () => {
@@ -224,9 +224,9 @@ describe('Exception Observer', () => {
     describe('when no decide response', () => {
         it('cannot be started', () => {
             expect(exceptionObserver.isEnabled).toBe(false)
-            expect(exceptionObserver.isCapturing).toBe(false)
+            expect(exceptionObserver.hasHandlers).toBe(false)
             exceptionObserver['startCapturing']()
-            expect(exceptionObserver.isCapturing).toBe(false)
+            expect(exceptionObserver.hasHandlers).toBe(false)
         })
     })
 
@@ -237,9 +237,9 @@ describe('Exception Observer', () => {
 
         it('cannot be started', () => {
             expect(exceptionObserver.isEnabled).toBe(false)
-            expect(exceptionObserver.isCapturing).toBe(false)
+            expect(exceptionObserver.hasHandlers).toBe(false)
             exceptionObserver['startCapturing']()
-            expect(exceptionObserver.isCapturing).toBe(false)
+            expect(exceptionObserver.hasHandlers).toBe(false)
         })
     })
 })

--- a/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
+++ b/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
@@ -162,9 +162,17 @@ describe('Exception Observer', () => {
             })
             expect(request.batchKey).toBe('exceptionEvent')
         })
+
+        it('should instrument handlers when started', () => {
+            posthog.config.capture_exceptions = false
+            exceptionObserver = new ExceptionObserver(posthog)
+
+            expect(exceptionObserver.hasHandlers).toBe(false)
+            expect(exceptionObserver.isEnabled).toBe(false)
+        })
     })
 
-    describe('when there are handlers already', () => {
+    describe('when there are handlers already present', () => {
         const originalOnError = jest.fn()
         const originalOnUnhandledRejection = jest.fn()
 

--- a/src/extensions/exception-autocapture/index.ts
+++ b/src/extensions/exception-autocapture/index.ts
@@ -22,10 +22,7 @@ export class ExceptionObserver {
     }
 
     public get isEnabled(): boolean {
-        if (
-            !isUndefined(this.instance.config.capture_exceptions) &&
-            isBoolean(this.instance.config.capture_exceptions)
-        ) {
+        if (isBoolean(this.instance.config.capture_exceptions)) {
             return this.instance.config.capture_exceptions
         }
         return this.remoteEnabled ?? false

--- a/src/extensions/exception-autocapture/index.ts
+++ b/src/extensions/exception-autocapture/index.ts
@@ -4,13 +4,13 @@ import { Properties, RemoteConfig } from '../../types'
 
 import { createLogger } from '../../utils/logger'
 import { EXCEPTION_CAPTURE_ENABLED_SERVER_SIDE } from '../../constants'
+import { isBoolean, isUndefined } from '../../utils/type-utils'
 
 const logger = createLogger('[ExceptionAutocapture]')
 
 export class ExceptionObserver {
     instance: PostHog
     remoteEnabled: boolean | undefined
-    private originalOnUnhandledRejectionHandler: Window['onunhandledrejection'] | null | undefined = undefined
     private unwrapOnError: (() => void) | undefined
     private unwrapUnhandledRejection: (() => void) | undefined
 
@@ -21,20 +21,22 @@ export class ExceptionObserver {
         this.startIfEnabled()
     }
 
-    get isEnabled() {
+    public get isEnabled(): boolean {
+        if (
+            !isUndefined(this.instance.config.capture_exceptions) &&
+            isBoolean(this.instance.config.capture_exceptions)
+        ) {
+            return this.instance.config.capture_exceptions
+        }
         return this.remoteEnabled ?? false
     }
 
-    get isCapturing() {
-        return !!(window?.onerror as any)?.__POSTHOG_INSTRUMENTED__
-    }
-
     get hasHandlers() {
-        return this.originalOnUnhandledRejectionHandler || this.unwrapOnError
+        return !isUndefined(this.unwrapOnError)
     }
 
     startIfEnabled(): void {
-        if (this.isEnabled && !this.isCapturing) {
+        if (this.isEnabled && !this.hasHandlers) {
             logger.info('enabled, starting...')
             this.loadScript(this.startCapturing)
         }
@@ -59,7 +61,7 @@ export class ExceptionObserver {
     }
 
     private startCapturing = () => {
-        if (!window || !this.isEnabled || this.hasHandlers || this.isCapturing) {
+        if (!window || !this.isEnabled || this.hasHandlers) {
             return
         }
 
@@ -83,7 +85,10 @@ export class ExceptionObserver {
 
     private stopCapturing() {
         this.unwrapOnError?.()
+        this.unwrapOnError = undefined
+
         this.unwrapUnhandledRejection?.()
+        this.unwrapUnhandledRejection = undefined
     }
 
     onRemoteConfig(response: RemoteConfig) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -780,7 +780,13 @@ export interface PostHogConfig {
      * @see {DeadClicksAutoCaptureConfig}
      * @default undefined
      */
-    capture_dead_clicks?: boolean | DeadClicksAutoCaptureConfig
+    capture_dead_clicks?: boolean | DeadClicksAutoCaptureConfig /**
+
+    * Determines whether to capture exceptions.
+    *
+    * @default undefined
+    */
+    capture_exceptions?: boolean
 
     /**
      * Determines whether to disable scroll properties.

--- a/src/types.ts
+++ b/src/types.ts
@@ -780,12 +780,13 @@ export interface PostHogConfig {
      * @see {DeadClicksAutoCaptureConfig}
      * @default undefined
      */
-    capture_dead_clicks?: boolean | DeadClicksAutoCaptureConfig /**
+    capture_dead_clicks?: boolean | DeadClicksAutoCaptureConfig
 
-    * Determines whether to capture exceptions.
-    *
-    * @default undefined
-    */
+    /**
+     * Determines whether to capture exceptions.
+     *
+     * @default undefined
+     */
     capture_exceptions?: boolean
 
     /**


### PR DESCRIPTION
## Changes

Right now there is no way to disable exception autocapture clientside.

Adds a config option that takes precedence over the server value