### PR TITLE
fix: Fix crash when config has circular references

### DIFF
--- a/src/__tests__/posthog-core.ts
+++ b/src/__tests__/posthog-core.ts
@@ -914,6 +914,15 @@ describe('posthog core', () => {
             expect(posthog.config.on_xhr_error).toBe(fakeOnXHRError)
         })
 
+        it('should not fail with recursive object in config', () => {
+            // this will happen if people are passing e.g. window.analytics
+            const config: Record<string, any> = {
+                debug: true,
+            }
+            config.recursive = config
+            posthogWith(config as Partial<PostHogConfig>)
+        })
+
         it.skip('does not load feature flags, session recording', () => {
             // TODO this didn't make a tonne of sense in the given form
             // it makes no sense now

--- a/src/posthog-core.ts
+++ b/src/posthog-core.ts
@@ -42,6 +42,7 @@ import {
     CaptureOptions,
     CaptureResult,
     Compression,
+    ConfigDefaults,
     EarlyAccessFeatureCallback,
     EarlyAccessFeatureStage,
     EventName,
@@ -56,7 +57,6 @@ import {
     SessionIdChangedCallback,
     SnippetArrayItem,
     ToolbarParams,
-    ConfigDefaults,
 } from './types'
 import {
     _copyAndTruncateStrings,
@@ -1899,18 +1899,11 @@ export class PostHog {
             }
             if (this.config.debug) {
                 Config.DEBUG = true
-                logger.info(
-                    'set_config',
-                    JSON.stringify(
-                        {
-                            config,
-                            oldConfig,
-                            newConfig: { ...this.config },
-                        },
-                        null,
-                        2
-                    )
-                )
+                logger.info('set_config', {
+                    config,
+                    oldConfig,
+                    newConfig: { ...this.config },
+                })
             }
 
             this.sessionRecording?.startIfEnabledOrStop()


### PR DESCRIPTION
## Changes

We were naively JSON.stringifying the config object, which will throw if there are circular references (or e.g. BigInts).

I remove the call to JSON.stringify as it was only used to change how the debug text appears in the browser console.

Also added a test to protect against future changes

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

