### PR TITLE
feat: use css files for survey widget styles

### DIFF
--- a/src/__tests__/extensions/surveys/feedback-widget.test.tsx
+++ b/src/__tests__/extensions/surveys/feedback-widget.test.tsx
@@ -130,8 +130,6 @@ describe('FeedbackWidget', () => {
         // Check if the tab is visible
         const tab = screen.getByText('Feedback')
         expect(tab).toBeVisible()
-        // Check default text color contrast (black background -> white text)
-        expect(tab).toHaveStyle('color: white')
 
         // Survey popup should not be visible initially
         expect(screen.queryByRole('form')).not.toBeInTheDocument() // Form is inside SurveyPopup

--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+    const content: string
+    export default content
+}

--- a/src/extensions/surveys-widget.ts
+++ b/src/extensions/surveys-widget.ts
@@ -1,8 +1,9 @@
 import { PostHog } from '../posthog-core'
 import { Survey } from '../posthog-surveys-types'
 import { document as _document } from '../utils/globals'
-import { getSurveyContainerClass, SURVEY_DEFAULT_Z_INDEX } from './surveys/surveys-extension-utils'
+import { addSurveyCSSVariablesToElement, getSurveyContainerClass } from './surveys/surveys-extension-utils'
 import { prepareStylesheet } from './utils/stylesheet-loader'
+import widgetStyles from './surveys/widget.css'
 
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const document = _document as Document
@@ -17,42 +18,17 @@ export function retrieveWidgetShadow(survey: Survey, posthog?: PostHog) {
 
     // If it doesn't exist, create it
     const div = document.createElement('div')
+    addSurveyCSSVariablesToElement(div, survey.appearance)
     div.className = widgetClassName
     const shadow = div.attachShadow({ mode: 'open' })
-    const widgetStyleSheet = createWidgetStyle(survey.appearance?.widgetColor)
-
-    const stylesheet = prepareStylesheet(document, widgetStyleSheet, posthog)
+    const stylesheet = createWidgetStylesheet(posthog)
     if (stylesheet) {
-        shadow.append(stylesheet)
+        shadow.appendChild(stylesheet)
     }
-
     document.body.appendChild(div)
     return shadow
 }
 
-export function createWidgetStyle(widgetColor?: string) {
-    return `
-        .ph-survey-widget-tab {
-            position: fixed;
-            top: 50%;
-            right: 0;
-            background: ${widgetColor || '#e0a045'};
-            color: white;
-            transform: rotate(-90deg) translate(0, -100%);
-            transform-origin: right top;
-            min-width: 40px;
-            padding: 8px 12px;
-            font-weight: 500;
-            border-radius: 3px 3px 0 0;
-            text-align: center;
-            cursor: pointer;
-            z-index: ${SURVEY_DEFAULT_Z_INDEX};
-        }
-        .ph-survey-widget-tab:hover {
-            padding-bottom: 13px;
-        }
-        .ph-survey-widget-button {
-            position: fixed;
-        }
-    `
+export function createWidgetStylesheet(posthog?: PostHog) {
+    return prepareStylesheet(document, typeof widgetStyles === 'string' ? widgetStyles : '', posthog)
 }

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -22,7 +22,7 @@ import {
 } from '../utils/survey-utils'
 import { isNull, isNumber } from '../utils/type-utils'
 import { uuidv7 } from '../uuidv7'
-import { createWidgetStyle, retrieveWidgetShadow } from './surveys-widget'
+import { createWidgetStylesheet, retrieveWidgetShadow } from './surveys-widget'
 import { ConfirmationMessage } from './surveys/components/ConfirmationMessage'
 import { Cancel } from './surveys/components/QuestionHeader'
 import {
@@ -51,7 +51,6 @@ import {
     sendSurveyEvent,
     setInProgressSurveyState,
     style,
-    SURVEY_DEFAULT_Z_INDEX,
     SurveyContext,
 } from './surveys/surveys-extension-utils'
 import { prepareStylesheet } from './utils/stylesheet-loader'
@@ -346,7 +345,7 @@ export class SurveyManager {
                     boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
                     borderBottom: `1.5px solid ${survey.appearance?.borderColor || '#c9c6c6'}`,
                     borderRadius: '10px',
-                    zIndex: SURVEY_DEFAULT_Z_INDEX,
+                    zIndex: defaultSurveyAppearance.zIndex,
                 }
 
                 // Dispatch event for the FeedbackWidget to catch
@@ -641,8 +640,7 @@ export const renderFeedbackWidgetPreview = ({
     forceDisableHtml?: boolean
     posthog?: PostHog
 }) => {
-    const stylesheetContent = createWidgetStyle(survey.appearance?.widgetColor)
-    const stylesheet = prepareStylesheet(document, stylesheetContent, posthog)
+    const stylesheet = createWidgetStylesheet(posthog)
     if (stylesheet) {
         root.appendChild(stylesheet)
     }
@@ -1165,12 +1163,7 @@ export function FeedbackWidget({
     return (
         <Preact.Fragment>
             {survey.appearance?.widgetType === 'tab' && (
-                <div
-                    className="ph-survey-widget-tab"
-                    onClick={() => !readOnly && setShowSurvey(!showSurvey)}
-                    style={{ color: getContrastingTextColor(survey.appearance.widgetColor) }}
-                >
-                    <div className="ph-survey-widget-tab-icon"></div>
+                <div className="ph-survey-widget-tab" onClick={() => !readOnly && setShowSurvey(!showSurvey)}>
                     {survey.appearance?.widgetLabel || ''}
                 </div>
             )}

--- a/src/extensions/surveys/widget.css
+++ b/src/extensions/surveys/widget.css
@@ -1,0 +1,28 @@
+:host {
+    /* Define CSS Variable for widget color */
+    --ph-widget-color: #e0a045; /* Default color */
+    --ph-widget-text-color: white; /* Default text color (usually white for contrast) */
+    --ph-widget-z-index: 2147483647; /* Default z-index */
+}
+
+.ph-survey-widget-tab {
+    position: fixed;
+    top: 50%;
+    right: 0;
+    background: var(--ph-widget-color);
+    color: var(--ph-widget-text-color);
+    transform: rotate(-90deg) translate(0, -100%);
+    transform-origin: right top;
+    min-width: 40px;
+    padding: 8px 12px;
+    font-weight: 500;
+    border-radius: 3px 3px 0 0;
+    text-align: center;
+    cursor: pointer;
+    z-index: var(--ph-widget-z-index);
+    transition: padding-bottom 0.1s ease-in-out;
+}
+
+.ph-survey-widget-tab:hover {
+    padding-bottom: 13px;
+}

--- a/src/extensions/surveys/widget.css
+++ b/src/extensions/surveys/widget.css
@@ -11,7 +11,7 @@
     right: 0;
     background: var(--ph-widget-color);
     color: var(--ph-widget-text-color);
-    transform: rotate(-90deg) translate(0, -100%);
+    transform: rotate(-90deg) translateY(-100%);
     transform-origin: right top;
     min-width: 40px;
     padding: 8px 12px;
@@ -20,9 +20,9 @@
     text-align: center;
     cursor: pointer;
     z-index: var(--ph-widget-z-index);
-    transition: padding-bottom 0.1s ease-in-out;
+    transition: transform 0.1s ease-in-out;
 }
 
 .ph-survey-widget-tab:hover {
-    padding-bottom: 13px;
+    transform: rotate(-90deg) translateY(-100%) scaleY(1.1);
 }


### PR DESCRIPTION
## Changes

now using CSS files for the widget styles.

Slightly increase in bundle size but that's because i'm already adding the tags for all variables necessary, including popup surveys.

Part of https://github.com/PostHog/posthog-js/issues/1940

Tested by making sure all our e2e and unit tests are still running, and verified locally too.