### PR TITLE
fix: style problems in multiple/single-choice questions

### DIFF
--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -817,14 +817,6 @@ export function usePopupVisibility(
                 sessionRecordingUrl: posthog.get_session_replay_url?.(),
             })
             localStorage.setItem('lastSeenSurveyDate', new Date().toISOString())
-            setTimeout(() => {
-                const inputField = document
-                    .querySelector(getSurveyContainerClass(survey, true))
-                    ?.shadowRoot?.querySelector('textarea') as HTMLElement
-                if (inputField) {
-                    inputField.focus()
-                }
-            }, 100)
         }
 
         addEventListener(window, 'PHSurveyClosed', handleSurveyClosed as EventListener)

--- a/packages/browser/src/extensions/surveys/components/QuestionTypes.tsx
+++ b/packages/browser/src/extensions/surveys/components/QuestionTypes.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from 'preact'
-import { useMemo, useRef, useState } from 'preact/hooks'
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
     BasicSurveyQuestion,
     LinkSurveyQuestion,
@@ -81,12 +81,19 @@ export function OpenTextQuestion({
 }: CommonQuestionProps & {
     question: BasicSurveyQuestion
 }) {
+    const inputRef = useRef<HTMLTextAreaElement>(null)
     const [text, setText] = useState<string>(() => {
         if (isString(initialValue)) {
             return initialValue
         }
         return ''
     })
+
+    useEffect(() => {
+        setTimeout(() => {
+            inputRef.current?.focus()
+        }, 100)
+    }, [])
 
     const htmlFor = `surveyQuestion${displayQuestionIndex}`
 
@@ -95,6 +102,7 @@ export function OpenTextQuestion({
             <div className="question-container">
                 <QuestionHeader question={question} forceDisableHtml={forceDisableHtml} htmlFor={htmlFor} />
                 <textarea
+                    ref={inputRef}
                     id={htmlFor}
                     rows={4}
                     placeholder={appearance?.placeholder}
@@ -444,7 +452,7 @@ export function MultipleChoiceQuestion({
                               : isArray(selectedChoices) && selectedChoices.includes(choice)
 
                         return (
-                            <label className={isOpenChoice ? ' choice-option-open' : ''} key={idx}>
+                            <label className={isOpenChoice ? 'choice-option-open' : ''} key={idx}>
                                 <input
                                     type={isSingleChoiceQuestion ? 'radio' : 'checkbox'}
                                     name={inputId}

--- a/packages/browser/src/extensions/surveys/survey.css
+++ b/packages/browser/src/extensions/surveys/survey.css
@@ -10,7 +10,6 @@
     --ph-survey-border-radius: 10px;
     --ph-survey-background-color: #eeeded;
     --ph-survey-box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    --ph-survey-disabled-button-opacity: 0.6;
     --ph-survey-submit-button-color: black;
     --ph-survey-submit-button-text-color: white;
     --ph-survey-rating-bg-color: white;
@@ -19,14 +18,16 @@
     --ph-survey-rating-active-text-color: white;
     --ph-survey-text-primary-color: #020617; /* Default text color, based on text-slate-950 */
     --ph-survey-text-subtle-color: #939393;
-    --ph-survey-input-background: white;
-    --ph-survey-scrollbar-thumb-color: var(--ph-survey-border-color);
-    --ph-survey-scrollbar-track-color: var(--ph-survey-background-color);
-    --ph-survey-input-text-color: #020617;
-    --ph-survey-outline-color: rgba(59, 130, 246, 0.8);
     /* Widget/Embedded Tab CSS Variables */
     --ph-widget-color: #e0a045; /* Default color */
     --ph-widget-text-color: white; /* Default text color (usually white for contrast) */
+    /* Not customizable atm */
+    --ph-survey-scrollbar-thumb-color: var(--ph-survey-border-color);
+    --ph-survey-scrollbar-track-color: var(--ph-survey-background-color);
+    --ph-survey-outline-color: rgba(59, 130, 246, 0.8);
+    --ph-survey-input-background: white;
+    --ph-survey-input-text-color: #020617;
+    --ph-survey-disabled-button-opacity: 0.6;
 }
 
 .ph-survey {
@@ -285,7 +286,14 @@
         gap: 8px;
         font-size: 13px;
         align-items: center;
-        flex-wrap: wrap;
+
+        & span {
+            color: inherit;
+        }
+
+        &.choice-option-open {
+            flex-wrap: wrap;
+        }
 
         &:hover {
             &:not(:has(input:checked)) {
@@ -313,6 +321,7 @@
         z-index: 1;
         position: relative;
         border-radius: 3px;
+        flex-shrink: 0;
         /* Smooth, welcoming transition with slight bounce */
         transition:
             all 0.2s cubic-bezier(0.4, 0, 0.2, 1),

--- a/packages/browser/src/extensions/surveys/survey.css
+++ b/packages/browser/src/extensions/surveys/survey.css
@@ -287,14 +287,6 @@
         font-size: 13px;
         align-items: center;
 
-        & span {
-            color: inherit;
-        }
-
-        &.choice-option-open {
-            flex-wrap: wrap;
-        }
-
         &:hover {
             &:not(:has(input:checked)) {
                 border-color: var(--ph-survey-text-subtle-color);
@@ -305,6 +297,14 @@
         &:has(input:checked) {
             border-color: var(--ph-survey-rating-active-bg-color);
             box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+        }
+
+        &.choice-option-open {
+            flex-wrap: wrap;
+        }
+
+        & span {
+            color: inherit;
         }
     }
 

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -63,12 +63,17 @@ export const defaultSurveyAppearance = {
     disabledButtonOpacity: '0.6',
     maxWidth: '300px',
     textSubtleColor: '#939393',
-    inputBackground: 'white',
     boxPadding: '20px 24px',
     boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
     borderRadius: '10px',
     shuffleQuestions: false,
     surveyPopupDelaySeconds: undefined,
+    // Not customizable atm
+    outlineColor: 'rgba(59, 130, 246, 0.8)',
+    inputBackground: 'white',
+    inputTextColor: getContrastingTextColor('white'),
+    scrollbarThumbColor: 'var(--ph-survey-border-color)',
+    scrollbarTrackColor: 'var(--ph-survey-background-color)',
 } as const
 
 export const addSurveyCSSVariablesToElement = (
@@ -79,9 +84,9 @@ export const addSurveyCSSVariablesToElement = (
     const effectiveAppearance = { ...defaultSurveyAppearance, ...appearance }
     const hostStyle = element.style
 
-    const isSurveyOnBottom = [SurveyPosition.Center, SurveyPosition.Left, SurveyPosition.Right].includes(
-        effectiveAppearance.position
-    )
+    const surveyHasBottomBorder =
+        ![SurveyPosition.Center, SurveyPosition.Left, SurveyPosition.Right].includes(effectiveAppearance.position) ||
+        (type === SurveyType.Widget && appearance?.widgetType === SurveyWidgetType.Tab)
 
     hostStyle.setProperty('--ph-survey-font-family', getFontFamily(effectiveAppearance.fontFamily))
     hostStyle.setProperty('--ph-survey-box-padding', effectiveAppearance.boxPadding)
@@ -89,7 +94,7 @@ export const addSurveyCSSVariablesToElement = (
     hostStyle.setProperty('--ph-survey-z-index', effectiveAppearance.zIndex)
     hostStyle.setProperty('--ph-survey-border-color', effectiveAppearance.borderColor)
     // Non-bottom surveys or tab surveys have the border bottom
-    if (!isSurveyOnBottom || (type === SurveyType.Widget && appearance?.widgetType !== SurveyWidgetType.Tab)) {
+    if (surveyHasBottomBorder) {
         hostStyle.setProperty('--ph-survey-border-radius', effectiveAppearance.borderRadius)
         hostStyle.setProperty('--ph-survey-border-bottom', '1.5px solid var(--ph-survey-border-color)')
     } else {
@@ -122,8 +127,6 @@ export const addSurveyCSSVariablesToElement = (
         getContrastingTextColor(effectiveAppearance.backgroundColor)
     )
     hostStyle.setProperty('--ph-survey-text-subtle-color', effectiveAppearance.textSubtleColor)
-    hostStyle.setProperty('--ph-survey-input-background', effectiveAppearance.inputBackground)
-    hostStyle.setProperty('--ph-survey-input-text-color', getContrastingTextColor(effectiveAppearance.inputBackground))
     hostStyle.setProperty('--ph-widget-color', effectiveAppearance.widgetColor)
     hostStyle.setProperty('--ph-widget-text-color', getContrastingTextColor(effectiveAppearance.widgetColor))
     hostStyle.setProperty('--ph-widget-z-index', effectiveAppearance.zIndex)
@@ -132,6 +135,12 @@ export const addSurveyCSSVariablesToElement = (
     if (effectiveAppearance.backgroundColor === 'white') {
         hostStyle.setProperty('--ph-survey-input-background', '#f8f8f8')
     }
+
+    hostStyle.setProperty('--ph-survey-input-background', effectiveAppearance.inputBackground)
+    hostStyle.setProperty('--ph-survey-input-text-color', getContrastingTextColor(effectiveAppearance.inputBackground))
+    hostStyle.setProperty('--ph-survey-scrollbar-thumb-color', effectiveAppearance.scrollbarThumbColor)
+    hostStyle.setProperty('--ph-survey-scrollbar-track-color', effectiveAppearance.scrollbarTrackColor)
+    hostStyle.setProperty('--ph-survey-outline-color', effectiveAppearance.outlineColor)
 }
 
 function nameToHex(name: string) {

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -71,7 +71,7 @@ export const defaultSurveyAppearance = {
     // Not customizable atm
     outlineColor: 'rgba(59, 130, 246, 0.8)',
     inputBackground: 'white',
-    inputTextColor: getContrastingTextColor('white'),
+    inputTextColor: BLACK_TEXT_COLOR,
     scrollbarThumbColor: 'var(--ph-survey-border-color)',
     scrollbarTrackColor: 'var(--ph-survey-background-color)',
 } as const


### PR DESCRIPTION
## Changes

This PR fixes two main problems.

**First one, it prevents this line break from happening:**

| Before | After |
|--------|--------|
| ![CleanShot 2025-06-16 at 00 36 03@2x](https://github.com/user-attachments/assets/7c026a6a-6cdd-4f69-af7d-acb1b9008741) | ![CleanShot 2025-06-16 at 00 35 29@2x](https://github.com/user-attachments/assets/453e1d19-5d62-41e8-8ab3-4ec3026f81d4) | 

**Second, it makes sure the label of the checkboxes/radio inputs has the proper, contrasted color:**

| Before | After |
|--------|--------|
| ![CleanShot 2025-06-16 at 01 17 08@2x](https://github.com/user-attachments/assets/b9664b9d-eafa-4f5c-8239-1ec918043f9c) | ![CleanShot 2025-06-16 at 01 16 29@2x](https://github.com/user-attachments/assets/fefe8676-99a7-445c-9be8-8668529d6f4d) | 


### Other misc changes

- Moves the autofocus on for open text directly into the question component. It simplifies the logic, plus now it autofocus for any question, not just the first one (i.e. last question is an open ended)
- Organizes the CSS code to make uncustomizable variables be closer together. No actual change

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing)) -> all tests passing
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

