### PR TITLE
chore: Optimize lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,18 +47,10 @@
         "typescript": "catalog:"
     },
     "lint-staged": {
-        "*.{ts,tsx,js,json}": "prettier --write",
-        "*.js": "eslint --cache --fix",
-        "*.{ts,tsx}": [
-            "eslint packages/browser/src --fix",
-            "eslint packages/core/src --fix",
-            "eslint packages/web/src --fix",
-            "eslint packages/react/src --fix",
-            "eslint packages/react-native/src --fix",
-            "eslint packages/nextjs-config/src --fix",
-            "eslint packages/ai/src --fix",
-            "eslint packages/browser/playwright --fix",
+        "*.{ts,tsx,js,jsx,mjs,cjs}": [
+            "eslint --cache --fix",
             "prettier --write"
-        ]
+        ],
+        "*.{json,md}": "prettier --write"
     }
 }


### PR DESCRIPTION

## Problem

We were linting every file multiple times in the pre-commit hook, which takes far longer than it should

## Changes

This should ensure that
* each file only gets linted once
* we using caching
* we cover more kinds of file in the repo
* we should still get package-specific linting rules applied to file in that package

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

n/a

### If releasing new changes
n/a
