### PR TITLE
fix: block vercel screenshot bot

### DIFF
--- a/packages/browser/src/utils/blocked-uas.ts
+++ b/packages/browser/src/utils/blocked-uas.ts
@@ -37,6 +37,7 @@ export const DEFAULT_BLOCKED_UA_STRS = [
     'trendictionbot',
     'turnitin',
     'twitterbot',
+    'vercel-screenshot',
     'vercelbot',
     'yahoo! slurp',
     'yandexbot',


### PR DESCRIPTION
Adds the` vercel-screenshot/1.0` user agent (and future versions) to the blocked uas list preventing artificial events from vercel's bot which crawls each new deployment for screenshots.