### PR TITLE
fix: resetting sampling to null should clear sampling for users

### DIFF
--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -870,8 +870,8 @@ describe('SessionRecording', () => {
                     makeDecideResponse({ sessionRecording: { endpoint: '/s/', sampleRate: null } })
                 )
 
-                // then check that a session is no longer sampled out (i.e. storage is null not false)
-                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(null)
+                // then check that a session is no longer sampled out (i.e. storage is cleared not false)
+                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(undefined)
                 expect(sessionRecording['status']).toBe('active')
             })
 
@@ -883,8 +883,8 @@ describe('SessionRecording', () => {
                     makeDecideResponse({ sessionRecording: { endpoint: '/s/', sampleRate: null } })
                 )
 
-                // then check that a session is no longer sampled out (i.e. storage is null not false)
-                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(null)
+                // then check that a session is no longer sampled out (i.e. storage is cleared not false)
+                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(undefined)
                 expect(sessionRecording['status']).toBe('active')
 
                 // set sample rate to 0, i.e. no sessions will run

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -874,6 +874,27 @@ describe('SessionRecording', () => {
                 expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(null)
                 expect(sessionRecording['status']).toBe('active')
             })
+
+            it('turning sample rate from null to 0, resets values as expected', () => {
+                sessionRecording.startIfEnabledOrStop()
+
+                // first turn sample rate to null
+                sessionRecording.onRemoteConfig(
+                    makeDecideResponse({ sessionRecording: { endpoint: '/s/', sampleRate: null } })
+                )
+
+                // then check that a session is no longer sampled out (i.e. storage is null not false)
+                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(null)
+                expect(sessionRecording['status']).toBe('active')
+
+                // set sample rate to 0, i.e. no sessions will run
+                sessionRecording.onRemoteConfig(
+                    makeDecideResponse({ sessionRecording: { endpoint: '/s/', sampleRate: '0.00' } })
+                )
+                // then check that a session is sampled (i.e. storage is false not true or null)
+                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(false)
+                expect(sessionRecording['status']).toBe('disabled')
+            })
         })
 
         describe('canvas', () => {

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -872,14 +872,6 @@ describe('SessionRecording', () => {
 
                 // then check that a session is no longer sampled out (i.e. storage is null not false)
                 expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(null)
-
-                // then start a new session
-                sessionManager.resetSessionId()
-                sessionId = 'session-id-' + uuidv7()
-                _emit(createIncrementalSnapshot({ data: { source: 1 } }))
-
-                // then check that the new session is not sampled out (i.e. storage is null not false and recording is active)
-                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(null)
                 expect(sessionRecording['status']).toBe('active')
             })
         })

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -611,9 +611,7 @@ export class SessionRecording {
     }
 
     private _resetSampling() {
-        this.instance.persistence?.register({
-            [SESSION_RECORDING_IS_SAMPLED]: null,
-        })
+        this.instance.persistence?.unregister(SESSION_RECORDING_IS_SAMPLED)
     }
 
     private makeSamplingDecision(sessionId: string): void {

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -610,6 +610,12 @@ export class SessionRecording {
         }
     }
 
+    private _resetSampling() {
+        this.instance.persistence?.register({
+            [SESSION_RECORDING_IS_SAMPLED]: null,
+        })
+    }
+
     private makeSamplingDecision(sessionId: string): void {
         const sessionIdChanged = this.sessionId !== sessionId
 
@@ -619,9 +625,7 @@ export class SessionRecording {
         const currentSampleRate = this.sampleRate
 
         if (!isNumber(currentSampleRate)) {
-            this.instance.persistence?.register({
-                [SESSION_RECORDING_IS_SAMPLED]: null,
-            })
+            this._resetSampling()
             return
         }
 
@@ -709,6 +713,9 @@ export class SessionRecording {
             this._samplingSessionListener = this.sessionManager.onSessionId((sessionId) => {
                 this.makeSamplingDecision(sessionId)
             })
+        }
+        if (isNullish(this.sampleRate)) {
+            this._resetSampling()
         }
     }
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -714,9 +714,6 @@ export class SessionRecording {
                 this.makeSamplingDecision(sessionId)
             })
         }
-        if (isNullish(this.sampleRate)) {
-            this._resetSampling()
-        }
     }
 
     private _persistRemoteConfig(response: RemoteConfig): void {
@@ -727,6 +724,10 @@ export class SessionRecording {
                 const receivedSampleRate = response.sessionRecording?.sampleRate
 
                 const parsedSampleRate = isNullish(receivedSampleRate) ? null : parseFloat(receivedSampleRate)
+                if (isNullish(parsedSampleRate)) {
+                    this._resetSampling()
+                }
+
                 const receivedMinimumDuration = response.sessionRecording?.minimumDurationMilliseconds
 
                 persistence.register({


### PR DESCRIPTION
we saw a case where a user had been sampled out (i.e. would not be recorded)

then the sample rate for the project was set back to null (i.e. no sampling)

but the user's browser never made a sampling decision again, so didn't pick up that it should reset the sampling decision

this changes things to clear any sampling decision whenever we see a null sample rate