### PR TITLE
feat: Make `getQueryParams` more resilient

### DIFF
--- a/src/__tests__/request-utils.test.ts
+++ b/src/__tests__/request-utils.test.ts
@@ -44,6 +44,8 @@ describe('request utils', () => {
             ['gets param when no match with trailing slash', '/', 'name', ''],
             ['gets param when no match and there are params', '/?test=123', 'name', ''],
             ['gets param when no match and there are params with trailing slash', '/?test=123', 'name', ''],
+            ['gets param when we have duplicate question marks', '??test=123', 'test', '123'],
+            ['gets trailing param when we have duplicate question marks', '??test=123&name=john', 'name', 'john'],
         ])('%s', (_name, url, param, expected) => {
             expect(getQueryParam(`https://example.com${url}`, param)).toEqual(expected)
         })

--- a/src/utils/request-utils.ts
+++ b/src/utils/request-utils.ts
@@ -41,11 +41,16 @@ export const formDataToQuery = function (formdata: Record<string, any> | FormDat
     return tph_arr.join(arg_separator)
 }
 
+// NOTE: Once we get rid of IE11/op_mini we can start using URLSearchParams
 export const getQueryParam = function (url: string, param: string): string {
     const withoutHash: string = url.split('#')[0] || ''
-    const queryParams: string = withoutHash.split('?')[1] || ''
 
-    const queryParts = queryParams.split('&')
+    // Split only on the first ? to sort problem out for those with multiple ?s
+    // and then remove them
+    const queryParams: string = withoutHash.split(/\?(.*)/)[1] || ''
+    const cleanedQueryParams = queryParams.replace(/^\?+/g, '')
+
+    const queryParts = cleanedQueryParams.split('&')
     let keyValuePair
 
     for (let i = 0; i < queryParts.length; i++) {


### PR DESCRIPTION
An SDK user has a slightly broken URL where they have two leading question marks, which is causing our `queryParam` parsing to break. Right now, because we split on `?` and get the second split, we're simply getting an empty string.

We're fixing this in two ways:
- where possible use built-in browser features to parse query params (with fallback to IE11 and op_mini)
- trim leading question marks to avoid this from happening again

See https://posthoghelp.zendesk.com/agent/tickets/25469 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/28561)