### PR TITLE
fix: dont require double click/page reload to show feedback surveys

### DIFF
--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -1088,7 +1088,7 @@ describe('onSurveyDismissedOrSent callback', () => {
         } as unknown as PostHog
     })
 
-    test('onSurveyDismissedOrSent is called when Cancel button is clicked in SurveyPopup', () => {
+    test('onPopupSurveyDismissed is called when Cancel button is clicked in SurveyPopup', () => {
         // Create a simple survey for testing
         const survey = {
             id: 'test-survey',
@@ -1127,7 +1127,7 @@ describe('onSurveyDismissedOrSent callback', () => {
                 survey: survey,
                 removeSurveyFromFocus: mockRemoveSurveyFromFocus,
                 isPopup: true,
-                onSurveyDismissedOrSent: mockOnSurveyDismissedOrSent,
+                onPopupSurveyDismissed: mockOnSurveyDismissedOrSent,
                 posthog: posthog,
             })
         )

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -1,10 +1,11 @@
 /* eslint-disable compat/compat */
 import { act, fireEvent, render, renderHook } from '@testing-library/preact'
 import {
+    SurveyManager,
+    SurveyPopup,
     generateSurveys,
     renderFeedbackWidgetPreview,
     renderSurveysPreview,
-    SurveyManager,
     useHideSurveyOnURLChange,
     usePopupVisibility,
 } from '../../extensions/surveys'
@@ -613,6 +614,7 @@ describe('usePopupVisibility URL changes should hide surveys accordingly', () =>
             feature_flag_keys: null,
             linked_flag_key: null,
             targeting_flag_key: null,
+            internal_targeting_flag_key: null,
             appearance: {},
         }) as Survey
 
@@ -1068,6 +1070,81 @@ describe('useHideSurveyOnURLChange', () => {
         })
 
         expect(mockRemoveSurveyFromFocus).not.toHaveBeenCalled()
+    })
+})
+
+describe('onSurveyDismissedOrSent callback', () => {
+    let posthog: PostHog
+
+    beforeEach(() => {
+        document.getElementsByTagName('html')[0].innerHTML = ''
+        localStorage.clear()
+        jest.clearAllMocks()
+
+        // Mock PostHog instance
+        posthog = {
+            capture: jest.fn(),
+            get_session_replay_url: jest.fn(),
+        } as unknown as PostHog
+    })
+
+    test('onSurveyDismissedOrSent is called when Cancel button is clicked in SurveyPopup', () => {
+        // Create a simple survey for testing
+        const survey = {
+            id: 'test-survey',
+            name: 'Test Survey',
+            description: 'Test Survey Description',
+            type: SurveyType.Popover,
+            questions: [
+                {
+                    type: SurveyQuestionType.Open,
+                    question: 'What do you think?',
+                    description: '',
+                    originalQuestionIndex: 0,
+                },
+            ],
+            start_date: new Date().toISOString(),
+            end_date: null,
+            feature_flag_keys: null,
+            linked_flag_key: null,
+            targeting_flag_key: null,
+            internal_targeting_flag_key: null,
+            appearance: {},
+            conditions: {
+                events: { values: [] },
+                actions: { values: [] },
+            },
+            current_iteration: 1,
+            current_iteration_start_date: new Date().toISOString(),
+        } as Survey
+
+        const mockOnSurveyDismissedOrSent = jest.fn()
+        const mockRemoveSurveyFromFocus = jest.fn()
+
+        // Render the SurveyPopup component with our mocked callback
+        render(
+            h(SurveyPopup, {
+                survey: survey,
+                removeSurveyFromFocus: mockRemoveSurveyFromFocus,
+                isPopup: true,
+                onSurveyDismissedOrSent: mockOnSurveyDismissedOrSent,
+                posthog: posthog,
+            })
+        )
+
+        // Find the Cancel button
+        const cancelButton = document.querySelector('.cancel-btn-wrapper')
+
+        // Verify the button exists
+        expect(cancelButton).not.toBeNull()
+
+        // Click the Cancel button
+        if (cancelButton) {
+            fireEvent.click(cancelButton)
+
+            // Verify our callback was called
+            expect(mockOnSurveyDismissedOrSent).toHaveBeenCalledTimes(1)
+        }
     })
 })
 

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -1073,7 +1073,7 @@ describe('useHideSurveyOnURLChange', () => {
     })
 })
 
