### PR TITLE
feat: Block Lighthouse cryptic user agent

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -165,6 +165,12 @@ describe('utils', () => {
                 'Mozilla/5.0 (compatible; SeznamBot/4.0; +https://o-seznam.cz/napoveda/vyhledavani/en/seznambot-crawler/)',
             ],
             ['BrightEdge Crawler/1.0 (crawler@brightedge.com)'],
+            [
+                'Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36',
+            ],
+            [
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
+            ],
         ])('blocks based on user agent', (botString) => {
             expect(isBlockedUA(botString, [])).toBe(true)
             expect(isBlockedUA(botString.toLowerCase(), [])).toBe(true)

--- a/src/utils/blocked-uas.ts
+++ b/src/utils/blocked-uas.ts
@@ -17,7 +17,6 @@ export const DEFAULT_BLOCKED_UA_STRS = [
     'bot.php',
     '(bot;',
     'bot/',
-    'chrome-lighthouse',
     'crawler',
     'dataforseobot',
     'deepscan',
@@ -80,6 +79,13 @@ export const DEFAULT_BLOCKED_UA_STRS = [
     'mediapartners-google',
     'storebot-google',
     'bytespider',
+
+    // Believe it or not, these are all from Lighthouse
+    // We'll make them an exhaustive match to decrease false positives
+    // https://github.com/GoogleChrome/lighthouse/blob/main/core/config/constants.js
+    'chrome-lighthouse',
+    'mozilla/5.0 (linux; android 11; moto g power (2022)) applewebkit/537.36 (khtml, like gecko) chrome/119.0.0.0 mobile safari/537.36', // Mobile UA for Lighthouse
+    'mozilla/5.0 (macintosh; intel mac os x 10_15_7) applewebkit/537.36 (khtml, like gecko) chrome/119.0.0.0 safari/537.36', // Desktop UA for Lighthouse
 ]
 
 /**


### PR DESCRIPTION
Believe it or not, this is Lighthouse's user agent. They don't usually include "lighthouse" in it anymore because some people were gaming the system for LH scores, so they use some cryptic UAs now. I'll just ignore this outright because not many people will actually have that UA, and this might cause some big bills for some customers.

https://github.com/GoogleChrome/lighthouse/blob/main/core/config/constants.js#L42