### PR TITLE
fix: word break on open ended choices

### DIFF
--- a/packages/browser/src/extensions/surveys/components/QuestionTypes.tsx
+++ b/packages/browser/src/extensions/surveys/components/QuestionTypes.tsx
@@ -456,15 +456,17 @@ export function MultipleChoiceQuestion({
 
                         return (
                             <label className={isOpenChoice ? 'choice-option-open' : ''} key={idx}>
-                                <input
-                                    type={isSingleChoiceQuestion ? 'radio' : 'checkbox'}
-                                    name={inputId}
-                                    checked={isChecked}
-                                    onChange={() => handleChoiceChange(choice, isOpenChoice)}
-                                    id={inputId}
-                                    aria-controls={openInputId}
-                                />
-                                <span>{isOpenChoice ? `${choice}:` : choice}</span>
+                                <div className="response-choice">
+                                    <input
+                                        type={isSingleChoiceQuestion ? 'radio' : 'checkbox'}
+                                        name={inputId}
+                                        checked={isChecked}
+                                        onChange={() => handleChoiceChange(choice, isOpenChoice)}
+                                        id={inputId}
+                                        aria-controls={openInputId}
+                                    />
+                                    <span>{isOpenChoice ? `${choice}:` : choice}</span>
+                                </div>
                                 {isOpenChoice && (
                                     <input
                                         type="text"

--- a/packages/browser/src/extensions/surveys/survey.css
+++ b/packages/browser/src/extensions/surveys/survey.css
@@ -279,13 +279,17 @@
     padding: 1px 0;
     border: none;
 
+    & label,
+    & .response-choice {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
     & label {
         /* The clickable label area that contains the input */
         cursor: pointer;
-        display: flex;
-        gap: 8px;
         font-size: 13px;
-        align-items: center;
 
         &:hover {
             &:not(:has(input:checked)) {


### PR DESCRIPTION
## Changes

Before:

![CleanShot 2025-06-30 at 14 40 46@2x](https://github.com/user-attachments/assets/686c0932-4b7b-4228-bbc0-66f4a7f8d28d)

After:

![CleanShot 2025-06-30 at 14 39 12@2x](https://github.com/user-attachments/assets/3fe54ad1-b901-4a2c-b73e-24e7adf6e5d1)

## Checklist
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

