### PR TITLE
fix: Fix backwards compatibility

### DIFF
--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -651,7 +651,7 @@ export const renderFeedbackWidgetPreview = ({
 }
 
 // This is the main exported function
-export function generateSurveys(posthog: PostHog, isSurveysEnabled: boolean) {
+export function generateSurveys(posthog: PostHog, isSurveysEnabled: boolean | undefined) {
     // NOTE: Important to ensure we never try and run surveys without a window environment
     if (!document || !window) {
         return
@@ -663,7 +663,9 @@ export function generateSurveys(posthog: PostHog, isSurveysEnabled: boolean) {
         return surveyManager
     }
 
-    if (!isSurveysEnabled) {
+    // NOTE: The `generateSurveys` function used to accept just a single parameter, without any `isSurveysEnabled` parameter.
+    // To keep compatibility with old clients, we'll consider `undefined` the same as `true`
+    if (isSurveysEnabled === false) {
         logger.info('There are no surveys to load or Surveys is disabled in the project settings.')
         return surveyManager
     }


### PR DESCRIPTION
When we introduced this new second argument to `generateSurveys` we broke all libraries running an older version of our code since they were all passing `undefined` to it. We need to treat `undefined` the same as `true` to guarantee older SDKs will keep displaying surveys.

This is only happening because when the SDK loads any extension from our server we are always serving the *latest* version rather than the version that was actually installed.

We should fix that too, but that requires a bigger lift, so in the meantime let's just make this backwards-compatible.

More context: https://app.slack.com/client/TSS5W8YQZ/C094AB8KVPC