### PR TITLE
chore: handle specific case in our error boundary

### DIFF
--- a/react/src/components/PostHogErrorBoundary.tsx
+++ b/react/src/components/PostHogErrorBoundary.tsx
@@ -41,6 +41,11 @@ export class PostHogErrorBoundary extends React.Component<PostHogErrorBoundaryPr
     }
 
     componentDidCatch(error: unknown, errorInfo: React.ErrorInfo) {
+        if (error instanceof Error && error.message.includes('removeChild') && error.message.includes('not a child')) {
+            // Translation interference, log but don't crash
+            console.warn('Chrome translation interference detected:', error)
+            return
+        }
         const { componentStack } = errorInfo
         const { additionalProperties } = this.props
         this.setState({


### PR DESCRIPTION
follow up from https://github.com/PostHog/posthog/pull/32626

prevent the error boundary for crashing and showing the error if it's a translation error failing to remove a child