### PR TITLE
chore: Generate bundle size viz

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,5 @@
 - [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
 - [ ] Accounted for the impact of any changes across different browsers
 - [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
+- [ ] Took care not to unnecessarily increase the bundle size
+

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -41,14 +41,14 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: Download bundle size visualisation
+          body-includes: Download bundle size visualization
       - name: Create or update artifact link comment
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            [Download bundle size visualisation](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.viz-upload.outputs.artifact-id }})
+            [Download bundle size visualization](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.viz-upload.outputs.artifact-id }})
           edit-mode: replace
 
       - uses: preactjs/compressed-size-action@v2

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -26,6 +26,31 @@ jobs:
       - name: Install package.json dependencies with pnpm
         run: pnpm install --frozen-lockfile
 
+      - name: Build library
+        run: pnpm build
+
+      - name: Upload bundle size visualization
+        uses: actions/upload-artifact@v4
+        id: viz-upload
+        with:
+          name: array.js.stats.html
+          path: stats/array.js.stats.html
+      - name: Find artifact link comment if it exists
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Download bundle size visualisation
+      - name: Create or update artifact link comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            [Download bundle size visualisation](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.viz-upload.outputs.artifact-id }})
+          edit-mode: replace
+
       - uses: preactjs/compressed-size-action@v2
         with:
           build-script: "build-rollup"

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -33,8 +33,8 @@ jobs:
         uses: actions/upload-artifact@v4
         id: viz-upload
         with:
-          name: array.js.stats.html
-          path: stats/array.js.stats.html
+          name: bundle-stats-array.html
+          path: bundle-stats-array.html
       - name: Find artifact link comment if it exists
         uses: peter-evans/find-comment@v3
         id: fc

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -27,7 +27,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build library
-        run: pnpm build
+        run: pnpm build-rollup
 
       - name: Upload bundle size visualization
         uses: actions/upload-artifact@v4

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -36,6 +36,7 @@ jobs:
 
             - name: Upload bundle size visualization
               uses: actions/upload-artifact@v4
+              id: viz-upload
               with:
                 name: array.js.stats.html
                 path: stats/array.js.stats.html
@@ -45,7 +46,7 @@ jobs:
               with:
                 issue-number: ${{ github.event.pull_request.number }}
                 body: |
-                  [See bundle size visualization](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
+                    [View bundle size viz](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.viz-upload.outputs.artifact-id }})
 
             - name: Install Playwright Browsers
               run: pnpm exec playwright install --with-deps

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -30,8 +30,23 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                 node-version: '18'
+
             - run: pnpm install
             - run: pnpm build
+
+            - name: Upload bundle size visualization
+              uses: actions/upload-artifact@v4
+              with:
+                name: array.js.stats.html
+                path: stats/array.js.stats.html
+
+            - name: Comment with artifact link
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                issue-number: ${{ github.event.pull_request.number }}
+                body: |
+                  [See bundle size visualization](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
+
             - name: Install Playwright Browsers
               run: pnpm exec playwright install --with-deps
             - name: Run Playwright tests

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -22,28 +22,6 @@ jobs:
 
             - run: pnpm test:unit
 
-            - name: Upload bundle size visualization
-              uses: actions/upload-artifact@v4
-              id: viz-upload
-              with:
-                name: array.js.stats.html
-                path: stats/array.js.stats.html
-            - name: Find artifact link comment if it exists
-              uses: peter-evans/find-comment@v3
-              id: fc
-              with:
-                issue-number: ${{ github.event.pull_request.number }}
-                comment-author: 'github-actions[bot]'
-                body-includes: Download bundle size visualisation
-            - name: Create or update artifact link comment
-              uses: peter-evans/create-or-update-comment@v4
-              with:
-                comment-id: ${{ steps.fc.outputs.comment-id }}
-                issue-number: ${{ github.event.pull_request.number }}
-                body: |
-                  [Download bundle size visualisation](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.viz-upload.outputs.artifact-id }})
-                edit-mode: replace
-
     integration:
         name: Playwright E2E tests
         runs-on: ubuntu-22.04

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -46,7 +46,8 @@ jobs:
               with:
                 issue-number: ${{ github.event.pull_request.number }}
                 body: |
-                    [View bundle size viz](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.viz-upload.outputs.artifact-id }})
+                    [Downlod bundle size visualisation](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.viz-upload.outputs.artifact-id }})
+                edit-mode: replace
 
             - name: Install Playwright Browsers
               run: pnpm exec playwright install --with-deps

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -19,7 +19,6 @@ jobs:
                 cache: 'pnpm'
             - run: pnpm install
             - run: pnpm build
-
             - run: pnpm test:unit
 
     integration:
