### PR TITLE
fix: check url match before trigger showSurvey

### DIFF
--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -228,10 +228,6 @@ export class SurveyManager {
                 if (!isNull(this.surveyInFocus)) {
                     return
                 }
-                // Adding this duplicate check to see if there's some sort of race-condition between getActiveMatchingSurveys and actual URL changes, as sometimes Surveys are shown up when they shouldn't be
-                if (!doesSurveyUrlMatch(survey)) {
-                    return
-                }
                 if (survey.type === SurveyType.Widget) {
                     if (
                         survey.appearance?.widgetType === 'tab' &&
@@ -410,6 +406,12 @@ export function usePopupVisibility(
         }
 
         const showSurvey = () => {
+            // check if the url is still matching, necessary for delayed surveys, as the URL may have changed
+            // since the survey was scheduled to appear
+            if (!doesSurveyUrlMatch(survey)) {
+                return
+            }
+
             setIsPopupVisible(true)
             window.dispatchEvent(new Event('PHSurveyShown'))
             posthog.capture('survey shown', {


### PR DESCRIPTION
## Changes

Surveys can be delayed by X seconds - which means they're rendered by the method [handleShowSurveyWithDelay](https://github.com/PostHog/posthog-js/blob/fix/chekc-url-for-delayed-surveys/src/extensions/surveys.tsx#L427).

It means that it's possible a survey which has a URL condition matches it, then scheduled to be displayed.

However, since the URL can change, we also need to check if it is still a match before actually showing the survey.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
