### PR TITLE
chore: remove unused function from survey extensions

### DIFF
--- a/src/entrypoints/surveys.ts
+++ b/src/entrypoints/surveys.ts
@@ -1,10 +1,8 @@
 import { generateSurveys } from '../extensions/surveys'
 
-import { canActivateRepeatedly } from '../extensions/surveys/surveys-extension-utils'
 import { assignableWindow } from '../utils/globals'
 
 assignableWindow.__PosthogExtensions__ = assignableWindow.__PosthogExtensions__ || {}
-assignableWindow.__PosthogExtensions__.canActivateRepeatedly = canActivateRepeatedly
 assignableWindow.__PosthogExtensions__.generateSurveys = generateSurveys
 
 // this used to be directly on window, but we moved it to __PosthogExtensions__

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -79,7 +79,6 @@ interface PostHogExtensions {
     }
     rrweb?: { record: any; version: string }
     rrwebPlugins?: { getRecordConsolePlugin: any; getRecordNetworkPlugin?: any }
-    canActivateRepeatedly?: (survey: any) => boolean
     generateSurveys?: (posthog: PostHog) => any | undefined
     postHogWebVitalsCallbacks?: {
         onLCP: (metric: any) => void


### PR DESCRIPTION
## Changes

`canActivateRepeatedly` is now only used in the extension/surveys.tsx file so no need to keep it on the global extensions