### PR TITLE
chore: add new question index to id map

### DIFF
--- a/playwright/surveys/question-types.spec.ts
+++ b/playwright/surveys/question-types.spec.ts
@@ -171,11 +171,23 @@ test.describe('surveys - core display logic', () => {
         expect(surveySent!.properties['$survey_id']).toEqual('12345')
         expect(surveySent!.properties[getSurveyResponseKey('open_text_1')]).toEqual('Great job!')
         expect(surveySent!.properties[getSurveyResponseKey('nps_rating_1')]).toBeNull()
-        expect(surveySent!.properties['$survey_question_index_to_id']).toEqual({
-            0: getSurveyResponseKey('multiple_choice_1'),
-            1: getSurveyResponseKey('open_text_1'),
-            2: getSurveyResponseKey('nps_rating_1'),
-        })
+        expect(surveySent!.properties['$survey_questions']).toEqual([
+            {
+                id: 'multiple_choice_1',
+                question: 'Which types of content would you like to see more of?',
+                index: 0,
+            },
+            {
+                id: 'open_text_1',
+                question: 'What feedback do you have for us?',
+                index: 1,
+            },
+            {
+                id: 'nps_rating_1',
+                question: 'Would you recommend surveys?',
+                index: 2,
+            },
+        ])
     })
 
     test('multiple choice questions with open choice', async ({ page, context }) => {
@@ -216,9 +228,13 @@ test.describe('surveys - core display logic', () => {
         ])
         const surveySent = captures.find((c) => c.event === 'survey sent')
         expect(surveySent!.properties[getSurveyResponseKey('multiple_choice_1')]).toEqual(['Tutorials', 'Newsletters'])
-        expect(surveySent!.properties['$survey_question_index_to_id']).toEqual({
-            0: getSurveyResponseKey('multiple_choice_1'),
-        })
+        expect(surveySent!.properties['$survey_questions']).toEqual([
+            {
+                id: 'multiple_choice_1',
+                question: 'Which types of content would you like to see more of?',
+                index: 0,
+            },
+        ])
     })
 
     test('single choice questions with open choice', async ({ page, context }) => {
@@ -265,8 +281,12 @@ test.describe('surveys - core display logic', () => {
         ])
         const surveySent = captures.find((c) => c.event === 'survey sent')
         expect(surveySent!.properties[getSurveyResponseKey('single_choice_1')]).toEqual('Product engineer')
-        expect(surveySent!.properties['$survey_question_index_to_id']).toEqual({
-            0: getSurveyResponseKey('single_choice_1'),
-        })
+        expect(surveySent!.properties['$survey_questions']).toEqual([
+            {
+                id: 'single_choice_1',
+                question: 'What is your occupation?',
+                index: 0,
+            },
+        ])
     })
 })

--- a/playwright/surveys/question-types.spec.ts
+++ b/playwright/surveys/question-types.spec.ts
@@ -171,6 +171,11 @@ test.describe('surveys - core display logic', () => {
         expect(surveySent!.properties['$survey_id']).toEqual('12345')
         expect(surveySent!.properties[getSurveyResponseKey('open_text_1')]).toEqual('Great job!')
         expect(surveySent!.properties[getSurveyResponseKey('nps_rating_1')]).toBeNull()
+        expect(surveySent!.properties['$survey_question_index_to_id']).toEqual({
+            0: getSurveyResponseKey('multiple_choice_1'),
+            1: getSurveyResponseKey('open_text_1'),
+            2: getSurveyResponseKey('nps_rating_1'),
+        })
     })
 
     test('multiple choice questions with open choice', async ({ page, context }) => {
@@ -211,6 +216,9 @@ test.describe('surveys - core display logic', () => {
         ])
         const surveySent = captures.find((c) => c.event === 'survey sent')
         expect(surveySent!.properties[getSurveyResponseKey('multiple_choice_1')]).toEqual(['Tutorials', 'Newsletters'])
+        expect(surveySent!.properties['$survey_question_index_to_id']).toEqual({
+            0: getSurveyResponseKey('multiple_choice_1'),
+        })
     })
 
     test('single choice questions with open choice', async ({ page, context }) => {
@@ -257,5 +265,8 @@ test.describe('surveys - core display logic', () => {
         ])
         const surveySent = captures.find((c) => c.event === 'survey sent')
         expect(surveySent!.properties[getSurveyResponseKey('single_choice_1')]).toEqual('Product engineer')
+        expect(surveySent!.properties['$survey_question_index_to_id']).toEqual({
+            0: getSurveyResponseKey('single_choice_1'),
+        })
     })
 })

