### PR TITLE
chore: Safer iteration of experimental `__add_tracing_headers`

### DIFF
--- a/packages/browser/src/extensions/tracing-headers.ts
+++ b/packages/browser/src/extensions/tracing-headers.ts
@@ -39,12 +39,14 @@ export class TracingHeaders {
     private _startCapturing = () => {
         if (isUndefined(this._restoreXHRPatch)) {
             assignableWindow.__PosthogExtensions__?.tracingHeadersPatchFns?._patchXHR(
+                this._instance.config.__add_tracing_headers || [],
                 this._instance.get_distinct_id(),
-                this._instance.sessionManager
+                this._instance.sessionManager,
             )
         }
         if (isUndefined(this._restoreFetchPatch)) {
             assignableWindow.__PosthogExtensions__?.tracingHeadersPatchFns?._patchFetch(
+                this._instance.config.__add_tracing_headers || [],
                 this._instance.get_distinct_id(),
                 this._instance.sessionManager
             )

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -968,9 +968,10 @@ export interface PostHogConfig {
 
     /**
      * PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION
-     * Whether to wrap fetch and add tracing headers to the request
+     * A list of hostnames for which to inject PostHog tracing headers to all requests
+     * (X-POSTHOG-DISTINCT-ID, X-POSTHOG-SESSION-ID, X-POSTHOG-WINDOW-ID)
      * */
-    __add_tracing_headers?: boolean
+    __add_tracing_headers?: string[]
 
     /**
      * PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION

--- a/packages/browser/src/utils/globals.ts
+++ b/packages/browser/src/utils/globals.ts
@@ -180,8 +180,8 @@ interface PostHogExtensions {
         onINP: (metric: any) => void
     }
     tracingHeadersPatchFns?: {
-        _patchFetch: (distinctId: string, sessionManager?: SessionIdManager) => () => void
-        _patchXHR: (distinctId: string, sessionManager?: SessionIdManager) => () => void
+        _patchFetch: (hostnames: string[], distinctId: string, sessionManager?: SessionIdManager) => () => void
+        _patchXHR: (hostnames: string[], distinctId: string, sessionManager?: SessionIdManager) => () => void
     }
     initDeadClicksAutocapture?: (
         ph: PostHog,


### PR DESCRIPTION
## Changes

Turns out it's not exactly safe to monkeypatch every single request made by the frontend. Enabling `__add_tracing_headers` in https://github.com/PostHog/posthog/pull/35384 broke Zendesk ticket submissions.

Updated take on `__add_tracing_headers`: it's now an _allowlist_ of hostnames.