### PR TITLE
fix: make callback on confirmation message instead

### DIFF
--- a/playwright/surveys/feedback-widget.spec.ts
+++ b/playwright/surveys/feedback-widget.spec.ts
@@ -212,41 +212,6 @@ test.describe('surveys - feedback widget', () => {
         )
     })
 
-    // ... existing code ...
-    test('auto contrasts text color for feedback tab', async ({ page, context }) => {
-        const surveysAPICall = page.route('**/surveys/**', async (route) => {
-            await route.fulfill({
-                json: {
-                    surveys: [
-                        {
-                            id: '123',
-                            name: 'Test survey',
-                            type: 'widget',
-                            start_date: '2021-01-01T00:00:00Z',
-                            questions: [openTextQuestion],
-                            appearance: {
-                                widgetLabel: 'white widget',
-                                widgetType: 'tab',
-                                widgetColor: 'white',
-                            },
-                        },
-                    ],
-                },
-            })
-        })
-
-        await start(startOptions, page, context)
-        await surveysAPICall
-
-        await expect(page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab')).toBeVisible()
-
-        await expect(page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab')).toHaveCSS('color', black)
-        await expect(page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab')).toHaveCSS(
-            'background-color',
-            white
-        )
-    })
-
     test('renders survey with schedule always and allows multiple submissions', async ({ page, context }) => {
         const surveysAPICall = page.route('**/surveys/**', async (route) => {
             await route.fulfill({

--- a/playwright/surveys/feedback-widget.spec.ts
+++ b/playwright/surveys/feedback-widget.spec.ts
@@ -1,3 +1,4 @@
+import { SurveySchedule } from '../../src/posthog-surveys-types'
 import { pollUntilEventCaptured } from '../utils/event-capture-utils'
 import { expect, test } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
@@ -209,5 +210,110 @@ test.describe('surveys - feedback widget', () => {
             'background-color',
             white
         )
+    })
+
+    // ... existing code ...
+    test('auto contrasts text color for feedback tab', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: '123',
+                            name: 'Test survey',
+                            type: 'widget',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [openTextQuestion],
+                            appearance: {
+                                widgetLabel: 'white widget',
+                                widgetType: 'tab',
+                                widgetColor: 'white',
+                            },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(startOptions, page, context)
+        await surveysAPICall
+
+        await expect(page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab')).toBeVisible()
+
+        await expect(page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab')).toHaveCSS('color', black)
+        await expect(page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab')).toHaveCSS(
+            'background-color',
+            white
+        )
+    })
+
+    test('renders survey with schedule always and allows multiple submissions', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: '123',
+                            name: 'Test survey',
+                            type: 'widget',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [openTextQuestion],
+                            appearance: {
+                                widgetLabel: 'Feedback',
+                                widgetType: 'tab',
+                                displayThankYouMessage: true,
+                            },
+                            conditions: {
+                                url: null,
+                                selector: null,
+                                scrolled: null,
+                            },
+                            schedule: SurveySchedule.Always,
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(startOptions, page, context)
+        await surveysAPICall
+
+        // 1. Check that the survey widget is rendered
+        await expect(page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab')).toBeVisible()
+
+        // 2. Open the survey
+        await page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab').click()
+        await expect(page.locator('.PostHogWidget123').locator('.survey-form')).toBeVisible()
+
+        // 3. Answer the survey
+        await page.locator('.PostHogWidget123').locator('.survey-form').locator('textarea').fill('first submission')
+        await page.locator('.PostHogWidget123').locator('.survey-form').locator('.form-submit').click()
+
+        // 4. Check for thank you message
+        await expect(page.locator('.PostHogWidget123').locator('.thank-you-message-header')).toBeVisible()
+        await expect(page.locator('.PostHogWidget123').locator('.thank-you-message-header')).toHaveText('Thank you!')
+
+        // Verify the event was sent
+        await pollUntilEventCaptured(page, 'survey sent')
+
+        // 5. Close the thank you message and click the survey tab again
+        await page.locator('.PostHogWidget123').locator('.form-submit').click()
+        await expect(page.locator('.PostHogWidget123').locator('.survey-form')).not.toBeVisible()
+
+        // Open the survey again
+        await page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab').click()
+
+        // 6. Verify survey is rendered again
+        await expect(page.locator('.PostHogWidget123').locator('.survey-form')).toBeVisible()
+
+        // Submit again with different text
+        await page.locator('.PostHogWidget123').locator('.survey-form').locator('textarea').fill('second submission')
+        await page.locator('.PostHogWidget123').locator('.survey-form').locator('.form-submit').click()
+
+        // Verify thank you message appears again
+        await expect(page.locator('.PostHogWidget123').locator('.thank-you-message-header')).toBeVisible()
+
+        // Verify second event was sent
+        await pollUntilEventCaptured(page, 'survey sent')
     })
 })

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -2,7 +2,6 @@
 import { act, fireEvent, render, renderHook } from '@testing-library/preact'
 import {
     SurveyManager,
-    SurveyPopup,
     generateSurveys,
     renderFeedbackWidgetPreview,
     renderSurveysPreview,
@@ -1197,81 +1196,6 @@ describe('useHideSurveyOnURLChange', () => {
         })
 
         expect(mockRemoveSurveyFromFocus).not.toHaveBeenCalled()
-    })
-})
-
-describe('onPopupSurveyDismissed callback', () => {
-    let posthog: PostHog
-
-    beforeEach(() => {
-        document.getElementsByTagName('html')[0].innerHTML = ''
-        localStorage.clear()
-        jest.clearAllMocks()
-
-        // Mock PostHog instance
-        posthog = {
-            capture: jest.fn(),
-            get_session_replay_url: jest.fn(),
-        } as unknown as PostHog
-    })
-
-    test('onPopupSurveyDismissed is called when Cancel button is clicked in SurveyPopup', () => {
-        // Create a simple survey for testing
-        const survey = {
-            id: 'test-survey',
-            name: 'Test Survey',
-            description: 'Test Survey Description',
-            type: SurveyType.Popover,
-            questions: [
-                {
-                    type: SurveyQuestionType.Open,
-                    question: 'What do you think?',
-                    description: '',
-                    id: 'question-a',
-                },
-            ],
-            start_date: new Date().toISOString(),
-            end_date: null,
-            feature_flag_keys: null,
-            linked_flag_key: null,
-            targeting_flag_key: null,
-            internal_targeting_flag_key: null,
-            appearance: {},
-            conditions: {
-                events: { values: [] },
-                actions: { values: [] },
-            },
-            current_iteration: 1,
-            current_iteration_start_date: new Date().toISOString(),
-        } as Survey
-
-        const onPopupSurveyDismissed = jest.fn()
-        const mockRemoveSurveyFromFocus = jest.fn()
-
-        // Render the SurveyPopup component with our mocked callback
-        render(
-            Preact.h(SurveyPopup, {
-                survey: survey,
-                removeSurveyFromFocus: mockRemoveSurveyFromFocus,
-                isPopup: true,
-                onPopupSurveyDismissed: onPopupSurveyDismissed,
-                posthog: posthog,
-            })
-        )
-
-        // Find the Cancel button
-        const cancelButton = document.querySelector('.cancel-btn-wrapper')
-
-        // Verify the button exists
-        expect(cancelButton).not.toBeNull()
-
-        // Click the Cancel button
-        if (cancelButton) {
-            fireEvent.click(cancelButton)
-
-            // Verify our callback was called
-            expect(onPopupSurveyDismissed).toHaveBeenCalledTimes(1)
-        }
     })
 })
 

--- a/src/__tests__/extensions/surveys/survey-popup.test.tsx
+++ b/src/__tests__/extensions/surveys/survey-popup.test.tsx
@@ -1,0 +1,119 @@
+import '@testing-library/jest-dom'
+import { fireEvent, render } from '@testing-library/preact'
+import { SurveyPopup } from '../../../extensions/surveys'
+import { Survey, SurveyQuestionType, SurveyType } from '../../../posthog-surveys-types'
+
+describe('SurveyPopup', () => {
+    // Create a basic mock survey for testing
+    const mockSurvey: Survey = {
+        id: 'test-survey',
+        name: 'Test Survey',
+        description: 'A test survey',
+        type: SurveyType.Popover,
+        feature_flag_keys: null,
+        linked_flag_key: null,
+        targeting_flag_key: null,
+        internal_targeting_flag_key: null,
+        questions: [
+            {
+                type: SurveyQuestionType.Open,
+                question: 'Test question',
+                description: 'Test description',
+                id: 'q1',
+            },
+        ],
+        appearance: {
+            displayThankYouMessage: true,
+            thankYouMessageHeader: 'Thank you for your feedback!',
+            thankYouMessageDescription: 'We appreciate your input.',
+            backgroundColor: '#ffffff',
+            borderColor: '#e5e5e5',
+            thankYouMessageCloseButtonText: 'Close',
+            whiteLabel: true,
+        },
+        conditions: null,
+        start_date: null,
+        end_date: null,
+        current_iteration: null,
+        current_iteration_start_date: null,
+        schedule: null,
+    }
+
+    beforeEach(() => {
+        // Reset DOM
+        document.getElementsByTagName('html')[0].innerHTML = ''
+        localStorage.clear()
+        jest.clearAllMocks()
+    })
+
+    test('calls onCloseConfirmationMessage when X button is clicked', () => {
+        // Create a mock function to test if it gets called
+        const mockOnCloseConfirmationMessage = jest.fn()
+        const mockRemoveSurveyFromFocus = jest.fn()
+
+        // Create a custom wrapper to set isSurveySent to true
+        // This simulates the state after survey submission when confirmation message is shown
+        const SurveyWrapper = () => {
+            return (
+                <SurveyPopup
+                    survey={mockSurvey}
+                    removeSurveyFromFocus={mockRemoveSurveyFromFocus}
+                    isPopup={true}
+                    onCloseConfirmationMessage={mockOnCloseConfirmationMessage}
+                    // Force the confirmation message to show by providing props that match showConfirmation condition
+                    // In the component: const shouldShowConfirmation = isSurveySent || previewPageIndex === survey.questions.length
+                    previewPageIndex={mockSurvey.questions.length}
+                />
+            )
+        }
+
+        // Render the component
+        const { container } = render(<SurveyWrapper />)
+
+        // Find the X/Cancel button directly in the container
+        const cancelButton = container.querySelector('button.form-cancel[aria-label="Close survey"]')
+
+        // Click the cancel button
+        if (cancelButton) {
+            fireEvent.click(cancelButton)
+            // Verify that onCloseConfirmationMessage was called
+            expect(mockOnCloseConfirmationMessage).toHaveBeenCalledTimes(1)
+        } else {
+            expect(cancelButton).not.toBeNull() // Use expect instead of fail
+        }
+    })
+
+    test('calls onCloseConfirmationMessage when Close button is clicked', () => {
+        // Create a mock function to test if it gets called
+        const mockOnCloseConfirmationMessage = jest.fn()
+        const mockRemoveSurveyFromFocus = jest.fn()
+
+        // Create a custom wrapper with confirmation message showing
+        const SurveyWrapper = () => {
+            return (
+                <SurveyPopup
+                    survey={mockSurvey}
+                    removeSurveyFromFocus={mockRemoveSurveyFromFocus}
+                    isPopup={true}
+                    onCloseConfirmationMessage={mockOnCloseConfirmationMessage}
+                    previewPageIndex={mockSurvey.questions.length}
+                />
+            )
+        }
+
+        // Render the component
+        const { container } = render(<SurveyWrapper />)
+
+        // Find the Close button directly in the container (rather than in Shadow DOM)
+        const closeButton = container.querySelector('button.form-submit')
+
+        // Click the Close button
+        if (closeButton) {
+            fireEvent.click(closeButton)
+            // Verify that onCloseConfirmationMessage was called
+            expect(mockOnCloseConfirmationMessage).toHaveBeenCalledTimes(1)
+        } else {
+            expect(closeButton).not.toBeNull() // Use expect instead of fail
+        }
+    })
+})

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -693,7 +693,7 @@ interface SurveyPopupProps {
     isPopup?: boolean
     onPreviewSubmit?: (res: string | string[] | number | null) => void
     onPopupSurveyDismissed?: () => void
-    onPopupSurveySent?: () => void
+    onCloseConfirmationMessage?: () => void
 }
 
 export function SurveyPopup({
@@ -706,7 +706,7 @@ export function SurveyPopup({
     isPopup,
     onPreviewSubmit = () => {},
     onPopupSurveyDismissed = () => {},
-    onPopupSurveySent = () => {},
+    onCloseConfirmationMessage = () => {},
 }: SurveyPopupProps) {
     const isPreviewMode = Number.isInteger(previewPageIndex)
     // NB: The client-side code passes the millisecondDelay in seconds, but setTimeout expects milliseconds, so we multiply by 1000
@@ -741,9 +741,6 @@ export function SurveyPopup({
                 },
                 isPopup: isPopup || false,
                 onPreviewSubmit,
-                onPopupSurveySent: () => {
-                    onPopupSurveySent()
-                },
             }}
         >
             {!shouldShowConfirmation ? (
@@ -761,7 +758,10 @@ export function SurveyPopup({
                     contentType={survey.appearance?.thankYouMessageDescriptionContentType}
                     appearance={survey.appearance || defaultSurveyAppearance}
                     styleOverrides={{ ...style, ...confirmationBoxLeftStyle }}
-                    onClose={() => setIsPopupVisible(false)}
+                    onClose={() => {
+                        setIsPopupVisible(false)
+                        onCloseConfirmationMessage()
+                    }}
                 />
             )}
         </SurveyContext.Provider>
@@ -783,8 +783,7 @@ export function Questions({
         survey.appearance?.backgroundColor || defaultSurveyAppearance.backgroundColor
     )
     const [questionsResponses, setQuestionsResponses] = useState({})
-    const { previewPageIndex, onPopupSurveyDismissed, isPopup, onPreviewSubmit, onPopupSurveySent } =
-        useContext(SurveyContext)
+    const { previewPageIndex, onPopupSurveyDismissed, isPopup, onPreviewSubmit } = useContext(SurveyContext)
     const [currentQuestionIndex, setCurrentQuestionIndex] = useState(previewPageIndex || 0)
     const surveyQuestions = useMemo(() => getDisplayOrderQuestions(survey), [survey])
 
@@ -819,7 +818,6 @@ export function Questions({
         const nextStep = getNextSurveyStep(survey, displayQuestionIndex, res)
         if (nextStep === SurveyQuestionBranchingType.End) {
             sendSurveyEvent({ ...questionsResponses, [responseKey]: res }, survey, posthog)
-            onPopupSurveySent()
         } else {
             setCurrentQuestionIndex(nextStep)
         }
@@ -1036,7 +1034,7 @@ export function FeedbackWidget({
                     removeSurveyFromFocus={removeSurveyFromFocus}
                     isPopup={true}
                     onPopupSurveyDismissed={resetShowSurvey}
-                    onPopupSurveySent={resetShowSurvey}
+                    onCloseConfirmationMessage={resetShowSurvey}
                 />
             )}
         </Preact.Fragment>

--- a/src/extensions/surveys/components/BottomSection.tsx
+++ b/src/extensions/surveys/components/BottomSection.tsx
@@ -31,6 +31,7 @@ export function BottomSection({
                 <button
                     className="form-submit"
                     disabled={submitDisabled}
+                    aria-label="Submit survey"
                     type="button"
                     style={isPopup ? { color: textColor } : {}}
                     onClick={() => {

--- a/src/extensions/surveys/components/ConfirmationMessage.tsx
+++ b/src/extensions/surveys/components/ConfirmationMessage.tsx
@@ -1,8 +1,8 @@
-import { BottomSection } from './BottomSection'
-import { Cancel } from './QuestionHeader'
+import { h } from 'preact'
 import { SurveyAppearance, SurveyQuestionDescriptionContentType } from '../../../posthog-surveys-types'
 import { defaultSurveyAppearance, getContrastingTextColor, renderChildrenAsTextOrHtml } from '../surveys-utils'
-import { h } from 'preact'
+import { BottomSection } from './BottomSection'
+import { Cancel } from './QuestionHeader'
 
 import { useContext } from 'preact/hooks'
 import { SurveyContext } from '../../surveys/surveys-utils'
@@ -29,30 +29,28 @@ export function ConfirmationMessage({
     const { isPopup } = useContext(SurveyContext)
 
     return (
-        <>
-            <div className="thank-you-message" style={{ ...styleOverrides }}>
-                <div className="thank-you-message-container">
-                    {isPopup && <Cancel onClick={() => onClose()} />}
-                    <h3 className="thank-you-message-header" style={{ color: textColor }}>
-                        {header}
-                    </h3>
-                    {description &&
-                        renderChildrenAsTextOrHtml({
-                            component: h('div', { className: 'thank-you-message-body' }),
-                            children: description,
-                            renderAsHtml: !forceDisableHtml && contentType !== 'text',
-                            style: { color: textColor },
-                        })}
-                    {isPopup && (
-                        <BottomSection
-                            text={appearance.thankYouMessageCloseButtonText || 'Close'}
-                            submitDisabled={false}
-                            appearance={appearance}
-                            onSubmit={() => onClose()}
-                        />
-                    )}
-                </div>
+        <div className="thank-you-message" style={{ ...styleOverrides }}>
+            <div className="thank-you-message-container">
+                {isPopup && <Cancel onClick={() => onClose()} />}
+                <h3 className="thank-you-message-header" style={{ color: textColor }}>
+                    {header}
+                </h3>
+                {description &&
+                    renderChildrenAsTextOrHtml({
+                        component: h('div', { className: 'thank-you-message-body' }),
+                        children: description,
+                        renderAsHtml: !forceDisableHtml && contentType !== 'text',
+                        style: { color: textColor },
+                    })}
+                {isPopup && (
+                    <BottomSection
+                        text={appearance.thankYouMessageCloseButtonText || 'Close'}
+                        submitDisabled={false}
+                        appearance={appearance}
+                        onSubmit={() => onClose()}
+                    />
+                )}
             </div>
-        </>
+        </div>
     )
 }

--- a/src/extensions/surveys/components/QuestionHeader.tsx
+++ b/src/extensions/surveys/components/QuestionHeader.tsx
@@ -1,8 +1,8 @@
-import { SurveyContext, defaultSurveyAppearance, renderChildrenAsTextOrHtml } from '../surveys-utils'
-import { cancelSVG } from '../icons'
+import { h } from 'preact'
 import { useContext } from 'preact/hooks'
 import { SurveyQuestionDescriptionContentType } from '../../../posthog-surveys-types'
-import { h } from 'preact'
+import { cancelSVG } from '../icons'
+import { SurveyContext, defaultSurveyAppearance, renderChildrenAsTextOrHtml } from '../surveys-utils'
 
 export function QuestionHeader({
     question,
@@ -35,8 +35,8 @@ export function Cancel({ onClick }: { onClick: () => void }) {
     const { isPreviewMode } = useContext(SurveyContext)
 
     return (
-        <div className="cancel-btn-wrapper" onClick={onClick} disabled={isPreviewMode}>
-            <button className="form-cancel" onClick={onClick} disabled={isPreviewMode}>
+        <div className="cancel-btn-wrapper">
+            <button className="form-cancel" onClick={onClick} disabled={isPreviewMode} aria-label="Close survey">
                 {cancelSVG}
             </button>
         </div>

--- a/src/extensions/surveys/components/QuestionHeader.tsx
+++ b/src/extensions/surveys/components/QuestionHeader.tsx
@@ -36,7 +36,13 @@ export function Cancel({ onClick }: { onClick: () => void }) {
 
     return (
         <div className="cancel-btn-wrapper">
-            <button className="form-cancel" onClick={onClick} disabled={isPreviewMode} aria-label="Close survey">
+            <button
+                className="form-cancel"
+                onClick={onClick}
+                disabled={isPreviewMode}
+                aria-label="Close survey"
+                role="button"
+            >
                 {cancelSVG}
             </button>
         </div>

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -741,7 +741,6 @@ interface SurveyContextProps {
     onPopupSurveyDismissed: () => void
     isPopup: boolean
     onPreviewSubmit: (res: string | string[] | number | null) => void
-    onPopupSurveySent: () => void
 }
 
 export const SurveyContext = createContext<SurveyContextProps>({
@@ -750,7 +749,6 @@ export const SurveyContext = createContext<SurveyContextProps>({
     onPopupSurveyDismissed: () => {},
     isPopup: true,
     onPreviewSubmit: () => {},
-    onPopupSurveySent: () => {},
 })
 
 interface RenderProps {


### PR DESCRIPTION
## Changes

after I fix I did for [this issue](https://github.com/PostHog/posthog-js/pull/1767), it introduced a bug for feedback surveys where the confirmation message is not shown for feedback survey since it's being closed in the same instant.

so, this PR does two things:

- address it so the `reset` for the feedback widget popup happens when the survey is closed
- creates an end to end test to make sure this error doesn't happen again

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
