### PR TITLE
fix: skip device type check if no devices set

### DIFF
--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -155,7 +155,7 @@ export function doesSurveyUrlMatch(survey: Survey): boolean {
 }
 
 export function doesSurveyDeviceTypesMatch(survey: Survey): boolean {
-    if (!survey.conditions?.deviceTypes) {
+    if (!survey.conditions?.deviceTypes || survey.conditions?.deviceTypes.length === 0) {
         return true
     }
     // if we dont know the device type, assume it is not a match


### PR DESCRIPTION
## Changes

skip device type check if no devices set

trivial change

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
