### PR TITLE
feat(err): return capture results from captureException

### DIFF
--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -2188,9 +2188,9 @@ export class PostHog {
     }
 
     /** Capture a caught exception manually */
-    captureException(error: unknown, additionalProperties?: Properties): void {
+    captureException(error: unknown, additionalProperties?: Properties): CaptureResult | undefined {
         const syntheticException = new Error('PostHog syntheticException')
-        this.exceptions.sendExceptionEvent({
+        return this.exceptions.sendExceptionEvent({
             ...errorToProperties(
                 isError(error) ? { error, event: error.message } : { event: error as Event | string },
                 // create synthetic error to get stack in cases where user input does not contain one

--- a/packages/browser/src/posthog-exceptions.ts
+++ b/packages/browser/src/posthog-exceptions.ts
@@ -1,6 +1,6 @@
 import { ERROR_TRACKING_SUPPRESSION_RULES } from './constants'
 import { PostHog } from './posthog-core'
-import { ErrorTrackingSuppressionRule, Properties, RemoteConfig } from './types'
+import { CaptureResult, ErrorTrackingSuppressionRule, Properties, RemoteConfig } from './types'
 import { createLogger } from './utils/logger'
 import { propertyComparisons } from './utils/property-utils'
 import { isArray, isString } from './utils/type-utils'
@@ -29,13 +29,13 @@ export class PostHogExceptions {
         }
     }
 
-    sendExceptionEvent(properties: Properties) {
+    sendExceptionEvent(properties: Properties): CaptureResult | undefined {
         if (this._matchesSuppressionRule(properties)) {
             logger.info('Skipping exception capture because a suppression rule matched')
             return
         }
 
-        this._instance.capture('$exception', properties, {
+        return this._instance.capture('$exception', properties, {
             _noTruncate: true,
             _batchKey: 'exceptionEvent',
         })


### PR DESCRIPTION
## Problem

- Some users need the event id to easily find an issue

## Changes

- Return capture results from the captureException method

