### PR TITLE
feat: add client initialization time

### DIFF
--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -458,6 +458,8 @@ export class PostHog {
         const initialPersistenceProps = { ...this.persistence.props }
         const initialSessionProps = { ...this.sessionPersistence.props }
 
+        this.register({ $initialization_time: new Date().toISOString() })
+
         this._requestQueue = new RequestQueue(
             (req) => this._send_retriable_request(req),
             this.config.request_queue_config


### PR DESCRIPTION
## Changes

When debugging a customers issue I found myself really wanting to know "is this just a problem because the user hasn't refreshed their page / client since a config change was made (e.g. exception autocapture disabled)"

With this flag I can easily rule that theory out by excluding any events that were initialised before the toggle was flipped :smart: