### PR TITLE
fix: survey feedback button not showing after url change

### DIFF
--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -966,6 +966,12 @@ describe('useHideSurveyOnURLChange', () => {
     let mockRemoveSurveyFromFocus: jest.Mock
     let mockSetSurveyVisible: jest.Mock
 
+    const BASE_SURVEY = {
+        id: 'test-survey',
+        type: SurveyType.Popover,
+        appearance: {},
+    }
+
     beforeEach(() => {
         // Store original history methods
         originalPushState = window.history.pushState
@@ -997,7 +1003,7 @@ describe('useHideSurveyOnURLChange', () => {
 
     it('should not do anything in preview mode', () => {
         const survey = {
-            id: 'test-survey',
+            ...BASE_SURVEY,
             conditions: {
                 url: 'example.com',
                 urlMatchType: 'exact' as const,
@@ -1025,7 +1031,7 @@ describe('useHideSurveyOnURLChange', () => {
 
     it('should not do anything if no URL conditions are set', () => {
         const survey = {
-            id: 'test-survey',
+            ...BASE_SURVEY,
             conditions: {
                 events: null,
                 actions: null,
@@ -1051,7 +1057,7 @@ describe('useHideSurveyOnURLChange', () => {
 
     it('should handle pushState navigation', () => {
         const survey = {
-            id: 'test-survey',
+            ...BASE_SURVEY,
             conditions: {
                 url: 'example.com',
                 urlMatchType: 'exact' as const,
@@ -1079,7 +1085,7 @@ describe('useHideSurveyOnURLChange', () => {
 
     it('should handle replaceState navigation', () => {
         const survey = {
-            id: 'test-survey',
+            ...BASE_SURVEY,
             conditions: {
                 url: 'example.com',
                 urlMatchType: 'exact' as const,
@@ -1107,7 +1113,7 @@ describe('useHideSurveyOnURLChange', () => {
 
     it('should handle popstate events', () => {
         const survey = {
-            id: 'test-survey',
+            ...BASE_SURVEY,
             conditions: {
                 url: 'example.com',
                 urlMatchType: 'exact' as const,
@@ -1139,7 +1145,7 @@ describe('useHideSurveyOnURLChange', () => {
 
     it('should handle hashchange events', () => {
         const survey = {
-            id: 'test-survey',
+            ...BASE_SURVEY,
             conditions: {
                 url: 'example.com',
                 urlMatchType: 'exact' as const,
@@ -1171,7 +1177,7 @@ describe('useHideSurveyOnURLChange', () => {
 
     it('should clean up event listeners and history methods on unmount', () => {
         const survey = {
-            id: 'test-survey',
+            ...BASE_SURVEY,
             conditions: {
                 url: 'example.com',
                 urlMatchType: 'exact' as const,
@@ -1206,7 +1212,7 @@ describe('useHideSurveyOnURLChange', () => {
 
     it('should keep survey visible when URL still matches after navigation', () => {
         const survey = {
-            id: 'test-survey',
+            ...BASE_SURVEY,
             conditions: {
                 url: 'example.com',
                 urlMatchType: 'icontains' as const,

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -1527,7 +1527,8 @@ describe('preview renders', () => {
         })
 
         // Find and click the submit button (using button type="button" instead of form-submit class)
-        const submitButton = container.querySelector('button[type="button"]')
+        const submitButton = container.querySelectorAll('button[type="button"]')[1]
+
         console.log('Found submit button:', !!submitButton)
         console.log('Submit button text:', submitButton?.textContent)
 

--- a/src/__tests__/extensions/surveys/feedback-widget.test.tsx
+++ b/src/__tests__/extensions/surveys/feedback-widget.test.tsx
@@ -1,0 +1,356 @@
+/* eslint-disable compat/compat */
+import '@testing-library/jest-dom'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { FeedbackWidget } from '../../../extensions/surveys'
+import { PostHog } from '../../../posthog-core' // Import PostHog type for mocking
+import { Survey, SurveyQuestionType, SurveyType, SurveyWidgetType } from '../../../posthog-surveys-types'
+
+// Mock PostHog instance
+const mockPosthog = {
+    capture: jest.fn(),
+    getActiveMatchingSurveys: jest.fn(),
+    featureFlags: {
+        isFeatureEnabled: jest.fn().mockReturnValue(true),
+    },
+    get_session_replay_url: jest.fn().mockReturnValue('http://example.com/replay'),
+} as unknown as PostHog
+
+// Base mock survey for widget type
+const baseWidgetSurvey: Survey = {
+    id: 'widget-survey-123',
+    name: 'Feedback Widget Survey',
+    description: 'Test description',
+    type: SurveyType.Widget,
+    questions: [
+        {
+            type: SurveyQuestionType.Open,
+            question: 'What is your feedback?',
+            description: 'Please be specific.',
+            id: 'q-open-1',
+        },
+    ],
+    appearance: {
+        widgetLabel: 'Feedback',
+        widgetType: SurveyWidgetType.Tab,
+        widgetColor: '#000000', // Black background
+        backgroundColor: '#ffffff', // White popup background
+        borderColor: '#e0e0e0',
+        displayThankYouMessage: true,
+        thankYouMessageHeader: 'Thanks!',
+        thankYouMessageDescription: 'We got your feedback.',
+        whiteLabel: false, // Assuming default
+    },
+    conditions: null,
+    linked_flag_key: null,
+    targeting_flag_key: null,
+    internal_targeting_flag_key: null,
+    start_date: '2023-01-01T00:00:00Z',
+    end_date: null,
+    current_iteration: null,
+    current_iteration_start_date: null,
+    schedule: null,
+    feature_flag_keys: null,
+}
+
+// Mock survey with URL condition
+const urlConditionWidgetSurvey: Survey = {
+    ...baseWidgetSurvey,
+    id: 'widget-survey-url',
+    conditions: {
+        url: 'http://test.com/specific-page',
+        urlMatchType: 'exact',
+        seenSurveyWaitPeriodInDays: null,
+        events: null,
+        actions: null,
+    },
+}
+
+// Mock survey for selector type
+const selectorWidgetSurvey: Survey = {
+    ...baseWidgetSurvey,
+    id: 'widget-survey-selector',
+    appearance: {
+        ...baseWidgetSurvey.appearance,
+        widgetType: SurveyWidgetType.Selector,
+        widgetSelector: '.my-custom-button',
+    },
+}
+
+describe('FeedbackWidget', () => {
+    let removeSurveyFromFocusMock: jest.Mock
+
+    beforeEach(() => {
+        cleanup()
+        removeSurveyFromFocusMock = jest.fn()
+        // Mock history API for URL change hook
+        Object.defineProperty(window, 'history', {
+            value: {
+                pushState: jest.fn(),
+                replaceState: jest.fn(),
+                // Add scrollRestoration if needed by your code, JSDOM defaults to 'auto'
+                scrollRestoration: 'manual',
+            },
+            writable: true,
+        })
+
+        // Mock form.submit to prevent JSDOM error
+        HTMLFormElement.prototype.submit = jest.fn()
+
+        jest.clearAllMocks()
+    })
+
+    afterEach(() => {
+        // Restore form submit
+        delete (HTMLFormElement.prototype as any).submit
+    })
+
+    const expectSurveyShowEvent = (surveyId: string) => {
+        expect(mockPosthog.capture).toHaveBeenCalledWith(
+            'survey shown',
+            expect.objectContaining({ $survey_id: surveyId })
+        )
+    }
+
+    const expectSurveySentEvent = (surveyId: string, response: Record<string, string>) => {
+        expect(mockPosthog.capture).toHaveBeenLastCalledWith(
+            'survey sent',
+            expect.objectContaining({ $survey_id: surveyId, ...response })
+        )
+    }
+
+    test('renders feedback tab and opens survey on click', () => {
+        render(
+            <FeedbackWidget
+                survey={baseWidgetSurvey}
+                posthog={mockPosthog}
+                removeSurveyFromFocus={removeSurveyFromFocusMock}
+            />
+        )
+
+        // Check if the tab is visible
+        const tab = screen.getByText('Feedback')
+        expect(tab).toBeVisible()
+        // Check default text color contrast (black background -> white text)
+        expect(tab).toHaveStyle('color: white')
+
+        // Survey popup should not be visible initially
+        expect(screen.queryByRole('form')).not.toBeInTheDocument() // Form is inside SurveyPopup
+
+        // Click the tab
+        fireEvent.click(tab)
+
+        // Survey popup should become visible
+        expect(screen.getByRole('form')).toBeVisible()
+        expect(screen.getByText('What is your feedback?')).toBeVisible()
+    })
+
+    test('submits survey response and shows thank you message', async () => {
+        render(
+            <FeedbackWidget
+                survey={baseWidgetSurvey}
+                posthog={mockPosthog}
+                removeSurveyFromFocus={removeSurveyFromFocusMock}
+            />
+        )
+
+        // Open the survey
+        const tab = screen.getByText('Feedback')
+        fireEvent.click(tab)
+
+        expectSurveyShowEvent(baseWidgetSurvey.id)
+
+        // Fill in the textarea
+        const textarea = screen.getByRole('textbox')
+        fireEvent.input(textarea, { target: { value: 'This is my feedback!' } })
+        expect(textarea).toHaveValue('This is my feedback!')
+
+        // Submit the form
+        const submitButton = screen.getByRole('button', { name: /submit/i })
+        fireEvent.click(submitButton)
+
+        // Wait for survey sent event dispatch (internally) and UI update
+        await waitFor(() => {
+            // Check if thank you message is displayed
+            expect(screen.getByText('Thanks!')).toBeVisible()
+            expect(screen.getByText('We got your feedback.')).toBeVisible()
+        })
+
+        expectSurveySentEvent(baseWidgetSurvey.id, { '$survey_response_q-open-1': 'This is my feedback!' })
+
+        // Form should be gone
+        expect(screen.queryByRole('form')).not.toBeInTheDocument()
+
+        // Close the thank you message
+        const closeButton = screen.getByRole('button', { name: /close/i })
+        fireEvent.click(closeButton)
+
+        // Thank you message should disappear
+        await waitFor(() => {
+            expect(screen.queryByText('Thanks!')).not.toBeInTheDocument()
+        })
+
+        // Check if removeSurveyFromFocus was called (after submission shows thank you, it calls it internally)
+        // This happens inside usePopupVisibility's handleSurveySent
+        expect(removeSurveyFromFocusMock).toHaveBeenCalledWith(baseWidgetSurvey.id)
+    })
+
+    test('hides/shows feedback tab based on URL condition', async () => {
+        // --- Start with a MATCHING URL ---
+        Object.defineProperty(window, 'location', {
+            value: { href: 'http://test.com/specific-page', pathname: '/specific-page', hash: '' },
+            writable: true,
+        })
+
+        render(
+            <FeedbackWidget
+                survey={urlConditionWidgetSurvey}
+                posthog={mockPosthog}
+                removeSurveyFromFocus={removeSurveyFromFocusMock}
+            />
+        )
+
+        // Initially, the tab should be visible because the URL matches
+        expect(screen.getByText('Feedback')).toBeVisible()
+
+        // --- Navigate to a NON-MATCHING URL ---
+        Object.defineProperty(window, 'location', {
+            value: { href: 'http://test.com/wrong-page', pathname: '/wrong-page', hash: '' },
+            writable: true,
+        })
+        // Simulate the event that triggers the checkUrlMatch in the hook
+        await act(async () => {
+            fireEvent(window, new PopStateEvent('popstate'))
+        })
+
+        // Wait for the hook to run and hide the widget
+        await waitFor(() => {
+            expect(screen.queryByText('Feedback')).not.toBeInTheDocument()
+        })
+
+        // --- Navigate back to the MATCHING URL ---
+        Object.defineProperty(window, 'location', {
+            value: { href: 'http://test.com/specific-page', pathname: '/specific-page', hash: '' },
+            writable: true,
+        })
+        // Simulate the event again
+        await act(async () => {
+            fireEvent(window, new PopStateEvent('popstate'))
+        })
+
+        // Now the widget should become visible again
+        // Use waitFor as the state update might not be immediate
+        await waitFor(() => {
+            expect(screen.getByText('Feedback')).toBeVisible()
+        })
+
+        // --- Navigate Away Again ---
+        Object.defineProperty(window, 'location', {
+            value: { href: 'http://test.com/another-wrong-page', pathname: '/another-wrong-page', hash: '' },
+            writable: true,
+        })
+        await act(async () => {
+            fireEvent(window, new PopStateEvent('popstate'))
+        })
+        await waitFor(() => {
+            expect(screen.queryByText('Feedback')).not.toBeInTheDocument()
+        })
+    })
+
+    test('does not render tab for selector widget type initially', () => {
+        render(
+            <FeedbackWidget
+                survey={selectorWidgetSurvey}
+                posthog={mockPosthog}
+                removeSurveyFromFocus={removeSurveyFromFocusMock}
+            />
+        )
+
+        // Selector type should not render the tab or the form initially
+        expect(screen.queryByText('Feedback')).not.toBeInTheDocument()
+        // The survey form should also not be visible
+        expect(screen.queryByRole('form')).not.toBeInTheDocument()
+    })
+
+    test('shows survey popup for selector widget when event is dispatched', async () => {
+        render(
+            <FeedbackWidget
+                survey={selectorWidgetSurvey}
+                posthog={mockPosthog}
+                removeSurveyFromFocus={removeSurveyFromFocusMock}
+            />
+        )
+
+        // Initially, no survey form
+        expect(screen.queryByRole('form')).not.toBeInTheDocument()
+
+        // Simulate the event dispatched by SurveyManager
+        const event = new CustomEvent('ph:show_survey_widget', {
+            detail: { surveyId: selectorWidgetSurvey.id, position: {} },
+        })
+        fireEvent(window, event)
+
+        // Expect survey shown event after dispatching the event
+        expectSurveyShowEvent(selectorWidgetSurvey.id)
+
+        // Wait for the state update triggered by the event listener
+        await waitFor(() => {
+            // Survey popup should now be visible
+            expect(screen.getByRole('form')).toBeVisible()
+            expect(screen.getByText('What is your feedback?')).toBeVisible()
+        })
+
+        // Test submitting this one too
+        const textarea = screen.getByRole('textbox')
+        fireEvent.input(textarea, { target: { value: 'Selector feedback!' } })
+        const submitButton = screen.getByRole('button', { name: /submit/i })
+        fireEvent.click(submitButton)
+
+        await waitFor(() => {
+            expect(screen.getByText('Thanks!')).toBeVisible()
+        })
+
+        expectSurveySentEvent(selectorWidgetSurvey.id, { '$survey_response_q-open-1': 'Selector feedback!' })
+
+        // Should be removed from focus after submission (handled internally by SurveyPopup -> usePopupVisibility)
+        expect(removeSurveyFromFocusMock).toHaveBeenCalledWith(selectorWidgetSurvey.id)
+    })
+
+    test('closes survey popup when cancel button is clicked', async () => {
+        render(
+            <FeedbackWidget
+                survey={baseWidgetSurvey}
+                posthog={mockPosthog}
+                removeSurveyFromFocus={removeSurveyFromFocusMock}
+            />
+        )
+
+        // Open the survey
+        fireEvent.click(screen.getByText('Feedback'))
+        expect(screen.getByRole('form')).toBeVisible()
+
+        // Find and click the cancel button (X) within the survey popup
+        const cancelButton = screen.getByRole('button', { name: /close survey/i })
+        fireEvent.click(cancelButton)
+
+        // Wait for the popup to close (state update needs waitFor)
+        await waitFor(() => {
+            expect(screen.queryByRole('form')).not.toBeInTheDocument()
+        })
+
+        // Check if posthog.capture was called for 'survey dismissed'
+        // Note: The dismissal event might happen *inside* SurveyPopup, not directly in FeedbackWidget.
+        // The important part for *this* test is that the form disappears and removeSurveyFromFocus is called.
+        // We can check the dismissed event in SurveyPopup tests if needed.
+        // Let's verify removeSurveyFromFocus was called, as that's FeedbackWidget's responsibility via props.
+        // SurveyPopup calls onPopupSurveyDismissed -> which calls removeSurveyFromFocus here
+        expect(removeSurveyFromFocusMock).toHaveBeenCalledWith(baseWidgetSurvey.id)
+
+        // Optionally, check for the dismiss event if it's guaranteed to be captured by this mock instance
+        expect(mockPosthog.capture).toHaveBeenCalledWith(
+            'survey dismissed',
+            expect.objectContaining({
+                $survey_id: baseWidgetSurvey.id,
+            })
+        )
+    })
+})

--- a/src/extensions/surveys-widget.ts
+++ b/src/extensions/surveys-widget.ts
@@ -7,9 +7,17 @@ import { prepareStylesheet } from './utils/stylesheet-loader'
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const document = _document as Document
 
-export function createWidgetShadow(survey: Survey, posthog?: PostHog) {
+export function retrieveWidgetShadow(survey: Survey, posthog?: PostHog) {
+    const widgetClassName = `PostHogWidget${survey.id}`
+    const existingDiv = document.querySelector(`.${widgetClassName}`) as HTMLDivElement | null
+
+    if (existingDiv && existingDiv.shadowRoot) {
+        return existingDiv.shadowRoot
+    }
+
+    // If it doesn't exist, create it
     const div = document.createElement('div')
-    div.className = `PostHogWidget${survey.id}`
+    div.className = widgetClassName
     const shadow = div.attachShadow({ mode: 'open' })
     const widgetStyleSheet = createWidgetStyle(survey.appearance?.widgetColor)
 

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -18,7 +18,7 @@ import { useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { document as _document, window as _window } from '../utils/globals'
 import { doesSurveyUrlMatch, SURVEY_LOGGER as logger } from '../utils/survey-utils'
 import { isNull, isNumber } from '../utils/type-utils'
-import { createWidgetShadow, createWidgetStyle } from './surveys-widget'
+import { createWidgetStyle, retrieveWidgetShadow } from './surveys-widget'
 import { ConfirmationMessage } from './surveys/components/ConfirmationMessage'
 import { Cancel } from './surveys/components/QuestionHeader'
 import {
@@ -238,26 +238,23 @@ export class SurveyManager {
 
     private handleWidget = (survey: Survey): void => {
         // Ensure widget container exists if it doesn't
-        if (document.querySelectorAll(getPosthogWidgetClass(survey.id)).length === 0) {
-            const shadow = createWidgetShadow(survey, this.posthog)
+        const shadow = retrieveWidgetShadow(survey, this.posthog)
+        const stylesheetContent = style(survey.appearance)
+        const stylesheet = prepareStylesheet(document, stylesheetContent, this.posthog)
 
-            const stylesheetContent = style(survey.appearance)
-            const stylesheet = prepareStylesheet(document, stylesheetContent, this.posthog)
-
-            if (stylesheet) {
-                shadow.appendChild(stylesheet)
-            }
-
-            Preact.render(
-                <FeedbackWidget
-                    key={'feedback-survey-' + survey.id} // Use unique key
-                    posthog={this.posthog}
-                    survey={survey}
-                    removeSurveyFromFocus={this.removeSurveyFromFocus}
-                />,
-                shadow
-            )
+        if (stylesheet) {
+            shadow.appendChild(stylesheet)
         }
+
+        Preact.render(
+            <FeedbackWidget
+                key={'feedback-survey-' + survey.id} // Use unique key
+                posthog={this.posthog}
+                survey={survey}
+                removeSurveyFromFocus={this.removeSurveyFromFocus}
+            />,
+            shadow
+        )
     }
 
     private removeWidgetSelectorListener = (surveyId: string): void => {
@@ -626,7 +623,7 @@ export function generateSurveys(posthog: PostHog) {
 }
 
 type UseHideSurveyOnURLChangeProps = {
-    survey: Pick<Survey, 'id' | 'conditions'>
+    survey: Pick<Survey, 'id' | 'conditions' | 'type' | 'appearance'>
     removeSurveyFromFocus: (id: string) => void
     setSurveyVisible: (visible: boolean) => void
     isPreviewMode?: boolean
@@ -654,11 +651,22 @@ export function useHideSurveyOnURLChange({
         }
 
         const checkUrlMatch = () => {
-            const urlCheck = doesSurveyUrlMatch(survey)
-            if (!urlCheck) {
-                setSurveyVisible(false)
-                return removeSurveyFromFocus(survey.id)
+            logger.info(`Checking URL match for survey ${survey.id}`)
+            const isSurveyTypeWidget = survey.type === SurveyType.Widget
+            const doesSurveyMatchUrlCondition = doesSurveyUrlMatch(survey)
+            const isSurveyWidgetTypeTab = survey.appearance?.widgetType === SurveyWidgetType.Tab && isSurveyTypeWidget
+
+            if (doesSurveyMatchUrlCondition) {
+                if (isSurveyWidgetTypeTab) {
+                    logger.info(`Showing survey ${survey.id} because it is a feedback button tab and URL matches`)
+                    setSurveyVisible(true)
+                }
+                return
             }
+
+            logger.info(`Hiding survey ${survey.id} because URL does not match`)
+            setSurveyVisible(false)
+            return removeSurveyFromFocus(survey.id)
         }
 
         // Listen for browser back/forward browser history changes
@@ -930,6 +938,7 @@ export function Questions({
     return (
         <form
             className="survey-form"
+            name="surveyForm"
             style={
                 isPopup
                     ? {

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -651,7 +651,6 @@ export function useHideSurveyOnURLChange({
         }
 
         const checkUrlMatch = () => {
-            logger.info(`Checking URL match for survey ${survey.id}`)
             const isSurveyTypeWidget = survey.type === SurveyType.Widget
             const doesSurveyMatchUrlCondition = doesSurveyUrlMatch(survey)
             const isSurveyWidgetTypeTab = survey.appearance?.widgetType === SurveyWidgetType.Tab && isSurveyTypeWidget

--- a/src/extensions/surveys/components/QuestionHeader.tsx
+++ b/src/extensions/surveys/components/QuestionHeader.tsx
@@ -41,6 +41,7 @@ export function Cancel({ onClick }: { onClick: () => void }) {
                 onClick={onClick}
                 disabled={isPreviewMode}
                 aria-label="Close survey"
+                type="button"
                 role="button"
             >
                 {cancelSVG}


### PR DESCRIPTION
## Changes

after the changes on https://github.com/PostHog/posthog-js/pull/1877, we moved the logic to render the FeedbackWidget directly into the SurveyManager.

however, that means that we were no longer showing the feedback survey again for when the style is the embedded tab.

so, this PR addresses it, and also adds through tests for the `FeedbackWidget` to ensure it's working as expected and covers this use case.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
