### PR TITLE
feat: allow using person properties in survey links

### DIFF
--- a/src/__tests__/extensions/surveys/question-types.test.tsx
+++ b/src/__tests__/extensions/surveys/question-types.test.tsx
@@ -207,13 +207,10 @@ describe('parseUserPropertiesInLink', () => {
         expect(parseUserPropertiesInLink(link, ph)).toBe(link)
     })
 
-    it('should handle empty property names within placeholders like {{ }} or {{  }} after trimming (checking stored)', () => {
-        const phWithEmptyKeyStored = mockPostHog({ [STORED_PERSON_PROPERTIES_KEY]: { '': 'emptyStoredPropValue' } })
+    it('should handle empty property names within placeholders like {{ }} or {{  }} after trimming (i.e. do nothing)', () => {
+        const phWithEmptyKeyStored = mockPostHog()
         const linkWithSpacedEmpty = 'https://example.com?a={{  }}&b={{ }}' // Testing two space and one space variants
-        expect(parseUserPropertiesInLink(linkWithSpacedEmpty, phWithEmptyKeyStored)).toBe(
-            'https://example.com?a=emptyStoredPropValue&b=emptyStoredPropValue'
-        )
-        // Truly empty placeholders {{}} should still not be replaced as per current logic
+        expect(parseUserPropertiesInLink(linkWithSpacedEmpty, phWithEmptyKeyStored)).toBe(linkWithSpacedEmpty)
         const linkWithTrueEmpty = 'https://example.com?a={{}}&b={{}} '
         expect(parseUserPropertiesInLink(linkWithTrueEmpty, phWithEmptyKeyStored)).toBe(linkWithTrueEmpty)
     })

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -897,6 +897,7 @@ export function SurveyPopup({
             isPopup: isPopup || false,
             surveySubmissionId: getInProgressSurvey?.surveySubmissionId || uuidv7(),
             onPreviewSubmit,
+            posthog,
         }
     }, [isPreviewMode, previewPageIndex, isPopup, posthog, survey, onPopupSurveyDismissed, onPreviewSubmit])
 

--- a/src/extensions/surveys/components/QuestionTypes.tsx
+++ b/src/extensions/surveys/components/QuestionTypes.tsx
@@ -88,16 +88,16 @@ export function parseUserPropertiesInLink(link: string, posthog?: PostHog) {
 
     const regex = /\{\{(.*?)\}\}/g
     let newLink = link
-    let match
+    let match: RegExpExecArray | null
 
     // Iterate over all matches and replace them
     while (!isNull((match = regex.exec(link)))) {
-        const placeholder = match[0] // The full placeholder e.g. {{property_name}}
-        const propertyNameWithPotentialWhitespace = match[1] // Property name is now always in match[1]
+        const placeholder = match.at(0) // The full placeholder e.g. {{property_name}}
+        const propertyNameWithPotentialWhitespace = match.at(1) // Property name is now always in match[1]
 
-        if (propertyNameWithPotentialWhitespace) {
+        if (placeholder && propertyNameWithPotentialWhitespace) {
             const propertyName = propertyNameWithPotentialWhitespace.trim()
-            if (propertyName || propertyNameWithPotentialWhitespace !== propertyName) {
+            if (propertyName !== '') {
                 const propertyValue =
                     posthog.get_property(propertyName) ||
                     posthog.get_property(STORED_PERSON_PROPERTIES_KEY)?.[propertyName]

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -16,11 +16,11 @@ import { SurveyMatchType } from '../../posthog-surveys-types'
 import { isMatchingRegex } from '../../utils/regex-utils'
 import { detectDeviceType } from '../../utils/user-agent-utils'
 import { prepareStylesheet } from '../utils/stylesheet-loader'
+import surveyStyles from './survey.css'
+import { useContext } from 'preact/hooks'
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const window = _window as Window & typeof globalThis
 const document = _document as Document
-import surveyStyles from './survey.css'
-import { useContext } from 'preact/hooks'
 
 export function getFontFamily(fontFamily?: string): string {
     if (fontFamily === 'inherit') {

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -20,6 +20,7 @@ import { prepareStylesheet } from '../utils/stylesheet-loader'
 const window = _window as Window & typeof globalThis
 const document = _document as Document
 import surveyStyles from './survey.css'
+import { useContext } from 'preact/hooks'
 
 export function getFontFamily(fontFamily?: string): string {
     if (fontFamily === 'inherit') {
@@ -536,6 +537,7 @@ interface SurveyContextProps {
     isPopup: boolean
     onPreviewSubmit: (res: string | string[] | number | null) => void
     surveySubmissionId: string
+    posthog: PostHog | undefined
 }
 
 export const SurveyContext = createContext<SurveyContextProps>({
@@ -545,7 +547,12 @@ export const SurveyContext = createContext<SurveyContextProps>({
     isPopup: true,
     onPreviewSubmit: () => {},
     surveySubmissionId: '',
+    posthog: undefined,
 })
+
+export const useSurveyContext = () => {
+    return useContext(SurveyContext)
+}
 
 interface RenderProps {
     component: VNode<{ className: string }>


### PR DESCRIPTION
## Changes

allows the usage of user properties in link-type questions so our customers can embed a person info as a URL parameter.

So `https://posthog.com/?email={{email}}` becomes `https://posthog.com/?email=test%40posthog.com`.

SDK part of https://github.com/PostHog/posthog/issues/26620

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

