### PR TITLE
chore: even more replay debug signal

### DIFF
--- a/playwright/session-recording/session-recording.spec.ts
+++ b/playwright/session-recording/session-recording.spec.ts
@@ -282,4 +282,16 @@ test.describe('Session recording - array.js', () => {
             'session_id_changed'
         )
     })
+
+    test('adds debug properties to captured events', async ({ page }) => {
+        await page.evaluate(() => {
+            const ph = (window as WindowWithPostHog).posthog
+            ph!.capture('an_event')
+        })
+        const capturedEvents = await page.capturedEvents()
+        expect(capturedEvents[0]['event']).toBe('an_event')
+        expect(capturedEvents[0]['properties']['$session_recording_start_reason']).toEqual('recording_initialized')
+        expect(capturedEvents[0]['properties']['$sdk_debug_current_session_duration']).toEqual('active')
+        expect(capturedEvents[0]['properties']['$sdk_debug_session_start']).toEqual('active')
+    })
 })

--- a/playwright/session-recording/session-recording.spec.ts
+++ b/playwright/session-recording/session-recording.spec.ts
@@ -284,14 +284,19 @@ test.describe('Session recording - array.js', () => {
     })
 
     test('adds debug properties to captured events', async ({ page }) => {
+        // make sure recording is running
+        await ensureActivitySendsSnapshots(page, ['$remote_config_received', '$session_options', '$posthog_config'])
+
         await page.evaluate(() => {
             const ph = (window as WindowWithPostHog).posthog
             ph!.capture('an_event')
         })
         const capturedEvents = await page.capturedEvents()
-        expect(capturedEvents[0]['event']).toBe('an_event')
-        expect(capturedEvents[0]['properties']['$session_recording_start_reason']).toEqual('recording_initialized')
-        expect(capturedEvents[0]['properties']['$sdk_debug_current_session_duration']).toEqual('active')
-        expect(capturedEvents[0]['properties']['$sdk_debug_session_start']).toEqual('active')
+        const targetEvent = capturedEvents.find((e) => e.event === 'an_event')
+        expect(targetEvent).toBeDefined()
+
+        expect(targetEvent!['properties']['$session_recording_start_reason']).toEqual('recording_initialized')
+        expect(targetEvent!['properties']['$sdk_debug_current_session_duration']).toBeDefined()
+        expect(targetEvent!['properties']['$sdk_debug_session_start']).toBeDefined()
     })
 })

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -461,6 +461,8 @@ describe('posthog core', () => {
                 $sdk_debug_replay_internal_buffer_length: 0,
                 $sdk_debug_replay_internal_buffer_size: 0,
                 $sdk_debug_retry_queue_size: 0,
+                $sdk_debug_current_session_duration: null,
+                $sdk_debug_session_start: 'no start timestamp',
             })
         })
 
@@ -488,6 +490,8 @@ describe('posthog core', () => {
                 $sdk_debug_replay_internal_buffer_length: 0,
                 $sdk_debug_replay_internal_buffer_size: 0,
                 $sdk_debug_retry_queue_size: 0,
+                $sdk_debug_current_session_duration: null,
+                $sdk_debug_session_start: 'no start timestamp',
             })
         })
 

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -462,7 +462,6 @@ describe('posthog core', () => {
                 $sdk_debug_replay_internal_buffer_size: 0,
                 $sdk_debug_retry_queue_size: 0,
                 $sdk_debug_current_session_duration: null,
-                $sdk_debug_session_start: 'no start timestamp',
             })
         })
 
@@ -491,7 +490,6 @@ describe('posthog core', () => {
                 $sdk_debug_replay_internal_buffer_size: 0,
                 $sdk_debug_retry_queue_size: 0,
                 $sdk_debug_current_session_duration: null,
-                $sdk_debug_session_start: 'no start timestamp',
             })
         })
 

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -1440,7 +1440,7 @@ export class SessionRecording {
             $sdk_debug_replay_internal_buffer_length: this.buffer.data.length,
             $sdk_debug_replay_internal_buffer_size: this.buffer.size,
             $sdk_debug_current_session_duration: this.sessionDuration,
-            $sdk_debug_session_start: isNullish(sessionStartTimestamp) ? 'no start timestamp' : sessionStartTimestamp,
+            $sdk_debug_session_start: sessionStartTimestamp,
         }
     }
 }

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -1426,4 +1426,21 @@ export class SessionRecording {
             this._tryAddCustomEvent(startReason, tagPayload)
         }
     }
+
+    /*
+     * whenever we capture an event we add these properties to the event
+     * these are used to debug issues with the session recording
+     * when looking at the event feed for a session
+     */
+    get sdkDebugProperties(): Properties {
+        const { sessionStartTimestamp } = this.sessionManager.checkAndGetSessionAndWindowId(true)
+
+        return {
+            $recording_status: this.status,
+            $sdk_debug_replay_internal_buffer_length: this.buffer.data.length,
+            $sdk_debug_replay_internal_buffer_size: this.buffer.size,
+            $sdk_debug_current_session_duration: this.sessionDuration,
+            $sdk_debug_session_start: isNullish(sessionStartTimestamp) ? 'no start timestamp' : sessionStartTimestamp,
+        }
+    }
 }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1007,9 +1007,7 @@ export class PostHog {
 
         try {
             if (this.sessionRecording) {
-                properties['$recording_status'] = this.sessionRecording.status
-                properties['$sdk_debug_replay_internal_buffer_length'] = this.sessionRecording['buffer'].data.length
-                properties['$sdk_debug_replay_internal_buffer_size'] = this.sessionRecording['buffer'].size
+                extend(properties, this.sessionRecording.sdkDebugProperties)
             }
             properties['$sdk_debug_retry_queue_size'] = this._retryQueue?.['queue']?.length
         } catch (e: any) {


### PR DESCRIPTION
a recording shows as active while still within its minimum duration so we can tell someone there is a recording to watch when e.g. they are three seconds into a ten second minimum

see https://posthog.slack.com/archives/C03PB072FMJ/p1744273599604909