### PR TITLE
fix(nextjs-config): support esm next configs

### DIFF
--- a/.changeset/sixty-pandas-unite.md
+++ b/.changeset/sixty-pandas-unite.md
@@ -1,0 +1,5 @@
+---
+'@posthog/nextjs-config': patch
+---
+
+Fix \_\_dirname is not defined error with ESM next configs

--- a/packages/nextjs-config/babel.config.js
+++ b/packages/nextjs-config/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  plugins: ['babel-plugin-transform-import-meta'],
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
+}

--- a/packages/nextjs-config/jest.config.js
+++ b/packages/nextjs-config/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  collectCoverage: true,
+  clearMocks: true,
+  coverageDirectory: 'coverage',
+  verbose: false,
+}

--- a/packages/nextjs-config/package.json
+++ b/packages/nextjs-config/package.json
@@ -22,6 +22,7 @@
     "lint:fix": "eslint src --fix",
     "build": "tsup src/index.ts --format cjs,esm --dts --out-dir dist",
     "dev": "tsup src/index.ts --format cjs,esm --dts --out-dir dist --watch",
+    "test:unit": "jest",
     "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz"
   },
   "exports": {
@@ -48,10 +49,12 @@
     "nextjs"
   ],
   "devDependencies": {
-    "@types/node": "^22.15.23",
-    "next": "^12.1.0",
-    "@posthog-tooling/tsconfig-base": "workspace:*",
     "@posthog-tooling/rollup-utils": "workspace:*",
+    "@posthog-tooling/tsconfig-base": "workspace:*",
+    "@types/node": "^22.15.23",
+    "babel-plugin-transform-import-meta": "^2.3.3",
+    "jest": "catalog:",
+    "next": "^12.1.0",
     "tsup": "catalog:"
   },
   "peerDependencies": {

--- a/packages/nextjs-config/src/utils.spec.ts
+++ b/packages/nextjs-config/src/utils.spec.ts
@@ -1,4 +1,14 @@
-import { buildLocalBinaryPaths } from './utils'
+import { buildLocalBinaryPaths, callPosthogCli } from './utils'
+import { spawn } from 'child_process'
+import fs from 'fs'
+
+jest.mock('child_process')
+jest.mock('fs')
+
+const mockSpawn = jest.mocked(spawn)
+const mockExistsSync = jest.mocked(fs.existsSync)
+
+const originalDirname = global.__dirname
 
 describe('buildLocalBinaryPaths', () => {
   it('generates possible binary locations', () => {
@@ -7,5 +17,33 @@ describe('buildLocalBinaryPaths', () => {
     expect(result.includes('/home/user/node_modules/.bin')).toBe(true)
     expect(result.includes('/home/node_modules/.bin')).toBe(true)
     expect(result.includes('/node_modules/.bin')).toBe(true)
+  })
+})
+
+describe('callPosthogCli', () => {
+  beforeEach(() => {
+    mockExistsSync.mockReturnValue(true)
+    mockSpawn.mockReturnValue({
+      on: jest.fn((event, callback) => {
+        if (event === 'close') {
+          setTimeout(() => callback(0), 0)
+        }
+      }),
+    } as any)
+  })
+
+  afterEach(() => {
+    global.__dirname = originalDirname
+  })
+
+  it('should not throw an error when __dirname is undefined in ESM context', async () => {
+    // CJS context
+    await expect(callPosthogCli(['--version'], process.env, false)).resolves.toBeUndefined()
+
+    // Simulate ESM context where __dirname is undefined
+    global.__dirname = undefined as any
+    await expect(callPosthogCli(['--version'], process.env, false)).resolves.toBeUndefined()
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/nextjs-config/src/utils.ts
+++ b/packages/nextjs-config/src/utils.ts
@@ -1,7 +1,47 @@
+import { spawn } from 'child_process'
 import path from 'path'
 import fs from 'fs'
+import url from 'url'
 
-export function resolveBinaryPath(envPath: string, cwd: string, binName: string): string {
+export async function callPosthogCli(args: string[], env: NodeJS.ProcessEnv, verbose: boolean): Promise<void> {
+  let binaryLocation
+  try {
+    binaryLocation = resolveBinaryPath(
+      process.env.PATH ?? '',
+      // __dirname is not available in ESM context
+      typeof __dirname === 'undefined' ? path.dirname(url.fileURLToPath(import.meta.url)) : __dirname,
+      'posthog-cli'
+    )
+  } catch (e) {
+    throw new Error(`Binary ${e} not found. Make sure postinstall script has been allowed for @posthog/cli`)
+  }
+
+  if (verbose) {
+    console.log('running posthog-cli from ', binaryLocation)
+  }
+
+  const child = spawn(binaryLocation, [...args], {
+    stdio: verbose ? 'inherit' : 'ignore',
+    env,
+    cwd: process.cwd(),
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`Command failed with code ${code}`))
+      }
+    })
+
+    child.on('error', (error) => {
+      reject(error)
+    })
+  })
+}
+
+function resolveBinaryPath(envPath: string, cwd: string, binName: string): string {
   const envLocations = envPath.split(path.delimiter)
   const localLocations = buildLocalBinaryPaths(cwd)
   const directories = [...new Set([...envLocations, ...localLocations])]

--- a/packages/nextjs-config/src/webpack-plugin.ts
+++ b/packages/nextjs-config/src/webpack-plugin.ts
@@ -1,7 +1,6 @@
 import { PostHogNextConfigComplete } from './config'
-import { spawn } from 'child_process'
 import path from 'path'
-import { resolveBinaryPath } from './utils'
+import { callPosthogCli } from './utils'
 
 type NextRuntime = 'edge' | 'nodejs' | undefined
 
@@ -84,37 +83,4 @@ export class SourcemapWebpackPlugin {
     }
     await callPosthogCli(cliOptions, envVars, this.posthogOptions.verbose)
   }
-}
-
-async function callPosthogCli(args: string[], env: NodeJS.ProcessEnv, verbose: boolean): Promise<void> {
-  let binaryLocation
-  try {
-    binaryLocation = resolveBinaryPath(process.env.PATH ?? '', __dirname, 'posthog-cli')
-  } catch (e) {
-    throw new Error(`Binary ${e} not found. Make sure postinstall script has been allowed for @posthog/cli`)
-  }
-
-  if (verbose) {
-    console.log('running posthog-cli from ', binaryLocation)
-  }
-
-  const child = spawn(binaryLocation, [...args], {
-    stdio: verbose ? 'inherit' : 'ignore',
-    env,
-    cwd: process.cwd(),
-  })
-
-  await new Promise<void>((resolve, reject) => {
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve()
-      } else {
-        reject(new Error(`Command failed with code ${code}`))
-      }
-    })
-
-    child.on('error', (error) => {
-      reject(error)
-    })
-  })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ catalogs:
       specifier: ^0.10.5
       version: 0.10.6
     jest:
