### PR TITLE
fix(err): add support for error causes

### DIFF
--- a/src/__tests__/extensions/exception-autocapture/error-conversion.test.ts
+++ b/src/__tests__/extensions/exception-autocapture/error-conversion.test.ts
@@ -199,7 +199,7 @@ describe('Error conversion', () => {
         expect(errorProperties.$exception_list[0].mechanism.handled).toEqual(false)
     })
 
-    it('should uses cause when it is an error', () => {
+    it('should use cause when it is an error', () => {
         class CustomError extends Error {
             constructor(message: string) {
                 super(message)

--- a/src/__tests__/extensions/exception-autocapture/error-conversion.test.ts
+++ b/src/__tests__/extensions/exception-autocapture/error-conversion.test.ts
@@ -198,4 +198,50 @@ describe('Error conversion', () => {
         expect(errorProperties.$exception_list[0].mechanism.synthetic).toEqual(false)
         expect(errorProperties.$exception_list[0].mechanism.handled).toEqual(false)
     })
+
+    it('should uses cause when it is an error', () => {
+        class CustomError extends Error {
+            constructor(message: string) {
+                super(message)
+                this.name = 'CustomError'
+            }
+        }
+        const originalError = new CustomError('my original error')
+        const error = new Error('my error', { cause: originalError })
+        const errorProperties: ErrorProperties = errorToProperties({ error, event: undefined })
+        expect(Object.keys(errorProperties)).toHaveLength(2)
+        expect(errorProperties.$exception_list[0].type).toEqual('Error')
+        expect(errorProperties.$exception_list[0].value).toEqual('my error')
+        expect(errorProperties.$exception_level).toEqual('error')
+        expect(errorProperties.$exception_list[0].mechanism.synthetic).toEqual(false)
+        expect(errorProperties.$exception_list[0].mechanism.handled).toEqual(true)
+        expect(errorProperties.$exception_list[1].type).toEqual('CustomError')
+        expect(errorProperties.$exception_list[1].value).toEqual('my original error')
+    })
+
+    it('should not use cause prop when it is a string', () => {
+        const originalError = 'original test'
+        const error = new Error('my error', { cause: originalError })
+        const errorProperties: ErrorProperties = errorToProperties({ error, event: undefined })
+        expect(Object.keys(errorProperties)).toHaveLength(2)
+        expect(errorProperties.$exception_list.length).toEqual(1)
+        expect(errorProperties.$exception_list[0].type).toEqual('Error')
+        expect(errorProperties.$exception_list[0].value).toEqual('my error')
+        expect(errorProperties.$exception_level).toEqual('error')
+        expect(errorProperties.$exception_list[0].mechanism.synthetic).toEqual(false)
+        expect(errorProperties.$exception_list[0].mechanism.handled).toEqual(true)
+    })
+
+    it('should forward synthetic and handled props when using cause', () => {
+        const originalError = new Error('my original error')
+        const error = new Error('my error', { cause: originalError })
+        const metadata = { handled: false, synthetic: false }
+        const errorProperties: ErrorProperties = errorToProperties({ error, event: undefined }, metadata)
+        expect(Object.keys(errorProperties)).toHaveLength(2)
+        expect(errorProperties.$exception_list.length).toEqual(2)
+        expect(errorProperties.$exception_list[0].mechanism.synthetic).toEqual(false)
+        expect(errorProperties.$exception_list[0].mechanism.handled).toEqual(false)
+        expect(errorProperties.$exception_list[1].mechanism.synthetic).toEqual(false)
+        expect(errorProperties.$exception_list[1].mechanism.handled).toEqual(false)
+    })
 })

--- a/src/extensions/exception-autocapture/error-conversion.ts
+++ b/src/extensions/exception-autocapture/error-conversion.ts
@@ -145,7 +145,7 @@ function exceptionFromError(error: Error, metadata?: ErrorMetadata): Exception {
 
 function exceptionListFromError(error: Error, metadata?: ErrorMetadata): ErrorProperties['$exception_list'] {
     const exception = exceptionFromError(error, metadata)
-    if (error.cause && isError(error.cause)) {
+    if (error.cause && isError(error.cause) && error.cause !== error) {
         // Cause could be an object or a string
         // For now we only support error causes
         // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause

--- a/src/extensions/exception-autocapture/error-conversion.ts
+++ b/src/extensions/exception-autocapture/error-conversion.ts
@@ -121,7 +121,7 @@ function getSkipFirstStackStringLines(ex: Error): number {
     return 0
 }
 
-function errorPropertiesFromError(error: Error, metadata?: ErrorMetadata): ErrorProperties {
+function exceptionFromError(error: Error, metadata?: ErrorMetadata): Exception {
     const frames = parseStackFrames(error)
 
     const handled = metadata?.handled ?? true
@@ -129,22 +129,40 @@ function errorPropertiesFromError(error: Error, metadata?: ErrorMetadata): Error
 
     const exceptionType = metadata?.overrideExceptionType ? metadata.overrideExceptionType : error.name
     const exceptionMessage = extractMessage(error)
-
     return {
-        $exception_list: [
-            {
-                type: exceptionType,
-                value: exceptionMessage,
-                stacktrace: {
-                    frames,
-                    type: 'raw',
-                },
-                mechanism: {
-                    handled,
-                    synthetic,
-                },
-            },
-        ],
+        type: exceptionType,
+        value: exceptionMessage,
+        stacktrace: {
+            frames,
+            type: 'raw',
+        },
+        mechanism: {
+            handled,
+            synthetic,
+        },
+    }
+}
+
+function exceptionListFromError(error: Error, metadata?: ErrorMetadata): ErrorProperties['$exception_list'] {
+    const exception = exceptionFromError(error, metadata)
+    if (error.cause && isError(error.cause)) {
+        // Cause could be an object or a string
+        // For now we only support error causes
+        // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+        return [
+            exception,
+            ...exceptionListFromError(error.cause, {
+                handled: metadata?.handled,
+                synthetic: metadata?.synthetic,
+            }),
+        ]
+    }
+    return [exception]
+}
+
+function errorPropertiesFromError(error: Error, metadata?: ErrorMetadata): ErrorProperties {
+    return {
+        $exception_list: exceptionListFromError(error, metadata),
         $exception_level: 'error',
     }
 }


### PR DESCRIPTION
## Changes

- Add support for error causes

Related to : https://posthog.com/questions/error-cause-is-lost-when-using-custom-error-types

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

