### PR TITLE
docs: use history_change option on SPA playgrounds 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -163,6 +163,9 @@ module.exports = {
             env: {
                 node: true,
             },
+            parserOptions: {
+                project: null,
+            },
         },
     ],
     root: true,

--- a/playground/error-tracking/nuxt-ts/plugins/posthog.client.js
+++ b/playground/error-tracking/nuxt-ts/plugins/posthog.client.js
@@ -6,7 +6,6 @@ export default defineNuxtPlugin((nuxtApp) => {
     const posthogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
         api_host: runtimeConfig.public.posthogHost,
         capture_pageview: 'history_change',
-        capture_pageleave: true, // automatically capture a pageleave event when the user leaves the site or closes the tab
         loaded: (posthog) => {
             if (import.meta.env.MODE === 'development') posthog.debug()
         },

--- a/playground/error-tracking/nuxt-ts/plugins/posthog.client.js
+++ b/playground/error-tracking/nuxt-ts/plugins/posthog.client.js
@@ -5,7 +5,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     const runtimeConfig = useRuntimeConfig()
     const posthogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
         api_host: runtimeConfig.public.posthogHost,
-        capture_pageview: false, // we add manual pageview capturing below
+        capture_pageview: 'history_change',
         capture_pageleave: true, // automatically capture a pageleave event when the user leaves the site or closes the tab
         loaded: (posthog) => {
             if (import.meta.env.MODE === 'development') posthog.debug()
@@ -15,16 +15,6 @@ export default defineNuxtPlugin((nuxtApp) => {
     // Capture rendering errors
     nuxtApp.hook('vue:error', (error) => {
         posthogClient.captureException(error)
-    })
-
-    // Make sure that pageviews are captured with each route change
-    const router = useRouter()
-    router.afterEach((to) => {
-        nextTick(() => {
-            posthog.capture('$pageview', {
-                current_url: to.fullPath,
-            })
-        })
     })
 
     return {

--- a/playground/nextjs/pages/_app.tsx
+++ b/playground/nextjs/pages/_app.tsx
@@ -1,7 +1,6 @@
 import '@/styles/globals.css'
 
 import type { AppProps } from 'next/app'
-import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 
 import { CookieBanner } from '@/src/CookieBanner'
@@ -14,8 +13,6 @@ import { PostHogProvider } from 'posthog-js/react'
 const CDP_DOMAINS = ['https://*.redditstatic.com', 'https://*.reddit.com'].join(' ')
 
 export default function App({ Component, pageProps }: AppProps) {
-    const router = useRouter()
-
     const user = useUser()
 
     useEffect(() => {
@@ -24,16 +21,6 @@ export default function App({ Component, pageProps }: AppProps) {
             posthogHelpers.setUser(user)
         }
     }, [user])
-
-    useEffect(() => {
-        // Track page views
-        const handleRouteChange = () => posthog.capture('$pageview')
-        router.events.on('routeChangeComplete', handleRouteChange)
-
-        return () => {
-            router.events.off('routeChangeComplete', handleRouteChange)
-        }
-    }, [])
 
     useEffect(() => {
         // make sure we initialize the WebSocket server

--- a/playground/nuxtjs/plugins/posthog.client.js
+++ b/playground/nuxtjs/plugins/posthog.client.js
@@ -7,7 +7,6 @@ export default defineNuxtPlugin(() => {
     const posthogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
         api_host: runtimeConfig.public.posthogHost,
         capture_pageview: 'history_change',
-        capture_pageleave: true, // automatically capture a pageleave event when the user leaves the site or closes the tab
         loaded: (posthog) => {
             if (import.meta.env.MODE === 'development') posthog.debug()
         },

--- a/playground/nuxtjs/plugins/posthog.client.js
+++ b/playground/nuxtjs/plugins/posthog.client.js
@@ -1,26 +1,16 @@
 // Keep in sync with https://github.com/PostHog/posthog.com/blob/master/contents/docs/integrate/_snippets/install-nuxt.mdx
-import { defineNuxtPlugin, useRuntimeConfig, useRouter, nextTick } from '#imports'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 import posthog from 'posthog-js'
 export default defineNuxtPlugin(() => {
     const runtimeConfig = useRuntimeConfig()
     const posthogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
         api_host: runtimeConfig.public.posthogHost,
-        capture_pageview: false, // we add manual pageview capturing below
+        capture_pageview: 'history_change',
         capture_pageleave: true, // automatically capture a pageleave event when the user leaves the site or closes the tab
         loaded: (posthog) => {
             if (import.meta.env.MODE === 'development') posthog.debug()
         },
-    })
-
-    // Make sure that pageviews are captured with each route change
-    const router = useRouter()
-    router.afterEach((to) => {
-        nextTick(() => {
-            posthog.capture('$pageview', {
-                current_url: to.fullPath,
-            })
-        })
     })
 
     return {

--- a/playground/react-router/app/components/Navigation.tsx
+++ b/playground/react-router/app/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router'
+import { Link } from 'react-router-dom'
 
 export function Navigation() {
     return (

--- a/playground/react-router/app/components/Navigation.tsx
+++ b/playground/react-router/app/components/Navigation.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router'
+
+export function Navigation() {
+    return (
+        <nav className="bg-gray-800 text-white p-4">
+            <div className="container mx-auto flex justify-between items-center">
+                <div className="text-xl font-bold">PostHog Demo</div>
+                <div className="flex space-x-4">
+                    <Link to="/" className="hover:text-gray-300">
+                        Home
+                    </Link>
+                    <Link to="/surveys" className="hover:text-gray-300">
+                        Surveys
+                    </Link>
+                </div>
+            </div>
+        </nav>
+    )
+}

--- a/playground/react-router/app/root.tsx
+++ b/playground/react-router/app/root.tsx
@@ -3,6 +3,7 @@ import { PostHogProvider } from 'posthog-js/react'
 
 import { isRouteErrorResponse, Links, Meta, Outlet, Scripts, ScrollRestoration } from 'react-router'
 import type { Route } from './+types/root'
+import { Navigation } from './components/Navigation'
 import './app.css'
 
 export const links: Route.LinksFunction = () => [
@@ -28,6 +29,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
                 <Links />
             </head>
             <body>
+                <Navigation />
                 {children}
                 <ScrollRestoration />
                 <Scripts />

--- a/playground/react-router/app/routes/home.tsx
+++ b/playground/react-router/app/routes/home.tsx
@@ -3,9 +3,13 @@ import type { Route } from './+types/home'
 
 // eslint-disable-next-line no-empty-pattern
 export function meta({}: Route.MetaArgs) {
-    return [{ title: 'New React Router App' }, { name: 'description', content: 'Welcome to React Router!' }]
+    return [{ title: 'PostHog React Router Demo' }]
 }
 
 export default function Home() {
-    return <Welcome />
+    return (
+        <div className="container mx-auto p-8">
+            <Welcome />
+        </div>
+    )
 }

--- a/playground/react-router/pnpm-lock.yaml
+++ b/playground/react-router/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^5.1.17
         version: 5.1.25
       posthog-js:
-        specifier: link:../..
+        specifier: file:../../dist/
         version: link:../..
       react:
         specifier: ^19.0.0

--- a/playground/session-recordings/index.html
+++ b/playground/session-recordings/index.html
@@ -99,6 +99,7 @@
                 api_host: 'http://localhost:8000',
                 disable_session_recording: true,
                 capture_performance: true,
+                capture_pageview: 'history_change',
             })
 
             posthog.init(
@@ -107,6 +108,7 @@
                     api_host: 'http://localhost:8000',
                     disable_session_recording: true,
                     capture_performance: true,
+                    capture_pageview: 'history_change',
                 },
                 'other'
             )

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -147,7 +147,7 @@ export const defaultConfig = (): PostHogConfig => ({
     custom_campaign_params: [],
     custom_blocked_useragents: [],
     save_referrer: true,
-    capture_pageview: true, // can be true, false, or 'history-change'
+    capture_pageview: true, // can be true, false, or 'history_change'
     capture_pageleave: 'if_capture_pageview', // We'll only capture pageleave events if capture_pageview is also true
     debug: (location && isString(location?.search) && location.search.indexOf('__posthog_debug=true') !== -1) || false,
     cookie_expiration: 365,


### PR DESCRIPTION
## Changes

Just the docs, I started to do that long ago but there was some missing bits which this PR updates.

To recall, this change all SPA playgrounds to use `capture_pageview: 'history_change'` config to track `pageviews`.

If you can test this locally, that would be great. I've tried them all but it could have some edge cases. 


## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

