### PR TITLE
fix: prevent multiple stylesheet creation for feedback survey

### DIFF
--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -246,10 +246,16 @@ export class SurveyManager {
         // Ensure widget container exists if it doesn't
         const shadow = retrieveWidgetShadow(survey, this._posthog)
         const stylesheetContent = style(survey.appearance)
-        const stylesheet = prepareStylesheet(document, stylesheetContent, this._posthog)
+        const styleId = 'ph-survey-widget-style' // Identifier for the style element
 
-        if (stylesheet) {
-            shadow.appendChild(stylesheet)
+        // Check if the stylesheet already exists
+        if (!shadow.querySelector(`style[data-style-id="${styleId}"]`)) {
+            const stylesheet = prepareStylesheet(document, stylesheetContent, this._posthog)
+
+            if (stylesheet) {
+                stylesheet.setAttribute('data-style-id', styleId) // Add identifier
+                shadow.appendChild(stylesheet)
+            }
         }
 
         Preact.render(

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -246,14 +246,14 @@ export class SurveyManager {
         // Ensure widget container exists if it doesn't
         const shadow = retrieveWidgetShadow(survey, this._posthog)
         const stylesheetContent = style(survey.appearance)
-        const styleId = 'ph-survey-widget-style' // Identifier for the style element
+        const WIDGET_STYLE_ID = 'ph-data-style-id'
 
         // Check if the stylesheet already exists
-        if (!shadow.querySelector(`style[data-style-id="${styleId}"]`)) {
+        if (!shadow.querySelector(`style[${WIDGET_STYLE_ID}="${WIDGET_STYLE_ID}"]`)) {
             const stylesheet = prepareStylesheet(document, stylesheetContent, this._posthog)
 
             if (stylesheet) {
-                stylesheet.setAttribute('data-style-id', styleId) // Add identifier
+                stylesheet.setAttribute(WIDGET_STYLE_ID, WIDGET_STYLE_ID) // Add identifier
                 shadow.appendChild(stylesheet)
             }
         }


### PR DESCRIPTION
## Changes

Fixes https://posthoghelp.zendesk.com/agent/tickets/29337 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/30939)

Surveys are evaluated for display logic every second.

However, Feedback Button/Widget surveys are mounted on the DOM once - which is intended, as they're more permanent.

Yet, every second we're adding the stylesheet again, since the survey matches the condition. We don't have to worry about the DOM element itself since Preact takes care of that - but we should prevent adding multiple <style> tags.

## Checklist
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size