### PR TITLE
chore(ci): optimize ci runs

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -11,10 +11,6 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Build library
-        run: pnpm build-rollup
-        working-directory: packages/browser
-
       - name: Upload bundle size visualization
         uses: actions/upload-artifact@v4
         id: viz-upload
@@ -41,5 +37,4 @@ jobs:
 
       - uses: preactjs/compressed-size-action@v2
         with:
-          build-script: "build-rollup"
           compression: "none"

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -12,14 +12,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+
       - name: Setup environment
         uses: ./.github/actions/setup
-        with:
-          build: true
+
       - run: pnpm test:unit
-      - run: pnpm write-mangled-property-names
-        working-directory: packages/browser
-      - run: git diff --exit-code # fail if e.g. the mangled properties list has changed, see rollup.config.js
 
   integration:
     name: Playwright E2E tests
@@ -33,21 +30,26 @@ jobs:
         uses: ./.github/actions/setup
         with:
           build: false
+
       - uses: ./.github/actions/is-affected
         id: is-affected
         with:
           package-name: posthog-js
+
       - name: Build package
         run: pnpm build
         if: steps.is-affected.outputs.is-affected == 'true'
+
       - name: Install Playwright Browsers
         if: steps.is-affected.outputs.is-affected == 'true'
         run: pnpm exec playwright install --with-deps
         working-directory: packages/browser
+
       - name: Run Playwright tests
         if: steps.is-affected.outputs.is-affected == 'true'
         run: pnpm exec playwright test
         working-directory: packages/browser
+
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && steps.is-affected.outputs.is-affected == 'true' }}
         with:
@@ -75,3 +77,19 @@ jobs:
         uses: ./.github/actions/setup
       - name: Lint all packages
         run: pnpm lint
+
+  write-mangled-property-names:
+    name: Write mangled property names
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+        with:
+          build: false
+
+      - run: pnpm write-mangled-property-names
+        working-directory: packages/browser
+
+      - run: git diff --exit-code # fail if e.g. the mangled properties list has changed, see rollup.config.js


### PR DESCRIPTION
## Changes

- Split write mangled property names job
- Build lib only once for bundle size checks

