### PR TITLE
fix: Sync consent with persistence immediately

### DIFF
--- a/packages/browser/src/__tests__/posthog-core.ts
+++ b/packages/browser/src/__tests__/posthog-core.ts
@@ -12,7 +12,6 @@ import { SessionIdManager } from '../sessionid'
 import { RequestQueue } from '../request-queue'
 import { SessionRecording } from '../extensions/replay/sessionrecording'
 import { SessionPropsManager } from '../session-props'
-import { sessionStore } from '../storage'
 
 let mockGetProperties: jest.Mock
 
@@ -1001,25 +1000,6 @@ describe('posthog core', () => {
                     $device_id: expect.stringMatching(/^custom-[0-9a-f-]+$/),
                     distinct_id: expect.stringMatching(/^custom-[0-9a-f-]+$/),
                 })
-            })
-        })
-
-        describe('persistence', () => {
-            it('should not write to session storage if opt_out_persistence_by_default is set', () => {
-                // mock session storage
-                const spy = jest.spyOn(sessionStore, '_set')
-
-                // init posthog with opt_out_capturing_by_default
-                defaultPostHog().init('testtoken', {
-                    opt_out_persistence_by_default: true,
-                    opt_out_capturing_by_default: true,
-                    persistence: 'localStorage+cookie',
-                })
-
-                // we do one call to check if session storage is supported, but don't actually store anything
-                // the main thing is that we don't store the session id or window id, etc. This test was added alongside
-                // a fix which prevented this
-                expect(spy.mock.calls).toEqual([['__support__', 'xyz']])
             })
         })
     })

--- a/packages/browser/src/__tests__/posthog-core.ts
+++ b/packages/browser/src/__tests__/posthog-core.ts
@@ -12,6 +12,7 @@ import { SessionIdManager } from '../sessionid'
 import { RequestQueue } from '../request-queue'
 import { SessionRecording } from '../extensions/replay/sessionrecording'
 import { SessionPropsManager } from '../session-props'
+import { sessionStore } from '../storage'
 
 let mockGetProperties: jest.Mock
 
@@ -1000,6 +1001,25 @@ describe('posthog core', () => {
                     $device_id: expect.stringMatching(/^custom-[0-9a-f-]+$/),
                     distinct_id: expect.stringMatching(/^custom-[0-9a-f-]+$/),
                 })
+            })
+        })
+
+        describe('persistence', () => {
+            it('should not write to session storage if opt_out_persistence_by_default is set', () => {
+                // mock session storage
+                const spy = jest.spyOn(sessionStore, '_set')
+
+                // init posthog with opt_out_capturing_by_default
+                defaultPostHog().init('testtoken', {
+                    opt_out_persistence_by_default: true,
+                    opt_out_capturing_by_default: true,
+                    persistence: 'localStorage+cookie',
+                })
+
+                // we do one call to check if session storage is supported, but don't actually store anything
+                // the main thing is that we don't store the session id or window id, etc. This test was added alongside
+                // a fix which prevented this
+                expect(spy.mock.calls).toEqual([['__support__', 'xyz']])
             })
         })
     })

--- a/packages/browser/src/__tests__/posthog-persistence.test.ts
+++ b/packages/browser/src/__tests__/posthog-persistence.test.ts
@@ -5,7 +5,12 @@ import { PostHogConfig } from '../types'
 import { PostHog } from '../posthog-core'
 import { window } from '../utils/globals'
 import { uuidv7 } from '../uuidv7'
-import { localPlusCookieStore, sessionStore } from '../storage'
+import {
+    localPlusCookieStore,
+    resetLocalStorageSupported,
+    resetSessionStorageSupported,
+    sessionStore,
+} from '../storage'
 import { defaultPostHog } from './helpers/posthog-instance'
 import Mock = jest.Mock
 
