### PR TITLE
feat(flags): add `advanced_only_evaluate_survey_feature_flags` config to explicitly only evaluate survey flags on the frontend

### DIFF
--- a/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -353,6 +353,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"false\\",
     \\"true\\"
   ],
+  \\"advanced_only_evaluate_survey_feature_flags\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
   \\"feature_flag_request_timeout_ms\\": \\"number\\",
   \\"surveys_request_timeout_ms\\": \\"number\\",
   \\"get_device_id\\": \\"(uuid: string) => string\\",

--- a/src/__tests__/posthog-core.loaded.test.ts
+++ b/src/__tests__/posthog-core.loaded.test.ts
@@ -84,6 +84,23 @@ describe('loaded() with flags', () => {
             })
         })
 
+        it('adds only_evaluate_survey_feature_flags query param when configured', async () => {
+            instance = await createPosthog({
+                advanced_only_evaluate_survey_feature_flags: true,
+                loaded: (ph) => {
+                    ph.group('org', 'bazinga', { name: 'Shelly' })
+                },
+            })
+
+            expect(instance._send_request).toHaveBeenCalledTimes(1)
+            expect(instance._send_request.mock.calls[0][0]).toMatchObject({
+                url: 'https://us.i.posthog.com/decide/?v=4&only_evaluate_survey_feature_flags=true',
+                data: {
+                    groups: { org: 'bazinga' },
+                },
+            })
+        })
+
         it('does call decide with a request for flags if called directly (via groups) even if disabled for first load', async () => {
             instance = await createPosthog({
                 advanced_disable_feature_flags_on_first_load: true,

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -182,6 +182,7 @@ export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     advanced_disable_decide: false,
     advanced_disable_feature_flags: false,
     advanced_disable_feature_flags_on_first_load: false,
+    advanced_only_evaluate_survey_feature_flags: false,
     advanced_disable_toolbar_metrics: false,
     feature_flag_request_timeout_ms: 3000,
     surveys_request_timeout_ms: SURVEYS_REQUEST_TIMEOUT_MS,

--- a/src/posthog-featureflags.ts
+++ b/src/posthog-featureflags.ts
@@ -398,6 +398,12 @@ export class PostHogFeatureFlags {
         const eligibleForFlagsV2 =
             this._instance.config.__preview_flags_v2 && this._instance.config.__preview_remote_config
 
+        const baseUrl = eligibleForFlagsV2 ? '/flags/?v=2' : '/decide/?v=4'
+        const queryParams = this._instance.config.advanced_only_evaluate_survey_feature_flags
+            ? '&only_evaluate_survey_feature_flags=true'
+            : ''
+        const url = this._instance.requestRouter.endpointFor('api', baseUrl + queryParams)
+
         if (eligibleForFlagsV2) {
             data.timezone = getTimezone()
         }
@@ -405,7 +411,7 @@ export class PostHogFeatureFlags {
         this._requestInFlight = true
         this._instance._send_request({
             method: 'POST',
-            url: this._instance.requestRouter.endpointFor('api', eligibleForFlagsV2 ? '/flags/?v=2' : '/decide/?v=4'),
+            url,
             data,
             compression: this._instance.config.disable_compression ? undefined : Compression.Base64,
             timeout: this._instance.config.feature_flag_request_timeout_ms,

--- a/src/types.ts
+++ b/src/types.ts
@@ -737,6 +737,15 @@ export interface PostHogConfig {
     advanced_disable_toolbar_metrics: boolean
 
     /**
+     * Determines whether PostHog should only evaluate feature flags for surveys.
+     * Useful for when you want to use this library to evaluate feature flags for surveys only but you have additional feature flags
+     * that you evaluate on the server side.
+     *
+     * @default false
+     */
+    advanced_only_evaluate_survey_feature_flags: boolean
+
+    /**
      * Sets timeout for fetching feature flags
      *
      * @default 3000


### PR DESCRIPTION
## Changes

Context: https://posthog.slack.com/archives/C075EH38BR8/p1748544593177269?thread_ts=1748335261.479809&cid=C075EH38BR8

Ships with https://github.com/PostHog/posthog/pull/32925.  That change should go first.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

