### PR TITLE
chore: deduplicate all $set calls done from setPersonProperties

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -67,7 +67,7 @@ import {
 import { isLikelyBot } from './utils/blocked-uas'
 import { Info } from './utils/event-utils'
 import { assignableWindow, document, location, navigator, userAgent, window } from './utils/globals'
-import { getIdentifyHash } from './utils/identify-utils'
+import { getPersonPropertiesHash } from './utils/identify-utils'
 import { logger } from './utils/logger'
 import { RequestRouter, RequestRouterRegion } from './utils/request-router'
 import { SimpleEventEmitter } from './utils/simple-event-emitter'
@@ -295,7 +295,7 @@ export class PostHog {
     analyticsDefaultEndpoint: string
     version = Config.LIB_VERSION
     _initialPersonProfilesConfig: 'always' | 'never' | 'identified_only' | null
-    _cachedIdentify: string | null
+    _cachedPersonProperties: string | null
 
     SentryIntegration: typeof SentryIntegration
     sentryIntegration: (options?: SentryIntegrationOptions) => ReturnType<typeof sentryIntegration>
@@ -323,7 +323,7 @@ export class PostHog {
         this.analyticsDefaultEndpoint = '/e/'
         this._initialPageviewCaptured = false
         this._initialPersonProfilesConfig = null
-        this._cachedIdentify = null
+        this._cachedPersonProperties = null
         this.featureFlags = new PostHogFeatureFlags(this)
         this.toolbar = new Toolbar(this)
         this.scrollManager = new ScrollManager(this)
@@ -1472,21 +1472,11 @@ export class PostHog {
             // let the reload feature flag request know to send this previous distinct id
             // for flag consistency
             this.featureFlags.setAnonymousDistinctId(previous_distinct_id)
-
-            this._cachedIdentify = getIdentifyHash(new_distinct_id, userPropertiesToSet, userPropertiesToSetOnce)
         } else if (userPropertiesToSet || userPropertiesToSetOnce) {
             // If the distinct_id is not changing, but we have user properties to set, we can check if they have changed
             // and if so, send a $set event
 
-            if (
-                this._cachedIdentify !== getIdentifyHash(new_distinct_id, userPropertiesToSet, userPropertiesToSetOnce)
-            ) {
-                this.setPersonProperties(userPropertiesToSet, userPropertiesToSetOnce)
-
-                this._cachedIdentify = getIdentifyHash(new_distinct_id, userPropertiesToSet, userPropertiesToSetOnce)
-            } else {
-                logger.info('A duplicate posthog.identify call was made with the same properties. It has been ignored.')
-            }
+            this.setPersonProperties(userPropertiesToSet, userPropertiesToSetOnce)
         }
 
         // Reload active feature flags if the user identity changes.
@@ -1516,12 +1506,30 @@ export class PostHog {
             return
         }
 
+        // if exactly this $set call has been sent before, don't send it again - determine based on hash of properties
+        if (
+            this._cachedPersonProperties !==
+            getPersonPropertiesHash(this.get_distinct_id(), userPropertiesToSet, userPropertiesToSetOnce)
+        ) {
+            this._cachedPersonProperties = getPersonPropertiesHash(
+                this.get_distinct_id(),
+                userPropertiesToSet,
+                userPropertiesToSetOnce
+            )
+        } else {
+            logger.info('A duplicate setPersonProperties call was made with the same properties. It has been ignored.')
+        }
+
         // Update current user properties
         this.setPersonPropertiesForFlags({ ...(userPropertiesToSetOnce || {}), ...(userPropertiesToSet || {}) })
 
-        // if exactly this $set call has been sent before, don't send it again - determine based on hash of properties
-
         this.capture('$set', { $set: userPropertiesToSet || {}, $set_once: userPropertiesToSetOnce || {} })
+
+        this._cachedPersonProperties = getPersonPropertiesHash(
+            this.get_distinct_id(),
+            userPropertiesToSet,
+            userPropertiesToSetOnce
+        )
     }
 
     /**
@@ -1630,6 +1638,7 @@ export class PostHog {
         this.persistence?.set_property(USER_STATE, 'anonymous')
         this.sessionManager?.resetSessionId()
         this._cachedIdentify = null
+        this._cachedPersonProperties = null
         if (this.config.__preview_experimental_cookieless_mode) {
             this.register_once(
                 {

--- a/src/utils/identify-utils.ts
+++ b/src/utils/identify-utils.ts
@@ -1,7 +1,7 @@
 import { jsonStringify } from '../request'
 import type { Properties } from '../types'
 
-export function getIdentifyHash(
+export function getPersonPropertiesHash(
     distinct_id: string,
     userPropertiesToSet?: Properties,
     userPropertiesToSetOnce?: Properties


### PR DESCRIPTION
## Changes

Move deduplication of set events from `identify` to `setPersonProperties` which is used by other methods calling `$set` (e.g. `people.$set`, `people.$set_once` and `.setPersonProperties`)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