-      specifier: ^29.7.0
+      specifier: 29.7.0
       version: 29.7.0
     jest-environment-jsdom:
       specifier: ^29.7.0
@@ -418,6 +418,12 @@ importers:
       '@types/node':
         specifier: ^22.15.23
         version: 22.16.5
+      babel-plugin-transform-import-meta:
+        specifier: ^2.3.3
+        version: 2.3.3(@babel/core@7.27.1)
+      jest:
+        specifier: 'catalog:'
+        version: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
       next:
         specifier: ^12.1.0
         version: 12.3.7(@babel/core@7.27.1)(react-dom@17.0.2(react@18.2.0))(react@18.2.0)
@@ -776,10 +782,6 @@ packages:
   '@babel/code-frame@7.10.4':
     resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
 
-  '@babel/code-frame@7.26.2':
-    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
@@ -879,10 +881,6 @@ packages:
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.25.9':
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.27.1':
@@ -1855,7 +1853,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.1.7':
     resolution: {integrity: sha512-F81fPthpT7QtVu1P7QeZMezGn0tCcalCh3ANIzWBaQZNG4vly7mo2dp3PMGzNdmXq6yt93bJ4HbfS+0/NpKl7g==}
@@ -3945,6 +3943,11 @@ packages:
 
   babel-plugin-transform-flow-enums@0.0.2:
     resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
+
+  babel-plugin-transform-import-meta@2.3.3:
+    resolution: {integrity: sha512-bbh30qz1m6ZU1ybJoNOhA2zaDvmeXMnGNBMVMDOJ1Fni4+wMBoy/j7MTRVmqAUCIcy54/rEnr9VEBsfcgbpm3Q==}
+    peerDependencies:
+      '@babel/core': ^7.10.0
 
   babel-preset-current-node-syntax@1.0.1:
     resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
@@ -7554,11 +7557,13 @@ packages:
 
   metro-react-native-babel-preset@0.67.0:
     resolution: {integrity: sha512-tgTG4j0SKwLHbLRELMmgkgkjV1biYkWlGGKOmM484/fJC6bpDikdaFhfjsyE+W+qt7I5szbCPCickMTNQ+zwig==}
+    deprecated: Use @react-native/babel-preset instead
     peerDependencies:
       '@babel/core': '*'
 
   metro-react-native-babel-preset@0.70.4:
     resolution: {integrity: sha512-qcJuLqvjlKhrOOuQShhVzCjjp7kHZIXCL+ybnYBqOY2ALVCyR3aELH0aUtOztRpJYFnqAMDOJmGqNVi6cUd24g==}
