### PR TITLE
fix: prevent survey events to affect multiple surveys

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
         "playwright": "pnpm exec playwright test --project webkit --project firefox --project chromium",
         "playwright-ui": "pnpm exec playwright test --ui --project webkit --project firefox --project chromium",
         "playwright-webserver": "npx http-server ./ -p 8082",
+        "playwright:surveys": "pnpm exec playwright test playwright/surveys/* --project webkit --project firefox --project chromium",
+        "playwright:surveys:ui": "pnpm exec playwright test playwright/surveys/* --ui --project webkit --project firefox --project chromium",
         "prepare": "[ -z \"$VERCEL\" ] && husky install || echo \"Skipping husky install on vercel build\"",
         "deprecate-old-versions": "node scripts/deprecate-old-versions.mjs",
         "check-testcafe-results": "ts-node testcafe/check-testcafe-results.js",

--- a/playwright/surveys/core-display-logic.spec.ts
+++ b/playwright/surveys/core-display-logic.spec.ts
@@ -38,14 +38,14 @@ test.describe('surveys - core display logic', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
 
         await page.reload()
 
         await start({ ...startOptions, type: 'reload' }, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
     })
 
     test('does not show the same survey to user if they have dismissed it before', async ({ page, context }) => {
@@ -69,9 +69,9 @@ test.describe('surveys - core display logic', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
-        await page.locator('.PostHogSurvey123').locator('.cancel-btn-wrapper').click()
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).not.toBeInViewport()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await page.locator('.PostHogSurvey-123').locator('.cancel-btn-wrapper').click()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).not.toBeInViewport()
 
         expect(
             await page.evaluate(() => {
@@ -84,7 +84,7 @@ test.describe('surveys - core display logic', () => {
         await start({ ...startOptions, type: 'reload' }, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).not.toBeInViewport()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).not.toBeInViewport()
     })
 
     test('does not show the same survey to user if they responded to it before', async ({ page, context }) => {
@@ -108,9 +108,9 @@ test.describe('surveys - core display logic', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
-        await page.locator('.PostHogSurvey123').locator('textarea').type('some feedback')
-        await page.locator('.PostHogSurvey123').locator('.form-submit').click()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await page.locator('.PostHogSurvey-123').locator('textarea').type('some feedback')
+        await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
 
         expect(
             await page.evaluate(() => {
@@ -118,14 +118,14 @@ test.describe('surveys - core display logic', () => {
             })
         ).toBeTruthy()
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).not.toBeInViewport()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).not.toBeInViewport()
 
         await page.reload()
 
         await start({ ...startOptions, type: 'reload' }, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).not.toBeInViewport()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).not.toBeInViewport()
 
         expect(
             await page.evaluate(() => {
@@ -159,7 +159,7 @@ test.describe('surveys - core display logic', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
 
         const lastSeenDate = await page.evaluate(() => {
             return window.localStorage.getItem('lastSeenSurveyDate')
@@ -172,7 +172,7 @@ test.describe('surveys - core display logic', () => {
         await start({ ...startOptions, type: 'reload' }, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).not.toBeInViewport()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).not.toBeInViewport()
     })
 
     test('does not allow user to submit non optional survey questions if they have not responded to it', async ({
@@ -200,9 +200,9 @@ test.describe('surveys - core display logic', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
-        await expect(page.locator('.PostHogSurvey123').locator('.form-submit')).toHaveAttribute('disabled')
-        await page.locator('.PostHogSurvey123').locator('textarea').type('some feedback')
-        await expect(page.locator('.PostHogSurvey123').locator('.form-submit')).not.toHaveAttribute('disabled')
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.form-submit')).toHaveAttribute('disabled')
+        await page.locator('.PostHogSurvey-123').locator('textarea').type('some feedback')
+        await expect(page.locator('.PostHogSurvey-123').locator('.form-submit')).not.toHaveAttribute('disabled')
     })
 })

--- a/playwright/surveys/customization.spec.ts
+++ b/playwright/surveys/customization.spec.ts
@@ -77,22 +77,25 @@ test.describe('surveys - customization', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question')).toHaveText(
             'What feedback do you have for us?'
         )
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question-description')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question-description')).toHaveText(
             'plain text description'
         )
 
-        await expect(page.locator('.PostHogSurvey123').locator('.footer-branding')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.footer-branding')).toBeVisible()
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question')).toHaveCSS('background-color', black)
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question')).toHaveCSS('color', white)
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question')).toHaveCSS(
+            'background-color',
+            black
+        )
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question')).toHaveCSS('color', white)
 
-        await page.locator('.PostHogSurvey123').locator('textarea').type('This is great!')
+        await page.locator('.PostHogSurvey-123').locator('textarea').type('This is great!')
 
-        await page.locator('.PostHogSurvey123').locator('.form-submit').click()
+        await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
 
         await pollUntilEventCaptured(page, 'survey sent')
     })
@@ -118,8 +121,8 @@ test.describe('surveys - customization', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
-        await expect(page.locator('.PostHogSurvey123').locator('.footer-branding')).not.toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.footer-branding')).not.toBeVisible()
     })
 
     test('allows html customization for question and thank you element description', async ({ page, context }) => {
@@ -142,11 +145,11 @@ test.describe('surveys - customization', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question')).toHaveText(
             'Book an interview with us'
         )
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question-description h2')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question-description h2')).toHaveText(
             'html description'
         )
     })
@@ -174,11 +177,11 @@ test.describe('surveys - customization', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question')).toHaveText(
             'Book an interview with us'
         )
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question-description h2')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question-description h2')).toHaveText(
             'html description'
         )
     })
