### PR TITLE
fix: check url matching on URL change for widget-type surveys

### DIFF
--- a/src/__tests__/posthog-surveys.test.ts
+++ b/src/__tests__/posthog-surveys.test.ts
@@ -1,0 +1,180 @@
+import { doesSurveyUrlMatch } from '../posthog-surveys'
+import { window } from '../utils/globals'
+
+// Mock the window.location
+const mockWindowLocation = (href: string | undefined) => {
+    Object.defineProperty(window, 'location', {
+        value: { href },
+        writable: true,
+    })
+}
+
+describe('doesSurveyUrlMatch', () => {
+    beforeEach(() => {
+        // Reset window.location before each test
+        mockWindowLocation(undefined)
+    })
+
+    it('should return true when no URL conditions are set', () => {
+        const survey = { conditions: { events: null, actions: null } }
+        expect(doesSurveyUrlMatch(survey)).toBe(true)
+
+        const surveyWithNullConditions = { conditions: { url: null, events: null, actions: null } }
+        expect(doesSurveyUrlMatch(surveyWithNullConditions)).toBe(true)
+    })
+
+    it('should return false when window.location.href is not available', () => {
+        const survey = { conditions: { url: 'example.com', events: null, actions: null } }
+        expect(doesSurveyUrlMatch(survey)).toBe(false)
+    })
+
+    describe('URL matching types', () => {
+        beforeEach(() => {
+            mockWindowLocation('https://example.com/path')
+        })
+
+        it('should match using icontains (default) match type', () => {
+            const survey = { conditions: { url: 'example.com', events: null, actions: null } }
+            expect(doesSurveyUrlMatch(survey)).toBe(true)
+
+            const nonMatchingSurvey = { conditions: { url: 'nonexistent.com', events: null, actions: null } }
+            expect(doesSurveyUrlMatch(nonMatchingSurvey)).toBe(false)
+        })
+
+        it('should match using explicit icontains match type', () => {
+            const survey = {
+                conditions: {
+                    url: 'example.com',
+                    urlMatchType: 'icontains' as const,
+                    events: null,
+                    actions: null,
+                },
+            }
+            expect(doesSurveyUrlMatch(survey)).toBe(true)
+
+            const caseInsensitiveSurvey = {
+                conditions: {
+                    url: 'EXAMPLE.COM',
+                    urlMatchType: 'icontains' as const,
+                    events: null,
+                    actions: null,
+                },
+            }
+            expect(doesSurveyUrlMatch(caseInsensitiveSurvey)).toBe(true)
+        })
+
+        it('should match using not_icontains match type', () => {
+            const survey = {
+                conditions: {
+                    url: 'nonexistent.com',
+                    urlMatchType: 'not_icontains' as const,
+                    events: null,
+                    actions: null,
+                },
+            }
+            expect(doesSurveyUrlMatch(survey)).toBe(true)
+
+            const nonMatchingSurvey = {
+                conditions: {
+                    url: 'example.com',
+                    urlMatchType: 'not_icontains' as const,
+                    events: null,
+                    actions: null,
+                },
+            }
+            expect(doesSurveyUrlMatch(nonMatchingSurvey)).toBe(false)
+        })
+
+        it('should match using regex match type', () => {
+            const survey = {
+                conditions: {
+                    url: '^https://.*\\.com/.*$',
+                    urlMatchType: 'regex' as const,
+                    events: null,
+                    actions: null,
+                },
+            }
+            expect(doesSurveyUrlMatch(survey)).toBe(true)
+
+            const nonMatchingSurvey = {
+                conditions: {
+                    url: '^https://.*\\.org/.*$',
+                    urlMatchType: 'regex' as const,
+                    events: null,
+                    actions: null,
+                },
+            }
+            expect(doesSurveyUrlMatch(nonMatchingSurvey)).toBe(false)
+        })
+
+        it('should match using not_regex match type', () => {
+            const survey = {
+                conditions: {
+                    url: '^https://.*\\.org/.*$',
+                    urlMatchType: 'not_regex' as const,
+                    events: null,
+                    actions: null,
+                },
+            }
+            expect(doesSurveyUrlMatch(survey)).toBe(true)
+
+            const nonMatchingSurvey = {
+                conditions: {
+                    url: '^https://.*\\.com/.*$',
+                    urlMatchType: 'not_regex' as const,
+                    events: null,
+                    actions: null,
+                },
+            }
+            expect(doesSurveyUrlMatch(nonMatchingSurvey)).toBe(false)
+        })
+
+        it('should match using exact match type', () => {
+            mockWindowLocation('https://example.com')
+
+            const survey = {
+                conditions: {
+                    url: 'https://example.com',
+                    urlMatchType: 'exact' as const,
+                    events: null,
+                    actions: null,
+                },
+            }
+            expect(doesSurveyUrlMatch(survey)).toBe(true)
+
+            const nonMatchingSurvey = {
+                conditions: {
+                    url: 'https://example.com/path',
+                    urlMatchType: 'exact' as const,
+                    events: null,
+                    actions: null,
+                },
+            }
+            expect(doesSurveyUrlMatch(nonMatchingSurvey)).toBe(false)
+        })
+
+        it('should match using is_not match type', () => {
+            mockWindowLocation('https://example.com')
+
+            const survey = {
+                conditions: {
+                    url: 'https://other.com',
+                    urlMatchType: 'is_not' as const,
+                    events: null,
+                    actions: null,
+                },
+            }
+            expect(doesSurveyUrlMatch(survey)).toBe(true)
+
+            const nonMatchingSurvey = {
+                conditions: {
+                    url: 'https://example.com',
+                    urlMatchType: 'is_not' as const,
+                    events: null,
+                    actions: null,
+                },
+            }
+            expect(doesSurveyUrlMatch(nonMatchingSurvey)).toBe(false)
+        })
+    })
+})

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -370,6 +370,16 @@ type UseHideSurveyOnURLChangeProps = {
     isPreviewMode?: boolean
 }
 
+/**
+ * This hook handles URL-based survey visibility after the initial mount.
+ * The initial URL check is handled by the `getActiveMatchingSurveys` method in  the `PostHogSurveys` class,
+ * which ensures the URL matches before displaying a survey for the first time.
+ * That is the method that is called every second to see if there's a matching survey.
+ *
+ * This separation of concerns means:
+ * 1. Initial URL matching is done by `getActiveMatchingSurveys` before displaying the survey
+ * 2. Subsequent URL changes are handled here to hide/show the survey as the user navigates
+ */
 export function useToggleSurveyOnURLChange({
     survey,
     removeSurveyFromFocus,

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -140,7 +140,7 @@ function defaultMatchType(matchType?: SurveyMatchType): SurveyMatchType {
 }
 
 // use urlMatchType to validate url condition, fallback to contains for backwards compatibility
-export function doesSurveyUrlMatch(survey: Survey): boolean {
+export function doesSurveyUrlMatch(survey: Pick<Survey, 'conditions'>): boolean {
     if (!survey.conditions?.url) {
         return true
     }


### PR DESCRIPTION
## Changes

we already did this fix for popover-type surveys here: https://github.com/PostHog/posthog-js/pull/1732

however, we just [got a ticket](https://posthoghelp.zendesk.com/agent/tickets/25697) that the same is stil lhappening for widget-type surveys

so I extracted that new logic into a hook, create tests for it (and also for `doesSurveyUrlMatch`), and then applied it to both cases

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
