### PR TITLE
fix: survey should reappear after url is matching again

### DIFF
--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -672,7 +672,7 @@ describe('SurveyManager', () => {
 
             // Test that clearTimeout is called with correct ID
             const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout')
-            surveyManager.getTestAPI().removeSurveyFromFocus(mockSurvey.id)
+            surveyManager.getTestAPI().removeSurveyFromFocus(mockSurvey)
             expect(clearTimeoutSpy).toHaveBeenCalledWith(timeoutId)
 
             // Verify timeout was removed from map
@@ -862,7 +862,7 @@ describe('usePopupVisibility URL changes should hide surveys accordingly', () =>
         })
 
         expect(mockRemoveSurveyFromFocus).toHaveBeenCalledTimes(1)
-        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith('test-survey')
+        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith(survey)
         expect(result.current.isPopupVisible).toBe(false)
     })
 
@@ -893,7 +893,7 @@ describe('usePopupVisibility URL changes should hide surveys accordingly', () =>
             window.history.replaceState({}, '', '/other/page')
         })
 
-        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith('test-survey')
+        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith(survey)
         expect(result.current.isPopupVisible).toBe(false)
     })
 
@@ -910,7 +910,7 @@ describe('usePopupVisibility URL changes should hide surveys accordingly', () =>
         })
 
         expect(mockRemoveSurveyFromFocus).toHaveBeenCalledTimes(1)
-        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith('test-survey')
+        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith(survey)
         expect(result.current.isPopupVisible).toBe(false)
     })
 
@@ -928,7 +928,7 @@ describe('usePopupVisibility URL changes should hide surveys accordingly', () =>
 
         // expect mockremoveSurvey to have been called only once
         expect(mockRemoveSurveyFromFocus).toHaveBeenCalledTimes(1)
-        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith('test-survey')
+        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith(survey)
         expect(result.current.isPopupVisible).toBe(false)
     })
 
@@ -983,7 +983,7 @@ describe('usePopupVisibility URL changes should hide surveys accordingly', () =>
 
         // Survey should still not be visible since URL no longer matches
         expect(result.current.isPopupVisible).toBe(false)
-        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith('test-survey')
+        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith(survey)
     })
 })
 
@@ -1107,7 +1107,7 @@ describe('useHideSurveyOnURLChange', () => {
             window.history.pushState({}, '', '/different-path')
         })
 
-        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith('test-survey')
+        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith(survey)
         expect(mockSetSurveyVisible).toHaveBeenCalledWith(false)
     })
 
@@ -1135,7 +1135,7 @@ describe('useHideSurveyOnURLChange', () => {
             window.history.replaceState({}, '', '/different-path')
         })
 
-        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith('test-survey')
+        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith(survey)
         expect(mockSetSurveyVisible).toHaveBeenCalledWith(false)
     })
 
@@ -1167,7 +1167,7 @@ describe('useHideSurveyOnURLChange', () => {
             window.dispatchEvent(new Event('popstate'))
         })
 
-        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith('test-survey')
+        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith(survey)
         expect(mockSetSurveyVisible).toHaveBeenCalledWith(false)
     })
 
@@ -1199,7 +1199,7 @@ describe('useHideSurveyOnURLChange', () => {
             window.dispatchEvent(new Event('hashchange'))
         })
 
