### PR TITLE
fix: web vitals running when capture_performance: false is set

### DIFF
--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -68,7 +68,9 @@ export class WebVitalsAutocapture {
         // Otherwise, check config
         const clientConfig = isObject(this.instance.config.capture_performance)
             ? this.instance.config.capture_performance.web_vitals
-            : undefined
+            : isBoolean(this.instance.config.capture_performance)
+              ? this.instance.config.capture_performance
+              : undefined
         return isBoolean(clientConfig) ? clientConfig : this._enabledServerSide
     }
 


### PR DESCRIPTION
## Changes

See https://posthoghelp.zendesk.com/agent/tickets/28722 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/31192)

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
