### PR TITLE
feat(web-analytics): Add $session property with an object of props on session_id lifecycle

### DIFF
--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -418,7 +418,7 @@ describe('posthog core', () => {
             } as unknown as SessionIdManager,
             sessionPropsManager: {
                 getSessionProps: jest.fn().mockReturnValue({
-                    someSessionProp: 'foo',
+                    $session_entry_referring_domain: 'https://referrer.example.com',
                 }),
             } as unknown as SessionPropsManager,
         }
@@ -447,7 +447,7 @@ describe('posthog core', () => {
                 persistent: 'prop',
                 $window_id: 'windowId',
                 $session_id: 'sessionId',
-                $session: { someSessionProp: 'foo' },
+                $session_entry_referring_domain: 'https://referrer.example.com',
                 $is_identified: false,
                 $process_person_profile: false,
                 $recording_status: 'buffering',

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -1,9 +1,9 @@
 import { mockLogger } from './helpers/mock-logger'
 
 import { Info } from '../utils/event-utils'
+import * as globals from '../utils/globals'
 import { document, window } from '../utils/globals'
 import { uuidv7 } from '../uuidv7'
-import * as globals from '../utils/globals'
 import { ENABLE_PERSON_PROCESSING, USER_STATE } from '../constants'
 import { createPosthogInstance, defaultPostHog } from './helpers/posthog-instance'
 import { PostHogConfig, RemoteConfig } from '../types'
@@ -12,6 +12,7 @@ import { PostHogPersistence } from '../posthog-persistence'
 import { SessionIdManager } from '../sessionid'
 import { RequestQueue } from '../request-queue'
 import { SessionRecording } from '../extensions/replay/sessionrecording'
+import { SessionPropsManager } from '../session-props'
 
 describe('posthog core', () => {
     const baseUTCDateTime = new Date(Date.UTC(2020, 0, 1, 0, 0, 0))
@@ -415,6 +416,11 @@ describe('posthog core', () => {
                     sessionId: 'sessionId',
                 }),
             } as unknown as SessionIdManager,
+            sessionPropsManager: {
+                getSessionProps: jest.fn().mockReturnValue({
+                    someSessionProp: 'foo',
+                }),
+            } as unknown as SessionPropsManager,
         }
 
         beforeEach(() => {
@@ -441,6 +447,7 @@ describe('posthog core', () => {
                 persistent: 'prop',
                 $window_id: 'windowId',
                 $session_id: 'sessionId',
+                $session: { someSessionProp: 'foo' },
                 $is_identified: false,
                 $process_person_profile: false,
                 $recording_status: 'buffering',
@@ -466,6 +473,7 @@ describe('posthog core', () => {
                 persistent: 'prop',
                 $window_id: 'windowId',
                 $session_id: 'sessionId',
+                $session: { someSessionProp: 'foo' },
                 $lib_custom_api_host: 'https://custom.posthog.com',
                 $is_identified: false,
                 $process_person_profile: false,
@@ -535,7 +543,7 @@ describe('posthog core', () => {
             )
 
             posthog.persistence.get_initial_props = () => ({ initial: 'prop' })
-            posthog.sessionPropsManager.getSetOnceInitialSessionPropsProps = () => ({ session: 'prop' })
+            posthog.sessionPropsManager.getSetOnceProps = () => ({ session: 'prop' })
             posthog.persistence.props[ENABLE_PERSON_PROCESSING] = true // person processing is needed for $set_once
             expect(posthog._calculate_set_once_properties({ key: 'prop' })).toEqual({
                 event_name: '$set_once',

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -473,7 +473,7 @@ describe('posthog core', () => {
                 persistent: 'prop',
                 $window_id: 'windowId',
                 $session_id: 'sessionId',
-                $session: { someSessionProp: 'foo' },
+                $session_entry_referring_domain: 'https://referrer.example.com',
                 $lib_custom_api_host: 'https://custom.posthog.com',
                 $is_identified: false,
                 $process_person_profile: false,

--- a/src/__tests__/session-props.test.ts
+++ b/src/__tests__/session-props.test.ts
@@ -124,4 +124,60 @@ describe('Session Props Manager', () => {
             utm_source: 'some-utm-source',
         })
     })
+
+    it('should convert a url and referrer into a full set of props', () => {
+        // arrange
+        const { persistence, sessionPropsManager } = createSessionPropsManager()
+        persistence.props = {
+            $client_session_props: {
+                props: {
+                    r: 'http://referrer.example.com/referrer',
+                    u: 'https://app.example.com/page?utm_source=example',
+                },
+                sessionId: 'session-id',
+            },
+        }
+
+        // act
+        const setOnceProps = sessionPropsManager.getSetOnceProps()
+        const sessionProps = sessionPropsManager.getSessionProps()
+
+        //assert
+        expect(setOnceProps).toEqual({
+            $current_url: 'https://app.example.com/page?utm_source=example',
+            $host: 'app.example.com',
+            $pathname: '/page',
+            $referrer: 'http://referrer.example.com/referrer',
+            $referring_domain: 'referrer.example.com',
+            _kx: null,
+            dclid: null,
+            fbclid: null,
+            gad_source: null,
+            gbraid: null,
+            gclid: null,
+            gclsrc: null,
+            igshid: null,
+            irclid: null,
+            li_fat_id: null,
+            mc_cid: null,
+            msclkid: null,
+            rdt_cid: null,
+            ttclid: null,
+            twclid: null,
+            utm_campaign: null,
+            utm_content: null,
+            utm_medium: null,
+            utm_source: 'example',
+            utm_term: null,
+            wbraid: null,
+        })
+        expect(sessionProps).toEqual({
+            $session_entry_referring_domain: 'referrer.example.com',
+            $session_entry_referrer: 'http://referrer.example.com/referrer',
+            $session_entry_url: 'https://app.example.com/page?utm_source=example',
+            $session_entry_host: 'app.example.com',
+            $session_entry_pathname: '/page',
+            $session_entry_utm_source: 'example',
+        })
+    })
 })

--- a/src/__tests__/session-props.test.ts
+++ b/src/__tests__/session-props.test.ts
@@ -117,7 +117,7 @@ describe('Session Props Manager', () => {
         }
 
         // act
-        const properties = sessionPropsManager.getSetOnceInitialSessionPropsProps()
+        const properties = sessionPropsManager.getSetOnceProps()
 
         //assert
         expect(properties).toEqual({

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -992,6 +992,9 @@ export class PostHog {
             properties['$session_id'] = sessionId
             properties['$window_id'] = windowId
         }
+        if (this.sessionPropsManager) {
+            properties['$session'] = this.sessionPropsManager.getSessionProps()
+        }
 
         try {
             if (this.sessionRecording) {
@@ -1097,7 +1100,7 @@ export class PostHog {
         }
         // if we're an identified person, send initial params with every event
         const initialProps = this.persistence.get_initial_props()
-        const sessionProps = this.sessionPropsManager?.getSetOnceInitialSessionPropsProps()
+        const sessionProps = this.sessionPropsManager?.getSetOnceProps()
         let setOnceProperties = extend({}, initialProps, sessionProps || {}, dataSetOnce || {})
         const sanitize_properties = this.config.sanitize_properties
         if (sanitize_properties) {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -993,7 +993,7 @@ export class PostHog {
             properties['$window_id'] = windowId
         }
         if (this.sessionPropsManager) {
-            properties['$session'] = this.sessionPropsManager.getSessionProps()
+            extend(properties, this.sessionPropsManager.getSessionProps())
         }
 
         try {

--- a/src/session-props.ts
+++ b/src/session-props.ts
@@ -1,16 +1,19 @@
-/* Client-side session parameters. These are primarily used by web analytics,
- * which relies on these for session analytics without the plugin server being
- * available for the person level set-once properties. Obviously not consistent
- * between client-side events and server-side events but this is acceptable
- * as web analytics only uses client-side.
+/* Store some session-level attribution-related properties in the persistence layer
  *
- * These have the same lifespan as a session_id
+ * These have the same lifespan as a session_id, meaning that if the session_id changes, these properties will be reset.
+ *
+ * We only store the entry URL and referrer, and derive many props (such as utm tags) from those.
+ *
+ * Given that the cookie is limited to 4K bytes, we don't want to store too much data, so we chose not to store device
+ * properties (such as browser, OS, etc) here, as usually getting the current value of those from event properties is
+ * sufficient.
  */
 import { Info } from './utils/event-utils'
 import type { SessionIdManager } from './sessionid'
 import type { PostHogPersistence } from './posthog-persistence'
 import { CLIENT_SESSION_PROPS } from './constants'
 import type { PostHog } from './posthog-core'
+import { stripEmptyProperties } from './utils'
 
 interface LegacySessionSourceProps {
     initialPathName: string
@@ -78,7 +81,7 @@ export class SessionPropsManager {
         this._persistence.register({ [CLIENT_SESSION_PROPS]: newProps })
     }
 
-    getSetOnceInitialSessionPropsProps() {
+    getSetOnceProps() {
         const p = this._getStored()?.props
         if (!p) {
             return {}
@@ -96,5 +99,10 @@ export class SessionPropsManager {
                 utm_term: p.utm_term,
             }
         }
+    }
+
+    getSessionProps() {
+        // it's the same props, but don't include null for unset properties
+        return stripEmptyProperties(this.getSetOnceProps())
     }
 }


### PR DESCRIPTION
## Changes

See https://posthog.slack.com/archives/C06GG249PR6/p1741000095036129 for the feature request

Adds $session_entry_X properties to events, which includes some properties that are scoped to the lifecycle of the session id

<img width="500" alt="Screenshot 2025-03-04 at 09 11 04" src="https://github.com/user-attachments/assets/3d43d0f0-2d0a-44b0-8b3e-a1da335a6da6" />

I debated using a `$session` object and putting all the props in there, but I don't know how well materialisation would work on nested properties.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
