### PR TITLE
fix: don't call ff events for surveys

### DIFF
--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -213,7 +213,7 @@ function getNextToTriggerPosition(target: HTMLElement, surveyWidth: number): Rea
 }
 
 // Keep in sync with posthog/constants.py on main repo
-const SURVEY_TARGETING_FLAG_PREFIX = 'survey-targeting'
+const SURVEY_TARGETING_FLAG_PREFIX = 'survey-targeting-'
 
 export class SurveyManager {
     private _posthog: PostHog

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -580,6 +580,7 @@ export class SurveyManager {
             manageWidgetSelectorListener: this._manageWidgetSelectorListener,
             sortSurveysByAppearanceDelay: this._sortSurveysByAppearanceDelay,
             checkFlags: this._checkFlags.bind(this),
+            isSurveyFeatureFlagEnabled: this._isSurveyFeatureFlagEnabled.bind(this),
         }
     }
 }

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -212,6 +212,9 @@ function getNextToTriggerPosition(target: HTMLElement, surveyWidth: number): Rea
     }
 }
 
+// Keep in sync with posthog/constants.py on main repo
+const SURVEY_TARGETING_FLAG_PREFIX = 'survey-targeting'
+
 export class SurveyManager {
     private _posthog: PostHog
     private _surveyInFocus: string | null
@@ -386,7 +389,9 @@ export class SurveyManager {
         if (!flagKey) {
             return true
         }
-        return !!this._posthog.featureFlags.isFeatureEnabled(flagKey, { send_event: false })
+        return !!this._posthog.featureFlags.isFeatureEnabled(flagKey, {
+            send_event: !flagKey.startsWith(SURVEY_TARGETING_FLAG_PREFIX),
+        })
     }
 
     private _isSurveyConditionMatched(survey: Survey): boolean {

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -386,7 +386,7 @@ export class SurveyManager {
         if (!flagKey) {
             return true
         }
-        return !!this._posthog.featureFlags.isFeatureEnabled(flagKey)
+        return !!this._posthog.featureFlags.isFeatureEnabled(flagKey, { send_event: false })
     }
 
     private _isSurveyConditionMatched(survey: Survey): boolean {
@@ -471,7 +471,7 @@ export class SurveyManager {
             if (!key || !value) {
                 return true
             }
-            return this._posthog.featureFlags.isFeatureEnabled(value)
+            return this._isSurveyFeatureFlagEnabled(value)
         })
     }
 


### PR DESCRIPTION
## Changes

don't call feature flag events for survey-related feature flags