### PR TITLE
fix(flags): Make sure flags are loaded when identify is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ These dependencies are marked as optional to reduce installation size for users 
 
 ## Testing
 
+> [!NOTE]
+> Run `pnpm build` at least once before running tests.
+
+
 - Unit tests: run `pnpm test`.
 - Cypress: run `pnpm start` to have a test server running and separately `pnpm cypress` to launch Cypress test engine.
 - Playwright: run e.g. `pnpm exec playwright test --ui --project webkit --project firefox` to run with UI and in webkit and firefox

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -306,7 +306,7 @@ export class PostHogFeatureFlags {
 
                 if (data.disable_flags && !this._additionalReloadRequested) {
                     // If flags are disabled then there is no need to call decide again (flags are the only thing that may change)
-                    // UNLESS, an adittional reload is requested.
+                    // UNLESS, an additional reload is requested.
                     return
                 }
 

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -304,8 +304,9 @@ export class PostHogFeatureFlags {
                     this.instance._onRemoteConfig(response.json ?? {})
                 }
 
-                if (data.disable_flags) {
+                if (data.disable_flags && !this._additionalReloadRequested) {
                     // If flags are disabled then there is no need to call decide again (flags are the only thing that may change)
+                    // UNLESS, an adittional reload is requested.
                     return
                 }
 


### PR DESCRIPTION
When setting `advanced_disable_feature_flags_on_first_load`, we do not load feature flags on `posthog.init`. However, we do call `/decide` with `disableFlags: true`. However, when a subsequent `identify` call occurs immediately after, it's supposed to load the feature flags, but wasn't due to a race condition.

This PR fixes that condition.

## Changes

Closes: #1766

## Testing

I tested manually and confirmed that it fixed the minimal repro provided in #1766. I hope to follow up with some sort of test automation, but it's tricky.