### PR TITLE
refactor: Extract event names to constants

### DIFF
--- a/functional_tests/identify.test.ts
+++ b/functional_tests/identify.test.ts
@@ -7,6 +7,7 @@ import { PostHog } from '../src/posthog-core'
 import { logger } from '../src/utils/logger'
 import { uuidv7 } from '../src/uuidv7'
 import { getRequests } from './mock-server'
+import { IDENTIFY_EVENT, SET_EVENT } from '../src/events'
 
 describe('FunctionalTests / Identify', () => {
     let token: string
@@ -25,7 +26,7 @@ describe('FunctionalTests / Identify', () => {
         await waitFor(() =>
             expect(getRequests(token)['/e/']).toContainEqual(
                 expect.objectContaining({
-                    event: '$identify',
+                    event: IDENTIFY_EVENT,
                     properties: expect.objectContaining({
                         distinct_id: 'test-id',
                         $anon_distinct_id: anonymousId,
@@ -47,7 +48,7 @@ describe('FunctionalTests / Identify', () => {
         await waitFor(() =>
             expect(getRequests(token)['/e/']).toContainEqual(
                 expect.objectContaining({
-                    event: '$identify',
+                    event: IDENTIFY_EVENT,
                     $set: { email: 'first@email.com' },
                     $set_once: expect.objectContaining({
                         location: 'first',
@@ -66,7 +67,7 @@ describe('FunctionalTests / Identify', () => {
         await waitFor(() =>
             expect(getRequests(token)['/e/']).toContainEqual(
                 expect.objectContaining({
-                    event: '$set',
+                    event: SET_EVENT,
                     properties: expect.objectContaining({
                         $browser: 'Safari',
                         $browser_version: null,
@@ -90,7 +91,7 @@ describe('FunctionalTests / Identify', () => {
         await waitFor(() =>
             expect(getRequests(token)['/e/']).toContainEqual(
                 expect.objectContaining({
-                    event: '$identify',
+                    event: IDENTIFY_EVENT,
                     $set: { email: 'first@email.com' },
                     $set_once: expect.objectContaining({
                         location: 'first',
@@ -110,7 +111,7 @@ describe('FunctionalTests / Identify', () => {
         await waitFor(() =>
             expect(getRequests(token)['/e/']).toContainEqual(
                 expect.objectContaining({
-                    event: '$set',
+                    event: SET_EVENT,
                     properties: expect.objectContaining({
                         $browser: 'Safari',
                         $browser_version: null,

--- a/playwright/autocapture-config.spec.ts
+++ b/playwright/autocapture-config.spec.ts
@@ -1,5 +1,6 @@
 import { test } from './utils/posthog-playwright-test-base'
 import { start } from './utils/setup'
+import { PAGEVIEW_EVENT, AUTOCAPTURE_EVENT } from '../src/events'
 
 const startOptions = {
     options: {},
@@ -36,7 +37,7 @@ test.describe('autocapture config', () => {
         await page.locator('[data-cy-input]').fill('hello posthog!')
         // blur the input
         await page.locator('body').click()
-        await page.expectCapturedEventsToBe(['custom-event', '$autocapture'])
+        await page.expectCapturedEventsToBe(['custom-event', AUTOCAPTURE_EVENT])
     })
 
     test('capture clicks when configured to', async ({ page, context }) => {
@@ -50,13 +51,13 @@ test.describe('autocapture config', () => {
         )
 
         await page.locator('[data-cy-custom-event-button]').click()
-        await page.expectCapturedEventsToBe(['$pageview', '$autocapture', 'custom-event'])
+        await page.expectCapturedEventsToBe([PAGEVIEW_EVENT, AUTOCAPTURE_EVENT, 'custom-event'])
 
         await page.locator('[data-cy-input]').fill('hello posthog!')
         // blur the input
         await page.locator('body').click()
         // no change autocapture event
-        await page.expectCapturedEventsToBe(['$pageview', '$autocapture', 'custom-event'])
+        await page.expectCapturedEventsToBe([PAGEVIEW_EVENT, AUTOCAPTURE_EVENT, 'custom-event'])
     })
 
     test('obeys url allowlist', async ({ page, context }) => {
@@ -70,7 +71,7 @@ test.describe('autocapture config', () => {
         )
 
         await page.locator('[data-cy-custom-event-button]').click()
-        await page.expectCapturedEventsToBe(['$pageview', 'custom-event'])
+        await page.expectCapturedEventsToBe([PAGEVIEW_EVENT, 'custom-event'])
 
         await page.resetCapturedEvents()
         await start(
@@ -83,7 +84,7 @@ test.describe('autocapture config', () => {
         )
 
         await page.locator('[data-cy-custom-event-button]').click()
-        await page.expectCapturedEventsToBe(['$pageview', '$autocapture', 'custom-event'])
+        await page.expectCapturedEventsToBe([PAGEVIEW_EVENT, AUTOCAPTURE_EVENT, 'custom-event'])
     })
 
     test('obeys element allowlist', async ({ page, context }) => {
@@ -97,7 +98,7 @@ test.describe('autocapture config', () => {
         )
 
         await page.locator('[data-cy-custom-event-button]').click()
-        await page.expectCapturedEventsToBe(['$pageview', '$autocapture', 'custom-event'])
+        await page.expectCapturedEventsToBe([PAGEVIEW_EVENT, AUTOCAPTURE_EVENT, 'custom-event'])
 
         await page.resetCapturedEvents()
         await start(
@@ -110,7 +111,7 @@ test.describe('autocapture config', () => {
         )
 
         await page.locator('[data-cy-custom-event-button]').click()
-        await page.expectCapturedEventsToBe(['$pageview', 'custom-event'])
+        await page.expectCapturedEventsToBe([PAGEVIEW_EVENT, 'custom-event'])
     })
 
     test('obeys css selector allowlist', async ({ page, context }) => {
@@ -127,7 +128,7 @@ test.describe('autocapture config', () => {
         )
 
         await page.locator('[data-cy-custom-event-button]').click()
-        await page.expectCapturedEventsToBe(['$pageview', '$autocapture', 'custom-event'])
+        await page.expectCapturedEventsToBe([PAGEVIEW_EVENT, AUTOCAPTURE_EVENT, 'custom-event'])
 
         await page.resetCapturedEvents()
         await start(
@@ -140,6 +141,6 @@ test.describe('autocapture config', () => {
         )
 
         await page.locator('[data-cy-custom-event-button]').click()
-        await page.expectCapturedEventsToBe(['$pageview', 'custom-event'])
+        await page.expectCapturedEventsToBe([PAGEVIEW_EVENT, 'custom-event'])
     })
 })

--- a/playwright/before_send.spec.ts
+++ b/playwright/before_send.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, WindowWithPostHog } from './utils/posthog-playwright-test-base'
 import { start } from './utils/setup'
 import { BeforeSendFn } from '../src/types'
+import { PAGEVIEW_EVENT, AUTOCAPTURE_EVENT } from '../src/events'
 
 const startOptions = {
     options: {
@@ -38,18 +39,20 @@ test.describe('before_send', () => {
                         return null
                     }
 
+                    if (cr.event === AUTOCAPTURE_EVENT) {
+                        return {
+                            ...cr,
+                            event: 'redacted',
+                        }
+                    }
+
                     if (cr.event === 'custom-event') {
                         counter++
                         if (counter === 2) {
                             return null
                         }
                     }
-                    if (cr.event === '$autocapture') {
-                        return {
-                            ...cr,
-                            event: 'redacted',
-                        }
-                    }
+
                     return cr
                 },
                 // these tests rely on existing before_send function to capture events
@@ -65,7 +68,7 @@ test.describe('before_send', () => {
 
         expect(captures).toEqual([
             // before adding the new before sendfn
-            '$pageview',
+            PAGEVIEW_EVENT,
             'redacted',
             'custom-event',
             // second button click only has the redacted autocapture event

--- a/playwright/before_send.spec.ts
+++ b/playwright/before_send.spec.ts
@@ -39,17 +39,17 @@ test.describe('before_send', () => {
                         return null
                     }
 
-                    if (cr.event === AUTOCAPTURE_EVENT) {
-                        return {
-                            ...cr,
-                            event: 'redacted',
-                        }
-                    }
-
                     if (cr.event === 'custom-event') {
                         counter++
                         if (counter === 2) {
                             return null
+                        }
+                    }
+
+                    if (cr.event === AUTOCAPTURE_EVENT) {
+                        return {
+                            ...cr,
+                            event: 'redacted',
                         }
                     }
 

--- a/playwright/dead-clicks.spec.ts
+++ b/playwright/dead-clicks.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from './utils/posthog-playwright-test-base'
 import { start } from './utils/setup'
 import { pollUntilEventCaptured } from './utils/event-capture-utils'
+import { DEAD_CLICK_EVENT } from '../src/events'
 
 const startOptions = {
     options: {
@@ -15,9 +16,9 @@ test.describe('Dead clicks', () => {
 
         await page.locator('[data-cy-not-an-order-button]').click()
 
-        await pollUntilEventCaptured(page, '$dead_click')
+        await pollUntilEventCaptured(page, DEAD_CLICK_EVENT)
 
-        const deadClicks = (await page.capturedEvents()).filter((event) => event.event === '$dead_click')
+        const deadClicks = (await page.capturedEvents()).filter((event) => event.event === DEAD_CLICK_EVENT)
         expect(deadClicks.length).toBe(1)
         const deadClick = deadClicks[0]
 

--- a/playwright/error-tracking.spec.ts
+++ b/playwright/error-tracking.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from './utils/posthog-playwright-test-base'
 import { start } from './utils/setup'
 import { pollUntilEventCaptured } from './utils/event-capture-utils'
+import { PAGEVIEW_EVENT, AUTOCAPTURE_EVENT, EXCEPTION_EVENT } from '../src/events'
 
 test.describe('Exception capture', () => {
     test.describe('Exception autocapture enabled', () => {
@@ -15,11 +16,11 @@ test.describe('Exception capture', () => {
         test('manual exception capture of error', async ({ page }) => {
             await page.click('[data-cy-exception-button]')
 
-            await pollUntilEventCaptured(page, '$exception')
+            await pollUntilEventCaptured(page, EXCEPTION_EVENT)
 
             const captures = await page.capturedEvents()
-            expect(captures.map((c) => c.event)).toEqual(['$pageview', '$autocapture', '$exception'])
-            expect(captures[2].event).toEqual('$exception')
+            expect(captures.map((c) => c.event)).toEqual([PAGEVIEW_EVENT, AUTOCAPTURE_EVENT, EXCEPTION_EVENT])
+            expect(captures[2].event).toEqual(EXCEPTION_EVENT)
             expect(captures[2].properties.extra_prop).toEqual(2)
             expect(captures[2].properties.$exception_source).toBeUndefined()
             expect(captures[2].properties.$exception_personURL).toBeUndefined()
@@ -30,11 +31,11 @@ test.describe('Exception capture', () => {
         test('manual exception capture of string', async ({ page }) => {
             await page.click('[data-cy-exception-string-button]')
 
-            await pollUntilEventCaptured(page, '$exception')
+            await pollUntilEventCaptured(page, EXCEPTION_EVENT)
 
             const captures = await page.capturedEvents()
-            expect(captures.map((c) => c.event)).toEqual(['$pageview', '$autocapture', '$exception'])
-            expect(captures[2].event).toEqual('$exception')
+            expect(captures.map((c) => c.event)).toEqual([PAGEVIEW_EVENT, AUTOCAPTURE_EVENT, EXCEPTION_EVENT])
+            expect(captures[2].event).toEqual(EXCEPTION_EVENT)
             expect(captures[2].properties.extra_prop).toEqual(2)
             expect(captures[2].properties.$exception_source).toBeUndefined()
             expect(captures[2].properties.$exception_personURL).toBeUndefined()
@@ -63,11 +64,11 @@ test.describe('Exception capture', () => {
         test('adds stacktrace to captured strings', async ({ page, browserName }) => {
             await page.click('[data-cy-exception-string-button]')
 
-            await pollUntilEventCaptured(page, '$exception')
+            await pollUntilEventCaptured(page, EXCEPTION_EVENT)
 
             const captures = await page.capturedEvents()
-            expect(captures.map((c) => c.event)).toEqual(['$pageview', '$autocapture', '$exception'])
-            expect(captures[2].event).toEqual('$exception')
+            expect(captures.map((c) => c.event)).toEqual([PAGEVIEW_EVENT, AUTOCAPTURE_EVENT, EXCEPTION_EVENT])
+            expect(captures[2].event).toEqual(EXCEPTION_EVENT)
             expect(captures[2].properties.$exception_list[0].stacktrace.type).toEqual('raw')
             expect(captures[2].properties.$exception_list[0].stacktrace.frames.length).toEqual(1)
             expect(captures[2].properties.$exception_list[0].stacktrace.frames[0].function).toEqual(

--- a/playwright/identify.spec.ts
+++ b/playwright/identify.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, WindowWithPostHog } from './utils/posthog-playwright-test-base'
 import { start } from './utils/setup'
+import { IDENTIFY_EVENT, PAGEVIEW_EVENT } from '../src/events'
 
 test.describe('Identify', () => {
     test.beforeEach(async ({ page, context }) => {
@@ -49,15 +50,15 @@ test.describe('Identify', () => {
         })
         const capturedEvents = await page.capturedEvents()
         const eventsSeen = capturedEvents.map((e) => e.event)
-        expect(eventsSeen.filter((e) => e === '$identify').length).toEqual(2)
+        expect(eventsSeen.filter((e) => e === IDENTIFY_EVENT).length).toEqual(2)
         expect(eventsSeen).toEqual([
-            '$pageview',
+            PAGEVIEW_EVENT,
             'an-anonymous-event',
-            '$identify',
+            IDENTIFY_EVENT,
             'an-identified-event',
             'another-identified-event',
             'an-anonymous-event',
-            '$identify',
+            IDENTIFY_EVENT,
             'an-identified-event',
         ])
         expect(new Set(capturedEvents.map((e) => e.properties['$device_id'])).size).toEqual(1)

--- a/playwright/opting-out.spec.ts
+++ b/playwright/opting-out.spec.ts
@@ -1,5 +1,6 @@
 import { test, WindowWithPostHog } from './utils/posthog-playwright-test-base'
 import { start, gotoPage } from './utils/setup'
+import { PAGEVIEW_EVENT, AUTOCAPTURE_EVENT, OPT_IN_EVENT } from '../src/events'
 
 test.describe('opting out', () => {
     test.describe('when not initialized', () => {
@@ -54,7 +55,7 @@ test.describe('opting out', () => {
                 ;(window as WindowWithPostHog).posthog?.opt_in_capturing()
             })
 
-            await page.expectCapturedEventsToBe(['$opt_in', '$pageview'])
+            await page.expectCapturedEventsToBe([OPT_IN_EVENT, PAGEVIEW_EVENT])
         })
 
         test('does not send a duplicate $pageview event when opting in', async ({ page, context }) => {
@@ -73,13 +74,13 @@ test.describe('opting out', () => {
                 context
             )
 
-            await page.expectCapturedEventsToBe(['$pageview'])
+            await page.expectCapturedEventsToBe([PAGEVIEW_EVENT])
 
             await page.evaluate(() => {
                 ;(window as WindowWithPostHog).posthog?.opt_in_capturing()
             })
 
-            await page.expectCapturedEventsToBe(['$pageview', '$opt_in'])
+            await page.expectCapturedEventsToBe([PAGEVIEW_EVENT, OPT_IN_EVENT])
         })
     })
 
@@ -96,11 +97,11 @@ test.describe('opting out', () => {
                 context
             )
 
-            await page.expectCapturedEventsToBe(['$pageview'])
+            await page.expectCapturedEventsToBe([PAGEVIEW_EVENT])
 
             await page.click('[data-cy-custom-event-button]')
 
-            await page.expectCapturedEventsToBe(['$pageview', '$autocapture', 'custom-event'])
+            await page.expectCapturedEventsToBe([PAGEVIEW_EVENT, AUTOCAPTURE_EVENT, 'custom-event'])
 
             await page.evaluate(() => {
                 ;(window as WindowWithPostHog).posthog?.opt_out_capturing()
@@ -109,7 +110,7 @@ test.describe('opting out', () => {
             await page.click('[data-cy-custom-event-button]')
 
             // no new events
-            await page.expectCapturedEventsToBe(['$pageview', '$autocapture', 'custom-event'])
+            await page.expectCapturedEventsToBe([PAGEVIEW_EVENT, AUTOCAPTURE_EVENT, 'custom-event'])
         })
     })
 })

--- a/playwright/session-recording/opting-out.spec.ts
+++ b/playwright/session-recording/opting-out.spec.ts
@@ -3,6 +3,7 @@ import { start } from '../utils/setup'
 import { BrowserContext, Page } from '@playwright/test'
 import { PostHogConfig } from '../../src/types'
 import { assertThatRecordingStarted, pollUntilEventCaptured } from '../utils/event-capture-utils'
+import { PAGEVIEW_EVENT, OPT_IN_EVENT, SNAPSHOT_EVENT } from '../../src/events'
 
 async function startWith(config: Partial<PostHogConfig>, page: Page, context: BrowserContext) {
     // there will be a decide call
@@ -50,7 +51,7 @@ test.describe('Session Recording - opting out', () => {
 
         await page.locator('[data-cy-input]').type('hello posthog!')
         await page.waitForTimeout(250) // short delay since there's no snapshot to wait for
-        await page.expectCapturedEventsToBe(['$pageview'])
+        await page.expectCapturedEventsToBe([PAGEVIEW_EVENT])
     })
 
     test('can start recording after starting opted out', async ({ page, context }) => {
@@ -67,12 +68,12 @@ test.describe('Session Recording - opting out', () => {
             },
         })
 
-        await page.expectCapturedEventsToBe(['$opt_in', '$pageview'])
+        await page.expectCapturedEventsToBe([OPT_IN_EVENT, PAGEVIEW_EVENT])
 
         await page.resetCapturedEvents()
 
         await page.locator('[data-cy-input]').type('hello posthog!')
-        await pollUntilEventCaptured(page, '$snapshot')
+        await pollUntilEventCaptured(page, SNAPSHOT_EVENT)
         await assertThatRecordingStarted(page)
     })
 
@@ -91,7 +92,7 @@ test.describe('Session Recording - opting out', () => {
         })
 
         await page.locator('[data-cy-input]').type('hello posthog!')
-        await pollUntilEventCaptured(page, '$snapshot')
+        await pollUntilEventCaptured(page, SNAPSHOT_EVENT)
         await assertThatRecordingStarted(page)
     })
 
@@ -121,6 +122,6 @@ test.describe('Session Recording - opting out', () => {
 
         const capturedEvents = await page.capturedEvents()
         // no snapshot events sent
-        expect(capturedEvents.map((x) => x.event)).toEqual(['$pageview', 'custom-event'])
+        expect(capturedEvents.map((x) => x.event)).toEqual([PAGEVIEW_EVENT, 'custom-event'])
     })
 })

--- a/playwright/session-recording/session-recording-array-full.spec.ts
+++ b/playwright/session-recording/session-recording-array-full.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, WindowWithPostHog } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
+import { PAGEVIEW_EVENT, SNAPSHOT_EVENT } from '../../src/events'
 
 const startOptions = {
     options: {
@@ -31,7 +32,7 @@ test.describe('session recording in array.full.js', () => {
             ph?.capture('test_registered_property')
         })
 
-        await page.expectCapturedEventsToBe(['$pageview', '$snapshot', 'test_registered_property'])
+        await page.expectCapturedEventsToBe([PAGEVIEW_EVENT, SNAPSHOT_EVENT, 'test_registered_property'])
         const capturedEvents = await page.capturedEvents()
 
         // don't care about network payloads here

--- a/playwright/session-recording/session-recording-ingestion-controls.spec.ts
+++ b/playwright/session-recording/session-recording-ingestion-controls.spec.ts
@@ -1,6 +1,7 @@
 import { test, WindowWithPostHog } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
 import { assertThatRecordingStarted, pollUntilEventCaptured } from '../utils/event-capture-utils'
+import { PAGEVIEW_EVENT, OPT_IN_EVENT, SNAPSHOT_EVENT } from '../../src/events'
 
 const startOptions = {
     options: {
@@ -41,7 +42,7 @@ test.describe('Session recording - multiple ingestion controls', () => {
             },
         })
 
-        await page.expectCapturedEventsToBe(['$opt_in', '$pageview'])
+        await page.expectCapturedEventsToBe([OPT_IN_EVENT, PAGEVIEW_EVENT])
 
         await page.evaluate(() => {
             const ph = (window as WindowWithPostHog).posthog
@@ -51,7 +52,7 @@ test.describe('Session recording - multiple ingestion controls', () => {
         // there's nothing to wait for... so, just wait a bit
         await page.waitForTimeout(250)
         // no new events
-        await page.expectCapturedEventsToBe(['$opt_in', '$pageview'])
+        await page.expectCapturedEventsToBe([OPT_IN_EVENT, PAGEVIEW_EVENT])
         await page.resetCapturedEvents()
 
         await page.evaluate(() => {
@@ -60,7 +61,7 @@ test.describe('Session recording - multiple ingestion controls', () => {
             ph?.startSessionRecording(true)
         })
         await page.locator('[data-cy-input]').type('hello posthog!')
-        await pollUntilEventCaptured(page, '$snapshot')
+        await pollUntilEventCaptured(page, SNAPSHOT_EVENT)
         await assertThatRecordingStarted(page)
     })
 })

--- a/playwright/session-recording/session-recording-linked-flags.spec.ts
+++ b/playwright/session-recording/session-recording-linked-flags.spec.ts
@@ -1,6 +1,7 @@
 import { test, WindowWithPostHog } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
 import { assertThatRecordingStarted, pollUntilEventCaptured } from '../utils/event-capture-utils'
+import { PAGEVIEW_EVENT, OPT_IN_EVENT, SNAPSHOT_EVENT } from '../../src/events'
 
 const startOptions = {
     options: {
@@ -38,7 +39,7 @@ test.describe('Session recording - linked flags', () => {
                 })
             },
         })
-        await page.expectCapturedEventsToBe(['$opt_in', '$pageview'])
+        await page.expectCapturedEventsToBe([OPT_IN_EVENT, PAGEVIEW_EVENT])
 
         await page.resetCapturedEvents()
 
@@ -47,7 +48,7 @@ test.describe('Session recording - linked flags', () => {
             ph?.startSessionRecording({ linked_flag: true })
         })
         await page.locator('[data-cy-input]').type('hello posthog!')
-        await pollUntilEventCaptured(page, '$snapshot')
+        await pollUntilEventCaptured(page, SNAPSHOT_EVENT)
         await assertThatRecordingStarted(page)
     })
 })

--- a/playwright/session-recording/session-recording-masking.spec.ts
+++ b/playwright/session-recording/session-recording-masking.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
 import { Page } from '@playwright/test'
 import { CaptureResult } from '../../src/types'
+import { SNAPSHOT_EVENT } from '../../src/events'
 
 // Local config not set
 // decide comes back - says we shouldn't mask
@@ -33,7 +34,7 @@ async function interactWithThePage(page: Page) {
     await page.waitForTimeout(2500)
     // no new events
     const events = await page.capturedEvents()
-    const snapshotEvents = events.filter((e) => e.event === '$snapshot')
+    const snapshotEvents = events.filter((e) => e.event === SNAPSHOT_EVENT)
     expect(snapshotEvents.length).toBeGreaterThan(0)
     return snapshotEvents
 }

--- a/playwright/session-recording/session-recording-network-recorder.spec.ts
+++ b/playwright/session-recording/session-recording-network-recorder.spec.ts
@@ -1,3 +1,4 @@
+import { SNAPSHOT_EVENT } from '../../src/events'
 import { test, expect } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
 import { Page } from '@playwright/test'
@@ -112,7 +113,7 @@ test.beforeEach(async ({ context }) => {
                     },
                 })
                 const capturedEvents = await page.capturedEvents()
-                const snapshots = capturedEvents.filter((c) => c.event === '$snapshot')
+                const snapshots = capturedEvents.filter((c) => c.event === SNAPSHOT_EVENT)
 
                 const capturedRequests: Record<string, any>[] = []
                 for (const snapshot of snapshots) {

--- a/playwright/session-recording/session-recording-sampling.spec.ts
+++ b/playwright/session-recording/session-recording-sampling.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, WindowWithPostHog } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
+import { PAGEVIEW_EVENT, SNAPSHOT_EVENT } from '../../src/events'
 
 const startOptions = {
     options: {
@@ -34,7 +35,7 @@ test.describe('Session recording - sampling', () => {
             },
         })
 
-        await page.expectCapturedEventsToBe(['$pageview'])
+        await page.expectCapturedEventsToBe([PAGEVIEW_EVENT])
         await page.resetCapturedEvents()
     })
 
@@ -83,6 +84,6 @@ test.describe('Session recording - sampling', () => {
 
         const afterReloadCapturedEvents = await page.capturedEvents()
         const lastCaptured = afterReloadCapturedEvents[afterReloadCapturedEvents.length - 1]
-        expect(lastCaptured['event']).toEqual('$snapshot')
+        expect(lastCaptured['event']).toEqual(SNAPSHOT_EVENT)
     })
 })

--- a/playwright/surveys/customization.spec.ts
+++ b/playwright/surveys/customization.spec.ts
@@ -1,6 +1,7 @@
 import { pollUntilEventCaptured } from '../utils/event-capture-utils'
 import { expect, test } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
+import { SURVEY_SENT_EVENT } from '../../src/events'
 
 const startOptions = {
     options: {},
@@ -97,7 +98,7 @@ test.describe('surveys - customization', () => {
 
         await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
 
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
     })
 
     test('does not show posthog logo if whiteLabel exists', async ({ page, context }) => {
@@ -223,7 +224,7 @@ test.describe('surveys - customization', () => {
         await expect(page.locator('.PostHogSurvey-123').locator('.thank-you-message-body h3')).toHaveText(
             'html thank you message!'
         )
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
     })
 
     test('does not render html customization for question descriptions if the question.survey-question-descriptionContentType does not permit it', async ({
@@ -300,6 +301,6 @@ test.describe('surveys - customization', () => {
         await expect(page.locator('.PostHogSurvey-123').locator('.thank-you-message-body')).toHaveText(
             '<h3>html thank you message!</h3>'
         )
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
     })
 })

--- a/playwright/surveys/feedback-widget.spec.ts
+++ b/playwright/surveys/feedback-widget.spec.ts
@@ -2,6 +2,7 @@ import { SurveySchedule } from '../../src/posthog-surveys-types'
 import { pollUntilEventCaptured } from '../utils/event-capture-utils'
 import { expect, test } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
+import { SURVEY_SHOWN_EVENT, SURVEY_SENT_EVENT, SURVEY_DISMISSED_EVENT } from '../../src/events'
 
 const startOptions = {
     options: {},
@@ -87,7 +88,7 @@ test.describe('surveys - feedback widget', () => {
 
         await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('textarea').fill('hello posthog!')
         await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('.form-submit').click()
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
     })
 
     test('displays feedback tab in a responsive manner ', async ({ page, context }) => {
@@ -171,7 +172,7 @@ test.describe('surveys - feedback widget', () => {
 
         await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('textarea').fill('hello posthog!')
         await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('.form-submit').click()
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
     })
 
     test('displays multiple question surveys and thank you confirmation if enabled', async ({ page, context }) => {
@@ -209,8 +210,8 @@ test.describe('surveys - feedback widget', () => {
         await page.locator('.PostHogSurvey-123 .form-submit').click()
         await page.locator('.PostHogSurvey-123 .form-submit').click()
 
-        await pollUntilEventCaptured(page, 'survey shown')
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SHOWN_EVENT)
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
     })
 
     test('auto contrasts text color for feedback tab', async ({ page, context }) => {
@@ -295,7 +296,7 @@ test.describe('surveys - feedback widget', () => {
         await expect(page.locator('.PostHogSurvey-123').locator('.thank-you-message-header')).toHaveText('Thank you!')
 
         // Verify the event was sent
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
 
         // 5. Close the thank you message and click the survey tab again
         await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
@@ -315,7 +316,7 @@ test.describe('surveys - feedback widget', () => {
         await expect(page.locator('.PostHogSurvey-123').locator('.thank-you-message-header')).toBeVisible()
 
         // Verify second event was sent
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
     })
 
     test('if multiple surveys being shown, sending one of them does not close the other one', async ({
@@ -372,7 +373,7 @@ test.describe('surveys - feedback widget', () => {
         await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('textarea').fill('first submission')
         await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('.form-submit').click()
 
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
 
         // click on the first survey confirmation message
         await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
@@ -432,7 +433,7 @@ test.describe('surveys - feedback widget', () => {
         // close first survey
         await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('.form-cancel').click()
 
-        await pollUntilEventCaptured(page, 'survey dismissed')
+        await pollUntilEventCaptured(page, SURVEY_DISMISSED_EVENT)
 
         // check if the second survey is still visible
         await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).not.toBeVisible()

--- a/playwright/surveys/question-types.spec.ts
+++ b/playwright/surveys/question-types.spec.ts
@@ -2,6 +2,13 @@ import { getSurveyResponseKey } from '../../src/extensions/surveys/surveys-exten
 import { pollUntilEventCaptured } from '../utils/event-capture-utils'
 import { expect, test } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
+import {
+    PAGEVIEW_EVENT,
+    AUTOCAPTURE_EVENT,
+    SURVEY_SHOWN_EVENT,
+    SURVEY_SENT_EVENT,
+    RAGECLICK_EVENT,
+} from '../../src/events'
 
 const startOptions = {
     options: {},
@@ -76,7 +83,7 @@ test.describe('surveys - core display logic', () => {
         await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('textarea').type('Great job!')
         await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
 
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
     })
 
     test('rating questions that are on the 10 scale start at 0', async ({ page, context }) => {
@@ -152,21 +159,21 @@ test.describe('surveys - core display logic', () => {
         await page.locator('.PostHogSurvey-12345').locator('.form-submit').click()
         await expect(page.locator('.PostHogSurvey-12345').locator('.thank-you-message')).not.toBeVisible()
 
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
         const captures = await page.capturedEvents()
         expect(captures.map((c) => c.event)).toEqual([
-            '$pageview',
-            'survey shown',
-            '$autocapture',
-            '$autocapture',
-            '$autocapture',
-            '$autocapture',
-            '$rageclick',
-            '$autocapture',
-            'survey sent',
-            '$autocapture',
+            PAGEVIEW_EVENT,
+            SURVEY_SHOWN_EVENT,
+            AUTOCAPTURE_EVENT,
+            AUTOCAPTURE_EVENT,
+            AUTOCAPTURE_EVENT,
+            AUTOCAPTURE_EVENT,
+            RAGECLICK_EVENT,
+            AUTOCAPTURE_EVENT,
+            SURVEY_SENT_EVENT,
+            AUTOCAPTURE_EVENT,
         ])
-        const surveySent = captures.find((c) => c.event === 'survey sent')
+        const surveySent = captures.find((c) => c.event === SURVEY_SENT_EVENT)
         expect(surveySent!.properties[getSurveyResponseKey('multiple_choice_1')]).toEqual(['Product Updates', 'Events'])
         expect(surveySent!.properties['$survey_id']).toEqual('12345')
         expect(surveySent!.properties[getSurveyResponseKey('open_text_1')]).toEqual('Great job!')
@@ -216,17 +223,17 @@ test.describe('surveys - core display logic', () => {
         await page.locator('.PostHogSurvey-12345').locator('input[type=text]').type('Newsletters')
         await page.locator('.PostHogSurvey-12345').locator('.form-submit').click()
 
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
         const captures = await page.capturedEvents()
         expect(captures.map((c) => c.event)).toEqual([
-            '$pageview',
-            'survey shown',
-            '$autocapture',
-            '$autocapture',
-            '$autocapture',
-            'survey sent',
+            PAGEVIEW_EVENT,
+            SURVEY_SHOWN_EVENT,
+            AUTOCAPTURE_EVENT,
+            AUTOCAPTURE_EVENT,
+            AUTOCAPTURE_EVENT,
+            SURVEY_SENT_EVENT,
         ])
-        const surveySent = captures.find((c) => c.event === 'survey sent')
+        const surveySent = captures.find((c) => c.event === SURVEY_SENT_EVENT)
         expect(surveySent!.properties[getSurveyResponseKey('multiple_choice_1')]).toEqual(['Tutorials', 'Newsletters'])
         expect(surveySent!.properties['$survey_questions']).toEqual([
             {
@@ -269,17 +276,17 @@ test.describe('surveys - core display logic', () => {
 
         await page.locator('.PostHogSurvey-12345').locator('.form-submit').click()
 
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
         const captures = await page.capturedEvents()
         expect(captures.map((c) => c.event)).toEqual([
-            '$pageview',
-            'survey shown',
-            '$autocapture',
-            '$autocapture',
-            '$autocapture',
-            'survey sent',
+            PAGEVIEW_EVENT,
+            SURVEY_SHOWN_EVENT,
+            AUTOCAPTURE_EVENT,
+            AUTOCAPTURE_EVENT,
+            AUTOCAPTURE_EVENT,
+            SURVEY_SENT_EVENT,
         ])
-        const surveySent = captures.find((c) => c.event === 'survey sent')
+        const surveySent = captures.find((c) => c.event === SURVEY_SENT_EVENT)
         expect(surveySent!.properties[getSurveyResponseKey('single_choice_1')]).toEqual('Product engineer')
         expect(surveySent!.properties['$survey_questions']).toEqual([
             {

--- a/playwright/surveys/response-capture.spec.ts
+++ b/playwright/surveys/response-capture.spec.ts
@@ -2,6 +2,7 @@ import { getSurveyResponseKey } from '../../src/extensions/surveys/surveys-exten
 import { pollUntilEventCaptured } from '../utils/event-capture-utils'
 import { expect, test } from '../utils/posthog-playwright-test-base'
 import { start } from '../utils/setup'
+import { SURVEY_DISMISSED_EVENT, SURVEY_SENT_EVENT, SURVEY_SHOWN_EVENT } from '../../src/events'
 
 const startOptions = {
     options: {},
@@ -39,15 +40,15 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await pollUntilEventCaptured(page, 'survey shown')
+        await pollUntilEventCaptured(page, SURVEY_SHOWN_EVENT)
 
         await page.locator('.PostHogSurvey-123 textarea').type('experiments is awesome!')
         await page.locator('.PostHogSurvey-123 .form-submit').click()
 
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
         const surveySentEvent = await page
             .capturedEvents()
-            .then((events) => events.find((e) => e.event === 'survey sent'))
+            .then((events) => events.find((e) => e.event === SURVEY_SENT_EVENT))
         expect(surveySentEvent!.properties).toEqual(
             expect.objectContaining({
                 $survey_id: '123',
@@ -85,10 +86,10 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await pollUntilEventCaptured(page, 'survey shown')
+        await pollUntilEventCaptured(page, SURVEY_SHOWN_EVENT)
         const surveyShownEvent = await page
             .capturedEvents()
-            .then((events) => events.find((e) => e.event === 'survey shown'))
+            .then((events) => events.find((e) => e.event === SURVEY_SHOWN_EVENT))
         expect(surveyShownEvent!.properties).toEqual(
             expect.objectContaining({
                 $survey_id: '123',
@@ -100,10 +101,10 @@ test.describe('surveys - feedback widget', () => {
         await page.locator('.PostHogSurvey-123 textarea').type('experiments is awesome!')
         await page.locator('.PostHogSurvey-123 .form-submit').click()
 
-        await pollUntilEventCaptured(page, 'survey sent')
+        await pollUntilEventCaptured(page, SURVEY_SENT_EVENT)
         const surveySentEvent = await page
             .capturedEvents()
-            .then((events) => events.find((e) => e.event === 'survey sent'))
+            .then((events) => events.find((e) => e.event === SURVEY_SENT_EVENT))
         expect(surveySentEvent!.properties).toEqual(
             expect.objectContaining({
                 $survey_id: '123',
@@ -142,7 +143,7 @@ test.describe('surveys - feedback widget', () => {
         await surveysAPICall
 
         await page.locator('.PostHogSurvey-123 .cancel-btn-wrapper').click()
-        await pollUntilEventCaptured(page, 'survey dismissed')
+        await pollUntilEventCaptured(page, SURVEY_DISMISSED_EVENT)
     })
 
     test('captures survey dismissed event with iteration', async ({ page, context }) => {
@@ -168,10 +169,10 @@ test.describe('surveys - feedback widget', () => {
         await surveysAPICall
 
         await page.locator('.PostHogSurvey-123 .cancel-btn-wrapper').click()
-        await pollUntilEventCaptured(page, 'survey dismissed')
+        await pollUntilEventCaptured(page, SURVEY_DISMISSED_EVENT)
         const surveyDismissedEvent = await page
             .capturedEvents()
-            .then((events) => events.find((e) => e.event === 'survey dismissed'))
+            .then((events) => events.find((e) => e.event === SURVEY_DISMISSED_EVENT))
         expect(surveyDismissedEvent!.properties).toEqual(
             expect.objectContaining({
                 $survey_id: '123',

--- a/playwright/utils/event-capture-utils.ts
+++ b/playwright/utils/event-capture-utils.ts
@@ -1,6 +1,7 @@
 import { Page } from '@playwright/test'
 import { EventName } from '../../src/types'
 import { expect } from './posthog-playwright-test-base'
+import { SNAPSHOT_EVENT } from '../../src/events'
 
 export async function pollUntilEventCaptured(
     page: Page,
@@ -23,7 +24,7 @@ export async function pollUntilEventCaptured(
 export async function assertThatRecordingStarted(page: Page) {
     const captures = await page.capturedEvents()
 
-    expect(captures.map((c) => c.event)).toEqual(['$snapshot'])
+    expect(captures.map((c) => c.event)).toEqual([SNAPSHOT_EVENT])
     const capturedSnapshot = captures[0]
 
     expect(capturedSnapshot).toBeDefined()

--- a/playwright/web-vitals.spec.ts
+++ b/playwright/web-vitals.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from './utils/posthog-playwright-test-base'
 import { start } from './utils/setup'
 import { pollUntilEventCaptured } from './utils/event-capture-utils'
+import { WEB_VITALS_EVENT } from '../src/events'
 
 const startOptions = {
     options: {
@@ -19,9 +20,9 @@ test.describe('Web Vitals', () => {
         await start(startOptions, page, context)
 
         // Wait for web vitals events to be captured
-        await pollUntilEventCaptured(page, '$web_vitals')
+        await pollUntilEventCaptured(page, WEB_VITALS_EVENT)
 
-        const webVitalsEvents = (await page.capturedEvents()).filter((event) => event.event === '$web_vitals')
+        const webVitalsEvents = (await page.capturedEvents()).filter((event) => event.event === WEB_VITALS_EVENT)
         expect(webVitalsEvents.length).toBeGreaterThan(0)
 
         const webVitalsEvent = webVitalsEvents[0]
@@ -60,7 +61,7 @@ test.describe('Web Vitals', () => {
         // Wait a bit to ensure no web vitals events are captured
         await page.waitForTimeout(5000)
 
-        const webVitalsEvents = (await page.capturedEvents()).filter((event) => event.event === '$web_vitals')
+        const webVitalsEvents = (await page.capturedEvents()).filter((event) => event.event === WEB_VITALS_EVENT)
         expect(webVitalsEvents.length).toBe(0)
     })
 })

--- a/react/src/components/PostHogFeature.tsx
+++ b/react/src/components/PostHogFeature.tsx
@@ -2,6 +2,7 @@ import { useFeatureFlagPayload, useFeatureFlagVariantKey, usePostHog } from '../
 import React, { Children, ReactNode, useCallback, useEffect, useRef } from 'react'
 import { PostHog } from '../context'
 import { isFunction, isNull, isUndefined } from '../utils/type-utils'
+import { FEATURE_INTERACTION, FEATURE_VIEW } from '../utils/event-utils'
 
 export type PostHogFeatureProps = React.HTMLProps<HTMLDivElement> & {
     flag: string
@@ -57,12 +58,12 @@ function captureFeatureInteraction({
 }) {
     const properties: Record<string, any> = {
         feature_flag: flag,
-        $set: { [`$feature_interaction/${flag}`]: flagVariant ?? true },
+        $set: { [`${FEATURE_INTERACTION}/${flag}`]: flagVariant ?? true },
     }
     if (typeof flagVariant === 'string') {
         properties.feature_flag_variant = flagVariant
     }
-    posthog.capture('$feature_interaction', properties)
+    posthog.capture(FEATURE_INTERACTION, properties)
 }
 
 function captureFeatureView({
@@ -76,12 +77,12 @@ function captureFeatureView({
 }) {
     const properties: Record<string, any> = {
         feature_flag: flag,
-        $set: { [`$feature_view/${flag}`]: flagVariant ?? true },
+        $set: { [`${FEATURE_VIEW}/${flag}`]: flagVariant ?? true },
     }
     if (typeof flagVariant === 'string') {
         properties.feature_flag_variant = flagVariant
     }
-    posthog.capture('$feature_view', properties)
+    posthog.capture(FEATURE_VIEW, properties)
 }
 
 function VisibilityAndClickTracker({

--- a/react/src/components/__tests__/PostHogFeature.test.jsx
+++ b/react/src/components/__tests__/PostHogFeature.test.jsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { PostHogProvider } from '../../context'
 import { PostHogFeature } from '../'
 import '@testing-library/jest-dom'
+import { FEATURE_INTERACTION, FEATURE_VIEW } from '../../utils/event-utils'
 
 const FEATURE_FLAG_STATUS = {
     multivariate_feature: 'string-value',
@@ -68,9 +69,9 @@ describe('PostHogFeature component', () => {
         given.render()
 
         fireEvent.click(screen.getByTestId('helloDiv'))
-        expect(given.posthog.capture).toHaveBeenCalledWith('$feature_interaction', {
+        expect(given.posthog.capture).toHaveBeenCalledWith(FEATURE_INTERACTION, {
             feature_flag: 'test',
-            $set: { '$feature_interaction/test': true },
+            $set: { [`${FEATURE_INTERACTION}/test`]: true },
         })
         expect(given.posthog.capture).toHaveBeenCalledTimes(1)
     })
@@ -79,9 +80,9 @@ describe('PostHogFeature component', () => {
         given.render()
 
         fireEvent.click(screen.getByTestId('helloDiv'))
-        expect(given.posthog.capture).toHaveBeenCalledWith('$feature_interaction', {
+        expect(given.posthog.capture).toHaveBeenCalledWith(FEATURE_INTERACTION, {
             feature_flag: 'test',
-            $set: { '$feature_interaction/test': true },
+            $set: { [`${FEATURE_INTERACTION}/test`]: true },
         })
         expect(given.posthog.capture).toHaveBeenCalledTimes(1)
 
@@ -111,9 +112,9 @@ describe('PostHogFeature component', () => {
         fireEvent.click(screen.getByTestId('worldDiv'))
         fireEvent.click(screen.getByTestId('worldDiv'))
         fireEvent.click(screen.getByTestId('worldDiv'))
-        expect(given.posthog.capture).toHaveBeenCalledWith('$feature_interaction', {
+        expect(given.posthog.capture).toHaveBeenCalledWith(FEATURE_INTERACTION, {
             feature_flag: 'test',
-            $set: { '$feature_interaction/test': true },
+            $set: { [`${FEATURE_INTERACTION}/test`]: true },
         })
         expect(given.posthog.capture).toHaveBeenCalledTimes(1)
     })
@@ -183,9 +184,9 @@ describe('PostHogFeature component', () => {
         fireEvent.click(screen.getByTestId('clicker'))
         fireEvent.click(screen.getByTestId('helloDiv'))
         fireEvent.click(screen.getByTestId('helloDiv'))
-        expect(given.posthog.capture).toHaveBeenCalledWith('$feature_interaction', {
+        expect(given.posthog.capture).toHaveBeenCalledWith(FEATURE_INTERACTION, {
             feature_flag: 'test',
-            $set: { '$feature_interaction/test': true },
+            $set: { [`${FEATURE_INTERACTION}/test`]: true },
         })
         expect(given.posthog.capture).toHaveBeenCalledTimes(1)
     })
@@ -262,10 +263,10 @@ describe('PostHogFeature component', () => {
         expect(given.posthog.capture).not.toHaveBeenCalled()
 
         fireEvent.click(screen.getByTestId('helloDiv'))
-        expect(given.posthog.capture).toHaveBeenCalledWith('$feature_interaction', {
+        expect(given.posthog.capture).toHaveBeenCalledWith(FEATURE_INTERACTION, {
             feature_flag: 'multivariate_feature',
             feature_flag_variant: 'string-value',
-            $set: { '$feature_interaction/multivariate_feature': 'string-value' },
+            $set: { [`${FEATURE_INTERACTION}/multivariate_feature`]: 'string-value' },
         })
         expect(given.posthog.capture).toHaveBeenCalledTimes(1)
     })

--- a/react/src/utils/event-utils.ts
+++ b/react/src/utils/event-utils.ts
@@ -1,0 +1,4 @@
+// These are not inside `src/events.ts` because they're only ever used in React
+// therefore it makes sense to keep them here
+export const FEATURE_INTERACTION = '$feature_interaction'
+export const FEATURE_VIEW = '$feature_view'

--- a/src/__tests__/ai.test.ts
+++ b/src/__tests__/ai.test.ts
@@ -1,6 +1,7 @@
 import { defaultPostHog } from './helpers/posthog-instance'
 import type { PostHogConfig } from '../types'
 import { uuidv7 } from '../uuidv7'
+import { AI_FEEDBACK_EVENT, AI_METRIC_EVENT } from '../events'
 
 describe('ai', () => {
     beforeEach(() => {
@@ -21,7 +22,7 @@ describe('ai', () => {
             posthog.captureTraceMetric('123', 'test', 'test')
 
             const { event, properties } = beforeSendMock.mock.calls[0][0]
-            expect(event).toBe('$ai_metric')
+            expect(event).toBe(AI_METRIC_EVENT)
             expect(properties['$ai_trace_id']).toBe('123')
             expect(properties['$ai_metric_name']).toBe('test')
             expect(properties['$ai_metric_value']).toBe('test')
@@ -33,7 +34,7 @@ describe('ai', () => {
             posthog.captureTraceMetric(123, 'test', 1)
 
             const { event, properties } = beforeSendMock.mock.calls[0][0]
-            expect(event).toBe('$ai_metric')
+            expect(event).toBe(AI_METRIC_EVENT)
             expect(properties['$ai_trace_id']).toBe('123')
             expect(properties['$ai_metric_name']).toBe('test')
             expect(properties['$ai_metric_value']).toBe('1')
@@ -45,7 +46,7 @@ describe('ai', () => {
             posthog.captureTraceMetric('test', 'test', false)
 
             const { event, properties } = beforeSendMock.mock.calls[0][0]
-            expect(event).toBe('$ai_metric')
+            expect(event).toBe(AI_METRIC_EVENT)
             expect(properties['$ai_trace_id']).toBe('test')
             expect(properties['$ai_metric_name']).toBe('test')
             expect(properties['$ai_metric_value']).toBe('false')
@@ -59,7 +60,7 @@ describe('ai', () => {
             posthog.captureTraceFeedback('123', 'feedback')
 
             const { event, properties } = beforeSendMock.mock.calls[0][0]
-            expect(event).toBe('$ai_feedback')
+            expect(event).toBe(AI_FEEDBACK_EVENT)
             expect(properties['$ai_trace_id']).toBe('123')
             expect(properties['$ai_feedback_text']).toBe('feedback')
         })
@@ -70,7 +71,7 @@ describe('ai', () => {
             posthog.captureTraceFeedback(123, 'feedback')
 
             const { event, properties } = beforeSendMock.mock.calls[0][0]
-            expect(event).toBe('$ai_feedback')
+            expect(event).toBe(AI_FEEDBACK_EVENT)
             expect(properties['$ai_trace_id']).toBe('123')
             expect(properties['$ai_feedback_text']).toBe('feedback')
         })

--- a/src/__tests__/autocapture.test.ts
+++ b/src/__tests__/autocapture.test.ts
@@ -16,6 +16,7 @@ import { window } from '../utils/globals'
 import { createPosthogInstance } from './helpers/posthog-instance'
 import { uuidv7 } from '../uuidv7'
 import { isUndefined } from '../utils/type-utils'
+import { AUTOCAPTURE_EVENT, COPY_AUTOCAPTURE_EVENT, RAGECLICK_EVENT } from '../events'
 
 // JS DOM doesn't have ClipboardEvent, so we need to mock it
 // see https://github.com/jsdom/jsdom/issues/1568
@@ -401,10 +402,10 @@ describe('Autocapture system', () => {
             autocapture['_captureEvent'](fakeEvent)
 
             expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual([
-                '$autocapture',
-                '$autocapture',
-                '$rageclick',
-                '$autocapture',
+                AUTOCAPTURE_EVENT,
+                AUTOCAPTURE_EVENT,
+                RAGECLICK_EVENT,
+                AUTOCAPTURE_EVENT,
             ])
         })
 
@@ -425,11 +426,11 @@ describe('Autocapture system', () => {
 
                 setWindowTextSelection('copy this test')
 
-                autocapture['_captureEvent'](fakeEvent, '$copy_autocapture')
+                autocapture['_captureEvent'](fakeEvent, COPY_AUTOCAPTURE_EVENT)
 
                 expect(beforeSendMock).toHaveBeenCalledTimes(1)
                 const mockCall = beforeSendMock.mock.calls[0][0]
-                expect(mockCall.event).toEqual('$copy_autocapture')
+                expect(mockCall.event).toEqual(COPY_AUTOCAPTURE_EVENT)
                 expect(mockCall.properties).toHaveProperty('$selected_content', 'copy this test')
                 expect(mockCall.properties).toHaveProperty('$copy_type', 'copy')
             })
@@ -441,11 +442,11 @@ describe('Autocapture system', () => {
 
                 setWindowTextSelection('cut this test')
 
-                autocapture['_captureEvent'](fakeEvent, '$copy_autocapture')
+                autocapture['_captureEvent'](fakeEvent, COPY_AUTOCAPTURE_EVENT)
 
                 const spyArgs = beforeSendMock.mock.calls
                 expect(spyArgs.length).toBe(1)
-                expect(spyArgs[0][0].event).toEqual('$copy_autocapture')
+                expect(spyArgs[0][0].event).toEqual(COPY_AUTOCAPTURE_EVENT)
                 expect(spyArgs[0][0].properties).toHaveProperty('$selected_content', 'cut this test')
                 expect(spyArgs[0][0].properties).toHaveProperty('$copy_type', 'cut')
             })
@@ -457,7 +458,7 @@ describe('Autocapture system', () => {
 
                 setWindowTextSelection('')
 
-                autocapture['_captureEvent'](fakeEvent, '$copy_autocapture')
+                autocapture['_captureEvent'](fakeEvent, COPY_AUTOCAPTURE_EVENT)
 
                 const spyArgs = beforeSendMock.mock.calls
                 expect(spyArgs.length).toBe(0)
@@ -471,7 +472,7 @@ describe('Autocapture system', () => {
                 // oh no, a social security number!
                 setWindowTextSelection('123-45-6789')
 
-                autocapture['_captureEvent'](fakeEvent, '$copy_autocapture')
+                autocapture['_captureEvent'](fakeEvent, COPY_AUTOCAPTURE_EVENT)
 
                 const spyArgs = beforeSendMock.mock.calls
                 expect(spyArgs.length).toBe(0)
@@ -554,7 +555,7 @@ describe('Autocapture system', () => {
             const captureArgs = beforeSendMock.mock.calls[0]
             const event = captureArgs[0].event
             const props = captureArgs[0].properties
-            expect(event).toBe('$autocapture')
+            expect(event).toBe(AUTOCAPTURE_EVENT)
             expect(props['$event_type']).toBe('click')
             expect(props['$elements'][0]).toHaveProperty('attr__href', 'https://test.com')
             expect(props['$elements'][1]).toHaveProperty('tag_name', 'span')
@@ -1012,9 +1013,9 @@ describe('Autocapture system', () => {
             simulateClick(button)
             simulateClick(button)
             expect(beforeSendMock).toHaveBeenCalledTimes(2)
-            expect(beforeSendMock.mock.calls[0][0].event).toBe('$autocapture')
+            expect(beforeSendMock.mock.calls[0][0].event).toBe(AUTOCAPTURE_EVENT)
             expect(beforeSendMock.mock.calls[0][0].properties['$event_type']).toBe('click')
-            expect(beforeSendMock.mock.calls[1][0].event).toBe('$autocapture')
+            expect(beforeSendMock.mock.calls[1][0].event).toBe(AUTOCAPTURE_EVENT)
             expect(beforeSendMock.mock.calls[1][0].properties['$event_type']).toBe('click')
         })
     })

--- a/src/__tests__/consent.test.ts
+++ b/src/__tests__/consent.test.ts
@@ -7,6 +7,7 @@ import { uuidv7 } from '../uuidv7'
 import { isNull } from '../utils/type-utils'
 import { document, assignableWindow, navigator } from '../utils/globals'
 import { PostHogConfig } from '../types'
+import { PAGEVIEW_EVENT, OPT_IN_EVENT } from '../events'
 
 const DEFAULT_PERSISTENCE_PREFIX = `__ph_opt_in_out_`
 const CUSTOM_PERSISTENCE_PREFIX = `𝓶𝓶𝓶𝓬𝓸𝓸𝓴𝓲𝓮𝓼`
@@ -91,7 +92,7 @@ describe('consentManager', () => {
 
         it('should send opt in event if not disabled', () => {
             posthog.opt_in_capturing()
-            expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: '$opt_in' }))
+            expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: OPT_IN_EVENT }))
         })
 
         it('should send opt in event with overrides', () => {
@@ -114,15 +115,15 @@ describe('consentManager', () => {
         it('should not send opt in event if false', () => {
             posthog.opt_in_capturing({ captureEventName: false })
             expect(beforeSendMock).toHaveBeenCalledTimes(1)
-            expect(beforeSendMock).not.toHaveBeenCalledWith(expect.objectContaining({ event: '$opt_in' }))
-            expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: '$pageview' }))
+            expect(beforeSendMock).not.toHaveBeenCalledWith(expect.objectContaining({ event: OPT_IN_EVENT }))
+            expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: PAGEVIEW_EVENT }))
         })
 
         it('should not send opt in event if false', () => {
             posthog.opt_in_capturing({ captureEventName: false })
             expect(beforeSendMock).toHaveBeenCalledTimes(1)
-            expect(beforeSendMock).not.toHaveBeenCalledWith(expect.objectContaining({ event: '$opt_in' }))
-            expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: '$pageview' }))
+            expect(beforeSendMock).not.toHaveBeenCalledWith(expect.objectContaining({ event: OPT_IN_EVENT }))
+            expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: PAGEVIEW_EVENT }))
         })
 
         it('should not send $pageview on opt in if capturing is disabled', () => {
@@ -143,10 +144,10 @@ describe('consentManager', () => {
             // eslint-disable-next-line compat/compat
             await new Promise((r) => setTimeout(r, 10))
             expect(beforeSendMock).toHaveBeenCalledTimes(1)
-            expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: '$pageview' }))
+            expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: PAGEVIEW_EVENT }))
             posthog.opt_in_capturing()
             expect(beforeSendMock).toHaveBeenCalledTimes(2)
-            expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: '$opt_in' }))
+            expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: OPT_IN_EVENT }))
         })
 
         it('should send $pageview on opt in if is has not been captured', async () => {
@@ -156,8 +157,8 @@ describe('consentManager', () => {
 
             posthog.opt_in_capturing()
             expect(beforeSendMock).toHaveBeenCalledTimes(2)
-            expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: '$opt_in' }))
-            expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: '$pageview' }))
+            expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: OPT_IN_EVENT }))
+            expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: PAGEVIEW_EVENT }))
             // Wait for the $pageview timeout to be called
             // eslint-disable-next-line compat/compat
             await new Promise((r) => setTimeout(r, 10))
@@ -171,14 +172,14 @@ describe('consentManager', () => {
 
             posthog.opt_in_capturing()
             expect(beforeSendMock).toHaveBeenCalledTimes(2)
-            expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: '$opt_in' }))
-            expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: '$pageview' }))
+            expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: OPT_IN_EVENT }))
+            expect(beforeSendMock).lastCalledWith(expect.objectContaining({ event: PAGEVIEW_EVENT }))
             // Wait for the $pageview timeout to be called
             // eslint-disable-next-line compat/compat
             await new Promise((r) => setTimeout(r, 10))
             posthog.opt_in_capturing()
             expect(beforeSendMock).toHaveBeenCalledTimes(3)
-            expect(beforeSendMock).not.lastCalledWith(expect.objectContaining({ event: '$pageview' }))
+            expect(beforeSendMock).not.lastCalledWith(expect.objectContaining({ event: PAGEVIEW_EVENT }))
         })
     })
 
@@ -244,7 +245,7 @@ describe('consentManager', () => {
                     posthog.on('eventCaptured', beforeSendMock)
 
                     posthog.opt_in_capturing()
-                    expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: '$opt_in' }))
+                    expect(beforeSendMock).toHaveBeenCalledWith(expect.objectContaining({ event: OPT_IN_EVENT }))
 
                     beforeSendMock.mockClear()
                     const captureEventName = `єνєηт`

--- a/src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts
+++ b/src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts
@@ -2,6 +2,7 @@ import { PostHog } from '../../posthog-core'
 import LazyLoadedDeadClicksAutocapture from '../../entrypoints/dead-clicks-autocapture'
 import { assignableWindow, document } from '../../utils/globals'
 import { autocaptureCompatibleElements } from '../../autocapture-utils'
+import { DEAD_CLICK_EVENT } from '../../events'
 
 // need to fake the timer before jsdom inits
 jest.useFakeTimers()
@@ -212,7 +213,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
 
             expect(lazyLoadedDeadClicksAutocapture['_clicks']).toHaveLength(0)
             expect(fakeInstance.capture).toHaveBeenCalledWith(
-                '$dead_click',
+                DEAD_CLICK_EVENT,
                 {
                     // faked system timestamp isn't moving so this is negative
                     $dead_click_absolute_delay_ms: -900,
@@ -255,7 +256,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
 
             expect(lazyLoadedDeadClicksAutocapture['_clicks']).toHaveLength(0)
             expect(fakeInstance.capture).toHaveBeenCalledWith(
-                '$dead_click',
+                DEAD_CLICK_EVENT,
                 {
                     // faked system timestamp isn't moving so this is negative
                     $dead_click_absolute_delay_ms: -900,
@@ -299,7 +300,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
 
             expect(lazyLoadedDeadClicksAutocapture['_clicks']).toHaveLength(0)
             expect(fakeInstance.capture).toHaveBeenCalledWith(
-                '$dead_click',
+                DEAD_CLICK_EVENT,
                 {
                     // faked system timestamp isn't moving so this is negative
                     $dead_click_absolute_delay_ms: -900,
@@ -342,7 +343,7 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
 
             expect(lazyLoadedDeadClicksAutocapture['_clicks']).toHaveLength(0)
             expect(fakeInstance.capture).toHaveBeenCalledWith(
-                '$dead_click',
+                DEAD_CLICK_EVENT,
                 {
                     $dead_click_absolute_delay_ms: 3001,
                     $dead_click_absolute_timeout: true,

--- a/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
+++ b/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
@@ -5,6 +5,7 @@ import { ExceptionObserver } from '../../../extensions/exception-autocapture'
 import { assignableWindow, window } from '../../../utils/globals'
 import { createPosthogInstance } from '../../helpers/posthog-instance'
 import { uuidv7 } from '../../../uuidv7'
+import { EXCEPTION_EVENT } from '../../../events'
 
 import posthogErrorWrappingFunctions from '../../../entrypoints/exception-autocapture'
 import { afterEach } from '@jest/globals'
@@ -97,7 +98,7 @@ describe('Exception Observer', () => {
             expect(captureCalls.length).toBe(1)
             const singleCall = captureCalls[0]
             expect(singleCall[0]).toMatchObject({
-                event: '$exception',
+                event: EXCEPTION_EVENT,
                 properties: {
                     $exception_personURL: expect.any(String),
                     $exception_list: [
@@ -126,7 +127,7 @@ describe('Exception Observer', () => {
             expect(captureCalls.length).toBe(1)
             const singleCall = captureCalls[0]
             expect(singleCall[0]).toMatchObject({
-                event: '$exception',
+                event: EXCEPTION_EVENT,
                 properties: {
                     $exception_personURL: expect.any(String),
                     $exception_list: [
@@ -149,7 +150,7 @@ describe('Exception Observer', () => {
             const request = sendRequestSpy.mock.calls[0][0]
             expect(request.url).toBe('http://localhost/e/?ip=1')
             expect(request.data).toMatchObject({
-                event: '$exception',
+                event: EXCEPTION_EVENT,
                 properties: {
                     $exception_personURL: expect.any(String),
                     $exception_list: [

--- a/src/__tests__/extensions/history-autocapture.test.ts
+++ b/src/__tests__/extensions/history-autocapture.test.ts
@@ -1,5 +1,6 @@
 import '../helpers/mock-logger'
 import { HistoryAutocapture } from '../../extensions/history-autocapture'
+import { PAGEVIEW_EVENT } from '../../events'
 
 describe('HistoryAutocapture', () => {
     let posthog: any
@@ -114,7 +115,7 @@ describe('HistoryAutocapture', () => {
             window.history.pushState({ page: 1 }, 'Test Page', '/new-path')
 
             expect(capture).toHaveBeenCalledTimes(1)
-            expect(capture).toHaveBeenCalledWith('$pageview', { navigation_type: 'pushState' })
+            expect(capture).toHaveBeenCalledWith(PAGEVIEW_EVENT, { navigation_type: 'pushState' })
         })
 
         it('should not capture pageview when pathname does not change with pushState', () => {
@@ -150,7 +151,7 @@ describe('HistoryAutocapture', () => {
             window.history.replaceState({ page: 2 }, 'Test Page 2', '/replaced-path')
 
             expect(capture).toHaveBeenCalledTimes(1)
-            expect(capture).toHaveBeenCalledWith('$pageview', { navigation_type: 'replaceState' })
+            expect(capture).toHaveBeenCalledWith(PAGEVIEW_EVENT, { navigation_type: 'replaceState' })
         })
 
         it('should not capture pageview when pathname does not change with replaceState', () => {
@@ -173,7 +174,7 @@ describe('HistoryAutocapture', () => {
             window.dispatchEvent(new PopStateEvent('popstate', { state: { page: 3 } }))
 
             expect(capture).toHaveBeenCalledTimes(1)
-            expect(capture).toHaveBeenCalledWith('$pageview', { navigation_type: 'popstate' })
+            expect(capture).toHaveBeenCalledWith(PAGEVIEW_EVENT, { navigation_type: 'popstate' })
         })
 
         it('should not capture pageview when pathname does not change with popstate', () => {
@@ -236,7 +237,7 @@ describe('HistoryAutocapture', () => {
             window.history.pushState({ page: 1 }, 'Products', '/products?category=electronics')
 
             expect(capture).toHaveBeenCalledTimes(1)
-            expect(capture).toHaveBeenCalledWith('$pageview', { navigation_type: 'pushState' })
+            expect(capture).toHaveBeenCalledWith(PAGEVIEW_EVENT, { navigation_type: 'pushState' })
         })
 
         it('should capture pageview when pathname changes even with hash changes', () => {
@@ -247,7 +248,7 @@ describe('HistoryAutocapture', () => {
             window.history.pushState({ page: 1 }, 'About', '/about#team')
 
             expect(capture).toHaveBeenCalledTimes(1)
-            expect(capture).toHaveBeenCalledWith('$pageview', { navigation_type: 'pushState' })
+            expect(capture).toHaveBeenCalledWith(PAGEVIEW_EVENT, { navigation_type: 'pushState' })
         })
 
         it('should capture pageview when pathname changes with query and hash changes', () => {
@@ -259,7 +260,7 @@ describe('HistoryAutocapture', () => {
             window.history.pushState({ page: 1 }, 'Blog', '/blog?author=john#comments')
 
             expect(capture).toHaveBeenCalledTimes(1)
-            expect(capture).toHaveBeenCalledWith('$pageview', { navigation_type: 'pushState' })
+            expect(capture).toHaveBeenCalledWith(PAGEVIEW_EVENT, { navigation_type: 'pushState' })
         })
 
         it('should not capture pageview when only query and hash change together', () => {
@@ -286,7 +287,7 @@ describe('HistoryAutocapture', () => {
             window.history.pushState({ page: 1 }, 'Home', '/')
 
             expect(capture).toHaveBeenCalledTimes(1)
-            expect(capture).toHaveBeenCalledWith('$pageview', { navigation_type: 'pushState' })
+            expect(capture).toHaveBeenCalledWith(PAGEVIEW_EVENT, { navigation_type: 'pushState' })
         })
 
         it('should capture pageview when changing from root path', () => {
@@ -305,7 +306,7 @@ describe('HistoryAutocapture', () => {
             window.history.pushState({ page: 1 }, 'Dashboard', '/dashboard')
 
             expect(capture).toHaveBeenCalledTimes(1)
-            expect(capture).toHaveBeenCalledWith('$pageview', { navigation_type: 'pushState' })
+            expect(capture).toHaveBeenCalledWith(PAGEVIEW_EVENT, { navigation_type: 'pushState' })
         })
 
         it('should not capture pageview for trailing slash differences in the same path', () => {
@@ -331,7 +332,7 @@ describe('HistoryAutocapture', () => {
             // Based on current implementation this SHOULD capture a pageview
             // because pathnames are directly compared without normalization
             expect(capture).toHaveBeenCalledTimes(1)
-            expect(capture).toHaveBeenCalledWith('$pageview', { navigation_type: 'pushState' })
+            expect(capture).toHaveBeenCalledWith(PAGEVIEW_EVENT, { navigation_type: 'pushState' })
         })
     })
 
@@ -340,7 +341,7 @@ describe('HistoryAutocapture', () => {
             // Setup capture to call pageViewManagerDoPageView to simulate
             // what would happen in the actual implementation
             capture.mockImplementation((eventName, properties) => {
-                if (eventName === '$pageview') {
+                if (eventName === PAGEVIEW_EVENT) {
                     pageViewManagerDoPageView(new Date(), 'test-uuid')
                 }
                 return { event: eventName, properties }
@@ -350,7 +351,7 @@ describe('HistoryAutocapture', () => {
             mockLocation.pathname = '/pageviewmanager-test'
             window.history.pushState({ page: 1 }, 'Test Page', '/pageviewmanager-test')
 
-            expect(capture).toHaveBeenCalledWith('$pageview', { navigation_type: 'pushState' })
+            expect(capture).toHaveBeenCalledWith(PAGEVIEW_EVENT, { navigation_type: 'pushState' })
             expect(pageViewManagerDoPageView).toHaveBeenCalledTimes(1)
         })
 
@@ -360,7 +361,7 @@ describe('HistoryAutocapture', () => {
 
             // Setup pageview sequence with proper ID tracking
             capture.mockImplementation((eventName, properties) => {
-                if (eventName === '$pageview') {
+                if (eventName === PAGEVIEW_EVENT) {
                     if (capture.mock.calls.length === 1) {
                         pageViewManagerDoPageView.mockReturnValueOnce({
                             $pageview_id: firstPageviewId,
@@ -390,7 +391,7 @@ describe('HistoryAutocapture', () => {
             window.history.pushState({ page: 2 }, 'Page 2', '/page-2')
 
             expect(capture).toHaveBeenCalledTimes(1)
-            expect(capture).toHaveBeenCalledWith('$pageview', { navigation_type: 'pushState' })
+            expect(capture).toHaveBeenCalledWith(PAGEVIEW_EVENT, { navigation_type: 'pushState' })
             expect(pageViewManagerDoPageView).toHaveBeenCalledTimes(1)
         })
     })

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -11,6 +11,7 @@ import {
     SESSION_RECORDING_MASKING,
     SESSION_RECORDING_NETWORK_PAYLOAD_CAPTURE,
 } from '../../../constants'
+import { EXCEPTION_EVENT, SNAPSHOT_EVENT } from '../../../events'
 import { SessionIdManager } from '../../../sessionid'
 import {
     FULL_SNAPSHOT_EVENT_TYPE,
@@ -864,7 +865,7 @@ describe('SessionRecording', () => {
 
             expect(posthog.capture).toHaveBeenCalledTimes(1)
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $snapshot_bytes: 60,
                     $snapshot_data: [
@@ -901,7 +902,7 @@ describe('SessionRecording', () => {
 
             expect(posthog.capture).toHaveBeenCalledTimes(1)
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $session_id: sessionId,
                     $window_id: 'windowId',
@@ -986,7 +987,7 @@ describe('SessionRecording', () => {
             _emit(createIncrementalSnapshot({ emit: 2 }))
 
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $session_id: 'otherSessionId',
                     $window_id: 'windowId',
@@ -1619,7 +1620,7 @@ describe('SessionRecording', () => {
                 windowId: expect.any(String),
             })
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $snapshot_data: [firstSnapshotEvent, secondSnapshot],
                     $session_id: firstSessionId,
@@ -1711,7 +1712,7 @@ describe('SessionRecording', () => {
 
             // the buffer is flushed on switch to idle
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $snapshot_data: [firstSnapshotEvent, secondSnapshot],
                     $session_id: firstSessionId,
@@ -1739,7 +1740,7 @@ describe('SessionRecording', () => {
 
             // the buffer is flushed, and a full snapshot is taken
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $snapshot_data: [firstSnapshotEvent, secondSnapshot],
                     $session_id: firstSessionId,
@@ -2165,7 +2166,7 @@ describe('SessionRecording', () => {
             sessionRecording['_flushBuffer']()
 
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $snapshot_data: [
                         {
@@ -2189,7 +2190,7 @@ describe('SessionRecording', () => {
             sessionRecording['_flushBuffer']()
 
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $snapshot_data: [
                         {
@@ -2212,7 +2213,7 @@ describe('SessionRecording', () => {
             sessionRecording['_flushBuffer']()
 
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $snapshot_data: [
                         {
@@ -2243,7 +2244,7 @@ describe('SessionRecording', () => {
             sessionRecording['_flushBuffer']()
 
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $snapshot_data: [
                         {
@@ -2278,7 +2279,7 @@ describe('SessionRecording', () => {
             sessionRecording['_flushBuffer']()
 
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $snapshot_data: [mouseEvent],
                     $session_id: sessionId,
@@ -2296,7 +2297,7 @@ describe('SessionRecording', () => {
             sessionRecording['_flushBuffer']()
 
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $snapshot_data: [
                         {
@@ -2322,7 +2323,7 @@ describe('SessionRecording', () => {
             sessionRecording['_flushBuffer']()
 
             expect(posthog.capture).toHaveBeenCalledWith(
-                '$snapshot',
+                SNAPSHOT_EVENT,
                 {
                     $snapshot_data: [
                         {
@@ -2472,7 +2473,7 @@ describe('SessionRecording', () => {
                 makeDecideResponse({
                     sessionRecording: {
                         endpoint: '/s/',
-                        eventTriggers: ['$exception'],
+                        eventTriggers: [EXCEPTION_EVENT],
                     },
                 })
             )
@@ -2489,7 +2490,7 @@ describe('SessionRecording', () => {
 
             expect(sessionRecording.status).toBe('buffering')
 
-            simpleEventEmitter.emit('eventCaptured', { event: '$exception' })
+            simpleEventEmitter.emit('eventCaptured', { event: EXCEPTION_EVENT })
 
             expect(sessionRecording.status).toBe('active')
             expect(sessionRecording['_buffer'].data).toHaveLength(0)
@@ -2500,7 +2501,7 @@ describe('SessionRecording', () => {
                 makeDecideResponse({
                     sessionRecording: {
                         endpoint: '/s/',
-                        eventTriggers: ['$exception'],
+                        eventTriggers: [EXCEPTION_EVENT],
                         urlTriggers: [{ url: 'start-on-me', matching: 'regex' }],
                         triggerMatchType: 'any',
                     },
@@ -2519,7 +2520,7 @@ describe('SessionRecording', () => {
 
             expect(sessionRecording.status).toBe('buffering')
 
-            simpleEventEmitter.emit('eventCaptured', { event: '$exception' })
+            simpleEventEmitter.emit('eventCaptured', { event: EXCEPTION_EVENT })
 
             // even though still waiting for URL to trigger
             expect(sessionRecording.status).toBe('active')
@@ -2565,7 +2566,7 @@ describe('SessionRecording', () => {
                 makeDecideResponse({
                     sessionRecording: {
                         endpoint: '/s/',
-                        eventTriggers: ['$exception'],
+                        eventTriggers: [EXCEPTION_EVENT],
                         sampleRate: '0.00', // i.e. never send recording
                         triggerMatchType: 'all',
                     },

--- a/src/__tests__/extensions/surveys/action-matcher.test.ts
+++ b/src/__tests__/extensions/surveys/action-matcher.test.ts
@@ -5,6 +5,7 @@ import { PostHogPersistence } from '../../../posthog-persistence'
 import { PostHog } from '../../../posthog-core'
 import { CaptureResult, PostHogConfig } from '../../../types'
 import { ActionMatcher } from '../../../extensions/surveys/action-matcher'
+import { AUTOCAPTURE_EVENT } from '../../../events'
 
 describe('action-matcher', () => {
     let config: PostHogConfig
@@ -86,7 +87,7 @@ describe('action-matcher', () => {
     })
 
     it('can match action on current_url exact', () => {
-        const pageViewAction = createAction(2, '$autocapture', 'https://us.posthog.com')
+        const pageViewAction = createAction(2, AUTOCAPTURE_EVENT, 'https://us.posthog.com')
         const actionMatcher = new ActionMatcher(instance)
         actionMatcher.register([pageViewAction])
 
@@ -99,10 +100,10 @@ describe('action-matcher', () => {
         }
 
         actionMatcher._addActionHook(onAction)
-        actionMatcher.on('$autocapture', createCaptureResult('$autocapture', 'https://eu.posthog.com'))
+        actionMatcher.on(AUTOCAPTURE_EVENT, createCaptureResult(AUTOCAPTURE_EVENT, 'https://eu.posthog.com'))
         expect(pageViewActionMatched).toBeFalsy()
 
-        actionMatcher.on('$autocapture', createCaptureResult('$autocapture', 'https://us.posthog.com'))
+        actionMatcher.on(AUTOCAPTURE_EVENT, createCaptureResult(AUTOCAPTURE_EVENT, 'https://us.posthog.com'))
         expect(pageViewActionMatched).toBeTruthy()
     })
 
@@ -120,16 +121,16 @@ describe('action-matcher', () => {
         }
 
         actionMatcher._addActionHook(onAction)
-        actionMatcher.on('$autocapture', createCaptureResult('$current_url_regexp', 'https://eu.posthog.com'))
+        actionMatcher.on(AUTOCAPTURE_EVENT, createCaptureResult('$current_url_regexp', 'https://eu.posthog.com'))
         expect(pageViewActionMatched).toBeTruthy()
         pageViewActionMatched = false
 
-        actionMatcher.on('$autocapture', createCaptureResult('$current_url_regexp', 'https://us.posthog.com'))
+        actionMatcher.on(AUTOCAPTURE_EVENT, createCaptureResult('$current_url_regexp', 'https://us.posthog.com'))
         expect(pageViewActionMatched).toBeTruthy()
     })
 
     it('can match action on html element selector', () => {
-        const buttonClickedAction = createAction(2, '$autocapture')
+        const buttonClickedAction = createAction(2, AUTOCAPTURE_EVENT)
         if (buttonClickedAction.steps) {
             buttonClickedAction.steps[0].selector = '* > #__next .flex > button:nth-child(2)'
         }
@@ -145,14 +146,14 @@ describe('action-matcher', () => {
         }
         actionMatcher._addActionHook(onAction)
 
-        const result = createCaptureResult('$autocapture', 'https://eu.posthog.com')
+        const result = createCaptureResult(AUTOCAPTURE_EVENT, 'https://eu.posthog.com')
         result.properties.$element_selectors = []
-        actionMatcher.on('$autocapture', result)
+        actionMatcher.on(AUTOCAPTURE_EVENT, result)
         expect(buttonClickedActionMatched).toBeFalsy()
 
         result.properties.$element_selectors = ['* > #__next .flex > button:nth-child(2)']
 
-        actionMatcher.on('$autocapture', result)
+        actionMatcher.on(AUTOCAPTURE_EVENT, result)
         expect(buttonClickedActionMatched).toBeTruthy()
     })
 })

--- a/src/__tests__/extensions/surveys/feedback-widget.test.tsx
+++ b/src/__tests__/extensions/surveys/feedback-widget.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { FeedbackWidget } from '../../../extensions/surveys'
 import { PostHog } from '../../../posthog-core' // Import PostHog type for mocking
 import { Survey, SurveyQuestionType, SurveyType, SurveyWidgetType } from '../../../posthog-surveys-types'
+import { SURVEY_DISMISSED_EVENT, SURVEY_SENT_EVENT, SURVEY_SHOWN_EVENT } from '../../../events'
 
 // Mock PostHog instance
 const mockPosthog = {
@@ -106,14 +107,14 @@ describe('FeedbackWidget', () => {
 
     const expectSurveyShowEvent = (surveyId: string) => {
         expect(mockPosthog.capture).toHaveBeenCalledWith(
-            'survey shown',
+            SURVEY_SHOWN_EVENT,
             expect.objectContaining({ $survey_id: surveyId })
         )
     }
 
     const expectSurveySentEvent = (surveyId: string, response: Record<string, string>) => {
         expect(mockPosthog.capture).toHaveBeenLastCalledWith(
-            'survey sent',
+            SURVEY_SENT_EVENT,
             expect.objectContaining({ $survey_id: surveyId, ...response })
         )
     }
@@ -347,7 +348,7 @@ describe('FeedbackWidget', () => {
 
         // Optionally, check for the dismiss event if it's guaranteed to be captured by this mock instance
         expect(mockPosthog.capture).toHaveBeenCalledWith(
-            'survey dismissed',
+            SURVEY_DISMISSED_EVENT,
             expect.objectContaining({
                 $survey_id: baseWidgetSurvey.id,
             })

--- a/src/__tests__/extensions/web-vitals.test.ts
+++ b/src/__tests__/extensions/web-vitals.test.ts
@@ -6,6 +6,7 @@ import { PostHog } from '../../posthog-core'
 import { DecideResponse, PerformanceCaptureConfig, RemoteConfig, SupportedWebVitalsMetrics } from '../../types'
 import { assignableWindow } from '../../utils/globals'
 import { DEFAULT_FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS, FIFTEEN_MINUTES_IN_MILLIS } from '../../extensions/web-vitals'
+import { WEB_VITALS_EVENT } from '../../events'
 
 jest.useFakeTimers()
 
@@ -152,7 +153,7 @@ describe('web vitals', () => {
 
                 expect(beforeSendMock.mock.lastCall).toMatchObject([
                     {
-                        event: '$web_vitals',
+                        event: WEB_VITALS_EVENT,
                         properties: expectedProperties,
                     },
                 ])
@@ -168,7 +169,7 @@ describe('web vitals', () => {
                 // for some reason advancing the timer emits a $pageview event as well 🤷
                 expect(beforeSendMock.mock.lastCall).toMatchObject([
                     {
-                        event: '$web_vitals',
+                        event: WEB_VITALS_EVENT,
                         properties: {
                             $web_vitals_CLS_event: expectedEmittedWebVitals('CLS'),
                             $web_vitals_CLS_value: 123.45,
@@ -187,7 +188,7 @@ describe('web vitals', () => {
 
                 expect(beforeSendMock.mock.lastCall).toMatchObject([
                     {
-                        event: '$web_vitals',
+                        event: WEB_VITALS_EVENT,
                         properties: {
                             $web_vitals_CLS_event: expectedEmittedWebVitals('CLS'),
                             $web_vitals_CLS_value: 123.45,

--- a/src/__tests__/featureflags.test.ts
+++ b/src/__tests__/featureflags.test.ts
@@ -4,6 +4,7 @@ import { filterActiveFeatureFlags, parseFeatureFlagDecideResponse, PostHogFeatur
 import { PostHogPersistence } from '../posthog-persistence'
 import { RequestRouter } from '../utils/request-router'
 import { PostHogConfig } from '../types'
+import { FEATURE_FLAG_CALLED_EVENT, FEATURE_ENROLLMENT_UPDATE_EVENT } from '../events'
 
 jest.useFakeTimers()
 jest.spyOn(global, 'setTimeout')
@@ -539,7 +540,7 @@ describe('featureflags', () => {
 
                 featureFlags.getFeatureFlag('beta-feature')
 
-                expect(instance.capture).toHaveBeenCalledWith('$feature_flag_called', {
+                expect(instance.capture).toHaveBeenCalledWith(FEATURE_FLAG_CALLED_EVENT, {
                     $feature_flag: 'beta-feature',
                     $feature_flag_response: true,
                     $feature_flag_payload: { overridden: 'payload' },
@@ -585,7 +586,7 @@ describe('featureflags', () => {
 
                 featureFlags.getFeatureFlag('beta-feature')
 
-                expect(instance.capture).toHaveBeenCalledWith('$feature_flag_called', {
+                expect(instance.capture).toHaveBeenCalledWith(FEATURE_FLAG_CALLED_EVENT, {
                     $feature_flag: 'beta-feature',
                     $feature_flag_response: true,
                     $feature_flag_payload: { overridden: { status: 'overridden' } },
@@ -601,7 +602,7 @@ describe('featureflags', () => {
 
                 featureFlags.getFeatureFlag('alpha-feature-2')
 
-                expect(instance.capture).toHaveBeenCalledWith('$feature_flag_called', {
+                expect(instance.capture).toHaveBeenCalledWith(FEATURE_FLAG_CALLED_EVENT, {
                     $feature_flag: 'alpha-feature-2',
                     $feature_flag_response: 'variant-1',
                     $feature_flag_payload: null,
@@ -616,7 +617,7 @@ describe('featureflags', () => {
 
                 featureFlags.getFeatureFlag('multivariate-flag')
 
-                expect(instance.capture).toHaveBeenCalledWith('$feature_flag_called', {
+                expect(instance.capture).toHaveBeenCalledWith(FEATURE_FLAG_CALLED_EVENT, {
                     $feature_flag: 'multivariate-flag',
                     $feature_flag_response: false,
                     $feature_flag_payload: null,
@@ -942,7 +943,7 @@ describe('featureflags', () => {
             featureFlags.updateEarlyAccessFeatureEnrollment('first-flag', true)
 
             expect(instance.capture).toHaveBeenCalledTimes(1)
-            expect(instance.capture).toHaveBeenCalledWith('$feature_enrollment_update', {
+            expect(instance.capture).toHaveBeenCalledWith(FEATURE_ENROLLMENT_UPDATE_EVENT, {
                 $feature_enrollment: true,
                 $feature_flag: 'first-flag',
                 $set: {
@@ -963,7 +964,7 @@ describe('featureflags', () => {
             featureFlags.updateEarlyAccessFeatureEnrollment('first-flag', false)
 
             expect(instance.capture).toHaveBeenCalledTimes(2)
-            expect(instance.capture).toHaveBeenCalledWith('$feature_enrollment_update', {
+            expect(instance.capture).toHaveBeenCalledWith(FEATURE_ENROLLMENT_UPDATE_EVENT, {
                 $feature_enrollment: false,
                 $feature_flag: 'first-flag',
                 $set: {
@@ -985,7 +986,7 @@ describe('featureflags', () => {
             featureFlags.updateEarlyAccessFeatureEnrollment('x-flag', true)
 
             expect(instance.capture).toHaveBeenCalledTimes(1)
-            expect(instance.capture).toHaveBeenCalledWith('$feature_enrollment_update', {
+            expect(instance.capture).toHaveBeenCalledWith(FEATURE_ENROLLMENT_UPDATE_EVENT, {
                 $feature_enrollment: true,
                 $feature_flag: 'x-flag',
                 $set: {
@@ -1577,7 +1578,7 @@ describe('featureflags', () => {
 
             // Verify capture call includes requestId
             expect(instance.capture).toHaveBeenCalledWith(
-                '$feature_flag_called',
+                FEATURE_FLAG_CALLED_EVENT,
                 expect.objectContaining({
                     $feature_flag: 'test-flag',
                     $feature_flag_response: true,
@@ -1617,7 +1618,7 @@ describe('featureflags', () => {
 
             // Verify capture call includes requestId
             expect(instance.capture).toHaveBeenCalledWith(
-                '$feature_flag_called',
+                FEATURE_FLAG_CALLED_EVENT,
                 expect.objectContaining({
                     $feature_flag: 'test-flag',
                     $feature_flag_response: 'variant-1',
@@ -1654,7 +1655,7 @@ describe('featureflags', () => {
             featureFlags.getFeatureFlag('test-flag')
 
             expect(instance.capture).toHaveBeenCalledWith(
-                '$feature_flag_called',
+                FEATURE_FLAG_CALLED_EVENT,
                 expect.objectContaining({
                     $feature_flag_request_id: NEW_REQUEST_ID,
                 })

--- a/src/__tests__/heatmaps.test.ts
+++ b/src/__tests__/heatmaps.test.ts
@@ -8,6 +8,7 @@ import { isObject } from '../utils/type-utils'
 import { beforeEach, expect } from '@jest/globals'
 import { HEATMAPS_ENABLED_SERVER_SIDE } from '../constants'
 import { Heatmaps } from '../heatmaps'
+import { HEATMAP_EVENT } from '../events'
 
 jest.useFakeTimers()
 
@@ -64,7 +65,7 @@ describe('heatmaps', () => {
 
         expect(beforeSendMock).toBeCalledTimes(1)
         expect(beforeSendMock.mock.lastCall[0]).toMatchObject({
-            event: '$$heatmap',
+            event: HEATMAP_EVENT,
             properties: {
                 $heatmap_data: {
                     'http://replaced/': [
@@ -87,7 +88,7 @@ describe('heatmaps', () => {
 
         expect(beforeSendMock).toBeCalledTimes(1)
         expect(beforeSendMock.mock.lastCall[0]).toMatchObject({
-            event: '$$heatmap',
+            event: HEATMAP_EVENT,
             properties: {
                 $heatmap_data: {
                     'http://replaced/': [
@@ -128,7 +129,7 @@ describe('heatmaps', () => {
         jest.advanceTimersByTime(posthog.heatmaps!.flushIntervalMilliseconds + 1)
 
         expect(beforeSendMock).toBeCalledTimes(1)
-        expect(beforeSendMock.mock.lastCall[0].event).toEqual('$$heatmap')
+        expect(beforeSendMock.mock.lastCall[0].event).toEqual(HEATMAP_EVENT)
         const heatmapData = beforeSendMock.mock.lastCall[0].properties.$heatmap_data
         expect(heatmapData).toBeDefined()
         expect(heatmapData['http://replaced/']).toHaveLength(4)
@@ -142,7 +143,7 @@ describe('heatmaps', () => {
         jest.advanceTimersByTime(posthog.heatmaps!.flushIntervalMilliseconds + 1)
 
         expect(beforeSendMock).toBeCalledTimes(1)
-        expect(beforeSendMock.mock.lastCall[0].event).toEqual('$$heatmap')
+        expect(beforeSendMock.mock.lastCall[0].event).toEqual(HEATMAP_EVENT)
         expect(beforeSendMock.mock.lastCall[0].properties.$heatmap_data).toBeDefined()
         expect(beforeSendMock.mock.lastCall[0].properties.$heatmap_data['http://replaced/']).toHaveLength(2)
 

--- a/src/__tests__/identify.test.ts
+++ b/src/__tests__/identify.test.ts
@@ -2,6 +2,7 @@ import { mockLogger } from './helpers/mock-logger'
 
 import { createPosthogInstance } from './helpers/posthog-instance'
 import { uuidv7 } from '../uuidv7'
+import { IDENTIFY_EVENT } from '../events'
 
 describe('identify', () => {
     // Note that there are other tests for identify in posthog-core.identify.js
@@ -55,7 +56,7 @@ describe('identify', () => {
         const eventBeforeIdentify = beforeSendMock.mock.calls[0]
         expect(eventBeforeIdentify[0].properties.$is_identified).toEqual(false)
         const identifyCall = beforeSendMock.mock.calls[1]
-        expect(identifyCall[0].event).toEqual('$identify')
+        expect(identifyCall[0].event).toEqual(IDENTIFY_EVENT)
         expect(identifyCall[0].properties.$is_identified).toEqual(true)
         const eventAfterIdentify = beforeSendMock.mock.calls[2]
         expect(eventAfterIdentify[0].properties.$is_identified).toEqual(true)

--- a/src/__tests__/loader.test.ts
+++ b/src/__tests__/loader.test.ts
@@ -10,6 +10,7 @@ import { defaultPostHog } from './helpers/posthog-instance'
 
 import sinon from 'sinon'
 import { assignableWindow, window } from '../utils/globals'
+import { PAGEVIEW_EVENT } from '../events'
 
 describe(`Module-based loader in Node env`, () => {
     const posthog = defaultPostHog()
@@ -49,7 +50,7 @@ describe(`Module-based loader in Node env`, () => {
         sinon.assert.calledOnce(posthog.capture as sinon.SinonSpy<any>)
         const captureArgs = (posthog.capture as sinon.SinonSpy<any>).args[0]
         const event = captureArgs[0]
-        expect(event).toBe('$pageview')
+        expect(event).toBe(PAGEVIEW_EVENT)
         expect(loaded).toBe(true)
 
         posthog.capture = _originalCapture

--- a/src/__tests__/personProcessing.test.ts
+++ b/src/__tests__/personProcessing.test.ts
@@ -4,6 +4,7 @@ import { createPosthogInstance } from './helpers/posthog-instance'
 import { uuidv7 } from '../uuidv7'
 import { INITIAL_CAMPAIGN_PARAMS, INITIAL_REFERRER_INFO } from '../constants'
 import { RemoteConfig } from '../types'
+import { SET_EVENT, GROUP_IDENTIFY_EVENT, CREATE_ALIAS_EVENT, IDENTIFY_EVENT } from '../events'
 
 const INITIAL_CAMPAIGN_PARAMS_NULL = {
     $initial_current_url: null,
@@ -209,7 +210,7 @@ describe('person processing', () => {
             const eventBeforeIdentify = beforeSendMock.mock.calls[0]
             expect(eventBeforeIdentify[0].properties.$process_person_profile).toEqual(false)
             const identifyCall = beforeSendMock.mock.calls[1]
-            expect(identifyCall[0].event).toEqual('$identify')
+            expect(identifyCall[0].event).toEqual(IDENTIFY_EVENT)
             expect(identifyCall[0].properties.$process_person_profile).toEqual(true)
             const eventAfterIdentify = beforeSendMock.mock.calls[2]
             expect(eventAfterIdentify[0].properties.$process_person_profile).toEqual(true)
@@ -228,7 +229,7 @@ describe('person processing', () => {
             const eventBeforeIdentify = beforeSendMock.mock.calls[0]
             expect(eventBeforeIdentify[0].properties.$process_person_profile).toEqual(true)
             const identifyCall = beforeSendMock.mock.calls[1]
-            expect(identifyCall[0].event).toEqual('$identify')
+            expect(identifyCall[0].event).toEqual(IDENTIFY_EVENT)
             expect(identifyCall[0].properties.$process_person_profile).toEqual(true)
             const eventAfterIdentify = beforeSendMock.mock.calls[2]
             expect(eventAfterIdentify[0].properties.$process_person_profile).toEqual(true)
@@ -243,7 +244,7 @@ describe('person processing', () => {
 
             // assert
             const identifyCall = beforeSendMock.mock.calls[0]
-            expect(identifyCall[0].event).toEqual('$identify')
+            expect(identifyCall[0].event).toEqual(IDENTIFY_EVENT)
             expect(identifyCall[0].$set_once).toEqual({
                 ...INITIAL_CAMPAIGN_PARAMS_NULL,
                 ...CAMPAIGN_PARAMS_NULL,
@@ -294,7 +295,7 @@ describe('person processing', () => {
 
             expect(eventS2Before[0].$set_once).toEqual(undefined)
 
-            expect(eventS2Identify[0].event).toEqual('$identify')
+            expect(eventS2Identify[0].event).toEqual(IDENTIFY_EVENT)
             expect(eventS2Identify[0].$set_once).toEqual({
                 ...INITIAL_CAMPAIGN_PARAMS_NULL,
                 ...CAMPAIGN_PARAMS_NULL,
@@ -363,7 +364,7 @@ describe('person processing', () => {
             // most properties are lost across subdomain, that's intentional as we don't want to save too many things in cookies
             expect(eventS2Before[0].properties.testProp).toEqual(undefined)
 
-            expect(eventS2Identify[0].event).toEqual('$identify')
+            expect(eventS2Identify[0].event).toEqual(IDENTIFY_EVENT)
             expect(eventS2Identify[0].$set_once).toEqual({
                 ...INITIAL_CAMPAIGN_PARAMS_NULL,
                 ...CAMPAIGN_PARAMS_NULL,
@@ -394,7 +395,7 @@ describe('person processing', () => {
 
             // assert
             const identifyCall = beforeSendMock.mock.calls[0]
-            expect(identifyCall[0].event).toEqual('$identify')
+            expect(identifyCall[0].event).toEqual(IDENTIFY_EVENT)
             expect(identifyCall[0].$set_once).toEqual({
                 ...INITIAL_CAMPAIGN_PARAMS_NULL,
                 ...CAMPAIGN_PARAMS_NULL,
@@ -422,7 +423,7 @@ describe('person processing', () => {
 
             // assert
             const identifyCall = beforeSendMock.mock.calls[0]
-            expect(identifyCall[0].event).toEqual('$identify')
+            expect(identifyCall[0].event).toEqual(IDENTIFY_EVENT)
             expect(identifyCall[0].$set_once).toEqual({
                 ...INITIAL_CAMPAIGN_PARAMS_NULL,
                 ...CAMPAIGN_PARAMS_NULL,
@@ -463,7 +464,7 @@ describe('person processing', () => {
 
             // assert
             const identifyCall = beforeSendMock.mock.calls[0]
-            expect(identifyCall[0].event).toEqual('$identify')
+            expect(identifyCall[0].event).toEqual(IDENTIFY_EVENT)
             expect(identifyCall[0].$set_once).toEqual({
                 ...CAMPAIGN_PARAMS_NULL,
                 $initial_referrer: 'https://deprecated-referrer.com',
@@ -557,7 +558,7 @@ describe('person processing', () => {
             const eventBeforeGroup = beforeSendMock.mock.calls[0]
             expect(eventBeforeGroup[0].properties.$process_person_profile).toEqual(false)
             const groupIdentify = beforeSendMock.mock.calls[1]
-            expect(groupIdentify[0].event).toEqual('$groupidentify')
+            expect(groupIdentify[0].event).toEqual(GROUP_IDENTIFY_EVENT)
             expect(groupIdentify[0].properties.$process_person_profile).toEqual(true)
             const eventAfterGroup = beforeSendMock.mock.calls[2]
             expect(eventAfterGroup[0].properties.$process_person_profile).toEqual(true)
@@ -611,7 +612,7 @@ describe('person processing', () => {
 
             // assert
             expect(beforeSendMock).toBeCalledTimes(1)
-            expect(beforeSendMock.mock.calls[0][0].event).toEqual('$set')
+            expect(beforeSendMock.mock.calls[0][0].event).toEqual(SET_EVENT)
         })
 
         it('should start person processing for identified_only users', async () => {
@@ -627,7 +628,7 @@ describe('person processing', () => {
             const eventBeforeGroup = beforeSendMock.mock.calls[0]
             expect(eventBeforeGroup[0].properties.$process_person_profile).toEqual(false)
             const set = beforeSendMock.mock.calls[1]
-            expect(set[0].event).toEqual('$set')
+            expect(set[0].event).toEqual(SET_EVENT)
             expect(set[0].properties.$process_person_profile).toEqual(true)
             const eventAfterGroup = beforeSendMock.mock.calls[2]
             expect(eventAfterGroup[0].properties.$process_person_profile).toEqual(true)
@@ -648,7 +649,7 @@ describe('person processing', () => {
             const eventBeforeGroup = beforeSendMock.mock.calls[0]
             expect(eventBeforeGroup[0].properties.$process_person_profile).toEqual(false)
             const alias = beforeSendMock.mock.calls[1]
-            expect(alias[0].event).toEqual('$create_alias')
+            expect(alias[0].event).toEqual(CREATE_ALIAS_EVENT)
             expect(alias[0].properties.$process_person_profile).toEqual(true)
             const eventAfterGroup = beforeSendMock.mock.calls[2]
             expect(eventAfterGroup[0].properties.$process_person_profile).toEqual(true)
@@ -685,7 +686,7 @@ describe('person processing', () => {
             const eventBeforeGroup = beforeSendMock.mock.calls[0]
             expect(eventBeforeGroup[0].properties.$process_person_profile).toEqual(false)
             const set = beforeSendMock.mock.calls[1]
-            expect(set[0].event).toEqual('$set')
+            expect(set[0].event).toEqual(SET_EVENT)
             expect(set[0].properties.$process_person_profile).toEqual(true)
             const eventAfterGroup = beforeSendMock.mock.calls[2]
             expect(eventAfterGroup[0].properties.$process_person_profile).toEqual(true)
@@ -830,7 +831,7 @@ describe('person processing', () => {
             expect(beforeSendMock).toHaveBeenCalledTimes(1)
             expect(beforeSendMock).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    event: '$set',
+                    event: SET_EVENT,
                     properties: expect.objectContaining({
                         $set: { email: 'john@example.com' },
                         $set_once: {},
@@ -886,8 +887,8 @@ describe('person processing', () => {
             posthog.setPersonProperties({ email: 'john@example.com' })
 
             const calls = beforeSendMock.mock.calls
-            expect(calls.filter((call) => call[0].event === '$set').length).toEqual(2)
-            expect(calls.filter((call) => call[0].event === '$identify').length).toEqual(1)
+            expect(calls.filter((call) => call[0].event === SET_EVENT).length).toEqual(2)
+            expect(calls.filter((call) => call[0].event === IDENTIFY_EVENT).length).toEqual(1)
         })
 
         it('should deduplicate when using people.set with identical properties', async () => {
@@ -944,7 +945,7 @@ describe('person processing', () => {
 
             expect(beforeSendMock).toHaveBeenCalledTimes(1)
             const calls = beforeSendMock.mock.calls
-            expect(calls.filter((call) => call[0].event === '$identify').length).toEqual(1)
+            expect(calls.filter((call) => call[0].event === IDENTIFY_EVENT).length).toEqual(1)
         })
 
         it('should not deduplicate a setPersonProperties call after identify() if the $set properties are different', async () => {
@@ -954,8 +955,8 @@ describe('person processing', () => {
             posthog.setPersonProperties({ email: 'jane@example.com' }, { first_seen: 'today' })
 
             const calls = beforeSendMock.mock.calls
-            expect(calls.filter((call) => call[0].event === '$identify').length).toEqual(1)
-            expect(calls.filter((call) => call[0].event === '$set').length).toEqual(1)
+            expect(calls.filter((call) => call[0].event === IDENTIFY_EVENT).length).toEqual(1)
+            expect(calls.filter((call) => call[0].event === SET_EVENT).length).toEqual(1)
         })
 
         it('should not deduplicate a setPersonProperties call after identify() if the $set_onceproperties are different', async () => {
@@ -965,8 +966,8 @@ describe('person processing', () => {
             posthog.setPersonProperties({ email: 'john@example.com' }, { first_seen: 'yesterday' })
 
             const calls = beforeSendMock.mock.calls
-            expect(calls.filter((call) => call[0].event === '$identify').length).toEqual(1)
-            expect(calls.filter((call) => call[0].event === '$set').length).toEqual(1)
+            expect(calls.filter((call) => call[0].event === IDENTIFY_EVENT).length).toEqual(1)
+            expect(calls.filter((call) => call[0].event === SET_EVENT).length).toEqual(1)
         })
 
         it('should not deduplicate a call after an identity change', async () => {
@@ -978,8 +979,8 @@ describe('person processing', () => {
 
             const calls = beforeSendMock.mock.calls
 
-            expect(calls.filter((call) => call[0].event === '$identify').length).toEqual(1)
-            expect(calls.filter((call) => call[0].event === '$set').length).toEqual(2)
+            expect(calls.filter((call) => call[0].event === IDENTIFY_EVENT).length).toEqual(1)
+            expect(calls.filter((call) => call[0].event === SET_EVENT).length).toEqual(2)
         })
     })
 })

--- a/src/__tests__/posthog-core.beforeSend.test.ts
+++ b/src/__tests__/posthog-core.beforeSend.test.ts
@@ -4,6 +4,7 @@ import { uuidv7 } from '../uuidv7'
 import { defaultPostHog } from './helpers/posthog-instance'
 import { CaptureResult, knownUnsafeEditableEvent, PostHogConfig } from '../types'
 import { PostHog } from '../posthog-core'
+import { SET_EVENT } from '../events'
 
 const rejectingEventFn = () => {
     return null
@@ -120,7 +121,7 @@ describe('posthog core - before send', () => {
         })
         ;(posthog._send_request as jest.Mock).mockClear()
 
-        const capturedData = posthog.capture('$set', {}, { $set: { value: 'provided' } })
+        const capturedData = posthog.capture(SET_EVENT, {}, { $set: { value: 'provided' } })
 
         expect(capturedData).toHaveProperty(['$set', 'value'], 'edited')
         expect(posthog._send_request).toHaveBeenCalledWith({

--- a/src/__tests__/posthog-core.identify.test.ts
+++ b/src/__tests__/posthog-core.identify.test.ts
@@ -3,6 +3,7 @@ import { PostHog } from '../posthog-core'
 import { assignableWindow } from '../utils/globals'
 import { uuidv7 } from '../uuidv7'
 import { defaultPostHog } from './helpers/posthog-instance'
+import { IDENTIFY_EVENT, SET_EVENT } from '../events'
 
 describe('identify()', () => {
     let instance: PostHog
@@ -58,7 +59,7 @@ describe('identify()', () => {
 
         expect(beforeSendMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                event: '$identify',
+                event: IDENTIFY_EVENT,
                 properties: expect.objectContaining({
                     distinct_id: 'calls capture when identity changes',
                     $anon_distinct_id: 'oldIdentity',
@@ -84,7 +85,7 @@ describe('identify()', () => {
 
         expect(beforeSendMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                event: '$identify',
+                event: IDENTIFY_EVENT,
                 properties: expect.objectContaining({
                     distinct_id: 'a-new-id',
                     $anon_distinct_id: 'oldIdentity',
@@ -103,7 +104,7 @@ describe('identify()', () => {
 
         expect(beforeSendMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                event: '$identify',
+                event: IDENTIFY_EVENT,
                 properties: expect.objectContaining({
                     distinct_id: 'a-new-id',
                     $anon_distinct_id: 'oldIdentity',
@@ -153,7 +154,7 @@ describe('identify()', () => {
 
         expect(beforeSendMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                event: '$identify',
+                event: IDENTIFY_EVENT,
                 properties: expect.objectContaining({
                     distinct_id: 'a-new-id',
                     $anon_distinct_id: 'oldIdentity',
@@ -167,7 +168,7 @@ describe('identify()', () => {
 
         expect(beforeSendMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                event: '$identify',
+                event: IDENTIFY_EVENT,
                 properties: expect.objectContaining({
                     distinct_id: 'a-new-id',
                     $anon_distinct_id: 'oldIdentity',
@@ -197,7 +198,7 @@ describe('identify()', () => {
 
             expect(beforeSendMock).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    event: '$set',
+                    event: SET_EVENT,
                     // get set at the top level and in properties
                     // $set: { email: 'john@example.com' },
                     // $set_once: expect.objectContaining({ howOftenAmISet: 'once!' }),
@@ -302,7 +303,7 @@ describe('identify()', () => {
 
             expect(beforeSendMock).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    event: '$set',
+                    event: SET_EVENT,
                     // get set at the top level and in properties
                     // $set: { email: 'john@example.com' },
                     // $set_once: expect.objectContaining({ name: 'john' }),
@@ -319,7 +320,7 @@ describe('identify()', () => {
 
             expect(beforeSendMock).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    event: '$set',
+                    event: SET_EVENT,
                     properties: expect.objectContaining({
                         $set: { email: 'john@example.com' },
                         $set_once: {},
@@ -334,7 +335,7 @@ describe('identify()', () => {
 
             expect(beforeSendMock).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    event: '$set',
+                    event: SET_EVENT,
                     properties: expect.objectContaining({
                         $set: {},
                         $set_once: { email: 'john@example.com' },

--- a/src/__tests__/posthog-core.test.ts
+++ b/src/__tests__/posthog-core.test.ts
@@ -1,6 +1,7 @@
 import { defaultPostHog } from './helpers/posthog-instance'
 import type { PostHogConfig } from '../types'
 import { uuidv7 } from '../uuidv7'
+import { PAGEVIEW_EVENT, RATE_LIMIT_EVENT } from '../events'
 
 describe('posthog core', () => {
     const mockURL = jest.fn()
@@ -92,7 +93,7 @@ describe('posthog core', () => {
                     posthog.capture(eventName, eventProperties)
                 }
                 expect(beforeSendMock).toHaveBeenCalledTimes(1)
-                expect(beforeSendMock.mock.calls[0][0].event).toBe('$$client_ingestion_warning')
+                expect(beforeSendMock.mock.calls[0][0].event).toBe(RATE_LIMIT_EVENT)
                 expect(console.error).toHaveBeenCalledTimes(50)
                 expect(console.error).toHaveBeenCalledWith(
                     '[PostHog.js]',
@@ -218,7 +219,7 @@ describe('posthog core', () => {
                 })
 
                 // act
-                posthog.capture('$pageview')
+                posthog.capture(PAGEVIEW_EVENT)
 
                 //assert
                 expect(beforeSendMock.mock.calls[0][0].properties).not.toHaveProperty('utm_source')
@@ -235,7 +236,7 @@ describe('posthog core', () => {
                 })
 
                 // act
-                posthog.capture('$pageview')
+                posthog.capture(PAGEVIEW_EVENT)
 
                 //assert
                 expect(beforeSendMock.mock.calls[0][0].properties.utm_source).toBe('source')

--- a/src/__tests__/rate-limiter.test.ts
+++ b/src/__tests__/rate-limiter.test.ts
@@ -1,6 +1,7 @@
 import { clearLoggerMocks, mockLogger } from './helpers/mock-logger'
 import { window } from '../../src/utils/globals'
 import { RateLimiter } from '../rate-limiter'
+import { RATE_LIMIT_EVENT } from '../events'
 
 describe('Rate Limiter', () => {
     let rateLimiter: RateLimiter
@@ -122,7 +123,7 @@ describe('Rate Limiter', () => {
 
             expect(mockPostHog.capture).toBeCalledTimes(1)
             expect(mockPostHog.capture).toHaveBeenCalledWith(
-                '$$client_ingestion_warning',
+                RATE_LIMIT_EVENT,
                 {
                     $$client_ingestion_warning_message:
                         'posthog-js client rate limited. Config is set to 10 events per second and 100 events burst limit.',

--- a/src/__tests__/request-queue.test.ts
+++ b/src/__tests__/request-queue.test.ts
@@ -1,3 +1,4 @@
+import { IDENTIFY_EVENT } from '../events'
 import { DEFAULT_FLUSH_INTERVAL_MS, RequestQueue } from '../request-queue'
 import { QueuedRequestWithOptions } from '../types'
 import { createPosthogInstance } from './helpers/posthog-instance'
@@ -57,7 +58,7 @@ describe('RequestQueue', () => {
                 url: '/e',
             })
             queue.enqueue({
-                data: { event: '$identify', timestamp: EPOCH - 2000 },
+                data: { event: IDENTIFY_EVENT, timestamp: EPOCH - 2000 },
                 url: '/identify',
             })
             queue.enqueue({
@@ -91,7 +92,7 @@ describe('RequestQueue', () => {
                 [
                     {
                         url: '/identify',
-                        data: [{ event: '$identify', offset: 2000 }],
+                        data: [{ event: IDENTIFY_EVENT, offset: 2000 }],
                     },
                 ],
                 [
@@ -107,7 +108,7 @@ describe('RequestQueue', () => {
         it('handles unload', () => {
             queue.enqueue({ url: '/s', data: { recording_payload: 'example' } })
             queue.enqueue({ url: '/e', data: { event: 'foo', timestamp: 1_610_000_000 } })
-            queue.enqueue({ url: '/identify', data: { event: '$identify', timestamp: 1_620_000_000 } })
+            queue.enqueue({ url: '/identify', data: { event: IDENTIFY_EVENT, timestamp: 1_620_000_000 } })
             queue.enqueue({ url: '/e', data: { event: 'bar', timestamp: 1_630_000_000 } })
             queue.unload()
 
@@ -128,14 +129,14 @@ describe('RequestQueue', () => {
             })
             expect(sendRequest).toHaveBeenNthCalledWith(3, {
                 url: '/identify',
-                data: [{ event: '$identify', timestamp: 1_620_000_000 }],
+                data: [{ event: IDENTIFY_EVENT, timestamp: 1_620_000_000 }],
                 transport: 'sendBeacon',
             })
         })
 
         it('handles unload with batchKeys', () => {
             queue.enqueue({ url: '/e', data: { event: 'foo', timestamp: 1_610_000_000 }, transport: 'XHR' })
-            queue.enqueue({ url: '/identify', data: { event: '$identify', timestamp: 1_620_000_000 } })
+            queue.enqueue({ url: '/identify', data: { event: IDENTIFY_EVENT, timestamp: 1_620_000_000 } })
             queue.enqueue({ url: '/e', data: { event: 'bar', timestamp: 1_630_000_000 } })
             queue.enqueue({
                 url: '/e',
@@ -162,7 +163,7 @@ describe('RequestQueue', () => {
                 url: '/e',
             })
             expect(sendRequest).toHaveBeenNthCalledWith(3, {
-                data: [{ event: '$identify', timestamp: 1620000000 }],
+                data: [{ event: IDENTIFY_EVENT, timestamp: 1620000000 }],
                 transport: 'sendBeacon',
                 url: '/identify',
             })

--- a/src/__tests__/segment.test.ts
+++ b/src/__tests__/segment.test.ts
@@ -13,6 +13,7 @@ import { USER_STATE } from '../constants'
 import { SegmentContext, SegmentPlugin } from '../extensions/segment-integration'
 import { PostHog } from '../posthog-core'
 import { assignableWindow } from '../utils/globals'
+import { IDENTIFY_EVENT } from '../events'
 
 describe(`Segment integration`, () => {
     let segment: any
@@ -149,7 +150,7 @@ describe(`Segment integration`, () => {
         if (segmentIntegration && segmentIntegration.identify) {
             segmentIntegration.identify({
                 event: {
-                    event: '$identify',
+                    event: IDENTIFY_EVENT,
                     userId: 'distinguished user',
                     anonymousId: 'anonymous segment user',
                 },

--- a/src/__tests__/utils/before-send-utils.test.ts
+++ b/src/__tests__/utils/before-send-utils.test.ts
@@ -1,6 +1,7 @@
 import { CaptureResult } from '../../types'
 import { isNull } from '../../utils/type-utils'
 import { sampleByDistinctId, sampleByEvent, sampleBySessionId } from '../../customizations/before-send'
+import { AUTOCAPTURE_EVENT } from '../../events'
 
 beforeAll(() => {
     let fiftyFiftyRandom = true
@@ -13,11 +14,11 @@ beforeAll(() => {
 
 describe('before send utils', () => {
     it('can sample by event name', () => {
-        const sampleFn = sampleByEvent(['$autocapture'], 0.5)
+        const sampleFn = sampleByEvent([AUTOCAPTURE_EVENT], 0.5)
 
         const results = []
         Array.from({ length: 100 }).forEach(() => {
-            const captureResult = { event: '$autocapture' } as unknown as CaptureResult
+            const captureResult = { event: AUTOCAPTURE_EVENT } as unknown as CaptureResult
             results.push(sampleFn(captureResult))
         })
         const emittedEvents = results.filter((r) => !isNull(r))
@@ -26,7 +27,7 @@ describe('before send utils', () => {
         expect(emittedEvents[0].properties).toMatchObject({
             $sample_type: ['sampleByEvent'],
             $sample_threshold: 0.5,
-            $sampled_events: ['$autocapture'],
+            $sampled_events: [AUTOCAPTURE_EVENT],
         })
     })
 
@@ -78,7 +79,7 @@ describe('before send utils', () => {
 
     it('can combine thresholds', () => {
         const sampleBySession = sampleBySessionId(0.5)
-        const sampleByEventFn = sampleByEvent(['$autocapture'], 0.5)
+        const sampleByEventFn = sampleByEvent([AUTOCAPTURE_EVENT], 0.5)
 
         const results = []
         const session_id_one = 'a-session-id'
@@ -86,7 +87,7 @@ describe('before send utils', () => {
         Array.from({ length: 100 }).forEach(() => {
             ;[session_id_one, session_id_two].forEach((session_id) => {
                 const captureResult = {
-                    event: '$autocapture',
+                    event: AUTOCAPTURE_EVENT,
                     properties: { $session_id: session_id },
                 } as unknown as CaptureResult
                 const firstBySession = sampleBySession(captureResult)

--- a/src/autocapture.ts
+++ b/src/autocapture.ts
@@ -15,7 +15,7 @@ import {
     splitClassString,
 } from './autocapture-utils'
 import RageClick from './extensions/rageclick'
-import { AutocaptureConfig, COPY_AUTOCAPTURE_EVENT, EventName, Properties, RemoteConfig } from './types'
+import { AutocaptureConfig, EventName, Properties, RemoteConfig } from './types'
 import { PostHog } from './posthog-core'
 import { AUTOCAPTURE_DISABLED_SERVER_SIDE } from './constants'
 
@@ -25,6 +25,7 @@ import { document, window } from './utils/globals'
 import { convertToURL } from './utils/request-utils'
 import { isDocumentFragment, isElementNode, isTag, isTextNode } from './utils/element-utils'
 import { includes } from './utils/string-utils'
+import { AUTOCAPTURE_EVENT, COPY_AUTOCAPTURE_EVENT, RAGECLICK_EVENT } from './events'
 
 const logger = createLogger('[AutoCapture]')
 
@@ -342,7 +343,7 @@ export class Autocapture {
         return !disabledClient && !disabledServer
     }
 
-    private _captureEvent(e: Event, eventName: EventName = '$autocapture'): boolean | void {
+    private _captureEvent(e: Event, eventName: EventName = AUTOCAPTURE_EVENT): boolean | void {
         if (!this.isEnabled) {
             return
         }
@@ -354,12 +355,12 @@ export class Autocapture {
             target = (target.parentNode || null) as Element | null
         }
 
-        if (eventName === '$autocapture' && e.type === 'click' && e instanceof MouseEvent) {
+        if (eventName === AUTOCAPTURE_EVENT && e.type === 'click' && e instanceof MouseEvent) {
             if (
                 this.instance.config.rageclick &&
                 this.rageclicks?.isRageClick(e.clientX, e.clientY, new Date().getTime())
             ) {
-                this._captureEvent(e, '$rageclick')
+                this._captureEvent(e, RAGECLICK_EVENT)
             }
         }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,6 +41,7 @@ export const FLAG_CALL_REPORTED = '$flag_call_reported'
 export const USER_STATE = '$user_state'
 export const CLIENT_SESSION_PROPS = '$client_session_props'
 export const CAPTURE_RATE_LIMIT = '$capture_rate_limit'
+export const WEB_EXPERIMENTS = '$web_experiments'
 
 /** @deprecated Delete this when INITIAL_PERSON_INFO has been around for long enough to ignore backwards compat */
 export const INITIAL_CAMPAIGN_PARAMS = '$initial_campaign_params'
@@ -57,8 +58,6 @@ export const TOOLBAR_CONTAINER_CLASS = 'toolbar-global-fade-container'
  * */
 export const COOKIELESS_SENTINEL_VALUE = '$posthog_cookieless'
 export const COOKIELESS_MODE_FLAG_PROPERTY = '$cookieless_mode'
-
-export const WEB_EXPERIMENTS = '$web_experiments'
 
 // These are properties that are reserved and will not be automatically included in events
 export const PERSISTENCE_RESERVED_PROPERTIES = [

--- a/src/entrypoints/dead-clicks-autocapture.ts
+++ b/src/entrypoints/dead-clicks-autocapture.ts
@@ -7,6 +7,7 @@ import { autocapturePropertiesForElement } from '../autocapture'
 import { isElementInToolbar, isElementNode, isTag } from '../utils/element-utils'
 import { getNativeMutationObserverImplementation } from '../utils/prototype-utils'
 import { addEventListener } from '../utils'
+import { DEAD_CLICK_EVENT } from '../events'
 
 function asClick(event: MouseEvent): DeadClickCandidate | null {
     const eventTarget = getEventTarget(event)
@@ -248,7 +249,7 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
         // TODO need to check safe and captur-able as with autocapture
         // TODO autocaputure config
         this.instance.capture(
-            '$dead_click',
+            DEAD_CLICK_EVENT,
             {
                 ...properties,
                 ...autocapturePropertiesForElement(click.node, {

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,38 @@
+/*
+ * Event Constants - used to identify builtin events
+ * Useful to reduce bundle size by not having to output the entire string for each event
+ */
+
+export const PAGEVIEW_EVENT = '$pageview'
+export const PAGELEAVE_EVENT = '$pageleave'
+export const SCREEN_EVENT = '$screen'
+
+export const AUTOCAPTURE_EVENT = '$autocapture'
+export const COPY_AUTOCAPTURE_EVENT = '$copy_autocapture'
+export const HEATMAP_EVENT = '$$heatmap'
+export const EXCEPTION_EVENT = '$exception'
+export const WEB_VITALS_EVENT = '$web_vitals'
+export const DEAD_CLICK_EVENT = '$dead_click'
+export const SNAPSHOT_EVENT = '$snapshot'
+export const RAGECLICK_EVENT = '$rageclick'
+
+export const SET_EVENT = '$set'
+export const IDENTIFY_EVENT = '$identify'
+export const GROUP_IDENTIFY_EVENT = '$groupidentify'
+export const CREATE_ALIAS_EVENT = '$create_alias'
+
+export const OPT_IN_EVENT = '$opt_in'
+
+export const AI_FEEDBACK_EVENT = '$ai_feedback'
+export const AI_METRIC_EVENT = '$ai_metric'
+
+export const FEATURE_FLAG_CALLED_EVENT = '$feature_flag_called'
+export const FEATURE_ENROLLMENT_UPDATE_EVENT = '$feature_enrollment_update'
+
+export const RATE_LIMIT_EVENT = '$$client_ingestion_warning'
+
+// These don't match the dollar + underscore naming convention,
+// but we need to keep them as they're used in the wild
+export const SURVEY_SHOWN_EVENT = 'survey shown'
+export const SURVEY_SENT_EVENT = 'survey sent'
+export const SURVEY_DISMISSED_EVENT = 'survey dismissed'

--- a/src/extensions/history-autocapture.ts
+++ b/src/extensions/history-autocapture.ts
@@ -3,6 +3,7 @@ import { window } from '../utils/globals'
 import { addEventListener } from '../utils'
 import { logger } from '../utils/logger'
 import { patch } from './replay/rrweb-plugins/patch'
+import { PAGEVIEW_EVENT } from '../events'
 
 /**
  * This class is used to capture pageview events when the user navigates using the history API (pushState, replaceState)
@@ -90,7 +91,7 @@ export class HistoryAutocapture {
 
             // Only capture pageview if the pathname has changed and the feature is enabled
             if (currentPathname !== this._lastPathname && this.isEnabled) {
-                this._instance.capture('$pageview', { navigation_type: navigationType })
+                this._instance.capture(PAGEVIEW_EVENT, { navigation_type: navigationType })
             }
 
             this._lastPathname = currentPathname

--- a/src/extensions/replay/sessionrecording.ts
+++ b/src/extensions/replay/sessionrecording.ts
@@ -11,6 +11,7 @@ import {
     SESSION_RECORDING_SCRIPT_CONFIG,
     SESSION_RECORDING_URL_TRIGGER_ACTIVATED_SESSION,
 } from '../../constants'
+import { PAGEVIEW_EVENT, SNAPSHOT_EVENT } from '../../events'
 import {
     estimateSize,
     INCREMENTAL_SNAPSHOT_EVENT_TYPE,
@@ -519,14 +520,14 @@ export class SessionRecording {
                     // it has the potential to block the main loop,
                     // so we catch all errors.
                     try {
-                        if (event.event === '$pageview') {
+                        if (event.event === PAGEVIEW_EVENT) {
                             const href = event?.properties.$current_url
                                 ? this._maskUrl(event?.properties.$current_url)
                                 : ''
                             if (!href) {
                                 return
                             }
-                            this._tryAddCustomEvent('$pageview', { href })
+                            this._tryAddCustomEvent(PAGEVIEW_EVENT, { href })
                         }
                     } catch (e) {
                         logger.error('Could not add $pageview to rrweb session', e)
@@ -1255,7 +1256,7 @@ export class SessionRecording {
 
     private _captureSnapshot(properties: Properties) {
         // :TRICKY: Make sure we batch these requests, use a custom endpoint and don't truncate the strings.
-        this._instance.capture('$snapshot', properties, {
+        this._instance.capture(SNAPSHOT_EVENT, properties, {
             _url: this._instance.requestRouter.endpointFor('api', this._endpoint),
             _noTruncate: true,
             _batchKey: SESSION_RECORDING_BATCH_KEY,

--- a/src/extensions/segment-integration.ts
+++ b/src/extensions/segment-integration.ts
@@ -22,6 +22,7 @@ import { createLogger } from '../utils/logger'
 import { USER_STATE } from '../constants'
 import { isFunction } from '../utils/type-utils'
 import { uuidv7 } from '../uuidv7'
+import { IDENTIFY_EVENT, PAGEVIEW_EVENT, SCREEN_EVENT } from '../events'
 
 const logger = createLogger('[SegmentIntegration]')
 
@@ -100,9 +101,9 @@ const createSegmentIntegration = (posthog: PostHog): SegmentPlugin => {
         // eslint-disable-next-line compat/compat
         load: () => Promise.resolve(),
         track: (ctx) => enrichEvent(ctx, ctx.event.event),
-        page: (ctx) => enrichEvent(ctx, '$pageview'),
-        identify: (ctx) => enrichEvent(ctx, '$identify'),
-        screen: (ctx) => enrichEvent(ctx, '$screen'),
+        page: (ctx) => enrichEvent(ctx, PAGEVIEW_EVENT),
+        identify: (ctx) => enrichEvent(ctx, IDENTIFY_EVENT),
+        screen: (ctx) => enrichEvent(ctx, SCREEN_EVENT),
     }
 }
 

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -52,6 +52,7 @@ import {
     SurveyContext,
 } from './surveys/surveys-extension-utils'
 import { prepareStylesheet } from './utils/stylesheet-loader'
+import { SURVEY_SHOWN_EVENT } from '../events'
 
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const window = _window as Window & typeof globalThis
@@ -810,7 +811,7 @@ export function usePopupVisibility(
 
             setIsPopupVisible(true)
             window.dispatchEvent(new Event('PHSurveyShown'))
-            posthog.capture('survey shown', {
+            posthog.capture(SURVEY_SHOWN_EVENT, {
                 $survey_name: survey.name,
                 $survey_id: survey.id,
                 $survey_iteration: survey.current_iteration,

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -15,6 +15,8 @@ import { prepareStylesheet } from '../utils/stylesheet-loader'
 import { SurveyMatchType } from '../../posthog-surveys-types'
 import { isMatchingRegex } from '../../utils/regex-utils'
 import { detectDeviceType } from '../../utils/user-agent-utils'
+import { SURVEY_DISMISSED_EVENT, SURVEY_SENT_EVENT } from '../../events'
+
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const window = _window as Window & typeof globalThis
 const document = _document as Document
@@ -568,7 +570,7 @@ export const sendSurveyEvent = (
     }
     localStorage.setItem(getSurveySeenKey(survey), 'true')
 
-    posthog.capture('survey sent', {
+    posthog.capture(SURVEY_SENT_EVENT, {
         $survey_name: survey.name,
         $survey_id: survey.id,
         $survey_iteration: survey.current_iteration,
@@ -596,7 +598,7 @@ export const dismissedSurveyEvent = (survey: Survey, posthog?: PostHog, readOnly
     if (readOnly) {
         return
     }
-    posthog.capture('survey dismissed', {
+    posthog.capture(SURVEY_DISMISSED_EVENT, {
         $survey_name: survey.name,
         $survey_id: survey.id,
         $survey_iteration: survey.current_iteration,

--- a/src/extensions/web-vitals/index.ts
+++ b/src/extensions/web-vitals/index.ts
@@ -4,6 +4,7 @@ import { createLogger } from '../../utils/logger'
 import { isBoolean, isNullish, isNumber, isObject, isUndefined } from '../../utils/type-utils'
 import { WEB_VITALS_ALLOWED_METRICS, WEB_VITALS_ENABLED_SERVER_SIDE } from '../../constants'
 import { assignableWindow, window, location } from '../../utils/globals'
+import { WEB_VITALS_EVENT } from '../../events'
 
 const logger = createLogger('[Web Vitals]')
 
@@ -133,7 +134,7 @@ export class WebVitalsAutocapture {
         }
 
         this._instance.capture(
-            '$web_vitals',
+            WEB_VITALS_EVENT,
             this._buffer.metrics.reduce(
                 (acc, metric) => ({
                     ...acc,

--- a/src/heatmaps.ts
+++ b/src/heatmaps.ts
@@ -11,6 +11,7 @@ import { isElementInToolbar, isElementNode, isTag } from './utils/element-utils'
 import { DeadClicksAutocapture, isDeadClicksEnabledForHeatmaps } from './extensions/dead-clicks-autocapture'
 import { includes } from './utils/string-utils'
 import { addEventListener } from './utils'
+import { HEATMAP_EVENT } from './events'
 
 const DEFAULT_FLUSH_INTERVAL = 5000
 
@@ -215,7 +216,7 @@ export class Heatmaps {
             return
         }
 
-        this.instance.capture('$$heatmap', {
+        this.instance.capture(HEATMAP_EVENT, {
             $heatmap_data: this.getAndClearBuffer(),
         })
     }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -127,7 +127,7 @@ type OnlyValidKeys<T, Shape> = T extends Shape ? (Exclude<keyof T, keyof Shape> 
 const instances: Record<string, PostHog> = {}
 
 // some globals for comparisons
-const __NOOP = () => { }
+const __NOOP = () => {}
 
 const PRIMARY_INSTANCE_NAME = 'posthog'
 
@@ -401,8 +401,8 @@ export class PostHog {
             namedPosthog._init(token, config, name)
             instances[name] = namedPosthog
 
-                // Add as a property to the primary instance (this isn't type-safe but its how it was always done)
-                ; (instances[PRIMARY_INSTANCE_NAME] as any)[name] = namedPosthog
+            // Add as a property to the primary instance (this isn't type-safe but its how it was always done)
+            ;(instances[PRIMARY_INSTANCE_NAME] as any)[name] = namedPosthog
 
             return namedPosthog
         }
@@ -620,8 +620,8 @@ export class PostHog {
             this.compression = includes(config['supportedCompression'], Compression.GZipJS)
                 ? Compression.GZipJS
                 : includes(config['supportedCompression'], Compression.Base64)
-                    ? Compression.Base64
-                    : undefined
+                  ? Compression.Base64
+                  : undefined
         }
 
         if (config.analytics?.endpoint) {
@@ -772,7 +772,7 @@ export class PostHog {
                 if (isArray(fn_name)) {
                     capturing_calls.push(item) // chained call e.g. posthog.get_group().set()
                 } else if (isFunction(item)) {
-                    ; (item as any).call(this)
+                    ;(item as any).call(this)
                 } else if (isArray(item) && fn_name === 'alias') {
                     alias_calls.push(item)
                 } else if (isArray(item) && fn_name.indexOf('capture') !== -1 && isFunction((this as any)[fn_name])) {
@@ -1086,9 +1086,9 @@ export class PostHog {
         } else {
             logger.error(
                 'Invalid value for property_denylist config: ' +
-                this.config.property_denylist +
-                ' or property_blacklist config: ' +
-                this.config.property_blacklist
+                    this.config.property_denylist +
+                    ' or property_blacklist config: ' +
+                    this.config.property_blacklist
             )
         }
 
@@ -1372,7 +1372,7 @@ export class PostHog {
      * @returns {Function} A function that can be called to unsubscribe the listener. E.g. Used by useEffect when the component unmounts.
      */
     onSessionId(callback: SessionIdChangedCallback): () => void {
-        return this.sessionManager?.onSessionId(callback) ?? (() => { })
+        return this.sessionManager?.onSessionId(callback) ?? __NOOP
     }
 
     /** Get list of all surveys. */
@@ -2288,7 +2288,7 @@ const add_dom_loaded_handler = function () {
         if ((dom_loaded_handler as any).done) {
             return
         }
-        ; (dom_loaded_handler as any).done = true
+        ;(dom_loaded_handler as any).done = true
 
         ENQUEUE_REQUESTS = false
 

--- a/src/posthog-exceptions.ts
+++ b/src/posthog-exceptions.ts
@@ -1,5 +1,6 @@
 import { PostHog } from './posthog-core'
 import { Properties } from './types'
+import { EXCEPTION_EVENT } from './events'
 
 export class PostHogExceptions {
     constructor(private readonly _instance: PostHog) {}
@@ -8,7 +9,7 @@ export class PostHogExceptions {
      * :TRICKY: Make sure we batch these requests
      */
     sendExceptionEvent(properties: Properties) {
-        this._instance.capture('$exception', properties, {
+        this._instance.capture(EXCEPTION_EVENT, properties, {
             _noTruncate: true,
             _batchKey: 'exceptionEvent',
         })

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -23,6 +23,7 @@ import {
     STORED_PERSON_PROPERTIES_KEY,
     FLAG_CALL_REPORTED,
 } from './constants'
+import { FEATURE_FLAG_CALLED_EVENT, FEATURE_ENROLLMENT_UPDATE_EVENT } from './events'
 
 import { isArray, isUndefined } from './utils/type-utils'
 import { createLogger } from './utils/logger'
@@ -525,7 +526,7 @@ export class PostHogFeatureFlags {
                     properties.$feature_flag_original_payload = flagDetails?.metadata?.original_payload
                 }
 
-                this._instance.capture('$feature_flag_called', properties)
+                this._instance.capture(FEATURE_FLAG_CALLED_EVENT, properties)
             }
         }
         return flagValue
@@ -754,7 +755,7 @@ export class PostHogFeatureFlags {
             properties['$early_access_feature_name'] = feature.name
         }
 
-        this._instance.capture('$feature_enrollment_update', properties)
+        this._instance.capture(FEATURE_ENROLLMENT_UPDATE_EVENT, properties)
         this.setPersonPropertiesForFlags(enrollmentPersonProp, false)
 
         const newFlags = { ...this.getFlagVariants(), [key]: isEnrolled }

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,4 +1,5 @@
 import { CAPTURE_RATE_LIMIT } from './constants'
+import { RATE_LIMIT_EVENT } from './events'
 import type { PostHog } from './posthog-core'
 import { RequestResponse } from './types'
 import { createLogger } from './utils/logger'
@@ -6,7 +7,6 @@ import { createLogger } from './utils/logger'
 const logger = createLogger('[RateLimiter]')
 
 const ONE_MINUTE_IN_MILLISECONDS = 60 * 1000
-const RATE_LIMIT_EVENT = '$$client_ingestion_warning'
 
 interface CaptureResponse {
     quota_limited?: string[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,27 +2,47 @@ import type { recordOptions } from './extensions/replay/types/rrweb'
 import type { SegmentAnalytics } from './extensions/segment-integration'
 import { PostHog } from './posthog-core'
 import { Survey } from './posthog-surveys-types'
+import {
+    PAGEVIEW_EVENT,
+    PAGELEAVE_EVENT,
+    GROUP_IDENTIFY_EVENT,
+    FEATURE_ENROLLMENT_UPDATE_EVENT,
+    SET_EVENT,
+    CREATE_ALIAS_EVENT,
+    FEATURE_FLAG_CALLED_EVENT,
+    RATE_LIMIT_EVENT,
+    SURVEY_SHOWN_EVENT,
+    SURVEY_SENT_EVENT,
+    SURVEY_DISMISSED_EVENT,
+    IDENTIFY_EVENT,
+    AUTOCAPTURE_EVENT,
+    DEAD_CLICK_EVENT,
+    WEB_VITALS_EVENT,
+    HEATMAP_EVENT,
+    EXCEPTION_EVENT,
+    OPT_IN_EVENT,
+    SNAPSHOT_EVENT,
+    RAGECLICK_EVENT,
+    COPY_AUTOCAPTURE_EVENT,
+} from './events'
 
 export type Property = any
 export type Properties = Record<string, Property>
 
-export const COPY_AUTOCAPTURE_EVENT = '$copy_autocapture'
-
 export const knownUnsafeEditableEvent = [
-    '$snapshot',
-    '$pageview',
-    '$pageleave',
-    '$set',
-    'survey dismissed',
-    'survey sent',
-    'survey shown',
-    '$identify',
-    '$groupidentify',
-    '$create_alias',
-    '$$client_ingestion_warning',
-    '$web_experiment_applied',
-    '$feature_enrollment_update',
-    '$feature_flag_called',
+    SNAPSHOT_EVENT,
+    PAGEVIEW_EVENT,
+    PAGELEAVE_EVENT,
+    SET_EVENT,
+    SURVEY_DISMISSED_EVENT,
+    SURVEY_SENT_EVENT,
+    SURVEY_SHOWN_EVENT,
+    IDENTIFY_EVENT,
+    GROUP_IDENTIFY_EVENT,
+    CREATE_ALIAS_EVENT,
+    RATE_LIMIT_EVENT,
+    FEATURE_ENROLLMENT_UPDATE_EVENT,
+    FEATURE_FLAG_CALLED_EVENT,
 ] as const
 
 /**
@@ -39,15 +59,14 @@ export type KnownUnsafeEditableEvent = (typeof knownUnsafeEditableEvent)[number]
  * So, it is safe to sample them to reduce the volume of events sent to PostHog
  */
 export type KnownEventName =
-    | '$heatmaps_data'
-    | '$opt_in'
-    | '$exception'
-    | '$$heatmap'
-    | '$web_vitals'
-    | '$dead_click'
-    | '$autocapture'
+    | typeof OPT_IN_EVENT
+    | typeof EXCEPTION_EVENT
+    | typeof HEATMAP_EVENT
+    | typeof WEB_VITALS_EVENT
+    | typeof DEAD_CLICK_EVENT
+    | typeof AUTOCAPTURE_EVENT
     | typeof COPY_AUTOCAPTURE_EVENT
-    | '$rageclick'
+    | typeof RAGECLICK_EVENT
 
 export type EventName =
     | KnownUnsafeEditableEvent

--- a/src/utils/survey-event-receiver.ts
+++ b/src/utils/survey-event-receiver.ts
@@ -6,8 +6,7 @@ import { PostHog } from '../posthog-core'
 import { CaptureResult } from '../types'
 import { SURVEY_LOGGER as logger } from './survey-utils'
 import { isUndefined } from './type-utils'
-
-const SURVEY_SHOWN_EVENT_NAME = 'survey shown'
+import { SURVEY_SHOWN_EVENT } from '../events'
 
 export class SurveyEventReceiver {
     // eventToSurveys is a mapping of event name to all the surveys that are activated by it
@@ -112,7 +111,7 @@ export class SurveyEventReceiver {
 
     onEvent(event: string, eventPayload?: CaptureResult): void {
         const existingActivatedSurveys: string[] = this._instance?.persistence?.props[SURVEYS_ACTIVATED] || []
-        if (SURVEY_SHOWN_EVENT_NAME === event && eventPayload && existingActivatedSurveys.length > 0) {
+        if (SURVEY_SHOWN_EVENT === event && eventPayload && existingActivatedSurveys.length > 0) {
             // remove survey that from activatedSurveys here.
             logger.info('survey event matched, removing survey from activated surveys', {
                 event,

--- a/testcafe/e2e.spec.js
+++ b/testcafe/e2e.spec.js
@@ -11,6 +11,9 @@ import {
 } from './helpers'
 import { expect } from 'expect'
 
+// We can't do this because those are TS files and we can only import JS files from here
+// import { PAGEVIEW_EVENT, AUTOCAPTURE_EVENT } from '../src/events'
+
 // eslint-disable-next-line no-undef
 fixture('posthog.js capture')
     .page('http://localhost:8000/playground/cypress-full/index.html')


### PR DESCRIPTION
We repeat these event names in several places. Most of them are in tests, yes, but there's a fair bit of repetition in some places, so let's extract them to a new `events.ts` file and import them from there instead