### PR TITLE
fix: do not allow non string `$current_url`  to be provided

### DIFF
--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -333,6 +333,13 @@ describe('posthog core', () => {
                 })
             )
         })
+
+        it('does not allow you to set complex current url', () => {
+            const posthog = posthogWith(defaultConfig, defaultOverrides)
+            const captureResult = posthog.capture('event-name', { $current_url: new URL('https://app.posthog.com/s/') })
+
+            expect(captureResult.properties.$current_url).toEqual('http://localhost/')
+        })
     })
 
     describe('_afterDecideResponse', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -864,7 +864,7 @@ export class PostHog {
         }
 
         if (properties?.$current_url && !isString(properties?.$current_url)) {
-            logger.error('Invalid $current_url property provided to posthog.capture. removing provided value')
+            logger.error('Invalid `$current_url` property provided to `posthog.capture`. Input must be a string. Ignoring provided value.')
             delete properties?.$current_url
         }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -863,6 +863,11 @@ export class PostHog {
             return
         }
 
+        if (properties?.$current_url && !isString(properties?.$current_url)) {
+            logger.error('Invalid $current_url property provided to posthog.capture. removing provided value')
+            delete properties?.$current_url
+        }
+
         // update persistence
         this.sessionPersistence.update_search_keyword()
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -864,7 +864,9 @@ export class PostHog {
         }
 
         if (properties?.$current_url && !isString(properties?.$current_url)) {
-            logger.error('Invalid `$current_url` property provided to `posthog.capture`. Input must be a string. Ignoring provided value.')
+            logger.error(
+                'Invalid `$current_url` property provided to `posthog.capture`. Input must be a string. Ignoring provided value.'
+            )
             delete properties?.$current_url
         }
 


### PR DESCRIPTION
we've had a few support tickets in replay that boil down to 

if you pass an invalid value to $current_url we accept it, use it, and then our UI explodes

let's add special casing to not allow someone to send e.g. `new URL(window.location.href)` when they think they're being helpful