@@ -208,16 +211,16 @@ test.describe('surveys - customization', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question')).toHaveText(
             'What feedback do you have for us?'
         )
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question-description')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question-description')).toHaveText(
             'plain text description'
         )
-        await page.locator('.PostHogSurvey123').locator('textarea').type('This is great!')
-        await page.locator('.PostHogSurvey123').locator('.form-submit').click()
-        await expect(page.locator('.PostHogSurvey123').locator('.thank-you-message-body h3')).toHaveText(
+        await page.locator('.PostHogSurvey-123').locator('textarea').type('This is great!')
+        await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
+        await expect(page.locator('.PostHogSurvey-123').locator('.thank-you-message-body h3')).toHaveText(
             'html thank you message!'
         )
         await pollUntilEventCaptured(page, 'survey sent')
@@ -246,17 +249,17 @@ test.describe('surveys - customization', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question')).toHaveText(
             'Book an interview with us'
         )
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question-description')).toHaveText(
-            // the escaped html is the content
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question-description h2')).toHaveCount(0)
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question-description')).toHaveText(
             '<h2>html description</h2>'
         )
     })
 
-    test('does not render html customization for thank you message body if the appearance.thankYouMessageDescriptionContentType does not permit it', async ({
+    test('does not render html customization for thank you message body if the question.thankYouMessageDescriptionContentType does not permit it', async ({
         page,
         context,
     }) => {
@@ -284,11 +287,17 @@ test.describe('surveys - customization', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
-        await page.locator('.PostHogSurvey123').locator('textarea').type('This is great!')
-        await page.locator('.PostHogSurvey123').locator('.form-submit').click()
-        await expect(page.locator('.PostHogSurvey123').locator('.thank-you-message-body')).toHaveText(
-            // the escaped html is the content
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question')).toHaveText(
+            'What feedback do you have for us?'
+        )
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question-description')).toHaveText(
+            'plain text description'
+        )
+        await page.locator('.PostHogSurvey-123').locator('textarea').type('This is great!')
+        await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
+        await expect(page.locator('.PostHogSurvey-123').locator('.thank-you-message-body h3')).toHaveCount(0)
+        await expect(page.locator('.PostHogSurvey-123').locator('.thank-you-message-body')).toHaveText(
             '<h3>html thank you message!</h3>'
         )
         await pollUntilEventCaptured(page, 'survey sent')

--- a/playwright/surveys/feedback-widget.spec.ts
+++ b/playwright/surveys/feedback-widget.spec.ts
@@ -77,16 +77,16 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogWidget123').locator('.survey-form')).not.toBeVisible()
-        await page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab').click()
-        await expect(page.locator('.PostHogWidget123').locator('.survey-form')).toBeVisible()
-        await expect(page.locator('.PostHogWidget123').locator('.survey-question')).toHaveText('Feedback for us?')
-        await expect(page.locator('.PostHogWidget123').locator('.survey-question-description')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).not.toBeVisible()
+        await page.locator('.PostHogSurvey-123').locator('.ph-survey-widget-tab').click()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question')).toHaveText('Feedback for us?')
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question-description')).toHaveText(
             'tab feedback widget'
         )
 
-        await page.locator('.PostHogWidget123').locator('.survey-form').locator('textarea').fill('hello posthog!')
-        await page.locator('.PostHogWidget123').locator('.survey-form').locator('.form-submit').click()
+        await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('textarea').fill('hello posthog!')
+        await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('.form-submit').click()
         await pollUntilEventCaptured(page, 'survey sent')
     })
 
@@ -119,10 +119,10 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab').click()
+        await page.locator('.PostHogSurvey-123').locator('.ph-survey-widget-tab').click()
         await page.setViewportSize({ width: 375, height: 667 })
 
-        await expect(page.locator('.PostHogWidget123').locator('.survey-form')).toBeInViewport()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeInViewport()
     })
 
     test('widgetType is custom selector', async ({ page, context }) => {
@@ -159,18 +159,18 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab')).not.toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.ph-survey-widget-tab')).not.toBeVisible()
         await page.locator('.test-surveys').click()
 
