### PR TITLE
fix: don't call receivedFeatureFlags if flags were disabled

### DIFF
--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -446,7 +446,9 @@ export class PostHogFeatureFlags {
                     return
                 }
 
-                this.receivedFeatureFlags(response.json ?? {}, errorsLoading)
+                if (!data.disable_flags) {
+                    this.receivedFeatureFlags(response.json ?? {}, errorsLoading)
+                }
 
                 if (this._additionalReloadRequested) {
                     this._additionalReloadRequested = false


### PR DESCRIPTION
## Changes

...

If someone uses the `advanced_disable_feature_flags_on_first_load` config option: 
- the `_callDecideEndpoint` function will be called to get the remote config. 
- However, if someone calls something like `setPersonProperties` while that is still processing, then `_additionalReloadRequested` will be set to true
- the callback for `_callDecideEndpoint` will end up calling `receivedFeatureFlags` with no flag data
- eventually onFeatureFlags is dispatched with no flag data which causes issues with our experiments.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [ ] Took care not to unnecessarily increase the bundle size

