### PR TITLE
feat(web-analytics): Handle set_once latest props in a cross-subdomain way

### DIFF
--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -529,11 +529,13 @@ describe('posthog core', () => {
             )
 
             posthog.persistence.get_initial_props = () => ({ initial: 'prop' })
+            posthog.sessionPropsManager.getSetOnceInitialSessionPropsProps = () => ({ session: 'prop' })
             posthog.persistence.props[ENABLE_PERSON_PROCESSING] = true // person processing is needed for $set_once
             expect(posthog._calculate_set_once_properties({ key: 'prop' })).toEqual({
                 event_name: '$set_once',
                 token: undefined,
                 initial: 'prop',
+                session: 'prop',
                 key: 'prop',
             })
         })

--- a/src/__tests__/session-props.test.ts
+++ b/src/__tests__/session-props.test.ts
@@ -117,11 +117,11 @@ describe('Session Props Manager', () => {
         }
 
         // act
-        const properties = sessionPropsManager.getSessionProps()
+        const properties = sessionPropsManager.getSetOnceInitialSessionPropsProps()
 
         //assert
         expect(properties).toEqual({
-            $client_session_initial_utm_source: 'some-utm-source',
+            utm_source: 'some-utm-source',
         })
     })
 })

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -250,7 +250,10 @@ export class PostHogPersistence {
 
         this.register_once(
             {
-                [INITIAL_PERSON_INFO]: Info.initialPersonInfo(),
+                [INITIAL_PERSON_INFO]: Info.personInfo({
+                    maskPersonalDataProperties: this.config.mask_personal_data_properties,
+                    customPersonalDataProperties: this.config.custom_personal_data_properties,
+                }),
             },
             undefined
         )

--- a/src/session-props.ts
+++ b/src/session-props.ts
@@ -51,7 +51,7 @@ export class SessionPropsManager {
         instance: PostHog,
         sessionIdManager: SessionIdManager,
         persistence: PostHogPersistence,
-        sessionSourceParamGenerator?: (instance?: PostHog) => LegacySessionSourceProps
+        sessionSourceParamGenerator?: (instance?: PostHog) => LegacySessionSourceProps | CurrentSessionSourceProps
     ) {
         this.instance = instance
         this._sessionIdManager = sessionIdManager

--- a/src/session-props.ts
+++ b/src/session-props.ts
@@ -6,16 +6,17 @@
  *
  * These have the same lifespan as a session_id
  */
-import { location } from './utils/globals'
 import { Info } from './utils/event-utils'
 import type { SessionIdManager } from './sessionid'
 import type { PostHogPersistence } from './posthog-persistence'
 import { CLIENT_SESSION_PROPS } from './constants'
 import type { PostHog } from './posthog-core'
+import { each } from './utils'
+import { stripLeadingDollar } from './utils/string-utils'
 
-interface SessionSourceProps {
+interface LegacySessionSourceProps {
     initialPathName: string
-    referringDomain: string // Is actually host, but named domain for internal consistency. Should contain a port if there is one.
+    referringDomain: string // Is actually referring host, but named referring domain for internal consistency. Should contain a port if there is one.
     utm_medium?: string
     utm_source?: string
     utm_campaign?: string
@@ -23,35 +24,36 @@ interface SessionSourceProps {
     utm_term?: string
 }
 
-interface StoredSessionSourceProps {
-    sessionId: string
-    props: SessionSourceProps
+interface CurrentSessionSourceProps {
+    r: string // Referring host
+    u: string | undefined // full URL
 }
 
-const generateSessionSourceParams = (instance?: PostHog): SessionSourceProps => {
-    const config = instance?.config
-    return {
-        initialPathName: location?.pathname || '',
-        referringDomain: Info.referringDomain(),
-        ...Info.campaignParams({
-            customTrackedParams: config?.custom_campaign_params,
-            maskPersonalDataProperties: config?.mask_personal_data_properties,
-            customPersonalDataProperties: config?.custom_personal_data_properties,
-        }),
-    }
+interface StoredSessionSourceProps {
+    sessionId: string
+    props: LegacySessionSourceProps | CurrentSessionSourceProps
+}
+
+const generateSessionSourceParams = (posthog?: PostHog): LegacySessionSourceProps | CurrentSessionSourceProps => {
+    return Info.personInfo({
+        maskPersonalDataProperties: posthog?.config.mask_personal_data_properties,
+        customPersonalDataProperties: posthog?.config.custom_personal_data_properties,
+    })
 }
 
 export class SessionPropsManager {
     private readonly instance: PostHog
     private readonly _sessionIdManager: SessionIdManager
     private readonly _persistence: PostHogPersistence
-    private readonly _sessionSourceParamGenerator: (instance?: PostHog) => SessionSourceProps
+    private readonly _sessionSourceParamGenerator: (
+        instance?: PostHog
+    ) => LegacySessionSourceProps | CurrentSessionSourceProps
 
     constructor(
         instance: PostHog,
         sessionIdManager: SessionIdManager,
         persistence: PostHogPersistence,
-        sessionSourceParamGenerator?: (instance?: PostHog) => SessionSourceProps
+        sessionSourceParamGenerator?: (instance?: PostHog) => LegacySessionSourceProps
     ) {
         this.instance = instance
         this._sessionIdManager = sessionIdManager
@@ -61,12 +63,12 @@ export class SessionPropsManager {
         this._sessionIdManager.onSessionId(this._onSessionIdCallback)
     }
 
-    _getStoredProps(): StoredSessionSourceProps | undefined {
+    _getStored(): StoredSessionSourceProps | undefined {
         return this._persistence.props[CLIENT_SESSION_PROPS]
     }
 
     _onSessionIdCallback = (sessionId: string) => {
-        const stored = this._getStoredProps()
+        const stored = this._getStored()
         if (stored && stored.sessionId === sessionId) {
             return
         }
@@ -78,20 +80,38 @@ export class SessionPropsManager {
         this._persistence.register({ [CLIENT_SESSION_PROPS]: newProps })
     }
 
-    getSessionProps() {
-        const p = this._getStoredProps()?.props
+    /**
+     * Return all available props. Might want to be filtered depending on the use case.
+     */
+    _props() {
+        const p = this._getStored()?.props
         if (!p) {
             return {}
         }
-
-        return {
-            $client_session_initial_referring_host: p.referringDomain,
-            $client_session_initial_pathname: p.initialPathName,
-            $client_session_initial_utm_source: p.utm_source,
-            $client_session_initial_utm_campaign: p.utm_campaign,
-            $client_session_initial_utm_medium: p.utm_medium,
-            $client_session_initial_utm_content: p.utm_content,
-            $client_session_initial_utm_term: p.utm_term,
+        if ('r' in p) {
+            return Info.personPropsFromInfo(p)
+        } else {
+            return {
+                $referring_domain: p.referringDomain,
+                $pathname: p.initialPathName,
+                utm_source: p.utm_source,
+                utm_campaign: p.utm_campaign,
+                utm_medium: p.utm_medium,
+                utm_content: p.utm_content,
+                utm_term: p.utm_term,
+            }
         }
+    }
+
+    getSessionProps() {
+        const result: Record<string, any> = {}
+        const p = this._props()
+        each(p, function (v, k) {
+            result['$client_session_' + stripLeadingDollar(k)] = v
+        })
+    }
+
+    getSetOnceInitialSessionPropsProps() {
+        return this._props()
     }
 }

--- a/src/session-props.ts
+++ b/src/session-props.ts
@@ -11,8 +11,6 @@ import type { SessionIdManager } from './sessionid'
 import type { PostHogPersistence } from './posthog-persistence'
 import { CLIENT_SESSION_PROPS } from './constants'
 import type { PostHog } from './posthog-core'
-import { each } from './utils'
-import { stripLeadingDollar } from './utils/string-utils'
 
 interface LegacySessionSourceProps {
     initialPathName: string
@@ -80,10 +78,7 @@ export class SessionPropsManager {
         this._persistence.register({ [CLIENT_SESSION_PROPS]: newProps })
     }
 
-    /**
-     * Return all available props. Might want to be filtered depending on the use case.
-     */
-    _props() {
+    getSetOnceInitialSessionPropsProps() {
         const p = this._getStored()?.props
         if (!p) {
             return {}
@@ -101,17 +96,5 @@ export class SessionPropsManager {
                 utm_term: p.utm_term,
             }
         }
-    }
-
-    getSessionProps() {
-        const result: Record<string, any> = {}
-        const p = this._props()
-        each(p, function (v, k) {
-            result['$client_session_' + stripLeadingDollar(k)] = v
-        })
-    }
-
-    getSetOnceInitialSessionPropsProps() {
-        return this._props()
     }
 }

--- a/src/utils/event-utils.ts
+++ b/src/utils/event-utils.ts
@@ -213,23 +213,24 @@ export const Info = {
     },
 
     personPropsFromInfo: function (info: Record<string, any>): Record<string, any> {
-        const { r: r, u: u } = info
-        const referring_domain = r == null ? undefined : r == '$direct' ? '$direct' : convertToURL(r)?.host
+        const { r: referrer, u: url } = info
+        const referring_domain =
+            referrer == null ? undefined : referrer == '$direct' ? '$direct' : convertToURL(referrer)?.host
 
         const props: Record<string, string | undefined> = {
-            $referrer: r,
+            $referrer: referrer,
             $referring_domain: referring_domain,
         }
-        if (u) {
-            props['$current_url'] = u
-            const location = convertToURL(u)
+        if (url) {
+            props['$current_url'] = url
+            const location = convertToURL(url)
             props['$host'] = location?.host
             props['$pathname'] = location?.pathname
-            const campaignParams = this._campaignParamsFromUrl(u)
+            const campaignParams = this._campaignParamsFromUrl(url)
             extend(props, campaignParams)
         }
-        if (r) {
-            const searchInfo = this._searchInfoFromReferrer(r)
+        if (referrer) {
+            const searchInfo = this._searchInfoFromReferrer(referrer)
             extend(props, searchInfo)
         }
         return props


### PR DESCRIPTION
## Changes

There are a few changes here

Change 1: the biggest one is that we send set_once props for the *latest* props now. Previously, we just sent *initial* props. This means that this user journey now works

* start on subdomain1.example.com
* go to subdomain2.example.com
* call identify()
* check latest props

Previously, they would not necessarily have latest props, which we saw in a ticket here https://posthog.slack.com/archives/C05LJK1N3CP/p1739469826803839. Now we are using the session-scoped props to set these.

Change 2: reduce how often we send set_once properties. Previously we were sending these with every event with person properties, now we only send them with the first one.

Change 3: the set_once properties will now get proper masking of personal data properties in saved URLs.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
