### PR TITLE
chore(): set all github actions to run on ubuntu-22.04

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     check-package-version:
         name: Check package version and detect an update
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         outputs:
             committed-version: ${{ steps.check-package-version.outputs.committed-version }}
             published-version: ${{ steps.check-package-version.outputs.published-version }}
@@ -23,7 +23,7 @@ jobs:
 
     release:
         name: Publish release if new version
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         needs: check-package-version
         if: needs.check-package-version.outputs.is-new-version == 'true'
         env:
@@ -94,7 +94,7 @@ jobs:
 
     create-posthog-main-repo-pull-request:
         name: Create main repo PR with new posthog-js version
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         needs: [check-package-version, release]
         env:
             COMMITTED_VERSION: ${{ needs.check-package-version.outputs.committed-version }}
@@ -179,7 +179,7 @@ jobs:
 
     create-posthog-com-repo-pull-request:
         name: Create posthog.com repo PR with new posthog-js version
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         needs: [check-package-version, release]
         env:
             COMMITTED_VERSION: ${{ needs.check-package-version.outputs.committed-version }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,29 +68,29 @@ jobs:
 
             - name: Create GitHub release
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  # read from the first until the second header in the changelog file
-                  # this assumes the formatting of the file
-                  # and that this workflow is always running for the most recent entry in the file 
-                  LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
-                  # the action we used to use was archived, and made it really difficult to create a release with a body
-                  # because the LAST_CHANGELOG_ENTRY contains bash special characters so passing it between steps
-                  # was a pain.
-                  # we can use the github cli to create a release with a body
-                  # all as part of one step
-                  gh api \
-                    --method POST \
-                    -H "Accept: application/vnd.github+json" \
-                    -H "X-GitHub-Api-Version: 2022-11-28" \
-                    /repos/posthog/posthog-js/releases \
-                    -f tag_name="v${{ env.COMMITTED_VERSION }}" \
-                  -f target_commitish='main' \
-                  -f name="${{ env.COMMITTED_VERSION }}" \
-                  -f body="$LAST_CHANGELOG_ENTRY" \
-                  -F draft=false \
-                  -F prerelease=false \
-                  -F generate_release_notes=false
+                # read from the first until the second header in the changelog file
+                # this assumes the formatting of the file
+                # and that this workflow is always running for the most recent entry in the file 
+                LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
+                # the action we used to use was archived, and made it really difficult to create a release with a body
+                # because the LAST_CHANGELOG_ENTRY contains bash special characters so passing it between steps
+                # was a pain.
+                # we can use the github cli to create a release with a body
+                # all as part of one step
+                gh api \
+                  --method POST \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  /repos/posthog/posthog-js/releases \
+                  -f tag_name="v${{ env.COMMITTED_VERSION }}" \
+                -f target_commitish='main' \
+                -f name="${{ env.COMMITTED_VERSION }}" \
+                -f body="$LAST_CHANGELOG_ENTRY" \
+                -F draft=false \
+                -F prerelease=false \
+                -F generate_release_notes=false 
 
     create-posthog-main-repo-pull-request:
         name: Create main repo PR with new posthog-js version
@@ -161,21 +161,21 @@ jobs:
 
             - name: Stamp PR
               run: |
-                  # unbelievably github has a race condition where if you commit and
-                  # approve too quickly on a PR with "auto-merge" enabled it can miss
-                  # the new commit in the merge commit (but it looks like the PR has the change)
-                  # Sleep 5 should work
-                  sleep 5
-                  pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+                # unbelievably github has a race condition where if you commit and
+                # approve too quickly on a PR with "auto-merge" enabled it can miss
+                # the new commit in the merge commit (but it looks like the PR has the change)
+                # Sleep 5 should work
+                sleep 5
+                pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 
-                  pull_number=${{ steps.main-repo-pr.outputs.pull-request-number }}
-                  curl -L \
-                  -X POST \
-                  -H "Accept: application/vnd.github+json" \
-                  -H "Authorization: Bearer ${{ steps.deployer.outputs.token }}" \
-                  -H "X-GitHub-Api-Version: 2022-11-28" \
-                  https://api.github.com/repos/posthog/posthog/pulls/${pull_number}/reviews \
-                  -d '{"body":"PostHog JS auto approved.","event":"APPROVE","comments":[]}'
+                pull_number=${{ steps.main-repo-pr.outputs.pull-request-number }}
+                curl -L \
+                -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ steps.deployer.outputs.token }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/posthog/posthog/pulls/${pull_number}/reviews \
+                -d '{"body":"PostHog JS auto approved.","event":"APPROVE","comments":[]}'
 
     create-posthog-com-repo-pull-request:
         name: Create posthog.com repo PR with new posthog-js version

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     check-package-version:
         name: Check package version and detect an update
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         outputs:
             committed-version: ${{ steps.check-package-version.outputs.committed-version }}
             published-version: ${{ steps.check-package-version.outputs.published-version }}
