### PR TITLE
feat: Only capture vitals on http and https

### DIFF
--- a/src/__tests__/extensions/web-vitals.test.ts
+++ b/src/__tests__/extensions/web-vitals.test.ts
@@ -299,38 +299,67 @@ describe('web vitals', () => {
         expect(posthog.webVitalsAutocapture!.isEnabled).toBe(false)
     })
 
-    it.each(['ftp:', 'ws:', 'wss:', 'chrome-extension:', 'chrome:', 'edge:', 'file:', 'about:', 'blob:'])(
-        'should not run on %s protocol',
-        async (protocol) => {
-            mockLocation.mockReturnValue({
-                protocol: protocol,
-                host: 'localhost',
-                pathname: '/',
-                search: '',
-                hash: '',
-                href: `${protocol}//localhost/`,
-            })
-
-            posthog = await createPosthogInstance(uuidv7(), {
-                before_send: beforeSendMock,
-                capture_performance: { web_vitals: true },
-            })
-
-            posthog.webVitalsAutocapture!.onRemoteConfig({
-                capturePerformance: { web_vitals: true },
-            } as DecideResponse)
-
-            expect(posthog.webVitalsAutocapture!.isEnabled).toBe(false)
-        }
-    )
-    it.each(['http:', 'https:'])('should run on %s protocol', async (protocol) => {
+    it.each([
+        // hybrid app tools
+        'capacitor',
+        'capacitor-electron',
+        'tauri',
+        'ionic',
+        'wails',
+        'android-app',
+        'ms-appx-web',
+        // browser extensions
+        'chrome',
+        'chrome-extension',
+        'moz-extension',
+        'safari-web-extension',
+        'vscode-webview',
+        // local files
+        'file',
+        'blob',
+        'data',
+        'content',
+        'dfile',
+        'javascript',
+        'about',
+        'localhost',
+        // email clients
+        'ms-outlook',
+        'email',
+        // misc
+        'ws',
+        'wss',
+        'ftp',
+        'unknown',
+    ])('should not run on %s protocol', async (protocol) => {
         mockLocation.mockReturnValue({
-            protocol: protocol,
+            protocol: protocol + ':',
             host: 'localhost',
             pathname: '/',
             search: '',
             hash: '',
-            href: `${protocol}//localhost/`,
+            href: `${protocol}://localhost/`,
+        })
+
+        posthog = await createPosthogInstance(uuidv7(), {
+            before_send: beforeSendMock,
+            capture_performance: { web_vitals: true },
+        })
+
+        posthog.webVitalsAutocapture!.onRemoteConfig({
+            capturePerformance: { web_vitals: true },
+        } as DecideResponse)
+
+        expect(posthog.webVitalsAutocapture!.isEnabled).toBe(false)
+    })
+    it.each(['http', 'https'])('should run on %s protocol', async (protocol) => {
+        mockLocation.mockReturnValue({
+            protocol: protocol + ':',
+            host: 'localhost',
+            pathname: '/',
+            search: '',
+            hash: '',
+            href: `${protocol}://localhost/`,
         })
 
         posthog = await createPosthogInstance(uuidv7(), {

--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -3,7 +3,7 @@ import { RemoteConfig, SupportedWebVitalsMetrics } from '../../types'
 import { createLogger } from '../../utils/logger'
 import { isBoolean, isNullish, isNumber, isObject, isUndefined } from '../../utils/type-utils'
 import { WEB_VITALS_ALLOWED_METRICS, WEB_VITALS_ENABLED_SERVER_SIDE } from '../../constants'
-import { assignableWindow, window } from '../../utils/globals'
+import { assignableWindow, window, location } from '../../utils/globals'
 
 const logger = createLogger('[Web Vitals]')
 
@@ -58,6 +58,13 @@ export class WebVitalsAutocapture {
     }
 
     public get isEnabled(): boolean {
+        // Always disable web vitals if we're not on http or https
+        const protocol = location?.protocol
+        if (protocol !== 'http:' && protocol !== 'https:') {
+            return false
+        }
+
+        // Otherwise, check config
         const clientConfig = isObject(this.instance.config.capture_performance)
             ? this.instance.config.capture_performance.web_vitals
             : undefined

--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -61,6 +61,7 @@ export class WebVitalsAutocapture {
         // Always disable web vitals if we're not on http or https
         const protocol = location?.protocol
         if (protocol !== 'http:' && protocol !== 'https:') {
+            logger.info('Web Vitals are disabled on non-http/https protocols')
             return false
         }
 


### PR DESCRIPTION
## Changes

Check the protocol when starting up web vitals, and don't enable it if we're not on http or https. (i.e. don't use web vitals on file:// urls)

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
