### PR TITLE
fix: default mask all inputs must be defined

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -468,12 +468,18 @@ describe('SessionRecording', () => {
                 { maskAllInputs: false },
                 { maskAllInputs: false, maskTextSelector: '*' },
             ],
+            [
+                'mask inputs default is correct if client sets text selector    ',
+                undefined,
+                { maskTextSelector: '*' },
+                { maskAllInputs: true, maskTextSelector: '*' },
+            ],
         ])(
             '%s',
             (
                 _name: string,
                 serverConfig: { maskAllInputs?: boolean; maskTextSelector?: string } | undefined,
-                clientConfig: { maskAllInputs: boolean; maskTextSelector?: string } | undefined,
+                clientConfig: { maskAllInputs?: boolean; maskTextSelector?: string } | undefined,
                 expected: { maskAllInputs: boolean; maskTextSelector?: string } | undefined
             ) => {
                 posthog.persistence?.register({

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -962,7 +962,7 @@ export class SessionRecording {
         }
 
         if (this.masking) {
-            sessionRecordingOptions.maskAllInputs = this.masking.maskAllInputs
+            sessionRecordingOptions.maskAllInputs = this.masking.maskAllInputs ?? true
             sessionRecordingOptions.maskTextSelector = this.masking.maskTextSelector ?? undefined
         }
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -398,7 +398,7 @@ export class SessionRecording {
 
         return !isUndefined(maskAllInputs) || !isUndefined(maskTextSelector)
             ? {
-                  maskAllInputs,
+                  maskAllInputs: maskAllInputs ?? true,
                   maskTextSelector,
               }
             : undefined


### PR DESCRIPTION
the default for mask all inputs is not clearly defined so there are routes through to get false when you're not expecting it. no bueno