### PR TITLE
chore(bundle size): strip console log messages from minimal bundle

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
         given: 'readonly',
         global: 'readonly',
         Buffer: 'readonly',
+        MINIMAL_BUILD: 'readonly',
     },
     parser: '@typescript-eslint/parser',
     parserOptions: {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
+        "@rollup/plugin-replace": "^6.0.2",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^12.1.2",
         "@rrweb/record": "2.0.0-alpha.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^16.0.0
         version: 16.0.0(rollup@4.28.1)
+      '@rollup/plugin-replace':
+        specifier: ^6.0.2
+        version: 6.0.2(rollup@4.28.1)
       '@rollup/plugin-terser':
         specifier: ^0.4.4
         version: 0.4.4(rollup@4.28.1)
@@ -1385,6 +1388,15 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-replace@6.0.2':
+    resolution: {integrity: sha512-7QaYCf8bqF04dOy7w/eHmJeNExxTYwvKAmlSAH/EaWWUzbT0h5sbF6bktFoX/0F/0qwng5/dWFMyf3gzaM8DsQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -7172,6 +7184,13 @@ snapshots:
       deepmerge: 4.2.2
       is-module: 1.0.0
       resolve: 1.22.8
+    optionalDependencies:
+      rollup: 4.28.1
+
+  '@rollup/plugin-replace@6.0.2(rollup@4.28.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.28.1)
+      magic-string: 0.30.12
     optionalDependencies:
       rollup: 4.28.1
 

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -1,3 +1,5 @@
+global.MINIMAL_BUILD = false
+
 beforeEach(() => {
     console.error = (...args) => {
         throw new Error(`Unexpected console.error: ${args}`)

--- a/src/__tests__/tsconfig.json
+++ b/src/__tests__/tsconfig.json
@@ -6,6 +6,6 @@
         "noImplicitReturns": false,
         "typeRoots": ["../../node_modules/@types", "../../src/types"]
     },
-    "include": ["./**/*.ts*"],
+    "include": ["./**/*.ts*", "../entrypoints/module.minimal.es.ts"],
     "exclude": []
 }

--- a/src/entrypoints/array minimal.ts
+++ b/src/entrypoints/array minimal.ts
@@ -1,2 +1,1 @@
-import './external-scripts-loader'
 import './array.no-external'

--- a/src/entrypoints/array minimal.ts
+++ b/src/entrypoints/array minimal.ts
@@ -1,0 +1,2 @@
+import './external-scripts-loader'
+import './array.no-external'

--- a/src/entrypoints/array minimal.ts
+++ b/src/entrypoints/array minimal.ts
@@ -1,1 +1,2 @@
+import './external-scripts-loader'
 import './array.no-external'

--- a/src/entrypoints/module.minimal.es.ts
+++ b/src/entrypoints/module.minimal.es.ts
@@ -1,0 +1,5 @@
+import { init_as_module } from '../posthog-core'
+export { PostHog } from '../posthog-core'
+export * from '../types'
+export const posthog = init_as_module()
+export default posthog


### PR DESCRIPTION
pulling changes out of https://github.com/PostHog/posthog-js/pull/1871

create a minimal bundle
as a first step, remove console log messages

9KB smaller without log messages ~5%
excluding the externals loader was only 1kb in comparison... will keep that in back pocket