### PR TITLE
chore(migration): update babel config

### DIFF
--- a/tooling/rollup-utils/package.json
+++ b/tooling/rollup-utils/package.json
@@ -2,11 +2,11 @@
     "name": "@posthog-tooling/rollup-utils",
     "version": "1.0.0",
     "description": "Rollup utilities for Posthog",
+    "type": "module",
     "main": "dist/index.js",
-    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "scripts": {
-        "build": "tsup src/index.ts --format cjs,esm --dts --out-dir dist"
+        "build": "tsc -b"
     },
     "keywords": [],
     "author": "",

--- a/tooling/rollup-utils/src/index.ts
+++ b/tooling/rollup-utils/src/index.ts
@@ -17,14 +17,10 @@ export const plugins = (extensions: string[]): Plugin[] => [
         tsconfig: `./tsconfig.json`,
     }),
     babel({
-        extensions,
+        configFile: './babel.config.js',
         babelHelpers: 'bundled',
+        extensions,
         include: [`./src/**/*`],
-        presets: [
-            ['@babel/preset-env', { targets: { node: 'current' } }],
-            '@babel/preset-typescript',
-            '@babel/preset-react',
-        ],
     }),
 ]
 

--- a/tooling/rollup-utils/tsconfig.json
+++ b/tooling/rollup-utils/tsconfig.json
@@ -1,10 +1,14 @@
 {
     "compilerOptions": {
+        "outDir": "dist",
         "target": "es6",
-        "module": "commonjs",
+        "module": "ES6",
+        "moduleResolution": "node",
         "strict": true,
         "esModuleInterop": true,
         "skipLibCheck": true,
+        "declaration": true,
+        "declarationMap": true,
         "forceConsistentCasingInFileNames": true
     },
     "include": ["src/**/*"],


### PR DESCRIPTION
Base PR: https://github.com/PostHog/posthog-js/pull/2042

## Problem
- Presets used for babel are package specific, supported node version should be explicit in package config.

## Changes
- Convert rollup-utils to esmodule
- Define babel configuration inside each project

