### PR TITLE
fix: return can render survey reason

### DIFF
--- a/playground/nextjs/pages/survey.tsx
+++ b/playground/nextjs/pages/survey.tsx
@@ -43,9 +43,9 @@ export default function SurveyForm() {
                 <button
                     onClick={() => {
                         const renderReason = posthog.canRenderSurvey(selectedSurvey)
-                        const message = renderReason.visible
+                        const message = renderReason?.visible
                             ? `Survey can be rendered: Yes`
-                            : `Survey cannot be rendered: ${renderReason.disabledReason || 'No reason provided'}`
+                            : `Survey cannot be rendered: ${renderReason?.disabledReason || 'No reason provided'}`
                         alert(message)
                     }}
                 >

--- a/playground/nextjs/pages/survey.tsx
+++ b/playground/nextjs/pages/survey.tsx
@@ -40,6 +40,17 @@ export default function SurveyForm() {
                 >
                     Render Survey below
                 </button>
+                <button
+                    onClick={() => {
+                        const renderReason = posthog.canRenderSurvey(selectedSurvey)
+                        const message = renderReason.visible
+                            ? `Survey can be rendered: Yes`
+                            : `Survey cannot be rendered: ${renderReason.disabledReason || 'No reason provided'}`
+                        alert(message)
+                    }}
+                >
+                    Check if survey can be rendered
+                </button>
             </div>
             <div className="flex items-center gap-2 flex-wrap">
                 <div id="survey-container">

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1373,7 +1373,7 @@ export class PostHog {
     }
 
     /** Checks the feature flags associated with this Survey to see if the survey can be rendered. */
-    canRenderSurvey(surveyId: string): SurveyRenderReason {
+    canRenderSurvey(surveyId: string): SurveyRenderReason | null {
         return this.surveys.canRenderSurvey(surveyId)
     }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -26,7 +26,7 @@ import { PostHogExceptions } from './posthog-exceptions'
 import { PostHogFeatureFlags } from './posthog-featureflags'
 import { PostHogPersistence } from './posthog-persistence'
 import { PostHogSurveys } from './posthog-surveys'
-import { SurveyCallback } from './posthog-surveys-types'
+import { SurveyCallback, SurveyRenderReason } from './posthog-surveys-types'
 import { RateLimiter } from './rate-limiter'
 import { RemoteConfigLoader } from './remote-config'
 import { extendURLParams, request, SUPPORTS_REQUEST } from './request'
@@ -1373,8 +1373,8 @@ export class PostHog {
     }
 
     /** Checks the feature flags associated with this Survey to see if the survey can be rendered. */
-    canRenderSurvey(surveyId: string): void {
-        this.surveys.canRenderSurvey(surveyId)
+    canRenderSurvey(surveyId: string): SurveyRenderReason {
+        return this.surveys.canRenderSurvey(surveyId)
     }
 
     /**

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -389,13 +389,15 @@ export class PostHogSurveys {
     canRenderSurvey(surveyId: string): SurveyRenderReason | null {
         if (isNullish(this._surveyManager)) {
             logger.warn('init was not called')
-            return { visible: false }
+            return { visible: false, disabledReason: 'SDK is not enabled or survey functionality is not yet loaded' }
         }
         let renderReason: SurveyRenderReason | null = null
         this.getSurveys((surveys) => {
             const survey = surveys.filter((x) => x.id === surveyId)[0]
             if (survey) {
                 renderReason = { ...this._surveyManager.canRenderSurvey(survey) }
+            } else {
+                renderReason = { visible: false, disabledReason: 'Survey not found' }
             }
         })
         return renderReason

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -1,14 +1,14 @@
 import { SURVEYS } from './constants'
 import { getSurveySeenStorageKeys } from './extensions/surveys/surveys-utils'
 import { PostHog } from './posthog-core'
-import { Survey, SurveyCallback, SurveyMatchType } from './posthog-surveys-types'
+import { Survey, SurveyCallback, SurveyMatchType, SurveyRenderReason } from './posthog-surveys-types'
 import { RemoteConfig } from './types'
 import { Info } from './utils/event-utils'
 import { assignableWindow, document, userAgent, window } from './utils/globals'
 import { createLogger } from './utils/logger'
 import { isMatchingRegex } from './utils/regex-utils'
 import { SurveyEventReceiver } from './utils/survey-event-receiver'
-import { isNullish, isArray } from './utils/type-utils'
+import { isArray, isNullish } from './utils/type-utils'
 
 const logger = createLogger('[Surveys]')
 
@@ -386,15 +386,17 @@ export class PostHogSurveys {
         return assignableWindow.__PosthogExtensions__.canActivateRepeatedly(survey)
     }
 
-    canRenderSurvey(surveyId: string) {
+    canRenderSurvey(surveyId: string): SurveyRenderReason {
         if (isNullish(this._surveyManager)) {
             logger.warn('init was not called')
-            return
+            return { visible: false }
         }
+        let renderReason: SurveyRenderReason = { visible: false }
         this.getSurveys((surveys) => {
             const survey = surveys.filter((x) => x.id === surveyId)[0]
-            this._surveyManager.canRenderSurvey(survey)
+            renderReason = { ...this._surveyManager.canRenderSurvey(survey) }
         })
+        return renderReason
     }
 
     renderSurvey(surveyId: string, selector: string) {

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -386,15 +386,17 @@ export class PostHogSurveys {
         return assignableWindow.__PosthogExtensions__.canActivateRepeatedly(survey)
     }
 
-    canRenderSurvey(surveyId: string): SurveyRenderReason {
+    canRenderSurvey(surveyId: string): SurveyRenderReason | null {
         if (isNullish(this._surveyManager)) {
             logger.warn('init was not called')
             return { visible: false }
         }
-        let renderReason: SurveyRenderReason = { visible: false }
+        let renderReason: SurveyRenderReason | null = null
         this.getSurveys((surveys) => {
             const survey = surveys.filter((x) => x.id === surveyId)[0]
-            renderReason = { ...this._surveyManager.canRenderSurvey(survey) }
+            if (survey) {
+                renderReason = { ...this._surveyManager.canRenderSurvey(survey) }
+            }
         })
         return renderReason
     }


### PR DESCRIPTION

## Changes

right now `canRenderSurvey` is useless because it doesn't return anything.

this fixes it and adds a helper button in the nextjs playground

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
