### PR TITLE
fix: prettier needed running

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -68,6 +68,6 @@ jobs:
                   cache: 'pnpm'
             - run: pnpm install
 
-            - run: pnpm prettier --check
+            - run: pnpm prettier:check
             - run: pnpm lint
             - run: pnpm tsc -b

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,13 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+protected_branch='main'
+current_branch=$(git branch --show-current)
+
+if [ $protected_branch = $current_branch ]
+then
+    echo "Pushing to $protected_branch is a sin! Instead, create a pull request and repent."
+    exit 1 # push will not execute
+else
+    exit 0 # push will execute
+fi

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
         "*.{ts,tsx}": [
             "eslint src --fix",
             "eslint playwright --fix",
-            "pnpm prettier"
+            "prettier --write"
         ]
     },
     "browserslist": [

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "lint": "eslint src && eslint playwright",
         "lint:fix": "eslint src --fix && eslint playwright --fix",
         "prettier": "prettier --write src/ functional_tests/ playwright/",
+        "prettier:check": "prettier --check src/ functional_tests/ playwright/",
         "prepublishOnly": "pnpm lint && pnpm build && pnpm test && pnpm test:react",
         "test": "pnpm test:unit && pnpm test:custom-eslint-rules && pnpm test:functional",
         "test:unit": "jest src",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "build-react": "cd react; NODE_ENV=dev pnpm i; pnpm build;",
         "lint": "eslint src && eslint playwright",
         "lint:fix": "eslint src --fix && eslint playwright --fix",
-        "prettier": "prettier --write src/ functional_tests/",
+        "prettier": "prettier --write src/ functional_tests/ playwright/",
         "prepublishOnly": "pnpm lint && pnpm build && pnpm test && pnpm test:react",
         "test": "pnpm test:unit && pnpm test:custom-eslint-rules && pnpm test:functional",
         "test:unit": "jest src",
@@ -135,7 +135,8 @@
         "*.js": "eslint --cache --fix",
         "*.{ts,tsx}": [
             "eslint src --fix",
-            "eslint playwright --fix"
+            "eslint playwright --fix",
+            "pnpm prettier"
         ]
     },
     "browserslist": [

--- a/src/__tests__/utils/external-scripts-loader.test.ts
+++ b/src/__tests__/utils/external-scripts-loader.test.ts
@@ -43,7 +43,7 @@ describe('external-scripts-loader', () => {
             const scripts = document!.getElementsByTagName('script')
             expect(scripts.length).toBe(1)
             expect(scripts[0].src).toMatchInlineSnapshot(`"https://us-assets.i.posthog.com/static/recorder.js?v=1.0.0"`)
-            
+
             // Verify both callbacks are called when script loads
             const event = new Event('test')
             scripts[0].onload!(event)


### PR DESCRIPTION
Somehow got a PR all the way to merged and being published before the publish failed because prettier hadn't been run

wat

labelled as patch so that my failed release gets retried

prettier fail here https://github.com/PostHog/posthog-js/actions/runs/13784405731/job/38548993523

🤣 GH actions warns on prettier errors without failing the step 🫠 

<img width="628" alt="Screenshot 2025-03-11 at 19 19 57" src="https://github.com/user-attachments/assets/649350d6-71dc-4717-8929-5ce441cb492d" />
