### PR TITLE
chore: new public APIs for capturing survey events

### DIFF
--- a/src/__tests__/extensions/surveys-utils.test.ts
+++ b/src/__tests__/extensions/surveys-utils.test.ts
@@ -126,7 +126,9 @@ describe('canActivateRepeatedly', () => {
         const survey = {
             schedule: SurveySchedule.Always,
             conditions: undefined,
-        } as Pick<Survey, 'type' | 'schedule' | 'conditions'>
+            id: 'test-survey-1',
+            current_iteration: 0,
+        } as Pick<Survey, 'type' | 'schedule' | 'conditions' | 'id' | 'current_iteration'>
         expect(canActivateRepeatedly(survey)).toBe(true)
     })
 
@@ -141,7 +143,9 @@ describe('canActivateRepeatedly', () => {
                 },
                 actions: { values: [] },
             },
-        } as Pick<Survey, 'type' | 'schedule' | 'conditions'>
+            id: 'test-survey-2',
+            current_iteration: 0,
+        } as Pick<Survey, 'type' | 'schedule' | 'conditions' | 'id' | 'current_iteration'>
         expect(canActivateRepeatedly(survey)).toBe(false)
     })
 
@@ -156,7 +160,9 @@ describe('canActivateRepeatedly', () => {
                 },
                 actions: { values: [] },
             },
-        } as Pick<Survey, 'type' | 'schedule' | 'conditions'>
+            id: 'test-survey-3',
+            current_iteration: 0,
+        } as Pick<Survey, 'type' | 'schedule' | 'conditions' | 'id' | 'current_iteration'>
         expect(canActivateRepeatedly(survey)).toBe(true)
     })
 
@@ -171,7 +177,9 @@ describe('canActivateRepeatedly', () => {
                 },
                 actions: { values: [] },
             },
-        } as Pick<Survey, 'type' | 'schedule' | 'conditions'>
+            id: 'test-survey-4',
+            current_iteration: 0,
+        } as Pick<Survey, 'type' | 'schedule' | 'conditions' | 'id' | 'current_iteration'>
         expect(canActivateRepeatedly(survey)).toBe(false)
     })
 })

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -7,9 +7,8 @@ import {
     renderSurveysPreview,
     useHideSurveyOnURLChange,
     usePopupVisibility,
-    validateSurveyResponses,
 } from '../../extensions/surveys'
