### PR TITLE
fix: send both id-based and index-based responses

### DIFF
--- a/playwright/surveys/question-types.spec.ts
+++ b/playwright/surveys/question-types.spec.ts
@@ -1,4 +1,3 @@
-import { getSurveyResponseKey } from '../../src/extensions/surveys/surveys-utils'
 import { pollUntilEventCaptured } from '../utils/event-capture-utils'
 import { expect, test } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
@@ -167,10 +166,13 @@ test.describe('surveys - core display logic', () => {
             '$autocapture',
         ])
         const surveySent = captures.find((c) => c.event === 'survey sent')
-        expect(surveySent!.properties[getSurveyResponseKey('multiple_choice_1')]).toEqual(['Product Updates', 'Events'])
+        expect(surveySent!.properties['$survey_response_multiple_choice_1']).toEqual(['Product Updates', 'Events'])
+        expect(surveySent!.properties['$survey_response']).toEqual(['Product Updates', 'Events'])
         expect(surveySent!.properties['$survey_id']).toEqual('12345')
-        expect(surveySent!.properties[getSurveyResponseKey('open_text_1')]).toEqual('Great job!')
-        expect(surveySent!.properties[getSurveyResponseKey('nps_rating_1')]).toBeNull()
+        expect(surveySent!.properties['$survey_response_open_text_1']).toEqual('Great job!')
+        expect(surveySent!.properties['$survey_response_1']).toEqual('Great job!')
+        expect(surveySent!.properties['$survey_response_nps_rating_1']).toBeNull()
+        expect(surveySent!.properties['$survey_response_2']).toBeNull()
     })
 
     test('multiple choice questions with open choice', async ({ page, context }) => {
@@ -210,7 +212,8 @@ test.describe('surveys - core display logic', () => {
             'survey sent',
         ])
         const surveySent = captures.find((c) => c.event === 'survey sent')
-        expect(surveySent!.properties[getSurveyResponseKey('multiple_choice_1')]).toEqual(['Tutorials', 'Newsletters'])
+        expect(surveySent!.properties['$survey_response_multiple_choice_1']).toEqual(['Tutorials', 'Newsletters'])
+        expect(surveySent!.properties['$survey_response']).toEqual(['Tutorials', 'Newsletters'])
     })
 
     test('single choice questions with open choice', async ({ page, context }) => {
@@ -256,6 +259,7 @@ test.describe('surveys - core display logic', () => {
             'survey sent',
         ])
         const surveySent = captures.find((c) => c.event === 'survey sent')
-        expect(surveySent!.properties[getSurveyResponseKey('single_choice_1')]).toEqual('Product engineer')
+        expect(surveySent!.properties['$survey_response_single_choice_1']).toEqual('Product engineer')
+        expect(surveySent!.properties['$survey_response']).toEqual('Product engineer')
     })
 })

--- a/playwright/surveys/response-capture.spec.ts
+++ b/playwright/surveys/response-capture.spec.ts
@@ -1,4 +1,3 @@
-import { getSurveyResponseKey } from '../../src/extensions/surveys/surveys-utils'
 import { pollUntilEventCaptured } from '../utils/event-capture-utils'
 import { expect, test } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
@@ -51,7 +50,8 @@ test.describe('surveys - feedback widget', () => {
         expect(surveySentEvent!.properties).toEqual(
             expect.objectContaining({
                 $survey_id: '123',
-                [getSurveyResponseKey('open_text_1')]: 'experiments is awesome!',
+                $survey_response: 'experiments is awesome!',
+                $survey_response_open_text_1: 'experiments is awesome!',
             })
         )
     })
