### PR TITLE
fix: Remove circular dependency

### DIFF
--- a/src/__tests__/request-utils.test.ts
+++ b/src/__tests__/request-utils.test.ts
@@ -1,5 +1,5 @@
 import { getQueryParam, formDataToQuery, maskQueryParams } from '../utils/request-utils'
-import { isMatchingRegex } from '../utils/string-utils'
+import { isMatchingRegex } from '../utils/regex-utils'
 
 describe('request utils', () => {
     describe('_HTTPBuildQuery', () => {

--- a/src/extensions/surveys/action-matcher.ts
+++ b/src/extensions/surveys/action-matcher.ts
@@ -4,7 +4,7 @@ import { SimpleEventEmitter } from '../../utils/simple-event-emitter'
 import { CaptureResult } from '../../types'
 import { isUndefined } from '../../utils/type-utils'
 import { window } from '../../utils/globals'
-import { isMatchingRegex } from '../../utils/string-utils'
+import { isMatchingRegex } from '../../utils/regex-utils'
 
 export class ActionMatcher {
     private readonly actionRegistry?: Set<SurveyActionType>

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -12,7 +12,7 @@ import { RemoteConfig } from './types'
 import { Info } from './utils/event-utils'
 import { assignableWindow, document, userAgent, window } from './utils/globals'
 import { createLogger } from './utils/logger'
-import { isMatchingRegex } from './utils/string-utils'
+import { isMatchingRegex } from './utils/regex-utils'
 import { SurveyEventReceiver } from './utils/survey-event-receiver'
 import { isNullish } from './utils/type-utils'
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -107,15 +107,6 @@ export function entries<T = any>(obj: Record<string, T>): [string, T][] {
     return resArray
 }
 
-export const isValidRegex = function (str: string): boolean {
-    try {
-        new RegExp(str)
-    } catch {
-        return false
-    }
-    return true
-}
-
 export const trySafe = function <T>(fn: () => T): T | undefined {
     try {
         return fn()

--- a/src/utils/regex-utils.ts
+++ b/src/utils/regex-utils.ts
@@ -1,0 +1,18 @@
+export const isValidRegex = function (str: string): boolean {
+    try {
+        new RegExp(str)
+    } catch {
+        return false
+    }
+    return true
+}
+
+export const isMatchingRegex = function (value: string, pattern: string): boolean {
+    if (!isValidRegex(pattern)) return false
+
+    try {
+        return new RegExp(pattern).test(value)
+    } catch {
+        return false
+    }
+}

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -1,4 +1,11 @@
-import { isValidRegex } from '.'
+export const isValidRegex = function (str: string): boolean {
+    try {
+        new RegExp(str)
+    } catch {
+        return false
+    }
+    return true
+}
 
 export function includes<T = any>(str: T[] | string, needle: T): boolean {
     return (str as any).indexOf(needle) !== -1
@@ -19,6 +26,7 @@ export function isDistinctIdStringLike(value: string): boolean {
 
 export const isMatchingRegex = function (value: string, pattern: string): boolean {
     if (!isValidRegex(pattern)) return false
+
     try {
         return new RegExp(pattern).test(value)
     } catch {

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -1,12 +1,3 @@
-export const isValidRegex = function (str: string): boolean {
-    try {
-        new RegExp(str)
-    } catch {
-        return false
-    }
-    return true
-}
-
 export function includes<T = any>(str: T[] | string, needle: T): boolean {
     return (str as any).indexOf(needle) !== -1
 }
@@ -22,14 +13,4 @@ export const stripLeadingDollar = function (s: string): string {
 
 export function isDistinctIdStringLike(value: string): boolean {
     return ['distinct_id', 'distinctid'].includes(value.toLowerCase())
-}
-
-export const isMatchingRegex = function (value: string, pattern: string): boolean {
-    if (!isValidRegex(pattern)) return false
-
-    try {
-        return new RegExp(pattern).test(value)
-    } catch {
-        return false
-    }
 }

--- a/src/web-experiments.ts
+++ b/src/web-experiments.ts
@@ -10,7 +10,7 @@ import {
 import { WEB_EXPERIMENTS } from './constants'
 import { isNullish, isString } from './utils/type-utils'
 import { getQueryParam } from './utils/request-utils'
-import { isMatchingRegex } from './utils/string-utils'
+import { isMatchingRegex } from './utils/regex-utils'
 import { logger } from './utils/logger'
 import { Info } from './utils/event-utils'
 import { isLikelyBot } from './utils/blocked-uas'


### PR DESCRIPTION
When bundling our SDK we were warned about circular dependency errors, because:

`src/utils/type-utils` depends on `src/utils/string-utils`
`src/utils/string-utils` depends on `src/utils`
`src/utils` depends on `src/string-utils`

We can remove the dependency by making `string-utils` self-contained copying the function it was importing from the index. AND also (follow-up below) by extracting this function to a new `regex-utils`

Turns out that function isn't being used anywhere else anyway.
