### PR TITLE
fix: simple loader race protection

### DIFF
--- a/src/__tests__/utils/external-scripts-loader.test.ts
+++ b/src/__tests__/utils/external-scripts-loader.test.ts
@@ -43,6 +43,12 @@ describe('external-scripts-loader', () => {
             const scripts = document!.getElementsByTagName('script')
             expect(scripts.length).toBe(1)
             expect(scripts[0].src).toMatchInlineSnapshot(`"https://us-assets.i.posthog.com/static/recorder.js?v=1.0.0"`)
+            
+            // Verify both callbacks are called when script loads
+            const event = new Event('test')
+            scripts[0].onload!(event)
+            expect(callback).toHaveBeenCalledTimes(2)
+            expect(callback).toHaveBeenCalledWith(undefined, event)
         })
 
         it("should add the script to the page when there aren't any preexisting scripts on the page", () => {

--- a/src/__tests__/utils/external-scripts-loader.test.ts
+++ b/src/__tests__/utils/external-scripts-loader.test.ts
@@ -41,7 +41,7 @@ describe('external-scripts-loader', () => {
             assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
 
             const scripts = document!.getElementsByTagName('script')
-            expect(scripts.length).toBe(1) // This will fail, showing the bug
+            expect(scripts.length).toBe(1)
             expect(scripts[0].src).toMatchInlineSnapshot(`"https://us-assets.i.posthog.com/static/recorder.js?v=1.0.0"`)
         })
 

--- a/src/__tests__/utils/external-scripts-loader.test.ts
+++ b/src/__tests__/utils/external-scripts-loader.test.ts
@@ -33,6 +33,18 @@ describe('external-scripts-loader', () => {
             expect(callback).toHaveBeenCalledWith(undefined, event)
         })
 
+        it('should not add duplicate scripts when called multiple times with the same URL', () => {
+            // First call to load the script
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
+
+            // Second call with the same script
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
+
+            const scripts = document!.getElementsByTagName('script')
+            expect(scripts.length).toBe(1) // This will fail, showing the bug
+            expect(scripts[0].src).toMatchInlineSnapshot(`"https://us-assets.i.posthog.com/static/recorder.js?v=1.0.0"`)
+        })
+
         it("should add the script to the page when there aren't any preexisting scripts on the page", () => {
             assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
             const scripts = document!.getElementsByTagName('script')

--- a/src/entrypoints/external-scripts-loader.ts
+++ b/src/entrypoints/external-scripts-loader.ts
@@ -10,13 +10,14 @@ const loadScript = (posthog: PostHog, url: string, callback: (error?: string | E
         return callback('Loading of external scripts is disabled')
     }
 
-    // Check if script already exists
+    // If we add a script more than once then the browser will parse and execute it
+    // So, even if idempotent we waste parsing and processing time
     const existingScripts = document?.querySelectorAll('script')
     if (existingScripts) {
         for (let i = 0; i < existingScripts.length; i++) {
             if (existingScripts[i].src === url) {
-                // Script already exists, just call the callback
-                return callback()
+                // Script already exists, do nothing, the first addition called the callback
+                return
             }
         }
     }

--- a/src/entrypoints/external-scripts-loader.ts
+++ b/src/entrypoints/external-scripts-loader.ts
@@ -10,6 +10,17 @@ const loadScript = (posthog: PostHog, url: string, callback: (error?: string | E
         return callback('Loading of external scripts is disabled')
     }
 
+    // Check if script already exists
+    const existingScripts = document?.querySelectorAll('script')
+    if (existingScripts) {
+        for (let i = 0; i < existingScripts.length; i++) {
+            if (existingScripts[i].src === url) {
+                // Script already exists, just call the callback
+                return callback()
+            }
+        }
+    }
+
     const addScript = () => {
         if (!document) {
             return callback('document not found')

--- a/src/entrypoints/external-scripts-loader.ts
+++ b/src/entrypoints/external-scripts-loader.ts
@@ -16,8 +16,8 @@ const loadScript = (posthog: PostHog, url: string, callback: (error?: string | E
     if (existingScripts) {
         for (let i = 0; i < existingScripts.length; i++) {
             if (existingScripts[i].src === url) {
-                // Script already exists, do nothing, the first addition called the callback
-                return
+                // Script already exists, we still call the callback, they have to be idempotent
+                return callback()
             }
         }
     }


### PR DESCRIPTION
the external script loader can add a script more than once

while the script might be idempotent it has to be parsed each time and will execute each time

let's add a simple check for the script's presence in the DOM and not add it if it's already there