### PR TITLE
fix: getRenderSurvey behavior

### DIFF
--- a/src/__tests__/posthog-surveys.test.ts
+++ b/src/__tests__/posthog-surveys.test.ts
@@ -118,6 +118,7 @@ describe('posthog-surveys', () => {
             it('should return false if surveys are not loaded', () => {
                 const result = surveys.canRenderSurvey(survey.id)
                 expect(result.visible).toBeFalsy()
+                expect(result.disabledReason).toEqual('SDK is not enabled or survey functionality is not yet loaded')
             })
 
             it('should return visible: true if surveys are loaded and the survey is eligible', () => {
@@ -128,6 +129,7 @@ describe('posthog-surveys', () => {
                 decideResponse.featureFlags[survey.linked_flag_key] = true
                 const result = surveys.canRenderSurvey(survey.id)
                 expect(result.visible).toBeTruthy()
+                expect(result.disabledReason).toBeUndefined()
             })
         })
 

--- a/src/__tests__/posthog-surveys.test.ts
+++ b/src/__tests__/posthog-surveys.test.ts
@@ -114,6 +114,24 @@ describe('posthog-surveys', () => {
             delete assignableWindow.__PosthogExtensions__
         })
 
+        describe('canRenderSurvey', () => {
+            it('should return false if surveys are not loaded', () => {
+                const result = surveys.canRenderSurvey(survey.id)
+                expect(result.visible).toBeFalsy()
+            })
+
+            it('should return visible: true if surveys are loaded and the survey is eligible', () => {
+                mockPostHog.get_property.mockReturnValue([survey])
+                surveys['_surveyManager'] = new SurveyManager(mockPostHog as PostHog)
+                decideResponse.featureFlags[survey.targeting_flag_key] = true
+                decideResponse.featureFlags[survey.internal_targeting_flag_key] = true
+                decideResponse.featureFlags[survey.linked_flag_key] = true
+                const result = surveys.canRenderSurvey(survey.id)
+                console.log(result)
+                expect(result.visible).toBeTruthy()
+            })
+        })
+
         describe('checkSurveyEligibility', () => {
             beforeEach(() => {
                 // mock getSurveys response

--- a/src/__tests__/posthog-surveys.test.ts
+++ b/src/__tests__/posthog-surveys.test.ts
@@ -127,7 +127,6 @@ describe('posthog-surveys', () => {
                 decideResponse.featureFlags[survey.internal_targeting_flag_key] = true
                 decideResponse.featureFlags[survey.linked_flag_key] = true
                 const result = surveys.canRenderSurvey(survey.id)
-                console.log(result)
                 expect(result.visible).toBeTruthy()
             })
         })

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -274,7 +274,7 @@ export class PostHogSurveys {
     }
 
     canRenderSurvey(surveyId: string): SurveyRenderReason {
-        if (!isNullish(this._surveyManager)) {
+        if (isNullish(this._surveyManager)) {
             logger.warn('init was not called')
             return { visible: false, disabledReason: 'SDK is not enabled or survey functionality is not yet loaded' }
         }


### PR DESCRIPTION
## Changes

getRenderSurvey is returning that surveys are not loaded when they are

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

