### PR TITLE
feat: export `PostHogProviderProps` type

### DIFF
--- a/react/src/context/PostHogProvider.tsx
+++ b/react/src/context/PostHogProvider.tsx
@@ -12,8 +12,6 @@ type AlreadyInitialized =
       }
     | false
 
-type WithOptionalChildren<T> = T & { children?: React.ReactNode | undefined }
-
 /**
  * Props for the PostHogProvider component.
  * This is a discriminated union type that ensures mutually exclusive props:
@@ -21,7 +19,7 @@ type WithOptionalChildren<T> = T & { children?: React.ReactNode | undefined }
  * - If `client` is provided, `apiKey` and `options` must not be provided
  * - If `apiKey` is provided, `client` must not be provided, and `options` is optional
  */
-type PostHogProviderProps =
+export type PostHogProviderProps =
     | { client: PostHog; apiKey?: never; options?: never }
     | { apiKey: string; options?: Partial<PostHogConfig>; client?: never }
 
@@ -40,7 +38,7 @@ type PostHogProviderProps =
  * have changed and only call `posthogJs.set_config` if they have, but it's better to
  * avoid unnecessary re-renders in the first place.
  */
-export function PostHogProvider({ children, client, apiKey, options }: WithOptionalChildren<PostHogProviderProps>) {
+export function PostHogProvider({ children, client, apiKey, options }: React.PropsWithChildren<PostHogProviderProps>) {
     // Used to detect if the client was already initialized
     // This is used to prevent double initialization when running under React.StrictMode
     // We're not storing a simple boolean here because we want to be able to detect if the


### PR DESCRIPTION
## Changes

I'm writing a wrapper for the React provider to only enable PostHog in production:

```ts
import { PostHogProvider as PostHogProviderOriginal } from 'posthog-js/react';
import type { ComponentProps } from 'react';

export function PostHogProvider({
  children,
  ...props
}: ComponentProps<typeof PostHogProviderOriginal>) {
  return process.env.NODE_ENV === 'production' ? (
    <PostHogProviderOriginal {...props}>{children}</PostHogProviderOriginal>
  ) : (
    children
  );
}
```

But ideally I can just reference the exported props:

```ts
import {
  PostHogProvider as PostHogProviderOriginal,
  // Does not exist yet
  type PostHogProviderProps
} from 'posthog-js/react';

export function PostHogProvider({
  children,
  ...props
}: PostHogProviderProps) {
  return process.env.NODE_ENV === 'production' ? (
    <PostHogProviderOriginal {...props}>{children}</PostHogProviderOriginal>
  ) : (
    children
  );
}
```

This pull request export the `PostHogProviderProps` type to allow easier access and further customizations.

While we are at it, I also replaced the custom `WithOptionalChildren` type with the identical [`React.PropsWithChildren`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a4450792b76f9faa16b0f91bcac5d6be1fcb66e6/types/react/index.d.ts#L1394) type. This change can be omitted if not desired.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
