### PR TITLE
feat: Add new `prepare_external_dependency_stylesheet` config option

### DIFF
--- a/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -137,6 +137,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"undefined\\",
     \\"(script: HTMLScriptElement) => HTMLScriptElement | null\\"
   ],
+  \\"prepare_external_dependency_stylesheet\\": [
+    \\"undefined\\",
+    \\"(stylesheet: HTMLStyleElement) => HTMLStyleElement | null\\"
+  ],
   \\"enable_recording_console_log\\": [
     \\"undefined\\",
     \\"false\\",

--- a/src/extensions/utils/stylesheet-loader.ts
+++ b/src/extensions/utils/stylesheet-loader.ts
@@ -1,0 +1,22 @@
+import { PostHog } from '../../posthog-core'
+import { document } from '../../utils/globals'
+import { createLogger } from '../../utils/logger'
+
+const logger = createLogger('[Stylesheet Loader]')
+
+export const prepareStylesheet = (innerText: string, posthog?: PostHog) => {
+    // Forcing the existence of `document` requires this function to be called in a browser environment
+    let stylesheet: HTMLStyleElement | null = document!.createElement('style')
+    stylesheet.innerText = innerText
+
+    if (posthog?.config.prepare_external_dependency_stylesheet) {
+        stylesheet = posthog.config.prepare_external_dependency_stylesheet(stylesheet)
+    }
+
+    if (!stylesheet) {
+        logger.error('prepare_external_dependency_stylesheet returned null')
+        return null
+    }
+
+    return stylesheet
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -478,6 +478,16 @@ export interface PostHogConfig {
     prepare_external_dependency_script?: (script: HTMLScriptElement) => HTMLScriptElement | null
 
     /**
+     * A function to be called when a stylesheet is being loaded.
+     * This can be used to modify the stylesheet before it is loaded.
+     * This is useful for adding a nonce to the stylesheet, for example.
+     *
+     * @param stylesheet - The stylesheet element that is being loaded.
+     * @returns The modified stylesheet element, or null if the stylesheet should not be loaded.
+     */
+    prepare_external_dependency_stylesheet?: (stylesheet: HTMLStyleElement) => HTMLStyleElement | null
+
+    /**
      * Determines whether PostHog should enable recording console logs.
      * When undefined, it falls back to the remote config setting.
      *


### PR DESCRIPTION
## Changes

This will let people customize the stylesheets we add to their websites. This is especially useful if they wanna add a `nonce` to the stylesheets we load.

Documentation PR (merged already): https://github.com/PostHog/posthog.com/pull/10757

Closes #1754