### PR TITLE
chore: more playground scenarios

### DIFF
--- a/playground/csp-violations/README.md
+++ b/playground/csp-violations/README.md
@@ -43,12 +43,26 @@ http://localhost:8080
 
 The playground includes examples for different types of CSP violations:
 
+### Basic CSP Violations
+
 1. **Inline Script Violation** - Tests violations of inline scripts
 2. **External Script Violation** - Tests loading scripts from non-allowed domains
 3. **External Image Violation** - Tests loading images from non-allowed domains
 4. **External Style Violation** - Tests loading stylesheets from non-allowed domains
 5. **XHR Violation** - Tests making XHR requests to non-allowed domains
 6. **Eval Violation** - Tests scripts with `eval` present
+
+### Report-To Debug Cases
+
+These test cases are specifically designed to debug report-to directive issues and test the logging functionality added in [PR #32868](https://github.com/PostHog/posthog/pull/32868):
+
+1. **Debug Enabled** - Tests CSP reports with `debug=true` parameter for verbose logging
+2. **Invalid Content Type** - Tests CSP reports sent with incorrect content type to trigger error logging
+3. **Report-URI Only** - Tests pages using only `report-uri` directive (no `report-to`)
+4. **Report-To Only** - Tests pages using only `report-to` directive (no `report-uri`)
+5. **Both Report Directives** - Tests pages using both `report-uri` and `report-to` directives
+6. **Malformed Reporting Endpoints** - Tests malformed `Reporting-Endpoints` header to trigger error logging
+7. **Sampling Test** - Generates multiple violations rapidly with random query parameters and hashes to bypass URL-based sampling and test sampling behavior and logging
 
 Each example will automatically trigger a CSP violation when the page loads, which will be reported to your configured CSP endpoint.
 


### PR DESCRIPTION
## Changes

A bunch of new test scenarios for the CSP playground I came up with for testing some logs locally for https://github.com/PostHog/posthog/pull/32868.

I also went with a bit more cases so we can use them for our rust port, as there are quite a few cases on the Python test suite.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

