### PR TITLE
chore: add onSurveysLoaded listener

### DIFF
--- a/src/__tests__/posthog-surveys.test.ts
+++ b/src/__tests__/posthog-surveys.test.ts
@@ -181,7 +181,6 @@ describe('posthog-surveys', () => {
                 })
                 expect(callback).toHaveBeenCalledTimes(1)
 
-                surveys.loadIfEnabled()
                 // callback is only called once, even if surveys are loaded again
                 expect(callback).toHaveBeenCalledTimes(1)
             })

--- a/src/__tests__/posthog-surveys.test.ts
+++ b/src/__tests__/posthog-surveys.test.ts
@@ -201,7 +201,9 @@ describe('posthog-surveys', () => {
                 surveys.getSurveys(mockCallback)
 
                 expect(mockPostHog._send_request).not.toHaveBeenCalled()
-                expect(mockCallback).toHaveBeenCalledWith(mockSurveys)
+                expect(mockCallback).toHaveBeenCalledWith(mockSurveys, {
+                    isLoaded: true,
+                })
                 expect(surveys['_isFetchingSurveys']).toBe(false)
             })
 
@@ -211,7 +213,10 @@ describe('posthog-surveys', () => {
                 surveys.getSurveys(mockCallback)
 
                 expect(mockPostHog._send_request).not.toHaveBeenCalled()
-                expect(mockCallback).toHaveBeenCalledWith([])
+                expect(mockCallback).toHaveBeenCalledWith([], {
+                    isLoaded: false,
+                    error: 'Surveys are already being loaded',
+                })
             })
 
             it('should reset _isFetchingSurveys after successful API call', () => {
@@ -222,7 +227,9 @@ describe('posthog-surveys', () => {
                 surveys.getSurveys(mockCallback)
 
                 expect(surveys['_isFetchingSurveys']).toBe(false)
-                expect(mockCallback).toHaveBeenCalledWith(mockSurveys)
+                expect(mockCallback).toHaveBeenCalledWith(mockSurveys, {
+                    isLoaded: true,
+                })
                 expect(mockPostHog.persistence?.register).toHaveBeenCalledWith({ [SURVEYS]: mockSurveys })
             })
 
@@ -234,7 +241,10 @@ describe('posthog-surveys', () => {
                 surveys.getSurveys(mockCallback)
 
                 expect(surveys['_isFetchingSurveys']).toBe(false)
-                expect(mockCallback).toHaveBeenCalledWith([])
+                expect(mockCallback).toHaveBeenCalledWith([], {
+                    isLoaded: false,
+                    error: 'Surveys API could not be loaded, status: 500',
+                })
             })
 
             it('should reset _isFetchingSurveys when API call throws error', () => {
@@ -256,7 +266,10 @@ describe('posthog-surveys', () => {
                 surveys.getSurveys(mockCallback)
 
                 expect(surveys['_isFetchingSurveys']).toBe(false)
-                expect(mockCallback).toHaveBeenCalledWith([])
+                expect(mockCallback).toHaveBeenCalledWith([], {
+                    isLoaded: false,
+                    error: 'Surveys API could not be loaded, status: 0',
+                })
             })
 
             it('should handle delayed successful responses correctly', () => {
@@ -281,7 +294,9 @@ describe('posthog-surveys', () => {
                 jest.advanceTimersByTime(100)
 
                 expect(surveys['_isFetchingSurveys']).toBe(false)
-                expect(mockCallback).toHaveBeenCalledWith(delayedSurveys)
+                expect(mockCallback).toHaveBeenCalledWith(delayedSurveys, {
+                    isLoaded: true,
+                })
                 expect(mockPostHog.persistence?.register).toHaveBeenCalledWith({ [SURVEYS]: delayedSurveys })
             })
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1331,8 +1331,7 @@ export class PostHog {
      *
      * Callback parameters:
      * - surveys: Survey[]: An array containing all survey objects fetched from PostHog
-     * - { errorsLoading }: { errorsLoading?: boolean }: An object indicating if an error occurred
-     *   during the request to load the surveys
+     * - { isLoaded, error }: { isLoaded: boolean, error?: string }: An object indicating if the surveys were loaded successfully
      *
      * @param {Function} callback The callback function will be called when surveys are loaded or updated.
      * @returns {Function} A function that can be called to unsubscribe the listener.

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1324,12 +1324,17 @@ export class PostHog {
     /*
      * Register an event listener that runs when surveys become available or when they change.
      * If there are surveys, the listener is called immediately in addition to being called on future changes.
-     *
+     * 
      * ### Usage:
      *
-     *     posthog.onSurveys(function(surveys) { // do something with surveys })
+     *     posthog.onSurveys(function(surveys, { errorsLoading }) { // do something })
      *
-     * @param {Function} [callback] The callback function will be called when surveys are loaded or updated.
+     * Callback parameters:
+     * - surveys: Survey[]: An array containing all survey objects fetched from PostHog
+     * - { errorsLoading }: { errorsLoading?: boolean }: An object indicating if an error occurred 
+     *   during the request to load the surveys
+     *
+     * @param {Function} callback The callback function will be called when surveys are loaded or updated.
      * @returns {Function} A function that can be called to unsubscribe the listener.
      */
     onSurveys(callback: SurveyCallback): () => void {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1324,21 +1324,21 @@ export class PostHog {
     /*
      * Register an event listener that runs when surveys become available or when they change.
      * If there are surveys, the listener is called immediately in addition to being called on future changes.
-     * 
+     *
      * ### Usage:
      *
      *     posthog.onSurveys(function(surveys, { errorsLoading }) { // do something })
      *
      * Callback parameters:
      * - surveys: Survey[]: An array containing all survey objects fetched from PostHog
-     * - { errorsLoading }: { errorsLoading?: boolean }: An object indicating if an error occurred 
+     * - { errorsLoading }: { errorsLoading?: boolean }: An object indicating if an error occurred
      *   during the request to load the surveys
      *
      * @param {Function} callback The callback function will be called when surveys are loaded or updated.
      * @returns {Function} A function that can be called to unsubscribe the listener.
      */
     onSurveys(callback: SurveyCallback): () => void {
-        return this.surveys.onSurveys(callback)
+        return this.surveys.onSurveysLoaded(callback)
     }
 
     /*

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1326,16 +1326,16 @@ export class PostHog {
      *
      * ### Usage:
      *
-     *     posthog.onSurveys((surveys, context) => { // do something })
+     *     posthog.onSurveysLoaded((surveys, context) => { // do something })
      *
      * Callback parameters:
-     * - surveys: Survey[]: An array containing all survey objects fetched from PostHog
+     * - surveys: Survey[]: An array containing all survey objects fetched from PostHog using the getSurveys method
      * - context: { isLoaded: boolean, error?: string }: An object indicating if the surveys were loaded successfully
      *
      * @param {Function} callback The callback function will be called when surveys are loaded or updated.
      * @returns {Function} A function that can be called to unsubscribe the listener.
      */
-    onSurveys(callback: SurveyCallback): () => void {
+    onSurveysLoaded(callback: SurveyCallback): () => void {
         return this.surveys.onSurveysLoaded(callback)
     }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1322,6 +1322,21 @@ export class PostHog {
     }
 
     /*
+     * Register an event listener that runs when surveys become available or when they change.
+     * If there are surveys, the listener is called immediately in addition to being called on future changes.
+     *
+     * ### Usage:
+     *
+     *     posthog.onSurveys(function(surveys) { // do something with surveys })
+     *
+     * @param {Function} [callback] The callback function will be called when surveys are loaded or updated.
+     * @returns {Function} A function that can be called to unsubscribe the listener.
+     */
+    onSurveys(callback: SurveyCallback): () => void {
+        return this.surveys.onSurveys(callback)
+    }
+
+    /*
      * Register an event listener that runs whenever the session id or window id change.
      * If there is already a session id, the listener is called immediately in addition to being called on future changes.
      *

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1322,16 +1322,15 @@ export class PostHog {
     }
 
     /*
-     * Register an event listener that runs when surveys become available or when they change.
-     * If there are surveys, the listener is called immediately in addition to being called on future changes.
+     * Register an event listener that runs when surveys are loaded.
      *
      * ### Usage:
      *
-     *     posthog.onSurveys(function(surveys, { errorsLoading }) { // do something })
+     *     posthog.onSurveys((surveys, context) => { // do something })
      *
      * Callback parameters:
      * - surveys: Survey[]: An array containing all survey objects fetched from PostHog
-     * - { isLoaded, error }: { isLoaded: boolean, error?: string }: An object indicating if the surveys were loaded successfully
+     * - context: { isLoaded: boolean, error?: string }: An object indicating if the surveys were loaded successfully
      *
      * @param {Function} callback The callback function will be called when surveys are loaded or updated.
      * @returns {Function} A function that can be called to unsubscribe the listener.

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -122,7 +122,7 @@ export interface SurveyResponse {
     surveys: Survey[]
 }
 
-export type SurveyCallback = (surveys: Survey[], context?: { errorsLoading?: boolean }) => void
+export type SurveyCallback = (surveys: Survey[], context?: { isLoaded: boolean; error?: string }) => void
 
 export type SurveyMatchType = 'regex' | 'not_regex' | 'exact' | 'is_not' | 'icontains' | 'not_icontains'
 

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -122,7 +122,7 @@ export interface SurveyResponse {
     surveys: Survey[]
 }
 
-export type SurveyCallback = (surveys: Survey[]) => void
+export type SurveyCallback = (surveys: Survey[], context?: { errorsLoading?: boolean }) => void
 
 export type SurveyMatchType = 'regex' | 'not_regex' | 'exact' | 'is_not' | 'icontains' | 'not_icontains'
 

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -193,6 +193,12 @@ export class PostHogSurveys {
      */
     onSurveysLoaded(callback: SurveyCallback): () => void {
         this._surveyCallbacks.push(callback)
+
+        if (this._surveyManager) {
+            this._notifySurveyCallbacks({
+                isLoaded: true,
+            })
+        }
         // Return unsubscribe function
         return () => {
             this._surveyCallbacks = this._surveyCallbacks.filter((cb: SurveyCallback) => cb !== callback)

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -172,9 +172,7 @@ export class PostHogSurveys {
     }
 
     /**
-     * Register an event listener that runs when surveys are initialized or updated.
-     * If there are already surveys loaded, the listener is called immediately in addition to being called on future changes.
-     *
+     * Register a callback that runs when surveys are initialized.
      * ### Usage:
      *
      *     posthog.onSurveysLoaded((surveys) => {

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -138,14 +138,9 @@ export class PostHogSurveys {
                         this._isInitializingSurveys = false
                         this._surveyEventReceiver = new SurveyEventReceiver(this.instance)
                         logger.info('Surveys loaded successfully')
-
-                        // run all the registered callbacks
                         this._notifySurveyCallbacks({
                             isLoaded: true,
                         })
-
-                        // Once surveys are loaded, fetch and notify callbacks
-                        this.getSurveys(() => {})
                     })
                 } else {
                     const error = 'PostHog loadExternalDependency extension not found. Cannot load remote config.'


### PR DESCRIPTION
## Changes

Adds onSurveys callback similarly to how onFeatureFlags works. This will allow users who use API surveys to wait until surveys are initialized before they call `renderSurveys` which can fail as shown here: https://github.com/PostHog/posthog/issues/29975

Example use case: rendering a survey as soon as it's ready (i.e. on page load).


## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