@@ -271,16 +276,24 @@ describe('persistence', () => {
 })
 
 describe('posthog instance persistence', () => {
+    beforeEach(() => {
+        resetSessionStorageSupported()
+        resetLocalStorageSupported()
+    })
     it('should not write to storage if opt_out_persistence_by_default and opt_out_capturing_by_default is true', () => {
         const sessionSpy = jest.spyOn(sessionStore, '_set')
         const localPlusCookieSpy = jest.spyOn(localPlusCookieStore, '_set')
 
         // init posthog while opting out
-        defaultPostHog().init(uuidv7(), {
-            opt_out_persistence_by_default: true,
-            opt_out_capturing_by_default: true,
-            persistence: 'localStorage+cookie',
-        })
+        defaultPostHog().init(
+            uuidv7(),
+            {
+                opt_out_persistence_by_default: true,
+                opt_out_capturing_by_default: true,
+                persistence: 'localStorage+cookie',
+            },
+            uuidv7()
+        )
 
         // we do one call to check if session storage is supported, but don't actually store anything
         // the important thing is that we don't store the session id or window id, etc. This test was added alongside
@@ -297,11 +310,15 @@ describe('posthog instance persistence', () => {
         const localPlusCookieSpy = jest.spyOn(localPlusCookieStore, '_set')
 
         // init posthog while opting out
-        defaultPostHog().init(uuidv7(), {
-            opt_out_persistence_by_default: false,
-            opt_out_capturing_by_default: false,
-            persistence: 'localStorage+cookie',
-        })
+        defaultPostHog().init(
+            uuidv7(),
+            {
+                opt_out_persistence_by_default: false,
+                opt_out_capturing_by_default: false,
+                persistence: 'localStorage+cookie',
+            },
+            uuidv7()
+        )
 
         const sessionCalls = sessionSpy.mock.calls.filter(([key]) => key !== '__support__')
         const localPlusCookieCalls = localPlusCookieSpy.mock.calls.filter(([key]) => key !== '__support__')

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -491,6 +491,7 @@ export class PostHog {
             this.config.persistence === 'sessionStorage' || this.config.persistence === 'memory'
                 ? this.persistence
                 : new PostHogPersistence({ ...this.config, persistence: 'sessionStorage' })
+        this._sync_opt_out_with_persistence()
 
         // should I store the initial person profiles config in persistence?
         const initialPersistenceProps = { ...this.persistence.props }
@@ -554,8 +555,6 @@ export class PostHog {
                 s: initialSessionProps,
             })
         }
-
-        this._sync_opt_out_with_persistence()
 
         // isUndefined doesn't provide typehint here so wouldn't reduce bundle as we'd need to assign
         // eslint-disable-next-line posthog-js/no-direct-undefined-check

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -60,7 +60,11 @@ export class PostHogPersistence {
     private _default_expiry: number | undefined
     private _cross_subdomain: boolean | undefined
 
-    constructor(config: PostHogConfig) {
+    /**
+     * @param {PostHogConfig} config initial PostHog configuration
+     * @param {boolean=} isDisabled should persistence be disabled (e.g. because of consent management)
+     */
+    constructor(config: PostHogConfig, isDisabled?: boolean) {
         this._config = config
         this.props = {}
         this._campaign_params_saved = false
@@ -70,8 +74,12 @@ export class PostHogPersistence {
         if (config.debug) {
             logger.info('Persistence loaded', config['persistence'], { ...this.props })
         }
-        this.update_config(config, config)
+        this.update_config(config, config, isDisabled)
         this.save()
+    }
+
+    public isDisabled(): boolean {
+        return !!this._disabled
     }
 
     private _buildStorage(config: PostHogConfig) {
@@ -308,9 +316,9 @@ export class PostHogPersistence {
         return props
     }
 
-    update_config(config: PostHogConfig, oldConfig: PostHogConfig): void {
+    update_config(config: PostHogConfig, oldConfig: PostHogConfig, isDisabled?: boolean): void {
         this._default_expiry = this._expire_days = config['cookie_expiration']
-        this.set_disabled(config['disable_persistence'])
+        this.set_disabled(config['disable_persistence'] || !!isDisabled)
         this.set_cross_subdomain(config['cross_subdomain_cookie'])
         this.set_secure(config['secure_cookie'])
 

--- a/packages/browser/src/storage.ts
+++ b/packages/browser/src/storage.ts
@@ -179,6 +179,9 @@ export const cookieStore: PersistentStore = {
 }
 
 let _localStorage_supported: boolean | null = null
+export const resetLocalStorageSupported = () => {
+    _localStorage_supported = null
+}
 
 export const localStore: PersistentStore = {
     _is_supported: function () {

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -135,6 +135,7 @@
         "_isSurveyConditionMatched",
         "_isSurveyFeatureFlagEnabled",
         "_isSurveysEnabled",
+        "_is_persistence_disabled",
         "_is_supported",
         "_lastActivityTimestamp",
         "_lastHref",


### PR DESCRIPTION
## Changes

Otherwise it was possible for us to write the windowId to sessionStorage in `sessionid.ts` despite `opt_out_capturing_by_default` being set.

Added a test to ensure this

Edit: testcafe is having some problems with Safari, but I don't believe there's a real problem with this PR

## Checklist
- [x] Tests for new code (see [advice on the tests we use](https://github.com/PostHog/posthog-js#tiers-of-testing))
- [x] Accounted for the impact of any changes across different browsers
- [x] Accounted for backwards compatibility of any changes (no breaking changes in posthog-js!)
- [x] Took care not to unnecessarily increase the bundle size

