### PR TITLE
fix: false flag should not trigger linked flags

### DIFF
--- a/playwright/session-recording/session-recording-linked-flags.spec.ts
+++ b/playwright/session-recording/session-recording-linked-flags.spec.ts
@@ -51,7 +51,15 @@ test.describe('Session recording - linked flags', () => {
             },
             decideResponseOverrides: {
                 sessionRecording: { linkedFlag: 'my-linked-flag' },
-                featureFlags: { 'my-linked-flag': false },
+                flags: {
+                    'my-linked-flag': {
+                        enabled: false,
+                        key: 'my-linked-flag',
+                        variant: undefined,
+                        metadata: undefined,
+                        reason: undefined,
+                    },
+                },
             },
         })
         await recorderPromise
@@ -73,7 +81,15 @@ test.describe('Session recording - linked flags', () => {
             },
             decideResponseOverrides: {
                 sessionRecording: { linkedFlag: 'my-linked-flag' },
-                featureFlags: { 'my-linked-flag': true },
+                flags: {
+                    'my-linked-flag': {
+                        enabled: true,
+                        key: 'my-linked-flag',
+                        variant: undefined,
+                        metadata: undefined,
+                        reason: undefined,
+                    },
+                },
             },
         })
 
@@ -95,7 +111,15 @@ test.describe('Session recording - linked flags', () => {
                 },
                 decideResponseOverrides: {
                     sessionRecording: { linkedFlag: 'my-linked-flag' },
-                    featureFlags: { 'not-my-linked-flag': true },
+                    flags: {
+                        'not-my-linked-flag': {
+                            enabled: true,
+                            key: 'not-my-linked-flag',
+                            variant: undefined,
+                            metadata: undefined,
+                            reason: undefined,
+                        },
+                    },
                 },
             },
             []

--- a/playwright/session-recording/session-recording-linked-flags.spec.ts
+++ b/playwright/session-recording/session-recording-linked-flags.spec.ts
@@ -1,10 +1,9 @@
 import { test, WindowWithPostHog } from '../utils/posthog-playwright-test-base'
-import { start } from '../utils/setup'
+import { start, StartOptions } from '../utils/setup'
 import { assertThatRecordingStarted, pollUntilEventCaptured } from '../utils/event-capture-utils'
 import { BrowserContext, Page } from '@playwright/test'
-import { DecideResponse } from '../../src/types'
 
