### PR TITLE
fix: stop feedback surveys to re-render every second

### DIFF
--- a/src/__tests__/extensions/surveys.test.ts
+++ b/src/__tests__/extensions/surveys.test.ts
@@ -31,9 +31,9 @@ describe('survey display logic', () => {
 
     test('retrieveSurveyShadow', () => {
         const surveyId = 'randomSurveyId'
-        const mockShadow = retrieveSurveyShadow({ id: surveyId, appearance: {} })
-        expect(mockShadow.mode).toBe('open')
-        expect(mockShadow.host.className).toBe(`PostHogSurvey-${surveyId}`)
+        const { shadow } = retrieveSurveyShadow({ id: surveyId, appearance: {}, type: SurveyType.Popover })
+        expect(shadow.mode).toBe('open')
+        expect(shadow.host.className).toBe(`PostHogSurvey-${surveyId}`)
     })
 
     const mockSurveys: Survey[] = [
@@ -449,7 +449,7 @@ describe('SurveyManager', () => {
 
         surveyManager.callSurveysAndEvaluateDisplayLogic()
 
-        expect(manageWidgetSelectorListenerSpy).toHaveBeenCalledWith(mockSurvey)
+        expect(manageWidgetSelectorListenerSpy).toHaveBeenCalledWith(mockSurvey, '.my-selector')
     })
 
     test('callSurveysAndEvaluateDisplayLogic should not call surveys in focus', () => {

--- a/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/src/extensions/surveys/surveys-extension-utils.tsx
@@ -332,7 +332,10 @@ export const retrieveSurveyShadow = (
     const existingDiv = document.querySelector(`.${widgetClassName}`)
 
     if (existingDiv && existingDiv.shadowRoot) {
-        return existingDiv.shadowRoot
+        return {
+            shadow: existingDiv.shadowRoot,
+            isNewlyCreated: false,
+        }
     }
 
     // If it doesn't exist, create it
@@ -349,7 +352,10 @@ export const retrieveSurveyShadow = (
         shadow.appendChild(stylesheet)
     }
     ;(element ? element : document.body).appendChild(div)
-    return shadow
+    return {
+        shadow,
+        isNewlyCreated: true,
+    }
 }
 
 interface SendSurveyEventArgs {

--- a/terser-mangled-names.json
+++ b/terser-mangled-names.json
@@ -222,6 +222,7 @@
         "_remove",
         "_removeEventTriggerCaptureHook",
         "_removePageViewCaptureHook",
+        "_removeSurveyFromDom",
         "_removeSurveyFromFocus",
         "_removeWidgetSelectorListener",
         "_reportStarted",


### PR DESCRIPTION
## Changes

Popover surveys have one thing that feedback surveys don't:  a restriction to only show one at a time.

Because of that, popover survey, by default, are only rendered once.

However, feedback surveys don't have such restrictions. Many can be displayed at once.

So, this PR addresses that, by making sure:

- Feedback surveys can now only be rendered once 
- Once they are no longer a match, they're actually removed from the DOM

It also does a couple of nice things like:

- Extracting magic numbers and strings into constants (thank you @marandaneto for all the lessons they're finally starting to take effect)
- Reducing code duplication a little bit

This should also fix https://github.com/PostHog/posthog/issues/32689 once it's live, as the clean up process is defined correctly to both remove the survey dom element and the selector listener.

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing)) -> all tests passing
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

