### PR TITLE
fix: timezone offset property not being sent

### DIFF
--- a/src/__tests__/utils/event-utils.test.ts
+++ b/src/__tests__/utils/event-utils.test.ts
@@ -51,8 +51,8 @@ describe(`event-utils`, () => {
 
         it('should have timezone and timezone offset', () => {
             const properties = getEventProperties()
-            expect(properties['$timezone']).toBeTruthy()
-            expect(properties['$timezone_offset']).toBeTruthy()
+            expect(properties).toHaveProperty('$timezone')
+            expect(properties).toHaveProperty('$timezone_offset')
         })
     })
 

--- a/src/__tests__/utils/event-utils.test.ts
+++ b/src/__tests__/utils/event-utils.test.ts
@@ -48,6 +48,12 @@ describe(`event-utils`, () => {
             const properties = getEventProperties(true, ['other'])
             expect(properties['$current_url']).toEqual('https://www.example.com/path?gclid=<masked>&other=<masked>')
         })
+
+        it('should have timezone and timezone offset', () => {
+            const properties = getEventProperties()
+            expect(properties['$timezone']).toBeTruthy()
+            expect(properties['$timezone_offset']).toBeTruthy()
+        })
     })
 
     describe('timezones', () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 import { Breaker, Properties } from '../types'
 import { nativeForEach, nativeIndexOf } from './globals'
 import { logger } from './logger'
-import { hasOwnProperty, isArray, isFormData, isNull, isNullish, isString } from './type-utils'
+import { hasOwnProperty, isArray, isFormData, isNull, isNullish, isNumber, isString } from './type-utils'
 
 const breaker: Breaker = {}
 
@@ -140,7 +140,7 @@ export const safewrapClass = function (klass: Function, functions: string[]): vo
 export const stripEmptyProperties = function (p: Properties): Properties {
     const ret: Properties = {}
     each(p, function (v, k) {
-        if (isString(v) && v.length > 0) {
+        if ((isString(v) && v.length > 0) || isNumber(v)) {
             ret[k] = v
         }
     })


### PR DESCRIPTION
## Changes

Turns out we were filtering out non-string properties. Let's not do that 😬 

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