-describe('onSurveyDismissedOrSent callback', () => {
+describe('onPopupSurveyDismissed callback', () => {
     let posthog: PostHog
 
     beforeEach(() => {
@@ -1118,7 +1118,7 @@ describe('onSurveyDismissedOrSent callback', () => {
             current_iteration_start_date: new Date().toISOString(),
         } as Survey
 
-        const mockOnSurveyDismissedOrSent = jest.fn()
+        const onPopupSurveyDismissed = jest.fn()
         const mockRemoveSurveyFromFocus = jest.fn()
 
         // Render the SurveyPopup component with our mocked callback
@@ -1127,7 +1127,7 @@ describe('onSurveyDismissedOrSent callback', () => {
                 survey: survey,
                 removeSurveyFromFocus: mockRemoveSurveyFromFocus,
                 isPopup: true,
-                onPopupSurveyDismissed: mockOnSurveyDismissedOrSent,
+                onPopupSurveyDismissed: onPopupSurveyDismissed,
                 posthog: posthog,
             })
         )
@@ -1143,7 +1143,7 @@ describe('onSurveyDismissedOrSent callback', () => {
             fireEvent.click(cancelButton)
 
             // Verify our callback was called
-            expect(mockOnSurveyDismissedOrSent).toHaveBeenCalledTimes(1)
+            expect(onPopupSurveyDismissed).toHaveBeenCalledTimes(1)
         }
     })
 })

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -746,14 +746,8 @@ export function Questions({
         survey.appearance?.backgroundColor || defaultSurveyAppearance.backgroundColor
     )
     const [questionsResponses, setQuestionsResponses] = useState({})
-    const {
-        isPreviewMode,
-        previewPageIndex,
-        onPopupSurveyDismissed: handleCloseSurveyPopup,
-        isPopup,
-        onPreviewSubmit,
-        onPopupSurveySent: onSurveyDismissedOrSent,
-    } = useContext(SurveyContext)
+    const { isPreviewMode, previewPageIndex, onPopupSurveyDismissed, isPopup, onPreviewSubmit, onPopupSurveySent } =
+        useContext(SurveyContext)
     const [currentQuestionIndex, setCurrentQuestionIndex] = useState(previewPageIndex || 0)
     const surveyQuestions = useMemo(() => getDisplayOrderQuestions(survey), [survey])
 
@@ -784,7 +778,7 @@ export function Questions({
         const nextStep = getNextSurveyStep(survey, displayQuestionIndex, res)
         if (nextStep === SurveyQuestionBranchingType.End) {
             sendSurveyEvent({ ...questionsResponses, [responseKey]: res }, survey, posthog)
-            onSurveyDismissedOrSent()
+            onPopupSurveySent()
         } else {
             setCurrentQuestionIndex(nextStep)
         }
@@ -826,8 +820,7 @@ export function Questions({
                             {isPopup && (
                                 <Cancel
                                     onClick={() => {
-                                        handleCloseSurveyPopup()
-                                        onSurveyDismissedOrSent()
+                                        onPopupSurveyDismissed()
                                     }}
                                 />
                             )}

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -655,7 +655,8 @@ interface SurveyPopupProps {
     removeSurveyFromFocus: (id: string) => void
     isPopup?: boolean
     onPreviewSubmit?: (res: string | string[] | number | null) => void
-    onSurveyDismissedOrSent?: () => void
+    onPopupSurveyDismissed?: () => void
+    onPopupSurveySent?: () => void
 }
 
 export function SurveyPopup({
@@ -667,7 +668,8 @@ export function SurveyPopup({
     removeSurveyFromFocus,
     isPopup,
     onPreviewSubmit = () => {},
-    onSurveyDismissedOrSent = () => {},
+    onPopupSurveyDismissed = () => {},
+    onPopupSurveySent = () => {},
 }: SurveyPopupProps) {
     const isPreviewMode = Number.isInteger(previewPageIndex)
     // NB: The client-side code passes the millisecondDelay in seconds, but setTimeout expects milliseconds, so we multiply by 1000
@@ -696,10 +698,15 @@ export function SurveyPopup({
             value={{
                 isPreviewMode,
                 previewPageIndex: previewPageIndex,
-                handleCloseSurveyPopup: () => dismissedSurveyEvent(survey, posthog, isPreviewMode),
+                onPopupSurveyDismissed: () => {
+                    dismissedSurveyEvent(survey, posthog, isPreviewMode)
+                    onPopupSurveyDismissed()
+                },
                 isPopup: isPopup || false,
                 onPreviewSubmit,
-                onSurveyDismissedOrSent,
+                onPopupSurveySent: () => {
+                    onPopupSurveySent()
+                },
             }}
         >
             {!shouldShowConfirmation ? (
@@ -742,10 +749,10 @@ export function Questions({
     const {
         isPreviewMode,
         previewPageIndex,
-        handleCloseSurveyPopup,
+        onPopupSurveyDismissed: handleCloseSurveyPopup,
         isPopup,
         onPreviewSubmit,
-        onSurveyDismissedOrSent,
+        onPopupSurveySent: onSurveyDismissedOrSent,
     } = useContext(SurveyContext)
     const [currentQuestionIndex, setCurrentQuestionIndex] = useState(previewPageIndex || 0)
     const surveyQuestions = useMemo(() => getDisplayOrderQuestions(survey), [survey])
@@ -906,6 +913,10 @@ export function FeedbackWidget({
         return null
     }
 
+    const resetShowSurvey = () => {
+        setShowSurvey(false)
+    }
+
     return (
         <Preact.Fragment>
             {survey.appearance?.widgetType === 'tab' && (
@@ -928,7 +939,8 @@ export function FeedbackWidget({
                     style={styleOverrides}
                     removeSurveyFromFocus={removeSurveyFromFocus}
                     isPopup={true}
-                    onSurveyDismissedOrSent={() => setShowSurvey(false)}
+                    onPopupSurveyDismissed={resetShowSurvey}
+                    onPopupSurveySent={resetShowSurvey}
                 />
             )}
         </Preact.Fragment>

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -735,6 +735,7 @@ interface SurveyContextProps {
     handleCloseSurveyPopup: () => void
     isPopup: boolean
     onPreviewSubmit: (res: string | string[] | number | null) => void
+    onSurveyDismissedOrSent: () => void
 }
 
 export const SurveyContext = createContext<SurveyContextProps>({
@@ -743,6 +744,7 @@ export const SurveyContext = createContext<SurveyContextProps>({
     handleCloseSurveyPopup: () => {},
     isPopup: true,
     onPreviewSubmit: () => {},
+    onSurveyDismissedOrSent: () => {},
 })
 
 interface RenderProps {

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -732,19 +732,19 @@ export const hasWaitPeriodPassed = (
 interface SurveyContextProps {
     isPreviewMode: boolean
     previewPageIndex: number | undefined
-    handleCloseSurveyPopup: () => void
+    onPopupSurveyDismissed: () => void
     isPopup: boolean
     onPreviewSubmit: (res: string | string[] | number | null) => void
-    onSurveyDismissedOrSent: () => void
+    onPopupSurveySent: () => void
 }
 
 export const SurveyContext = createContext<SurveyContextProps>({
     isPreviewMode: false,
     previewPageIndex: 0,
-    handleCloseSurveyPopup: () => {},
+    onPopupSurveyDismissed: () => {},
     isPopup: true,
     onPreviewSubmit: () => {},
-    onSurveyDismissedOrSent: () => {},
+    onPopupSurveySent: () => {},
 })
 
 interface RenderProps {


### PR DESCRIPTION
## Changes

adds a new option on SurveyContext to do something after a survey is submitted.

also, right now, for widget-type surveys (tab style), we have to click on the button twice to show the survey again after dismissing it. this PR fixes that

and, for selector, it only opens again if you do a full page reload

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