-import { retrieveSurveyShadow } from '../../extensions/surveys/surveys-extension-utils'
+import { retrieveSurveyShadow, validateSurveyResponses } from '../../extensions/surveys/surveys-extension-utils'
 import {
     Survey,
     SurveyQuestionType,

--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -1763,7 +1763,7 @@ describe('validateSurveyResponses', () => {
                 type: SurveyQuestionType.Open,
             },
             {
-                id: undefined as any, // Testing runtime behavior with undefined ID
+                id: undefined, // Testing runtime behavior with undefined ID
                 question: 'Question with no ID property',
                 type: SurveyQuestionType.Open,
             },

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -183,6 +183,81 @@ const getSurveyResponseValue = (responses: Record<string, string | number | stri
     return response
 }
 
+/**
+ * Validates that survey responses have the correct format for the public API.
+ * This ensures that customers using the public API provide responses in the expected format.
+ *
+ * @param responses - The responses object to validate
+ * @param surveyQuestions - Array of survey questions to validate response keys against
+ * @returns An object with 'valid' boolean and optional 'errors' array
+ */
+const validateSurveyResponses = (
+    responses: Record<string, any>,
+    surveyQuestions: SurveyQuestion[]
+): { valid: boolean; errors?: string[] } => {
+    const errors: string[] = []
+
+    // Check if responses is an object
+    if (!responses || typeof responses !== 'object' || isArray(responses)) {
+        return { valid: false, errors: ['Responses must be a non-null object'] }
+    }
+
+    // Get valid question IDs
+    const validQuestionIds = new Set(surveyQuestions.map((q) => q.id).filter((id) => id))
+
+    // Validate each response entry
+    for (const [key, value] of Object.entries(responses)) {
+        // Check if key starts with the correct prefix
+        if (!key.startsWith(SurveyEventProperties.SURVEY_RESPONSE)) {
+            errors.push(`Response key "${key}" must start with "${SurveyEventProperties.SURVEY_RESPONSE}"`)
+            continue
+        }
+
+        // Check if key follows the expected format (should have an underscore and question ID after the prefix)
+        const expectedPrefix = `${SurveyEventProperties.SURVEY_RESPONSE}_`
+        if (!key.startsWith(expectedPrefix) || key === SurveyEventProperties.SURVEY_RESPONSE) {
+            errors.push(`Response key "${key}" must follow the format "${expectedPrefix}<questionId>"`)
+            continue
+        }
+
+        // Extract question ID from the key
+        const questionId = key.substring(expectedPrefix.length)
+
+        // Check if question ID is empty (this is also a format error)
+        if (!questionId) {
+            errors.push(`Response key "${key}" must follow the format "${expectedPrefix}<questionId>"`)
+            continue
+        }
+
+        // Validate that the question ID exists in the survey
+        if (!validQuestionIds.has(questionId)) {
+            errors.push(
+                `Response key "${key}" references question ID "${questionId}" which does not exist in the survey`
+            )
+            continue
+        }
+
+        // Check if value has correct type
+        if (!isNull(value) && typeof value !== 'string' && typeof value !== 'number' && !isArray(value)) {
+            errors.push(`Response value for key "${key}" must be a string, number, array of strings, or null`)
+            continue
+        }
+
+        // If it's an array, check that all elements are strings
+        if (isArray(value)) {
+            const invalidElements = value.filter((item) => typeof item !== 'string')
+            if (invalidElements.length > 0) {
+                errors.push(`Response value for key "${key}" is an array but contains non-string elements`)
+            }
+        }
+    }
+
+    return {
+        valid: errors.length === 0,
+        errors: errors.length > 0 ? errors : undefined,
+    }
+}
+
 const getSurveyInteractionProperty = (survey: Survey, action: string): string => {
     let surveyProperty = `$survey_${action}/${survey.id}`
     if (survey.current_iteration && survey.current_iteration > 0) {
@@ -220,6 +295,13 @@ export class SurveyManager {
         surveySubmissionId = uuidv7(),
         isSurveyCompleted,
     }: SendSurveyEventArgs) => {
+        // Validate responses to make sure they are in the correct format
+        const validation = validateSurveyResponses(responses, survey.questions)
+        if (!validation.valid) {
+            logger.error('Invalid survey responses format:', validation.errors)
+            return
+        }
+
         // Mark as seen in localStorage regardless of completion status
         localStorage.setItem(getSurveySeenKey(survey), 'true')
 
@@ -1316,3 +1398,6 @@ const getQuestionComponent = ({
 
     return <Component {...componentProps} key={question.id} />
 }
+
+// Export the validation function for public API usage
+export { validateSurveyResponses }

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -258,7 +258,7 @@ const validateSurveyResponses = (
     }
 }
 
-const getSurveyInteractionProperty = (survey: Survey, action: string): string => {
+const getSurveyInteractionProperty = (survey: Pick<Survey, 'id' | 'current_iteration'>, action: string): string => {
     let surveyProperty = `$survey_${action}/${survey.id}`
     if (survey.current_iteration && survey.current_iteration > 0) {
         surveyProperty = `$survey_${action}/${survey.id}/${survey.current_iteration}`
@@ -279,7 +279,9 @@ export class SurveyManager {
         this._surveyInFocus = null
     }
 
-    public captureSurveyShownEvent = (survey: Survey) => {
+    public captureSurveyShownEvent = (
+        survey: Pick<Survey, 'id' | 'name' | 'current_iteration' | 'current_iteration_start_date'>
+    ) => {
         this._posthog.capture(SurveyEventName.SHOWN, {
             [SurveyEventProperties.SURVEY_NAME]: survey.name,
             [SurveyEventProperties.SURVEY_ID]: survey.id,
@@ -332,7 +334,10 @@ export class SurveyManager {
         }
     }
 
-    public captureSurveyDismissedEvent = (survey: Survey, readOnly?: boolean) => {
+    public captureSurveyDismissedEvent = (
+        survey: Pick<Survey, 'id' | 'name' | 'current_iteration' | 'current_iteration_start_date' | 'questions'>,
+        readOnly?: boolean
+    ) => {
         if (readOnly) {
             return
         }

--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -227,7 +227,6 @@ export class SurveyManager {
         const validation = validateSurveyResponses(responses, survey.questions)
         if (!validation.valid) {
             logger.error('Invalid survey responses format:', validation.errors)
-            return
         }
 
         // Mark as seen in localStorage regardless of completion status

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../posthog-surveys-types'
 import { document as _document, window as _window, userAgent } from '../../utils/globals'
 import { SURVEY_LOGGER as logger, SURVEY_IN_PROGRESS_PREFIX, SURVEY_SEEN_PREFIX } from '../../utils/survey-utils'
-import { isNullish } from '../../utils/type-utils'
+import { isArray, isNull, isNullish } from '../../utils/type-utils'
 
 import { detectDeviceType } from '../../utils/user-agent-utils'
 import { propertyComparisons } from '../../utils/property-utils'
@@ -584,4 +584,79 @@ export const clearInProgressSurveyState = (survey: Pick<Survey, 'id' | 'current_
 export function getSurveyContainerClass(survey: Pick<Survey, 'id'>, asSelector = false): string {
     const className = `PostHogSurvey-${survey.id}`
     return asSelector ? `.${className}` : className
+}
+
+/**
+ * Validates that survey responses have the correct format for the public API.
+ * This ensures that customers using the public API provide responses in the expected format.
+ *
+ * @param responses - The responses object to validate
+ * @param surveyQuestions - Array of survey questions to validate response keys against
+ * @returns An object with 'valid' boolean and optional 'errors' array
+ */
+export function validateSurveyResponses(
+    responses: Record<string, any>,
+    surveyQuestions: SurveyQuestion[]
+): { valid: boolean; errors?: string[] } {
+    const errors: string[] = []
+
+    // Check if responses is an object
+    if (!responses || typeof responses !== 'object' || isArray(responses)) {
+        return { valid: false, errors: ['Responses must be a non-null object'] }
+    }
+
+    // Get valid question IDs
+    const validQuestionIds = new Set(surveyQuestions.map((q) => q.id).filter((id) => id))
+
+    // Validate each response entry
+    for (const [key, value] of Object.entries(responses)) {
+        // Check if key starts with the correct prefix
+        if (!key.startsWith(SurveyEventProperties.SURVEY_RESPONSE)) {
+            errors.push(`Response key "${key}" must start with "${SurveyEventProperties.SURVEY_RESPONSE}"`)
+            continue
+        }
+
+        // Check if key follows the expected format (should have an underscore and question ID after the prefix)
+        const expectedPrefix = `${SurveyEventProperties.SURVEY_RESPONSE}_`
+        if (!key.startsWith(expectedPrefix) || key === SurveyEventProperties.SURVEY_RESPONSE) {
+            errors.push(`Response key "${key}" must follow the format "${expectedPrefix}<questionId>"`)
+            continue
+        }
+
+        // Extract question ID from the key
+        const questionId = key.substring(expectedPrefix.length)
+
+        // Check if question ID is empty (this is also a format error)
+        if (!questionId) {
+            errors.push(`Response key "${key}" must follow the format "${expectedPrefix}<questionId>"`)
+            continue
+        }
+
+        // Validate that the question ID exists in the survey
+        if (!validQuestionIds.has(questionId)) {
+            errors.push(
+                `Response key "${key}" references question ID "${questionId}" which does not exist in the survey`
+            )
+            continue
+        }
+
+        // Check if value has correct type
+        if (!isNull(value) && typeof value !== 'string' && typeof value !== 'number' && !isArray(value)) {
+            errors.push(`Response value for key "${key}" must be a string, number, array of strings, or null`)
+            continue
+        }
+
+        // If it's an array, check that all elements are strings
+        if (isArray(value)) {
+            const invalidElements = value.filter((item) => typeof item !== 'string')
+            if (invalidElements.length > 0) {
+                errors.push(`Response value for key "${key}" is an array but contains non-string elements`)
+            }
+        }
+    }
+
+    return {
+        valid: errors.length === 0,
+        errors: errors.length > 0 ? errors : undefined,
+    }
 }

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -4,6 +4,7 @@ import {
     MultipleSurveyQuestion,
     Survey,
     SurveyAppearance,
+    SurveyEventProperties,
     SurveyPosition,
     SurveyQuestion,
     SurveySchedule,
@@ -35,7 +36,7 @@ export function getFontFamily(fontFamily?: string): string {
 }
 
 export function getSurveyResponseKey(questionId: string) {
-    return `$survey_response_${questionId}`
+    return `${SurveyEventProperties.SURVEY_RESPONSE}_${questionId}`
 }
 
 const BLACK_TEXT_COLOR = '#020617' // Maps out to text-slate-950 from tailwind colors. Intended for text use outside interactive elements like buttons

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -423,7 +423,7 @@ export const getSurveySeen = (survey: Survey): boolean => {
     return false
 }
 
-export const getSurveySeenKey = (survey: Survey): string => {
+export const getSurveySeenKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
     let surveySeenKey = `${SURVEY_SEEN_PREFIX}${survey.id}`
     if (survey.current_iteration && survey.current_iteration > 0) {
         surveySeenKey = `${SURVEY_SEEN_PREFIX}${survey.id}_${survey.current_iteration}`

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -258,7 +258,7 @@ export enum SurveyEventProperties {
 
 export interface SendSurveyEventArgs {
     responses: Record<string, string | number | string[] | null>
-    survey: Survey
+    survey: Pick<Survey, 'id' | 'name' | 'current_iteration' | 'current_iteration_start_date' | 'questions'>
     surveySubmissionId: string
     isSurveyCompleted: boolean
 }

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -237,3 +237,28 @@ export interface ActionStepType {
     /** @default StringMatching.Contains */
     url_matching?: ActionStepStringMatching | null
 }
+
+export enum SurveyEventName {
+    SHOWN = 'survey shown',
+    DISMISSED = 'survey dismissed',
+    SENT = 'survey sent',
+}
+
+export enum SurveyEventProperties {
+    SURVEY_ID = '$survey_id',
+    SURVEY_NAME = '$survey_name',
+    SURVEY_RESPONSE = '$survey_response',
+    SURVEY_ITERATION = '$survey_iteration',
+    SURVEY_ITERATION_START_DATE = '$survey_iteration_start_date',
+    SURVEY_PARTIALLY_COMPLETED = '$survey_partially_completed',
+    SURVEY_SUBMISSION_ID = '$survey_submission_id',
+    SURVEY_QUESTIONS = '$survey_questions',
+    SURVEY_COMPLETED = '$survey_completed',
+}
+
+export interface SendSurveyEventArgs {
+    responses: Record<string, string | number | string[] | null>
+    survey: Survey
+    surveySubmissionId: string
+    isSurveyCompleted: boolean
+}

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -1,7 +1,7 @@
 import { SURVEYS } from './constants'
 import { SurveyManager } from './extensions/surveys'
 import { PostHog } from './posthog-core'
-import { Survey, SurveyCallback, SurveyRenderReason } from './posthog-surveys-types'
+import { SendSurveyEventArgs, Survey, SurveyCallback, SurveyRenderReason } from './posthog-surveys-types'
 import { RemoteConfig } from './types'
 import { assignableWindow, document } from './utils/globals'
 import { SurveyEventReceiver } from './utils/survey-event-receiver'
@@ -324,5 +324,29 @@ export class PostHogSurveys {
             return
         }
         this._surveyManager.renderSurvey(survey, elem)
+    }
+
+    captureSurveyShownEvent = (survey: Survey) => {
+        if (isNullish(this._surveyManager)) {
+            logger.warn('surveys not loaded')
+            return
+        }
+        this._surveyManager.captureSurveyShownEvent(survey)
+    }
+
+    captureSurveySentEvent = (args: SendSurveyEventArgs) => {
+        if (isNullish(this._surveyManager)) {
+            logger.warn('surveys not loaded')
+            return
+        }
+        this._surveyManager.captureSurveySentEvent(args)
+    }
+
+    captureSurveyDismissedEvent = (survey: Survey) => {
+        if (isNullish(this._surveyManager)) {
+            logger.warn('surveys not loaded')
+            return
+        }
+        this._surveyManager.captureSurveyDismissedEvent(survey)
     }
 }

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -342,11 +342,11 @@ export class PostHogSurveys {
         this._surveyManager.captureSurveySentEvent(args)
     }
 
-    captureSurveyDismissedEvent(survey: Survey) {
+    captureSurveyDismissedEvent(survey: Survey, readOnly?: boolean) {
         if (isNullish(this._surveyManager)) {
             logger.warn('surveys not loaded')
             return
         }
-        this._surveyManager.captureSurveyDismissedEvent(survey)
+        this._surveyManager.captureSurveyDismissedEvent(survey, readOnly)
     }
 }

--- a/src/posthog-surveys.ts
+++ b/src/posthog-surveys.ts
@@ -326,7 +326,7 @@ export class PostHogSurveys {
         this._surveyManager.renderSurvey(survey, elem)
     }
 
-    captureSurveyShownEvent = (survey: Survey) => {
+    captureSurveyShownEvent(survey: Survey) {
         if (isNullish(this._surveyManager)) {
             logger.warn('surveys not loaded')
             return
@@ -334,7 +334,7 @@ export class PostHogSurveys {
         this._surveyManager.captureSurveyShownEvent(survey)
     }
 
-    captureSurveySentEvent = (args: SendSurveyEventArgs) => {
+    captureSurveySentEvent(args: SendSurveyEventArgs) {
         if (isNullish(this._surveyManager)) {
             logger.warn('surveys not loaded')
             return
@@ -342,7 +342,7 @@ export class PostHogSurveys {
         this._surveyManager.captureSurveySentEvent(args)
     }
 
-    captureSurveyDismissedEvent = (survey: Survey) => {
+    captureSurveyDismissedEvent(survey: Survey) {
         if (isNullish(this._surveyManager)) {
             logger.warn('surveys not loaded')
             return


### PR DESCRIPTION
right now, for API surveys, we guide the customer for all properties necessary.

however, this has a few problems:

- local storage values are not updated, like `lastSurveySeen` and `surveySeen{surveyId`
- the person property that tracks the survey is responded is also not set, so for API surveys, the survey will just always be visible for the user and always come back when calling `getActiveMatchingSurveys`, even if it was already answered

so this PR gets our current `sendSurveySent` and `dismissedSurveyEvent` and exposes them in our `PostHogSurveys` class.

it also does a validation for survey sent events to make sure that they have the correct format when sending those events.

Tests:

- added unit tests for the new validation
- and all our e2e tests are still passing to make sure everything is working as expected