### PR TITLE
chore: include response within the survey_quesiton property

### DIFF
--- a/playwright/surveys/question-types.spec.ts
+++ b/playwright/surveys/question-types.spec.ts
@@ -73,7 +73,7 @@ test.describe('surveys - core display logic', () => {
         await expect(page.locator('.PostHogSurvey-123').locator('.survey-question-description')).toHaveText(
             'plain text description'
         )
-        await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('textarea').type('Great job!')
+        await page.locator('.PostHogSurvey-123').locator('.survey-form').locator('textarea').fill('Great job!')
         await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
 
         await pollUntilEventCaptured(page, 'survey sent')
@@ -111,7 +111,7 @@ test.describe('surveys - core display logic', () => {
         await page.locator('.PostHogSurvey-123').locator('.ratings-number').first().click()
         await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
 
-        await expect(page.locator('.PostHogSurvey-123').locator('.ratings-number').first()).toHaveText('1')
+        await expect(page.locator('.PostHogSurvey-123').locator('.ratings-number').first()).toHaveText('0')
     })
 
     test('multiple question surveys', async ({ page, context }) => {
@@ -144,7 +144,7 @@ test.describe('surveys - core display logic', () => {
         await page.locator('.PostHogSurvey-12345').locator('#surveyQuestion0Choice2').click()
         await page.locator('.PostHogSurvey-12345').locator('.form-submit').click()
 
-        await page.locator('.PostHogSurvey-12345').locator('textarea').type('Great job!')
+        await page.locator('.PostHogSurvey-12345').locator('textarea').fill('Great job!')
         await page.locator('.PostHogSurvey-12345').locator('.form-submit').click()
         await page.locator('.PostHogSurvey-12345').locator('.form-submit').click()
 
@@ -167,7 +167,9 @@ test.describe('surveys - core display logic', () => {
             '$autocapture',
         ])
         const surveySent = captures.find((c) => c.event === 'survey sent')
-        expect(surveySent!.properties[getSurveyResponseKey('multiple_choice_1')]).toEqual(['Product Updates', 'Events'])
+        expect(surveySent!.properties[getSurveyResponseKey('multiple_choice_1')]).toEqual(
+            expect.arrayContaining(['Product Updates', 'Events'])
+        )
         expect(surveySent!.properties['$survey_id']).toEqual('12345')
         expect(surveySent!.properties[getSurveyResponseKey('open_text_1')]).toEqual('Great job!')
         expect(surveySent!.properties[getSurveyResponseKey('nps_rating_1')]).toBeNull()
@@ -175,14 +177,17 @@ test.describe('surveys - core display logic', () => {
             {
                 id: 'multiple_choice_1',
                 question: 'Which types of content would you like to see more of?',
+                response: ['Product Updates', 'Events'],
             },
             {
                 id: 'open_text_1',
                 question: 'What feedback do you have for us?',
+                response: 'Great job!',
             },
             {
                 id: 'nps_rating_1',
                 question: 'Would you recommend surveys?',
+                response: null,
             },
         ])
     })
@@ -229,6 +234,7 @@ test.describe('surveys - core display logic', () => {
             {
                 id: 'multiple_choice_1',
                 question: 'Which types of content would you like to see more of?',
+                response: ['Tutorials', 'Newsletters'],
             },
         ])
     })
@@ -281,6 +287,7 @@ test.describe('surveys - core display logic', () => {
             {
                 id: 'single_choice_1',
                 question: 'What is your occupation?',
+                response: 'Product engineer',
             },
         ])
     })

--- a/playwright/surveys/response-capture.spec.ts
+++ b/playwright/surveys/response-capture.spec.ts
@@ -58,6 +58,7 @@ test.describe('surveys - feedback widget', () => {
                     {
                         id: 'open_text_1',
                         question: 'What feedback do you have for us?',
+                        response: 'experiments is awesome!',
                     },
                 ],
             })
@@ -117,6 +118,7 @@ test.describe('surveys - feedback widget', () => {
                     {
                         id: 'open_text_1',
                         question: 'What feedback do you have for us?',
+                        response: 'experiments is awesome!',
                     },
                 ],
             })

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -1258,5 +1258,5 @@ const getQuestionComponent = ({
     const Component = questionComponents[question.type]
     const componentProps = { ...commonProps, ...additionalProps[question.type] }
 
-    return <Component {...componentProps} />
+    return <Component {...componentProps} key={question.id} />
 }

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -590,6 +590,7 @@ export const sendSurveyEvent = ({
         $survey_questions: survey.questions.map((question) => ({
             id: question.id,
             question: question.question,
+            response: question.id ? responses[getSurveyResponseKey(question.id)] : null,
         })),
         $survey_submission_id: surveySubmissionId,
         $survey_completed: isSurveyCompleted,
@@ -633,6 +634,7 @@ export const dismissedSurveyEvent = (survey: Survey, posthog?: PostHog, readOnly
         $survey_questions: survey.questions.map((question) => ({
             id: question.id,
             question: question.question,
+            response: question.id ? inProgressSurvey?.responses[getSurveyResponseKey(question.id)] : null,
         })),
         $set: {
             [getSurveyInteractionProperty(survey, 'dismissed')]: true,

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../posthog-surveys-types'
 import { document as _document, window as _window, userAgent } from '../../utils/globals'
 import { SURVEY_LOGGER as logger, SURVEY_IN_PROGRESS_PREFIX, SURVEY_SEEN_PREFIX } from '../../utils/survey-utils'
-import { isNullish } from '../../utils/type-utils'
+import { isNullish, isArray } from '../../utils/type-utils'
 import { prepareStylesheet } from '../utils/stylesheet-loader'
 
 import { SurveyMatchType } from '../../posthog-surveys-types'
@@ -566,6 +566,17 @@ interface SendSurveyEventArgs {
     posthog?: PostHog
 }
 
+const getSurveyResponseValue = (responses: Record<string, string | number | string[] | null>, questionId?: string) => {
+    if (!questionId) {
+        return null
+    }
+    const response = responses[getSurveyResponseKey(questionId)]
+    if (isArray(response)) {
+        return [...response]
+    }
+    return response
+}
+
 export const sendSurveyEvent = ({
     responses,
     survey,
@@ -590,7 +601,7 @@ export const sendSurveyEvent = ({
         $survey_questions: survey.questions.map((question) => ({
             id: question.id,
             question: question.question,
-            response: question.id ? responses[getSurveyResponseKey(question.id)] : null,
+            response: getSurveyResponseValue(responses, question.id),
         })),
         $survey_submission_id: surveySubmissionId,
         $survey_completed: isSurveyCompleted,
@@ -634,7 +645,7 @@ export const dismissedSurveyEvent = (survey: Survey, posthog?: PostHog, readOnly
         $survey_questions: survey.questions.map((question) => ({
             id: question.id,
             question: question.question,
-            response: question.id ? inProgressSurvey?.responses[getSurveyResponseKey(question.id)] : null,
+            response: getSurveyResponseValue(inProgressSurvey?.responses || {}, question.id),
         })),
         $set: {
             [getSurveyInteractionProperty(survey, 'dismissed')]: true,


### PR DESCRIPTION
## Changes

includes the survey response within the $survey_questions property in the survey sent/dismissed events.

this will a key case for handling zapier integrations where we're not able to use the `getSurveyResponse` function to retrieve survey questions. as this allow us to get both question and response with a single property at a small cost of duplicating a small byte of info.