### PR TITLE
fix: modernise domain spelunking cookie setting code

### DIFF
--- a/src/__tests__/storage.test.ts
+++ b/src/__tests__/storage.test.ts
@@ -21,8 +21,8 @@ describe('sessionStore', () => {
             set cookie(value) {
                 //needs to refuse known public suffixes, like a browser would
                 // value arrives like dmn_chk_1699961248575=1;domain=.uk
-                const domain = value.split('domain=')
-                if (['.uk', '.com', '.au', '.com.au', '.co.uk'].includes(domain[1])) return
+                const domain = value.split('domain=')[1].split(';')[0]
+                if (['.uk', '.com', '.au', '.com.au', '.co.uk'].includes(domain)) return
                 this.value_ += value + ';'
             },
         }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -13,7 +13,6 @@ import { logger } from './utils/logger'
 import { window, document } from './utils/globals'
 import { uuidv7 } from './uuidv7'
 
-const Y1970 = 'Thu, 01 Jan 1970 00:00:00 GMT'
 // we store the discovered subdomain in memory because it might be read multiple times
 let firstNonPublicSubDomain = ''
 
@@ -48,18 +47,17 @@ export function seekFirstNonPublicSubDomain(hostname: string, cookieJar = docume
     const list = hostname.split('.')
     let len = Math.min(list.length, 8) // paranoia - we know this number should be small
     const key = 'dmn_chk_' + uuidv7()
-    const R = new RegExp('(^|;)\\s*' + key + '=1')
 
     while (!firstNonPublicSubDomain && len--) {
         const candidate = list.slice(len).join('.')
-        const candidateCookieValue = key + '=1;domain=.' + candidate
+        const candidateCookieValue = key + '=1;domain=.' + candidate + ';path=/'
 
         // try to set cookie
         cookieJar.cookie = candidateCookieValue
 
-        if (R.test(cookieJar.cookie)) {
+        if (cookieJar.cookie.includes(key)) {
             // the cookie was accepted by the browser, remove the test cookie
-            cookieJar.cookie = candidateCookieValue + ';expires=' + Y1970
+            cookieJar.cookie = candidateCookieValue + ';max-age=' + 0
             firstNonPublicSubDomain = candidate
         }
     }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -52,13 +52,14 @@ export function seekFirstNonPublicSubDomain(hostname: string, cookieJar = docume
 
     while (!firstNonPublicSubDomain && len--) {
         const candidate = list.slice(len).join('.')
-        const candidateCookieValue = key + '=1;domain=.' + candidate + ';expires=' + Y1970 + ';path=/'
+        const candidateCookieValue = key + '=1;domain=.' + candidate
 
         // try to set cookie
         cookieJar.cookie = candidateCookieValue
 
         if (R.test(cookieJar.cookie)) {
-            // the cookie was accepted by the browser
+            // the cookie was accepted by the browser, remove the test cookie
+            cookieJar.cookie = candidateCookieValue + ';expires=' + Y1970
             firstNonPublicSubDomain = candidate
         }
     }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -52,12 +52,12 @@ export function seekFirstNonPublicSubDomain(hostname: string, cookieJar = docume
         const candidate = list.slice(len).join('.')
         const candidateCookieValue = key + '=1;domain=.' + candidate + ';path=/'
 
-        // try to set cookie
-        cookieJar.cookie = candidateCookieValue
+        // try to set cookie, include a short expiry in seconds since we'll check immediately
+        cookieJar.cookie = candidateCookieValue + ';max-age=3'
 
         if (cookieJar.cookie.includes(key)) {
             // the cookie was accepted by the browser, remove the test cookie
-            cookieJar.cookie = candidateCookieValue + ';max-age=' + 0
+            cookieJar.cookie = candidateCookieValue + ';max-age=0'
             firstNonPublicSubDomain = candidate
         }
     }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -52,14 +52,13 @@ export function seekFirstNonPublicSubDomain(hostname: string, cookieJar = docume
 
     while (!firstNonPublicSubDomain && len--) {
         const candidate = list.slice(len).join('.')
-        const candidateCookieValue = key + '=1;domain=.' + candidate
+        const candidateCookieValue = key + '=1;domain=.' + candidate + ';expires=' + Y1970 + ';path=/'
 
         // try to set cookie
         cookieJar.cookie = candidateCookieValue
 
         if (R.test(cookieJar.cookie)) {
-            // the cookie was accepted by the browser, remove the test cookie
-            cookieJar.cookie = candidateCookieValue + ';expires=' + Y1970
+            // the cookie was accepted by the browser
             firstNonPublicSubDomain = candidate
         }
     }


### PR DESCRIPTION
A user reports they sometimes get 431 errors as a result of the domain check cookies.

That's surprising since we set at most 8 and they are expired if accepted by the browser

But, we no longer support IE11 so we can remove the regex test here
And we can shift to the more "modern" max age which we can set a few seconds into the future giving us time to check without leaving the cookie around if something goes wrong

see internal links: https://posthoghelp.zendesk.com/agent/tickets/30280 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/32784) and https://posthog.slack.com/archives/C03P7NL6RMW/p1747837404395389