### PR TITLE
fix: Fix response based branching for open choice questions

### DIFF
--- a/src/__tests__/surveys.test.ts
+++ b/src/__tests__/surveys.test.ts
@@ -993,6 +993,32 @@ describe('surveys', () => {
             expect(getNextSurveyStep(survey, 0, 'Maybe')).toEqual(3)
         })
 
+        it('should branch out correctly based on a single choice response, with an open ended choice', () => {
+            survey.questions = [
+                {
+                    type: SurveyQuestionType.SingleChoice,
+                    question: 'Will you leave us a review?',
+                    choices: ['Yes', 'No', 'Maybe', 'Sometimes', 'Other'],
+                    branching: {
+                        type: SurveyQuestionBranchingType.ResponseBased,
+                        responseValues: {
+                            '0': 'end',
+                            '1': 1,
+                            '4': 'end',
+                        },
+                    },
+                    hasOpenChoice: true,
+                },
+                { type: SurveyQuestionType.Open, question: 'Why yes?' },
+                { type: SurveyQuestionType.Open, question: 'Why no?' },
+                { type: SurveyQuestionType.Open, question: 'Why maybe?' },
+            ] as unknown[] as SurveyQuestion[]
+            expect(getNextSurveyStep(survey, 0, 'Yes')).toEqual('end')
+            expect(getNextSurveyStep(survey, 0, 'No')).toEqual(1)
+            expect(getNextSurveyStep(survey, 0, 'Maybe')).toEqual(1)
+            expect(getNextSurveyStep(survey, 0, 'this is another answer')).toEqual('end')
+        })
+
         // Response-based branching, scale 1-3
         it('should branch out the negative/neutral/positive respondends correctly (scale 1-3)', () => {
             survey.questions = [

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -110,7 +110,13 @@ export function getNextSurveyStep(
         if (question.type === SurveyQuestionType.SingleChoice) {
             // :KLUDGE: for now, look up the choiceIndex based on the response
             // TODO: once QuestionTypes.MultipleChoiceQuestion is refactored, pass the selected choiceIndex into this method
-            const selectedChoiceIndex = question.choices.indexOf(`${response}`)
+            let selectedChoiceIndex = question.choices.indexOf(`${response}`)
+
+            if (selectedChoiceIndex === -1 && question.hasOpenChoice) {
+                // if the response is not found in the choices, it must be the open choice,
+                // which is always the last choice
+                selectedChoiceIndex = question.choices.length - 1
+            }
 
             if (question.branching?.responseValues?.hasOwnProperty(selectedChoiceIndex)) {
                 const nextStep = question.branching.responseValues[selectedChoiceIndex]


### PR DESCRIPTION
## Changes

Raised in [#29150](https://posthoghelp.zendesk.com/agent/tickets/29150) - there's a bug when using response based branching for open questions.

_Note: I haven't had chance to check whether this is or could be an issue in other SDKs - opinions on this welcomed!_

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [ ] Took care not to unnecessarily increase the bundle size

