### PR TITLE
fix: heatmaps unload listener

### DIFF
--- a/src/__tests__/heatmaps.test.ts
+++ b/src/__tests__/heatmaps.test.ts
@@ -80,6 +80,29 @@ describe('heatmaps', () => {
         })
     })
 
+    it('should flush on window unload', async () => {
+        posthog.heatmaps?.['_onClick']?.(createMockMouseEvent())
+
+        window.dispatchEvent(new Event('beforeunload'))
+
+        expect(beforeSendMock).toBeCalledTimes(1)
+        expect(beforeSendMock.mock.lastCall[0]).toMatchObject({
+            event: '$$heatmap',
+            properties: {
+                $heatmap_data: {
+                    'http://replaced/': [
+                        {
+                            target_fixed: false,
+                            type: 'click',
+                            x: 10,
+                            y: 20,
+                        },
+                    ],
+                },
+            },
+        })
+    })
+
     it('requires interval to pass before sending data', async () => {
         posthog.heatmaps?.['_onClick']?.(createMockMouseEvent())
 

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -59,8 +59,6 @@ export class Heatmaps {
     constructor(instance: PostHog) {
         this.instance = instance
         this._enabledServerSide = !!this.instance.persistence?.props[HEATMAPS_ENABLED_SERVER_SIDE]
-
-        addEventListener(window, 'beforeunload', this.flush)
     }
 
     public get flushIntervalMilliseconds(): number {
@@ -129,6 +127,8 @@ export class Heatmaps {
         if (!window || !document) {
             return
         }
+
+        addEventListener(window, 'beforeunload', this.flush.bind(this))
 
         addEventListener(document, 'click', (e) => this._onClick((e || window?.event) as MouseEvent), { capture: true })
         addEventListener(document, 'mousemove', (e) => this._onMouseMove((e || window?.event) as MouseEvent), {


### PR DESCRIPTION
fixes https://github.com/PostHog/posthog-js/issues/1735

we shouldn't be setting up listeners in the constructor anyway since we can init heatmaps and not be enabled

so, moves into the setup method, and binds this