### PR TITLE
fix: Block Leikibot

### DIFF
--- a/src/utils/blocked-uas.ts
+++ b/src/utils/blocked-uas.ts
@@ -19,6 +19,7 @@ export const DEFAULT_BLOCKED_UA_STRS = [
     'http://yandex.com/bots',
     'hubspot',
     'ia_archiver',
+    'leikibot',
     'linkedinbot',
     'meta-externalagent',
     'mj12bot',


### PR DESCRIPTION
## Changes

Added Leikibot/1.0 to the UA blocklist as requested by https://posthoghelp.zendesk.com/agent/tickets/31598 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/33513)

