### PR TITLE
Send timezone to flags v2

### DIFF
--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -72,6 +72,14 @@ export default function Home() {
                 <button className="ph-no-capture">Ignore certain elements</button>
 
                 <button
+                    onClick={() => {
+                        posthog?.reloadFeatureFlags()
+                    }}
+                >
+                    Reload feature flags
+                </button>
+
+                <button
                     onClick={() =>
                         posthog?.setPersonProperties({
                             email: `user-${randomID()}@posthog.com`,

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -26,6 +26,7 @@ import {
 
 import { isArray, isUndefined } from './utils/type-utils'
 import { createLogger } from './utils/logger'
+import { Info } from './utils/event-utils'
 
 const logger = createLogger('[FeatureFlags]')
 
@@ -396,6 +397,10 @@ export class PostHogFeatureFlags {
         // `/flags/` to get the flag evaluation data).
         const eligibleForFlagsV2 =
             this.instance.config.__preview_flags_v2 && this.instance.config.__preview_remote_config
+
+        if (eligibleForFlagsV2) {
+            data.timezone = Info.timezone()
+        }
 
         this._requestInFlight = true
         this.instance._send_request({


### PR DESCRIPTION
## Changes

Send timezone to flags v2. It's needed to figure out the user's calendar date, for the cookieless hash. We should merge https://github.com/PostHog/posthog/pull/30304 first

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
