### PR TITLE
fix(node): Add group identify immediate

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -409,6 +409,29 @@ export abstract class PostHogCoreStateless {
     })
   }
 
+  protected groupIdentifyStatelessImmediate(
+    groupType: string,
+    groupKey: string | number,
+    groupProperties?: PostHogEventProperties,
+    options?: PostHogCaptureOptions,
+    distinctId?: string,
+    eventProperties?: PostHogEventProperties
+  ): void {
+    this.wrap(() => {
+      const payload = this.buildPayload({
+        distinct_id: distinctId || `$${groupType}_${groupKey}`,
+        event: '$groupidentify',
+        properties: {
+          $group_type: groupType,
+          $group_key: groupKey,
+          $group_set: groupProperties || {},
+          ...(eventProperties || {}),
+        },
+      })
+      this.sendImmediate('capture', payload, options)
+    })
+  }
+
   protected async getRemoteConfig(): Promise<PostHogRemoteConfig | undefined> {
     await this._initPromise
 

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -603,6 +603,9 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     super.groupIdentifyStateless(groupType, groupKey, properties, { disableGeoip }, distinctId)
   }
 
+  groupIdentifyImmediate({ groupType, groupKey, properties, distinctId, disableGeoip }: GroupIdentifyMessage): void {
+    super.groupIdentifyImmediate(groupType, groupKey, properties, { disableGeoip }, distinctId)
+  }
   /**
    * Reloads the feature flag definitions from the server for local evaluation.
    * This is useful to call if you want to ensure that the feature flags are up to date before calling getFeatureFlag.

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -255,6 +255,15 @@ export interface IPostHog {
   groupIdentify({ groupType, groupKey, properties }: GroupIdentifyMessage): void
 
   /**
+   * @description Sets a groups properties immediately. Useful for edge environments where the usual queue-based sending is not preferable. Do not mix immediate and non-immediate calls.
+   *
+   * @param groupType Type of group (ex: 'company'). Limited to 5 per project
+   * @param groupKey Unique identifier for that type of group (ex: 'id:5')
+   * @param properties OPTIONAL | which can be a object with any information you'd like to add
+   */
+  groupIdentifyImmediate({ groupType, groupKey, properties }: GroupIdentifyMessage): void
+
+  /**
    * @description Force an immediate reload of the polled feature flags. Please note that they are
    * already polled automatically at a regular interval.
    */


### PR DESCRIPTION
## Problem

Related: https://github.com/PostHog/posthog/issues/35899

## Changes

Added `groupIdentifyStatelessImmediate`, but tbh I'm not sure if this is necessary because user can use `captureImmediate`. Will check with him.

(P.S, my first time making a PR here, if there is anything i'm not doing correctly please let me know, thanks!)

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
