### PR TITLE
chore: workspace migration (linting)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,7 @@
 /*eslint-env node */
 
+// https://eslint.org/docs/v8.x/use/configure/configuration-files
+
 const rules = {
     'prettier/prettier': 'error',
     'prefer-spread': 'off',
@@ -33,6 +35,7 @@ const extend = [
 ]
 
 module.exports = {
+    root: true,
     env: {
         browser: true,
         es6: true,
@@ -47,7 +50,7 @@ module.exports = {
     parserOptions: {
         ecmaVersion: 2018,
         sourceType: 'module',
-        project: './tsconfig.json',
+        project: null,
     },
     plugins: [
         'prettier',
@@ -59,57 +62,18 @@ module.exports = {
     ],
     extends: extend,
     rules,
-    settings: {
-        react: {
-            version: '17.0',
-        },
-        'import/resolver': {
-            node: {
-                paths: ['../../eslint-rules'], // Add the directory containing your custom rules
-                extensions: ['.js', '.jsx', '.ts', '.tsx'], // Ensure ESLint resolves both JS and TS files
-            },
-        },
-    },
     overrides: [
-        {
-            files: 'src/**/*',
-            rules: {
-                ...rules,
-                'no-restricted-globals': ['error', 'document', 'window'],
-            },
-        },
-        {
-            files: 'src/__tests__/**/*',
-            // the same set of config as in the root
-            // but excluding the 'plugin:compat/recommended' rule
-            // we don't mind using the latest features in our tests
-            extends: extend.filter((s) => s !== 'plugin:compat/recommended'),
-            rules: {
-                ...rules,
-                'no-console': 'off',
-                'no-restricted-globals': 'off',
-                'compat/compat': 'off',
-            },
-            parserOptions: {
-                project: './src/__tests__/tsconfig.json',
-            },
-        },
         {
             files: ['**/*.js'],
             parserOptions: {
                 project: null, // <- prevents the TS parser from trying to parse it with type info
             },
             rules: {
-                ...rules,
                 '@typescript-eslint/naming-convention': 'off',
             },
         },
         {
-            files: 'react/src/**/',
-            extends: [...extend, 'plugin:react/recommended', 'plugin:react-hooks/recommended'],
-        },
-        {
-            files: 'eslint-rules/**/*',
+            files: 'eslint-rules/**/*.js',
             extends: ['eslint:recommended', 'prettier'],
             rules: {
                 'prettier/prettier': 'error',
@@ -122,52 +86,5 @@ module.exports = {
                 node: true,
             },
         },
-        {
-            files: 'cypress/**/*',
-            globals: {
-                cy: true,
-                Cypress: true,
-            },
-        },
-        {
-            files: 'testcafe/**/*',
-            globals: {
-                __dirname: true,
-            },
-        },
-        {
-            files: ['playwright/**/*.ts'],
-            rules: {
-                'posthog-js/no-direct-array-check': 'off',
-                'posthog-js/no-direct-undefined-check': 'off',
-                'posthog-js/no-direct-null-check': 'off',
-                '@typescript-eslint/naming-convention': 'off',
-            },
-            parserOptions: {
-                project: null,
-            },
-        },
-        {
-            files: ['react/**/*.ts'],
-            rules: {
-                'posthog-js/no-direct-null-check': 'off',
-            },
-        },
-        {
-            files: ['playground/**/*'],
-            rules: {
-                'no-console': 'off',
-                '@typescript-eslint/no-require-imports': 'off',
-                'no-undef': 'off',
-            },
-            env: {
-                node: true,
-            },
-            parserOptions: {
-                project: null,
-            },
-        },
     ],
-    root: true,
-    ignorePatterns: ['playground/error-tracking/**/*'],
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# npx lint-staged
+pnpx lint-staged

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -2,7 +2,7 @@ const { readdirSync } = require('fs')
 const { basename } = require('path')
 
 const projectName = 'posthog-js'
-const ruleFiles = readdirSync('eslint-rules').filter(
+const ruleFiles = readdirSync(__dirname).filter(
     (file) => file.endsWith('.js') && file !== 'index.js' && !file.endsWith('test.js')
 )
 const configs = {

--- a/eslint-rules/package.json
+++ b/eslint-rules/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "eslint-plugin-posthog-js",
+    "main": "index.js",
+    "type": "commonjs"
+}

--- a/package.json
+++ b/package.json
@@ -5,5 +5,30 @@
             "@rrweb/rrweb-plugin-console-record@2.0.0-alpha.17": "patches/@rrweb__rrweb-plugin-console-record@2.0.0-alpha.17.patch",
             "@rrweb/record@2.0.0-alpha.17": "patches/@rrweb__record@2.0.0-alpha.17.patch"
         }
+    },
+    "devDependencies": {
+        "eslint": "8.57.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-config-posthog-js": "workspace:./eslint-rules",
+        "eslint-plugin-compat": "^6.0.1",
+        "eslint-plugin-jest": "^28.8.3",
+        "eslint-plugin-no-only-tests": "^3.1.0",
+        "eslint-plugin-posthog-js": "workspace:./eslint-rules",
+        "eslint-plugin-prettier": "^5.2.1",
+        "eslint-plugin-react": "^7.30.1",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "@typescript-eslint/eslint-plugin": "^8.29.1",
+        "@typescript-eslint/parser": "^8.29.1",
+        "@types/eslint": "^8.44.6",
+        "lint-staged": "^10.2.11"
+    },
+    "lint-staged": {
+        "*.{ts,tsx,js,json}": "prettier --write",
+        "*.js": "eslint --cache --fix",
+        "*.{ts,tsx}": [
+            "eslint packages/browser/src --fix",
+            "eslint packages/browser/playwright --fix",
+            "prettier --write"
+        ]
     }
 }

--- a/packages/browser/.eslintrc.js
+++ b/packages/browser/.eslintrc.js
@@ -1,0 +1,69 @@
+/*eslint-env node */
+
+module.exports = {
+    parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+        project: true,
+    },
+    overrides: [
+        {
+            files: './src/**/*',
+            rules: {
+                'no-restricted-globals': ['error', 'document', 'window'],
+            },
+        },
+        {
+            files: './src/__tests__/**/*',
+            // the same set of config as in the root
+            // but excluding the 'plugin:compat/recommended' rule
+            // we don't mind using the latest features in our tests
+            // extends: extend.filter((s) => s !== 'plugin:compat/recommended'),
+            rules: {
+                'no-console': 'off',
+                'no-restricted-globals': 'off',
+                'compat/compat': 'off',
+            },
+        },
+        {
+            files: './playground/cypress/**/*',
+            globals: {
+                cy: true,
+                Cypress: true,
+            },
+        },
+        {
+            files: './testcafe/**/*',
+            globals: {
+                __dirname: true,
+            },
+        },
+        {
+            files: './playwright/**/*.ts',
+            rules: {
+                'posthog-js/no-direct-array-check': 'off',
+                'posthog-js/no-direct-undefined-check': 'off',
+                'posthog-js/no-direct-null-check': 'off',
+                '@typescript-eslint/naming-convention': 'off',
+            },
+            parserOptions: {
+                project: null,
+            },
+        },
+        {
+            files: './playground/**/*',
+            rules: {
+                'no-console': 'off',
+                '@typescript-eslint/no-require-imports': 'off',
+                'no-undef': 'off',
+            },
+            env: {
+                node: true,
+            },
+            parserOptions: {
+                project: null,
+            },
+        },
+    ],
+    ignorePatterns: ['./playground/error-tracking/**/*'],
+}

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -78,29 +78,16 @@
         "@testing-library/dom": "^9.3.0",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/preact": "^3.2.4",
-        "@types/eslint": "^8.44.6",
         "@types/jest": "^27.5.2",
         "@types/node": "^22.5.0",
         "@types/react-dom": "^18.0.10",
         "@types/sinon": "^17.0.1",
         "@types/web": "^0.0.222",
-        "@typescript-eslint/eslint-plugin": "^8.29.1",
-        "@typescript-eslint/parser": "^8.29.1",
         "babel-jest": "^26.6.3",
         "browserslist": "^4.24.5",
         "compare-versions": "^6.1.0",
         "cssnano": "^7.0.7",
         "date-fns": "^3.6.0",
-        "eslint": "8.57.0",
-        "eslint-config-posthog-js": "link:eslint-rules",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-compat": "^6.0.1",
-        "eslint-plugin-jest": "^28.8.3",
-        "eslint-plugin-no-only-tests": "^3.1.0",
-        "eslint-plugin-posthog-js": "link:eslint-rules",
-        "eslint-plugin-prettier": "^5.2.1",
-        "eslint-plugin-react": "^7.30.1",
-        "eslint-plugin-react-hooks": "^4.6.0",
         "expect": "^29.7.0",
         "fast-check": "^2.17.0",
         "http-server": "14.1.1",
@@ -109,7 +96,7 @@
         "jest": "^27.5.1",
         "jsdom": "16.5.0",
         "jsdom-global": "3.0.2",
-        "lint-staged": "^10.2.11",
+        
         "localStorage": "1.0.4",
         "msw": "^1.3.3",
         "node-fetch": "^2.6.11",
@@ -142,15 +129,6 @@
         "rrweb-snapshot": {
             "optional": true
         }
-    },
-    "lint-staged": {
-        "*.{ts,tsx,js,json}": "prettier --write",
-        "*.js": "eslint --cache --fix",
-        "*.{ts,tsx}": [
-            "eslint src --fix",
-            "eslint playwright --fix",
-            "prettier --write"
-        ]
     },
     "browserslist": [
         "> 0.5%, last 2 versions, Firefox ESR, not dead, IE 11"

--- a/packages/browser/react/.eslintrc.js
+++ b/packages/browser/react/.eslintrc.js
@@ -1,0 +1,26 @@
+/*eslint-env node */
+
+module.exports = {
+    settings: {
+        react: {
+            version: '17.0',
+        },
+    },
+    parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+        project: true,
+    },
+    overrides: [
+        {
+            files: './src/**',
+            extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
+        },
+        {
+            files: ['./src/**/*.ts'],
+            rules: {
+                'posthog-js/no-direct-null-check': 'off',
+            },
+        },
+    ],
+}

--- a/packages/browser/src/__tests__/tsconfig.json
+++ b/packages/browser/src/__tests__/tsconfig.json
@@ -7,6 +7,6 @@
         "typeRoots": ["../../node_modules/@types", "../../src/types"],
         "allowJs": true
     },
-    "include": ["./**/*.ts*"],
+    "include": ["./**/*.ts*", "setup.js"],
     "exclude": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,52 @@ patchedDependencies:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@types/eslint':
+        specifier: ^8.44.6
+        version: 8.44.6
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.29.1(@typescript-eslint/parser@8.29.1(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.29.1(eslint@8.57.0)(typescript@5.5.4)
+      eslint:
+        specifier: 8.57.0
+        version: 8.57.0
+      eslint-config-posthog-js:
+        specifier: workspace:./eslint-rules
+        version: link:eslint-rules
+      eslint-config-prettier:
+        specifier: ^8.5.0
+        version: 8.5.0(eslint@8.57.0)
+      eslint-plugin-compat:
+        specifier: ^6.0.1
+        version: 6.0.1(eslint@8.57.0)
+      eslint-plugin-jest:
+        specifier: ^28.8.3
+        version: 28.8.3(@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@8.29.1(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(jest@27.5.1(node-notifier@8.0.2))(typescript@5.5.4)
+      eslint-plugin-no-only-tests:
+        specifier: ^3.1.0
+        version: 3.1.0
+      eslint-plugin-posthog-js:
+        specifier: workspace:./eslint-rules
+        version: link:eslint-rules
+      eslint-plugin-prettier:
+        specifier: ^5.2.1
+        version: 5.2.1(@types/eslint@8.44.6)(eslint-config-prettier@8.5.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.4.2)
+      eslint-plugin-react:
+        specifier: ^7.30.1
+        version: 7.30.1(eslint@8.57.0)
+      eslint-plugin-react-hooks:
+        specifier: ^4.6.0
+        version: 4.6.0(eslint@8.57.0)
+      lint-staged:
+        specifier: ^10.2.11
+        version: 10.2.11
+
+  eslint-rules: {}
 
   packages/browser:
     dependencies:
@@ -109,9 +154,6 @@ importers:
       '@testing-library/preact':
         specifier: ^3.2.4
         version: 3.2.4(preact@10.19.3)
-      '@types/eslint':
-        specifier: ^8.44.6
-        version: 8.44.6
       '@types/jest':
         specifier: ^27.5.2
         version: 27.5.2
@@ -127,12 +169,6 @@ importers:
       '@types/web':
         specifier: ^0.0.222
         version: 0.0.222
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.29.1
-        version: 8.29.1(@typescript-eslint/parser@8.29.1(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/parser':
-        specifier: ^8.29.1
-        version: 8.29.1(eslint@8.57.0)(typescript@5.5.4)
       babel-jest:
         specifier: ^26.6.3
         version: 26.6.3(@babel/core@7.27.1)
@@ -148,36 +184,6 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
-      eslint:
-        specifier: 8.57.0
-        version: 8.57.0
-      eslint-config-posthog-js:
-        specifier: link:eslint-rules
-        version: link:eslint-rules
-      eslint-config-prettier:
-        specifier: ^8.5.0
-        version: 8.5.0(eslint@8.57.0)
-      eslint-plugin-compat:
-        specifier: ^6.0.1
-        version: 6.0.1(eslint@8.57.0)
-      eslint-plugin-jest:
-        specifier: ^28.8.3
-        version: 28.8.3(@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@8.29.1(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.5.4)))(typescript@5.5.4)
-      eslint-plugin-no-only-tests:
-        specifier: ^3.1.0
-        version: 3.1.0
-      eslint-plugin-posthog-js:
-        specifier: link:eslint-rules
-        version: link:eslint-rules
-      eslint-plugin-prettier:
-        specifier: ^5.2.1
-        version: 5.2.1(@types/eslint@8.44.6)(eslint-config-prettier@8.5.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.4.2)
-      eslint-plugin-react:
-        specifier: ^7.30.1
-        version: 7.30.1(eslint@8.57.0)
-      eslint-plugin-react-hooks:
-        specifier: ^4.6.0
-        version: 4.6.0(eslint@8.57.0)
       expect:
         specifier: ^29.7.0
         version: 29.7.0
@@ -10030,7 +10036,7 @@ snapshots:
       lodash.memoize: 4.1.2
       semver: 7.6.3
 
-  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@8.29.1(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.5.4)))(typescript@5.5.4):
+  eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.29.1(@typescript-eslint/parser@8.29.1(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(jest@27.5.1(node-notifier@8.0.2))(typescript@5.5.4):
     dependencies:
       '@typescript-eslint/utils': 8.29.1(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   # all packages in direct subdirs of packages/
   - "packages/*"
   - "packages/browser/react"
+  - "eslint-rules"


### PR DESCRIPTION
Migration PR: https://github.com/PostHog/posthog-js/pull/1991

## Changes

- add eslint-rules as a workspace package
- update package path in eslint config
- split eslint config into 3 files (base, browser, react)

