### PR TITLE
feat: add more debug signals

### DIFF
--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -444,6 +444,9 @@ describe('posthog core', () => {
                 $is_identified: false,
                 $process_person_profile: false,
                 $recording_status: 'buffering',
+                $sdk_debug_replay_internal_buffer_length: 0,
+                $sdk_debug_replay_internal_buffer_size: 0,
+                $sdk_debug_retry_queue_size: 0,
             })
         })
 
@@ -467,6 +470,9 @@ describe('posthog core', () => {
                 $is_identified: false,
                 $process_person_profile: false,
                 $recording_status: 'buffering',
+                $sdk_debug_replay_internal_buffer_length: 0,
+                $sdk_debug_replay_internal_buffer_size: 0,
+                $sdk_debug_retry_queue_size: 0,
             })
         })
 
@@ -562,6 +568,40 @@ describe('posthog core', () => {
             expect(posthog._calculate_event_properties('$pageview', {}, new Date(), uuid)).toEqual(
                 expect.objectContaining({ title: 'test' })
             )
+        })
+
+        it('includes pageview id from previous pageview', () => {
+            const pageview1Properties = posthog._calculate_event_properties(
+                '$pageview',
+                {},
+                new Date(),
+                'pageview-id-1'
+            )
+            expect(pageview1Properties.$pageview_id).toEqual('pageview-id-1')
+
+            const event1Properties = posthog._calculate_event_properties('custom event', {}, new Date(), 'event-id-1')
+            expect(event1Properties.$pageview_id).toEqual('pageview-id-1')
+
+            const pageview2Properties = posthog._calculate_event_properties(
+                '$pageview',
+                {},
+                new Date(),
+                'pageview-id-2'
+            )
+            expect(pageview2Properties.$pageview_id).toEqual('pageview-id-2')
+            expect(pageview2Properties.$prev_pageview_id).toEqual('pageview-id-1')
+
+            const event2Properties = posthog._calculate_event_properties('custom event', {}, new Date(), 'event-id-2')
+            expect(event2Properties.$pageview_id).toEqual('pageview-id-2')
+
+            const pageleaveProperties = posthog._calculate_event_properties(
+                '$pageleave',
+                {},
+                new Date(),
+                'pageleave-id'
+            )
+            expect(pageleaveProperties.$pageview_id).toEqual('pageview-id-2')
+            expect(pageleaveProperties.$prev_pageview_id).toEqual('pageview-id-2')
         })
 
         it('includes pageview id from previous pageview', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -996,8 +996,8 @@ export class PostHog {
                 properties['$sdk_debug_replay_internal_buffer_size'] = this.sessionRecording['buffer'].size
             }
             properties['$sdk_debug_retry_queue_size'] = this._retryQueue?.['queue']?.length
-        } catch {
-            properties['$sdk_debug_error_capturing_properties'] = true
+        } catch (e: any) {
+            properties['$sdk_debug_error_capturing_properties'] = String(e)
         }
 
         if (this.requestRouter.region === RequestRouterRegion.CUSTOM) {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -991,6 +991,13 @@ export class PostHog {
 
         if (this.sessionRecording) {
             properties['$recording_status'] = this.sessionRecording.status
+            try {
+                properties['$sdk_debug_replay_internal_buffer_length'] = this.sessionRecording['buffer'].data.length
+                properties['$sdk_debug_replay_internal_buffer_size'] = this.sessionRecording['buffer'].size
+                properties['$sdk_debug_retry_queue_size'] = this._retryQueue?.['queue']?.length
+            } catch {
+                properties['$recording_debug_error_capturing_properties'] = true
+            }
         }
 
         if (this.requestRouter.region === RequestRouterRegion.CUSTOM) {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -989,15 +989,15 @@ export class PostHog {
             properties['$window_id'] = windowId
         }
 
-        if (this.sessionRecording) {
-            properties['$recording_status'] = this.sessionRecording.status
-            try {
+        try {
+            if (this.sessionRecording) {
+                properties['$recording_status'] = this.sessionRecording.status
                 properties['$sdk_debug_replay_internal_buffer_length'] = this.sessionRecording['buffer'].data.length
                 properties['$sdk_debug_replay_internal_buffer_size'] = this.sessionRecording['buffer'].size
-                properties['$sdk_debug_retry_queue_size'] = this._retryQueue?.['queue']?.length
-            } catch {
-                properties['$recording_debug_error_capturing_properties'] = true
             }
+            properties['$sdk_debug_retry_queue_size'] = this._retryQueue?.['queue']?.length
+        } catch {
+            properties['$sdk_debug_error_capturing_properties'] = true
         }
 
         if (this.requestRouter.region === RequestRouterRegion.CUSTOM) {


### PR DESCRIPTION
it can be tricky to know what is happening when users report errors

let's add more debug signals

<img width="926" alt="Screenshot 2025-02-17 at 12 40 01" src="https://github.com/user-attachments/assets/9f86900b-af0a-41b3-8611-dc9c02c264df" />

needs a follow-up to add these to core definitions