### PR TITLE
fix: Fix site app loading

### DIFF
--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -310,7 +310,7 @@ describe('SiteApps', () => {
                     siteApps: [
                         {
                             id: '1',
-                            init: jest.fn((config: Omit<AppConfig, 'processEvent'>) => {
+                            init: jest.fn((config: AppConfig) => {
                                 const processEvent = jest.fn()
                                 appConfigs.push({ ...config, processEvent })
                                 onInit?.(config)

--- a/src/__tests__/site-apps.ts
+++ b/src/__tests__/site-apps.ts
@@ -298,32 +298,35 @@ describe('SiteApps', () => {
     })
 
     describe('onRemoteConfig', () => {
-        let appConfigs: {
+        interface AppConfig {
             posthog: PostHog
             callback: (success: boolean) => void
-        }[] = []
-
-        beforeEach(() => {
-            appConfigs = []
+        }
+        let appConfigs: (AppConfig & { processEvent: jest.Mock })[] = []
+        const init = (onInit?: (appConfig: AppConfig) => void) => {
             assignableWindow._POSTHOG_REMOTE_CONFIG = {
                 [token]: {
                     config: {},
                     siteApps: [
                         {
                             id: '1',
-                            init: jest.fn((config) => {
-                                appConfigs.push(config)
+                            init: jest.fn((config: Omit<AppConfig, 'processEvent'>) => {
+                                const processEvent = jest.fn()
+                                appConfigs.push({ ...config, processEvent })
+                                onInit?.(config)
                                 return {
-                                    processEvent: jest.fn(),
+                                    processEvent,
                                 }
                             }),
                         },
                         {
                             id: '2',
-                            init: jest.fn((config) => {
-                                appConfigs.push(config)
+                            init: jest.fn((config: AppConfig) => {
+                                const processEvent = jest.fn()
+                                appConfigs.push({ ...config, processEvent })
+                                onInit?.(config)
                                 return {
-                                    processEvent: jest.fn(),
+                                    processEvent,
                                 }
                             }),
                         },
@@ -332,14 +335,20 @@ describe('SiteApps', () => {
             } as any
 
             siteAppsInstance.init()
+        }
+
+        beforeEach(() => {
+            appConfigs = []
         })
 
         it('sets up the eventCaptured listener if site apps', () => {
+            init()
             siteAppsInstance.onRemoteConfig({} as RemoteConfig)
             expect(posthog.on).toHaveBeenCalledWith('eventCaptured', expect.any(Function))
         })
 
         it('does not sets up the eventCaptured listener if no site apps', () => {
+            init()
             assignableWindow._POSTHOG_REMOTE_CONFIG = {
                 [token]: {
                     config: {},
@@ -351,11 +360,13 @@ describe('SiteApps', () => {
         })
 
         it('loads site apps via the window object if defined', () => {
+            init()
             siteAppsInstance.onRemoteConfig({} as RemoteConfig)
             expect(appConfigs[0]).toBeDefined()
             expect(siteAppsInstance.apps['1']).toEqual({
                 errored: false,
                 loaded: false,
+                processedBuffer: false,
                 id: '1',
                 processEvent: expect.any(Function),
             })
@@ -365,17 +376,20 @@ describe('SiteApps', () => {
             expect(siteAppsInstance.apps['1']).toEqual({
                 errored: false,
                 loaded: true,
+                processedBuffer: false,
                 id: '1',
                 processEvent: expect.any(Function),
             })
         })
 
         it('marks site app as errored if callback fails', () => {
+            init()
             siteAppsInstance.onRemoteConfig({} as RemoteConfig)
             expect(appConfigs[0]).toBeDefined()
             expect(siteAppsInstance.apps['1']).toMatchObject({
                 errored: false,
                 loaded: false,
+                processedBuffer: false,
             })
 
             appConfigs[0].callback(false)
@@ -383,10 +397,12 @@ describe('SiteApps', () => {
             expect(siteAppsInstance.apps['1']).toMatchObject({
                 errored: true,
                 loaded: true,
+                processedBuffer: false,
             })
         })
 
         it('calls the processEvent method if it exists and events are buffered', () => {
+            init()
             emitCaptureEvent?.('test_event1', { event: 'test_event1' } as any)
             siteAppsInstance.onRemoteConfig({} as RemoteConfig)
             emitCaptureEvent?.('test_event2', { event: 'test_event2' } as any)
@@ -402,7 +418,8 @@ describe('SiteApps', () => {
             )
         })
 
-        it('clears the buffer after all apps are loaded', () => {
+        it('clears the buffer after all apps are loaded, when succeeding async', () => {
+            init()
             emitCaptureEvent?.('test_event1', { event: 'test_event1' } as any)
             emitCaptureEvent?.('test_event2', { event: 'test_event2' } as any)
             expect(siteAppsInstance['bufferedInvocations'].length).toBe(2)
@@ -410,11 +427,30 @@ describe('SiteApps', () => {
             siteAppsInstance.onRemoteConfig({} as RemoteConfig)
             appConfigs[0].callback(true)
             expect(siteAppsInstance['bufferedInvocations'].length).toBe(2)
-            appConfigs[1].callback(false)
+            appConfigs[1].callback(true)
             expect(siteAppsInstance['bufferedInvocations'].length).toBe(0)
+
+            expect(siteAppsInstance.apps['1'].processEvent).toHaveBeenCalledTimes(2)
+            expect(siteAppsInstance.apps['2'].processEvent).toHaveBeenCalledTimes(2)
+        })
+
+        it('clears the buffer after all apps are loaded, when succeeding sync', () => {
+            init(({ callback }) => {
+                callback(true)
+            })
+            emitCaptureEvent?.('test_event1', { event: 'test_event1' } as any)
+            emitCaptureEvent?.('test_event2', { event: 'test_event2' } as any)
+            expect(siteAppsInstance['bufferedInvocations'].length).toBe(2)
+
+            siteAppsInstance.onRemoteConfig({} as RemoteConfig)
+            expect(siteAppsInstance['bufferedInvocations'].length).toBe(0)
+
+            expect(siteAppsInstance.apps['1'].processEvent).toHaveBeenCalledTimes(2)
+            expect(siteAppsInstance.apps['2'].processEvent).toHaveBeenCalledTimes(2)
         })
 
         it('logs error if site apps are disabled but response contains site apps', () => {
+            init()
             posthog.config.opt_in_site_apps = false
             assignableWindow.POSTHOG_DEBUG = true
 

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -83,32 +83,28 @@ export class SiteApps {
     }
 
     setupSiteApp(loader: SiteAppLoader) {
-        const app: SiteApp = {
-            id: loader.id,
-            loaded: false,
-            errored: false,
-        }
-        this.apps[loader.id] = app
-
-        const onLoaded = (success: boolean) => {
-            this.apps[loader.id].errored = !success
-            this.apps[loader.id].loaded = true
-
-            logger.info(`Site app with id ${loader.id} ${success ? 'loaded' : 'errored'}`)
-
-            if (success && this.bufferedInvocations.length) {
+        const app = this.apps[loader.id]
+        const processBufferedEvents = () => {
+            if (!app.errored && this.bufferedInvocations.length) {
                 logger.info(`Processing ${this.bufferedInvocations.length} events for site app with id ${loader.id}`)
                 this.bufferedInvocations.forEach((globals) => app.processEvent?.(globals))
+                app.processedBuffer = true
             }
 
-            for (const app of Object.values(this.apps)) {
-                if (!app.loaded) {
-                    // If any other apps are not loaded, we don't want to stop buffering
-                    return
-                }
+            if (Object.keys(this.apps).every((id) => this.apps[id].processedBuffer || this.apps[id].errored)) {
+                this.stopBuffering?.()
             }
+        }
 
-            this.stopBuffering?.()
+        let hasInitReturned = false
+        const onLoaded = (success: boolean) => {
+            app.errored = !success
+            app.loaded = true
+            logger.info(`Site app with id ${loader.id} ${success ? 'loaded' : 'errored'}`)
+            // ensure that we don't call processBufferedEvents until after init() returns and we've set up processEvent
+            if (hasInitReturned) {
+                processBufferedEvents()
+            }
         }
 
         try {
@@ -118,13 +114,40 @@ export class SiteApps {
                     onLoaded(success)
                 },
             })
-
             if (processEvent) {
                 app.processEvent = processEvent
             }
+            hasInitReturned = true
         } catch (e) {
             logger.error(`Error while initializing PostHog app with config id ${loader.id}`, e)
             onLoaded(false)
+        }
+
+        // if the app loaded synchronously, process the events now
+        if (hasInitReturned && app.loaded) {
+            try {
+                processBufferedEvents()
+            } catch (e) {
+                logger.error(`Error while processing buffered events PostHog app with config id ${loader.id}`, e)
+                app.errored = true
+            }
+        }
+    }
+
+    private setupSiteApps() {
+        const siteAppLoaders = this.siteAppLoaders || []
+
+        // do this in 2 passes, so that this.apps is populated before we call init
+        for (const loader of siteAppLoaders) {
+            this.apps[loader.id] = {
+                id: loader.id,
+                loaded: false,
+                errored: false,
+                processedBuffer: false,
+            }
+        }
+        for (const loader of siteAppLoaders) {
+            this.setupSiteApp(loader)
         }
     }
 
@@ -151,9 +174,7 @@ export class SiteApps {
                 return
             }
 
-            for (const app of this.siteAppLoaders) {
-                this.setupSiteApp(app)
-            }
+            this.setupSiteApps()
 
             // NOTE: We could improve this to only fire if we actually have listeners for the event
             this.instance.on('eventCaptured', (event) => this.onCapturedEvent(event))

--- a/src/site-apps.ts
+++ b/src/site-apps.ts
@@ -91,7 +91,7 @@ export class SiteApps {
                 app.processedBuffer = true
             }
 
-            if (Object.keys(this.apps).every((id) => this.apps[id].processedBuffer || this.apps[id].errored)) {
+            if (Object.values(this.apps).every((app) => app.processedBuffer || app.errored)) {
                 this.stopBuffering?.()
             }
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1363,6 +1363,7 @@ export type SiteApp = {
     id: string
     loaded: boolean
     errored: boolean
+    processedBuffer: boolean
     processEvent?: (globals: SiteAppGlobals) => void
 }
 


### PR DESCRIPTION
## Changes

There were some bugs with site app loading, which this PR fixes

* It was possible to process batched events for a site app before the init call had returned.
* It was possible for one app to init immediately, and clear out the batched events for yet-to-be-initialized apps

I made one existing test fail by asserting that processEvents had been called the right number of times on both apps, and made a new failing test where the init call returns immediately. These changes fix both tests.

See also https://posthog.slack.com/archives/C06GG249PR6/p1741183829699909

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
