### PR TITLE
fix: autofocus on text input when open ended question is rendered

### DIFF
--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -35,8 +35,8 @@ import {
     RatingQuestion,
 } from './surveys/components/QuestionTypes'
 import {
+    addSurveyCSSVariablesToElement,
     canActivateRepeatedly,
-    retrieveSurveyShadow,
     defaultSurveyAppearance,
     dismissedSurveyEvent,
     doesSurveyDeviceTypesMatch,
@@ -47,13 +47,13 @@ import {
     getSurveyContainerClass,
     getSurveyResponseKey,
     getSurveySeen,
+    getSurveyStylesheet,
     hasWaitPeriodPassed,
     isSurveyInProgress,
+    retrieveSurveyShadow,
     sendSurveyEvent,
     setInProgressSurveyState,
     SurveyContext,
-    getSurveyStylesheet,
-    addSurveyCSSVariablesToElement,
 } from './surveys/surveys-extension-utils'
 
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
@@ -823,14 +823,6 @@ export function usePopupVisibility(
                 sessionRecordingUrl: posthog.get_session_replay_url?.(),
             })
             localStorage.setItem('lastSeenSurveyDate', new Date().toISOString())
-            setTimeout(() => {
-                const inputField = document
-                    .querySelector(getSurveyContainerClass(survey, true))
-                    ?.shadowRoot?.querySelector('textarea') as HTMLElement
-                if (inputField) {
-                    inputField.focus()
-                }
-            }, 100)
         }
 
         addEventListener(window, 'PHSurveyClosed', handleSurveyClosed as EventListener)

--- a/packages/browser/src/extensions/surveys/components/QuestionTypes.tsx
+++ b/packages/browser/src/extensions/surveys/components/QuestionTypes.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from 'preact'
-import { useMemo, useRef, useState } from 'preact/hooks'
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
     BasicSurveyQuestion,
     LinkSurveyQuestion,
@@ -81,12 +81,19 @@ export function OpenTextQuestion({
 }: CommonQuestionProps & {
     question: BasicSurveyQuestion
 }) {
+    const inputRef = useRef<HTMLTextAreaElement>(null)
     const [text, setText] = useState<string>(() => {
         if (isString(initialValue)) {
             return initialValue
         }
         return ''
     })
+
+    useEffect(() => {
+        setTimeout(() => {
+            inputRef.current?.focus()
+        }, 100)
+    }, [])
 
     const htmlFor = `surveyQuestion${displayQuestionIndex}`
 
@@ -95,6 +102,7 @@ export function OpenTextQuestion({
             <div className="question-container">
                 <QuestionHeader question={question} forceDisableHtml={forceDisableHtml} htmlFor={htmlFor} />
                 <textarea
+                    ref={inputRef}
                     id={htmlFor}
                     rows={4}
                     placeholder={appearance?.placeholder}
@@ -444,7 +452,7 @@ export function MultipleChoiceQuestion({
                               : isArray(selectedChoices) && selectedChoices.includes(choice)
 
                         return (
-                            <label className={isOpenChoice ? ' choice-option-open' : ''} key={idx}>
+                            <label className={isOpenChoice ? 'choice-option-open' : ''} key={idx}>
                                 <input
                                     type={isSingleChoiceQuestion ? 'radio' : 'checkbox'}
                                     name={inputId}


### PR DESCRIPTION
## Changes

Moves the autofocus on for open text directly into the question component. It simplifies the logic, plus now it autofocus for any question, not just the first one (i.e. last question is an open ended)
