### PR TITLE
fix: Fix dev on nextjs playground

### DIFF
--- a/packages/browser/react/package.json
+++ b/packages/browser/react/package.json
@@ -15,14 +15,14 @@
     "scripts": {
         "prebuild": "npm run clean",
         "start": "tsc-watch",
-        "clean": "rimraf dist",
+        "clean": "pnpx rimraf dist",
         "build": "pnpm clean && cross-env NODE_ENV=production rollup -c rollup.config.ts",
         "test": "jest",
         "lint": "eslint src",
         "test:debug": "jest --runInBand",
         "prepublishOnly": "pnpm test && pnpm build",
         "link-posthog-js": "pnpm link ..",
-        "clean-node-modules": "rimraf node_modules && pnpm run link-posthog-js"
+        "clean-node-modules": "pnpx rimraf node_modules && pnpm run link-posthog-js"
     },
     "main": "dist/umd/index.js",
     "module": "dist/esm/index.js",
@@ -57,7 +57,6 @@
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "react-test-renderer": "^17.0.1",
-        "rimraf": "^3.0.2",
         "rollup": "^2.35.1",
         "rollup-plugin-typescript2": "^0.29.0",
         "ts-jest": "^26.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,9 +323,6 @@ importers:
       react-test-renderer:
         specifier: ^17.0.1
         version: 17.0.2(react@17.0.2)
-      rimraf:
-        specifier: ^3.0.2
-        version: 3.0.2
       rollup:
         specifier: ^2.35.1
         version: 2.79.2


### PR DESCRIPTION
## Changes

I ran into a problem where node_modules was already deleted, then we tried to rimraf node_modules. Let's change how this works, so that rimraf is run with pnpx, so it's idempotent

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

