### PR TITLE
fix: add minimal bundle output (#65)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,11 @@ module.exports = {
         given: 'readonly',
         global: 'readonly',
         Buffer: 'readonly',
+<<<<<<< Updated upstream
+=======
+        MINIMAL_BUILD: 'readonly',
+        BUILD_VERSION: 'readonly',
+>>>>>>> Stashed changes
     },
     parser: '@typescript-eslint/parser',
     parserOptions: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,11 +33,8 @@ module.exports = {
         given: 'readonly',
         global: 'readonly',
         Buffer: 'readonly',
-<<<<<<< Updated upstream
-=======
         MINIMAL_BUILD: 'readonly',
         BUILD_VERSION: 'readonly',
->>>>>>> Stashed changes
     },
     parser: '@typescript-eslint/parser',
     parserOptions: {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
+        "@rollup/plugin-replace": "^6.0.2",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.2",
         "@rrweb/record": "2.0.0-alpha.17",

--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -2,7 +2,7 @@
 import { PostHogFeature, useActiveFeatureFlags, usePostHog } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
 import { cookieConsentGiven, PERSON_PROCESSING_MODE } from '@/src/posthog'
-import { setAllPersonProfilePropertiesAsPersonPropertiesForFlags } from 'posthog-js/lib/src/customizations'
+import { setAllPersonProfilePropertiesAsPersonPropertiesForFlags } from 'posthog-js/lib/customizations'
 import { STORED_PERSON_PROPERTIES_KEY } from '../../../src/constants'
 
 export default function Home() {

--- a/plugins/ts-private-prefixer.mjs
+++ b/plugins/ts-private-prefixer.mjs
@@ -1,0 +1,131 @@
+import ts from 'typescript'
+
+const prefix = '_ಠ_ಠ_'
+
+/**
+ * Custom TypeScript transformer factory that adds prefixes to private properties and methods, and updates
+ * all references within the class.
+ */
+export default function privatePrefixerTransformer(program) {
+    return (context) => {
+        const renamedSymbols = new Map()
+        const typeChecker = program.getTypeChecker()
+
+        const updatePropertyAccesses = (node) => {
+            // Handle property accesses (this.property or ClassName.staticProperty)
+            if (ts.isPropertyAccessExpression(node)) {
+                const symbol = typeChecker.getSymbolAtLocation(node.name)
+                if (symbol && renamedSymbols.has(symbol)) {
+                    const newName = renamedSymbols.get(symbol)
+                    return ts.factory.updatePropertyAccessExpression(
+                        node,
+                        node.expression,
+                        ts.factory.createIdentifier(newName)
+                    )
+                }
+            }
+            // Handle bracket notation property access (this['property'] or ClassName['property'])
+            else if (
+                ts.isElementAccessExpression(node) &&
+                node.argumentExpression.kind === ts.SyntaxKind.StringLiteral
+            ) {
+                const propName = node.argumentExpression.text
+                for (const [symbol, newName] of renamedSymbols.entries()) {
+                    if (symbol.escapedName === propName) {
+                        return ts.factory.updateElementAccessExpression(
+                            node,
+                            node.expression,
+                            ts.factory.createStringLiteral(newName)
+                        )
+                    }
+                }
+            }
+
+            return ts.visitEachChild(node, updatePropertyAccesses, context)
+        }
+
+        const visit = (node) => {
+            if (ts.isClassDeclaration(node)) {
+                const processedMembers = []
+                let needsReferenceUpdate = false
+
+                // First pass: rename private properties and methods, avoid messing with static
+                for (const member of node.members) {
+                    // Skip renaming properties with initializers in the class body
+                    if (ts.isPropertyDeclaration(member) && member.initializer) {
+                        processedMembers.push(member)
+                        continue
+                    }
+
+                    if (member.modifiers?.some((m) => m.kind === ts.SyntaxKind.PrivateKeyword)) {
+                        let name
+
+                        if (ts.isPropertyDeclaration(member) || ts.isMethodDeclaration(member)) {
+                            name = member.name
+                        }
+
+                        if (name && ts.isIdentifier(name) && !name.text.startsWith(prefix)) {
+                            const symbol = typeChecker.getSymbolAtLocation(name)
+                            const newName = `${prefix}${name.text}`
+
+                            if (symbol) {
+                                renamedSymbols.set(symbol, newName)
+                                needsReferenceUpdate = true
+                            }
+
+                            if (ts.isPropertyDeclaration(member)) {
+                                const newMember = ts.factory.updatePropertyDeclaration(
+                                    member,
+                                    member.modifiers,
+                                    ts.factory.createIdentifier(newName),
+                                    member.questionToken,
+                                    member.type,
+                                    member.initializer
+                                )
+                                processedMembers.push(newMember)
+                                continue
+                            } else if (ts.isMethodDeclaration(member)) {
+                                const newMember = ts.factory.updateMethodDeclaration(
+                                    member,
+                                    member.modifiers,
+                                    member.asteriskToken,
+                                    ts.factory.createIdentifier(newName),
+                                    member.questionToken,
+                                    member.typeParameters,
+                                    member.parameters,
+                                    member.type,
+                                    member.body
+                                )
+                                processedMembers.push(newMember)
+                                continue
+                            }
+                        }
+                    }
+
+                    processedMembers.push(member)
+                }
+
+                const updatedClass = ts.factory.updateClassDeclaration(
+                    node,
+                    node.modifiers,
+                    node.name,
+                    node.typeParameters,
+                    node.heritageClauses,
+                    processedMembers
+                )
+
+                // If we renamed anything, we need to update references
+                if (needsReferenceUpdate) {
+                    // Second pass: update references within method bodies
+                    return ts.visitEachChild(updatedClass, updatePropertyAccesses, context)
+                }
+
+                return updatedClass
+            }
+
+            return ts.visitEachChild(node, visit, context)
+        }
+
+        return (sourceFile) => ts.visitNode(sourceFile, visit)
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^16.0.0
         version: 16.0.0(rollup@4.28.1)
+      '@rollup/plugin-replace':
+        specifier: ^6.0.2
+        version: 6.0.2(rollup@4.28.1)
       '@rollup/plugin-terser':
         specifier: ^0.4.4
         version: 0.4.4(rollup@4.28.1)
@@ -1382,6 +1385,15 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-replace@6.0.2':
+    resolution: {integrity: sha512-7QaYCf8bqF04dOy7w/eHmJeNExxTYwvKAmlSAH/EaWWUzbT0h5sbF6bktFoX/0F/0qwng5/dWFMyf3gzaM8DsQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -7094,6 +7106,13 @@ snapshots:
       deepmerge: 4.2.2
       is-module: 1.0.0
       resolve: 1.22.8
+    optionalDependencies:
+      rollup: 4.28.1
+
+  '@rollup/plugin-replace@6.0.2(rollup@4.28.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.28.1)
+      magic-string: 0.30.12
     optionalDependencies:
       rollup: 4.28.1
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,10 @@ const plugins = (es5, minimal) => [
         minimal
             ? {
                   MINIMAL_BUILD: true,
+                  'logger.debug': 'console.debug',
+                  'logger.info': 'console.info',
+                  'logger.warn': 'console.warn',
+                  'logger.error': 'console.warn', // Intentional, as console.error will not get dropped
                   preventAssignment: true,
               }
             : {
@@ -64,6 +68,7 @@ const plugins = (es5, minimal) => [
         compress: {
             // 5 is the default if unspecified
             ecma: es5 ? 5 : 6,
+            drop_console: minimal ? ['log', 'info', 'warn', 'debug'] : false,
         },
     }),
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ import terser from '@rollup/plugin-terser'
 import { visualizer } from 'rollup-plugin-visualizer'
 import commonjs from '@rollup/plugin-commonjs'
 import { version } from './package.json' assert { type: 'json' }
+import privatePrefixerTransformer from './plugins/ts-private-prefixer'
 import fs from 'fs'
 import path from 'path'
 
@@ -35,6 +36,13 @@ const plugins = (es5, minimal) => [
         compilerOptions: {
             target: 'ESNext',
         },
+        transformers: minimal
+            ? function (program) {
+                  return {
+                      before: [privatePrefixerTransformer(program)],
+                  }
+              }
+            : undefined,
     }),
     commonjs(),
     babel({
@@ -78,6 +86,13 @@ const plugins = (es5, minimal) => [
             ecma: es5 ? 5 : 6,
             drop_console: minimal ? ['log', 'info', 'warn', 'debug'] : false,
         },
+        mangle: minimal
+            ? {
+                  properties: {
+                      regex: /^_ಠ_ಠ_[\w_$]+/,
+                  },
+              }
+            : true,
     }),
 ]
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import babel from '@rollup/plugin-babel'
+import replace from '@rollup/plugin-replace'
 import json from '@rollup/plugin-json'
 import resolve from '@rollup/plugin-node-resolve'
 import typescript from '@rollup/plugin-typescript'
@@ -9,7 +10,17 @@ import commonjs from '@rollup/plugin-commonjs'
 import fs from 'fs'
 import path from 'path'
 
-const plugins = (es5) => [
+const plugins = (es5, minimal) => [
+    replace(
+        minimal
+            ? {
+                  MINIMAL_BUILD: true,
+                  preventAssignment: true,
+              }
+            : {
+                  preventAssignment: true,
+              }
+    ),
     json(),
     resolve({ browser: true }),
     typescript({ sourceMap: true, outDir: './dist' }),
@@ -74,7 +85,7 @@ const entrypointTargets = entrypoints.map((file) => {
 
     const fileName = fileParts.join('.')
 
-    const pluginsForThisFile = plugins(fileName.includes('es5'))
+    const pluginsForThisFile = plugins(fileName.includes('es5'), fileName.includes('minimal'))
 
     // we're allowed to console log in this file :)
     // eslint-disable-next-line no-console

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -1,3 +1,5 @@
+global.MINIMAL_BUILD = false
+
 beforeEach(() => {
     console.error = (...args) => {
         throw new Error(`Unexpected console.error: ${args}`)

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -1,4 +1,5 @@
 global.MINIMAL_BUILD = false
+global.BUILD_VERSION = '0.0.0'
 
 beforeEach(() => {
     console.error = (...args) => {

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -229,12 +229,12 @@ export function autocapturePropertiesForElement(
 }
 
 export class Autocapture {
-    instance: PostHog
-    _initialized: boolean = false
-    _isDisabledServerSide: boolean | null = null
-    _elementSelectors: Set<string> | null
-    rageclicks = new RageClick()
-    _elementsChainAsString = false
+    private instance: PostHog
+    private _initialized: boolean = false
+    private _isDisabledServerSide: boolean | null = null
+    private _elementSelectors: Set<string> | null
+    private rageclicks = new RageClick()
+    private _elementsChainAsString = false
 
     constructor(instance: PostHog) {
         this.instance = instance

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,13 @@
-import packageInfo from '../package.json'
+/**
+ * Set by @rollup/plugin-replace at build-time
+ */
+declare const BUILD_VERSION: string;
 
 // overridden in posthog-core,
 // e.g.     Config.DEBUG = Config.DEBUG || instance.config.debug
 const Config = {
     DEBUG: false,
-    LIB_VERSION: packageInfo.version,
+    LIB_VERSION: BUILD_VERSION,
 }
 
 export default Config

--- a/src/entrypoints/module.minimal.es.ts
+++ b/src/entrypoints/module.minimal.es.ts
@@ -1,0 +1,5 @@
+import { init_as_module } from '../posthog-core'
+export { PostHog } from '../posthog-core'
+export * from '../types'
+export const posthog = init_as_module()
+export default posthog

--- a/src/extensions/exception-autocapture/index.ts
+++ b/src/extensions/exception-autocapture/index.ts
@@ -134,6 +134,6 @@ export class ExceptionObserver {
             this.instance.config.token
         }/person/${this.instance.get_distinct_id()}`
 
-        this.instance.exceptions.sendExceptionEvent(errorProperties)
+        this.instance.exceptions?.sendExceptionEvent(errorProperties)
     }
 }

--- a/src/extensions/exception-autocapture/index.ts
+++ b/src/extensions/exception-autocapture/index.ts
@@ -9,9 +9,9 @@ import { isObject, isUndefined } from '../../utils/type-utils'
 const logger = createLogger('[ExceptionAutocapture]')
 
 export class ExceptionObserver {
-    instance: PostHog
-    remoteEnabled: boolean | undefined
-    config: Required<ExceptionAutoCaptureConfig>
+    private instance: PostHog
+    private remoteEnabled: boolean | undefined
+    private config: Required<ExceptionAutoCaptureConfig>
     private unwrapOnError: (() => void) | undefined
     private unwrapUnhandledRejection: (() => void) | undefined
     private unwrapConsoleError: (() => void) | undefined

--- a/src/extensions/rageclick.ts
+++ b/src/extensions/rageclick.ts
@@ -7,7 +7,7 @@ const RAGE_CLICK_TIMEOUT_MS = 1000
 const RAGE_CLICK_CLICK_COUNT = 3
 
 export default class RageClick {
-    clicks: { x: number; y: number; timestamp: number }[]
+    private clicks: { x: number; y: number; timestamp: number }[]
 
     constructor() {
         this.clicks = []

--- a/src/extensions/sentry-integration.ts
+++ b/src/extensions/sentry-integration.ts
@@ -135,7 +135,7 @@ export function createEventProcessor(
                 event.event_id
         }
 
-        _posthog.exceptions.sendExceptionEvent(data)
+        _posthog.exceptions?.sendExceptionEvent(data)
 
         return event
     }

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -315,7 +315,7 @@ export class SurveyManager {
         }
 
         const linkedFlagCheck = survey.linked_flag_key
-            ? this.posthog.featureFlags.isFeatureEnabled(survey.linked_flag_key)
+            ? !!this.posthog.featureFlags?.isFeatureEnabled(survey.linked_flag_key)
             : true
 
         if (!linkedFlagCheck) {
@@ -324,7 +324,7 @@ export class SurveyManager {
         }
 
         const targetingFlagCheck = survey.targeting_flag_key
-            ? this.posthog.featureFlags.isFeatureEnabled(survey.targeting_flag_key)
+            ? !!this.posthog.featureFlags?.isFeatureEnabled(survey.targeting_flag_key)
             : true
 
         if (!targetingFlagCheck) {
@@ -333,7 +333,7 @@ export class SurveyManager {
         }
 
         const internalTargetingFlagCheck = survey.internal_targeting_flag_key
-            ? this.posthog.featureFlags.isFeatureEnabled(survey.internal_targeting_flag_key)
+            ? !!this.posthog.featureFlags?.isFeatureEnabled(survey.internal_targeting_flag_key)
             : true
 
         if (!internalTargetingFlagCheck) {

--- a/src/extensions/toolbar.ts
+++ b/src/extensions/toolbar.ts
@@ -24,7 +24,7 @@ enum ToolbarState {
 }
 
 export class Toolbar {
-    instance: PostHog
+    private instance: PostHog
 
     constructor(instance: PostHog) {
         this.instance = instance

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -45,11 +45,11 @@ function isValidMouseEvent(e: unknown): e is MouseEvent {
 }
 
 export class Heatmaps {
-    instance: PostHog
-    rageclicks = new RageClick()
-    _enabledServerSide: boolean = false
-    _initialized = false
-    _mouseMoveTimeout: ReturnType<typeof setTimeout> | undefined
+    private instance: PostHog
+    private rageclicks = new RageClick()
+    private _enabledServerSide: boolean = false
+    private _initialized = false
+    private _mouseMoveTimeout: ReturnType<typeof setTimeout> | undefined
 
     // TODO: Periodically flush this if no other event has taken care of it
     private buffer: HeatmapEventBuffer

--- a/src/page-view.ts
+++ b/src/page-view.ts
@@ -30,7 +30,7 @@ interface PageViewEventProperties {
 
 export class PageViewManager {
     _currentPageview?: { timestamp: Date; pageViewId: string | undefined; pathname: string | undefined }
-    _instance: PostHog
+    private _instance: PostHog
 
     constructor(instance: PostHog) {
         this._instance = instance

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1266,6 +1266,10 @@ export class PostHog {
      * @param {Object|String} options (optional) If {send_event: false}, we won't send an $feature_flag_call event to PostHog.
      */
     getFeatureFlag(key: string, options?: { send_event?: boolean }): boolean | string | undefined {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         return this.featureFlags?.getFeatureFlag(key, options)
     }
 
@@ -1282,6 +1286,10 @@ export class PostHog {
      * @param {Object|String} prop Key of the feature flag.
      */
     getFeatureFlagPayload(key: string): JsonType {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         const payload = this.featureFlags?.getFeatureFlagPayload(key)
         try {
             return JSON.parse(payload as any)
@@ -1301,15 +1309,27 @@ export class PostHog {
      * @param {Object|String} options (optional) If {send_event: false}, we won't send an $feature_flag_call event to PostHog.
      */
     isFeatureEnabled(key: string, options?: { send_event: boolean }): boolean | undefined {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         return this.featureFlags?.isFeatureEnabled(key, options)
     }
 
     reloadFeatureFlags(): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         this.featureFlags?.reloadFeatureFlags()
     }
 
     /** Opt the user in or out of an early access feature. */
     updateEarlyAccessFeatureEnrollment(key: string, isEnrolled: boolean): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         this.featureFlags?.updateEarlyAccessFeatureEnrollment(key, isEnrolled)
     }
 
@@ -1319,6 +1339,10 @@ export class PostHog {
         force_reload = false,
         stages?: EarlyAccessFeatureStage[]
     ): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         return this.featureFlags?.getEarlyAccessFeatures(callback, force_reload, stages)
     }
 
@@ -1349,6 +1373,10 @@ export class PostHog {
      * @returns {Function} A function that can be called to unsubscribe the listener. Used by useEffect when the component unmounts.
      */
     onFeatureFlags(callback: FeatureFlagsCallback): () => void {
+        if (MINIMAL_BUILD) {
+            return __NOOP
+        }
+
         return this.featureFlags?.onFeatureFlags(callback) || __NOOP
     }
 
@@ -1367,6 +1395,10 @@ export class PostHog {
      * @returns {Function} A function that can be called to unsubscribe the listener.
      */
     onSurveysLoaded(callback: SurveyCallback): () => void {
+        if (MINIMAL_BUILD) {
+            return __NOOP
+        }
+
         return this.surveys?.onSurveysLoaded(callback) || __NOOP
     }
 
@@ -1389,21 +1421,37 @@ export class PostHog {
 
     /** Get list of all surveys. */
     getSurveys(callback: SurveyCallback, forceReload = false): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         this.surveys?.getSurveys(callback, forceReload)
     }
 
     /** Get surveys that should be enabled for the current user. */
     getActiveMatchingSurveys(callback: SurveyCallback, forceReload = false): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         this.surveys?.getActiveMatchingSurveys(callback, forceReload)
     }
 
     /** Render a survey on a specific element. */
     renderSurvey(surveyId: string, selector: string): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         this.surveys?.renderSurvey(surveyId, selector)
     }
 
     /** Checks the feature flags associated with this Survey to see if the survey can be rendered. */
     canRenderSurvey(surveyId: string): SurveyRenderReason | null {
+        if (MINIMAL_BUILD) {
+            return null
+        }
+
         return this.surveys?.canRenderSurvey(surveyId) || null
     }
 
@@ -1644,10 +1692,18 @@ export class PostHog {
      * to update user properties.
      */
     setPersonPropertiesForFlags(properties: Properties, reloadFeatureFlags = true): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         this.featureFlags?.setPersonPropertiesForFlags(properties, reloadFeatureFlags)
     }
 
     resetPersonPropertiesForFlags(): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         this.featureFlags?.resetPersonPropertiesForFlags()
     }
 
@@ -1660,6 +1716,10 @@ export class PostHog {
      *     setGroupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } })
      */
     setGroupPropertiesForFlags(properties: { [type: string]: Properties }, reloadFeatureFlags = true): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         if (!this._requirePersonProcessing('posthog.setGroupPropertiesForFlags')) {
             return
         }
@@ -1667,6 +1727,10 @@ export class PostHog {
     }
 
     resetGroupPropertiesForFlags(group_type?: string): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         this.featureFlags?.resetGroupPropertiesForFlags(group_type)
     }
 
@@ -1760,6 +1824,10 @@ export class PostHog {
      * @param options.timestampLookBack How many seconds to look back for the timestamp (defaults to 10)
      */
     get_session_replay_url(options?: { withTimestamp?: boolean; timestampLookBack?: number }): string {
+        if (MINIMAL_BUILD) {
+            return ''
+        }
+
         if (!this.sessionManager) {
             return ''
         }
@@ -1880,6 +1948,10 @@ export class PostHog {
     startSessionRecording(
         override?: { sampling?: boolean; linked_flag?: boolean; url_trigger?: true; event_trigger?: true } | true
     ): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         const overrideAll = override === true
         const overrideConfig = {
             sampling: overrideAll || !!override?.sampling,
@@ -1917,6 +1989,10 @@ export class PostHog {
      * disable_session_recording to true
      */
     stopSessionRecording(): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         this.set_config({ disable_session_recording: true })
     }
 
@@ -1925,11 +2001,19 @@ export class PostHog {
      * is currently running
      */
     sessionRecordingStarted(): boolean {
+        if (MINIMAL_BUILD) {
+            return false
+        }
+
         return !!this.sessionRecording?.started
     }
 
     /** Capture a caught exception manually */
     captureException(error: unknown, additionalProperties?: Properties): void {
+        if (MINIMAL_BUILD) {
+            return
+        }
+
         const syntheticException = new Error('PostHog syntheticException')
         this.exceptions?.sendExceptionEvent({
             ...errorToProperties(
@@ -1948,6 +2032,10 @@ export class PostHog {
      * @param toolbarParams
      */
     loadToolbar(params: ToolbarParams): boolean {
+        if (MINIMAL_BUILD) {
+            return false
+        }
+
         return !!this.toolbar?.loadToolbar(params)
     }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -289,19 +289,19 @@ export class PostHog {
     deadClicksAutocapture?: DeadClicksAutocapture
 
     _requestQueue?: RequestQueue
-    _retryQueue?: RetryQueue
+    private _retryQueue?: RetryQueue
     sessionRecording?: SessionRecording
     webPerformance = new DeprecatedWebPerformanceObserver()
 
-    _initialPageviewCaptured: boolean
-    _personProcessingSetOncePropertiesSent: boolean = false
-    _triggered_notifs: any
+    private _initialPageviewCaptured: boolean
+    private _personProcessingSetOncePropertiesSent: boolean = false
+    private _triggered_notifs: any
     compression?: Compression
-    __request_queue: QueuedRequestWithOptions[]
+    private __request_queue: QueuedRequestWithOptions[]
     analyticsDefaultEndpoint: string
     version = Config.LIB_VERSION
-    _initialPersonProfilesConfig: 'always' | 'never' | 'identified_only' | null
-    _cachedPersonProperties: string | null
+    private _initialPersonProfilesConfig: 'always' | 'never' | 'identified_only' | null
+    private _cachedPersonProperties: string | null
 
     SentryIntegration?: typeof SentryIntegration
     sentryIntegration?: (options?: SentryIntegrationOptions) => ReturnType<typeof sentryIntegration>

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -500,7 +500,7 @@ export class PostHogFeatureFlags {
                 }
 
                 if (!isUndefined(flagDetails?.metadata?.version)) {
-                    properties.$feature_flag_version = flagDetails.metadata.version
+                    properties.$feature_flag_version = flagDetails!.metadata!.version
                 }
 
                 const reason = flagDetails?.reason?.description ?? flagDetails?.reason?.code
@@ -516,9 +516,9 @@ export class PostHogFeatureFlags {
                 // We want to capture the original values in case someone forgets they were using overrides
                 // and is wondering why their app is acting weird.
                 if (!isUndefined(flagDetails?.original_variant) || !isUndefined(flagDetails?.original_enabled)) {
-                    properties.$feature_flag_original_response = !isUndefined(flagDetails.original_variant)
-                        ? flagDetails.original_variant
-                        : flagDetails.original_enabled
+                    properties.$feature_flag_original_response = !isUndefined(flagDetails?.original_variant)
+                        ? flagDetails!.original_variant
+                        : flagDetails!.original_enabled
                 }
 
                 if (flagDetails?.metadata?.original_payload) {

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -153,9 +153,9 @@ export enum QuotaLimitedResource {
 }
 
 export class PostHogFeatureFlags {
-    _override_warning: boolean = false
-    featureFlagEventHandlers: FeatureFlagsCallback[]
-    $anon_distinct_id: string | undefined
+    private _override_warning: boolean = false
+    private featureFlagEventHandlers: FeatureFlagsCallback[]
+    private $anon_distinct_id: string | undefined
     private _hasLoadedFlags: boolean = false
     private _requestInFlight: boolean = false
     private _reloadingDisabled: boolean = false

--- a/src/posthog-persistence.ts
+++ b/src/posthog-persistence.ts
@@ -45,14 +45,14 @@ const parseName = (config: PostHogConfig): string => {
 export class PostHogPersistence {
     private config: PostHogConfig
     props: Properties
-    storage: PersistentStore
-    campaign_params_saved: boolean
-    name: string
+    private storage: PersistentStore
+    private campaign_params_saved: boolean
+    private name: string
     disabled: boolean | undefined
-    secure: boolean | undefined
-    expire_days: number | undefined
-    default_expiry: number | undefined
-    cross_subdomain: boolean | undefined
+    private secure: boolean | undefined
+    private expire_days: number | undefined
+    private default_expiry: number | undefined
+    private cross_subdomain: boolean | undefined
 
     constructor(config: PostHogConfig) {
         this.config = config

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -303,7 +303,7 @@ export class PostHogSurveys {
         if (!flagKey) {
             return true
         }
-        return this.instance.featureFlags.isFeatureEnabled(flagKey)
+        return !!this.instance.featureFlags?.isFeatureEnabled(flagKey)
     }
 
     getActiveMatchingSurveys(callback: SurveyCallback, forceReload = false) {
@@ -373,7 +373,7 @@ export class PostHogSurveys {
             if (!key || !value) {
                 return true
             }
-            return this.instance.featureFlags.isFeatureEnabled(value)
+            return !!this.instance.featureFlags?.isFeatureEnabled(value)
         })
     }
 
@@ -383,7 +383,7 @@ export class PostHogSurveys {
             logger.warn('init was not called')
             return false // TODO does it make sense to have a default here?
         }
-        return assignableWindow.__PosthogExtensions__.canActivateRepeatedly(survey)
+        return assignableWindow.__PosthogExtensions__?.canActivateRepeatedly(survey)
     }
 
     canRenderSurvey(surveyId: string): SurveyRenderReason | null {

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -13,12 +13,12 @@ interface CaptureResponse {
 }
 
 export class RateLimiter {
-    instance: PostHog
+    private instance: PostHog
     serverLimits: Record<string, number> = {}
 
-    captureEventsPerSecond: number
-    captureEventsBurstLimit: number
-    lastEventRateLimited = false
+    private captureEventsPerSecond: number
+    private captureEventsBurstLimit: number
+    private lastEventRateLimited = false
 
     constructor(instance: PostHog) {
         this.instance = instance

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -85,7 +85,7 @@ export class RemoteConfigLoader {
         if (config.hasFeatureFlags !== false) {
             // If the config has feature flags, we need to call decide to get the feature flags
             // This completely separates it from the config logic which is good in terms of separation of concerns
-            this.instance.featureFlags.ensureFlagsLoaded()
+            this.instance.featureFlags?.ensureFlagsLoaded()
         }
     }
 }

--- a/src/utils/request-router.ts
+++ b/src/utils/request-router.ts
@@ -17,7 +17,7 @@ export type RequestRouterTarget = 'api' | 'ui' | 'assets'
 const ingestionDomain = 'i.posthog.com'
 
 export class RequestRouter {
-    instance: PostHog
+    private instance: PostHog
     private _regionCache: Record<string, RequestRouterRegion> = {}
 
     constructor(instance: PostHog) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
         "noUnusedParameters": true,
         "sourceMap": true,
         "inlineSources": true,
-        "resolveJsonModule": true,
         "downlevelIteration": true,
         "declaration": true,
         "jsx": "preserve",


### PR DESCRIPTION
## Changes

This PR introduces build-time flags around various optional extension initializers. Once bundled, Terser can effectively remove extension code and their dependencies.

Additionally, `debug`, `info`, `warn`, and `error` log statements were removed from the minimal bundle. Critical logs have been kept.

Furthermore, importing of version number from `package.json` when building was refactored to use Rollup's replace plugin. As a result, this addressed outputting of individual type definitions for all files in `/src` that were being placed in `/dist` directory.

### Breaking Changes

Since we are adding a new named bundle, 

### What can still be improved

- It should be possible to modify `package.json` to export this bundle as a named export (e.g., `import posthog from 'posthog-js/tiny'`).
- Code and tests can be refactored to mark more properties as private, which should add another 1-2% bundle size saving.

Closes #65

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
