### PR TITLE
fix: Stop logging error when client is uninitialized

### DIFF
--- a/react/src/context/PostHogProvider.tsx
+++ b/react/src/context/PostHogProvider.tsx
@@ -61,10 +61,6 @@ export function PostHogProvider({ children, client, apiKey, options }: WithOptio
                 )
             }
 
-            if (!client.__loaded) {
-                console.warn('[PostHog.js] you should provide an _initialized_ `client` to `PostHogProvider` .')
-            }
-
             return client
         }
 


### PR DESCRIPTION
This causes errors on NextJS because it will be uninitialized on the server-side. We already make it pretty clear that you should control initializing the client when passing it in as a prop, so let's give up on the error log altogether

Closes #1802