### PR TITLE
fix: unexpected undefined should be expected

### DIFF
--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -153,8 +153,8 @@ export type compressedIncrementalStyleSnapshotEvent = {
         styleId?: number
         replace?: string
         replaceSync?: string
-        adds: string
-        removes: string
+        adds?: string
+        removes?: string
     }
 }
 
@@ -209,8 +209,8 @@ function compressEvent(event: eventWithTime): eventWithTime | compressedEventWit
                 cv: '2024-10',
                 data: {
                     ...event.data,
-                    adds: gzipToString(event.data.adds),
-                    removes: gzipToString(event.data.removes),
+                    adds: event.data.adds ? gzipToString(event.data.adds) : undefined,
+                    removes: event.data.removes ? gzipToString(event.data.removes) : undefined,
                 },
             }
         }


### PR DESCRIPTION
While investigating something else on a customer site I noticed an error caused by this code

The error is handled and safe, but it turns out unnecessary.

I'd typed stylesheet rules as always having adds and removes, but they can be undefined.

Let's fix that.