### PR TITLE
fix: getSurveySeen and waitPeriod checks

### DIFF
--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -190,18 +190,6 @@ export class SurveyManager {
     }
 
     private _handlePopoverSurvey = (survey: Survey): void => {
-        const surveyWaitPeriodInDays = survey.conditions?.seenSurveyWaitPeriodInDays
-        const lastSeenSurveyDate = localStorage.getItem(`lastSeenSurveyDate`)
-
-        if (!hasWaitPeriodPassed(lastSeenSurveyDate, surveyWaitPeriodInDays)) {
-            return
-        }
-
-        const surveySeen = getSurveySeen(survey)
-        if (surveySeen) {
-            return
-        }
-
         this._clearSurveyTimeout(survey.id)
         this._addSurveyToFocus(survey)
         const delaySeconds = survey.appearance?.surveyPopupDelaySeconds || 0
@@ -427,6 +415,18 @@ export class SurveyManager {
             eligibility.eligible = false
             eligibility.reason =
                 'Survey internal targeting flag is not enabled and survey cannot activate repeatedly and survey is not in progress'
+            return eligibility
+        }
+
+        if (!hasWaitPeriodPassed(survey.conditions?.seenSurveyWaitPeriodInDays)) {
+            eligibility.eligible = false
+            eligibility.reason = `Survey wait period has not passed`
+            return eligibility
+        }
+
+        if (getSurveySeen(survey)) {
+            eligibility.eligible = false
+            eligibility.reason = `Survey has already been seen and it can't be activated again`
             return eligibility
         }
 

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -540,10 +540,10 @@ const getSurveyInteractionProperty = (survey: Survey, action: string): string =>
     return surveyProperty
 }
 
-export const hasWaitPeriodPassed = (
-    lastSeenSurveyDate: string | null,
-    waitPeriodInDays: number | undefined
-): boolean => {
+const LAST_SEEN_SURVEY_DATE_KEY = 'lastSeenSurveyDate'
+
+export const hasWaitPeriodPassed = (waitPeriodInDays: number | undefined): boolean => {
+    const lastSeenSurveyDate = localStorage.getItem(LAST_SEEN_SURVEY_DATE_KEY)
     if (!waitPeriodInDays || !lastSeenSurveyDate) {
         return true
     }


### PR DESCRIPTION
right now, both `getSurveySeen` and `hasWaitPeriodPassed` are only executed for popover surveys.

this PR moves them to the `checkSurveyEligibility` method instead so they work for all surveys.

it also adds unit tests the two functions, and integration tests within the `checkSurveyEligibility` to make sure this is working as expected.