@@ -23,7 +23,7 @@ jobs:
 
     release:
         name: Publish release if new version
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         needs: check-package-version
         if: needs.check-package-version.outputs.is-new-version == 'true'
         env:
@@ -68,33 +68,33 @@ jobs:
 
             - name: Create GitHub release
               env:
-                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                # read from the first until the second header in the changelog file
-                # this assumes the formatting of the file
-                # and that this workflow is always running for the most recent entry in the file 
-                LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
-                # the action we used to use was archived, and made it really difficult to create a release with a body
-                # because the LAST_CHANGELOG_ENTRY contains bash special characters so passing it between steps
-                # was a pain.
-                # we can use the github cli to create a release with a body
-                # all as part of one step
-                gh api \
-                  --method POST \
-                  -H "Accept: application/vnd.github+json" \
-                  -H "X-GitHub-Api-Version: 2022-11-28" \
-                  /repos/posthog/posthog-js/releases \
-                  -f tag_name="v${{ env.COMMITTED_VERSION }}" \
-                -f target_commitish='main' \
-                -f name="${{ env.COMMITTED_VERSION }}" \
-                -f body="$LAST_CHANGELOG_ENTRY" \
-                -F draft=false \
-                -F prerelease=false \
-                -F generate_release_notes=false 
+                  # read from the first until the second header in the changelog file
+                  # this assumes the formatting of the file
+                  # and that this workflow is always running for the most recent entry in the file 
+                  LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
+                  # the action we used to use was archived, and made it really difficult to create a release with a body
+                  # because the LAST_CHANGELOG_ENTRY contains bash special characters so passing it between steps
+                  # was a pain.
+                  # we can use the github cli to create a release with a body
+                  # all as part of one step
+                  gh api \
+                    --method POST \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "X-GitHub-Api-Version: 2022-11-28" \
+                    /repos/posthog/posthog-js/releases \
+                    -f tag_name="v${{ env.COMMITTED_VERSION }}" \
+                  -f target_commitish='main' \
+                  -f name="${{ env.COMMITTED_VERSION }}" \
+                  -f body="$LAST_CHANGELOG_ENTRY" \
+                  -F draft=false \
+                  -F prerelease=false \
+                  -F generate_release_notes=false
 
     create-posthog-main-repo-pull-request:
         name: Create main repo PR with new posthog-js version
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         needs: [check-package-version, release]
         env:
             COMMITTED_VERSION: ${{ needs.check-package-version.outputs.committed-version }}
@@ -161,25 +161,25 @@ jobs:
 
             - name: Stamp PR
               run: |
-                # unbelievably github has a race condition where if you commit and
-                # approve too quickly on a PR with "auto-merge" enabled it can miss
-                # the new commit in the merge commit (but it looks like the PR has the change)
-                # Sleep 5 should work
-                sleep 5
-                pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+                  # unbelievably github has a race condition where if you commit and
+                  # approve too quickly on a PR with "auto-merge" enabled it can miss
+                  # the new commit in the merge commit (but it looks like the PR has the change)
+                  # Sleep 5 should work
+                  sleep 5
+                  pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 
-                pull_number=${{ steps.main-repo-pr.outputs.pull-request-number }}
-                curl -L \
-                -X POST \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer ${{ steps.deployer.outputs.token }}" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/posthog/posthog/pulls/${pull_number}/reviews \
-                -d '{"body":"PostHog JS auto approved.","event":"APPROVE","comments":[]}'
+                  pull_number=${{ steps.main-repo-pr.outputs.pull-request-number }}
+                  curl -L \
+                  -X POST \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Authorization: Bearer ${{ steps.deployer.outputs.token }}" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  https://api.github.com/repos/posthog/posthog/pulls/${pull_number}/reviews \
+                  -d '{"body":"PostHog JS auto approved.","event":"APPROVE","comments":[]}'
 
     create-posthog-com-repo-pull-request:
         name: Create posthog.com repo PR with new posthog-js version
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         needs: [check-package-version, release]
         env:
             COMMITTED_VERSION: ${{ needs.check-package-version.outputs.committed-version }}

--- a/.github/workflows/es-check.yml
+++ b/.github/workflows/es-check.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   ssr:
     name: Build and check ES5/ES6 support
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/label-alpha-release.yml
+++ b/.github/workflows/label-alpha-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-permissions:
     name: "Check user has permission to release"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
 # can have multiple outputs
 #      check-result: ${{ steps.check-permissions.outputs.check-result }}
@@ -21,7 +21,7 @@ jobs:
           require: 'write'
   warn-when-failed:
     name: Warn when the user does not have the required permissions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: check-permissions
     if: needs.check-permissions.outputs.require-result == 'false'
     steps:
@@ -30,7 +30,7 @@ jobs:
 
   label-alpha-release:
     name: Release alpha version based on PR label
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: check-permissions
     if: needs.check-permissions.outputs.require-result == 'true' && 
         contains(github.event.pull_request.labels.*.name, 'release alpha')

