### PR TITLE
feat: Add calculateEventProperties to public API

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -161,6 +161,7 @@ const plugins = (es5) => [
                           // possibly used by naughty users - we should decide if we want make these part of the public API, but be cautious for now
                           '_isIdentified',
                           '_is_bot',
+                          '_calculate_event_properties', // deprecated in favour of calculateEventProperties
 
                           // URL parameters
                           '__posthog_debug',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -156,6 +156,7 @@ const plugins = (es5) => [
                           'posthog',
                           'version',
                           'surveys',
+                          'calculateEventProperties',
 
                           // possibly used by naughty users - we should decide if we want make these part of the public API, but be cautious for now
                           '_isIdentified',

--- a/src/__tests__/posthog-core.test.ts
+++ b/src/__tests__/posthog-core.test.ts
@@ -53,7 +53,7 @@ describe('posthog core', () => {
             })
 
             // act
-            const actual = posthog._calculate_event_properties(eventName, eventProperties, new Date())
+            const actual = posthog.calculateEventProperties(eventName, eventProperties, new Date())
 
             // assert
             expect(actual['event']).toBe('prop')

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -456,7 +456,7 @@ describe('posthog core', () => {
         })
 
         it('returns calculated properties', () => {
-            expect(posthog._calculate_event_properties('custom_event', { event: 'prop' }, new Date(), uuid)).toEqual({
+            expect(posthog.calculateEventProperties('custom_event', { event: 'prop' }, new Date(), uuid)).toEqual({
                 token: 'testtoken',
                 event: 'prop',
                 $lib: 'web',
@@ -483,7 +483,7 @@ describe('posthog core', () => {
                 overrides
             )
 
-            expect(posthog._calculate_event_properties('custom_event', { event: 'prop' }, new Date(), uuid)).toEqual({
+            expect(posthog.calculateEventProperties('custom_event', { event: 'prop' }, new Date(), uuid)).toEqual({
                 token: 'testtoken',
                 event: 'prop',
                 $lib: 'web',
@@ -514,7 +514,7 @@ describe('posthog core', () => {
             )
 
             expect(
-                posthog._calculate_event_properties('custom_event', { event: 'prop' }, new Date(), uuid)[
+                posthog.calculateEventProperties('custom_event', { event: 'prop' }, new Date(), uuid)[
                     '$process_person_profile'
                 ]
             ).toEqual(false)
@@ -528,7 +528,7 @@ describe('posthog core', () => {
                 overrides
             )
 
-            expect(posthog._calculate_event_properties('$snapshot', { event: 'prop' }, new Date(), uuid)).toEqual({
+            expect(posthog.calculateEventProperties('$snapshot', { event: 'prop' }, new Date(), uuid)).toEqual({
                 token: 'testtoken',
                 event: 'prop',
                 distinct_id: 'abc',
@@ -545,7 +545,7 @@ describe('posthog core', () => {
                 overrides
             )
 
-            expect(posthog._calculate_event_properties('custom_event', { event: 'prop' }, new Date(), uuid)).toEqual({
+            expect(posthog.calculateEventProperties('custom_event', { event: 'prop' }, new Date(), uuid)).toEqual({
                 event_name: 'custom_event',
                 token: 'testtoken',
                 $process_person_profile: false,
@@ -576,7 +576,7 @@ describe('posthog core', () => {
         it('saves $snapshot data and token for $snapshot events', () => {
             posthog = posthogWith({}, overrides)
 
-            expect(posthog._calculate_event_properties('$snapshot', { $snapshot_data: {} }, new Date(), uuid)).toEqual({
+            expect(posthog.calculateEventProperties('$snapshot', { $snapshot_data: {} }, new Date(), uuid)).toEqual({
                 token: 'testtoken',
                 $snapshot_data: {},
                 distinct_id: 'abc',
@@ -586,7 +586,7 @@ describe('posthog core', () => {
         it("doesn't modify properties passed into it", () => {
             const properties = { prop1: 'val1', prop2: 'val2' }
 
-            posthog._calculate_event_properties('custom_event', properties, new Date(), uuid)
+            posthog.calculateEventProperties('custom_event', properties, new Date(), uuid)
 
             expect(Object.keys(properties)).toEqual(['prop1', 'prop2'])
         })
@@ -594,75 +594,45 @@ describe('posthog core', () => {
         it('adds page title to $pageview', () => {
             document!.title = 'test'
 
-            expect(posthog._calculate_event_properties('$pageview', {}, new Date(), uuid)).toEqual(
+            expect(posthog.calculateEventProperties('$pageview', {}, new Date(), uuid)).toEqual(
                 expect.objectContaining({ title: 'test' })
             )
         })
 
         it('includes pageview id from previous pageview', () => {
-            const pageview1Properties = posthog._calculate_event_properties(
-                '$pageview',
-                {},
-                new Date(),
-                'pageview-id-1'
-            )
+            const pageview1Properties = posthog.calculateEventProperties('$pageview', {}, new Date(), 'pageview-id-1')
             expect(pageview1Properties.$pageview_id).toEqual('pageview-id-1')
 
-            const event1Properties = posthog._calculate_event_properties('custom event', {}, new Date(), 'event-id-1')
+            const event1Properties = posthog.calculateEventProperties('custom event', {}, new Date(), 'event-id-1')
             expect(event1Properties.$pageview_id).toEqual('pageview-id-1')
 
-            const pageview2Properties = posthog._calculate_event_properties(
-                '$pageview',
-                {},
-                new Date(),
-                'pageview-id-2'
-            )
+            const pageview2Properties = posthog.calculateEventProperties('$pageview', {}, new Date(), 'pageview-id-2')
             expect(pageview2Properties.$pageview_id).toEqual('pageview-id-2')
             expect(pageview2Properties.$prev_pageview_id).toEqual('pageview-id-1')
 
-            const event2Properties = posthog._calculate_event_properties('custom event', {}, new Date(), 'event-id-2')
+            const event2Properties = posthog.calculateEventProperties('custom event', {}, new Date(), 'event-id-2')
             expect(event2Properties.$pageview_id).toEqual('pageview-id-2')
 
-            const pageleaveProperties = posthog._calculate_event_properties(
-                '$pageleave',
-                {},
-                new Date(),
-                'pageleave-id'
-            )
+            const pageleaveProperties = posthog.calculateEventProperties('$pageleave', {}, new Date(), 'pageleave-id')
             expect(pageleaveProperties.$pageview_id).toEqual('pageview-id-2')
             expect(pageleaveProperties.$prev_pageview_id).toEqual('pageview-id-2')
         })
 
         it('includes pageview id from previous pageview', () => {
-            const pageview1Properties = posthog._calculate_event_properties(
-                '$pageview',
-                {},
-                new Date(),
-                'pageview-id-1'
-            )
+            const pageview1Properties = posthog.calculateEventProperties('$pageview', {}, new Date(), 'pageview-id-1')
             expect(pageview1Properties.$pageview_id).toEqual('pageview-id-1')
 
-            const event1Properties = posthog._calculate_event_properties('custom event', {}, new Date(), 'event-id-1')
+            const event1Properties = posthog.calculateEventProperties('custom event', {}, new Date(), 'event-id-1')
             expect(event1Properties.$pageview_id).toEqual('pageview-id-1')
 
-            const pageview2Properties = posthog._calculate_event_properties(
-                '$pageview',
-                {},
-                new Date(),
-                'pageview-id-2'
-            )
+            const pageview2Properties = posthog.calculateEventProperties('$pageview', {}, new Date(), 'pageview-id-2')
             expect(pageview2Properties.$pageview_id).toEqual('pageview-id-2')
             expect(pageview2Properties.$prev_pageview_id).toEqual('pageview-id-1')
 
-            const event2Properties = posthog._calculate_event_properties('custom event', {}, new Date(), 'event-id-2')
+            const event2Properties = posthog.calculateEventProperties('custom event', {}, new Date(), 'event-id-2')
             expect(event2Properties.$pageview_id).toEqual('pageview-id-2')
 
-            const pageleaveProperties = posthog._calculate_event_properties(
-                '$pageleave',
-                {},
-                new Date(),
-                'pageleave-id'
-            )
+            const pageleaveProperties = posthog.calculateEventProperties('$pageleave', {}, new Date(), 'pageleave-id')
             expect(pageleaveProperties.$pageview_id).toEqual('pageview-id-2')
             expect(pageleaveProperties.$prev_pageview_id).toEqual('pageview-id-2')
         })

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -617,25 +617,6 @@ describe('posthog core', () => {
             expect(pageleaveProperties.$pageview_id).toEqual('pageview-id-2')
             expect(pageleaveProperties.$prev_pageview_id).toEqual('pageview-id-2')
         })
-
-        it('includes pageview id from previous pageview', () => {
-            const pageview1Properties = posthog.calculateEventProperties('$pageview', {}, new Date(), 'pageview-id-1')
-            expect(pageview1Properties.$pageview_id).toEqual('pageview-id-1')
-
-            const event1Properties = posthog.calculateEventProperties('custom event', {}, new Date(), 'event-id-1')
-            expect(event1Properties.$pageview_id).toEqual('pageview-id-1')
-
-            const pageview2Properties = posthog.calculateEventProperties('$pageview', {}, new Date(), 'pageview-id-2')
-            expect(pageview2Properties.$pageview_id).toEqual('pageview-id-2')
-            expect(pageview2Properties.$prev_pageview_id).toEqual('pageview-id-1')
-
-            const event2Properties = posthog.calculateEventProperties('custom event', {}, new Date(), 'event-id-2')
-            expect(event2Properties.$pageview_id).toEqual('pageview-id-2')
-
-            const pageleaveProperties = posthog.calculateEventProperties('$pageleave', {}, new Date(), 'pageleave-id')
-            expect(pageleaveProperties.$pageview_id).toEqual('pageview-id-2')
-            expect(pageleaveProperties.$prev_pageview_id).toEqual('pageview-id-2')
-        })
     })
 
     describe('_handle_unload()', () => {

--- a/src/extensions/segment-integration.ts
+++ b/src/extensions/segment-integration.ts
@@ -82,11 +82,7 @@ const createSegmentIntegration = (posthog: PostHog): SegmentPlugin => {
             posthog.identify(ctx.event.userId)
         }
 
-        const additionalProperties = posthog._calculate_event_properties(
-            eventName,
-            ctx.event.properties ?? {},
-            new Date()
-        )
+        const additionalProperties = posthog.calculateEventProperties(eventName, ctx.event.properties)
         ctx.event.properties = Object.assign({}, additionalProperties, ctx.event.properties)
         return ctx
     }

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -903,7 +903,7 @@ export class PostHog {
         let data: CaptureResult = {
             uuid,
             event: event_name,
-            properties: this._calculate_event_properties(event_name, properties || {}, timestamp, uuid),
+            properties: this.calculateEventProperties(event_name, properties || {}, timestamp, uuid),
         }
 
         if (clientRateLimitContext) {
@@ -965,20 +965,35 @@ export class PostHog {
         return this.on('eventCaptured', (data) => callback(data.event, data))
     }
 
-    _calculate_event_properties(
-        event_name: string,
-        event_properties: Properties,
+    /**
+     * calculateEventProperties
+     *
+     * This method is used internally to calculate the event properties before sending it to PostHog. It can also be
+     * used by integrations (e.g. Segment) to enrich events with PostHog properties before sending them to Segment,
+     * which is required for some PostHog products to work correctly. (e.g. to have a correct $session_id property).
+     *
+     * @param {String} eventName The name of the event. This can be anything the user does - 'Button Click', 'Sign Up', '$pageview', etc.
+     * @param {Object} eventProperties The properties to include with the event.
+     * @param {Date} [timestamp] The timestamp of the event, e.g. for calculating time on page. If not set, it'll automatically be set to the current time.
+     * @param {String} [uuid] The uuid of the event, e.g. for storing the $pageview ID.
+     * @param {Boolean} [readOnly] Set this if you do not intend to actually send the event, and therefore do not want to update internal state e.g. session timeout
+
+     */
+    public calculateEventProperties(
+        eventName: string,
+        eventProperties: Properties,
         timestamp?: Date,
-        uuid?: string
+        uuid?: string,
+        readOnly?: boolean
     ): Properties {
         timestamp = timestamp || new Date()
         if (!this.persistence || !this.sessionPersistence) {
-            return event_properties
+            return eventProperties
         }
 
         // set defaults
-        const startTimestamp = this.persistence.remove_event_timer(event_name)
-        let properties = { ...event_properties }
+        const startTimestamp = readOnly ? undefined : this.persistence.remove_event_timer(eventName)
+        let properties = { ...eventProperties }
         properties['token'] = this.config.token
 
         if (this.config.__preview_experimental_cookieless_mode) {
@@ -986,7 +1001,7 @@ export class PostHog {
             properties[COOKIELESS_MODE_FLAG_PROPERTY] = true
         }
 
-        if (event_name === '$snapshot') {
+        if (eventName === '$snapshot') {
             const persistenceProps = { ...this.persistence.properties(), ...this.sessionPersistence.properties() }
             properties['distinct_id'] = persistenceProps.distinct_id
             if (
@@ -1005,7 +1020,10 @@ export class PostHog {
         )
 
         if (this.sessionManager) {
-            const { sessionId, windowId } = this.sessionManager.checkAndGetSessionAndWindowId()
+            const { sessionId, windowId } = this.sessionManager.checkAndGetSessionAndWindowId(
+                readOnly,
+                timestamp.getTime()
+            )
             properties['$session_id'] = sessionId
             properties['$window_id'] = windowId
         }
@@ -1027,16 +1045,16 @@ export class PostHog {
         }
 
         let pageviewProperties: Record<string, any>
-        if (event_name === '$pageview') {
+        if (eventName === '$pageview' && !readOnly) {
             pageviewProperties = this.pageViewManager.doPageView(timestamp, uuid)
-        } else if (event_name === '$pageleave') {
+        } else if (eventName === '$pageleave' && !readOnly) {
             pageviewProperties = this.pageViewManager.doPageLeave(timestamp)
         } else {
             pageviewProperties = this.pageViewManager.doEvent()
         }
         properties = extend(properties, pageviewProperties)
 
-        if (event_name === '$pageview' && document) {
+        if (eventName === '$pageview' && document) {
             properties['title'] = document.title
         }
 
@@ -1083,14 +1101,14 @@ export class PostHog {
         const sanitize_properties = this.config.sanitize_properties
         if (sanitize_properties) {
             logger.error('sanitize_properties is deprecated. Use before_send instead')
-            properties = sanitize_properties(properties, event_name)
+            properties = sanitize_properties(properties, eventName)
         }
 
         // add person processing flag as very last step, so it cannot be overridden
         const hasPersonProcessing = this._hasPersonProcessing()
         properties['$process_person_profile'] = hasPersonProcessing
         // if the event has person processing, ensure that all future events will too, even if the setting changes
-        if (hasPersonProcessing) {
+        if (hasPersonProcessing && !readOnly) {
             this._requirePersonProcessing('_calculate_event_properties')
         }
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1115,6 +1115,9 @@ export class PostHog {
         return properties
     }
 
+    /** @deprecated - deprecated in 1.241.0, use `calculateEventProperties` instead  */
+    _calculate_event_properties = this.calculateEventProperties.bind(this)
+
     /**
      * Add additional set_once properties to the event when creating a person profile. This allows us to create the
      * profile with mostly-accurate properties, despite earlier events not setting them. We do this by storing them in

--- a/terser-mangled-names.json
+++ b/terser-mangled-names.json
@@ -21,7 +21,6 @@
         "_bufferedInvocations",
         "_buildStorage",
         "_cachedPersonProperties",
-        "_calculate_event_properties",
         "_calculate_set_once_properties",
         "_callDecideEndpoint",
         "_callLoadToolbar",


### PR DESCRIPTION
## Changes

We hid `_calculate_event_properties` as part of the property mangling work that hid all private methods and methods beginning with `_`.

It turns out that there are some valid uses for this method (see https://posthog.slack.com/archives/C03JJKLEC8L/p1746810877789529?thread_ts=1746572351.320289&cid=C03JJKLEC8L), and we should make it part of the public API.

I did this and added a `readOnly` argument, so it can be used without updating the internal state.

I also unhid `_calculate_event_properties` but added a deprecation warning to it

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

