### PR TITLE
fix: hide feedback tab if survey is not recurring

### DIFF
--- a/src/extensions/surveys.tsx
+++ b/src/extensions/surveys.tsx
@@ -1088,6 +1088,10 @@ export function FeedbackWidget({
     const [showSurvey, setShowSurvey] = useState(false)
     const [styleOverrides, setStyleOverrides] = useState<React.CSSProperties>({})
 
+    const toggleSurvey = () => {
+        setShowSurvey(!showSurvey)
+    }
+
     useEffect(() => {
         if (!posthog) {
             logger.error('FeedbackWidget called without a PostHog instance.')
@@ -1109,7 +1113,7 @@ export function FeedbackWidget({
             if (customEvent.detail?.surveyId === survey.id) {
                 logger.info(`Received show event for feedback button survey ${survey.id}`)
                 setStyleOverrides(customEvent.detail.position || {})
-                setShowSurvey(true) // Show the survey popup
+                toggleSurvey()
             }
         }
 
@@ -1138,6 +1142,10 @@ export function FeedbackWidget({
     }
 
     const resetShowSurvey = () => {
+        // hide the feedback button after answering or closing the survey if it's not always show
+        if (survey.schedule !== SurveySchedule.Always) {
+            setIsFeedbackButtonVisible(false)
+        }
         // important so our view transition has time to run
         setTimeout(() => {
             setShowSurvey(false)
@@ -1147,7 +1155,7 @@ export function FeedbackWidget({
     return (
         <Preact.Fragment>
             {survey.appearance?.widgetType === 'tab' && (
-                <button className="ph-survey-widget-tab" onClick={() => setShowSurvey(!showSurvey)} disabled={readOnly}>
+                <button className="ph-survey-widget-tab" onClick={toggleSurvey} disabled={readOnly}>
                     {survey.appearance?.widgetLabel || ''}
                 </button>
             )}


### PR DESCRIPTION
otherwise, the feedback tab is visible until the page is refreshed, and a user can answer it multiple times even if the survey is set to only receive one response.