+    deprecated: Use @react-native/babel-preset instead
     peerDependencies:
       '@babel/core': '*'
 
@@ -9678,6 +9683,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -11005,12 +11011,6 @@ snapshots:
     dependencies:
       '@babel/highlight': 7.25.9
 
-  '@babel/code-frame@7.26.2':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -11090,7 +11090,7 @@ snapshots:
       '@babel/traverse': 7.27.1
       debug: 4.4.0
       lodash.debounce: 4.0.8
-      resolve: 1.22.8
+      resolve: 1.22.10
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -11174,8 +11174,6 @@ snapshots:
       - supports-color
 
   '@babel/helper-string-parser@7.27.1': {}
-
-  '@babel/helper-validator-identifier@7.25.9': {}
 
   '@babel/helper-validator-identifier@7.27.1': {}
 
@@ -12205,17 +12203,17 @@ snapshots:
   '@emnapi/core@1.4.5':
     dependencies:
       '@emnapi/wasi-threads': 1.0.4
-      tslib: 2.7.0
+      tslib: 2.8.1
     optional: true
 
   '@emnapi/runtime@1.4.5':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
     optional: true
 
   '@emnapi/wasi-threads@1.0.4':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
     optional: true
 
   '@esbuild/aix-ppc64@0.25.8':
@@ -12751,11 +12749,48 @@ snapshots:
       '@types/node': 22.17.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      ci-info: 3.3.0
+      ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.9
       jest-changed-files: 29.7.0
       jest-config: 29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0(node-notifier@8.0.2)
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.17.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.9
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -12788,7 +12823,7 @@ snapshots:
       '@types/node': 22.17.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      ci-info: 3.3.0
+      ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.9
       jest-changed-files: 29.7.0
@@ -12920,7 +12955,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.29
       '@types/node': 22.17.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
@@ -12960,7 +12995,7 @@ snapshots:
 
   '@jest/source-map@29.6.3':
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.29
       callsites: 3.1.0
       graceful-fs: 4.2.9
 
@@ -13038,7 +13073,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.1
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.29
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
@@ -13048,7 +13083,7 @@ snapshots:
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
       micromatch: 4.0.8
-      pirates: 4.0.5
+      pirates: 4.0.7
       slash: 3.0.0
       write-file-atomic: 4.0.2
     transitivePeerDependencies:
@@ -13620,7 +13655,7 @@ snapshots:
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.6.3
+      semver: 7.7.2
 
   '@npmcli/move-file@1.1.2':
     dependencies:
@@ -14547,7 +14582,7 @@ snapshots:
 
   '@tybys/wasm-util@0.10.0':
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
     optional: true
 
   '@types/argparse@1.0.38': {}
@@ -15169,7 +15204,7 @@ snapshots:
 
   ast-types@0.14.2:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   astral-regex@1.0.0: {}
 
@@ -15384,6 +15419,12 @@ snapshots:
       '@babel/plugin-syntax-flow': 7.12.13(@babel/core@7.27.1)
     transitivePeerDependencies:
       - '@babel/core'
+
+  babel-plugin-transform-import-meta@2.3.3(@babel/core@7.27.1):
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/template': 7.27.2
+      tslib: 2.8.1
 
   babel-preset-current-node-syntax@1.0.1(@babel/core@7.27.1):
     dependencies:
@@ -16049,6 +16090,21 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.9
       jest-config: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  create-jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.9
+      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -17035,7 +17091,7 @@ snapshots:
 
   execa@5.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.0
@@ -17248,7 +17304,7 @@ snapshots:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.4
+      micromatch: 4.0.8
 
   fast-glob@3.3.3:
     dependencies:
@@ -17785,7 +17841,7 @@ snapshots:
   graphql-tag@2.12.6(graphql@15.8.0):
     dependencies:
       graphql: 15.8.0
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   graphql@15.8.0: {}
 
@@ -18524,7 +18580,7 @@ snapshots:
       '@babel/parser': 7.27.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
-      semver: 7.6.3
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -18536,7 +18592,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.1
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -18670,6 +18726,27 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+    dependencies:
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      exit: 0.1.2
+      import-local: 3.0.2
+      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@22.17.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2)):
     dependencies:
       '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
@@ -18698,7 +18775,7 @@ snapshots:
       '@jest/types': 27.5.1
       babel-jest: 27.5.1(@babel/core@7.27.1)
       chalk: 4.1.2
-      ci-info: 3.3.0
+      ci-info: 3.9.0
       deepmerge: 4.2.2
       glob: 7.2.3
       graceful-fs: 4.2.9
