### PR TITLE
chore: apply survey seen attributes on posthog capture

### DIFF
--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -4,6 +4,8 @@ import { PostHog } from '../posthog-core'
 import {
     Survey,
     SurveyCallback,
+    SurveyEventName,
+    SurveyEventProperties,
     SurveyPosition,
     SurveyQuestion,
     SurveyQuestionBranchingType,
@@ -783,11 +785,11 @@ export function usePopupVisibility(
             }
             setIsPopupVisible(true)
             window.dispatchEvent(new Event('PHSurveyShown'))
-            posthog.capture('survey shown', {
-                $survey_name: survey.name,
-                $survey_id: survey.id,
-                $survey_iteration: survey.current_iteration,
-                $survey_iteration_start_date: survey.current_iteration_start_date,
+            posthog.capture(SurveyEventName.SHOWN, {
+                [SurveyEventProperties.SURVEY_NAME]: survey.name,
+                [SurveyEventProperties.SURVEY_ID]: survey.id,
+                [SurveyEventProperties.SURVEY_ITERATION]: survey.current_iteration,
+                [SurveyEventProperties.SURVEY_ITERATION_START_DATE]: survey.current_iteration_start_date,
                 sessionRecordingUrl: posthog.get_session_replay_url?.(),
             })
             localStorage.setItem('lastSeenSurveyDate', new Date().toISOString())

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -27,7 +27,7 @@ import { PostHogExceptions } from './posthog-exceptions'
 import { PostHogFeatureFlags } from './posthog-featureflags'
 import { PostHogPersistence } from './posthog-persistence'
 import { PostHogSurveys } from './posthog-surveys'
-import { SurveyCallback, SurveyRenderReason } from './posthog-surveys-types'
+import { SurveyCallback, SurveyEventName, SurveyEventProperties, SurveyRenderReason } from './posthog-surveys-types'
 import { RateLimiter } from './rate-limiter'
 import { RemoteConfigLoader } from './remote-config'
 import { extendURLParams, request, SUPPORTS_REQUEST } from './request'
@@ -75,6 +75,7 @@ import { getPersonPropertiesHash } from './utils/property-utils'
 import { RequestRouter, RequestRouterRegion } from './utils/request-router'
 import { SimpleEventEmitter } from './utils/simple-event-emitter'
 import { includes, isDistinctIdStringLike } from './utils/string-utils'
+import { getSurveyInteractionProperty, getSurveySeenKey } from './utils/survey-utils'
 import {
     isArray,
     isEmptyObject,
@@ -934,6 +935,19 @@ export class PostHog {
         const finalSet = { ...data.properties['$set'], ...data['$set'] }
         if (!isEmptyObject(finalSet)) {
             this.setPersonPropertiesForFlags(finalSet)
+        }
+
+        if (event_name === SurveyEventName.DISMISSED || event_name === SurveyEventName.SENT) {
+            const surveyId = properties?.[SurveyEventProperties.SURVEY_ID]
+            const surveyIteration = properties?.[SurveyEventProperties.SURVEY_ITERATION]
+            localStorage.setItem(getSurveySeenKey({ id: surveyId, current_iteration: surveyIteration }), 'true')
+            data.$set = {
+                ...data.$set,
+                [getSurveyInteractionProperty(
+                    { id: surveyId, current_iteration: surveyIteration },
+                    event_name === SurveyEventName.SENT ? 'responded' : 'dismissed'
+                )]: true,
+            }
         }
 
         if (!isNullish(this.config.before_send)) {

--- a/src/posthog-surveys-types.ts
+++ b/src/posthog-surveys-types.ts
@@ -237,3 +237,21 @@ export interface ActionStepType {
     /** @default StringMatching.Contains */
     url_matching?: ActionStepStringMatching | null
 }
+
+export enum SurveyEventName {
+    SHOWN = 'survey shown',
+    DISMISSED = 'survey dismissed',
+    SENT = 'survey sent',
+}
+
+export enum SurveyEventProperties {
+    SURVEY_ID = '$survey_id',
+    SURVEY_NAME = '$survey_name',
+    SURVEY_RESPONSE = '$survey_response',
+    SURVEY_ITERATION = '$survey_iteration',
+    SURVEY_ITERATION_START_DATE = '$survey_iteration_start_date',
+    SURVEY_PARTIALLY_COMPLETED = '$survey_partially_completed',
+    SURVEY_SUBMISSION_ID = '$survey_submission_id',
+    SURVEY_QUESTIONS = '$survey_questions',
+    SURVEY_COMPLETED = '$survey_completed',
+}

--- a/src/utils/survey-utils.ts
+++ b/src/utils/survey-utils.ts
@@ -17,3 +17,24 @@ export function doesSurveyActivateByAction(survey: Pick<Survey, 'conditions'>): 
 
 export const SURVEY_SEEN_PREFIX = 'seenSurvey_'
 export const SURVEY_IN_PROGRESS_PREFIX = 'inProgressSurvey_'
+
+export const getSurveyInteractionProperty = (
+    survey: Pick<Survey, 'id' | 'current_iteration'>,
+    action: 'responded' | 'dismissed'
+): string => {
+    let surveyProperty = `$survey_${action}/${survey.id}`
+    if (survey.current_iteration && survey.current_iteration > 0) {
+        surveyProperty = `$survey_${action}/${survey.id}/${survey.current_iteration}`
+    }
+
+    return surveyProperty
+}
+
+export const getSurveySeenKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
+    let surveySeenKey = `${SURVEY_SEEN_PREFIX}${survey.id}`
+    if (survey.current_iteration && survey.current_iteration > 0) {
+        surveySeenKey = `${SURVEY_SEEN_PREFIX}${survey.id}_${survey.current_iteration}`
+    }
+
+    return surveySeenKey
+}


### PR DESCRIPTION
follow up from https://github.com/PostHog/posthog-js/pull/1983.

small changes to `posthog.capture` to make sure we are always marking as survey as seen when capturing events.

The motivation is to make the case for API surveys a little bit easier for the customer. Otherwise, they will also need to remember to set those person properties in a very specific way that I don't think is necessary.

We had a few complains so far about API surveys being shown to multiple people, and this will fix that issue.