### PR TITLE
fix: Updates to spec generation

### DIFF
--- a/packages/browser/scripts/specs/constants.js
+++ b/packages/browser/scripts/specs/constants.js
@@ -1,26 +1,4 @@
-const NO_DOCS_TYPES = [
-    'string',
-    'number',
-    'boolean',
-    'integer',
-    'object',
-    'array',
-    'null',
-    'undefined',
-    'any',
-    'unknown',
-    'void',
-    'Date',
-    'RegExp',
-    'Error',
-    'Symbol',
-    'BigInt',
-    'Map',
-    'Set',
-    'PostHog' // The entire ref is the posthog class lol
-];
-
-const HOG_REF = '0.1';
+const HOG_REF = '0.2';
 
 const SPEC_INFO = {
     id: 'posthog-js',
@@ -89,7 +67,6 @@ const PROPERTY_EXAMPLE = `// It can be a string
 }
 `
 module.exports = {
-    NO_DOCS_TYPES,
     HOG_REF,
     SPEC_INFO,
     OUTPUT_FILE_PATH,

--- a/packages/browser/scripts/specs/parser.js
+++ b/packages/browser/scripts/specs/parser.js
@@ -5,7 +5,7 @@ const methods = require('./methods');
 const types = require('./types');
 const { writeFileSync, readFileSync } = require('fs');
 const path = require('path');
-const { NO_DOCS_TYPES, HOG_REF, SPEC_INFO, OUTPUT_FILE_PATH, PROPERTIES_EXAMPLE, PROPERTY_EXAMPLE } = require('./constants');
+const { HOG_REF, SPEC_INFO, OUTPUT_FILE_PATH, PROPERTIES_EXAMPLE, PROPERTY_EXAMPLE } = require('./constants');
 
 const loadPackageInfo = (dirPath) => 
     JSON.parse(readFileSync(path.resolve(dirPath, '../../package.json'), 'utf8'));
@@ -82,7 +82,6 @@ const composeOutput = (packageJson, posthogClass, functions, types) => ({
         version: packageJson.version,
         ...SPEC_INFO
     },
-    noDocsTypes: NO_DOCS_TYPES,
     classes: [createClassDefinition(posthogClass, functions)],
     types
 });

--- a/packages/browser/scripts/specs/types.js
+++ b/packages/browser/scripts/specs/types.js
@@ -311,8 +311,8 @@ function generateTypeExample(signature) {
         return 'string';
     }
     if (signature.includes('|')) {
-        const parts = signature.split('|').map(p => p.trim()).slice(0, 3);
-        return parts.length < 3 ? parts.join(' | ') : parts.concat('...').join(' | ');
+        const parts = signature.split('|').map(p => p.trim());
+        return parts.join(' | ');
     }
     return signature;
 }

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -862,8 +862,10 @@ export class PostHog {
      * do not wish to rely on our convenience methods
      * (created in the snippet).
      *
-     * ### Usage:
-     *     posthog.push(['register', { a: 'b' }]);
+     * @example
+     * ```js
+     * posthog.push(['register', { a: 'b' }]);
+     * ```
      *
      * @param {Array} item A [function_name, args...] array to be executed
      */

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1036,8 +1036,6 @@ export class PostHog {
     }
 
     /**
-     * calculateEventProperties
-     *
      * This method is used internally to calculate the event properties before sending it to PostHog. It can also be
      * used by integrations (e.g. Segment) to enrich events with PostHog properties before sending them to Segment,
      * which is required for some PostHog products to work correctly. (e.g. to have a correct $session_id property).
@@ -1047,7 +1045,8 @@ export class PostHog {
      * @param {Date} [timestamp] The timestamp of the event, e.g. for calculating time on page. If not set, it'll automatically be set to the current time.
      * @param {String} [uuid] The uuid of the event, e.g. for storing the $pageview ID.
      * @param {Boolean} [readOnly] Set this if you do not intend to actually send the event, and therefore do not want to update internal state e.g. session timeout
-
+     * 
+     * @internal
      */
     public calculateEventProperties(
         eventName: string,

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1045,7 +1045,7 @@ export class PostHog {
      * @param {Date} [timestamp] The timestamp of the event, e.g. for calculating time on page. If not set, it'll automatically be set to the current time.
      * @param {String} [uuid] The uuid of the event, e.g. for storing the $pageview ID.
      * @param {Boolean} [readOnly] Set this if you do not intend to actually send the event, and therefore do not want to update internal state e.g. session timeout
-     * 
+     *
      * @internal
      */
     public calculateEventProperties(


### PR DESCRIPTION
## Problem

- No doc types are no longer needed (we figured our a smarter way to display types on the website)
- Marks a method that doesn't look public internal, hiding it from specs
- Fixes a bug with types that joins many literals

## Changes

Updates spec gen code.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
