### PR TITLE
fix: Add warning for when the user tries to identify using the cookieless sentinel distinct ID

### DIFF
--- a/src/__tests__/posthog-core.identify.test.ts
+++ b/src/__tests__/posthog-core.identify.test.ts
@@ -242,6 +242,21 @@ describe('identify()', () => {
                 'Unique user id has not been set in posthog.identify'
             )
         })
+
+        it('does not update user', () => {
+            console.error = jest.fn()
+
+            instance.debug()
+
+            instance.identify('$posthog_cookieless')
+
+            expect(beforeSendMock).not.toHaveBeenCalled()
+            expect(instance.register).not.toHaveBeenCalled()
+            expect(console.error).toHaveBeenCalledWith(
+                '[PostHog.js]',
+                'The string "$posthog_cookieless" was set in posthog.identify which indicates an error. This ID is only use as a sentinel value.'
+            )
+        })
     })
 
     describe('reloading feature flags', () => {

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -1513,6 +1513,12 @@ export class PostHog {
             )
             return
         }
+        if (new_distinct_id === COOKIELESS_SENTINEL_VALUE) {
+            logger.critical(
+                `The string "${COOKIELESS_SENTINEL_VALUE}" was set in posthog.identify which indicates an error. This ID is only use as a sentinel value.`
+            )
+            return
+        }
 
         if (!this._requirePersonProcessing('posthog.identify')) {
             return


### PR DESCRIPTION
## Changes

Sometimes people store the distinct ID and set it again later. With cookieless, this can do weird things, so let's prevent this.

## Checklist
- [ ] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [ ] Accounted for the impact of any changes across different browsers
- [ ] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [ ] Took care not to unnecessarily increase the bundle size

