### PR TITLE
chore(flags): Remove feature flag payloads from persistence

### DIFF
--- a/playwright/utils/setup.ts
+++ b/playwright/utils/setup.ts
@@ -59,6 +59,7 @@ export async function start(
         editorParams: {},
         featureFlags: { 'session-recording-player': true },
         featureFlagPayloads: {},
+        flags: {},
         errorsWhileComputingFlags: false,
         toolbarParams: {},
         toolbarVersion: 'toolbar',

--- a/src/__tests__/posthog-core.loaded.test.ts
+++ b/src/__tests__/posthog-core.loaded.test.ts
@@ -128,7 +128,23 @@ describe('loaded() with flags', () => {
                     featureFlags: { 'test-flag': true },
                 },
                 expectedCall: true,
-                expectedArgs: { featureFlags: { 'test-flag': true } },
+                expectedArgs: {
+                    featureFlags: { 'test-flag': true },
+                    flags: {
+                        'test-flag': {
+                            key: 'test-flag',
+                            enabled: true,
+                            variant: undefined,
+                            reason: undefined,
+                            metadata: {
+                                id: undefined,
+                                version: undefined,
+                                description: undefined,
+                                payload: undefined,
+                            },
+                        },
+                    },
+                },
             },
             {
                 name: 'processes feature flags when other resources are quota limited',
@@ -137,7 +153,24 @@ describe('loaded() with flags', () => {
                     featureFlags: { 'test-flag': true },
                 },
                 expectedCall: true,
-                expectedArgs: { quotaLimited: ['recordings'], featureFlags: { 'test-flag': true } },
+                expectedArgs: {
+                    quotaLimited: ['recordings'],
+                    featureFlags: { 'test-flag': true },
+                    flags: {
+                        'test-flag': {
+                            key: 'test-flag',
+                            enabled: true,
+                            variant: undefined,
+                            reason: undefined,
+                            metadata: {
+                                id: undefined,
+                                version: undefined,
+                                description: undefined,
+                                payload: undefined,
+                            },
+                        },
+                    },
+                },
             },
         ])('$name', async ({ response, expectedCall, expectedArgs }) => {
             instance._send_request = jest.fn(({ callback }) =>

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -22,7 +22,7 @@ import { WebVitalsAutocapture } from './extensions/web-vitals'
 import { Heatmaps } from './heatmaps'
 import { PageViewManager } from './page-view'
 import { PostHogExceptions } from './posthog-exceptions'
-import { PostHogFeatureFlags } from './posthog-featureflags'
+import { createFeatureFlagDetailsFromLegacyDecideResponse, PostHogFeatureFlags } from './posthog-featureflags'
 import { PostHogPersistence } from './posthog-persistence'
 import { PostHogSurveys } from './posthog-surveys'
 import { SurveyCallback } from './posthog-surveys-types'
@@ -533,7 +533,10 @@ export class PostHog {
                     return res
                 }, {})
 
-            this.featureFlags.receivedFeatureFlags({ featureFlags: activeFlags, featureFlagPayloads })
+            // Need to contruct a flagDetails object from the bootstrapped activeFlags and featureFlagPayloads
+            const flagDetails = createFeatureFlagDetailsFromLegacyDecideResponse(activeFlags, featureFlagPayloads)
+
+            this.featureFlags.receivedFeatureFlags({ flags: flagDetails })
         }
 
         if (this.config.__preview_experimental_cookieless_mode) {
@@ -2078,7 +2081,7 @@ export class PostHog {
     }
 
     /**
-     * Opt the user out of data capturing and cookies/localstorage for this PostHog instance.
+     * Opt the user out of data capturing and cookies/localstorage for this PostHog instance
      * If the config.opt_out_persistence_by_default is set to true, the SDK persistence will be disabled.
      *
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1390,7 +1390,7 @@ export type FeatureFlagDetail = {
 }
 
 export type FeatureFlagMetadata = {
-    id: number
+    id: number | undefined
     version: number | undefined
     description: string | undefined
     payload: JsonType | undefined


### PR DESCRIPTION
We already store feature flag details in persistence, so we can calculate payloads from that rather than storing payloads twice. We still store active feature flags as well as calculated flags in persistence and that's probably just fine as the data is a lot less and we use those everywhere.

## Changes

This is a refactoring. No behavioral changes other than `$feature_flag_payloads` is no longer stored in local storage.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)

## Testing

- Tested manually in an incognito browser to see that `$feature_flag_payloads` no longer is stored in local storage.