### PR TITLE
fix: last seen survey date logic

### DIFF
--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -32,6 +32,7 @@ import {
     getContrastingTextColor,
     getDisplayOrderQuestions,
     getSurveySeen,
+    hasWaitPeriodPassed,
     sendSurveyEvent,
     style,
     SurveyContext,
@@ -69,13 +70,9 @@ export class SurveyManager {
     private handlePopoverSurvey = (survey: Survey): void => {
         const surveyWaitPeriodInDays = survey.conditions?.seenSurveyWaitPeriodInDays
         const lastSeenSurveyDate = localStorage.getItem(`lastSeenSurveyDate`)
-        if (surveyWaitPeriodInDays && lastSeenSurveyDate) {
-            const today = new Date()
-            const diff = Math.abs(today.getTime() - new Date(lastSeenSurveyDate).getTime())
-            const diffDaysFromToday = Math.ceil(diff / (1000 * 3600 * 24))
-            if (diffDaysFromToday < surveyWaitPeriodInDays) {
-                return
-            }
+
+        if (!hasWaitPeriodPassed(lastSeenSurveyDate, surveyWaitPeriodInDays)) {
+            return
         }
 
         const surveySeen = getSurveySeen(survey)

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -694,6 +694,20 @@ const getSurveyInteractionProperty = (survey: Survey, action: string): string =>
     return surveyProperty
 }
 
+export const hasWaitPeriodPassed = (
+    lastSeenSurveyDate: string | null,
+    waitPeriodInDays: number | undefined
+): boolean => {
+    if (!waitPeriodInDays || !lastSeenSurveyDate) {
+        return true
+    }
+
+    const today = new Date()
+    const diff = Math.abs(today.getTime() - new Date(lastSeenSurveyDate).getTime())
+    const diffDaysFromToday = Math.ceil(diff / (1000 * 3600 * 24))
+    return diffDaysFromToday > waitPeriodInDays
+}
+
 interface SurveyContextProps {
     isPreviewMode: boolean
     previewPageIndex: number | undefined


### PR DESCRIPTION
## Changes

currently, if you set up a survey to wait for 1 day to show again, it'll be displayed straight way.

that's because the logic that tests this case is wrong - if only 5 minutes have passed, it'll still render it.

So I extracted that logic into a separate function to fix the logic and make it easier to create tests for it
...

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
