### PR TITLE
chore: do not organize imports using VS Code functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "jest.runMode": "on-demand",
     "jest.rootPath": "src",
-    "jest.jestCommandLine": "pnpm test:unit"
+    "jest.jestCommandLine": "pnpm test:unit",
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": "never"
+    }
 }


### PR DESCRIPTION
## Changes

let's make prettier the only source of formatting in the repo. prevents this VS Code setting from changing the imports order