@@ -18732,7 +18809,7 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.27.1)
       chalk: 4.1.2
-      ci-info: 3.3.0
+      ci-info: 3.9.0
       deepmerge: 4.2.2
       glob: 7.2.3
       graceful-fs: 4.2.9
@@ -18756,6 +18833,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+    dependencies:
+      '@babel/core': 7.27.1
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.27.1)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.2.2
+      glob: 7.2.3
+      graceful-fs: 4.2.9
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.16.5
+      ts-node: 10.9.2(@types/node@22.16.5)(typescript@5.8.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-config@29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.27.1
@@ -18763,7 +18871,7 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.27.1)
       chalk: 4.1.2
-      ci-info: 3.3.0
+      ci-info: 3.9.0
       deepmerge: 4.2.2
       glob: 7.2.3
       graceful-fs: 4.2.9
@@ -18787,6 +18895,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+    dependencies:
+      '@babel/core': 7.27.1
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.27.1)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.2.2
+      glob: 7.2.3
+      graceful-fs: 4.2.9
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.17.0
+      ts-node: 10.9.2(@types/node@22.16.5)(typescript@5.8.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-config@29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.27.1
@@ -18794,7 +18933,7 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.27.1)
       chalk: 4.1.2
-      ci-info: 3.3.0
+      ci-info: 3.9.0
       deepmerge: 4.2.2
       glob: 7.2.3
       graceful-fs: 4.2.9
@@ -19139,7 +19278,7 @@ snapshots:
       jest-pnp-resolver: 1.2.2(jest-resolve@29.7.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
-      resolve: 1.22.8
+      resolve: 1.22.10
       resolve.exports: 2.0.3
       slash: 3.0.0
 
@@ -19310,7 +19449,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.6.3
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -19454,6 +19593,20 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.0.2
       jest-cli: 29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2))
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+    dependencies:
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      '@jest/types': 29.6.3
+      import-local: 3.0.2
+      jest-cli: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -20942,7 +21095,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.1.6
@@ -21833,7 +21986,7 @@ snapshots:
       ast-types: 0.14.2
       esprima: 4.0.1
       source-map: 0.6.1
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   redent@3.0.0:
     dependencies:
@@ -22217,7 +22370,7 @@ snapshots:
 
   rxjs@7.8.1:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -22263,7 +22416,7 @@ snapshots:
       fb-watchman: 2.0.1
       micromatch: 3.1.10
       minimist: 1.2.8
-      walker: 1.0.7
+      walker: 1.0.8
     transitivePeerDependencies:
       - supports-color
 
@@ -22844,7 +22997,7 @@ snapshots:
   synckit@0.9.2:
     dependencies:
       '@pkgr/core': 0.1.1
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   tar@6.2.1:
     dependencies:
@@ -23297,6 +23450,25 @@ snapshots:
       yn: 3.1.1
     optional: true
 
+  ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.16.5
+      acorn: 8.11.3
+      acorn-walk: 8.3.3
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
   ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -23663,7 +23835,7 @@ snapshots:
 
   v8-to-istanbul@9.3.0:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.29
       '@types/istanbul-lib-coverage': 2.0.3
       convert-source-map: 2.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,17 +1,16 @@
 packages:
-  # all packages in direct subdirs of packages/
-  - "packages/*"
-  - "tooling/*"
+  - packages/*
+  - tooling/*
 
 catalog:
-  tsup: "^8.5.0"
-  typescript: "^5.5.4"
-  rollup: "^4.44.1"
-  tslib: "^2.5.0"
-  jest: "^29.7.0"
-  jest-environment-jsdom: "^29.7.0"
-  jest-environment-node: "^29.7.0"
-  jest-expo: "^47.0.1"
-  "@types/jest": "^29.7.0"
-  ts-jest: "^29.0.0"
-  "@rslib/core": "^0.10.5"
+  tsup: ^8.5.0
+  typescript: ^5.5.4
+  rollup: ^4.44.1
+  tslib: ^2.5.0
+  jest: 29.7.0
+  jest-environment-jsdom: ^29.7.0
+  jest-environment-node: ^29.7.0
+  jest-expo: ^47.0.1
+  '@types/jest': ^29.7.0
+  ts-jest: ^29.0.0
+  '@rslib/core': ^0.10.5


### PR DESCRIPTION
## Problem

Currently the @posthog/nextjs-config package does not work properly with a ESM next config (via `next.config.mjs` rather than `next.config.js`) because it is checking for the `__dirname` global which only exists in a CJS context.

## Changes

- Added a check for `__dirname` and use alternative method if unavailable
- Added tests for the above which also involved setting up some missing boilerplate
- Moved `callPosthogCli` to `utils.ts`

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [x] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
