### PR TITLE
fix: set survey properties before sending the event

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -931,13 +931,6 @@ export class PostHog {
             data.properties['$event_time_override_system_time'] = systemTime
         }
 
-        // Top-level $set overriding values from the one from properties is taken from the plugin-server normalizeEvent
-        // This doesn't handle $set_once, because posthog-people doesn't either
-        const finalSet = { ...data.properties['$set'], ...data['$set'] }
-        if (!isEmptyObject(finalSet)) {
-            this.setPersonPropertiesForFlags(finalSet)
-        }
-
         if (event_name === SurveyEventName.DISMISSED || event_name === SurveyEventName.SENT) {
             const surveyId = properties?.[SurveyEventProperties.SURVEY_ID]
             const surveyIteration = properties?.[SurveyEventProperties.SURVEY_ITERATION]
@@ -949,6 +942,13 @@ export class PostHog {
                     event_name === SurveyEventName.SENT ? 'responded' : 'dismissed'
                 )]: true,
             }
+        }
+
+        // Top-level $set overriding values from the one from properties is taken from the plugin-server normalizeEvent
+        // This doesn't handle $set_once, because posthog-people doesn't either
+        const finalSet = { ...data.properties['$set'], ...data['$set'] }
+        if (!isEmptyObject(finalSet)) {
+            this.setPersonPropertiesForFlags(finalSet)
         }
 
         if (!isNullish(this.config.before_send)) {


### PR DESCRIPTION
## Changes

setting the required properties for survey has to happen before the `setPersonPropertiesForFlags` method, to make sure those properties are accounted for in the `finalSet`.

This was causing surveys to show up repeatedly, as the survey feature flags were not being updated right away. Once this is merged, it'll no longer happen