### PR TITLE
feat(flags): Add version info to $feature_flag_called request

### DIFF
--- a/playwright/session-recording/session-recording-network-recorder.spec.ts
+++ b/playwright/session-recording/session-recording-network-recorder.spec.ts
@@ -134,7 +134,7 @@ test.beforeEach(async ({ context }) => {
                               // webkit isn't capturing this failed request in the pre-wrapped fetch performance observer records
                               // [/https:\/\/localhost:\d+\/array\/test%20token\/config.js/, 'script'],
                               [
-                                  /https:\/\/localhost:\d+\/decide\/\?v=3&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
+                                  /https:\/\/localhost:\d+\/decide\/\?v=4&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
                                   'fetch',
                               ],
                               // webkit isn't capturing this failed request in the pre-wrapped fetch performance observer records
@@ -158,7 +158,7 @@ test.beforeEach(async ({ context }) => {
                               [/https:\/\/localhost:\d+\/static\/array.js/, 'script'],
                               [/https:\/\/localhost:\d+\/array\/test%20token\/config.js/, 'script'],
                               [
-                                  /https:\/\/localhost:\d+\/decide\/\?v=3&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
+                                  /https:\/\/localhost:\d+\/decide\/\?v=4&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
                                   'fetch',
                               ],
                               [

--- a/playwright/session-recording/session-recording-network-recorder.spec.ts
+++ b/playwright/session-recording/session-recording-network-recorder.spec.ts
@@ -134,7 +134,7 @@ test.beforeEach(async ({ context }) => {
                               // webkit isn't capturing this failed request in the pre-wrapped fetch performance observer records
                               // [/https:\/\/localhost:\d+\/array\/test%20token\/config.js/, 'script'],
                               [
-                                  /https:\/\/localhost:\d+\/decide\/\?v=4&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
+                                  /https:\/\/localhost:\d+\/decide\/\?v=3&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
                                   'fetch',
                               ],
                               // webkit isn't capturing this failed request in the pre-wrapped fetch performance observer records
@@ -158,7 +158,7 @@ test.beforeEach(async ({ context }) => {
                               [/https:\/\/localhost:\d+\/static\/array.js/, 'script'],
                               [/https:\/\/localhost:\d+\/array\/test%20token\/config.js/, 'script'],
                               [
-                                  /https:\/\/localhost:\d+\/decide\/\?v=4&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
+                                  /https:\/\/localhost:\d+\/decide\/\?v=3&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
                                   'fetch',
                               ],
                               [

--- a/src/__tests__/featureflags.test.ts
+++ b/src/__tests__/featureflags.test.ts
@@ -1599,7 +1599,7 @@ describe('featureflags', () => {
                         enabled: true,
                         variant: 'variant-1',
                         reason: {
-                            description: 'test-reason',
+                            description: 'Matched condition set 1',
                             code: 'test-code',
                             condition_index: 1,
                         },
@@ -1623,11 +1623,7 @@ describe('featureflags', () => {
                     $feature_flag_response: 'variant-1',
                     $feature_flag_request_id: TEST_REQUEST_ID,
                     $feature_flag_version: 42,
-                    $feature_flag_reason: {
-                        description: 'test-reason',
-                        code: 'test-code',
-                        condition_index: 1,
-                    },
+                    $feature_flag_reason: 'Matched condition set 1',
                     $feature_flag_id: 23,
                 })
             )

--- a/src/__tests__/featureflags.test.ts
+++ b/src/__tests__/featureflags.test.ts
@@ -1796,7 +1796,7 @@ describe('parseFeatureFlagDecideResponse', () => {
                     enabled: false,
                     variant: undefined,
                     reason: {
-                        code: 'no_maching_condition',
+                        code: 'no_matching_condition',
                         condition_index: undefined,
                         description: undefined,
                     },

--- a/src/__tests__/featureflags.test.ts
+++ b/src/__tests__/featureflags.test.ts
@@ -1877,7 +1877,7 @@ describe('parseFeatureFlagDecideResponse', () => {
                     enabled: false,
                     variant: undefined,
                     reason: {
-                        code: 'no_maching_condition',
+                        code: 'no_matching_condition',
                         condition_index: undefined,
                         description: undefined,
                     },

--- a/src/__tests__/featureflags.test.ts
+++ b/src/__tests__/featureflags.test.ts
@@ -1623,7 +1623,11 @@ describe('featureflags', () => {
                     $feature_flag_response: 'variant-1',
                     $feature_flag_request_id: TEST_REQUEST_ID,
                     $feature_flag_version: 42,
-                    $feature_flag_reason: 'test-reason',
+                    $feature_flag_reason: {
+                        description: 'test-reason',
+                        code: 'test-code',
+                        condition_index: 1,
+                    },
                     $feature_flag_id: 23,
                 })
             )

--- a/src/__tests__/posthog-core.loaded.test.ts
+++ b/src/__tests__/posthog-core.loaded.test.ts
@@ -41,7 +41,7 @@ describe('loaded() with flags', () => {
             expect(instance._send_request).toHaveBeenCalledTimes(1)
 
             expect(instance._send_request.mock.calls[0][0]).toMatchObject({
-                url: 'https://us.i.posthog.com/decide/?v=3',
+                url: 'https://us.i.posthog.com/decide/?v=4',
                 data: {
                     groups: { org: 'bazinga' },
                 },
@@ -64,7 +64,7 @@ describe('loaded() with flags', () => {
             expect(instance._send_request).toHaveBeenCalledTimes(1)
 
             expect(instance._send_request.mock.calls[0][0]).toMatchObject({
-                url: 'https://us.i.posthog.com/decide/?v=3',
+                url: 'https://us.i.posthog.com/decide/?v=4',
                 data: {
                     groups: { org: 'bazinga' },
                 },
@@ -77,7 +77,7 @@ describe('loaded() with flags', () => {
             expect(instance._send_request).toHaveBeenCalledTimes(2)
 
             expect(instance._send_request.mock.calls[1][0]).toMatchObject({
-                url: 'https://us.i.posthog.com/decide/?v=3',
+                url: 'https://us.i.posthog.com/decide/?v=4',
                 data: {
                     groups: { org: 'bazinga2' },
                 },

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -1219,7 +1219,7 @@ describe('posthog core', () => {
                 })
 
                 expect(sendRequestMock.mock.calls[0][0]).toMatchObject({
-                    url: 'http://localhost/decide/?v=3',
+                    url: 'http://localhost/decide/?v=4',
                 })
             })
 

--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -58,7 +58,7 @@ describe('request-router', () => {
         ['  https://app.posthog.com       ', 'https://us.i.posthog.com/'],
         ['https://example.com/', 'https://example.com/'],
     ])('should sanitize the api_host values for "%s"', (apiHost, expected) => {
-        expect(router(apiHost).endpointFor('api', '/decide?v=3')).toEqual(`${expected}decide?v=3`)
+        expect(router(apiHost).endpointFor('api', '/decide?v=4')).toEqual(`${expected}decide?v=4`)
     })
 
     it('should use the ui_host if provided', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,7 @@ export const SESSION_RECORDING_EVENT_TRIGGER_ACTIVATED_SESSION = '$session_recor
 export const SESSION_RECORDING_EVENT_TRIGGER_STATUS = '$session_recording_event_trigger_status'
 export const ENABLED_FEATURE_FLAGS = '$enabled_feature_flags'
 export const PERSISTENCE_EARLY_ACCESS_FEATURES = '$early_access_features'
+export const PERSISTENCE_FEATURE_FLAG_DETAILS = '$feature_flag_details'
 export const STORED_PERSON_PROPERTIES_KEY = '$stored_person_properties'
 export const STORED_GROUP_PROPERTIES_KEY = '$stored_group_properties'
 export const SURVEYS = '$surveys'
@@ -71,6 +72,7 @@ export const PERSISTENCE_RESERVED_PROPERTIES = [
     ENABLED_FEATURE_FLAGS,
     USER_STATE,
     PERSISTENCE_EARLY_ACCESS_FEATURES,
+    PERSISTENCE_FEATURE_FLAG_DETAILS,
     STORED_GROUP_PROPERTIES_KEY,
     STORED_PERSON_PROPERTIES_KEY,
     SURVEYS,

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -488,7 +488,7 @@ export class PostHogFeatureFlags {
                     properties.$feature_flag_version = flagDetails.metadata.version
                 }
 
-                const reason = flagDetails?.reason
+                const reason = flagDetails?.reason?.description ?? flagDetails?.reason?.code
                 if (reason) {
                     properties.$feature_flag_reason = reason
                 }

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -631,23 +631,23 @@ export class PostHogFeatureFlags {
      *
      * ### Usage:
      *
-     *     - posthog.feature_flags.overrideFeatureFlags(false) // clear all overrides
-     *     - posthog.feature_flags.overrideFeatureFlags(['beta-feature']) // enable flags
-     *     - posthog.feature_flags.overrideFeatureFlags({'beta-feature': 'variant'}) // set variants
-     *     - posthog.feature_flags.overrideFeatureFlags({ // set both flags and payloads
+     *     - posthog.featureFlags.overrideFeatureFlags(false) // clear all overrides
+     *     - posthog.featureFlags.overrideFeatureFlags(['beta-feature']) // enable flags
+     *     - posthog.featureFlags.overrideFeatureFlags({'beta-feature': 'variant'}) // set variants
+     *     - posthog.featureFlags.overrideFeatureFlags({ // set both flags and payloads
      *         flags: {'beta-feature': 'variant'},
      *         payloads: { 'beta-feature': { someData: true } }
      *       })
-     *     - posthog.feature_flags.overrideFeatureFlags({ // only override payloads
+     *     - posthog.featureFlags.overrideFeatureFlags({ // only override payloads
      *         payloads: { 'beta-feature': { someData: true } }
      *       })
      */
     overrideFeatureFlags(overrideOptions: OverrideFeatureFlagsOptions): void {
         if (!this.instance.__loaded || !this.instance.persistence) {
-            return logger.uninitializedWarning('posthog.feature_flags.overrideFeatureFlags')
+            return logger.uninitializedWarning('posthog.featureFlags.overrideFeatureFlags')
         }
 
-        // Clear all overrides if false, lets you do something like posthog.feature_flags.overrideFeatureFlags(false)
+        // Clear all overrides if false, lets you do something like posthog.featureFlags.overrideFeatureFlags(false)
         if (overrideOptions === false) {
             this.instance.persistence.unregister(PERSISTENCE_OVERRIDE_FEATURE_FLAGS)
             this.instance.persistence.unregister(PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS)
@@ -663,7 +663,7 @@ export class PostHogFeatureFlags {
             const options = overrideOptions
             this._override_warning = Boolean(options.suppressWarning ?? false)
 
-            // Handle flags if provided, lets you do something like posthog.feature_flags.overrideFeatureFlags({flags: ['beta-feature']})
+            // Handle flags if provided, lets you do something like posthog.featureFlags.overrideFeatureFlags({flags: ['beta-feature']})
             if ('flags' in options) {
                 if (options.flags === false) {
                     this.instance.persistence.unregister(PERSISTENCE_OVERRIDE_FEATURE_FLAGS)
@@ -680,7 +680,7 @@ export class PostHogFeatureFlags {
                 }
             }
 
-            // Handle payloads independently, lets you do something like posthog.feature_flags.overrideFeatureFlags({payloads: { 'beta-feature': { someData: true } }})
+            // Handle payloads independently, lets you do something like posthog.featureFlags.overrideFeatureFlags({payloads: { 'beta-feature': { someData: true } }})
             if ('payloads' in options) {
                 if (options.payloads === false) {
                     this.instance.persistence.unregister(PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS)

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -484,7 +484,7 @@ export class PostHogFeatureFlags {
                     $used_bootstrap_value: !this._flagsLoadedFromRemote,
                 }
 
-                if (flagDetails?.metadata?.version) {
+                if (!isUndefined(flagDetails?.metadata?.version)) {
                     properties.$feature_flag_version = flagDetails.metadata.version
                 }
 

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -488,7 +488,7 @@ export class PostHogFeatureFlags {
                     properties.$feature_flag_version = flagDetails.metadata.version
                 }
 
-                const reason = flagDetails?.reason?.description ?? flagDetails?.reason?.code
+                const reason = flagDetails?.reason
                 if (reason) {
                     properties.$feature_flag_reason = reason
                 }

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -17,6 +17,7 @@ import { PostHogPersistence } from './posthog-persistence'
 
 import {
     PERSISTENCE_EARLY_ACCESS_FEATURES,
+    PERSISTENCE_FEATURE_FLAG_DETAILS,
     ENABLED_FEATURE_FLAGS,
     STORED_GROUP_PROPERTIES_KEY,
     STORED_PERSON_PROPERTIES_KEY,
@@ -31,7 +32,6 @@ const logger = createLogger('[FeatureFlags]')
 const PERSISTENCE_ACTIVE_FEATURE_FLAGS = '$active_feature_flags'
 const PERSISTENCE_OVERRIDE_FEATURE_FLAGS = '$override_feature_flags'
 const PERSISTENCE_FEATURE_FLAG_PAYLOADS = '$feature_flag_payloads'
-const PERSISTENCE_FEATURE_FLAG_DETAILS = '$feature_flag_details'
 const PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS = '$override_feature_flag_payloads'
 const PERSISTENCE_FEATURE_FLAG_REQUEST_ID = '$feature_flag_request_id'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1390,6 +1390,7 @@ export type FeatureFlagMetadata = {
     version: number | undefined
     description: string | undefined
     payload: JsonType | undefined
+    original_payload?: JsonType | undefined // Only used when overriding a flag payload.
 }
 
 export type EvaluationReason = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1380,7 +1380,11 @@ export type FeatureFlagsCallback = (
 export type FeatureFlagDetail = {
     key: string
     enabled: boolean
+    // Only used when overriding a flag payload.
+    original_enabled?: boolean | undefined
     variant: string | undefined
+    // Only used when overriding a flag payload.
+    original_variant?: string | undefined
     reason: EvaluationReason | undefined
     metadata: FeatureFlagMetadata | undefined
 }
@@ -1390,7 +1394,8 @@ export type FeatureFlagMetadata = {
     version: number | undefined
     description: string | undefined
     payload: JsonType | undefined
-    original_payload?: JsonType | undefined // Only used when overriding a flag payload.
+    // Only used when overriding a flag payload.
+    original_payload?: JsonType | undefined
 }
 
 export type EvaluationReason = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1336,6 +1336,7 @@ export interface DecideResponse extends RemoteConfig {
     featureFlagPayloads: Record<string, JsonType>
     errorsWhileComputingFlags: boolean
     requestId?: string
+    flags: Record<string, FeatureFlagDetail>
 }
 
 export type SiteAppGlobals = {
@@ -1375,6 +1376,27 @@ export type FeatureFlagsCallback = (
         errorsLoading?: boolean
     }
 ) => void
+
+export type FeatureFlagDetail = {
+    key: string
+    enabled: boolean
+    variant: string | undefined
+    reason: EvaluationReason | undefined
+    metadata: FeatureFlagMetadata | undefined
+}
+
+export type FeatureFlagMetadata = {
+    id: number
+    version: number | undefined
+    description: string | undefined
+    payload: JsonType | undefined
+}
+
+export type EvaluationReason = {
+    code: string
+    condition_index: number | undefined
+    description: string | undefined
+}
 
 export type RemoteConfigFeatureFlagCallback = (payload: JsonType) => void
 


### PR DESCRIPTION
This PR adds `/decide?v=4` support to `posthog-js`. What we get with this support are the following:

## A new `getFeatureFlagDetails(key)` method

This returns the full details of a feature flag. For example:

```json
{
    "beta-feature-flag": {
    "key": "beta-feature-flag",
    "enabled": true,
    "variant": "variant-3",
    "reason": {
        "code": "condition_match",
        "condition_index": 0,
        "description": null
    },
    "metadata": {
        "id": 8,
        "payload": "{\"paylod\": \"3\"}",
        "version": 19,
        "description": ""
    }
}
```

This includes an evaluation `reason`. It also includes `metadata` such as the db id of the flag and its version.

There's also the corresponding `getFlagsWithDetails()` method to get all the flag details.

## Updates to the `$feature_flag_called` event

When capturing the `$feature_flag_called` event, additional information are now captured:

1. `$feature_flag_version`: The version of the feature flag.
2. `$feature_flag_id`: The database id of the flag. A flag can be deleted and recreated with the same key, so this helps us determine if that's the case.
3. `$feature_flag_reason`: The reason the flag evaluated as it did. For now, it's just the evaluation code, but once https://github.com/PostHog/posthog/issues/29445 is completed, this will include a human friendly description.
4. `$feature_flag_original_response`: This contains the original response in the situation that the client overrode the flag via a call to `overrideFeatureFlags()`.
5.  `$feature_flag_original_payload`: This contains the original payload in the situation that the client overrode the payload via a call to `overrideFeatureFlags()`.

Sending the original values will help debug in the rare situation that a customer is confused by a flag result and forgot they were overriding it. 😆 

## Backwards compatibility:

The changes are all backwards compatible with `/decide?v=3`. Any requests for `/decide?v=4` today will return a `v=3` response. Once https://github.com/PostHog/posthog/pull/29751 is deployed, then these new additions will "light up".