### PR TITLE
fix: Switch from regex to trim

### DIFF
--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -1,6 +1,6 @@
 export function includes(str: string, needle: string): boolean
 export function includes<T>(arr: T[], needle: T): boolean
-export function includes<T = any>(str: T[] | string, needle: string): boolean {
+export function includes(str: unknown[] | string, needle: unknown): boolean {
     return (str as any).indexOf(needle) !== -1
 }
 

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -1,12 +1,19 @@
-export function includes<T = any>(str: T[] | string, needle: T): boolean {
+export function includes(str: string, needle: string): boolean
+export function includes<T>(arr: T[], needle: T): boolean
+export function includes<T = any>(str: T[] | string, needle: string): boolean {
     return (str as any).indexOf(needle) !== -1
+}
+
+export const trim = function (str: string): string {
+    // Previous implementation was using underscore's trim function.
+    // When switching to just using the native trim() function, we ran some tests to make sure that it was able to trim both the BOM character \uFEFF and the NBSP character \u00A0.
+    // We tested modern Chrome (134.0.6998.118) and Firefox (136.0.2), and IE11 running on Windows 10, and all of them were able to trim both characters.
+    // See https://posthog.slack.com/archives/C0113360FFV/p1742811455647359
+    return str.trim()
 }
 
 // UNDERSCORE
 // Embed part of the Underscore Library
-export const trim = function (str: string): string {
-    return str.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '')
-}
 export const stripLeadingDollar = function (s: string): string {
     return s.replace(/^\$/, '')
 }


### PR DESCRIPTION
## Changes

Change from using a regex-based trim to native trim

Also tightened up some types in the same file as I have a problem

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