-        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith('test-survey')
+        expect(mockRemoveSurveyFromFocus).toHaveBeenCalledWith(survey)
         expect(mockSetSurveyVisible).toHaveBeenCalledWith(false)
     })
 

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -345,7 +345,7 @@ describe('SurveyManager', () => {
 
     test('removeSurveyFromFocus should remove survey ID from surveyInFocus', () => {
         surveyManager.getTestAPI().addSurveyToFocus('survey1')
-        surveyManager.getTestAPI().removeSurveyFromFocus('survey1')
+        surveyManager.getTestAPI().removeSurveyFromFocus({ id: 'survey1', appearance: {} })
         expect(surveyManager.getTestAPI().surveyInFocus).toBe(null)
     })
 
@@ -476,7 +476,7 @@ describe('SurveyManager', () => {
         expect(surveyManager.getTestAPI().surveyInFocus).toBe('survey1')
         expect(handlePopoverSurveyMock).not.toHaveBeenCalled()
 
-        surveyManager.getTestAPI().removeSurveyFromFocus('survey1')
+        surveyManager.getTestAPI().removeSurveyFromFocus({ id: 'survey1', appearance: {} })
 
         surveyManager.callSurveysAndEvaluateDisplayLogic()
 
@@ -685,7 +685,7 @@ describe('SurveyManager', () => {
             const firstTimeoutId = surveyManager.getTestAPI().surveyTimeouts.get(mockSurvey.id)
 
             // Clear and reset to test second survey
-            surveyManager.getTestAPI().removeSurveyFromFocus(mockSurvey.id)
+            surveyManager.getTestAPI().removeSurveyFromFocus(mockSurvey)
 
             // Create and schedule second survey
             const mockSurvey2 = {

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -339,12 +339,12 @@ describe('SurveyManager', () => {
     })
 
     test('addSurveyToFocus should add survey ID to surveyInFocus', () => {
-        surveyManager.getTestAPI().addSurveyToFocus('survey1')
+        surveyManager.getTestAPI().addSurveyToFocus({ id: 'survey1' })
         expect(surveyManager.getTestAPI().surveyInFocus).toEqual('survey1')
     })
 
     test('removeSurveyFromFocus should remove survey ID from surveyInFocus', () => {
-        surveyManager.getTestAPI().addSurveyToFocus('survey1')
+        surveyManager.getTestAPI().addSurveyToFocus({ id: 'survey1' })
         surveyManager.getTestAPI().removeSurveyFromFocus({ id: 'survey1', appearance: {} })
         expect(surveyManager.getTestAPI().surveyInFocus).toBe(null)
     })
@@ -455,7 +455,7 @@ describe('SurveyManager', () => {
     test('callSurveysAndEvaluateDisplayLogic should not call surveys in focus', () => {
         mockPostHog.surveys.getSurveys = jest.fn((callback) => callback(mockSurveys))
 
-        surveyManager.getTestAPI().addSurveyToFocus('survey1')
+        surveyManager.getTestAPI().addSurveyToFocus({ id: 'survey1' })
         surveyManager.callSurveysAndEvaluateDisplayLogic()
 
         expect(mockPostHog.surveys.getSurveys).toHaveBeenCalledTimes(1)
@@ -465,7 +465,7 @@ describe('SurveyManager', () => {
     test('surveyInFocus handling works correctly with in callSurveysAndEvaluateDisplayLogic', () => {
         mockPostHog.surveys.getSurveys = jest.fn((callback) => callback(mockSurveys))
 
-        surveyManager.getTestAPI().addSurveyToFocus('survey1')
+        surveyManager.getTestAPI().addSurveyToFocus({ id: 'survey1' })
         surveyManager.callSurveysAndEvaluateDisplayLogic()
 
         const handlePopoverSurveyMock = jest
@@ -641,7 +641,7 @@ describe('SurveyManager', () => {
             // Mock doesSurveyUrlMatch to always return true, used in handlePopoverSurvey
             jest.spyOn(surveyManager as any, '_handlePopoverSurvey').mockImplementation((survey: Survey) => {
                 // Add survey to focus and create a timeout
-                surveyManager.getTestAPI().addSurveyToFocus(survey.id)
+                surveyManager.getTestAPI().addSurveyToFocus(survey)
 
                 if (survey.appearance?.surveyPopupDelaySeconds) {
                     const timeoutId = setTimeout(() => {

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -363,7 +363,7 @@ describe('SurveyManager', () => {
 
         // First popover should be handled
         expect(handlePopoverSurveySpy).toHaveBeenCalledWith(mockSurveys[0])
-        expect(addSurveyToFocusSpy).toHaveBeenCalledWith(mockSurveys[0].id)
+        expect(addSurveyToFocusSpy).toHaveBeenCalledWith(mockSurveys[0])
         expect(surveyManager.getTestAPI().surveyInFocus).toBe(mockSurveys[0].id)
 
         // Call the function again to check that the second popover is not handled

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -217,7 +217,7 @@ export class SurveyManager {
         }
         const timeoutId = setTimeout(() => {
             if (!doesSurveyUrlMatch(survey)) {
-                return this._removeSurveyFromFocus(survey.id)
+                return this._removeSurveyFromFocus(survey)
             }
             // rendering with surveyPopupDelaySeconds = 0 because we're already handling the timeout here
             Preact.render(
@@ -528,12 +528,17 @@ export class SurveyManager {
         this._surveyInFocus = id
     }
 
-    private _removeSurveyFromFocus = (id: string): void => {
-        if (this._surveyInFocus !== id) {
-            logger.error(`Survey ${id} is not in focus. Cannot remove survey ${id}.`)
+    private _removeSurveyFromFocus = (survey: Pick<Survey, 'id' | 'appearance'>): void => {
+        if (this._surveyInFocus !== survey.id) {
+            logger.error(`Survey ${survey.id} is not in focus. Cannot remove survey ${survey.id}.`)
         }
-        this._clearSurveyTimeout(id)
+        this._clearSurveyTimeout(survey.id)
         this._surveyInFocus = null
+        // Remove survey from the DOM and reset Preact lifecycle
+        const shadow = retrieveSurveyShadow(survey, this._posthog)
+        Preact.render(null, shadow)
+        const shadowContainer = document.querySelector(getSurveyContainerClass(survey, true))
+        shadowContainer?.remove()
     }
 
     // Expose internal state and methods for testing
@@ -630,7 +635,7 @@ export function generateSurveys(posthog: PostHog) {
 
 type UseHideSurveyOnURLChangeProps = {
     survey: Pick<Survey, 'id' | 'conditions' | 'type' | 'appearance'>
-    removeSurveyFromFocus?: (id: string) => void
+    removeSurveyFromFocus?: (survey: Pick<Survey, 'id' | 'appearance'>) => void
     setSurveyVisible: (visible: boolean) => void
     isPreviewMode?: boolean
 }
@@ -671,7 +676,7 @@ export function useHideSurveyOnURLChange({
 
             logger.info(`Hiding survey ${survey.id} because URL does not match`)
             setSurveyVisible(false)
-            return removeSurveyFromFocus(survey.id)
+            return removeSurveyFromFocus(survey)
         }
 
         // Listen for browser back/forward browser history changes
@@ -708,7 +713,7 @@ export function usePopupVisibility(
     posthog: PostHog | undefined,
     millisecondDelay: number,
     isPreviewMode: boolean,
-    removeSurveyFromFocus: (id: string) => void,
+    removeSurveyFromFocus: (survey: Pick<Survey, 'id' | 'appearance'>) => void,
     surveyContainerRef?: React.RefObject<HTMLDivElement>
 ) {
     const [isPopupVisible, setIsPopupVisible] = useState(isPreviewMode || millisecondDelay === 0)
@@ -717,11 +722,7 @@ export function usePopupVisibility(
     const hidePopupWithViewTransition = () => {
         const removeDOMAndHidePopup = () => {
             if (survey.type === SurveyType.Popover) {
-                removeSurveyFromFocus(survey.id)
-                const shadow = retrieveSurveyShadow(survey, posthog)
-                Preact.render(null, shadow)
-                const shadowContainer = document.querySelector(getSurveyContainerClass(survey, true))
-                shadowContainer?.remove()
+                removeSurveyFromFocus(survey)
             }
             setIsPopupVisible(false)
         }
@@ -834,7 +835,7 @@ interface SurveyPopupProps {
     posthog?: PostHog
     style?: React.CSSProperties
     previewPageIndex?: number | undefined
-    removeSurveyFromFocus?: (id: string) => void
+    removeSurveyFromFocus?: (survey: Pick<Survey, 'id' | 'appearance'>) => void
     isPopup?: boolean
     onPreviewSubmit?: (res: string | string[] | number | null) => void
     onPopupSurveyDismissed?: () => void
@@ -884,6 +885,7 @@ export function SurveyPopup({
         removeSurveyFromFocus,
         surveyContainerRef
     )
+
     const shouldShowConfirmation = isSurveySent || previewPageIndex === survey.questions.length
     const surveyContextValue = useMemo(() => {
         const getInProgressSurvey = getInProgressSurveyState(survey)
@@ -897,6 +899,7 @@ export function SurveyPopup({
             isPopup: isPopup || false,
             surveySubmissionId: getInProgressSurvey?.surveySubmissionId || uuidv7(),
             onPreviewSubmit,
+            posthog,
         }
     }, [isPreviewMode, previewPageIndex, isPopup, posthog, survey, onPopupSurveyDismissed, onPreviewSubmit])
 

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -202,7 +202,7 @@ export class SurveyManager {
         }
 
         this._clearSurveyTimeout(survey.id)
-        this._addSurveyToFocus(survey.id)
+        this._addSurveyToFocus(survey)
         const delaySeconds = survey.appearance?.surveyPopupDelaySeconds || 0
         const shadow = retrieveSurveyShadow(survey, this._posthog)
         if (delaySeconds <= 0) {
@@ -521,11 +521,11 @@ export class SurveyManager {
         }, forceReload)
     }
 
-    private _addSurveyToFocus = (id: string): void => {
+    private _addSurveyToFocus = (survey: Pick<Survey, 'id'>): void => {
         if (!isNull(this._surveyInFocus)) {
-            logger.error(`Survey ${[...this._surveyInFocus]} already in focus. Cannot add survey ${id}.`)
+            logger.error(`Survey ${[...this._surveyInFocus]} already in focus. Cannot add survey ${survey.id}.`)
         }
-        this._surveyInFocus = id
+        this._surveyInFocus = survey.id
     }
 
     private _removeSurveyFromFocus = (survey: Pick<Survey, 'id' | 'appearance'>): void => {


### PR DESCRIPTION
## Changes

moves the logic to remove the DOM and reset Preact lifecycle to the `SurveyManager`. this way whenever we call `removeSurveyFromFocus` from anywhere on the code, we also handle removing the DOM / reseting SurveyPopup state.

also fixes an issue where a survey is not reappearing once the URL changes without reloading the page.