### PR TITLE
fix: reset flags internal state when posthog.reset is called

### DIFF
--- a/packages/browser/src/__tests__/posthog-core.reset.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.reset.test.ts
@@ -77,6 +77,26 @@ describe('reset()', () => {
         )
     })
 
+    it('resets feature flags internal state', () => {
+        instance.featureFlags.receivedFeatureFlags({
+            featureFlags: { 'test-flag': true, 'another-flag': 'variant' },
+            featureFlagPayloads: {},
+        })
+
+        expect(instance.featureFlags.hasLoadedFlags).toBe(true)
+        expect(instance.featureFlags.getFlags()).toEqual(['test-flag', 'another-flag'])
+
+        instance.reset()
+
+        expect(instance.featureFlags.hasLoadedFlags).toBe(false)
+        expect(instance.featureFlags.getFlags()).toEqual([])
+
+        const mockCallback = jest.fn()
+        instance.featureFlags.onFeatureFlags(mockCallback)
+
+        expect(mockCallback).not.toHaveBeenCalled()
+    })
+
     describe('when calling reset(true)', () => {
         it('does reset the device id', () => {
             const initialDeviceId = instance.get_property('$device_id')

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1749,6 +1749,7 @@ export class PostHog {
         this.persistence?.clear()
         this.sessionPersistence?.clear()
         this.surveys.reset()
+        this.featureFlags.reset()
         this.persistence?.set_property(USER_STATE, 'anonymous')
         this.sessionManager?.resetSessionId()
         this._cachedPersonProperties = null

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -1047,4 +1047,16 @@ export class PostHogFeatureFlags {
             this._instance.unregister(STORED_GROUP_PROPERTIES_KEY)
         }
     }
+
+    reset(): void {
+        this._hasLoadedFlags = false
+        this._requestInFlight = false
+        this._reloadingDisabled = false
+        this._additionalReloadRequested = false
+        this._flagsCalled = false
+        this._flagsLoadedFromRemote = false
+        this.$anon_distinct_id = undefined
+        this._clearDebouncer()
+        this._override_warning = false
+    }
 }


### PR DESCRIPTION
## Changes
https://posthoghelp.zendesk.com/agent/tickets/33165 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/35702)

A user pointed out that the callback passed to `onFeatureFlags` is run even after`posthog.reset()` is called and there are no flags present. This change adds resting the internal state of flags when `posthog.reset()` is called.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

