### PR TITLE
fix(react-native): emoji rating style

### DIFF
--- a/.changeset/rude-tigers-try.md
+++ b/.changeset/rude-tigers-try.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': minor
+---
+
+fix emoji rating row wrappign

--- a/.changeset/rude-tigers-try.md
+++ b/.changeset/rude-tigers-try.md
@@ -2,4 +2,4 @@
 'posthog-react-native': patch
 ---
 
-fix emoji rating row wrappign
+fix emoji rating row wrap

--- a/.changeset/rude-tigers-try.md
+++ b/.changeset/rude-tigers-try.md
@@ -1,5 +1,5 @@
 ---
-'posthog-react-native': minor
+'posthog-react-native': patch
 ---
 
 fix emoji rating row wrappign

--- a/packages/react-native/src/surveys/components/QuestionTypes.tsx
+++ b/packages/react-native/src/surveys/components/QuestionTypes.tsx
@@ -306,11 +306,12 @@ const styles = StyleSheet.create({
   },
   ratingOptionsEmoji: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    flexWrap: 'wrap', // Allows items to wrap to a new line
+    justifyContent: 'space-around',
+    flexWrap: 'nowrap',
+    flex: 1,
   },
   ratingsEmoji: {
-    padding: 10,
+    padding: 4,
   },
   ratingOptionsNumber: {
     margin: 10,


### PR DESCRIPTION
## Problem

Fixes wrapping issue on emoji rating questions in RN surveys. 

Context: https://posthog.slack.com/archives/C07QD3LT8U9/p1753964211036269

@lucasheriques @marandaneto Also noticed that on RN (and mobile SDKs in general I think) we assign rating button styling from appearance to emoji ratings as well. On web, however, it's always black for active, and black 50% on inactive. Which of the two do you think makes sense?

## Before
<img width="346" height="360" alt="image" src="https://github.com/user-attachments/assets/d1b81628-5596-4d93-9355-9575cb63bb87" />

## After
<img width="346" alt="CleanShot 2025-08-01 at 09 31 18@2x" src="https://github.com/user-attachments/assets/9d69f632-9b4a-4dfb-a078-019b21c5fd3a" />
<img width="346" alt="CleanShot 2025-08-01 at 09 27 25@2x" src="https://github.com/user-attachments/assets/e5722649-80fc-4752-8bcc-44028c5ad7c6" />

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
