### PR TITLE
chore(ci): fix react peer dependencies

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
     "access": "restricted",
     "baseBranch": "main",
     "updateInternalDependencies": "patch",
-    "ignore": []
+    "ignore": [],
+    "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+        "onlyUpdatePeerDependentsWhenOutOfRange": true
+    }
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,8 +7,6 @@
     "access": "restricted",
     "baseBranch": "main",
     "updateInternalDependencies": "patch",
-    "ignore": [],
-    "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-        "onlyUpdatePeerDependentsWhenOutOfRange": true
-    }
+    "bumpVersionsWithWorkspaceProtocolOnly": true,
+    "ignore": []
 }

--- a/.github/workflows/label-version-bump.yml
+++ b/.github/workflows/label-version-bump.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Commit updated lockfile
         uses: EndBug/add-and-commit@v7
         with:
-          add: "pnpm-lock.yaml"
+          add: "."
           branch: ${{ github.event.pull_request.base.ref }}
           message: "chore: update versions and lockfile"
           github_token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 ## 1.257.2 - 2025-07-22
 
 - chore: Safer iteration of experimental `__add_tracing_headers` (#2100)
@@ -2762,7 +2763,7 @@ Manual addition of version 1.66.0 because CI failed to automatically bump the ve
 
 ## 1.52.0 - 2023-04-05
 
-- fix: Track referrer/search params per browser session (#496)  
+- fix: Track referrer/search params per browser session (#496)
   _**Note:** This change improves the accuracy of properties `$referrer` and `$referring_domain` in a major way. Previously, the values of these properties often represented pure backlinks in non-SPAs (non-single-page applications). Now those values will represent the true referrer for the current browser-level session (effectively: for the tab). Due to this, referrer data after this update \_may_ look different. It will be significantly more accurate though.\_
 - ci: Point out and close stale issues/PRs (#602)
 - docs(testcafe): update docs removing posthog server requirements (#594)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,7 @@
     ],
     "peerDependencies": {
         "@types/react": ">=16.8.0",
-        "posthog-js": "workspace:*",
+        "posthog-js": "workspace:~",
         "react": ">=16.8.0"
     },
     "peerDependenciesMeta": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,7 @@
     ],
     "peerDependencies": {
         "@types/react": ">=16.8.0",
-        "posthog-js": "workspace:~",
+        "posthog-js": ">=1.257.2",
         "react": ">=16.8.0"
     },
     "peerDependenciesMeta": {


### PR DESCRIPTION
## Problem

- Right now releasing a patch or minor version of posthog-js, create a major version bump in @posthog/react.
- Add all files generated by changesets

There is a [PR](https://github.com/changesets/changesets/pull/1132) that is being ignored since 2023 about this issue.

## Changes

- hardcode peer dependencies in posthog-react, to avoid unecessary releases