### PR TITLE
fix: Reverse error message

### DIFF
--- a/react/src/context/PostHogProvider.tsx
+++ b/react/src/context/PostHogProvider.tsx
@@ -61,8 +61,8 @@ export function PostHogProvider({ children, client, apiKey, options }: WithOptio
                 )
             }
 
-            if (client.__loaded) {
-                console.warn('[PostHog.js] `client` was already loaded elsewhere. This may cause issues.')
+            if (!client.__loaded) {
+                console.warn('[PostHog.js] you should provide an _initialized_ `client` to `PostHogProvider` .')
             }
 
             return client


### PR DESCRIPTION
## Changes

I believe that this is the wrong way around. The docs says here https://posthog.com/docs/libraries/react#posthog-provider 
> The provider can either take an initialized client instance OR an API key and an optional options object.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
