### PR TITLE
chore(flags): support handling optional `requestId`s in `/decide` responses

### DIFF
--- a/src/__tests__/featureflags.test.ts
+++ b/src/__tests__/featureflags.test.ts
@@ -1213,6 +1213,75 @@ describe('featureflags', () => {
             })
         })
     })
+
+    describe('Feature Flag Request ID', () => {
+        const TEST_REQUEST_ID = 'test-request-id-123'
+
+        it('saves requestId from decide response', () => {
+            featureFlags.receivedFeatureFlags({
+                featureFlags: { 'test-flag': true },
+                featureFlagPayloads: {},
+                requestId: TEST_REQUEST_ID,
+            })
+
+            expect(instance.get_property('$feature_flag_request_id')).toEqual(TEST_REQUEST_ID)
+        })
+
+        it('includes requestId in feature flag called event', () => {
+            // Setup flags with requestId
+            featureFlags.receivedFeatureFlags({
+                featureFlags: { 'test-flag': true },
+                featureFlagPayloads: {},
+                requestId: TEST_REQUEST_ID,
+            })
+            featureFlags._hasLoadedFlags = true
+
+            // Test flag call
+            featureFlags.getFeatureFlag('test-flag')
+
+            // Verify capture call includes requestId
+            expect(instance.capture).toHaveBeenCalledWith(
+                '$feature_flag_called',
+                expect.objectContaining({
+                    $feature_flag: 'test-flag',
+                    $feature_flag_response: true,
+                    $feature_flag_request_id: TEST_REQUEST_ID,
+                })
+            )
+        })
+
+        it('updates requestId when new decide response is received', () => {
+            // First decide response
+            featureFlags.receivedFeatureFlags({
+                featureFlags: { 'test-flag': true },
+                featureFlagPayloads: {},
+                requestId: TEST_REQUEST_ID,
+            })
+
+            expect(instance.get_property('$feature_flag_request_id')).toEqual(TEST_REQUEST_ID)
+
+            // Second decide response with new ID
+            const NEW_REQUEST_ID = 'new-request-id-456'
+            featureFlags.receivedFeatureFlags({
+                featureFlags: { 'test-flag': true },
+                featureFlagPayloads: {},
+                requestId: NEW_REQUEST_ID,
+            })
+
+            expect(instance.get_property('$feature_flag_request_id')).toEqual(NEW_REQUEST_ID)
+
+            // Verify new ID is used in events
+            featureFlags._hasLoadedFlags = true
+            featureFlags.getFeatureFlag('test-flag')
+
+            expect(instance.capture).toHaveBeenCalledWith(
+                '$feature_flag_called',
+                expect.objectContaining({
+                    $feature_flag_request_id: NEW_REQUEST_ID,
+                })
+            )
+        })
+    })
 })
 
 describe('parseFeatureFlagDecideResponse', () => {
@@ -1268,6 +1337,21 @@ describe('parseFeatureFlagDecideResponse', () => {
 
         expect(persistence.register).not.toHaveBeenCalled()
         expect(persistence.unregister).not.toHaveBeenCalled()
+    })
+
+    it('parses the requestId from the decide response', () => {
+        const decideResponse = {
+            featureFlags: { 'test-flag': true },
+            requestId: 'test-request-id-123',
+        }
+        parseFeatureFlagDecideResponse(decideResponse, persistence)
+
+        expect(persistence.register).toHaveBeenCalledWith({
+            $active_feature_flags: ['test-flag'],
+            $enabled_feature_flags: { 'test-flag': true },
+            $feature_flag_payloads: {},
+            $feature_flag_request_id: 'test-request-id-123',
+        })
     })
 })
 

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -30,6 +30,7 @@ const PERSISTENCE_ACTIVE_FEATURE_FLAGS = '$active_feature_flags'
 const PERSISTENCE_OVERRIDE_FEATURE_FLAGS = '$override_feature_flags'
 const PERSISTENCE_FEATURE_FLAG_PAYLOADS = '$feature_flag_payloads'
 const PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS = '$override_feature_flag_payloads'
+const PERSISTENCE_FEATURE_FLAG_REQUEST_ID = '$feature_flag_request_id'
 
 export const filterActiveFeatureFlags = (featureFlags?: Record<string, string | boolean>) => {
     const activeFeatureFlags: Record<string, string | boolean> = {}
@@ -49,6 +50,7 @@ export const parseFeatureFlagDecideResponse = (
 ) => {
     const flags = response['featureFlags']
     const flagPayloads = response['featureFlagPayloads']
+    const requestId = response['requestId']
     if (!flags) {
         return
     }
@@ -81,6 +83,7 @@ export const parseFeatureFlagDecideResponse = (
             [PERSISTENCE_ACTIVE_FEATURE_FLAGS]: Object.keys(filterActiveFeatureFlags(newFeatureFlags)),
             [ENABLED_FEATURE_FLAGS]: newFeatureFlags || {},
             [PERSISTENCE_FEATURE_FLAG_PAYLOADS]: newFeatureFlagPayloads || {},
+            ...(requestId ? { [PERSISTENCE_FEATURE_FLAG_REQUEST_ID]: requestId } : {}),
         })
 }
 
@@ -347,6 +350,7 @@ export class PostHogFeatureFlags {
         }
         const flagValue = this.getFlagVariants()[key]
         const flagReportValue = `${flagValue}`
+        const requestId = this.instance.get_property(PERSISTENCE_FEATURE_FLAG_REQUEST_ID) || undefined
         const flagCallReported: Record<string, string[]> = this.instance.get_property(FLAG_CALL_REPORTED) || {}
 
         if (options.send_event || !('send_event' in options)) {
@@ -362,6 +366,7 @@ export class PostHogFeatureFlags {
                     $feature_flag: key,
                     $feature_flag_response: flagValue,
                     $feature_flag_payload: this.getFeatureFlagPayload(key) || null,
+                    $feature_flag_request_id: requestId,
                     $feature_flag_bootstrapped_response: this.instance.config.bootstrap?.featureFlags?.[key] || null,
                     $feature_flag_bootstrapped_payload:
                         this.instance.config.bootstrap?.featureFlagPayloads?.[key] || null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1335,6 +1335,7 @@ export interface DecideResponse extends RemoteConfig {
     featureFlags: Record<string, string | boolean>
     featureFlagPayloads: Record<string, JsonType>
     errorsWhileComputingFlags: boolean
+    requestId?: string
 }
 
 export type SiteAppGlobals = {


### PR DESCRIPTION
## Changes

Supports the changes here: https://github.com/PostHog/posthog/pull/29563