### PR TITLE
feat: better positioning for survey selectors

### DIFF
--- a/playground/nextjs/pages/survey.tsx
+++ b/playground/nextjs/pages/survey.tsx
@@ -1,6 +1,6 @@
+import type { Survey } from 'posthog-js'
 import { usePostHog } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
-import type { Survey } from 'posthog-js'
 
 export default function SurveyForm() {
     const posthog = usePostHog()
@@ -29,6 +29,7 @@ export default function SurveyForm() {
     return (
         <>
             <div className="flex items-center gap-2 flex-wrap">
+                <button className="survey-feedback-button">Feedback</button>
                 <select value={selectedSurvey} onChange={handleChange}>
                     <option value="">Select a survey</option>
                     {arraySurveyItems}
@@ -44,6 +45,28 @@ export default function SurveyForm() {
                 <div id="survey-container">
                     <h1>hello world</h1>
                 </div>
+            </div>
+
+            {/* Add spacer to push the bottom button down */}
+            <div style={{ height: '70vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <p>Scroll down to see the bottom feedback button</p>
+            </div>
+
+            {/* Bottom feedback button */}
+            <div style={{ padding: '20px', textAlign: 'center', borderTop: '1px solid #eee' }}>
+                <button
+                    className="survey-feedback-button"
+                    style={{
+                        padding: '10px 20px',
+                        background: '#1D4AFF',
+                        color: 'white',
+                        borderRadius: '4px',
+                        border: 'none',
+                        cursor: 'pointer',
+                    }}
+                >
+                    Feedback (Bottom)
+                </button>
             </div>
         </>
     )

--- a/src/extensions/surveys-widget.ts
+++ b/src/extensions/surveys-widget.ts
@@ -1,6 +1,7 @@
 import { PostHog } from '../posthog-core'
 import { Survey } from '../posthog-surveys-types'
 import { document as _document } from '../utils/globals'
+import { SURVEY_DEFAULT_Z_INDEX } from './surveys/surveys-utils'
 import { prepareStylesheet } from './utils/stylesheet-loader'
 
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
@@ -37,7 +38,7 @@ export function createWidgetStyle(widgetColor?: string) {
             border-radius: 3px 3px 0 0;
             text-align: center;
             cursor: pointer;
-            z-index: 9999999;
+            z-index: ${SURVEY_DEFAULT_Z_INDEX};
         }
         .ph-survey-widget-tab:hover {
             padding-bottom: 13px;

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -35,6 +35,7 @@ import {
     hasWaitPeriodPassed,
     sendSurveyEvent,
     style,
+    SURVEY_DEFAULT_Z_INDEX,
     SurveyContext,
 } from './surveys/surveys-utils'
 import { prepareStylesheet } from './utils/stylesheet-loader'
@@ -960,7 +961,7 @@ export function FeedbackWidget({
                     border: `1.5px solid ${survey.appearance?.borderColor || '#c9c6c6'}`,
                     borderRadius: '10px',
                     width: `${surveyWidth}px`,
-                    zIndex: 2147483647,
+                    zIndex: SURVEY_DEFAULT_Z_INDEX,
                     boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
                     maxHeight: showAbove
                         ? `calc(100vh - 40px - ${spacing * 2}px)`

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -44,6 +44,10 @@ const logger = createLogger('[Surveys]')
 const window = _window as Window & typeof globalThis
 const document = _document as Document
 
+function getPosthogWidgetClass(surveyId: string) {
+    return `.PostHogWidget${surveyId}`
+}
+
 function getRatingBucketForResponseValue(responseValue: number, scale: number) {
     if (scale === 3) {
         if (responseValue < 1 || responseValue > 3) {
@@ -227,7 +231,7 @@ export class SurveyManager {
                 // we have to check if user selector already has a survey listener attached to it because we always have to check if it's on the page or not
                 if (!selectorOnPage.getAttribute('PHWidgetSurveyClickListener')) {
                     const surveyPopup = document
-                        .querySelector(`.PostHogWidget${survey.id}`)
+                        .querySelector(getPosthogWidgetClass(survey.id))
                         ?.shadowRoot?.querySelector(`.survey-form`) as HTMLFormElement
 
                     addEventListener(selectorOnPage, 'click', () => {
@@ -606,7 +610,7 @@ export function usePopupVisibility(
             localStorage.setItem('lastSeenSurveyDate', new Date().toISOString())
             setTimeout(() => {
                 const inputField = document
-                    .querySelector('.PostHogWidget' + survey.id)
+                    .querySelector(getPosthogWidgetClass(survey.id))
                     ?.shadowRoot?.querySelector('textarea, input[type="text"]') as HTMLElement
                 if (inputField) {
                     inputField.focus()

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -48,7 +48,7 @@ export const style = (appearance: SurveyAppearance | null) => {
               text-align: left;
               max-width: ${parseInt(appearance?.maxWidth || '300')}px;
               width: 100%;
-              z-index: ${parseInt(appearance?.zIndex || '99999')};
+              z-index: ${parseInt(appearance?.zIndex || '2147482647')};
               border: 1.5px solid ${appearance?.borderColor || '#c9c6c6'};
               border-bottom: 0px;
               ${positions[appearance?.position || 'right'] || 'right: 30px;'}

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -18,6 +18,8 @@ const SurveySeenPrefix = 'seenSurvey_'
 
 const logger = createLogger('[Surveys]')
 
+export const SURVEY_DEFAULT_Z_INDEX = 2147483647
+
 export function getFontFamily(fontFamily?: string): string {
     if (fontFamily === 'inherit') {
         return 'inherit'
@@ -48,7 +50,7 @@ export const style = (appearance: SurveyAppearance | null) => {
               text-align: left;
               max-width: ${parseInt(appearance?.maxWidth || '300')}px;
               width: 100%;
-              z-index: ${parseInt(appearance?.zIndex || '2147482647')};
+              z-index: ${parseInt(appearance?.zIndex || SURVEY_DEFAULT_Z_INDEX.toString())};
               border: 1.5px solid ${appearance?.borderColor || '#c9c6c6'};
               border-bottom: 0px;
               ${positions[appearance?.position || 'right'] || 'right: 30px;'}


### PR DESCRIPTION
# Make surveys appear next to buttons instead of in the corner

This PR changes where surveys show up when triggered from buttons on the page, making them easier to use.

## What changed

- Surveys now pop up right next to the button you clicked instead of always appearing in the bottom-right corner
- Added a consistent small gap (12px) between the button and survey
- Made sure surveys work well on small screens by keeping them fully visible
- Fixed the X button display issue by removing some unnecessary styling

## Before & After

Before: Surveys would show up in the bottom-right corner, far away from the button you clicked. (like for all other current surveys)

After: Surveys now appear right next to the button you clicked, making it clear what triggered the survey.

| Survey on top | Survey on bottom |
|--------|--------|
| ![CleanShot 2025-02-28 at 22 44 42@2x](https://github.com/user-attachments/assets/d5e50fa4-4a53-4679-afca-a752d8fa4458) | ![CleanShot 2025-02-28 at 22 45 29@2x](https://github.com/user-attachments/assets/4604ae69-33f5-41e0-807b-81d998edfacb) | 

## Testing

I tested this on phones, tablets and desktops to make sure it looks good everywhere. The survey now properly appears above the button when there's not enough room below it.

## Why no automated tests?

We went with manual testing because:

1. This is mostly about how things look on screen, which is hard to test with code, especially when we don't have an easy way atm to mock surveys (no other tests do this)
2. The positioning depends on screen size and button location - things that are tricky to simulate in tests
3. The best way to check if it works was to actually try it on different devices and screen sizes
4. The changes don't affect how the surveys work, just where they appear

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
