### PR TITLE
chore: new survey config

### DIFF
--- a/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -126,6 +126,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"false\\",
     \\"true\\"
   ],
+  \\"disable_surveys_automatic_display\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
   \\"disable_web_experiments\\": [
     \\"false\\",
     \\"true\\"

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -74,6 +74,9 @@ describe('survey display logic', () => {
         },
         get_session_replay_url: jest.fn(),
         capture: jest.fn().mockImplementation((eventName) => eventName),
+        config: {
+            disable_surveys_automatic_display: false,
+        },
     } as unknown as PostHog
 
     test('callSurveysAndEvaluateDisplayLogic runs on interval irrespective of url change', () => {

--- a/packages/browser/src/__tests__/helpers/posthog-instance.ts
+++ b/packages/browser/src/__tests__/helpers/posthog-instance.ts
@@ -33,6 +33,7 @@ export const createPosthogInstance = async (
                 request_batching: false,
                 api_host: 'http://localhost',
                 disable_surveys: true,
+                disable_surveys_automatic_display: false,
                 ...config,
                 loaded: (p) => {
                     config.loaded?.(p)

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -658,6 +658,11 @@ export function generateSurveys(posthog: PostHog) {
     }
 
     const surveyManager = new SurveyManager(posthog)
+    if (posthog.config.disable_surveys_automatic_display) {
+        logger.info('Surveys automatic display is disabled. Skipping call surveys and evaluate display logic.')
+        return surveyManager
+    }
+
     surveyManager.callSurveysAndEvaluateDisplayLogic(true)
 
     // recalculate surveys every second to check if URL or selectors have changed

--- a/packages/browser/src/extensions/surveys/components/QuestionTypes.tsx
+++ b/packages/browser/src/extensions/surveys/components/QuestionTypes.tsx
@@ -81,6 +81,7 @@ export function OpenTextQuestion({
 }: CommonQuestionProps & {
     question: BasicSurveyQuestion
 }) {
+    const { isPreviewMode } = useSurveyContext()
     const inputRef = useRef<HTMLTextAreaElement>(null)
     const [text, setText] = useState<string>(() => {
         if (isString(initialValue)) {
@@ -91,9 +92,11 @@ export function OpenTextQuestion({
 
     useEffect(() => {
         setTimeout(() => {
-            inputRef.current?.focus()
+            if (!isPreviewMode) {
+                inputRef.current?.focus()
+            }
         }, 100)
-    }, [])
+    }, [isPreviewMode])
 
     const htmlFor = `surveyQuestion${displayQuestionIndex}`
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -160,6 +160,7 @@ export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     disable_persistence: false,
     disable_web_experiments: true, // disabled in beta.
     disable_surveys: false,
+    disable_surveys_automatic_display: false,
     disable_external_dependency_loading: false,
     enable_recording_console_log: undefined, // When undefined, it falls back to the server-side setting
     secure_cookie: window?.location?.protocol === 'https:',

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -474,11 +474,18 @@ export interface PostHogConfig {
     disable_cookie?: boolean
 
     /**
-     * Determines whether PostHog should disable surveys.
+     * Determines whether PostHog should disable all surveys functionality.
      *
      * @default false
      */
     disable_surveys: boolean
+
+    /**
+     * Determines whether PostHog should disable automatic display of surveys. If this is true, popup or widget surveys will not be shown when display conditions are met.
+     *
+     * @default false
+     */
+    disable_surveys_automatic_display: boolean
 
     /**
      * Determines whether PostHog should disable web experiments.


### PR DESCRIPTION
## Changes

Adds a new setting, `disable_surveys_automatic_display`. When this is true, no surveys will be shown automatically.

Necessary for [fullscreen surveys](https://github.com/PostHog/posthog/pull/33948), so we don't trigger any surveys on that page.

Also fixes a small issue where we're automatically focusing the open text input even in the survey preview.