@@ -100,7 +100,8 @@ test.describe('surveys - feedback widget', () => {
         expect(surveySentEvent!.properties).toEqual(
             expect.objectContaining({
                 $survey_id: '123',
-                [getSurveyResponseKey('open_text_1')]: 'experiments is awesome!',
+                $survey_response_open_text_1: 'experiments is awesome!',
+                $survey_response: 'experiments is awesome!',
                 $survey_iteration: 2,
                 $survey_iteration_start_date: '12-12-2004',
             })

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -31,7 +31,7 @@ import {
     dismissedSurveyEvent,
     getContrastingTextColor,
     getDisplayOrderQuestions,
-    getSurveyResponseKey,
+    getSurveyResponseKeys,
     getSurveySeen,
     hasWaitPeriodPassed,
     sendSurveyEvent,
@@ -745,6 +745,10 @@ export function SurveyPopup({
     ) : null
 }
 
+interface QuestionResponses {
+    [key: string]: string | string[] | number | null
+}
+
 export function Questions({
     survey,
     forceDisableHtml,
@@ -759,7 +763,7 @@ export function Questions({
     const textColor = getContrastingTextColor(
         survey.appearance?.backgroundColor || defaultSurveyAppearance.backgroundColor
     )
-    const [questionsResponses, setQuestionsResponses] = useState({})
+    const [questionsResponses, setQuestionsResponses] = useState<QuestionResponses>({})
     const { previewPageIndex, onPopupSurveyDismissed, isPopup, onPreviewSubmit, onPopupSurveySent } =
         useContext(SurveyContext)
     const [currentQuestionIndex, setCurrentQuestionIndex] = useState(previewPageIndex || 0)
@@ -789,9 +793,13 @@ export function Questions({
             return
         }
 
-        const responseKey = getSurveyResponseKey(questionId)
-
-        setQuestionsResponses({ ...questionsResponses, [responseKey]: res })
+        const [responseKey, responseKeyIndex] = getSurveyResponseKeys(survey, questionId)
+        const newQuestionsResponses: QuestionResponses = { ...questionsResponses }
+        newQuestionsResponses[responseKey] = res
+        if (responseKeyIndex) {
+            newQuestionsResponses[responseKeyIndex] = res
+        }
+        setQuestionsResponses(newQuestionsResponses)
 
         const nextStep = getNextSurveyStep(survey, displayQuestionIndex, res)
         if (nextStep === SurveyQuestionBranchingType.End) {

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -30,8 +30,23 @@ export function getFontFamily(fontFamily?: string): string {
     return fontFamily ? `${fontFamily}, ${defaultFontStack}` : `-apple-system, ${defaultFontStack}`
 }
 
-export function getSurveyResponseKey(questionId: string) {
+function getSurveyIdBasedResponseKey(questionId: string) {
     return `$survey_response_${questionId}`
+}
+
+function getSurveyIndexBasedResponseKey(questionIndex: number) {
+    return questionIndex === 0 ? '$survey_response' : `$survey_response_${questionIndex}`
+}
+
+export function getSurveyResponseKeys(survey: Survey, questionId: string): [string, string | undefined] {
+    const questionIndex = survey.questions.findIndex((question) => question.id === questionId)
+
+    // This case shouldn't happen, but adding a fallback to avoid errors if it ever does.
+    if (questionIndex === -1) {
+        return [getSurveyIdBasedResponseKey(questionId), undefined]
+    }
+
+    return [getSurveyIdBasedResponseKey(questionId), getSurveyIndexBasedResponseKey(questionIndex)]
 }
 
 export const style = (appearance: SurveyAppearance | null) => {


### PR DESCRIPTION
## Changes

we updated how we [send survey responses](https://github.com/PostHog/posthog-js/pull/1764) 4 days ago, to only rely on the question ID to send the information.

however, the problem with that is this is kind of a breaking change: we had cases where people like to rely on the position to build custom insights and be able to know, consistently, what will be the key that will hold the survey value.

Examples:

- [Extracting the NPS in an insight](https://posthog.slack.com/archives/C06UTAJJEHM/p1741654526117729); [another example](https://posthoghelp.zendesk.com/agent/tickets/26739)
- [Creating zapier automations](https://posthog.slack.com/archives/C07QD3LT8U9/p1741695305536929?thread_ts=1741691950.494259&cid=C07QD3LT8U9)

while we should be relying on question ID to get responses, until we can reliably fix those use cases, we need to be sending both.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
