### PR TITLE
feat: Improve how PostHogProvider works with SSR

### DIFF
--- a/react/src/context/PostHogProvider.tsx
+++ b/react/src/context/PostHogProvider.tsx
@@ -48,7 +48,6 @@ export function PostHogProvider({ children, client, apiKey, options }: WithOptio
     const alreadyInitializedRef = useRef<AlreadyInitialized>(false)
 
     const posthog = useMemo(() => {
-        console.log('useMemo', { client, apiKey, options, alreadyInitializedRef })
         if (client) {
             if (apiKey) {
                 console.warn(

--- a/react/src/context/PostHogProvider.tsx
+++ b/react/src/context/PostHogProvider.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import posthogJs, { PostHogConfig } from 'posthog-js'
 
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef } from 'react'
 import { PostHog, PostHogContext } from './PostHogContext'
 import { isDeepEqual } from '../utils/object-utils'
 
@@ -45,60 +45,45 @@ export function PostHogProvider({ children, client, apiKey, options }: WithOptio
     // This is used to prevent double initialization when running under React.StrictMode
     // We're not storing a simple boolean here because we want to be able to detect if the
     // apiKey or options have changed.
-    const [alreadyInitialized, setAlreadyInitialized] = useState<AlreadyInitialized>(false)
+    const alreadyInitializedRef = useRef<AlreadyInitialized>(false)
 
     const posthog = useMemo(() => {
+        console.log('useMemo', { client, apiKey, options, alreadyInitializedRef })
         if (client) {
             if (apiKey) {
                 console.warn(
                     '[PostHog.js] You have provided both `client` and `apiKey` to `PostHogProvider`. `apiKey` will be ignored in favour of `client`.'
                 )
             }
-
             if (options) {
                 console.warn(
                     '[PostHog.js] You have provided both `client` and `options` to `PostHogProvider`. `options` will be ignored in favour of `client`.'
                 )
             }
-
             return client
         }
 
         if (apiKey) {
-            // If the client was already initialized, we'll attempt to return the existing instance
-            // This is likely to occur when someone is developing locally under `React.StrictMode`
-            //
-            // There's no built-in way to detect React.StrictMode, so we set a flag to check if the client was already initialized
-            // and return the existing instance if it was.
-            //
-            // This might also be triggered if someone attempts to change their `apiKey` or
-            // set a different set of `options`. This is handled separately below.
-            if (alreadyInitialized !== false) {
-                // Changing the apiKey isn't well supported and we'll simply log a message suggesting them
-                // to take control of the `client` initialization themselves. This is tricky to handle
-                // ourselves because we wouldn't know if we should call `.reset()` or not, for example.
-                if (apiKey !== alreadyInitialized.previousAPIKey) {
-                    console.warn(
-                        "[PostHog.js] You have provided a different `apiKey` to `PostHogProvider` than the one that was already initialized. This is not supported by our provider and we'll keep using the previous key. If you need to toggle between API Keys you need to control the `client` yourself and pass it in as a prop rather than an `apiKey` prop."
-                    )
-                }
+            // return the global client, we'll initialize it in the useEffect
+            return posthogJs
+        }
 
-                // Changing options is better supported because we can just call `posthogJs.set_config(options)`
-                // and they'll be good to go with their new config. The SDK will know how to handle the changes.
-                if (options && !isDeepEqual(options, alreadyInitialized.previousOptions)) {
-                    posthogJs.set_config(options)
-                }
+        console.warn(
+            '[PostHog.js] No `apiKey` or `client` were provided to `PostHogProvider`. Using default global `window.posthog` instance. You must initialize it manually. This is not recommended behavior.'
+        )
+        return posthogJs
+    }, [client, apiKey, JSON.stringify(options)]) // Stringify options to be a stable reference
 
-                // Keep track of the possibly-new set of apiKey and options
-                setAlreadyInitialized({
-                    previousAPIKey: apiKey,
-                    previousOptions: options ?? {},
-                })
+    // TRICKY: The init needs to happen in a useEffect rather than useMemo, as useEffect does not happen during SSR. Otherwise
+    // we'd end up trying to call posthogJs.init() on the server, which can cause issues around hydration and double-init.
+    useEffect(() => {
+        if (client) {
+            // if the user has passed their own client, assume they will also handle calling init().
+            return
+        }
+        const alreadyInitialized = alreadyInitializedRef.current
 
-                // Return the same already-initialized global client
-                return posthogJs
-            }
-
+        if (!alreadyInitialized) {
             // If it's the first time running this, but it has been loaded elsewhere, warn the user about it.
             if (posthogJs.__loaded) {
                 console.warn('[PostHog.js] `posthog` was already loaded elsewhere. This may cause issues.')
@@ -108,20 +93,38 @@ export function PostHogProvider({ children, client, apiKey, options }: WithOptio
             posthogJs.init(apiKey, options)
 
             // Keep track of whether the client was already initialized
-            // This is used to prevent double initialization when running under React.StrictMode
-            setAlreadyInitialized({
+            // This is used to prevent double initialization when running under React.StrictMode, and to know when options change
+            alreadyInitializedRef.current = {
                 previousAPIKey: apiKey,
                 previousOptions: options ?? {},
-            })
+            }
+        } else {
+            // If the client was already initialized, we might still end up running the effect again for a few reasons:
+            // * someone is developing locally under `React.StrictMode`
+            // * the config has changed
+            // * the apiKey has changed (not supported!)
+            //
+            // Changing the apiKey isn't well supported and we'll simply log a message suggesting them
+            // to take control of the `client` initialization themselves. This is tricky to handle
+            // ourselves because we wouldn't know if we should call `.reset()` or not, for example.
+            if (apiKey !== alreadyInitialized.previousAPIKey) {
+                console.warn(
+                    "[PostHog.js] You have provided a different `apiKey` to `PostHogProvider` than the one that was already initialized. This is not supported by our provider and we'll keep using the previous key. If you need to toggle between API Keys you need to control the `client` yourself and pass it in as a prop rather than an `apiKey` prop."
+                )
+            }
 
-            // Return global client
-            return posthogJs
+            // Changing options is better supported because we can just call `posthogJs.set_config(options)`
+            // and they'll be good to go with their new config. The SDK will know how to handle the changes.
+            if (options && !isDeepEqual(options, alreadyInitialized.previousOptions)) {
+                posthogJs.set_config(options)
+            }
+
+            // Keep track of the possibly-new set of apiKey and options
+            alreadyInitializedRef.current = {
+                previousAPIKey: apiKey,
+                previousOptions: options ?? {},
+            }
         }
-
-        console.warn(
-            '[PostHog.js] No `apiKey` or `client` were provided to `PostHogProvider`. Using default global `window.posthog` instance. You must initialize it manually. This is not recommended behavior.'
-        )
-        return posthogJs
     }, [client, apiKey, JSON.stringify(options)]) // Stringify options to be a stable reference
 
     return <PostHogContext.Provider value={{ client: posthog }}>{children}</PostHogContext.Provider>


### PR DESCRIPTION
## Changes

Change the useState -> useMemo, and move the actual init call to a useEffect.

This should remove the need to do this in nextjs:

```tsx
export function PHProvider({ children }) {
  useEffect(() => {
    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
      person_profiles: 'identified_only',
      capture_pageview: false,
      capture_pageleave: true // Enable pageleave capture
    })
  }, []);

  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
}
```
and instead, people can just do 
```tsx
export function PHProvider({ children }) {
  return <PostHogProvider
    apiKey={process.env.NEXT_PUBLIC_POSTHOG_KEY}
    options={{
      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
      person_profiles: 'identified_only',
      capture_pageview: false,
      capture_pageleave: true // Enable pageleave capture
    }}>{children}</PostHogProvider>
}
```


## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
