### PR TITLE
feat: Avoid tracking pageview from prerenders

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "@types/node": "^22.5.0",
         "@types/react-dom": "^18.0.10",
         "@types/sinon": "^17.0.1",
-        "@types/web": "^0.0.154",
+        "@types/web": "^0.0.222",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
         "@typescript-eslint/parser": "^8.29.1",
         "babel-jest": "^26.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2203,8 +2203,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001680:
-    resolution: {integrity: sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==}
+  caniuse-lite@1.0.30001715:
+    resolution: {integrity: sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==}
 
   capture-exit@2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
@@ -8055,7 +8055,7 @@ snapshots:
 
   browserslist@4.24.2:
     dependencies:
-      caniuse-lite: 1.0.30001680
+      caniuse-lite: 1.0.30001715
       electron-to-chromium: 1.5.62
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
@@ -8121,7 +8121,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001680: {}
+  caniuse-lite@1.0.30001715: {}
 
   capture-exit@2.0.0:
     dependencies:
@@ -8606,7 +8606,7 @@ snapshots:
       '@mdn/browser-compat-data': 5.6.16
       ast-metadata-inferer: 0.8.0
       browserslist: 4.24.2
-      caniuse-lite: 1.0.30001680
+      caniuse-lite: 1.0.30001715
       eslint: 8.57.0
       find-up: 5.0.0
       globals: 15.12.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,8 +123,8 @@ importers:
         specifier: ^17.0.1
         version: 17.0.1
       '@types/web':
-        specifier: ^0.0.154
-        version: 0.0.154
+        specifier: ^0.0.222
+        version: 0.0.222
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.29.1
         version: 8.29.1(@typescript-eslint/parser@8.29.1(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
@@ -1708,8 +1708,8 @@ packages:
   '@types/stack-utils@2.0.1':
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
 
-  '@types/web@0.0.154':
-    resolution: {integrity: sha512-Tc10Nkpbb8AgM3iGnrvpKVb6x8pzrZpMCPqMJe8htXoEdNDKojEevNAkCjxkjCLZF2p1ZB+gknAwdbkypxwxKg==}
+  '@types/web@0.0.222':
+    resolution: {integrity: sha512-vBvVv2L5ArWQenebQiUCtZNpL4mguLCbrZ8aqzVCundYRvwZZzlqBP7EEpoUszLnztmzWmBxQ4+4nHAMFlfYlA==}
 
   '@types/yargs-parser@15.0.0':
     resolution: {integrity: sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==}
@@ -7519,7 +7519,7 @@ snapshots:
 
   '@types/stack-utils@2.0.1': {}
 
-  '@types/web@0.0.154': {}
+  '@types/web@0.0.222': {}
 
   '@types/yargs-parser@15.0.0': {}
 

--- a/terser-mangled-names.json
+++ b/terser-mangled-names.json
@@ -298,6 +298,7 @@
         "_urlBlocklist",
         "_urlTriggerStatus",
         "_urlTriggers",
+        "_visibilityStateListener",
         "_widgetSelectorListeners",
         "_windowId",
         "_windowIdGenerator",


### PR DESCRIPTION
Chrome and some frameworks such as Wordpress prerender a page because they want the loading time to be fast. We were, however, including that render (which runs Javascript) as a pageview even though that page might never actually be shown to the user.

We're now being slightly more cautious about it and not triggering the pageview when we can safely detect the page isnt visible. We then attach a listener and only ever trigger the `pageview` in case the page is actually displayed

Inspired by the behavior in https://github.com/plausible/analytics/blob/beb3ae087b7e7310a13cb012d109ab38d31301d5/tracker/src/plausible.js