--- a/.github/workflows/label-version-bump.yml
+++ b/.github/workflows/label-version-bump.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     label-version-bump:
         name: Bump version based on PR label
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         if: |
             github.event.pull_request.merged
             && (

--- a/.github/workflows/label-version-bump.yml
+++ b/.github/workflows/label-version-bump.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     label-version-bump:
         name: Bump version based on PR label
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         if: |
             github.event.pull_request.merged
             && (
@@ -76,5 +76,5 @@ jobs:
               uses: EndBug/add-and-commit@v7
               with:
                   branch: ${{ github.event.pull_request.base.ref }}
-                  message: "chore: Bump version to ${{ steps.versions.outputs.new-version }}"
+                  message: 'chore: Bump version to ${{ steps.versions.outputs.new-version }}'
                   github_token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -15,11 +15,11 @@ jobs:
             - uses: pnpm/action-setup@v4
             - uses: actions/setup-node@v4
               with:
-                node-version: '18'
-                cache: 'pnpm'
+                  node-version: '18'
+                  cache: 'pnpm'
             - run: pnpm install
             - run: pnpm build
-            - run: pnpm test:unit
+            - run: pnpm test:unit --verbose
 
     integration:
         name: Playwright E2E tests
@@ -29,7 +29,7 @@ jobs:
             - uses: pnpm/action-setup@v4
             - uses: actions/setup-node@v4
               with:
-                node-version: '18'
+                  node-version: '18'
             - run: pnpm install
             - run: pnpm build
             - name: Install Playwright Browsers
@@ -39,9 +39,9 @@ jobs:
             - uses: actions/upload-artifact@v4
               if: ${{ !cancelled() }}
               with:
-                name: playwright-report
-                path: playwright-report/
-                retention-days: 30
+                  name: playwright-report
+                  path: playwright-report/
+                  retention-days: 30
 
     functional:
         name: Functional tests
@@ -51,8 +51,8 @@ jobs:
             - uses: pnpm/action-setup@v4
             - uses: actions/setup-node@v4
               with:
-                node-version: '18'
-                cache: 'pnpm'
+                  node-version: '18'
+                  cache: 'pnpm'
             - run: pnpm install
             - run: pnpm run test:functional
 

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     integration:
         name: Playwright E2E tests
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4
@@ -45,7 +45,7 @@ jobs:
 
     functional:
         name: Functional tests
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4
@@ -58,7 +58,7 @@ jobs:
 
     lint:
         name: Lint
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -9,17 +9,17 @@ on:
 jobs:
     unit:
         name: Unit tests
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: '18'
-                  cache: 'pnpm'
+                node-version: '18'
+                cache: 'pnpm'
             - run: pnpm install
             - run: pnpm build
-            - run: pnpm test:unit --verbose
+            - run: pnpm test:unit
 
     integration:
         name: Playwright E2E tests
@@ -29,7 +29,7 @@ jobs:
             - uses: pnpm/action-setup@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: '18'
+                node-version: '18'
             - run: pnpm install
             - run: pnpm build
             - name: Install Playwright Browsers
@@ -39,9 +39,9 @@ jobs:
             - uses: actions/upload-artifact@v4
               if: ${{ !cancelled() }}
               with:
-                  name: playwright-report
-                  path: playwright-report/
-                  retention-days: 30
+                name: playwright-report
+                path: playwright-report/
+                retention-days: 30
 
     functional:
         name: Functional tests
@@ -51,8 +51,8 @@ jobs:
             - uses: pnpm/action-setup@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: '18'
-                  cache: 'pnpm'
+                node-version: '18'
+                cache: 'pnpm'
             - run: pnpm install
             - run: pnpm run test:functional
 

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     lint-pr:
         name: Validate PR title against Conventional Commits
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - uses: amannn/action-semantic-pull-request@v4
               env:

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
     unit:
         name: Check minimum TS version
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         strategy:
           matrix:
             node-version: [ 18, 20, 22, 23 ]

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     check-description:
         name: Check that PR has description
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         steps:
             - name: Check if PR is shame-worthy
               id: is-shame-worthy

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     check-description:
         name: Check that PR has description
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - name: Check if PR is shame-worthy
               id: is-shame-worthy

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   react:
     name: Test with React
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,7 +7,7 @@ jobs:
     stale:
         # Only unleash the stale bot on PostHog/posthog, as there's no POSTHOG_BOT_GITHUB_TOKEN token on forks
         if: ${{ github.repository == 'PostHog/posthog-js' }}
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/stale@v6
               with:

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   browsers:
     name: Test on ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:


### PR DESCRIPTION
## Changes

Last few runs have been hit by Ubuntu 20.04 brownout: https://github.com/PostHog/posthog-js/actions/workflows/label-version-bump.yml

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
