### PR TITLE
feat: allow answer question when clicking on the choice

### DIFF
--- a/playwright/surveys/question-types.spec.ts
+++ b/playwright/surveys/question-types.spec.ts
@@ -68,8 +68,8 @@ const singleChoiceSkipButtonQuestion = {
 
 const appearanceWithThanks = {
     displayThankYouMessage: true,
-    thankyouMessageHeader: 'Thanks!',
-    thankyouMessageBody: 'We appreciate your feedback.',
+    thankYouMessageHeader: 'Thanks!',
+    thankYouMessageBody: 'We appreciate your feedback.',
 }
 
 test.describe('surveys - core display logic', () => {
@@ -368,7 +368,7 @@ test.describe('surveys - skipSubmitButton functionality', () => {
         // Thank you message
         await expect(surveyLocator.locator('.thank-you-message')).toBeVisible()
         await expect(surveyLocator.locator('.thank-you-message h3')).toHaveText(
-            appearanceWithThanks.thankyouMessageHeader
+            appearanceWithThanks.thankYouMessageHeader
         )
         await surveyLocator.locator('.form-submit').click() // Click to dismiss thank you
         await expect(surveyLocator.locator('.thank-you-message')).not.toBeVisible()

--- a/playwright/surveys/question-types.spec.ts
+++ b/playwright/surveys/question-types.spec.ts
@@ -38,6 +38,34 @@ const singleChoiceQuestion = {
     choices: ['Product Manager', 'Engineer', 'Designer', 'Other'],
     id: 'single_choice_1',
 }
+
+const emojiRatingSkipButtonQuestion = {
+    type: 'rating' as const,
+    display: 'emoji' as const,
+    scale: 3,
+    question: 'Rate your mood (emoji, skip)',
+    id: 'emoji_rating_skip_1',
+    skipSubmitButton: true,
+}
+
+const numberRatingSkipButtonQuestion = {
+    type: 'rating' as const,
+    display: 'number' as const,
+    scale: 5,
+    question: 'Rate your experience (number, skip)',
+    id: 'number_rating_skip_1',
+    skipSubmitButton: true,
+}
+
+const singleChoiceSkipButtonQuestion = {
+    type: 'single_choice' as const,
+    question: 'Your favorite season (skip)?',
+    choices: ['Spring', 'Summer', 'Autumn', 'Winter'],
+    hasOpenChoice: false,
+    id: 'single_choice_skip_1',
+    skipSubmitButton: true,
+}
+
 const appearanceWithThanks = {
     displayThankYouMessage: true,
     thankyouMessageHeader: 'Thanks!',
@@ -290,5 +318,91 @@ test.describe('surveys - core display logic', () => {
                 response: 'Product engineer',
             },
         ])
+    })
+})
+
+test.describe('surveys - skipSubmitButton functionality', () => {
+    test('handles questions with skipSubmitButton correctly and sends event', async ({ page, context }) => {
+        const surveyId = 'skip_button_survey_123'
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: surveyId,
+                            name: 'Test Skip Submit Button Survey',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [
+                                emojiRatingSkipButtonQuestion,
+                                numberRatingSkipButtonQuestion,
+                                singleChoiceSkipButtonQuestion,
+                            ],
+                            appearance: appearanceWithThanks,
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(startOptions, page, context)
+        await surveysAPICall
+
+        const surveyLocator = page.locator(`.PostHogSurvey-${surveyId}`)
+
+        // Question 1: Emoji Rating
+        await expect(surveyLocator.locator('.survey-question')).toHaveText(emojiRatingSkipButtonQuestion.question)
+        await expect(surveyLocator.locator('.form-submit')).not.toBeVisible()
+        await surveyLocator.locator('button[aria-label="Rate 2"]').click() // Click 2nd emoji (value 2 for scale 3)
+
+        // Question 2: Number Rating (should appear automatically)
+        await expect(surveyLocator.locator('.survey-question')).toHaveText(numberRatingSkipButtonQuestion.question)
+        await expect(surveyLocator.locator('.form-submit')).not.toBeVisible()
+        await surveyLocator.locator('button[aria-label="Rate 4"]').click() // Click rating 4 for scale 5
+
+        // Question 3: Single Choice (should appear automatically)
+        await expect(surveyLocator.locator('.survey-question')).toHaveText(singleChoiceSkipButtonQuestion.question)
+        await expect(surveyLocator.locator('.form-submit')).not.toBeVisible()
+        await surveyLocator.locator('label:has-text("Summer")').click() // Click "Summer"
+
+        // Thank you message
+        await expect(surveyLocator.locator('.thank-you-message')).toBeVisible()
+        await expect(surveyLocator.locator('.thank-you-message h3')).toHaveText(
+            appearanceWithThanks.thankyouMessageHeader
+        )
+        await surveyLocator.locator('.form-submit').click() // Click to dismiss thank you
+        await expect(surveyLocator.locator('.thank-you-message')).not.toBeVisible()
+
+        // Event validation
+        await pollUntilEventCaptured(page, 'survey sent')
+        const captures = await page.capturedEvents()
+        const surveySentEvent = captures.find(
+            (c) => c.event === 'survey sent' && c.properties['$survey_id'] === surveyId
+        )
+        expect(surveySentEvent).toBeDefined()
+
+        expect(surveySentEvent!.properties[getSurveyResponseKey(emojiRatingSkipButtonQuestion.id)]).toBe(2)
+        expect(surveySentEvent!.properties[getSurveyResponseKey(numberRatingSkipButtonQuestion.id)]).toBe(4)
+        expect(surveySentEvent!.properties[getSurveyResponseKey(singleChoiceSkipButtonQuestion.id)]).toBe('Summer')
+
+        expect(surveySentEvent!.properties['$survey_questions']).toEqual(
+            expect.arrayContaining([
+                {
+                    id: emojiRatingSkipButtonQuestion.id,
+                    question: emojiRatingSkipButtonQuestion.question,
+                    response: 2,
+                },
+                {
+                    id: numberRatingSkipButtonQuestion.id,
+                    question: numberRatingSkipButtonQuestion.question,
+                    response: 4,
+                },
+                {
+                    id: singleChoiceSkipButtonQuestion.id,
+                    question: singleChoiceSkipButtonQuestion.question,
+                    response: 'Summer',
+                },
+            ])
+        )
     })
 })

--- a/src/__tests__/extensions/surveys/question-types.test.tsx
+++ b/src/__tests__/extensions/surveys/question-types.test.tsx
@@ -107,11 +107,11 @@ describe('MultipleChoiceQuestion', () => {
                 <MultipleChoiceQuestion {...baseProps} onSubmit={onSubmitMock} question={singleChoiceSkipQuestion} />
             )
 
+            expect(queryByText('Submit')).not.toBeInTheDocument()
             // Click on 'Blue' option
             fireEvent.click(getByLabelText('Blue'))
 
             expect(onSubmitMock).toHaveBeenCalledWith('Blue')
-            expect(queryByText('Submit')).not.toBeInTheDocument()
         })
 
         it('shows submit button if skipSubmitButton is false', () => {
@@ -119,9 +119,9 @@ describe('MultipleChoiceQuestion', () => {
             const { getByLabelText, queryByText } = render(
                 <MultipleChoiceQuestion {...baseProps} question={question} />
             )
+            expect(queryByText('Submit')).toBeInTheDocument()
             fireEvent.click(getByLabelText('Blue'))
             expect(baseProps.onSubmit).not.toHaveBeenCalled()
-            expect(queryByText('Submit')).toBeInTheDocument()
         })
 
         it('shows submit button if skipSubmitButton is true but hasOpenChoice is true', () => {
@@ -146,9 +146,9 @@ describe('MultipleChoiceQuestion', () => {
             const { getByLabelText, queryByText } = render(
                 <MultipleChoiceQuestion {...baseProps} question={question} />
             )
+            expect(queryByText('Submit')).toBeInTheDocument()
             fireEvent.click(getByLabelText('Blue'))
             expect(baseProps.onSubmit).not.toHaveBeenCalled()
-            expect(queryByText('Submit')).toBeInTheDocument()
         })
     })
 
@@ -462,12 +462,12 @@ describe('RatingQuestion', () => {
             render(<RatingQuestion {...baseProps} onSubmit={onSubmitMock} question={ratingSkipQuestion} />)
             const button3 = getRatingButton(3)
 
+            expect(screen.queryByText(mockAppearance.submitButtonText)).not.toBeInTheDocument()
             fireEvent.click(button3)
 
             await waitFor(() => {
                 expect(onSubmitMock).toHaveBeenCalledWith(3)
             })
-            expect(screen.queryByText(mockAppearance.submitButtonText)).not.toBeInTheDocument()
         })
 
         it('submits rating immediately and hides button for emoji display', async () => {
@@ -477,12 +477,12 @@ describe('RatingQuestion', () => {
             // Click the emoji button that corresponds to rating value 1
             const specificEmojiButton = screen.getByRole('button', { name: 'Rate 1' })
 
+            expect(screen.queryByText(mockAppearance.submitButtonText)).not.toBeInTheDocument()
             fireEvent.click(specificEmojiButton)
 
             await waitFor(() => {
                 expect(onSubmitMock).toHaveBeenCalledWith(1)
             })
-            expect(screen.queryByText(mockAppearance.submitButtonText)).not.toBeInTheDocument()
         })
 
         it('shows submit button if skipSubmitButton is false for number display', () => {

--- a/src/__tests__/extensions/surveys/question-types.test.tsx
+++ b/src/__tests__/extensions/surveys/question-types.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen } from '@testing-library/preact'
+import { fireEvent, render, screen, waitFor } from '@testing-library/preact'
 import {
     MultipleChoiceQuestion,
     OpenTextQuestion,
@@ -87,6 +87,68 @@ describe('MultipleChoiceQuestion', () => {
             setTimeout(() => {
                 expect(document.activeElement).toBe(openInput)
             }, 0)
+        })
+    })
+
+    describe('SingleChoice with skipSubmitButton', () => {
+        const singleChoiceSkipQuestion: MultipleSurveyQuestion = {
+            type: SurveyQuestionType.SingleChoice,
+            question: 'What is your favorite color?',
+            description: 'Choose one color',
+            choices: ['Red', 'Blue', 'Green'],
+            hasOpenChoice: false,
+            optional: false,
+            skipSubmitButton: true,
+        }
+
+        it('submits the selected choice immediately and hides button', () => {
+            const onSubmitMock = jest.fn()
+            const { getByLabelText, queryByText } = render(
+                <MultipleChoiceQuestion {...baseProps} onSubmit={onSubmitMock} question={singleChoiceSkipQuestion} />
+            )
+
+            // Click on 'Blue' option
+            fireEvent.click(getByLabelText('Blue'))
+
+            expect(onSubmitMock).toHaveBeenCalledWith('Blue')
+            expect(queryByText('Submit')).not.toBeInTheDocument()
+        })
+
+        it('shows submit button if skipSubmitButton is false', () => {
+            const question = { ...singleChoiceSkipQuestion, skipSubmitButton: false }
+            const { getByLabelText, queryByText } = render(
+                <MultipleChoiceQuestion {...baseProps} question={question} />
+            )
+            fireEvent.click(getByLabelText('Blue'))
+            expect(baseProps.onSubmit).not.toHaveBeenCalled()
+            expect(queryByText('Submit')).toBeInTheDocument()
+        })
+
+        it('shows submit button if skipSubmitButton is true but hasOpenChoice is true', () => {
+            const question = {
+                ...singleChoiceSkipQuestion,
+                hasOpenChoice: true,
+                choices: [...singleChoiceSkipQuestion.choices, 'Other'],
+            }
+            const { getByLabelText, queryByText } = render(
+                <MultipleChoiceQuestion {...baseProps} question={question} />
+            )
+            fireEvent.click(getByLabelText('Blue'))
+            expect(baseProps.onSubmit).not.toHaveBeenCalled()
+            expect(queryByText('Submit')).toBeInTheDocument()
+        })
+
+        it('shows submit button if skipSubmitButton but the type is multiple choice', () => {
+            const question: MultipleSurveyQuestion = {
+                ...singleChoiceSkipQuestion,
+                type: SurveyQuestionType.MultipleChoice,
+            }
+            const { getByLabelText, queryByText } = render(
+                <MultipleChoiceQuestion {...baseProps} question={question} />
+            )
+            fireEvent.click(getByLabelText('Blue'))
+            expect(baseProps.onSubmit).not.toHaveBeenCalled()
+            expect(queryByText('Submit')).toBeInTheDocument()
         })
     })
 
@@ -375,5 +437,78 @@ describe('RatingQuestion', () => {
 
         fireEvent.click(button3)
         expect(submitButton).not.toBeDisabled()
+    })
+
+    describe('RatingQuestion with skipSubmitButton', () => {
+        const ratingSkipQuestion: RatingSurveyQuestion = {
+            type: SurveyQuestionType.Rating,
+            question: 'How would you rate your experience?',
+            description: 'Scale from 1 to 5',
+            display: 'number',
+            scale: 5,
+            lowerBoundLabel: 'Bad',
+            upperBoundLabel: 'Good',
+            optional: false,
+            skipSubmitButton: true,
+        }
+
+        const ratingEmojiSkipQuestion: RatingSurveyQuestion = {
+            ...ratingSkipQuestion,
+            display: 'emoji',
+        }
+
+        it('submits rating immediately and hides button for number display', async () => {
+            const onSubmitMock = jest.fn()
+            render(<RatingQuestion {...baseProps} onSubmit={onSubmitMock} question={ratingSkipQuestion} />)
+            const button3 = getRatingButton(3)
+
+            fireEvent.click(button3)
+
+            await waitFor(() => {
+                expect(onSubmitMock).toHaveBeenCalledWith(3)
+            })
+            expect(screen.queryByText(mockAppearance.submitButtonText)).not.toBeInTheDocument()
+        })
+
+        it('submits rating immediately and hides button for emoji display', async () => {
+            const onSubmitMock = jest.fn()
+            render(<RatingQuestion {...baseProps} onSubmit={onSubmitMock} question={ratingEmojiSkipQuestion} />)
+
+            // Click the emoji button that corresponds to rating value 1
+            const specificEmojiButton = screen.getByRole('button', { name: 'Rate 1' })
+
+            fireEvent.click(specificEmojiButton)
+
+            await waitFor(() => {
+                expect(onSubmitMock).toHaveBeenCalledWith(1)
+            })
+            expect(screen.queryByText(mockAppearance.submitButtonText)).not.toBeInTheDocument()
+        })
+
+        it('shows submit button if skipSubmitButton is false for number display', () => {
+            const question = { ...ratingSkipQuestion, skipSubmitButton: false }
+            const onSubmitMock = jest.fn()
+            render(<RatingQuestion {...baseProps} onSubmit={onSubmitMock} question={question} />)
+            const button3 = getRatingButton(3)
+
+            fireEvent.click(button3)
+
+            expect(onSubmitMock).not.toHaveBeenCalled()
+            expect(screen.queryByText(mockAppearance.submitButtonText)).toBeInTheDocument()
+        })
+
+        it('shows submit button if skipSubmitButton is false for emoji display', () => {
+            const question = { ...ratingEmojiSkipQuestion, skipSubmitButton: false }
+            const onSubmitMock = jest.fn()
+            render(<RatingQuestion {...baseProps} onSubmit={onSubmitMock} question={question} />)
+
+            // Click the emoji button that corresponds to rating value 1
+            const specificEmojiButton = screen.getByRole('button', { name: 'Rate 1' })
+
+            fireEvent.click(specificEmojiButton)
+
+            expect(onSubmitMock).not.toHaveBeenCalled()
+            expect(screen.queryByText(mockAppearance.submitButtonText)).toBeInTheDocument()
+        })
     })
 })

--- a/src/extensions/surveys/components/BottomSection.tsx
+++ b/src/extensions/surveys/components/BottomSection.tsx
@@ -26,28 +26,26 @@ export function BottomSection({
     const { isPreviewMode } = useContext(SurveyContext)
     return (
         <div className="bottom-section">
-            <div className="buttons">
-                {!skipSubmitButton && (
-                    <button
-                        className="form-submit"
-                        disabled={submitDisabled}
-                        aria-label="Submit survey"
-                        type="button"
-                        onClick={() => {
-                            if (link) {
-                                window?.open(link)
-                            }
-                            if (isPreviewMode) {
-                                onPreviewSubmit?.()
-                            } else {
-                                onSubmit()
-                            }
-                        }}
-                    >
-                        {text}
-                    </button>
-                )}
-            </div>
+            {!skipSubmitButton && (
+                <button
+                    className="form-submit"
+                    disabled={submitDisabled}
+                    aria-label="Submit survey"
+                    type="button"
+                    onClick={() => {
+                        if (link) {
+                            window?.open(link)
+                        }
+                        if (isPreviewMode) {
+                            onPreviewSubmit?.()
+                        } else {
+                            onSubmit()
+                        }
+                    }}
+                >
+                    {text}
+                </button>
+            )}
             {!appearance.whiteLabel && <PostHogLogo />}
         </div>
     )

--- a/src/extensions/surveys/components/BottomSection.tsx
+++ b/src/extensions/surveys/components/BottomSection.tsx
@@ -13,6 +13,7 @@ export function BottomSection({
     onSubmit,
     link,
     onPreviewSubmit,
+    skipSubmitButton,
 }: {
     text: string
     submitDisabled: boolean
@@ -20,29 +21,32 @@ export function BottomSection({
     onSubmit: () => void
     link?: string | null
     onPreviewSubmit?: () => void
+    skipSubmitButton?: boolean
 }) {
     const { isPreviewMode } = useContext(SurveyContext)
     return (
         <div className="bottom-section">
             <div className="buttons">
-                <button
-                    className="form-submit"
-                    disabled={submitDisabled}
-                    aria-label="Submit survey"
-                    type="button"
-                    onClick={() => {
-                        if (link) {
-                            window?.open(link)
-                        }
-                        if (isPreviewMode) {
-                            onPreviewSubmit?.()
-                        } else {
-                            onSubmit()
-                        }
-                    }}
-                >
-                    {text}
-                </button>
+                {!skipSubmitButton && (
+                    <button
+                        className="form-submit"
+                        disabled={submitDisabled}
+                        aria-label="Submit survey"
+                        type="button"
+                        onClick={() => {
+                            if (link) {
+                                window?.open(link)
+                            }
+                            if (isPreviewMode) {
+                                onPreviewSubmit?.()
+                            } else {
+                                onSubmit()
+                            }
+                        }}
+                    >
+                        {text}
+                    </button>
+                )}
             </div>
             {!appearance.whiteLabel && <PostHogLogo />}
         </div>

--- a/src/extensions/surveys/components/QuestionTypes.tsx
+++ b/src/extensions/surveys/components/QuestionTypes.tsx
@@ -216,15 +216,14 @@ export function RatingQuestion({
                     </div>
                 </div>
             </div>
-            {!question.skipSubmitButton && (
-                <BottomSection
-                    text={question.buttonText || appearance?.submitButtonText || 'Submit'}
-                    submitDisabled={isNull(rating) && !question.optional}
-                    appearance={appearance}
-                    onSubmit={() => onSubmit(rating)}
-                    onPreviewSubmit={() => onPreviewSubmit(rating)}
-                />
-            )}
+            <BottomSection
+                text={question.buttonText || appearance?.submitButtonText || 'Submit'}
+                submitDisabled={isNull(rating) && !question.optional}
+                appearance={appearance}
+                onSubmit={() => onSubmit(rating)}
+                onPreviewSubmit={() => onPreviewSubmit(rating)}
+                skipSubmitButton={question.skipSubmitButton}
+            />
         </Fragment>
     )
 }
@@ -431,36 +430,35 @@ export function MultipleChoiceQuestion({
                     })}
                 </div>
             </div>
-            {!shouldSkipSubmit && (
-                <BottomSection
-                    text={question.buttonText || 'Submit'}
-                    submitDisabled={isSubmitDisabled(
-                        selectedChoices,
-                        openChoiceSelected,
-                        openEndedInput,
-                        !!question.optional
-                    )}
-                    appearance={appearance}
-                    onSubmit={() => {
-                        if (openChoiceSelected && question.type === SurveyQuestionType.MultipleChoice) {
-                            if (isArray(selectedChoices)) {
-                                onSubmit([...selectedChoices, openEndedInput])
-                            }
-                        } else {
-                            onSubmit(selectedChoices)
+            <BottomSection
+                text={question.buttonText || 'Submit'}
+                submitDisabled={isSubmitDisabled(
+                    selectedChoices,
+                    openChoiceSelected,
+                    openEndedInput,
+                    !!question.optional
+                )}
+                appearance={appearance}
+                onSubmit={() => {
+                    if (openChoiceSelected && question.type === SurveyQuestionType.MultipleChoice) {
+                        if (isArray(selectedChoices)) {
+                            onSubmit([...selectedChoices, openEndedInput])
                         }
-                    }}
-                    onPreviewSubmit={() => {
-                        if (openChoiceSelected && question.type === SurveyQuestionType.MultipleChoice) {
-                            if (isArray(selectedChoices)) {
-                                onPreviewSubmit([...selectedChoices, openEndedInput])
-                            }
-                        } else {
-                            onPreviewSubmit(selectedChoices)
+                    } else {
+                        onSubmit(selectedChoices)
+                    }
+                }}
+                onPreviewSubmit={() => {
+                    if (openChoiceSelected && question.type === SurveyQuestionType.MultipleChoice) {
+                        if (isArray(selectedChoices)) {
+                            onPreviewSubmit([...selectedChoices, openEndedInput])
                         }
-                    }}
-                />
-            )}
+                    } else {
+                        onPreviewSubmit(selectedChoices)
+                    }
+                }}
+                skipSubmitButton={shouldSkipSubmit}
+            />
         </Fragment>
     )
 }

--- a/src/extensions/surveys/components/QuestionTypes.tsx
+++ b/src/extensions/surveys/components/QuestionTypes.tsx
@@ -17,7 +17,7 @@ import {
     veryDissatisfiedEmoji,
     verySatisfiedEmoji,
 } from '../icons'
-import { getDisplayOrderChoices } from '../surveys-extension-utils'
+import { getDisplayOrderChoices, useSurveyContext } from '../surveys-extension-utils'
 import { BottomSection } from './BottomSection'
 import { QuestionHeader } from './QuestionHeader'
 
@@ -137,6 +137,15 @@ export function RatingQuestion({
         return null
     })
 
+    const { isPreviewMode } = useSurveyContext()
+
+    const handleSubmit = (num: number) => {
+        if (isPreviewMode) {
+            return onPreviewSubmit(num)
+        }
+        return onSubmit(num)
+    }
+
     return (
         <Fragment>
             <div className="question-container">
@@ -162,9 +171,10 @@ export function RatingQuestion({
                                             key={idx}
                                             type="button"
                                             onClick={() => {
-                                                setRating(idx + 1)
+                                                const response = idx + 1
+                                                setRating(response)
                                                 if (question.skipSubmitButton) {
-                                                    onSubmit(idx + 1)
+                                                    handleSubmit(response)
                                                 }
                                             }}
                                         >
@@ -188,10 +198,10 @@ export function RatingQuestion({
                                             active={active}
                                             appearance={appearance}
                                             num={number}
-                                            setActiveNumber={(num) => {
-                                                setRating(num)
+                                            setActiveNumber={(response) => {
+                                                setRating(response)
                                                 if (question.skipSubmitButton) {
-                                                    onSubmit(num)
+                                                    handleSubmit(response)
                                                 }
                                             }}
                                         />
@@ -313,6 +323,7 @@ export function MultipleChoiceQuestion({
         }
         return ''
     })
+    const { isPreviewMode } = useSurveyContext()
 
     const inputType = question.type === SurveyQuestionType.SingleChoice ? 'radio' : 'checkbox'
     const shouldSkipSubmit =
@@ -334,6 +345,9 @@ export function MultipleChoiceQuestion({
             setOpenChoiceSelected(false) // Deselect open choice when selecting another option
             if (shouldSkipSubmit) {
                 onSubmit(val)
+                if (isPreviewMode) {
+                    onPreviewSubmit(val)
+                }
             }
             return
         }

--- a/src/extensions/surveys/survey.css
+++ b/src/extensions/surveys/survey.css
@@ -399,12 +399,6 @@
 }
 
 /* --- Buttons --- */
-.buttons {
-    /* Container for buttons if needed */
-    display: flex;
-    justify-content: center;
-}
-
 /* Submit Button */
 .form-submit {
     box-sizing: border-box;

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -20,6 +20,7 @@ import { prepareStylesheet } from '../utils/stylesheet-loader'
 const window = _window as Window & typeof globalThis
 const document = _document as Document
 import surveyStyles from './survey.css'
+import { useContext } from 'preact/hooks'
 
 export function getFontFamily(fontFamily?: string): string {
     if (fontFamily === 'inherit') {
@@ -546,6 +547,10 @@ export const SurveyContext = createContext<SurveyContextProps>({
     onPreviewSubmit: () => {},
     surveySubmissionId: '',
 })
+
+export const useSurveyContext = () => {
+    return useContext(SurveyContext)
+}
 
 interface RenderProps {
     component: VNode<{ className: string }>

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -56,7 +56,7 @@ export const defaultSurveyAppearance = {
     maxWidth: '300px',
     textSubtleColor: '#939393',
     inputBackground: 'white',
-    boxPadding: '20px 24px 10px',
+    boxPadding: '20px 24px',
 } as const
 
 export const addSurveyCSSVariablesToElement = (element: HTMLElement, appearance?: SurveyAppearance | null) => {

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -89,6 +89,7 @@ export interface RatingSurveyQuestion extends SurveyQuestionBase {
     scale: 3 | 5 | 7 | 10
     lowerBoundLabel: string
     upperBoundLabel: string
+    skipSubmitButton?: boolean
 }
 
 export interface MultipleSurveyQuestion extends SurveyQuestionBase {
@@ -96,6 +97,7 @@ export interface MultipleSurveyQuestion extends SurveyQuestionBase {
     choices: string[]
     hasOpenChoice?: boolean
     shuffleOptions?: boolean
+    skipSubmitButton?: boolean
 }
 
 export enum SurveyQuestionType {


### PR DESCRIPTION
## Changes

SDK part for https://github.com/PostHog/posthog/issues/30196.

Allow answering rating questions or single choice without open-ended questions.

![CleanShot 2025-05-14 at 21 01 59](https://github.com/user-attachments/assets/274ce36e-af3d-43a7-902c-147000cecd54)

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

