### PR TITLE
feat: allow widget surveys to be repeated indefinitely

### DIFF
--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -1,6 +1,13 @@
 import { VNode, cloneElement, createContext } from 'preact'
 import { PostHog } from '../../posthog-core'
-import { MultipleSurveyQuestion, Survey, SurveyAppearance, SurveyQuestion } from '../../posthog-surveys-types'
+import {
+    MultipleSurveyQuestion,
+    Survey,
+    SurveyAppearance,
+    SurveyQuestion,
+    SurveySchedule,
+    SurveyType,
+} from '../../posthog-surveys-types'
 import { document as _document, window as _window } from '../../utils/globals'
 import { createLogger } from '../../utils/logger'
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
@@ -645,6 +652,10 @@ export const hasEvents = (survey: Survey): boolean => {
 }
 
 export const canActivateRepeatedly = (survey: Survey): boolean => {
+    if (survey.schedule === SurveySchedule.Always && survey.type === SurveyType.Widget) {
+        return true
+    }
+
     return !!(survey.conditions?.events?.repeatedActivation && hasEvents(survey))
 }
 

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -647,11 +647,11 @@ export const getDisplayOrderQuestions = (survey: Survey): SurveyQuestion[] => {
     return reverseIfUnshuffled(survey.questions, shuffle(survey.questions))
 }
 
-export const hasEvents = (survey: Survey): boolean => {
+export const hasEvents = (survey: Pick<Survey, 'conditions'>): boolean => {
     return survey.conditions?.events?.values?.length != undefined && survey.conditions?.events?.values?.length > 0
 }
 
-export const canActivateRepeatedly = (survey: Survey): boolean => {
+export const canActivateRepeatedly = (survey: Pick<Survey, 'schedule' | 'type' | 'conditions'>): boolean => {
     if (survey.schedule === SurveySchedule.Always && survey.type === SurveyType.Widget) {
         return true
     }

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -144,6 +144,12 @@ export interface SurveyRenderReason {
     disabledReason?: string
 }
 
+export enum SurveySchedule {
+    Once = 'once',
+    Recurring = 'recurring',
+    Always = 'always',
+}
+
 export interface Survey {
     // Sync this with the backend's SurveyAPISerializer!
     id: string
@@ -182,6 +188,7 @@ export interface Survey {
     end_date: string | null
     current_iteration: number | null
     current_iteration_start_date: string | null
+    schedule?: SurveySchedule | null
 }
 
 export interface SurveyActionType {


### PR DESCRIPTION
## Changes

add a new check for surveys repeating: if theyir type is `Widget` and the schedule is `Always`

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
