### PR TITLE
feat: remote image masking

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -469,18 +469,34 @@ describe('SessionRecording', () => {
                 { maskAllInputs: false, maskTextSelector: '*' },
             ],
             [
-                'mask inputs default is correct if client sets text selector    ',
+                'mask inputs default is correct if client sets text selector',
                 undefined,
                 { maskTextSelector: '*' },
                 { maskAllInputs: true, maskTextSelector: '*' },
+            ],
+            [
+                'can set blockSelector to img',
+                undefined,
+                { blockSelector: 'img' },
+                { maskAllInputs: true, maskTextSelector: undefined, blockSelector: 'img' },
+            ],
+            [
+                'can set blockSelector to some other selector',
+                undefined,
+                { blockSelector: 'div' },
+                { maskAllInputs: true, maskTextSelector: undefined, blockSelector: 'div' },
             ],
         ])(
             '%s',
             (
                 _name: string,
-                serverConfig: { maskAllInputs?: boolean; maskTextSelector?: string } | undefined,
-                clientConfig: { maskAllInputs?: boolean; maskTextSelector?: string } | undefined,
-                expected: { maskAllInputs: boolean; maskTextSelector?: string } | undefined
+                serverConfig:
+                    | { maskAllInputs?: boolean; maskTextSelector?: string; blockSelector?: string }
+                    | undefined,
+                clientConfig:
+                    | { maskAllInputs?: boolean; maskTextSelector?: string; blockSelector?: string }
+                    | undefined,
+                expected: { maskAllInputs: boolean; maskTextSelector?: string; blockSelector?: string } | undefined
             ) => {
                 posthog.persistence?.register({
                     [SESSION_RECORDING_MASKING]: serverConfig,
@@ -488,6 +504,7 @@ describe('SessionRecording', () => {
 
                 posthog.config.session_recording.maskAllInputs = clientConfig?.maskAllInputs
                 posthog.config.session_recording.maskTextSelector = clientConfig?.maskTextSelector
+                posthog.config.session_recording.blockSelector = clientConfig?.blockSelector
 
                 expect(sessionRecording['masking']).toEqual(expected)
             }

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -386,20 +386,25 @@ export class SessionRecording {
             : undefined
     }
 
-    private get masking(): Pick<SessionRecordingOptions, 'maskAllInputs' | 'maskTextSelector'> | undefined {
+    private get masking():
+        | Pick<SessionRecordingOptions, 'maskAllInputs' | 'maskTextSelector' | 'blockSelector'>
+        | undefined {
         const masking_server_side = this.instance.get_property(SESSION_RECORDING_MASKING)
         const masking_client_side = {
             maskAllInputs: this.instance.config.session_recording?.maskAllInputs,
             maskTextSelector: this.instance.config.session_recording?.maskTextSelector,
+            blockSelector: this.instance.config.session_recording?.blockSelector,
         }
 
         const maskAllInputs = masking_client_side?.maskAllInputs ?? masking_server_side?.maskAllInputs
         const maskTextSelector = masking_client_side?.maskTextSelector ?? masking_server_side?.maskTextSelector
+        const blockSelector = masking_client_side?.blockSelector ?? masking_server_side?.blockSelector
 
-        return !isUndefined(maskAllInputs) || !isUndefined(maskTextSelector)
+        return !isUndefined(maskAllInputs) || !isUndefined(maskTextSelector) || !isUndefined(blockSelector)
             ? {
                   maskAllInputs: maskAllInputs ?? true,
                   maskTextSelector,
+                  blockSelector,
               }
             : undefined
     }
@@ -964,6 +969,7 @@ export class SessionRecording {
         if (this.masking) {
             sessionRecordingOptions.maskAllInputs = this.masking.maskAllInputs ?? true
             sessionRecordingOptions.maskTextSelector = this.masking.maskTextSelector ?? undefined
+            sessionRecordingOptions.blockSelector = this.masking.blockSelector ?? undefined
         }
 
         if (!this.rrwebRecord) {


### PR DESCRIPTION
let's set blockSelector: img for folk that want it

pairs with a nice malbec or https://github.com/PostHog/posthog/pull/29898

(tested locally with the nextjs playground)