-        await expect(page.locator('.PostHogWidget123').locator('.survey-form')).toBeVisible({ timeout: 8000 })
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible({ timeout: 8000 })
 
-        await expect(page.locator('.PostHogWidget123').locator('.survey-question')).toHaveText('Feedback for us?')
-        await expect(page.locator('.PostHogWidget123').locator('.survey-question-description')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question')).toHaveText('Feedback for us?')
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question-description')).toHaveText(
             'custom selector widget'
         )
 
-        await page.locator('.PostHogWidget123').locator('.survey-form').locator('textarea').fill('hello posthog!')
-        await page.locator('.PostHogWidget123').locator('.survey-form').locator('.form-submit').click()
+        await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('textarea').fill('hello posthog!')
+        await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('.form-submit').click()
         await pollUntilEventCaptured(page, 'survey sent')
     })
 
@@ -199,15 +199,15 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab').click()
-        await expect(page.locator('.PostHogWidget123').locator('.survey-form')).toBeVisible()
+        await page.locator('.PostHogSurvey-123').locator('.ph-survey-widget-tab').click()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
 
-        await page.locator('.PostHogWidget123').locator('#surveyQuestion0Choice1').click()
-        await page.locator('.PostHogWidget123').locator('.survey-form').locator('.form-submit').click()
+        await page.locator('.PostHogSurvey-123').locator('#surveyQuestion0Choice1').click()
+        await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('.form-submit').click()
 
-        await page.locator('.PostHogWidget123 textarea').first().type('Because I want to learn more about posthog')
-        await page.locator('.PostHogWidget123 .form-submit').click()
-        await page.locator('.PostHogWidget123 .form-submit').click()
+        await page.locator('.PostHogSurvey-123 textarea').first().type('Because I want to learn more about posthog')
+        await page.locator('.PostHogSurvey-123 .form-submit').click()
+        await page.locator('.PostHogSurvey-123 .form-submit').click()
 
         await pollUntilEventCaptured(page, 'survey shown')
         await pollUntilEventCaptured(page, 'survey sent')
@@ -238,10 +238,10 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.ph-survey-widget-tab')).toBeVisible()
 
