### PR TITLE
fix: Block newer google bots

### DIFF
--- a/src/utils/blocked-uas.ts
+++ b/src/utils/blocked-uas.ts
@@ -84,9 +84,12 @@ export const DEFAULT_BLOCKED_UA_STRS = [
     'google web preview',
     'google-read-aloud',
     'googlebot',
+    'googleother',
+    'google-cloudvertexbot',
     'googleweblight',
     'mediapartners-google',
     'storebot-google',
+    'google-inspectiontool',
     'bytespider',
 ]
 


### PR DESCRIPTION
Extracted from https://developers.google.com/search/docs/crawling-indexing/google-common-crawlers