### PR TITLE
fix: make survey widget with selector work with SPAs

### DIFF
--- a/playground/nextjs/pages/survey.tsx
+++ b/playground/nextjs/pages/survey.tsx
@@ -29,7 +29,7 @@ export default function SurveyForm() {
     return (
         <>
             <div className="flex items-center gap-2 flex-wrap">
-                <button className="survey-feedback-button">Feedback</button>
+                <button id="feedback-button">Feedback</button>
                 <select value={selectedSurvey} onChange={handleChange}>
                     <option value="">Select a survey</option>
                     {arraySurveyItems}
@@ -66,7 +66,7 @@ export default function SurveyForm() {
             {/* Bottom feedback button */}
             <div style={{ padding: '20px', textAlign: 'center', borderTop: '1px solid #eee' }}>
                 <button
-                    className="survey-feedback-button"
+                    id="feedback-button-bottom"
                     style={{
                         padding: '10px 20px',
                         background: '#1D4AFF',

--- a/playground/react-router/package.json
+++ b/playground/react-router/package.json
@@ -12,7 +12,7 @@
         "@react-router/node": "^7.5.0",
         "@react-router/serve": "^7.5.0",
         "isbot": "^5.1.17",
-        "posthog-js": "^1.234.10",
+        "posthog-js": "file:../../posthog-js",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.5.0"

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -367,8 +367,8 @@ describe('SurveyManager', () => {
             .spyOn(surveyManager as any, 'handlePopoverSurvey')
             .mockImplementation(() => {})
         const handleWidgetMock = jest.spyOn(surveyManager as any, 'handleWidget').mockImplementation(() => {})
-        const handleWidgetSelectorMock = jest
-            .spyOn(surveyManager as any, 'handleWidgetSelector')
+        const manageWidgetSelectorListener = jest
+            .spyOn(surveyManager as any, 'manageWidgetSelectorListener')
             .mockImplementation(() => {})
         jest.spyOn(surveyManager as any, 'canShowNextEventBasedSurvey').mockReturnValue(true)
 
@@ -377,7 +377,7 @@ describe('SurveyManager', () => {
         expect(mockPostHog.getActiveMatchingSurveys).toHaveBeenCalled()
         expect(handlePopoverSurveyMock).toHaveBeenCalledWith(mockSurveys[0])
         expect(handleWidgetMock).not.toHaveBeenCalled()
-        expect(handleWidgetSelectorMock).not.toHaveBeenCalled()
+        expect(manageWidgetSelectorListener).not.toHaveBeenCalled()
     })
 
     test('handleWidget should render the widget correctly', () => {

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -381,48 +381,61 @@ describe('SurveyManager', () => {
     })
 
     test('handleWidget should render the widget correctly', () => {
-        const mockSurvey = mockSurveys[1]
-        const handleWidgetMock = jest.spyOn(surveyManager as any, 'handleWidget').mockImplementation(() => {})
-        surveyManager.getTestAPI().handleWidget(mockSurvey)
-        expect(handleWidgetMock).toHaveBeenCalledWith(mockSurvey)
-    })
-
-    test('handleWidgetSelector should set up the widget selector correctly', () => {
-        const mockSurvey: Survey = {
-            id: 'testSurvey1',
-            name: 'Test survey 1',
-            description: 'Test survey description 1',
+        // Add a minimal widget survey to the mock surveys array
+        mockSurveys.push({
+            id: 'widgetSurvey1',
+            name: 'Widget Survey',
+            description: 'A widget survey',
             type: SurveyType.Widget,
             linked_flag_key: null,
             targeting_flag_key: null,
             internal_targeting_flag_key: null,
-            questions: [
-                {
-                    question: 'How satisfied are you with our newest product?',
-                    description: 'This is a question description',
-                    descriptionContentType: 'text',
-                    type: SurveyQuestionType.Rating,
-                    display: 'number',
-                    scale: 10,
-                    lowerBoundLabel: 'Not Satisfied',
-                    upperBoundLabel: 'Very Satisfied',
-                    id: 'question-a',
-                },
-            ],
-            appearance: {},
+            questions: [],
+            appearance: { widgetType: 'tab' }, // Specify widget type
             conditions: null,
             start_date: '2021-01-01T00:00:00.000Z',
             end_date: null,
             current_iteration: null,
             current_iteration_start_date: null,
             feature_flag_keys: [],
+        })
+        const mockSurvey = mockSurveys[1]
+        const handleWidgetSpy = jest.spyOn(surveyManager as any, 'handleWidget')
+        surveyManager.getTestAPI().handleWidget(mockSurvey) // Call the actual method
+        expect(handleWidgetSpy).toHaveBeenCalledWith(mockSurvey)
+        // We can add more specific assertions here if needed, e.g., checking if the shadow DOM was created
+        // For now, just ensuring it was called seems sufficient for this test's scope.
+    })
+
+    test('manageWidgetSelectorListener should be called for selector widgets', () => {
+        const mockSurvey: Survey = {
+            id: 'selectorWidgetSurvey',
+            name: 'Selector Widget Survey',
+            description: 'A selector widget survey',
+            type: SurveyType.Widget,
+            questions: [],
+            appearance: {
+                widgetType: 'selector',
+                widgetSelector: '.my-selector',
+            },
+            conditions: null,
+            start_date: '2021-01-01T00:00:00.000Z',
+            end_date: null,
+            current_iteration: null,
+            current_iteration_start_date: null,
+            feature_flag_keys: [],
+            linked_flag_key: null,
+            targeting_flag_key: null,
+            internal_targeting_flag_key: null,
         }
-        document.body.innerHTML = '<div class="widget-selector"></div>'
-        const handleWidgetSelectorMock = jest
-            .spyOn(surveyManager as any, 'handleWidgetSelector')
-            .mockImplementation(() => {})
-        surveyManager.getTestAPI().handleWidgetSelector(mockSurvey)
-        expect(handleWidgetSelectorMock).toHaveBeenNthCalledWith(1, mockSurvey)
+        mockPostHog.getActiveMatchingSurveys = jest.fn((callback) => callback([mockSurvey]))
+        document.body.innerHTML = '<div class="my-selector">Click Me</div>'
+
+        const manageWidgetSelectorListenerSpy = jest.spyOn(surveyManager as any, 'manageWidgetSelectorListener')
+
+        surveyManager.callSurveysAndEvaluateDisplayLogic()
+
+        expect(manageWidgetSelectorListenerSpy).toHaveBeenCalledWith(mockSurvey)
     })
 
     test('callSurveysAndEvaluateDisplayLogic should not call surveys in focus', () => {

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -999,11 +999,9 @@ export function FeedbackWidget({
             return
         }
 
-        // Handle Tab positioning (remains the same)
         if (survey.appearance?.widgetType === 'tab') {
             if (widgetRef.current) {
                 const widgetPos = widgetRef.current.getBoundingClientRect()
-                // Use setStyleOverrides here for consistency, although this style isn't dynamic like the selector one
                 setStyleOverrides({
                     top: '50%',
                     left: parseInt(`${widgetPos.right - 360}`),
@@ -1013,9 +1011,6 @@ export function FeedbackWidget({
                 })
             }
         }
-        // REMOVED: Selector listener attachment logic is moved to SurveyManager
-
-        // Listen for the custom event dispatched by SurveyManager
         const handleShowSurvey = (event: Event) => {
             const customEvent = event as CustomEvent
             // Check if the event is for this specific survey instance
@@ -1039,7 +1034,7 @@ export function FeedbackWidget({
         survey.appearance?.widgetType,
         survey.appearance?.widgetSelector,
         survey.appearance?.borderColor,
-    ]) // Added dependencies
+    ])
 
     useHideSurveyOnURLChange({
         survey,

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -10,10 +10,10 @@ import {
     SurveySchedule,
     SurveyType,
 } from '../posthog-surveys-types'
+import { addEventListener } from '../utils'
 
 import * as Preact from 'preact'
 import { useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks'
-import { addEventListener } from '../utils'
 import { document as _document, window as _window } from '../utils/globals'
 import { createLogger } from '../utils/logger'
 import { isNull, isNumber } from '../utils/type-utils'
@@ -50,6 +50,8 @@ const document = _document as Document
 function getPosthogWidgetClass(surveyId: string) {
     return `.PostHogWidget${surveyId}`
 }
+
+const DISPATCH_FEEDBACK_WIDGET_EVENT = 'ph:show_survey_widget'
 
 function getRatingBucketForResponseValue(responseValue: number, scale: number) {
     if (scale === 3) {
@@ -158,6 +160,7 @@ export class SurveyManager {
     private posthog: PostHog
     private surveyInFocus: string | null
     private surveyTimeouts: Map<string, NodeJS.Timeout> = new Map()
+    private widgetSelectorListeners: Map<string, { element: Element; listener: EventListener }> = new Map()
 
     constructor(posthog: PostHog) {
         this.posthog = posthog
@@ -234,52 +237,119 @@ export class SurveyManager {
     }
 
     private handleWidget = (survey: Survey): void => {
-        const shadow = createWidgetShadow(survey, this.posthog)
+        // Ensure widget container exists if it doesn't
+        if (document.querySelectorAll(getPosthogWidgetClass(survey.id)).length === 0) {
+            const shadow = createWidgetShadow(survey, this.posthog)
 
-        const stylesheetContent = style(survey.appearance)
-        const stylesheet = prepareStylesheet(document, stylesheetContent, this.posthog)
+            const stylesheetContent = style(survey.appearance)
+            const stylesheet = prepareStylesheet(document, stylesheetContent, this.posthog)
 
-        if (stylesheet) {
-            shadow.appendChild(stylesheet)
+            if (stylesheet) {
+                shadow.appendChild(stylesheet)
+            }
+
+            Preact.render(
+                <FeedbackWidget
+                    key={'feedback-survey-' + survey.id} // Use unique key
+                    posthog={this.posthog}
+                    survey={survey}
+                    removeSurveyFromFocus={this.removeSurveyFromFocus}
+                />,
+                shadow
+            )
         }
-
-        Preact.render(
-            <FeedbackWidget
-                key={'feedback-survey'}
-                posthog={this.posthog}
-                survey={survey}
-                removeSurveyFromFocus={this.removeSurveyFromFocus}
-            />,
-            shadow
-        )
     }
 
-    private handleWidgetSelector = (survey: Survey): void => {
-        const selectorOnPage =
-            survey.appearance?.widgetSelector && document.querySelector(survey.appearance.widgetSelector)
-        if (selectorOnPage) {
-            if (document.querySelectorAll(`.PostHogWidget${survey.id}`).length === 0) {
-                this.handleWidget(survey)
-            } else if (document.querySelectorAll(`.PostHogWidget${survey.id}`).length === 1) {
-                // we have to check if user selector already has a survey listener attached to it because we always have to check if it's on the page or not
-                if (!selectorOnPage.getAttribute('PHWidgetSurveyClickListener')) {
-                    const surveyPopup = document
-                        .querySelector(getPosthogWidgetClass(survey.id))
-                        ?.shadowRoot?.querySelector(`.survey-form`) as HTMLFormElement
+    private removeWidgetSelectorListener = (surveyId: string): void => {
+        const existing = this.widgetSelectorListeners.get(surveyId)
+        if (existing) {
+            existing.element.removeEventListener('click', existing.listener)
+            existing.element.removeAttribute('PHWidgetSurveyClickListener')
+            this.widgetSelectorListeners.delete(surveyId)
+            logger.info(`Removed click listener for survey ${surveyId}`)
+        }
+    }
 
-                    addEventListener(selectorOnPage, 'click', () => {
-                        if (surveyPopup) {
-                            surveyPopup.style.display = surveyPopup.style.display === 'none' ? 'block' : 'none'
-                            addEventListener(surveyPopup, 'PHSurveyClosed', () => {
-                                this.removeSurveyFromFocus(survey.id)
-                                surveyPopup.style.display = 'none'
-                            })
-                        }
-                    })
+    private manageWidgetSelectorListener = (survey: Survey): void => {
+        const selector = survey.appearance?.widgetSelector
+        if (!selector) {
+            return
+        }
 
-                    selectorOnPage.setAttribute('PHWidgetSurveyClickListener', 'true')
-                }
+        const currentElement = document.querySelector(selector)
+        const existingListenerData = this.widgetSelectorListeners.get(survey.id)
+
+        if (!currentElement) {
+            // Element not found, remove listener if it exists
+            if (existingListenerData) {
+                this.removeWidgetSelectorListener(survey.id)
             }
+            return
+        }
+
+        // Ensure the base widget is rendered first if needed
+        this.handleWidget(survey)
+
+        if (existingListenerData) {
+            // Listener exists, check if element changed
+            if (currentElement !== existingListenerData.element) {
+                logger.info(`Selector element changed for survey ${survey.id}. Re-attaching listener.`)
+                this.removeWidgetSelectorListener(survey.id)
+                // Continue to attach listener to the new element below
+            } else {
+                // Element is the same, listener already attached, do nothing
+                return
+            }
+        }
+
+        // Element found, and no listener attached (or it was just removed from old element)
+        if (!currentElement.hasAttribute('PHWidgetSurveyClickListener')) {
+            const listener = (event: Event) => {
+                event.stopPropagation() // Prevent bubbling
+
+                const buttonRect = (event.currentTarget as HTMLElement).getBoundingClientRect()
+                const viewportHeight = window.innerHeight
+                const viewportWidth = window.innerWidth
+                const surveyWidth = parseInt(survey.appearance?.maxWidth || '300')
+                const estimatedMinSurveyHeight = 250 // Keep this estimation
+                const buttonCenterX = buttonRect.left + buttonRect.width / 2
+                let left = buttonCenterX - surveyWidth / 2
+                const horizontalPadding = 20
+                if (left + surveyWidth > viewportWidth - horizontalPadding) {
+                    left = viewportWidth - surveyWidth - horizontalPadding
+                }
+                if (left < horizontalPadding) {
+                    left = horizontalPadding
+                }
+                const spacing = 12
+                const spaceBelow = viewportHeight - buttonRect.bottom
+                const spaceAbove = buttonRect.top
+                const showAbove = spaceBelow < estimatedMinSurveyHeight && spaceAbove > spaceBelow
+
+                const positionStyles: React.CSSProperties = {
+                    position: 'fixed',
+                    top: showAbove ? 'auto' : `${buttonRect.bottom + spacing}px`,
+                    left: `${left}px`,
+                    right: 'auto',
+                    bottom: showAbove ? `${viewportHeight - buttonRect.top + spacing}px` : 'auto',
+                    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+                    borderBottom: `1.5px solid ${survey.appearance?.borderColor || '#c9c6c6'}`,
+                    borderRadius: '10px',
+                    zIndex: SURVEY_DEFAULT_Z_INDEX,
+                }
+
+                // Dispatch event for the FeedbackWidget to catch
+                window.dispatchEvent(
+                    new CustomEvent(DISPATCH_FEEDBACK_WIDGET_EVENT, {
+                        detail: { surveyId: survey.id, position: positionStyles },
+                    })
+                )
+            }
+
+            addEventListener(currentElement, 'click', listener)
+            currentElement.setAttribute('PHWidgetSurveyClickListener', 'true')
+            this.widgetSelectorListeners.set(survey.id, { element: currentElement, listener })
+            logger.info(`Attached click listener for survey ${survey.id}`)
         }
     }
 
@@ -377,25 +447,36 @@ export class SurveyManager {
             // for each survey in the queue in order, and only display one survey at a time.
             const nonAPISurveyQueue = this.sortSurveysByAppearanceDelay(nonAPISurveys)
 
+            // Keep track of surveys processed this cycle to remove listeners for inactive ones
+            const activeSelectorSurveyIds = new Set<string>()
+
             nonAPISurveyQueue.forEach((survey) => {
-                // We only evaluate the display logic for one survey at a time
-                if (!isNull(this.surveyInFocus)) {
-                    return
-                }
+                // Widget Type Logic
                 if (survey.type === SurveyType.Widget) {
-                    if (
-                        survey.appearance?.widgetType === 'tab' &&
-                        document.querySelectorAll(`.PostHogWidget${survey.id}`).length === 0
-                    ) {
+                    if (survey.appearance?.widgetType === 'tab') {
+                        // Render tab widget if not already present
                         this.handleWidget(survey)
-                    }
-                    if (survey.appearance?.widgetType === 'selector' && survey.appearance?.widgetSelector) {
-                        this.handleWidgetSelector(survey)
+                    } else if (survey.appearance?.widgetType === 'selector' && survey.appearance?.widgetSelector) {
+                        activeSelectorSurveyIds.add(survey.id)
+                        // Manage the listener attachment/detachment dynamically
+                        this.manageWidgetSelectorListener(survey)
                     }
                 }
 
-                if (survey.type === SurveyType.Popover && this.canShowNextEventBasedSurvey()) {
+                // Popover Type Logic (only one shown at a time)
+                if (
+                    isNull(this.surveyInFocus) &&
+                    survey.type === SurveyType.Popover &&
+                    this.canShowNextEventBasedSurvey()
+                ) {
                     this.handlePopoverSurvey(survey)
+                }
+            })
+
+            // Clean up listeners for surveys that are no longer active or matched
+            this.widgetSelectorListeners.forEach((_, surveyId) => {
+                if (!activeSelectorSurveyIds.has(surveyId)) {
+                    this.removeWidgetSelectorListener(surveyId)
                 }
             })
         }, forceReload)
@@ -426,7 +507,7 @@ export class SurveyManager {
             canShowNextEventBasedSurvey: this.canShowNextEventBasedSurvey,
             handleWidget: this.handleWidget,
             handlePopoverSurvey: this.handlePopoverSurvey,
-            handleWidgetSelector: this.handleWidgetSelector,
+            manageWidgetSelectorListener: this.manageWidgetSelectorListener,
             sortSurveysByAppearanceDelay: this.sortSurveysByAppearanceDelay,
         }
     }
@@ -906,7 +987,7 @@ export function FeedbackWidget({
 }): JSX.Element | null {
     const [isFeedbackButtonVisible, setIsFeedbackButtonVisible] = useState(true)
     const [showSurvey, setShowSurvey] = useState(false)
-    const [styleOverrides, setStyle] = useState({})
+    const [styleOverrides, setStyleOverrides] = useState<React.CSSProperties>({})
     const widgetRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
@@ -918,85 +999,47 @@ export function FeedbackWidget({
             return
         }
 
+        // Handle Tab positioning (remains the same)
         if (survey.appearance?.widgetType === 'tab') {
             if (widgetRef.current) {
                 const widgetPos = widgetRef.current.getBoundingClientRect()
-                const style = {
+                // Use setStyleOverrides here for consistency, although this style isn't dynamic like the selector one
+                setStyleOverrides({
                     top: '50%',
                     left: parseInt(`${widgetPos.right - 360}`),
                     bottom: 'auto',
                     borderRadius: 10,
                     borderBottom: `1.5px solid ${survey.appearance?.borderColor || '#c9c6c6'}`,
-                }
-                setStyle(style)
+                })
             }
         }
-        if (survey.appearance?.widgetType === 'selector') {
-            const widget = document.querySelector(survey.appearance.widgetSelector || '') ?? undefined
+        // REMOVED: Selector listener attachment logic is moved to SurveyManager
 
-            addEventListener(widget, 'click', (event) => {
-                // Calculate position based on the selector button
-                const buttonRect = (event.currentTarget as HTMLElement).getBoundingClientRect()
-                const viewportHeight = window.innerHeight
-                const viewportWidth = window.innerWidth
-
-                // Get survey width from maxWidth or default to 300px
-                const surveyWidth = parseInt(survey.appearance?.maxWidth || '300')
-
-                // Estimated minimum survey height (we don't know exact height yet)
-                const estimatedMinSurveyHeight = 250
-
-                // Calculate horizontal center position of the button
-                const buttonCenterX = buttonRect.left + buttonRect.width / 2
-
-                // Calculate horizontal center position
-                let left = buttonCenterX - surveyWidth / 2
-
-                // Ensure the survey doesn't go off-screen horizontally (with padding)
-                const horizontalPadding = 20
-                if (left + surveyWidth > viewportWidth - horizontalPadding) {
-                    left = viewportWidth - surveyWidth - horizontalPadding
-                }
-                if (left < horizontalPadding) {
-                    left = horizontalPadding
-                }
-
-                // Simple spacing between button and survey
-                const spacing = 12
-
-                // Determine if we should show above or below
-                const spaceBelow = viewportHeight - buttonRect.bottom
-                const spaceAbove = buttonRect.top
-
-                // Prefer below if there's enough space, otherwise try above
-                const showAbove = spaceBelow < estimatedMinSurveyHeight && spaceAbove > spaceBelow
-
-                // If both above and below have insufficient space, prefer below as fallback
-                // For positioning logic only - scrolling will still make it accessible
-
-                // Set style overrides for positioning
-                setStyle((prev) => ({
-                    ...prev,
-                    position: 'fixed', // Fixed to viewport
-                    top: showAbove ? 'auto' : buttonRect.bottom + spacing + 'px',
-                    left: left + 'px',
-                    right: 'auto',
-                    bottom: showAbove ? viewportHeight - buttonRect.top + spacing + 'px' : 'auto',
-                    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
-                    borderBottom: `1.5px solid ${survey.appearance?.borderColor || '#c9c6c6'}`,
-                    borderRadius: '10px',
-                    zIndex: SURVEY_DEFAULT_Z_INDEX, // High z-index to ensure visibility
-                }))
-
-                setShowSurvey(!showSurvey)
-
-                // Prevent event from bubbling up to parent elements
-                event.stopPropagation()
-            })
-
-            widget?.setAttribute('PHWidgetSurveyClickListener', 'true')
+        // Listen for the custom event dispatched by SurveyManager
+        const handleShowSurvey = (event: Event) => {
+            const customEvent = event as CustomEvent
+            // Check if the event is for this specific survey instance
+            if (customEvent.detail?.surveyId === survey.id) {
+                logger.info(`Received show event for survey ${survey.id}`)
+                setStyleOverrides(customEvent.detail.position || {})
+                setShowSurvey(true) // Show the survey popup
+            }
         }
-    }, [])
+
+        addEventListener(window, DISPATCH_FEEDBACK_WIDGET_EVENT, handleShowSurvey)
+
+        // Cleanup listener on component unmount
+        return () => {
+            window.removeEventListener(DISPATCH_FEEDBACK_WIDGET_EVENT, handleShowSurvey)
+        }
+    }, [
+        posthog,
+        readOnly,
+        survey.id,
+        survey.appearance?.widgetType,
+        survey.appearance?.widgetSelector,
+        survey.appearance?.borderColor,
+    ]) // Added dependencies
 
     useHideSurveyOnURLChange({
         survey,

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -9,6 +9,7 @@ import {
     SurveyRenderReason,
     SurveySchedule,
     SurveyType,
+    SurveyWidgetType,
 } from '../posthog-surveys-types'
 import { addEventListener } from '../utils'
 
@@ -453,10 +454,13 @@ export class SurveyManager {
             nonAPISurveyQueue.forEach((survey) => {
                 // Widget Type Logic
                 if (survey.type === SurveyType.Widget) {
-                    if (survey.appearance?.widgetType === 'tab') {
+                    if (survey.appearance?.widgetType === SurveyWidgetType.Tab) {
                         // Render tab widget if not already present
                         this.handleWidget(survey)
-                    } else if (survey.appearance?.widgetType === 'selector' && survey.appearance?.widgetSelector) {
+                    } else if (
+                        survey.appearance?.widgetType === SurveyWidgetType.Selector &&
+                        survey.appearance?.widgetSelector
+                    ) {
                         activeSelectorSurveyIds.add(survey.id)
                         // Manage the listener attachment/detachment dynamically
                         this.manageWidgetSelectorListener(survey)

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -4,6 +4,12 @@
  * See https://github.com/PostHog/posthog-js/issues/698
  */
 
+export enum SurveyWidgetType {
+    Button = 'button',
+    Tab = 'tab',
+    Selector = 'selector',
+}
+
 export interface SurveyAppearance {
     // keep in sync with frontend/src/types.ts -> SurveyAppearance
     backgroundColor?: string
@@ -30,7 +36,7 @@ export interface SurveyAppearance {
     shuffleQuestions?: boolean
     surveyPopupDelaySeconds?: number
     // widget options
-    widgetType?: 'button' | 'tab' | 'selector'
+    widgetType?: SurveyWidgetType
     widgetSelector?: string
     widgetLabel?: string
     widgetColor?: string

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 import { Breaker, Properties } from '../types'
-import { hasOwnProperty, isArray, isFormData, isNull, isNullish, isString } from './type-utils'
-import { logger } from './logger'
 import { nativeForEach, nativeIndexOf } from './globals'
+import { logger } from './logger'
+import { hasOwnProperty, isArray, isFormData, isNull, isNullish, isString } from './type-utils'
 
 const breaker: Breaker = {}
 


### PR DESCRIPTION
## Changes

This PR fixes selector-triggered feedback widgets (`widgetType: 'selector'`) in Single Page Applications (SPAs).

**Problem:** The previous implementation attached click listeners directly in the `FeedbackWidget`. SPA navigation often destroys and recreates DOM elements, causing these listeners to be lost.

**Solution:** Listener management is now centralized in `SurveyManager`. It dynamically finds the selector element during periodic checks and manages listener attachment/detachment. On click, it dispatches a window event (`ph:show_survey_widget`), telling the `FeedbackWidget` when and where to display the survey popup.

**Testing:** Added unit tests for the new `SurveyManager` listener logic. Ran through our e2e tests to make sure previous flows are not broken.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
