### PR TITLE
fix: padding on cancel button

### DIFF
--- a/playwright/surveys/core-display-logic.spec.ts
+++ b/playwright/surveys/core-display-logic.spec.ts
@@ -70,7 +70,7 @@ test.describe('surveys - core display logic', () => {
         await surveysAPICall
 
         await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
-        await page.locator('.PostHogSurvey-123').locator('.cancel-btn-wrapper').click()
+        await page.locator('.PostHogSurvey-123').locator('.form-cancel').click()
         await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).not.toBeInViewport()
 
         expect(

--- a/playwright/surveys/response-capture.spec.ts
+++ b/playwright/surveys/response-capture.spec.ts
@@ -145,7 +145,7 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await page.locator('.PostHogSurvey-123 .cancel-btn-wrapper').click()
+        await page.locator('.PostHogSurvey-123 .form-cancel').click()
         await pollUntilEventCaptured(page, 'survey dismissed')
         const surveyDismissedEvent = await page
             .capturedEvents()
@@ -180,7 +180,7 @@ test.describe('surveys - feedback widget', () => {
         await start(startOptions, page, context)
         await surveysAPICall
 
-        await page.locator('.PostHogSurvey-123 .cancel-btn-wrapper').click()
+        await page.locator('.PostHogSurvey-123 .form-cancel').click()
         await pollUntilEventCaptured(page, 'survey dismissed')
         const surveyDismissedEvent = await page
             .capturedEvents()
@@ -341,7 +341,7 @@ test.describe('surveys - feedback widget', () => {
             })
         )
 
-        await page.locator('.PostHogSurvey-123 .cancel-btn-wrapper').click()
+        await page.locator('.PostHogSurvey-123 .form-cancel').click()
         await pollUntilEventCaptured(page, 'survey dismissed')
         const surveyDismissedEvent = await page
             .capturedEvents()

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -212,7 +212,6 @@ export class SurveyManager {
                         posthog={this._posthog}
                         survey={survey}
                         removeSurveyFromFocus={this._removeSurveyFromFocus}
-                        isPopup={true}
                     />,
                     shadow
                 )
@@ -228,7 +227,6 @@ export class SurveyManager {
                         posthog={this._posthog}
                         survey={{ ...survey, appearance: { ...survey.appearance, surveyPopupDelaySeconds: 0 } }}
                         removeSurveyFromFocus={this._removeSurveyFromFocus}
-                        isPopup={true}
                     />,
                     shadow
                 )
@@ -627,7 +625,6 @@ export const renderSurveysPreview = ({
             onPreviewSubmit={onPreviewSubmit}
             previewPageIndex={previewPageIndex}
             removeSurveyFromFocus={() => {}}
-            isPopup={true}
         />,
         parentElement
     )
@@ -877,7 +874,7 @@ export function SurveyPopup({
     style,
     previewPageIndex,
     removeSurveyFromFocus,
-    isPopup,
+    isPopup = true,
     onPreviewSubmit = () => {},
     onPopupSurveyDismissed = () => {},
     onCloseConfirmationMessage = () => {},
@@ -1052,6 +1049,14 @@ export function Questions({
                     : {}
             }
         >
+            {isPopup && (
+                <Cancel
+                    onClick={() => {
+                        onPopupSurveyDismissed()
+                    }}
+                />
+            )}
+
             <div
                 className="survey-box"
                 style={
@@ -1063,13 +1068,6 @@ export function Questions({
                         : {}
                 }
             >
-                {isPopup && (
-                    <Cancel
-                        onClick={() => {
-                            onPopupSurveyDismissed()
-                        }}
-                    />
-                )}
                 {getQuestionComponent({
                     question: currentQuestion,
                     forceDisableHtml,
@@ -1184,7 +1182,6 @@ export function FeedbackWidget({
                     forceDisableHtml={forceDisableHtml}
                     style={styleOverrides}
                     removeSurveyFromFocus={removeSurveyFromFocus}
-                    isPopup={true}
                     onPopupSurveyDismissed={resetShowSurvey}
                     onCloseConfirmationMessage={resetShowSurvey}
                 />

--- a/src/extensions/surveys/components/QuestionHeader.tsx
+++ b/src/extensions/surveys/components/QuestionHeader.tsx
@@ -41,7 +41,6 @@ export function Cancel({ onClick }: { onClick: () => void }) {
             disabled={isPreviewMode}
             aria-label="Close survey"
             type="button"
-            role="button"
         >
             {cancelSVG}
         </button>

--- a/src/extensions/surveys/components/QuestionHeader.tsx
+++ b/src/extensions/surveys/components/QuestionHeader.tsx
@@ -35,17 +35,15 @@ export function Cancel({ onClick }: { onClick: () => void }) {
     const { isPreviewMode } = useContext(SurveyContext)
 
     return (
-        <div className="cancel-btn-wrapper">
-            <button
-                className="form-cancel"
-                onClick={onClick}
-                disabled={isPreviewMode}
-                aria-label="Close survey"
-                type="button"
-                role="button"
-            >
-                {cancelSVG}
-            </button>
-        </div>
+        <button
+            className="form-cancel"
+            onClick={onClick}
+            disabled={isPreviewMode}
+            aria-label="Close survey"
+            type="button"
+            role="button"
+        >
+            {cancelSVG}
+        </button>
     )
 }

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -19,7 +19,6 @@ import { detectDeviceType } from '../../utils/user-agent-utils'
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const window = _window as Window & typeof globalThis
 const document = _document as Document
-
 export const SURVEY_DEFAULT_Z_INDEX = 2147483647
 
 export function getFontFamily(fontFamily?: string): string {

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -130,7 +130,6 @@ export const style = (appearance: SurveyAppearance | null) => {
           }
           .form-cancel {
               border: 1.5px solid ${appearance?.borderColor || '#c9c6c6'};
-              border-radius: 100%;
               background: white;
               border-radius: 100%;
               line-height: 0;

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -129,25 +129,17 @@ export const style = (appearance: SurveyAppearance | null) => {
               width: 100%;
           }
           .form-cancel {
-              display: flex;
-              float: right;
-              border: none;
-              background: none;
-              cursor: pointer;
-          }
-          .cancel-btn-wrapper {
-              position: absolute;
-              width: 35px;
-              height: 35px;
+              border: 1.5px solid ${appearance?.borderColor || '#c9c6c6'};
               border-radius: 100%;
+              background: white;
+              border-radius: 100%;
+              line-height: 0;
+              cursor: pointer;
+              padding: 12px;
+              position: absolute;
               top: 0;
               right: 0;
               transform: translate(50%, -50%);
-              background: white;
-              border: 1.5px solid ${appearance?.borderColor || '#c9c6c6'};
-              display: flex;
-              justify-content: center;
-              align-items: center;
           }
           .bolded { font-weight: 600; }
           .buttons {


### PR DESCRIPTION
## Changes

right now, you can only click cancel on the survey if you click exactly on the X button due to a lack of padding.

and, there's also a bunch of unnecessary style tags that I'm cleaning up and overall just making the button markup simpler.

Now the button container works as expected. No visual changes:

![CleanShot 2025-05-07 at 21 11 32@2x](https://github.com/user-attachments/assets/99566b99-4794-4739-b6a5-c774f58ea545)