--- a/playwright/surveys/response-capture.spec.ts
+++ b/playwright/surveys/response-capture.spec.ts
@@ -52,9 +52,13 @@ test.describe('surveys - feedback widget', () => {
             expect.objectContaining({
                 $survey_id: '123',
                 [getSurveyResponseKey('open_text_1')]: 'experiments is awesome!',
-                $survey_question_index_to_id: {
-                    0: getSurveyResponseKey('open_text_1'),
-                },
+                $survey_questions: [
+                    {
+                        id: 'open_text_1',
+                        question: 'What feedback do you have for us?',
+                        index: 0,
+                    },
+                ],
             })
         )
     })
@@ -106,9 +110,13 @@ test.describe('surveys - feedback widget', () => {
                 [getSurveyResponseKey('open_text_1')]: 'experiments is awesome!',
                 $survey_iteration: 2,
                 $survey_iteration_start_date: '12-12-2004',
-                $survey_question_index_to_id: {
-                    0: getSurveyResponseKey('open_text_1'),
-                },
+                $survey_questions: [
+                    {
+                        id: 'open_text_1',
+                        question: 'What feedback do you have for us?',
+                        index: 0,
+                    },
+                ],
             })
         )
     })

--- a/playwright/surveys/response-capture.spec.ts
+++ b/playwright/surveys/response-capture.spec.ts
@@ -52,6 +52,9 @@ test.describe('surveys - feedback widget', () => {
             expect.objectContaining({
                 $survey_id: '123',
                 [getSurveyResponseKey('open_text_1')]: 'experiments is awesome!',
+                $survey_question_index_to_id: {
+                    0: getSurveyResponseKey('open_text_1'),
+                },
             })
         )
     })
@@ -103,6 +106,9 @@ test.describe('surveys - feedback widget', () => {
                 [getSurveyResponseKey('open_text_1')]: 'experiments is awesome!',
                 $survey_iteration: 2,
                 $survey_iteration_start_date: '12-12-2004',
+                $survey_question_index_to_id: {
+                    0: getSurveyResponseKey('open_text_1'),
+                },
             })
         )
     })

--- a/src/__tests__/utils/external-scripts-loader.test.ts
+++ b/src/__tests__/utils/external-scripts-loader.test.ts
@@ -43,7 +43,7 @@ describe('external-scripts-loader', () => {
             const scripts = document!.getElementsByTagName('script')
             expect(scripts.length).toBe(1)
             expect(scripts[0].src).toMatchInlineSnapshot(`"https://us-assets.i.posthog.com/static/recorder.js?v=1.0.0"`)
-            
+
             // Verify both callbacks are called when script loads
             const event = new Event('test')
             scripts[0].onload!(event)

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -34,6 +34,16 @@ export function getSurveyResponseKey(questionId: string) {
     return `$survey_response_${questionId}`
 }
 
+function getSurveyIndexToIdMap(survey: Survey) {
+    return survey.questions.reduce<Record<number, string>>((acc, question, index) => {
+        if (!question.id) {
+            return acc
+        }
+        acc[index] = getSurveyResponseKey(question.id)
+        return acc
+    }, {})
+}
+
 export const style = (appearance: SurveyAppearance | null) => {
     const positions = {
         left: 'left: 30px;',
@@ -581,6 +591,7 @@ export const sendSurveyEvent = (
         $survey_iteration_start_date: survey.current_iteration_start_date,
         $survey_questions: survey.questions.map((question) => question.question),
         sessionRecordingUrl: posthog.get_session_replay_url?.(),
+        $survey_question_index_to_id: getSurveyIndexToIdMap(survey),
         ...responses,
         $set: {
             [getSurveyInteractionProperty(survey, 'responded')]: true,

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -34,16 +34,6 @@ export function getSurveyResponseKey(questionId: string) {
     return `$survey_response_${questionId}`
 }
 
-function getSurveyIndexToIdMap(survey: Survey) {
-    return survey.questions.reduce<Record<number, string>>((acc, question, index) => {
-        if (!question.id) {
-            return acc
-        }
-        acc[index] = getSurveyResponseKey(question.id)
-        return acc
-    }, {})
-}
-
 export const style = (appearance: SurveyAppearance | null) => {
     const positions = {
         left: 'left: 30px;',
@@ -589,9 +579,12 @@ export const sendSurveyEvent = (
         $survey_id: survey.id,
         $survey_iteration: survey.current_iteration,
         $survey_iteration_start_date: survey.current_iteration_start_date,
-        $survey_questions: survey.questions.map((question) => question.question),
+        $survey_questions: survey.questions.map((question, index) => ({
+            id: question.id,
+            question: question.question,
+            index,
+        })),
         sessionRecordingUrl: posthog.get_session_replay_url?.(),
-        $survey_question_index_to_id: getSurveyIndexToIdMap(survey),
         ...responses,
         $set: {
             [getSurveyInteractionProperty(survey, 'responded')]: true,


### PR DESCRIPTION
## Changes

add a new map from question index to its ID to help build queries from just the survey event, without relying on hardcoded ids

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
