### PR TITLE
feat(segment): identify only when segment.identify() is called

### DIFF
--- a/src/extensions/segment-integration.ts
+++ b/src/extensions/segment-integration.ts
@@ -68,7 +68,7 @@ const createSegmentIntegration = (posthog: PostHog): SegmentPlugin => {
         logger.warn('This browser does not have Promise support, and can not use the segment integration')
     }
 
-    const enrichEvent = (ctx: SegmentContext, eventName: string | undefined) => {
+    const enrichEvent = (ctx: SegmentContext, eventName: string | undefined, checkIdentity: boolean) => {
         if (!eventName) {
             return ctx
         }
@@ -77,7 +77,8 @@ const createSegmentIntegration = (posthog: PostHog): SegmentPlugin => {
             logger.info('No userId set, resetting PostHog')
             posthog.reset()
         }
-        if (ctx.event.userId && ctx.event.userId !== posthog.get_distinct_id()) {
+
+        if (checkIdentity && ctx.event.userId && ctx.event.userId !== posthog.get_distinct_id()) {
             logger.info('UserId set, identifying with PostHog')
             posthog.identify(ctx.event.userId)
         }
@@ -99,10 +100,10 @@ const createSegmentIntegration = (posthog: PostHog): SegmentPlugin => {
         // check and early return above
         // eslint-disable-next-line compat/compat
         load: () => Promise.resolve(),
-        track: (ctx) => enrichEvent(ctx, ctx.event.event),
-        page: (ctx) => enrichEvent(ctx, '$pageview'),
-        identify: (ctx) => enrichEvent(ctx, '$identify'),
-        screen: (ctx) => enrichEvent(ctx, '$screen'),
+        track: (ctx) => enrichEvent(ctx, ctx.event.event, false),
+        page: (ctx) => enrichEvent(ctx, '$pageview', false),
+        identify: (ctx) => enrichEvent(ctx, '$identify', true),
+        screen: (ctx) => enrichEvent(ctx, '$screen', false),
     }
 }
 


### PR DESCRIPTION
## Changes

Ticket: https://posthoghelp.zendesk.com/agent/tickets/28276 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/31750)

Previously, any Segment event containing a userId would trigger posthog.identify(), potentially identifying anonymous users unexpectedly. 
This change ensures that user identification only happens during explicit Segment `identify()` calls, while other events like `track`, `page`, `screen` preserve the user's anonymous state.

> Speculative fix - lacking context and know-how on testing this out

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
