### PR TITLE
fix: center positioning for surveys

### DIFF
--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -846,7 +846,12 @@ function getPopoverPosition(position: SurveyPosition = SurveyPosition.Right, sur
         case SurveyPosition.Left:
             return { left: '30px' }
         case SurveyPosition.Center:
-            return { left: '50%', transform: 'translateX(-50%)' }
+            return {
+                left: '0',
+                right: '0',
+                marginLeft: 'auto',
+                marginRight: 'auto',
+            }
         default:
         case SurveyPosition.Right:
             return { right: surveyWidgetType && surveyWidgetType === SurveyWidgetType.Tab ? '60px' : '30px' }


### PR DESCRIPTION
## Changes

center positioning is slightly to the right because i'm using transform for animations now too. switch to use just left/right/margins now

![CleanShot 2025-05-15 at 11 34 27@2x](https://github.com/user-attachments/assets/7c39a6da-e783-46ba-b949-8545b96ae729)
