### PR TITLE
fix(flags): Revert "feat(flags): Enjoy the benefits of `/decide?v=4`. `$feature_flag_called` events contain more details such as flag version"

### DIFF
--- a/playwright/session-recording/session-recording-network-recorder.spec.ts
+++ b/playwright/session-recording/session-recording-network-recorder.spec.ts
@@ -134,7 +134,7 @@ test.beforeEach(async ({ context }) => {
                               // webkit isn't capturing this failed request in the pre-wrapped fetch performance observer records
                               // [/https:\/\/localhost:\d+\/array\/test%20token\/config.js/, 'script'],
                               [
-                                  /https:\/\/localhost:\d+\/decide\/\?v=4&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
+                                  /https:\/\/localhost:\d+\/decide\/\?v=3&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
                                   'fetch',
                               ],
                               // webkit isn't capturing this failed request in the pre-wrapped fetch performance observer records
@@ -158,7 +158,7 @@ test.beforeEach(async ({ context }) => {
                               [/https:\/\/localhost:\d+\/static\/array.js/, 'script'],
                               [/https:\/\/localhost:\d+\/array\/test%20token\/config.js/, 'script'],
                               [
-                                  /https:\/\/localhost:\d+\/decide\/\?v=4&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
+                                  /https:\/\/localhost:\d+\/decide\/\?v=3&ip=1&_=\d+&ver=1\.\d\d\d\.\d+&compression=base64/,
                                   'fetch',
                               ],
                               [

--- a/src/__tests__/posthog-core.loaded.test.ts
+++ b/src/__tests__/posthog-core.loaded.test.ts
@@ -41,7 +41,7 @@ describe('loaded() with flags', () => {
             expect(instance._send_request).toHaveBeenCalledTimes(1)
 
             expect(instance._send_request.mock.calls[0][0]).toMatchObject({
-                url: 'https://us.i.posthog.com/decide/?v=4',
+                url: 'https://us.i.posthog.com/decide/?v=3',
                 data: {
                     groups: { org: 'bazinga' },
                 },
@@ -64,7 +64,7 @@ describe('loaded() with flags', () => {
             expect(instance._send_request).toHaveBeenCalledTimes(1)
 
             expect(instance._send_request.mock.calls[0][0]).toMatchObject({
-                url: 'https://us.i.posthog.com/decide/?v=4',
+                url: 'https://us.i.posthog.com/decide/?v=3',
                 data: {
                     groups: { org: 'bazinga' },
                 },
@@ -77,7 +77,7 @@ describe('loaded() with flags', () => {
             expect(instance._send_request).toHaveBeenCalledTimes(2)
 
             expect(instance._send_request.mock.calls[1][0]).toMatchObject({
-                url: 'https://us.i.posthog.com/decide/?v=4',
+                url: 'https://us.i.posthog.com/decide/?v=3',
                 data: {
                     groups: { org: 'bazinga2' },
                 },

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -1219,7 +1219,7 @@ describe('posthog core', () => {
                 })
 
                 expect(sendRequestMock.mock.calls[0][0]).toMatchObject({
-                    url: 'http://localhost/decide/?v=4',
+                    url: 'http://localhost/decide/?v=3',
                 })
             })
 

--- a/src/__tests__/utils/request-router.test.ts
+++ b/src/__tests__/utils/request-router.test.ts
@@ -58,7 +58,7 @@ describe('request-router', () => {
         ['  https://app.posthog.com       ', 'https://us.i.posthog.com/'],
         ['https://example.com/', 'https://example.com/'],
     ])('should sanitize the api_host values for "%s"', (apiHost, expected) => {
-        expect(router(apiHost).endpointFor('api', '/decide?v=4')).toEqual(`${expected}decide?v=4`)
+        expect(router(apiHost).endpointFor('api', '/decide?v=3')).toEqual(`${expected}decide?v=3`)
     })
 
     it('should use the ui_host if provided', () => {

--- a/src/entrypoints/array.full.es5.ts
+++ b/src/entrypoints/array.full.es5.ts
@@ -5,8 +5,6 @@
 // it doesn't include recorder which doesn't support IE11,
 // and it doesn't include web-vitals which doesn't support IE11
 
-import 'core-js/features/object/from-entries'
-
 import './surveys'
 import './exception-autocapture'
 import './tracing-headers'

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -393,7 +393,7 @@ export class PostHogFeatureFlags {
         this._requestInFlight = true
         this.instance._send_request({
             method: 'POST',
-            url: this.instance.requestRouter.endpointFor('api', '/decide/?v=4'),
+            url: this.instance.requestRouter.endpointFor('api', '/decide/?v=3'),
             data,
             compression: this.instance.config.disable_compression ? undefined : Compression.Base64,
             timeout: this.instance.config.feature_flag_request_timeout_ms,
@@ -557,7 +557,7 @@ export class PostHogFeatureFlags {
         const token = this.instance.config.token
         this.instance._send_request({
             method: 'POST',
-            url: this.instance.requestRouter.endpointFor('api', '/decide/?v=4'),
+            url: this.instance.requestRouter.endpointFor('api', '/decide/?v=3'),
             data: {
                 distinct_id: this.instance.get_distinct_id(),
                 token,


### PR DESCRIPTION
Reverts PostHog/posthog-js#1838

Oof, v4 responses from `/decide` were not smart about flags that were just straight disabled, let's roll back to v3