### PR TITLE
feat: Block Chrome-Lighthouse UA (used by ahrefs)

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -134,6 +134,9 @@ describe('utils', () => {
             [
                 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/13.6.3 Chrome/114.0.5735.289 Electron/25.8.4 Safari/537.36',
             ],
+            [
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4590.2 Safari/537.36 Chrome-Lighthouse',
+            ],
         ])('blocks based on user agent', (botString) => {
             expect(isBlockedUA(botString, [])).toBe(true)
             expect(isBlockedUA(botString.toLowerCase(), [])).toBe(true)

--- a/src/utils/blocked-uas.ts
+++ b/src/utils/blocked-uas.ts
@@ -8,6 +8,7 @@ export const DEFAULT_BLOCKED_UA_STRS = [
     'bingpreview',
     'bot.htm',
     'bot.php',
+    'chrome-lighthouse',
     'crawler',
     'deepscan',
     'duckduckbot',


### PR DESCRIPTION
## Changes
Block Chrome-Lighthouse user agent 

See https://posthoghelp.zendesk.com/agent/tickets/25267 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/33353)

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
