### PR TITLE
chore: a sacrifical version to get patch version back into sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.230.3 - 2025-03-13
+
+This version doesn't exist but we did fail to publish it, since then patch version bump has been failing
+We have skipped this version
+
 ## 1.230.2 - 2025-03-11
 
 - fix: simple loader race protection (#1804)


### PR DESCRIPTION
autobump job is failing and so I can't release a fix
i did see 1.230.3 fail previously
git may be refusing that commit 🤷 

see e.g. https://github.com/PostHog/posthog-js/actions/runs/13832984749?pr=1820