### PR TITLE
fix: canvas quality value

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -350,6 +350,35 @@ describe('SessionRecording', () => {
                 expect(sessionRecording['canvasRecording']).toMatchObject({ enabled: expected, fps: 4, quality: 0.1 })
             }
         )
+
+        it.each([
+            ['max fps and quality', 12, '1.0', 12, 1],
+            ['min fps and quality', 0, '0.0', 0, 0],
+            ['mid fps and quality', 6, '0.5', 6, 0.5],
+            ['null fps and quality', null, null, 4, 0.4],
+            ['undefined fps and quality', undefined, undefined, 4, 0.4],
+            ['string fps and quality', '12', '1.0', 4, 1],
+            ['over max fps and quality', 15, '1.5', 12, 1],
+        ])(
+            '%s',
+            (
+                _name: string,
+                fps: number | string | null | undefined,
+                quality: string | null | undefined,
+                expectedFps: number,
+                expectedQuality: number
+            ) => {
+                posthog.persistence?.register({
+                    [SESSION_RECORDING_CANVAS_RECORDING]: { enabled: true, fps, quality },
+                })
+
+                expect(sessionRecording['canvasRecording']).toMatchObject({
+                    enabled: true,
+                    fps: expectedFps,
+                    quality: expectedQuality,
+                })
+            }
+        )
     })
 
     describe('network timing capture config', () => {

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -344,10 +344,10 @@ describe('SessionRecording', () => {
             '%s',
             (_name: string, serverSide: boolean | undefined, clientSide: boolean | undefined, expected: boolean) => {
                 posthog.persistence?.register({
-                    [SESSION_RECORDING_CANVAS_RECORDING]: { enabled: serverSide, fps: 4, quality: 0.1 },
+                    [SESSION_RECORDING_CANVAS_RECORDING]: { enabled: serverSide, fps: 4, quality: '0.1' },
                 })
                 posthog.config.session_recording.captureCanvas = { recordCanvas: clientSide }
-                expect(sessionRecording['canvasRecording']).toMatchObject({ enabled: expected })
+                expect(sessionRecording['canvasRecording']).toMatchObject({ enabled: expected, fps: 4, quality: 0.1 })
             }
         )
     })

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -337,9 +337,14 @@ export class SessionRecording {
         const canvasRecording_client_side = this.instance.config.session_recording.captureCanvas
         const canvasRecording_server_side = this.instance.get_property(SESSION_RECORDING_CANVAS_RECORDING)
 
-        const enabled = canvasRecording_client_side?.recordCanvas ?? canvasRecording_server_side?.enabled ?? false
-        const fps = canvasRecording_client_side?.canvasFps ?? canvasRecording_server_side?.fps ?? 0
-        const quality = canvasRecording_client_side?.canvasQuality ?? canvasRecording_server_side?.quality ?? 0
+        const enabled: boolean =
+            canvasRecording_client_side?.recordCanvas ?? canvasRecording_server_side?.enabled ?? false
+        const fps: number = canvasRecording_client_side?.canvasFps ?? canvasRecording_server_side?.fps ?? 0
+        let quality: string | number =
+            canvasRecording_client_side?.canvasQuality ?? canvasRecording_server_side?.quality ?? 0
+        if (typeof quality === 'string') {
+            quality = parseFloat(quality)
+        }
 
         return {
             enabled,

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -339,17 +339,17 @@ export class SessionRecording {
 
         const enabled: boolean =
             canvasRecording_client_side?.recordCanvas ?? canvasRecording_server_side?.enabled ?? false
-        const fps: number = canvasRecording_client_side?.canvasFps ?? canvasRecording_server_side?.fps ?? 0
+        const fps: number = canvasRecording_client_side?.canvasFps ?? canvasRecording_server_side?.fps ?? 4
         let quality: string | number =
-            canvasRecording_client_side?.canvasQuality ?? canvasRecording_server_side?.quality ?? 0
+            canvasRecording_client_side?.canvasQuality ?? canvasRecording_server_side?.quality ?? 0.4
         if (typeof quality === 'string') {
             quality = parseFloat(quality)
         }
 
         return {
             enabled,
-            fps: clampToRange(fps, 0, 12, 'canvas recording fps'),
-            quality: clampToRange(quality, 0, 1, 'canvas recording quality'),
+            fps: clampToRange(fps, 0, 12, 'canvas recording fps', 4),
+            quality: clampToRange(quality, 0, 1, 'canvas recording quality', 0.4),
         }
     }
 


### PR DESCRIPTION
when clamping canvas quality to range we aren't first checking it's a number 😓 

this improves that and adds a matrix test to validate the config parsing