### PR TITLE
chore: Make the flags demo runnable

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -153,6 +153,17 @@ module.exports = {
                 'posthog-js/no-direct-null-check': 'off',
             },
         },
+        {
+            files: ['playground/**/*'],
+            rules: {
+                'no-console': 'off',
+                '@typescript-eslint/no-require-imports': 'off',
+                'no-undef': 'off',
+            },
+            env: {
+                node: true,
+            },
+        },
     ],
     root: true,
 }

--- a/playground/flags/demo.html
+++ b/playground/flags/demo.html
@@ -1,7 +1,18 @@
-<script src="../../dist/array.js"></script>
-<script>
-    posthog.init('sTMFPsFhdP1Ssg', {api_host: 'http://127.0.0.1:8000', debug: true, persistence: 'memory', loaded: function(posthog) { posthog.identify('test')}})
-</script>
+<html>
+<head>
+    <script src="../../dist/array.js"></script>
+    <script>
+        posthog.init('sTMFPsFhdP1Ssg', {
+            api_host: 'http://127.0.0.1:8000',
+            debug: true,
+            persistence: 'memory',
+            advanced_disable_feature_flags_on_first_load: true,
+            loaded: function(posthog) {
+                //posthog.identify('test')
+            }
+        })
+    </script>
+</head>
 <h2>Demo site</h2>
 <button>Here's a button you could click if you want to</button><br /><br />
 <body class='asdlfkjj asdlfkj asdflkj asdflkj asdf'>
@@ -37,10 +48,10 @@
         posthog.onFeatureFlags(function(featureFlags) {
             console.log(featureFlags)
             if(posthog.isFeatureEnabled('beta-feature')) {
+                console.log('beta-feature enabled!')
                 document.getElementById('feature').style.display = 'block'
             }
         })
-
     </script>
-
 </body>
+</html>

--- a/playground/flags/package.json
+++ b/playground/flags/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "flags",
+    "version": "1.0.0",
+    "main": "server.js",
+    "scripts": {
+        "build": "cd ../.. && pnpm install && pnpm run build",
+        "start": "npm run build && node server.js"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "description": "",
+    "dependencies": {
+        "express": "^4.18.2"
+    }
+}

--- a/playground/flags/server.js
+++ b/playground/flags/server.js
@@ -1,0 +1,16 @@
+const express = require('express')
+const path = require('path')
+const app = express()
+const port = 3000
+
+// Serve static files from the dist directory
+app.use('/dist', express.static(path.join(__dirname, '../../dist')))
+
+// Serve the demo.html file
+app.get('/', (req, res) => {
+    res.sendFile(path.join(__dirname, 'demo.html'))
+})
+
+app.listen(port, () => {
+    console.log(`Demo server running at http://localhost:${port}`)
+})


### PR DESCRIPTION
The `playground/flags` directory had a `demo.html` file in there, but it looked incomplete and there wasn't any clear way to run the demo. So I turned it into a simple node project using express so we have a quick way to test out changes to the client library.

I also excluded the `playground` directory from our eslint checks since it's just a playground.

This doesn't affect the actual library.