-const startOptions = {
+const startOptions: StartOptions = {
     options: {
         session_recording: {},
         opt_out_capturing_by_default: true,
@@ -12,7 +11,7 @@ const startOptions = {
     decideResponseOverrides: {
         sessionRecording: {
             endpoint: '/ses/',
-            // a flag that doesn't exist, can never be recorded
+            // a flag which doesn't exist can never be recorded
             linkedFlag: 'i am a flag that does not exist',
         },
         capturePerformance: true,
@@ -25,75 +24,82 @@ test.describe('Session recording - linked flags', () => {
     const startWithFlags = async (
         page: Page,
         context: BrowserContext,
-        decideResponseOverrides: Partial<DecideResponse>
+        startOptionsOverrides: Partial<StartOptions> = {},
+        expectedStartingEvents: string[] = ['$pageview']
     ) => {
         await start(
             {
                 ...startOptions,
+                ...startOptionsOverrides,
                 decideResponseOverrides: {
                     ...startOptions.decideResponseOverrides,
-                    ...decideResponseOverrides,
+                    ...startOptionsOverrides.decideResponseOverrides,
                 },
             },
             page,
             context
         )
-        await page.expectCapturedEventsToBe([])
+        await page.expectCapturedEventsToBe(expectedStartingEvents)
         await page.resetCapturedEvents()
     }
 
     test('does not start when boolean linked flag is false', async ({ page, context }) => {
+        const recorderPromise = page.waitForResponse('**/recorder.js*')
         await startWithFlags(page, context, {
-            sessionRecording: { linkedFlag: 'my-linked-flag' },
-            featureFlags: { 'my-linked-flag': false },
-        })
-
-        await page.waitingForNetworkCausedBy({
-            urlPatternsToWaitFor: ['**/recorder.js*'],
-            action: async () => {
-                await page.evaluate(() => {
-                    const ph = (window as WindowWithPostHog).posthog
-                    ph?.opt_in_capturing()
-                })
+            options: {
+                opt_out_capturing_by_default: false,
+            },
+            decideResponseOverrides: {
+                sessionRecording: { linkedFlag: 'my-linked-flag' },
+                featureFlags: { 'my-linked-flag': false },
             },
         })
-
-        await page.expectCapturedEventsToBe(['$opt_in', '$pageview'])
+        await recorderPromise
 
         // even activity won't trigger a snapshot, we're buffering
         await page.locator('[data-cy-input]').type('hello posthog!')
         // short delay since there's no snapshot to wait for
         await page.waitForTimeout(250)
-        await page.expectCapturedEventsToBe(['$opt_in', '$pageview'])
+
+        await page.expectCapturedEventsToBe([])
     })
 
     test('starts when boolean linked flag is true', async ({ page, context }) => {
-        await startWithFlags(page, context, {
-            sessionRecording: { linkedFlag: 'my-linked-flag' },
-            featureFlags: { 'my-linked-flag': true },
-        })
+        const recorderPromise = page.waitForResponse('**/recorder.js*')
 
-        await page.waitingForNetworkCausedBy({
-            urlPatternsToWaitFor: ['**/recorder.js*'],
-            action: async () => {
-                await page.evaluate(() => {
-                    const ph = (window as WindowWithPostHog).posthog
-                    ph?.opt_in_capturing()
-                })
+        await startWithFlags(page, context, {
+            options: {
+                opt_out_capturing_by_default: false,
+            },
+            decideResponseOverrides: {
+                sessionRecording: { linkedFlag: 'my-linked-flag' },
+                featureFlags: { 'my-linked-flag': true },
             },
         })
 
-        await page.expectCapturedEventsToBe(['$opt_in', '$pageview'])
+        await recorderPromise
+
         await page.locator('[data-cy-input]').type('hello posthog!')
         await pollUntilEventCaptured(page, '$snapshot')
         await assertThatRecordingStarted(page)
     })
 
     test('can opt in and override linked flag', async ({ page, context }) => {
-        await startWithFlags(page, context, {
-            sessionRecording: { linkedFlag: 'my-linked-flag' },
-            featureFlags: { 'not-my-linked-flag': true },
-        })
+        await startWithFlags(
+            page,
+            context,
+            {
+                options: {
+                    // we start opted out, so we can test the opt-in and override
+                    opt_out_capturing_by_default: true,
+                },
+                decideResponseOverrides: {
+                    sessionRecording: { linkedFlag: 'my-linked-flag' },
+                    featureFlags: { 'not-my-linked-flag': true },
+                },
+            },
+            []
+        )
 
         await page.waitingForNetworkCausedBy({
             urlPatternsToWaitFor: ['**/recorder.js*'],

--- a/playwright/utils/posthog-playwright-test-base.ts
+++ b/playwright/utils/posthog-playwright-test-base.ts
@@ -20,7 +20,7 @@ export type WindowWithPostHog = typeof globalThis & {
 
 declare module '@playwright/test' {
     /*
-     to support tests running in parallel
+     to support tests running in parallel,
      we keep captured events in the window object
      for a page with custom methods added
      to the Playwright Page object

--- a/playwright/utils/setup.ts
+++ b/playwright/utils/setup.ts
@@ -19,6 +19,22 @@ export async function gotoPage(page: Page, url: string) {
     await page.goto(url)
 }
 
+export interface StartOptions {
+    waitForDecide?: boolean
+    initPosthog?: boolean
+    resetOnInit?: boolean
+    // playwright is stricter than cypress on access to the window object
+    // sometimes you need to pass functions here that will run on window in the correct page
+    runBeforePostHogInit?: (pg: Page) => void
+    // playwright is stricter than cypress on access to the window object
+    // sometimes you need to pass functions here that will run on window in the correct page
+    runAfterPostHogInit?: (pg: Page) => void
+    type?: 'navigate' | 'reload'
+    options?: Partial<PostHogConfig>
+    decideResponseOverrides?: Partial<DecideResponse>
+    url?: string
+}
+
 export async function start(
     {
         waitForDecide = true,
@@ -34,21 +50,7 @@ export async function start(
             capturePerformance: true,
         },
         url = '/playground/cypress-full/index.html',
-    }: {
-        waitForDecide?: boolean
-        initPosthog?: boolean
-        resetOnInit?: boolean
-        // playwright is stricter than cypress on access to the window object
-        // sometimes you need to pass functions here that will run on window in the correct page
-        runBeforePostHogInit?: (pg: Page) => void
-        // playwright is stricter than cypress on access to the window object
-        // sometimes you need to pass functions here that will run on window in the correct page
-        runAfterPostHogInit?: (pg: Page) => void
-        type?: 'navigate' | 'reload'
-        options?: Partial<PostHogConfig>
-        decideResponseOverrides?: Partial<DecideResponse>
-        url?: string
-    },
+    }: StartOptions,
     page: Page,
     context: BrowserContext
 ) {

--- a/src/__tests__/extensions/replay/sessionrecording.test.ts
+++ b/src/__tests__/extensions/replay/sessionrecording.test.ts
@@ -1788,6 +1788,20 @@ describe('SessionRecording', () => {
             expect(sessionRecording.status).toEqual('buffering')
         })
 
+        it('does not react to flags that are present but false', () => {
+            sessionRecording.onRemoteConfig(
+                makeDecideResponse({ sessionRecording: { endpoint: '/s/', linkedFlag: 'the-flag-key' } })
+            )
+
+            expect(sessionRecording.status).toEqual('buffering')
+
+            expect(onFeatureFlagsCallback).not.toBeNull()
+
+            onFeatureFlagsCallback?.(['the-flag-key'], { 'the-flag-key': false })
+            expect(sessionRecording['_linkedFlagMatching'].linkedFlagSeen).toEqual(false)
+            expect(sessionRecording.status).toEqual('buffering')
+        })
+
         it('can handle linked flags with variants', () => {
             expect(sessionRecording['_linkedFlagMatching'].linkedFlag).toEqual(null)
             expect(sessionRecording['_linkedFlagMatching'].linkedFlagSeen).toEqual(false)

--- a/src/extensions/replay/triggerMatching.ts
+++ b/src/extensions/replay/triggerMatching.ts
@@ -215,7 +215,10 @@ export class LinkedFlagMatching implements TriggerStatusMatching {
             const linkedVariant = isString(this.linkedFlag) ? null : this.linkedFlag.variant
             this._flaglistenerCleanup = this._instance.onFeatureFlags((_flags, variants) => {
                 const flagIsPresent = isObject(variants) && linkedFlag in variants
-                const linkedFlagMatches = linkedVariant ? variants[linkedFlag] === linkedVariant : flagIsPresent
+                const linkedFlagMatches =
+                    flagIsPresent &&
+                    (linkedVariant ? variants[linkedFlag] === linkedVariant : variants[linkedFlag] === true)
+
                 if (linkedFlagMatches) {
                     onStarted(linkedFlag, linkedVariant)
                 }


### PR DESCRIPTION
finally a false flag that isn't a conspiracy theory!

it used to be safe to check for the presence of a flag 

but we recently started returning flags that are enabled but false

so, it's not safe any more and replay linked flags was broken as a result

i had seen that we changed that API but wrote this code so long ago I totally missed this consequence