### PR TITLE
chore: allow all surveys to be repeated if schedule is always

### DIFF
--- a/src/__tests__/extensions/surveys-utils.test.ts
+++ b/src/__tests__/extensions/surveys-utils.test.ts
@@ -121,22 +121,12 @@ describe('hasEvents', () => {
 })
 
 describe('canActivateRepeatedly', () => {
-    it('should return true when survey is a Widget type with Always schedule', () => {
+    it('should return true when survey the schedule is Always', () => {
         const survey = {
-            type: SurveyType.Widget,
             schedule: SurveySchedule.Always,
             conditions: undefined,
         } as Pick<Survey, 'type' | 'schedule' | 'conditions'>
         expect(canActivateRepeatedly(survey)).toBe(true)
-    })
-
-    it('should return false when survey is not a Widget type with Always schedule', () => {
-        const survey = {
-            type: SurveyType.Popover,
-            schedule: SurveySchedule.Always,
-            conditions: undefined,
-        } as Pick<Survey, 'type' | 'schedule' | 'conditions'>
-        expect(canActivateRepeatedly(survey)).toBe(false)
     })
 
     it('should return false when survey has no events', () => {

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -9,7 +9,7 @@ import {
     usePopupVisibility,
 } from '../../extensions/surveys'
 import { createShadow } from '../../extensions/surveys/surveys-utils'
-import { Survey, SurveyQuestionType, SurveyType } from '../../posthog-surveys-types'
+import { Survey, SurveyQuestionType, SurveySchedule, SurveyType } from '../../posthog-surveys-types'
 
 import { afterAll, beforeAll, beforeEach } from '@jest/globals'
 import '@testing-library/jest-dom'
@@ -471,6 +471,26 @@ describe('SurveyManager', () => {
             { id: '2', appearance: { surveyPopupDelaySeconds: 2 } },
             { id: '1', appearance: { surveyPopupDelaySeconds: 5 } },
             { id: '4', appearance: { surveyPopupDelaySeconds: 8 } },
+        ])
+    })
+
+    test('sortSurveysByAppearanceDelay should sort Always surveys last', () => {
+        const surveys: Survey[] = [
+            { id: '1', appearance: { surveyPopupDelaySeconds: 5 }, schedule: 'event' },
+            { id: '2', appearance: { surveyPopupDelaySeconds: 2 }, schedule: SurveySchedule.Always },
+            { id: '3', appearance: {}, schedule: 'event' },
+            { id: '4', appearance: { surveyPopupDelaySeconds: 8 }, schedule: SurveySchedule.Always },
+            { id: '5', appearance: { surveyPopupDelaySeconds: 1 }, schedule: 'event' },
+        ] as unknown as Survey[]
+
+        const sortedSurveys = surveyManager.getTestAPI().sortSurveysByAppearanceDelay(surveys)
+
+        expect(sortedSurveys).toEqual([
+            { id: '3', appearance: {}, schedule: 'event' },
+            { id: '5', appearance: { surveyPopupDelaySeconds: 1 }, schedule: 'event' },
+            { id: '1', appearance: { surveyPopupDelaySeconds: 5 }, schedule: 'event' },
+            { id: '2', appearance: { surveyPopupDelaySeconds: 2 }, schedule: SurveySchedule.Always },
+            { id: '4', appearance: { surveyPopupDelaySeconds: 8 }, schedule: SurveySchedule.Always },
         ])
     })
 

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -7,6 +7,7 @@ import {
     SurveyQuestionBranchingType,
     SurveyQuestionType,
     SurveyRenderReason,
+    SurveySchedule,
     SurveyType,
 } from '../posthog-surveys-types'
 
@@ -289,9 +290,19 @@ export class SurveyManager {
      * @returns The surveys sorted by their appearance delay
      */
     private sortSurveysByAppearanceDelay(surveys: Survey[]): Survey[] {
-        return surveys.sort(
-            (a, b) => (a.appearance?.surveyPopupDelaySeconds || 0) - (b.appearance?.surveyPopupDelaySeconds || 0)
-        )
+        return surveys.sort((a, b) => {
+            const aIsAlways = a.schedule === SurveySchedule.Always
+            const bIsAlways = b.schedule === SurveySchedule.Always
+
+            if (aIsAlways && !bIsAlways) {
+                return 1 // a comes after b
+            }
+            if (!aIsAlways && bIsAlways) {
+                return -1 // a comes before b
+            }
+            // If both are Always or neither is Always, sort by delay
+            return (a.appearance?.surveyPopupDelaySeconds || 0) - (b.appearance?.surveyPopupDelaySeconds || 0)
+        })
     }
 
     /**

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -666,7 +666,7 @@ export const hasEvents = (survey: Pick<Survey, 'conditions'>): boolean => {
     return survey.conditions?.events?.values?.length != undefined && survey.conditions?.events?.values?.length > 0
 }
 
-export const canActivateRepeatedly = (survey: Pick<Survey, 'schedule' | 'type' | 'conditions'>): boolean => {
+export const canActivateRepeatedly = (survey: Pick<Survey, 'schedule' | 'conditions'>): boolean => {
     return (
         !!(survey.conditions?.events?.repeatedActivation && hasEvents(survey)) ||
         survey.schedule === SurveySchedule.Always

--- a/src/extensions/surveys/surveys-utils.tsx
+++ b/src/extensions/surveys/surveys-utils.tsx
@@ -6,7 +6,6 @@ import {
     SurveyAppearance,
     SurveyQuestion,
     SurveySchedule,
-    SurveyType,
 } from '../../posthog-surveys-types'
 import { document as _document, window as _window } from '../../utils/globals'
 import { createLogger } from '../../utils/logger'
@@ -668,11 +667,10 @@ export const hasEvents = (survey: Pick<Survey, 'conditions'>): boolean => {
 }
 
 export const canActivateRepeatedly = (survey: Pick<Survey, 'schedule' | 'type' | 'conditions'>): boolean => {
-    if (survey.schedule === SurveySchedule.Always && survey.type === SurveyType.Widget) {
-        return true
-    }
-
-    return !!(survey.conditions?.events?.repeatedActivation && hasEvents(survey))
+    return (
+        !!(survey.conditions?.events?.repeatedActivation && hasEvents(survey)) ||
+        survey.schedule === SurveySchedule.Always
+    )
 }
 
 /**


### PR DESCRIPTION
## Changes

instead of restricting this option only for widget surveys, let's allow them for all surveys.

there has been feedback before where customers would like to test surveys locally, so this is useful for those occasions.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing)) - check if all tests are still running
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
