### PR TITLE
feat: Add "defaults" to config

### DIFF
--- a/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -207,6 +207,11 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"true\\"
   ],
   \\"properties_string_max_length\\": \\"number\\",
+  \\"defaults\\": [
+    \\"undefined\\",
+    \\"\\\\\\"2025-05-24\\\\\\"\\",
+    \\"\\\\\\"unset\\\\\\"\\"
+  ],
   \\"session_recording\\": {
     \\"blockClass\\": [
       \\"undefined\\",

--- a/src/__tests__/config-snapshot.test.ts
+++ b/src/__tests__/config-snapshot.test.ts
@@ -1,5 +1,8 @@
 import ts from 'typescript'
 import path from 'path'
+import { PostHog } from '../posthog-core'
+import { PostHogConfig } from '../types'
+import { isFunction } from '../utils/type-utils'
 
 type ProcessedType = string | Record<string, string | string[] | Record<string, any> | any[]> | ProcessedType[]
 function extractTypeInfo(filePath: string, typeName: string): string {
@@ -54,9 +57,49 @@ function extractTypeInfo(filePath: string, typeName: string): string {
 // This guarantees that the config types are stable and won't change
 // or that, at least, we won't ever remove any options from the config
 // and/or change the types of existing options.
-describe('config snapshot', () => {
-    it('for PostHogConfig', () => {
-        const typeInfo = extractTypeInfo(path.resolve(__dirname, '../types.ts'), 'PostHogConfig')
-        expect(typeInfo).toMatchSnapshot()
+describe('config', () => {
+    describe('snapshot', () => {
+        it('for PostHogConfig', () => {
+            const typeInfo = extractTypeInfo(path.resolve(__dirname, '../types.ts'), 'PostHogConfig')
+            expect(typeInfo).toMatchSnapshot()
+        })
+    })
+
+    describe('compatibilityDate', () => {
+        it('should set capture_pageview to true when defaults is undefined', () => {
+            const posthog = new PostHog()
+            posthog._init('test-token')
+            expect(posthog.config.capture_pageview).toBe(true)
+        })
+
+        it('should set capture_pageview to history_change when defaults is 2025-05-24', () => {
+            const posthog = new PostHog()
+            posthog._init('test-token', { defaults: '2025-05-24' })
+            expect(posthog.config.capture_pageview).toBe('history_change')
+        })
+
+        it('should preserve other default config values when setting defaults', () => {
+            const posthog1 = new PostHog()
+            posthog1._init('test-token')
+            const config1 = { ...posthog1.config }
+
+            const posthog2 = new PostHog()
+            posthog2._init('test-token', { defaults: '2025-05-24' })
+            const config2 = posthog2.config
+
+            // Check that all other config values remain the same
+            const allKeys = new Set([...Object.keys(config1), ...Object.keys(config2)])
+            allKeys.forEach((key) => {
+                if (!['capture_pageview', 'defaults'].includes(key)) {
+                    const val1 = config1[key as keyof PostHogConfig]
+                    const val2 = config2[key as keyof PostHogConfig]
+                    if (isFunction(val1)) {
+                        expect(isFunction(val2)).toBe(true)
+                    } else {
+                        expect(val2).toEqual(val1)
+                    }
+                }
+            })
+        })
     })
 })

--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -472,6 +472,7 @@ describe('posthog core', () => {
                 $sdk_debug_replay_internal_buffer_size: 0,
                 $sdk_debug_retry_queue_size: 0,
                 $sdk_debug_current_session_duration: null,
+                $config_defaults: 'unset',
             })
         })
 
@@ -500,6 +501,7 @@ describe('posthog core', () => {
                 $sdk_debug_replay_internal_buffer_size: 0,
                 $sdk_debug_retry_queue_size: 0,
                 $sdk_debug_current_session_duration: null,
+                $config_defaults: 'unset',
             })
         })
 
@@ -532,6 +534,7 @@ describe('posthog core', () => {
                 token: 'testtoken',
                 event: 'prop',
                 distinct_id: 'abc',
+                $config_defaults: 'unset',
             })
             expect(posthog.sessionManager.checkAndGetSessionAndWindowId).not.toHaveBeenCalled()
         })
@@ -580,6 +583,7 @@ describe('posthog core', () => {
                 token: 'testtoken',
                 $snapshot_data: {},
                 distinct_id: 'abc',
+                $config_defaults: 'unset',
             })
         })
 

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -56,6 +56,7 @@ import {
     SessionIdChangedCallback,
     SnippetArrayItem,
     ToolbarParams,
+    ConfigDefaults,
 } from './types'
 import {
     _copyAndTruncateStrings,
@@ -133,7 +134,7 @@ let ENQUEUE_REQUESTS = !SUPPORTS_REQUEST && userAgent?.indexOf('MSIE') === -1 &&
 // NOTE: Remember to update `types.ts` when changing a default value
 // to guarantee documentation is up to date, make sure to also update our website docs
 // NOTE²: This shouldn't ever change because we try very hard to be backwards-compatible
-export const defaultConfig = (): PostHogConfig => ({
+export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     api_host: 'https://us.i.posthog.com',
     ui_host: null,
     token: '',
@@ -147,8 +148,9 @@ export const defaultConfig = (): PostHogConfig => ({
     custom_campaign_params: [],
     custom_blocked_useragents: [],
     save_referrer: true,
-    capture_pageview: true, // can be true, false, or 'history_change'
+    capture_pageview: defaults === '2025-05-24' ? 'history_change' : true,
     capture_pageleave: 'if_capture_pageview', // We'll only capture pageleave events if capture_pageview is also true
+    defaults: defaults ?? 'unset',
     debug: (location && isString(location?.search) && location.search.indexOf('__posthog_debug=true') !== -1) || false,
     cookie_expiration: 365,
     upgrade: false,
@@ -431,7 +433,7 @@ export class PostHog {
         }
 
         this.set_config(
-            extend({}, defaultConfig(), configRenames(config), {
+            extend({}, defaultConfig(config.defaults), configRenames(config), {
                 name: name,
                 token: token,
             })
@@ -996,6 +998,10 @@ export class PostHog {
         const startTimestamp = readOnly ? undefined : this.persistence.remove_event_timer(eventName)
         let properties = { ...eventProperties }
         properties['token'] = this.config.token
+
+        if (this.config.defaults) {
+            properties['$config_defaults'] = this.config.defaults
+        }
 
         if (this.config.__preview_experimental_cookieless_mode) {
             // Set a flag to tell the plugin server to use cookieless server hash mode

--- a/src/types.ts
+++ b/src/types.ts
@@ -276,6 +276,12 @@ export interface HeatmapConfig {
 export type BeforeSendFn = (cr: CaptureResult | null) => CaptureResult | null
 
 /**
+ * Configuration defaults for breaking changes. When set to a specific date,
+ * enables new default behaviors that were introduced on that date.
+ */
+export type ConfigDefaults = '2025-05-24' | 'unset'
+
+/**
  * Configuration options for the PostHog JavaScript SDK.
  * @see https://posthog.com/docs/libraries/js#config
  */
@@ -638,6 +644,17 @@ export interface PostHogConfig {
      * @default 65535
      */
     properties_string_max_length: number
+
+    /**
+     * Configuration defaults for breaking changes. When set to a specific date,
+     * enables new default behaviors that were introduced on that date.
+     *
+     * - `undefined`: Use legacy default behaviors
+     * - `'2025-05-24'`: Use updated default behaviors (e.g. capture_pageview defaults to 'history_change')
+     *
+     * @default undefined
+     */
+    defaults?: ConfigDefaults
 
     /**
      * Determines the session recording options.


### PR DESCRIPTION
## Changes

See https://posthog.slack.com/archives/C03P7NL6RMW/p1747948930053279 for the discussion

We want to make `capture_pageview: 'history_change'` the default, but don't want to make a breaking change.

This lets us update the default config without breaking anyone's code.

(We will need to update our code examples to add a pinned value)

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [ ] Took care not to unnecessarily increase the bundle size

