### PR TITLE
chore: Make `@rrweb/types` a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,9 @@
         "typescript": "^5.5.4",
         "yargs": "^17.7.2"
     },
+    "peerDependencies": {
+        "@rrweb/types": "2.0.0-alpha.17"
+    },
     "lint-staged": {
         "*.{ts,tsx,js,json}": "prettier --write",
         "*.js": "eslint --cache --fix",

--- a/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -249,8 +249,8 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"slimDOMOptions\\": [
       \\"undefined\\",
       \\"true\\",
-      \\"\\\\\\"all\\\\\\"\\",
-      \\"Partial<{ script: boolean; comment: boolean; headFavicon: boolean; headWhitespace: boolean; headMetaDescKeywords: boolean; headMetaSocial: boolean; headMetaRobots: boolean; headMetaHttpEquiv: boolean; headMetaAuthorship: boolean; headMetaVerification: boolean; headTitleMutations: boolean; }>\\"
+      \\"Partial<{ script: boolean; comment: boolean; headFavicon: boolean; headWhitespace: boolean; headMetaDescKeywords: boolean; headMetaSocial: boolean; headMetaRobots: boolean; headMetaHttpEquiv: boolean; headMetaAuthorship: boolean; headMetaVerification: boolean; headTitleMutations: boolean; }>\\",
+      \\"\\\\\\"all\\\\\\"\\"
     ],
     \\"collectFonts\\": [
       \\"undefined\\",

--- a/src/__tests__/extensions/replay/mutation-rate-limiter.test.ts
+++ b/src/__tests__/extensions/replay/mutation-rate-limiter.test.ts
@@ -2,10 +2,11 @@ import { MutationRateLimiter } from '../../../extensions/replay/mutation-rate-li
 import {
     INCREMENTAL_SNAPSHOT_EVENT_TYPE,
     MUTATION_SOURCE_TYPE,
-    rrwebRecord,
 } from '../../../extensions/replay/sessionrecording-utils'
+import type { rrwebRecord } from '../../../extensions/replay/types/rrweb'
 import { jest } from '@jest/globals'
-import { eventWithTime, mutationData } from '@rrweb/types'
+import type { eventWithTime, mutationData } from '@rrweb/types'
+
 jest.useFakeTimers()
 
 const makeEvent = (mutations: {

--- a/src/__tests__/extensions/replay/sessionrecording-utils.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording-utils.test.ts
@@ -11,7 +11,7 @@ import {
     circularReferenceReplacer,
 } from '../../../extensions/replay/sessionrecording-utils'
 import { largeString, threeMBAudioURI, threeMBImageURI } from '../test_data/sessionrecording-utils-test-data'
-import { eventWithTime } from '@rrweb/types'
+import type { eventWithTime } from '@rrweb/types'
 
 describe(`SessionRecording utility functions`, () => {
     describe(`filterLargeDataURLs`, () => {

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -35,15 +35,15 @@ import {
 import { assignableWindow, window } from '../../../utils/globals'
 import { RequestRouter } from '../../../utils/request-router'
 import {
-    customEvent,
+    type customEvent,
     EventType,
-    eventWithTime,
-    fullSnapshotEvent,
-    incrementalData,
-    incrementalSnapshotEvent,
+    type eventWithTime,
+    type fullSnapshotEvent,
+    type incrementalData,
+    type incrementalSnapshotEvent,
     IncrementalSource,
-    metaEvent,
-    pluginEvent,
+    type metaEvent,
+    type pluginEvent,
 } from '@rrweb/types'
 import Mock = jest.Mock
 import { ConsentManager } from '../../../consent'

--- a/src/extensions/replay/mutation-rate-limiter.ts
+++ b/src/extensions/replay/mutation-rate-limiter.ts
@@ -1,5 +1,7 @@
 import type { eventWithTime, mutationCallbackParam } from '@rrweb/types'
-import { INCREMENTAL_SNAPSHOT_EVENT_TYPE, MUTATION_SOURCE_TYPE, rrwebRecord } from './sessionrecording-utils'
+import { INCREMENTAL_SNAPSHOT_EVENT_TYPE, MUTATION_SOURCE_TYPE } from './sessionrecording-utils'
+import type { rrwebRecord } from './types/rrweb'
+
 import { clampToRange } from '../../utils/number-utils'
 
 export class MutationRateLimiter {

--- a/src/extensions/replay/sessionrecording-utils.ts
+++ b/src/extensions/replay/sessionrecording-utils.ts
@@ -1,5 +1,4 @@
-import type { eventWithTime, listenerHandler, pluginEvent } from '@rrweb/types'
-import type { record } from '@rrweb/record'
+import type { eventWithTime, pluginEvent } from '@rrweb/types'
 
 import { isObject } from '../../utils/type-utils'
 import { SnapshotBuffer } from './sessionrecording'
@@ -39,18 +38,6 @@ export const PLUGIN_EVENT_TYPE = 6
 export const MUTATION_SOURCE_TYPE = 0
 
 export const MAX_MESSAGE_SIZE = 5000000 // ~5mb
-
-export type rrwebRecord = {
-    (options: recordOptions): listenerHandler
-    addCustomEvent: (tag: string, payload: any) => void
-    takeFullSnapshot: () => void
-    mirror: {
-        getId(n: Node | undefined | null): number
-        getNode(id: number): Node | null
-    }
-}
-
-export declare type recordOptions = Exclude<Parameters<typeof record<eventWithTime>>[0], undefined>
 
 /*
  * Check whether a data payload is nearing 5mb. If it is, it checks the data for

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -13,11 +13,10 @@ import {
 import {
     estimateSize,
     INCREMENTAL_SNAPSHOT_EVENT_TYPE,
-    recordOptions,
-    rrwebRecord,
     splitBuffer,
     truncateLargeConsoleLogs,
 } from './sessionrecording-utils'
+import type { recordOptions, rrwebRecord } from './types/rrweb'
 import { PostHog } from '../../posthog-core'
 import {
     CaptureResult,
@@ -29,7 +28,7 @@ import {
     SessionRecordingUrlTrigger,
 } from '../../types'
 import {
-    customEvent,
+    type customEvent,
     EventType,
     type eventWithTime,
     IncrementalSource,

--- a/src/extensions/replay/types/rrweb.ts
+++ b/src/extensions/replay/types/rrweb.ts
@@ -1,0 +1,117 @@
+// This file is supposed to replicate some of the types hidden inside `@rrweb/record`
+// to guarantee that our users can use this library - and validate types - without
+// having to install `@rrweb/record`
+//
+// They might still need to install `@rrweb/types` to use this file,
+// but that's a much lighter library.
+//
+// NOTE: This file should be updated and kept in sync with `@rrweb/record` if we ever update it.
+// NOTE²: The initial types are not exported, we're only exporting the two types at the bottom.
+//        They're only here to allow the bottom types to be more easily defined.
+
+import type {
+    blockClass,
+    eventWithTime,
+    hooksParam,
+    KeepIframeSrcFn,
+    maskTextClass,
+    PackFn,
+    RecordPlugin,
+    SamplingStrategy,
+} from '@rrweb/types'
+
+// Replication of `MaskInputOptions` from inside `@rrweb/record/rrweb-snapshot`
+type MaskInputOptions = Partial<{
+    color: boolean
+    date: boolean
+    'datetime-local': boolean
+    email: boolean
+    month: boolean
+    number: boolean
+    range: boolean
+    search: boolean
+    tel: boolean
+    text: boolean
+    time: boolean
+    url: boolean
+    week: boolean
+    textarea: boolean
+    select: boolean
+    password: boolean
+}>
+
+// Replication of `MaskInputFn` from inside `@rrweb/record/rrweb-snapshot`
+type MaskInputFn = (text: string, element: HTMLElement) => string
+
+// Replication of `MaskTextFn` from inside `@rrweb/record/rrweb-snapshot`
+type MaskTextFn = (text: string, element: HTMLElement | null) => string
+
+// Replication of `SlimDOMOptions` from inside `@rrweb/record/rrweb-snapshot`
+type SlimDOMOptions = Partial<{
+    script: boolean
+    comment: boolean
+    headFavicon: boolean
+    headWhitespace: boolean
+    headMetaDescKeywords: boolean
+    headMetaSocial: boolean
+    headMetaRobots: boolean
+    headMetaHttpEquiv: boolean
+    headMetaAuthorship: boolean
+    headMetaVerification: boolean
+    headTitleMutations: boolean
+}>
+
+// Replication of `DataURLOptions` from inside `@rrweb/record/rrweb-snapshot`
+type DataURLOptions = Partial<{
+    type: string
+    quality: number
+}>
+
+// Replication of `ErrorHandler` from inside `@rrweb/record`
+type ErrorHandler = (error: unknown) => void | boolean
+
+// Replication of `recordOptions` from inside `@rrweb/record`
+export type recordOptions = {
+    emit?: (e: eventWithTime, isCheckout?: boolean) => void
+    checkoutEveryNth?: number
+    checkoutEveryNms?: number
+    blockClass?: blockClass
+    blockSelector?: string
+    ignoreClass?: string
+    ignoreSelector?: string
+    maskTextClass?: maskTextClass
+    maskTextSelector?: string
+    maskAllInputs?: boolean
+    maskInputOptions?: MaskInputOptions
+    maskInputFn?: MaskInputFn
+    maskTextFn?: MaskTextFn
+    slimDOMOptions?: SlimDOMOptions | 'all' | true
+    ignoreCSSAttributes?: Set<string>
+    inlineStylesheet?: boolean
+    hooks?: hooksParam
+    packFn?: PackFn
+    sampling?: SamplingStrategy
+    dataURLOptions?: DataURLOptions
+    recordDOM?: boolean
+    recordCanvas?: boolean
+    recordCrossOriginIframes?: boolean
+    recordAfter?: 'DOMContentLoaded' | 'load'
+    userTriggeredOnInput?: boolean
+    collectFonts?: boolean
+    inlineImages?: boolean
+    plugins?: RecordPlugin[]
+    mousemoveWait?: number
+    keepIframeSrcFn?: KeepIframeSrcFn
+    errorHandler?: ErrorHandler
+}
+
+// Replication of `record` from inside `@rrweb/record`
+export type rrwebRecord = {
+    (options: recordOptions): () => void
+    addCustomEvent: (tag: string, payload: any) => void
+    takeFullSnapshot: () => void
+    mirror: {
+        getId(n: Node | undefined | null): number
+        getNode(id: number): Node | null
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { PostHog } from './posthog-core'
 import type { SegmentAnalytics } from './extensions/segment-integration'
-import { recordOptions } from './extensions/replay/sessionrecording-utils'
+import type { recordOptions } from './extensions/replay/types/rrweb'
 
 export type Property = any
 export type Properties = Record<string, Property>


### PR DESCRIPTION
Some users aren't willing to turn `skipLibCheck` off which causes errors with us importing types from `@rrweb/types` but making that a developer dependency. In some other cases, namely, those using the Angular compiler, they actually can't turn this off, which is blocking their use of newer posthog-js versions

We can fix that in two ways:
- Let's add `@rrweb/types` as a peer dependency, this way users will know that they need to install the library themselves to get types to work
- Let's stop using `@rrweb/record` types to prevent people from having to install it. This increases our maintenance burden because we need to keep the types ourselves, but it implies they won't need to bundle a heavy library if they don't need it.

---

> How did you check this work?

I checked the new `module.d.ts` file, it doesn't include `@rrweb/record` anymore, just `@rrweb/types` which is just TS definitions so it shouldn't matter for bundle size

Closes #1662