### PR TITLE
chore: force version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.230.2",
+    "version": "1.230.3",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",


### PR DESCRIPTION
bumping minor didn't work either. see https://github.com/PostHog/posthog-js/actions/runs/13833784252?pr=1822

let's force the release 

(i'll separately fix the job, but need to get a fix out)