### PR TITLE
chore: publish new posthog-js and update PR checklist

### DIFF
--- a/.changeset/hip-cups-dress.md
+++ b/.changeset/hip-cups-dress.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix early access features accumulation in persistence

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,3 +27,10 @@
 - [ ] Accounted for the impact of any changes across different platforms
 - [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
 - [ ] Took care not to unnecessarily increase the bundle size
+
+### If releasing new changes
+
+- [ ] Ran `pnpm changeset` to generate a changeset file
+- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
+
+<!-- For more details check RELEASING.md -->


### PR DESCRIPTION
adds checklist item about publishing a new version.

Tagging feature flags team to review because I [added a new changeset for this new PR](https://github.com/PostHog/posthog-js/pull/2131)