### PR TITLE
fix(flags): do not reset $anon_distinct_id after first decide call if advanced_disable_feature_flags_on_first_load is true

### DIFF
--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -293,7 +293,9 @@ export class PostHogFeatureFlags {
                     // successful request
                     // reset anon_distinct_id after at least a single request with it
                     // makes it through
-                    this.$anon_distinct_id = undefined
+                    if (!this._additionalReloadRequested) {
+                        this.$anon_distinct_id = undefined
+                    }
                     errorsLoading = false
                 }
 


### PR DESCRIPTION

## Changes

Follow up to https://github.com/PostHog/posthog-js/pull/1785, this PR addresses the same case where advanced_disable_feature_flags_on_first_load is set. The second decide call needs $anon_distinct_id to be present in order for authentication persistence to work as intended

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