-        await expect(page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab')).toHaveCSS('color', black)
-        await expect(page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab')).toHaveCSS(
+        await expect(page.locator('.PostHogSurvey-123').locator('.ph-survey-widget-tab')).toHaveCSS('color', black)
+        await expect(page.locator('.PostHogSurvey-123').locator('.ph-survey-widget-tab')).toHaveCSS(
             'background-color',
             white
         )
@@ -262,6 +262,7 @@ test.describe('surveys - feedback widget', () => {
                                 widgetLabel: 'Feedback',
                                 widgetType: 'tab',
                                 displayThankYouMessage: true,
+                                thankyouMessageHeader: 'Thank you!',
                             },
                             conditions: {
                                 url: null,
@@ -279,39 +280,39 @@ test.describe('surveys - feedback widget', () => {
         await surveysAPICall
 
         // 1. Check that the survey widget is rendered
-        await expect(page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.ph-survey-widget-tab')).toBeVisible()
 
         // 2. Open the survey
-        await page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab').click()
-        await expect(page.locator('.PostHogWidget123').locator('.survey-form')).toBeVisible()
+        await page.locator('.PostHogSurvey-123').locator('.ph-survey-widget-tab').click()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
 
         // 3. Answer the survey
-        await page.locator('.PostHogWidget123').locator('.survey-form').locator('textarea').fill('first submission')
-        await page.locator('.PostHogWidget123').locator('.survey-form').locator('.form-submit').click()
+        await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('textarea').fill('first submission')
+        await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('.form-submit').click()
 
         // 4. Check for thank you message
-        await expect(page.locator('.PostHogWidget123').locator('.thank-you-message-header')).toBeVisible()
-        await expect(page.locator('.PostHogWidget123').locator('.thank-you-message-header')).toHaveText('Thank you!')
+        await expect(page.locator('.PostHogSurvey-123').locator('.thank-you-message-header')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.thank-you-message-header')).toHaveText('Thank you!')
 
         // Verify the event was sent
         await pollUntilEventCaptured(page, 'survey sent')
 
         // 5. Close the thank you message and click the survey tab again
-        await page.locator('.PostHogWidget123').locator('.form-submit').click()
-        await expect(page.locator('.PostHogWidget123').locator('.survey-form')).not.toBeVisible()
+        await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).not.toBeVisible()
 
         // Open the survey again
-        await page.locator('.PostHogWidget123').locator('.ph-survey-widget-tab').click()
+        await page.locator('.PostHogSurvey-123').locator('.ph-survey-widget-tab').click()
 
         // 6. Verify survey is rendered again
-        await expect(page.locator('.PostHogWidget123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
 
         // Submit again with different text
-        await page.locator('.PostHogWidget123').locator('.survey-form').locator('textarea').fill('second submission')
-        await page.locator('.PostHogWidget123').locator('.survey-form').locator('.form-submit').click()
+        await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('textarea').fill('second submission')
+        await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('.form-submit').click()
 
         // Verify thank you message appears again
-        await expect(page.locator('.PostHogWidget123').locator('.thank-you-message-header')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.thank-you-message-header')).toBeVisible()
 
         // Verify second event was sent
         await pollUntilEventCaptured(page, 'survey sent')

--- a/playwright/surveys/feedback-widget.spec.ts
+++ b/playwright/surveys/feedback-widget.spec.ts
@@ -436,8 +436,5 @@ test.describe('surveys - feedback widget', () => {
 
         // check if the second survey is still visible
         await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).not.toBeVisible()
-
-        // check if the second survey is still visible
-        await expect(page.locator('.PostHogSurvey-456').locator('.survey-form')).toBeVisible()
     })
 })

--- a/playwright/surveys/question-types.spec.ts
+++ b/playwright/surveys/question-types.spec.ts
@@ -66,15 +66,15 @@ test.describe('surveys - core display logic', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question')).toHaveText(
             'What feedback do you have for us?'
         )
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-question-description')).toHaveText(
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-question-description')).toHaveText(
             'plain text description'
         )
-        await page.locator('.PostHogSurvey123').locator('.survey-form').locator('textarea').type('Great job!')
-        await page.locator('.PostHogSurvey123').locator('.form-submit').click()
+        await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('textarea').type('Great job!')
+        await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
 
         await pollUntilEventCaptured(page, 'survey sent')
     })
@@ -100,18 +100,18 @@ test.describe('surveys - core display logic', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123').locator('.survey-form')).toBeVisible()
-        await expect(page.locator('.PostHogSurvey123').locator('.ratings-number')).toHaveCount(11)
+        await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123').locator('.ratings-number')).toHaveCount(11)
         let i = 0
-        for (const rating of await page.locator('.PostHogSurvey123').locator('.ratings-number').all()) {
+        for (const rating of await page.locator('.PostHogSurvey-123').locator('.ratings-number').all()) {
             await expect(rating).toBeVisible()
             await expect(rating).toHaveText(`${i++}`)
         }
 
-        await page.locator('.PostHogSurvey123').locator('.ratings-number').first().click()
-        await page.locator('.PostHogSurvey123').locator('.form-submit').click()
+        await page.locator('.PostHogSurvey-123').locator('.ratings-number').first().click()
+        await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
 
-        await expect(page.locator('.PostHogSurvey123').locator('.ratings-number').first()).toHaveText('1')
+        await expect(page.locator('.PostHogSurvey-123').locator('.ratings-number').first()).toHaveText('1')
     })
 
     test('multiple question surveys', async ({ page, context }) => {
@@ -139,18 +139,18 @@ test.describe('surveys - core display logic', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey12345').locator('.survey-form')).toBeVisible()
-        await page.locator('.PostHogSurvey12345').locator('#surveyQuestion0Choice1').click()
-        await page.locator('.PostHogSurvey12345').locator('#surveyQuestion0Choice2').click()
-        await page.locator('.PostHogSurvey12345').locator('.form-submit').click()
+        await expect(page.locator('.PostHogSurvey-12345').locator('.survey-form')).toBeVisible()
+        await page.locator('.PostHogSurvey-12345').locator('#surveyQuestion0Choice1').click()
+        await page.locator('.PostHogSurvey-12345').locator('#surveyQuestion0Choice2').click()
+        await page.locator('.PostHogSurvey-12345').locator('.form-submit').click()
 
-        await page.locator('.PostHogSurvey12345').locator('textarea').type('Great job!')
-        await page.locator('.PostHogSurvey12345').locator('.form-submit').click()
-        await page.locator('.PostHogSurvey12345').locator('.form-submit').click()
+        await page.locator('.PostHogSurvey-12345').locator('textarea').type('Great job!')
+        await page.locator('.PostHogSurvey-12345').locator('.form-submit').click()
+        await page.locator('.PostHogSurvey-12345').locator('.form-submit').click()
 
-        await expect(page.locator('.PostHogSurvey12345').locator('.thank-you-message')).toBeVisible()
-        await page.locator('.PostHogSurvey12345').locator('.form-submit').click()
-        await expect(page.locator('.PostHogSurvey12345').locator('.thank-you-message')).not.toBeVisible()
+        await expect(page.locator('.PostHogSurvey-12345').locator('.thank-you-message')).toBeVisible()
+        await page.locator('.PostHogSurvey-12345').locator('.form-submit').click()
+        await expect(page.locator('.PostHogSurvey-12345').locator('.thank-you-message')).not.toBeVisible()
 
         await pollUntilEventCaptured(page, 'survey sent')
         const captures = await page.capturedEvents()
@@ -210,11 +210,11 @@ test.describe('surveys - core display logic', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey12345').locator('.survey-form')).toBeVisible()
-        await page.locator('.PostHogSurvey12345').locator('#surveyQuestion0Choice3').click()
-        await page.locator('.PostHogSurvey12345').locator('#surveyQuestion0Choice0').click()
-        await page.locator('.PostHogSurvey12345').locator('input[type=text]').type('Newsletters')
-        await page.locator('.PostHogSurvey12345').locator('.form-submit').click()
+        await expect(page.locator('.PostHogSurvey-12345').locator('.survey-form')).toBeVisible()
+        await page.locator('.PostHogSurvey-12345').locator('#surveyQuestion0Choice3').click()
+        await page.locator('.PostHogSurvey-12345').locator('#surveyQuestion0Choice0').click()
+        await page.locator('.PostHogSurvey-12345').locator('input[type=text]').type('Newsletters')
+        await page.locator('.PostHogSurvey-12345').locator('.form-submit').click()
 
         await pollUntilEventCaptured(page, 'survey sent')
         const captures = await page.capturedEvents()
@@ -258,16 +258,16 @@ test.describe('surveys - core display logic', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey12345').locator('.survey-form')).toBeVisible()
-        await page.locator('.PostHogSurvey12345').locator('#surveyQuestion0Choice3').click()
+        await expect(page.locator('.PostHogSurvey-12345').locator('.survey-form')).toBeVisible()
+        await page.locator('.PostHogSurvey-12345').locator('#surveyQuestion0Choice3').click()
         // TODO: you have to click on the input to activate it, really clicking on the parent should select the input
-        await page.locator('.PostHogSurvey12345').locator('#surveyQuestion0Choice3Open').click()
+        await page.locator('.PostHogSurvey-12345').locator('#surveyQuestion0Choice3Open').click()
         await page
-            .locator('.PostHogSurvey12345')
+            .locator('.PostHogSurvey-12345')
             .locator('input[type=text]#surveyQuestion0Choice3Open')
             .type('Product engineer')
 
-        await page.locator('.PostHogSurvey12345').locator('.form-submit').click()
+        await page.locator('.PostHogSurvey-12345').locator('.form-submit').click()
 
         await pollUntilEventCaptured(page, 'survey sent')
         const captures = await page.capturedEvents()

--- a/playwright/surveys/response-capture.spec.ts
+++ b/playwright/surveys/response-capture.spec.ts
@@ -41,8 +41,8 @@ test.describe('surveys - feedback widget', () => {
 
         await pollUntilEventCaptured(page, 'survey shown')
 
-        await page.locator('.PostHogSurvey123 textarea').type('experiments is awesome!')
-        await page.locator('.PostHogSurvey123 .form-submit').click()
+        await page.locator('.PostHogSurvey-123 textarea').type('experiments is awesome!')
+        await page.locator('.PostHogSurvey-123 .form-submit').click()
 
         await pollUntilEventCaptured(page, 'survey sent')
         const surveySentEvent = await page
@@ -97,8 +97,8 @@ test.describe('surveys - feedback widget', () => {
             })
         )
 
-        await page.locator('.PostHogSurvey123 textarea').type('experiments is awesome!')
-        await page.locator('.PostHogSurvey123 .form-submit').click()
+        await page.locator('.PostHogSurvey-123 textarea').type('experiments is awesome!')
+        await page.locator('.PostHogSurvey-123 .form-submit').click()
 
         await pollUntilEventCaptured(page, 'survey sent')
         const surveySentEvent = await page
@@ -141,7 +141,7 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await page.locator('.PostHogSurvey123 .cancel-btn-wrapper').click()
+        await page.locator('.PostHogSurvey-123 .cancel-btn-wrapper').click()
         await pollUntilEventCaptured(page, 'survey dismissed')
     })
 
@@ -167,7 +167,7 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await page.locator('.PostHogSurvey123 .cancel-btn-wrapper').click()
+        await page.locator('.PostHogSurvey-123 .cancel-btn-wrapper').click()
         await pollUntilEventCaptured(page, 'survey dismissed')
         const surveyDismissedEvent = await page
             .capturedEvents()

--- a/playwright/surveys/thank-you-message.spec.ts
+++ b/playwright/surveys/thank-you-message.spec.ts
@@ -46,11 +46,11 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123 .ratings-emoji')).toHaveCount(5)
-        await page.locator('.PostHogSurvey123 .ratings-emoji').first().click()
+        await expect(page.locator('.PostHogSurvey-123 .ratings-emoji')).toHaveCount(5)
+        await page.locator('.PostHogSurvey-123 .ratings-emoji').first().click()
 
-        await page.locator('.PostHogSurvey123 .form-submit').click()
-        await expect(page.locator('.PostHogSurvey123 .thank-you-message')).toBeVisible()
+        await page.locator('.PostHogSurvey-123 .form-submit').click()
+        await expect(page.locator('.PostHogSurvey-123 .thank-you-message')).toBeVisible()
     })
 
     test('counts down with auto disappear after 5 seconds', async ({ page, context }) => {
@@ -74,12 +74,12 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await expect(page.locator('.PostHogSurvey123 .ratings-emoji')).toHaveCount(5)
-        await page.locator('.PostHogSurvey123 .ratings-emoji').first().click()
-        await page.locator('.PostHogSurvey123 .form-submit').click()
+        await expect(page.locator('.PostHogSurvey-123 .ratings-emoji')).toHaveCount(5)
+        await page.locator('.PostHogSurvey-123 .ratings-emoji').first().click()
+        await page.locator('.PostHogSurvey-123 .form-submit').click()
 
-        await expect(page.locator('.PostHogSurvey123 .thank-you-message')).toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123 .thank-you-message')).toBeVisible()
         await page.waitForTimeout(5000)
-        await expect(page.locator('.PostHogSurvey123 .thank-you-message')).not.toBeVisible()
+        await expect(page.locator('.PostHogSurvey-123 .thank-you-message')).not.toBeVisible()
     })
 })

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -457,14 +457,17 @@ describe('SurveyManager', () => {
         surveyManager.getTestAPI().addSurveyToFocus('survey1')
         surveyManager.callSurveysAndEvaluateDisplayLogic()
 
-        expect(mockPostHog.surveys.getSurveys).toHaveBeenCalledTimes(1)
-        expect(surveyManager.getTestAPI().surveyInFocus).toBe('survey1')
-
         const handlePopoverSurveyMock = jest
             .spyOn(surveyManager as any, '_handlePopoverSurvey')
             .mockImplementation(() => {})
 
+        expect(mockPostHog.surveys.getSurveys).toHaveBeenCalledTimes(1)
+        expect(surveyManager.getTestAPI().surveyInFocus).toBe('survey1')
+        expect(handlePopoverSurveyMock).not.toHaveBeenCalled()
+
         surveyManager.getTestAPI().removeSurveyFromFocus('survey1')
+        jest.spyOn(surveyManager as any, '_canShowNextEventBasedSurvey').mockReturnValue(true)
+
         surveyManager.callSurveysAndEvaluateDisplayLogic()
 
         expect(mockPostHog.surveys.getSurveys).toHaveBeenCalledTimes(2)

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -32,7 +32,7 @@ describe('survey display logic', () => {
         const surveyId = 'randomSurveyId'
         const mockShadow = createShadow(`.survey-${surveyId}-form {}`, surveyId)
         expect(mockShadow.mode).toBe('open')
-        expect(mockShadow.host.className).toBe(`PostHogSurvey${surveyId}`)
+        expect(mockShadow.host.className).toBe(`PostHogSurvey-${surveyId}`)
     })
 
     const mockSurveys: Survey[] = [
@@ -145,7 +145,7 @@ describe('usePopupVisibility', () => {
     test('should hide popup when PHSurveyClosed event is dispatched', () => {
         const { result } = renderHook(() => usePopupVisibility(mockSurvey, mockPostHog, 0, false, removeSurvey))
         act(() => {
-            window.dispatchEvent(new Event('PHSurveyClosed'))
+            window.dispatchEvent(new CustomEvent('PHSurveyClosed', { detail: { surveyId: mockSurvey.id } }))
         })
         expect(result.current.isPopupVisible).toBe(false)
     })
@@ -161,7 +161,7 @@ describe('usePopupVisibility', () => {
 
         const { result } = renderHook(() => usePopupVisibility(mockSurvey, mockPostHog, 0, false, removeSurvey))
         act(() => {
-            window.dispatchEvent(new Event('PHSurveySent'))
+            window.dispatchEvent(new CustomEvent('PHSurveySent', { detail: { surveyId: mockSurvey.id } }))
         })
 
         expect(result.current.isSurveySent).toBe(true)

--- a/src/extensions/surveys-widget.ts
+++ b/src/extensions/surveys-widget.ts
@@ -1,14 +1,14 @@
 import { PostHog } from '../posthog-core'
 import { Survey } from '../posthog-surveys-types'
 import { document as _document } from '../utils/globals'
-import { SURVEY_DEFAULT_Z_INDEX } from './surveys/surveys-extension-utils'
+import { getSurveyContainerClass, SURVEY_DEFAULT_Z_INDEX } from './surveys/surveys-extension-utils'
 import { prepareStylesheet } from './utils/stylesheet-loader'
 
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const document = _document as Document
 
 export function retrieveWidgetShadow(survey: Survey, posthog?: PostHog) {
-    const widgetClassName = `PostHogSurvey-${survey.id}`
+    const widgetClassName = getSurveyContainerClass(survey)
     const existingDiv = document.querySelector(`.${widgetClassName}`) as HTMLDivElement | null
 
     if (existingDiv && existingDiv.shadowRoot) {

--- a/src/extensions/surveys-widget.ts
+++ b/src/extensions/surveys-widget.ts
@@ -8,7 +8,7 @@ import { prepareStylesheet } from './utils/stylesheet-loader'
 const document = _document as Document
 
 export function retrieveWidgetShadow(survey: Survey, posthog?: PostHog) {
-    const widgetClassName = `PostHogWidget${survey.id}`
+    const widgetClassName = `PostHogSurvey-${survey.id}`
     const existingDiv = document.querySelector(`.${widgetClassName}`) as HTMLDivElement | null
 
     if (existingDiv && existingDiv.shadowRoot) {

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -820,7 +820,7 @@ export function usePopupVisibility(
             localStorage.setItem('lastSeenSurveyDate', new Date().toISOString())
             setTimeout(() => {
                 const inputField = document
-                    .querySelector(`.${getSurveyContainerClass(survey)}`)
+                    .querySelector(getSurveyContainerClass(survey, true))
                     ?.shadowRoot?.querySelector('textarea, input[type="text"]') as HTMLElement
                 if (inputField) {
                     inputField.focus()

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -820,7 +820,7 @@ export function usePopupVisibility(
             localStorage.setItem('lastSeenSurveyDate', new Date().toISOString())
             setTimeout(() => {
                 const inputField = document
-                    .querySelector(`.${getSurveyContainerClass(survey.id)}`)
+                    .querySelector(`.${getSurveyContainerClass(survey)}`)
                     ?.shadowRoot?.querySelector('textarea, input[type="text"]') as HTMLElement
                 if (inputField) {
                     inputField.focus()

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -57,7 +57,7 @@ const window = _window as Window & typeof globalThis
 const document = _document as Document
 
 function getPosthogWidgetClass(surveyId: string) {
-    return `.PostHogWidget${surveyId}`
+    return `.PostHogSurvey-${surveyId}`
 }
 
 const DISPATCH_FEEDBACK_WIDGET_EVENT = 'ph:show_survey_widget'
@@ -779,12 +779,18 @@ export function usePopupVisibility(
             return
         }
 
-        const handleSurveyClosed = () => {
+        const handleSurveyClosed = (event: CustomEvent) => {
+            if (event.detail.surveyId !== survey.id) {
+                return
+            }
             removeSurveyFromFocus(survey.id)
             setIsPopupVisible(false)
         }
 
-        const handleSurveySent = () => {
+        const handleSurveySent = (event: CustomEvent) => {
+            if (event.detail.surveyId !== survey.id) {
+                return
+            }
             if (!survey.appearance?.displayThankYouMessage) {
                 removeSurveyFromFocus(survey.id)
                 setIsPopupVisible(false)
@@ -825,8 +831,8 @@ export function usePopupVisibility(
             }, 100)
         }
 
-        addEventListener(window, 'PHSurveyClosed', handleSurveyClosed)
-        addEventListener(window, 'PHSurveySent', handleSurveySent)
+        addEventListener(window, 'PHSurveyClosed', handleSurveyClosed as EventListener)
+        addEventListener(window, 'PHSurveySent', handleSurveySent as EventListener)
 
         if (millisecondDelay > 0) {
             // This path is only used for direct usage of SurveyPopup,
@@ -834,15 +840,15 @@ export function usePopupVisibility(
             const timeoutId = setTimeout(showSurvey, millisecondDelay)
             return () => {
                 clearTimeout(timeoutId)
-                window.removeEventListener('PHSurveyClosed', handleSurveyClosed)
-                window.removeEventListener('PHSurveySent', handleSurveySent)
+                window.removeEventListener('PHSurveyClosed', handleSurveyClosed as EventListener)
+                window.removeEventListener('PHSurveySent', handleSurveySent as EventListener)
             }
         } else {
             // This is the path used for surveys managed by SurveyManager
             showSurvey()
             return () => {
-                window.removeEventListener('PHSurveyClosed', handleSurveyClosed)
-                window.removeEventListener('PHSurveySent', handleSurveySent)
+                window.removeEventListener('PHSurveyClosed', handleSurveyClosed as EventListener)
+                window.removeEventListener('PHSurveySent', handleSurveySent as EventListener)
             }
         }
     }, [])

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -42,6 +42,7 @@ import {
     doesSurveyUrlMatch,
     getContrastingTextColor,
     getDisplayOrderQuestions,
+    getSurveyContainerClass,
     getSurveyResponseKey,
     getSurveySeen,
     hasWaitPeriodPassed,
@@ -55,10 +56,6 @@ import { prepareStylesheet } from './utils/stylesheet-loader'
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const window = _window as Window & typeof globalThis
 const document = _document as Document
-
-function getPosthogWidgetClass(surveyId: string) {
-    return `.PostHogSurvey-${surveyId}`
-}
 
 const DISPATCH_FEEDBACK_WIDGET_EVENT = 'ph:show_survey_widget'
 
@@ -823,7 +820,7 @@ export function usePopupVisibility(
             localStorage.setItem('lastSeenSurveyDate', new Date().toISOString())
             setTimeout(() => {
                 const inputField = document
-                    .querySelector(getPosthogWidgetClass(survey.id))
+                    .querySelector(`.${getSurveyContainerClass(survey.id)}`)
                     ?.shadowRoot?.querySelector('textarea, input[type="text"]') as HTMLElement
                 if (inputField) {
                     inputField.focus()

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -559,7 +559,7 @@ export const defaultBackgroundColor = '#eeeded'
 
 export const createShadow = (styleSheet: string, surveyId: string, element?: Element, posthog?: PostHog) => {
     const div = document.createElement('div')
-    div.className = `PostHogSurvey-${surveyId}`
+    div.className = getSurveyContainerClass({ id: surveyId })
     const shadow = div.attachShadow({ mode: 'open' })
     if (styleSheet) {
         const styleElement = prepareStylesheet(document, styleSheet, posthog)
@@ -813,4 +813,8 @@ export function doesSurveyMatchSelector(survey: Survey): boolean {
         return true
     }
     return !!document?.querySelector(survey.conditions.selector)
+}
+
+export function getSurveyContainerClass(survey: Pick<Survey, 'id'>): string {
+    return `PostHogSurvey-${survey.id}`
 }

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -815,6 +815,7 @@ export function doesSurveyMatchSelector(survey: Survey): boolean {
     return !!document?.querySelector(survey.conditions.selector)
 }
 
-export function getSurveyContainerClass(survey: Pick<Survey, 'id'>): string {
-    return `PostHogSurvey-${survey.id}`
+export function getSurveyContainerClass(survey: Pick<Survey, 'id'>, asSelector = false): string {
+    const className = `PostHogSurvey-${survey.id}`
+    return asSelector ? `.${className}` : className
 }

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -559,7 +559,7 @@ export const defaultBackgroundColor = '#eeeded'
 
 export const createShadow = (styleSheet: string, surveyId: string, element?: Element, posthog?: PostHog) => {
     const div = document.createElement('div')
-    div.className = `PostHogSurvey${surveyId}`
+    div.className = `PostHogSurvey-${surveyId}`
     const shadow = div.attachShadow({ mode: 'open' })
     if (styleSheet) {
         const styleElement = prepareStylesheet(document, styleSheet, posthog)
@@ -598,7 +598,7 @@ export const sendSurveyEvent = (
             [getSurveyInteractionProperty(survey, 'responded')]: true,
         },
     })
-    window.dispatchEvent(new Event('PHSurveySent'))
+    window.dispatchEvent(new CustomEvent('PHSurveySent', { detail: { surveyId: survey.id } }))
 }
 
 export const dismissedSurveyEvent = (survey: Survey, posthog?: PostHog, readOnly?: boolean) => {
@@ -621,7 +621,7 @@ export const dismissedSurveyEvent = (survey: Survey, posthog?: PostHog, readOnly
         },
     })
     localStorage.setItem(getSurveySeenKey(survey), 'true')
-    window.dispatchEvent(new Event('PHSurveyClosed'))
+    window.dispatchEvent(new CustomEvent('PHSurveyClosed', { detail: { surveyId: survey.id } }))
 }
 
 // Use the Fisher-yates algorithm to shuffle this array


### PR DESCRIPTION
## Changes

There's a bug right now that, if a survey sent/dismissed event is sent, it closes any other surveys that might be visible.

While we only support one popup survey being shown, for feedback surveys there's no such restriction.

So this PR changes the event emitters for PHSurveySent and PHSurveyClosed to also check for the survey id to only close the survey in the event context. This is tested using a e2e test.

There's also another change, in preparation for a bigger one: it changes the survey class container name from being `PostHogWidget${surveyId}` or `PostHogSurvey${surveyId}` depending on the type to be a unified `PostHogSurvey-${surveyId}`.

This is needed to have constant class names between surveys no matter the type. There's no functional changes. But it does require updating most of our e2e tests to the new value.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

