### PR TITLE
fix: Stop autocapture turned on if eventually ad-blocked

### DIFF
--- a/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -17,6 +17,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
   \\"autocapture\\": [
     \\"false\\",
     \\"true\\",
+    \\"\\\\\\"wait_for_server\\\\\\"\\",
     {
       \\"url_allowlist\\": [
         \\"undefined\\",

--- a/src/types.ts
+++ b/src/types.ts
@@ -320,11 +320,20 @@ export interface PostHogConfig {
 
     /**
      * Determines whether PostHog should autocapture events.
+     * When set to `false` it will not capture any events.
+     * When set to `true` it will start capturing events immediately,
+     * even before the server data has loaded.
+     * When set to `'wait_for_server'` it will wait for the server data to load before capturing events,
+     * not capturing any events if the server data is not loaded/available.
+     *
+     * You can also pass in an object to configure autocapture.
+     * @see {AutocaptureConfig} for more details.
+     *
      * This setting does not affect capturing pageview events (see `capture_pageview`).
      *
      * @default true
      */
-    autocapture: boolean | AutocaptureConfig
+    autocapture: boolean | 'wait_for_server' | AutocaptureConfig
 
     /**
      * Determines whether PostHog should capture rage clicks.


### PR DESCRIPTION
## Changes

The existing code works great if we aren't adblocked, but it has a major flaw if /decide calls are **eventually** blocked after being previously going through.

Think of the following scenario:
- Person loads PostHog and we get from the backend that we should autocapture
- Store `true` in the persistent store
- Person's adblocker is turned on and starts blocking requests to `/decide`
- Company turns autocapture off in their settings
- When person tries hitting `/decide` it fails to get the new `false` state and reuses the `true` value

Note that this is only a problem when adblocker is blocking `/decide` but not blocking `/e`. I've found at least one case where this is happening in production, so let's protect against that.