### PR TITLE
feat(flags): Add remote config feature flag method that bypasses cached values

### DIFF
--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -364,7 +364,7 @@ export class PostHogFeatureFlags {
      * Fetches the payload for a remote config feature flag. This method will bypass any cached values and fetch the latest
      * value from the PostHog API.
      *
-     * Note: Encrypted remote config payloads will not be redacted, not decrypted in the response.
+     * Note: Encrypted remote config payloads will not be redacted, nor decrypted in the response.
      *
      * ### Usage:
      *

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -9,6 +9,7 @@ import {
     JsonType,
     Compression,
     EarlyAccessFeature,
+    RemoteConfigFeatureFlagCallback,
 } from './types'
 import { PostHogPersistence } from './posthog-persistence'
 
@@ -357,6 +358,37 @@ export class PostHogFeatureFlags {
     getFeatureFlagPayload(key: string): JsonType {
         const payloads = this.getFlagPayloads()
         return payloads[key]
+    }
+
+    /*
+     * Fetches the payload for a remote config feature flag. This method will bypass any cached values and fetch the latest
+     * value from the PostHog API.
+     *
+     * Note: Encrypted remote config payloads will not be redacted, not decrypted in the response.
+     *
+     * ### Usage:
+     *
+     *     getRemoteConfigPayload("home-page-welcome-message", (payload) => console.log(`Fetched remote config: ${payload}`))
+     *
+     * @param {String} key Key of the feature flag.
+     * @param {Function} [callback] The callback function will be called once the remote config feature flag payload has been fetched.
+     */
+    getRemoteConfigPayload(key: string, callback: RemoteConfigFeatureFlagCallback): void {
+        const token = this.instance.config.token
+        this.instance._send_request({
+            method: 'POST',
+            url: this.instance.requestRouter.endpointFor('api', '/decide/?v=3'),
+            data: {
+                distinct_id: this.instance.get_distinct_id(),
+                token,
+            },
+            compression: this.instance.config.disable_compression ? undefined : Compression.Base64,
+            timeout: this.instance.config.feature_flag_request_timeout_ms,
+            callback: (response) => {
+                const flagPayloads = response.json?.['featureFlagPayloads']
+                callback(flagPayloads?.[key] || undefined)
+            },
+        })
     }
 
     /*

--- a/src/types.ts
+++ b/src/types.ts
@@ -1356,6 +1356,8 @@ export type FeatureFlagsCallback = (
     }
 ) => void
 
+export type RemoteConfigFeatureFlagCallback = (payload: JsonType) => void
+
 export interface PersistentStore {
     is_supported: () => boolean
     error: (error: any) => void


### PR DESCRIPTION
## Changes

Adds `getRemoteConfigPayload` to feature flags, which re-calls `/decide` and returns the single remote config feature flag payload:

<img width="689" alt="Screenshot 2025-02-12 at 7 00 48 PM" src="https://github.com/user-attachments/assets/39c0fda9-e383-4b9b-8253-f0352e062160" />
<img width="365" alt="Screenshot 2025-02-12 at 7 00 41 PM" src="https://github.com/user-attachments/assets/11b1e197-4486-4a76-b482-6dbc605e8d5a" />

Context: https://posthog.slack.com/archives/C074A08LP1B/p1739376378507109

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
  - Looking into this!
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
