### PR TITLE
WIP: Update nextjs playground to show how in-app to browser conversions might work

### DIFF
--- a/playground/nextjs/pages/mobile-app-attribution.tsx
+++ b/playground/nextjs/pages/mobile-app-attribution.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react'
+import { posthog } from '@/src/posthog'
+
+const MobileAppAttribution = () => {
+    useEffect(() => {
+        if (
+            navigator.userAgent.toLowerCase().includes('linkedin') ||
+            navigator.userAgent.toLowerCase().includes('facebook')
+        ) {
+            const params = new URLSearchParams(window.location.search)
+            params.set('__ph_distinct_id', posthog.get_distinct_id())
+            params.set('__ph_is_identified', posthog._isIdentified() ? 'true' : 'false')
+            params.set('__ph_session_id', posthog.get_session_id())
+            window.location.search = params.toString()
+        }
+    })
+    return (
+        <div className="max-w-sm mx-auto space-y-4">
+            Try posting a link to this page to LinkedIn or Facebook etc, then open with the in-app browser. Then try
+            pressing the "open in safari" button. If you check the activity tab, these should appear to be the same
+            person.
+        </div>
+    )
+}
+
+export default MobileAppAttribution

--- a/playground/nextjs/src/posthog.ts
+++ b/playground/nextjs/src/posthog.ts
@@ -6,6 +6,7 @@
 
 import posthogJS, { PostHog, PostHogConfig } from 'posthog-js'
 import { User } from './auth'
+import { BootstrapConfig } from '../../../src/types'
 
 export const PERSON_PROCESSING_MODE: 'always' | 'identified_only' | 'never' =
     (process.env.NEXT_PUBLIC_POSTHOG_PERSON_PROCESSING_MODE as any) || 'identified_only'
@@ -51,8 +52,23 @@ export const updatePostHogConsent = (consentGiven: boolean) => {
 }
 
 if (typeof window !== 'undefined') {
+    const searchParams = new URLSearchParams(window.location.search)
+    const bootstrapDistinctId = searchParams.get('__ph_distinct_id')
+    const bootstrapIsIdentified = searchParams.get('__ph_is_identified')
+    const bootstrapSessionId = searchParams.get('__ph_session_id')
+
+    let bootstrap: BootstrapConfig | undefined
+    if (bootstrapDistinctId && bootstrapIsIdentified && bootstrapSessionId) {
+        bootstrap = {
+            distinctID: bootstrapDistinctId,
+            isIdentifiedID: bootstrapIsIdentified === 'true',
+            sessionID: bootstrapSessionId,
+        }
+    }
+
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || '', {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+        bootstrap,
         session_recording: {
             recordCrossOriginIframes: true,
             blockSelector: '.ph-block-image',


### PR DESCRIPTION
## Changes
Update nextjs playground to show how in-app to browser conversions might work.

Essentially we just make sure that we keep the distinct id and session id in the URL, so that if it's opened in another browser, we bring that state with us

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
