### PR TITLE
fix: surveys loading without /flags call

### DIFF
--- a/.changeset/social-chefs-dream.md
+++ b/.changeset/social-chefs-dream.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+- Fix surveys loading with advanced_enable_surveys config

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -80,7 +80,8 @@ export class PostHogSurveys {
         }
 
         // waiting for remote config to load
-        if (isUndefined(this._isSurveysEnabled)) {
+        // if surveys is forced enable (like external surveys), ignore the remote config and load surveys
+        if (isUndefined(this._isSurveysEnabled) && !this._instance.config.advanced_enable_surveys) {
             return
         }
 


### PR DESCRIPTION
## Problem

if `advanced_enable_surveys` is on, we don't need to wait until the remote config is loaded, and can move on with the initialization.

this is so we're able to load external surveys with any calls to `/flags`, so loading is faster and also can't be ad-blocked.

was supposed to be [on this PR](https://github.com/PostHog/posthog-js/pull/2172), but forgot to commit this fix before merging

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code -> all e2e tests running
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
