### PR TITLE
fix: check surveys timeout in the survey manager level

### DIFF
--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -642,9 +642,12 @@ describe('SurveyManager', () => {
                 // Add survey to focus and create a timeout
                 surveyManager.getTestAPI().addSurveyToFocus(survey.id)
 
-                // Create and store timeoutId
                 if (survey.appearance?.surveyPopupDelaySeconds) {
-                    const timeoutId = setTimeout(() => {}, survey.appearance.surveyPopupDelaySeconds * 1000)
+                    const timeoutId = setTimeout(() => {
+                        // This simulates what would happen when the timeout completes
+                        // In the real implementation, it would render the survey
+                        surveyManager.getTestAPI().surveyTimeouts.delete(survey.id)
+                    }, survey.appearance.surveyPopupDelaySeconds * 1000)
                     surveyManager.getTestAPI().surveyTimeouts.set(survey.id, timeoutId)
                 }
             })

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -179,10 +179,8 @@ export class SurveyManager {
     }
 
     private clearSurveyTimeout(surveyId: string) {
-        if (this.surveyTimeouts.has(surveyId)) {
-            clearTimeout(this.surveyTimeouts.get(surveyId))
-            this.surveyTimeouts.delete(surveyId)
-        }
+        clearTimeout(this.surveyTimeouts.get(surveyId))
+        this.surveyTimeouts.delete(surveyId)
     }
 
     private handlePopoverSurvey = (survey: Survey): void => {
@@ -215,6 +213,7 @@ export class SurveyManager {
                 if (!doesSurveyUrlMatch(survey)) {
                     return this.removeSurveyFromFocus(survey.id)
                 }
+                // rendering with surveyPopupDelaySeconds = 0 because we're already handling the timeout here
                 Preact.render(
                     <SurveyPopup
                         key={'popover-survey'}

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -179,8 +179,11 @@ export class SurveyManager {
     }
 
     private clearSurveyTimeout(surveyId: string) {
-        clearTimeout(this.surveyTimeouts.get(surveyId))
-        this.surveyTimeouts.delete(surveyId)
+        const timeout = this.surveyTimeouts.get(surveyId)
+        if (timeout) {
+            clearTimeout(timeout)
+            this.surveyTimeouts.delete(surveyId)
+        }
     }
 
     private handlePopoverSurvey = (survey: Survey): void => {

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -215,7 +215,6 @@ export class SurveyManager {
                 if (!doesSurveyUrlMatch(survey)) {
                     return this.removeSurveyFromFocus(survey.id)
                 }
-
                 Preact.render(
                     <SurveyPopup
                         key={'popover-survey'}

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -650,7 +650,6 @@ export function usePopupVisibility(
             }, 100)
         }
 
-        // Add event listeners
         addEventListener(window, 'PHSurveyClosed', handleSurveyClosed)
         addEventListener(window, 'PHSurveySent', handleSurveySent)
 
@@ -658,17 +657,14 @@ export function usePopupVisibility(
             // This path is only used for direct usage of SurveyPopup,
             // not for surveys managed by SurveyManager
             const timeoutId = setTimeout(showSurvey, millisecondDelay)
-
             return () => {
                 clearTimeout(timeoutId)
                 window.removeEventListener('PHSurveyClosed', handleSurveyClosed)
                 window.removeEventListener('PHSurveySent', handleSurveySent)
             }
         } else {
-            // No delay, show immediately
             // This is the path used for surveys managed by SurveyManager
             showSurvey()
-
             return () => {
                 window.removeEventListener('PHSurveyClosed', handleSurveyClosed)
                 window.removeEventListener('PHSurveySent', handleSurveySent)

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -156,6 +156,7 @@ export function getNextSurveyStep(
 export class SurveyManager {
     private posthog: PostHog
     private surveyInFocus: string | null
+    private surveyTimeouts: Map<string, NodeJS.Timeout> = new Map()
 
     constructor(posthog: PostHog) {
         this.posthog = posthog
@@ -177,6 +178,13 @@ export class SurveyManager {
         return true
     }
 
+    private clearSurveyTimeout(surveyId: string) {
+        if (this.surveyTimeouts.has(surveyId)) {
+            clearTimeout(this.surveyTimeouts.get(surveyId))
+            this.surveyTimeouts.delete(surveyId)
+        }
+    }
+
     private handlePopoverSurvey = (survey: Survey): void => {
         const surveyWaitPeriodInDays = survey.conditions?.seenSurveyWaitPeriodInDays
         const lastSeenSurveyDate = localStorage.getItem(`lastSeenSurveyDate`)
@@ -187,18 +195,39 @@ export class SurveyManager {
 
         const surveySeen = getSurveySeen(survey)
         if (!surveySeen) {
+            this.clearSurveyTimeout(survey.id)
             this.addSurveyToFocus(survey.id)
+            const delaySeconds = survey.appearance?.surveyPopupDelaySeconds || 0
             const shadow = createShadow(style(survey?.appearance), survey.id, undefined, this.posthog)
-            Preact.render(
-                <SurveyPopup
-                    key={'popover-survey'}
-                    posthog={this.posthog}
-                    survey={survey}
-                    removeSurveyFromFocus={this.removeSurveyFromFocus}
-                    isPopup={true}
-                />,
-                shadow
-            )
+            if (delaySeconds <= 0) {
+                return Preact.render(
+                    <SurveyPopup
+                        key={'popover-survey'}
+                        posthog={this.posthog}
+                        survey={survey}
+                        removeSurveyFromFocus={this.removeSurveyFromFocus}
+                        isPopup={true}
+                    />,
+                    shadow
+                )
+            }
+            const timeoutId = setTimeout(() => {
+                if (!doesSurveyUrlMatch(survey)) {
+                    return this.removeSurveyFromFocus(survey.id)
+                }
+
+                Preact.render(
+                    <SurveyPopup
+                        key={'popover-survey'}
+                        posthog={this.posthog}
+                        survey={{ ...survey, appearance: { ...survey.appearance, surveyPopupDelaySeconds: 0 } }}
+                        removeSurveyFromFocus={this.removeSurveyFromFocus}
+                        isPopup={true}
+                    />,
+                    shadow
+                )
+            }, delaySeconds * 1000)
+            this.surveyTimeouts.set(survey.id, timeoutId)
         }
     }
 
@@ -371,6 +400,7 @@ export class SurveyManager {
         if (this.surveyInFocus !== id) {
             logger.error(`Survey ${id} is not in focus. Cannot remove survey ${id}.`)
         }
+        this.clearSurveyTimeout(id)
         this.surveyInFocus = null
     }
 
@@ -380,6 +410,7 @@ export class SurveyManager {
             addSurveyToFocus: this.addSurveyToFocus,
             removeSurveyFromFocus: this.removeSurveyFromFocus,
             surveyInFocus: this.surveyInFocus,
+            surveyTimeouts: this.surveyTimeouts,
             canShowNextEventBasedSurvey: this.canShowNextEventBasedSurvey,
             handleWidget: this.handleWidget,
             handlePopoverSurvey: this.handlePopoverSurvey,
@@ -595,7 +626,6 @@ export function usePopupVisibility(
 
         const showSurvey = () => {
             // check if the url is still matching, necessary for delayed surveys, as the URL may have changed
-            // since the survey was scheduled to appear
             if (!doesSurveyUrlMatch(survey)) {
                 return
             }
@@ -620,33 +650,29 @@ export function usePopupVisibility(
             }, 100)
         }
 
-        const handleShowSurveyWithDelay = () => {
-            const timeoutId = setTimeout(() => {
-                showSurvey()
-            }, millisecondDelay)
+        // Add event listeners
+        addEventListener(window, 'PHSurveyClosed', handleSurveyClosed)
+        addEventListener(window, 'PHSurveySent', handleSurveySent)
+
+        if (millisecondDelay > 0) {
+            // This path is only used for direct usage of SurveyPopup,
+            // not for surveys managed by SurveyManager
+            const timeoutId = setTimeout(showSurvey, millisecondDelay)
 
             return () => {
                 clearTimeout(timeoutId)
                 window.removeEventListener('PHSurveyClosed', handleSurveyClosed)
                 window.removeEventListener('PHSurveySent', handleSurveySent)
             }
-        }
-
-        const handleShowSurveyImmediately = () => {
+        } else {
+            // No delay, show immediately
+            // This is the path used for surveys managed by SurveyManager
             showSurvey()
+
             return () => {
                 window.removeEventListener('PHSurveyClosed', handleSurveyClosed)
                 window.removeEventListener('PHSurveySent', handleSurveySent)
             }
-        }
-
-        addEventListener(window, 'PHSurveyClosed', handleSurveyClosed)
-        addEventListener(window, 'PHSurveySent', handleSurveySent)
-
-        if (millisecondDelay > 0) {
-            return handleShowSurveyWithDelay()
-        } else {
-            return handleShowSurveyImmediately()
         }
     }, [])
 


### PR DESCRIPTION
## Changes

[fixes issues on this thread:](https://posthog.slack.com/archives/C07QD3LT8U9/p1742237034541509)

instead of handling timeouts in the SurveyPopup level (And rendering it even before it's needed), instead, we handle it directly on the `SurveyManager` level.

this way we can also guarantee no duplicate timeouts will be triggered - as we now track those timeouts in the class. And clear them every time we re-render a survey.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
