### PR TITLE
feat: do not start recorder active-active

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -1478,7 +1478,7 @@ describe('SessionRecording', () => {
     describe('idle timeouts', () => {
         let startingTimestamp = -1
 
-        function emitInactiveEvent(activityTimestamp: number, expectIdle: boolean = false) {
+        function emitInactiveEvent(activityTimestamp: number, expectIdle: boolean | 'unknown' = false) {
             const snapshotEvent = {
                 event: 123,
                 type: INCREMENTAL_SNAPSHOT_EVENT_TYPE,
@@ -1538,6 +1538,29 @@ describe('SessionRecording', () => {
 
         afterEach(() => {
             jest.useRealTimers()
+        })
+
+        it('starts neither idle nor active', () => {
+            expect(sessionRecording['isIdle']).toEqual('unknown')
+        })
+
+        it('does not emit events until after first active event', () => {
+            const a = emitInactiveEvent(startingTimestamp + 100, 'unknown')
+            const b = emitInactiveEvent(startingTimestamp + 110, 'unknown')
+            const c = emitInactiveEvent(startingTimestamp + 120, 'unknown')
+            _emit(createFullSnapshot({}), 'unknown')
+            expect(sessionRecording['isIdle']).toEqual('unknown')
+            expect(posthog.capture).not.toHaveBeenCalled()
+
+            const d = emitActiveEvent(startingTimestamp + 200)
+            expect(sessionRecording['isIdle']).toEqual(false)
+            // but all events are buffered
+            expect(sessionRecording['buffer']).toEqual({
+                data: [a, b, c, createFullSnapshot({}), d],
+                sessionId: sessionId,
+                size: 442,
+                windowId: expect.any(String),
+            })
         })
 
         it('does not emit plugin events when idle', () => {
@@ -2255,6 +2278,9 @@ describe('SessionRecording', () => {
             posthog.config.session_recording.compress_events = true
             sessionRecording.onRemoteConfig(makeDecideResponse({ sessionRecording: { endpoint: '/s/' } }))
             sessionRecording.startIfEnabledOrStop()
+            // need to have active event to start recording
+            _emit(createIncrementalSnapshot({ type: 3 }))
+            sessionRecording['_flushBuffer']()
         })
 
         it('compresses full snapshot data', () => {


### PR DESCRIPTION
while investigating a supprt ticket we saw that a user had a large spike of crawls from ahrefs

ahrefs do not provide a custom user agent that can be detected as a bot and blocked (by our SDK's default user agent blocking)

so that large spike of sessions were all recorded and exhausted the user's free limit

but all of them were recordings with no user activity (sort of... some had a little keyboard activity, presumably accidental or behaviour built into the crawler)

this made me realise... we start the recorder active and wait for a lack of user activity to tell us that it is idle

instead we can start the recorder idle and let the presence of user activity switch to active

(in reality i started "unknown" so I could skip some debug logging and make things more clear)