### PR TITLE
chore(ci): fix workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: "Release"
 
 permissions:
   contents: write
+  actions: write
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         package:
           - name: posthog-react-native
@@ -60,7 +61,7 @@ jobs:
       - name: Dispatch posthog upgrade for ${{ matrix.package.name }}
         if: matrix.package.name == 'posthog-js' && steps.check-package-version.outputs.is-new-version == 'true'
         run: |
-          curl -X POST \
+          curl -f -X POST \
                -H "Accept: application/vnd.github+json" \
                -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                https://api.github.com/repos/posthog/posthog-js/actions/workflows/posthog-upgrade.yml/dispatches \
@@ -75,7 +76,7 @@ jobs:
       - name: Dispatch posthog.com upgrade for ${{ matrix.package.name }}
         if: matrix.package.name == 'posthog-js' && steps.check-package-version.outputs.is-new-version == 'true'
         run: |
-          curl -X POST \
+          curl -f -X POST \
                -H "Accept: application/vnd.github+json" \
                -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                https://api.github.com/repos/posthog/posthog-js/actions/workflows/posthog-com-upgrade.yml/dispatches \


### PR DESCRIPTION
Fix: https://github.com/PostHog/posthog-js/actions/runs/16664571740/job/47168280438

## Problem

- posthog-js is not updated on main repo and posthog.com because of permission issues

## Changes

- fix workflow dispatch permissions
- make job fail on unsuccessful dispatch
- fix matrix strategy to still release other packages