@@ -31,10 +30,8 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                 node-version: '18'
-
             - run: pnpm install
             - run: pnpm build
-
             - name: Install Playwright Browsers
               run: pnpm exec playwright install --with-deps
             - name: Run Playwright tests

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -41,12 +41,21 @@ jobs:
                 name: array.js.stats.html
                 path: stats/array.js.stats.html
 
+            - name: Find Comment
+              uses: peter-evans/find-comment@v3
+              id: fc
+              with:
+                issue-number: ${{ github.event.pull_request.number }}
+                comment-author: 'github-actions[bot]'
+                body-includes: Download bundle size visualisation
+
             - name: Comment with artifact link
               uses: peter-evans/create-or-update-comment@v4
               with:
+                comment-id: ${{ steps.fc.outputs.comment-id }}
                 issue-number: ${{ github.event.pull_request.number }}
                 body: |
-                    [Downlod bundle size visualisation](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.viz-upload.outputs.artifact-id }})
+                    [Download bundle size visualisation](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.viz-upload.outputs.artifact-id }})
                 edit-mode: replace
 
             - name: Install Playwright Browsers

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -19,7 +19,30 @@ jobs:
                 cache: 'pnpm'
             - run: pnpm install
             - run: pnpm build
+
             - run: pnpm test:unit
+
+            - name: Upload bundle size visualization
+              uses: actions/upload-artifact@v4
+              id: viz-upload
+              with:
+                name: array.js.stats.html
+                path: stats/array.js.stats.html
+            - name: Find artifact link comment if it exists
+              uses: peter-evans/find-comment@v3
+              id: fc
+              with:
+                issue-number: ${{ github.event.pull_request.number }}
+                comment-author: 'github-actions[bot]'
+                body-includes: Download bundle size visualisation
+            - name: Create or update artifact link comment
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                comment-id: ${{ steps.fc.outputs.comment-id }}
+                issue-number: ${{ github.event.pull_request.number }}
+                body: |
+                  [Download bundle size visualisation](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.viz-upload.outputs.artifact-id }})
+                edit-mode: replace
 
     integration:
         name: Playwright E2E tests
@@ -33,30 +56,6 @@ jobs:
 
             - run: pnpm install
             - run: pnpm build
-
-            - name: Upload bundle size visualization
-              uses: actions/upload-artifact@v4
-              id: viz-upload
-              with:
-                name: array.js.stats.html
-                path: stats/array.js.stats.html
-
-            - name: Find Comment
-              uses: peter-evans/find-comment@v3
-              id: fc
-              with:
-                issue-number: ${{ github.event.pull_request.number }}
-                comment-author: 'github-actions[bot]'
-                body-includes: Download bundle size visualisation
-
-            - name: Comment with artifact link
-              uses: peter-evans/create-or-update-comment@v4
-              with:
-                comment-id: ${{ steps.fc.outputs.comment-id }}
-                issue-number: ${{ github.event.pull_request.number }}
-                body: |
-                    [Download bundle size visualisation](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.viz-upload.outputs.artifact-id }})
-                edit-mode: replace
 
             - name: Install Playwright Browsers
               run: pnpm exec playwright install --with-deps

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ cypress/downloads/downloads.html
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/stats

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,6 +55,13 @@ const plugins = (es5) => [
             ecma: es5 ? 5 : 6,
         },
     }),
+    visualizer((outputOptions) => {
+        const fileName = path.join('./stats/', path.basename(outputOptions.file) + '.stats.html')
+        return {
+            filename: fileName,
+            gzipSize: true,
+        }
+    }), // should always be last
 ]
 
 const entrypoints = fs.readdirSync('./src/entrypoints')

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,13 +55,6 @@ const plugins = (es5) => [
             ecma: es5 ? 5 : 6,
         },
     }),
-    visualizer((outputOptions) => {
-        const fileName = path.join('./stats/', path.basename(outputOptions.file) + '.stats.html')
-        return {
-            filename: fileName,
-            gzipSize: true,
-        }
-    }), // should always be last
 ]
 
 const entrypoints = fs.readdirSync('./src/entrypoints')
@@ -106,7 +99,7 @@ const entrypointTargets = entrypoints.map((file) => {
                 ...(format === 'cjs' ? { exports: 'auto' } : {}),
             },
         ],
-        plugins: [...pluginsForThisFile, visualizer({ filename: `bundle-stats-${fileName}.html` })],
+        plugins: [...pluginsForThisFile, visualizer({ filename: `bundle-stats-${fileName}.html`, gzipSize: true })],
     }
 })
 


### PR DESCRIPTION
## Changes

Add a new automatic comment which contains a link to the bundle size visualizer. Try it below!

I also added a line about bundle size to the checklist

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
