### PR TITLE
feat(cookieless): Split cookieless into 2 modes, 'always' and 'on_reject'

### DIFF
--- a/.changeset/lovely-cameras-knock.md
+++ b/.changeset/lovely-cameras-knock.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+Support 2 cookieless modes - 'always' and 'on_reject'

--- a/packages/browser/playground/nextjs/src/CookieBanner.tsx
+++ b/packages/browser/playground/nextjs/src/CookieBanner.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable posthog-js/no-direct-null-check */
-import { useEffect, useState } from 'react'
+import { useEffect, useState, ReactElement } from 'react'
 import { cookieConsentGiven, posthog, updatePostHogConsent } from './posthog'
 
 export function useCookieConsent(): [boolean | null, (consentGiven: boolean) => void] {
@@ -20,11 +20,11 @@ export function useCookieConsent(): [boolean | null, (consentGiven: boolean) => 
     return [consentGiven, setConsentGiven]
 }
 
-export function CookieBanner() {
+export function CookieBanner(): ReactElement | null {
     const [consentGiven, setConsentGiven] = useCookieConsent()
 
     if (consentGiven === null || posthog.config.cookieless_mode === 'always') {
-        return
+        return null
     }
 
     return (

--- a/packages/browser/playground/nextjs/src/CookieBanner.tsx
+++ b/packages/browser/playground/nextjs/src/CookieBanner.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable posthog-js/no-direct-null-check */
 import { useEffect, useState } from 'react'
-import { cookieConsentGiven, updatePostHogConsent } from './posthog'
+import { cookieConsentGiven, posthog, updatePostHogConsent } from './posthog'
 
 export function useCookieConsent(): [boolean | null, (consentGiven: boolean) => void] {
     const [consentGiven, setConsentGiven] = useState<boolean | null>(null)
@@ -10,7 +10,9 @@ export function useCookieConsent(): [boolean | null, (consentGiven: boolean) => 
     }, [])
 
     useEffect(() => {
-        if (consentGiven === null) return
+        if (consentGiven === null || posthog.config.cookieless_mode === 'always') {
+            return
+        }
 
         updatePostHogConsent(consentGiven)
     }, [consentGiven])
@@ -21,7 +23,9 @@ export function useCookieConsent(): [boolean | null, (consentGiven: boolean) => 
 export function CookieBanner() {
     const [consentGiven, setConsentGiven] = useCookieConsent()
 
-    if (consentGiven === null) return null
+    if (consentGiven === null || posthog.config.cookieless_mode === 'always') {
+        return
+    }
 
     return (
         <div className="fixed right-2 bottom-2 border rounded p-2 bg-gray-100 text-sm">

--- a/packages/browser/playground/nextjs/src/posthog.ts
+++ b/packages/browser/playground/nextjs/src/posthog.ts
@@ -40,7 +40,6 @@ export const configForConsent = (): Partial<PostHogConfig> => {
 }
 
 export const updatePostHogConsent = (consentGiven: boolean) => {
-    console.log(`updatePostHogConsent(${consentGiven})`)
     if (consentGiven) {
         posthog.opt_in_capturing()
     } else {

--- a/packages/browser/playground/nextjs/src/posthog.ts
+++ b/packages/browser/playground/nextjs/src/posthog.ts
@@ -40,6 +40,7 @@ export const configForConsent = (): Partial<PostHogConfig> => {
 }
 
 export const updatePostHogConsent = (consentGiven: boolean) => {
+    console.log(`updatePostHogConsent(${consentGiven})`)
     if (consentGiven) {
         posthog.opt_in_capturing()
     } else {
@@ -65,14 +66,12 @@ if (typeof window !== 'undefined') {
         person_profiles: PERSON_PROCESSING_MODE === 'never' ? 'identified_only' : PERSON_PROCESSING_MODE,
         persistence_name: `${process.env.NEXT_PUBLIC_POSTHOG_KEY}_nextjs`,
         opt_in_site_apps: true,
-        opt_out_capturing_by_default: true,
-        opt_out_persistence_by_default: true,
         integrations: {
             intercom: true,
             crispChat: true,
         },
         __preview_remote_config: true,
-        __preview_experimental_cookieless_mode: false,
+        cookieless_mode: 'on_reject',
         __preview_flags_v2: true,
         ...configForConsent(),
     })

--- a/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -176,6 +176,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"null\\",
     \\"string\\"
   ],
+  \\"consent_persistence_name\\": [
+    \\"null\\",
+    \\"string\\"
+  ],
   \\"opt_in_site_apps\\": [
     \\"false\\",
     \\"true\\"
@@ -526,16 +530,16 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"undefined\\",
     \\"Record<ExternalIntegrationKind, boolean>\\"
   ],
+  \\"cookieless_mode\\": [
+    \\"undefined\\",
+    \\"\\\\\\"always\\\\\\"\\",
+    \\"\\\\\\"on_reject\\\\\\"\\"
+  ],
   \\"__add_tracing_headers\\": [
     \\"undefined\\",
     \\"string[]\\"
   ],
   \\"__preview_remote_config\\": [
-    \\"undefined\\",
-    \\"false\\",
-    \\"true\\"
-  ],
-  \\"__preview_experimental_cookieless_mode\\": [
     \\"undefined\\",
     \\"false\\",
     \\"true\\"

--- a/packages/browser/src/__tests__/cookieless.test.ts
+++ b/packages/browser/src/__tests__/cookieless.test.ts
@@ -1,89 +1,213 @@
 import type { PostHogConfig } from '../types'
 import { uuidv7 } from '../uuidv7'
-import { defaultPostHog } from './helpers/posthog-instance'
+import { createPosthogInstance } from './helpers/posthog-instance'
+const uuidV7Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+jest.mock('../utils/globals', () => {
+    const orig = jest.requireActual('../utils/globals')
+    const mockURLGetter = jest.fn()
+    const mockReferrerGetter = jest.fn()
+    const mockedCookieBox = { cookie: '' }
+    return {
+        ...orig,
+        mockURLGetter,
+        mockReferrerGetter,
+        mockedCookieBox: mockedCookieBox,
+        document: {
+            ...orig.document,
+            createElement: (...args: any[]) => orig.document.createElement(...args),
+            body: {},
+            get referrer() {
+                return mockReferrerGetter()
+            },
+            get URL() {
+                return mockURLGetter()
+            },
+            get cookie() {
+                return mockedCookieBox.cookie
+            },
+            set cookie(value: string) {
+                mockedCookieBox.cookie = value
+            },
+            addEventListener(_, event, callback) {
+                if (event === 'DOMContentLoaded') {
+                    callback()
+                }
+            },
+            readyState: 'complete',
+            visibilityState: 'visible',
+        },
+        get location() {
+            const url = mockURLGetter()
+            return {
+                href: url,
+                toString: () => url,
+            }
+        },
+    }
+})
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { mockURLGetter, mockedCookieBox, document } = require('../utils/globals')
 
 describe('cookieless', () => {
     const eventName = 'custom_event'
     const eventProperties = {
         event: 'prop',
     }
-    const identifiedDistinctId = 'user-1'
-    const setup = (config: Partial<PostHogConfig> = {}, token: string = uuidv7()) => {
+    const setup = async (config: Partial<PostHogConfig> = {}, token: string = uuidv7()) => {
         const beforeSendMock = jest.fn().mockImplementation((e) => e)
-        const posthog = defaultPostHog().init(token, { ...config, before_send: beforeSendMock }, token)!
+        const posthog = await createPosthogInstance(token, {
+            ...config,
+            before_send: beforeSendMock,
+        })!
         posthog.debug()
         return { posthog, beforeSendMock }
     }
 
-    it('should send events with the sentinel distinct id', () => {
-        const { posthog, beforeSendMock } = setup({
-            persistence: 'memory',
-            __preview_experimental_cookieless_mode: true,
-            disable_surveys: true,
+    beforeEach(() => {
+        mockURLGetter.mockImplementation(() => 'http://localhost')
+        mockedCookieBox.cookie = ''
+    })
+
+    describe('always mode', () => {
+        it('should not set any cookies', async () => {
+            const { posthog, beforeSendMock } = await setup({
+                cookieless_mode: 'always',
+            })
+            posthog.capture(eventName, eventProperties)
+
+            expect(beforeSendMock).toBeCalledTimes(1)
+            const event = beforeSendMock.mock.calls[0][0]
+            expect(event.event).toBe(eventName)
+            expect(event.properties.distinct_id).toBe('$posthog_cookieless')
+            expect(event.properties.$anon_distinct_id).toBe(undefined)
+            expect(event.properties.$device_id).toBe(null)
+            expect(event.properties.$session_id).toBe(undefined)
+            expect(event.properties.$window_id).toBe(undefined)
+            expect(event.properties.$cookieless_mode).toEqual(true)
+            expect(document.cookie).toBe('')
+
+            // should ignore cookie consent, and throw in test code due to logging an error
+            expect(() => posthog.opt_in_capturing()).toThrow()
+        })
+    })
+
+    describe('on_reject mode', () => {
+        it('should not send any events before opt in, then send non-cookieless events', async () => {
+            const { posthog, beforeSendMock } = await setup({
+                cookieless_mode: 'on_reject',
+            })
+            posthog.capture('eventBeforeOptIn') // will be dropped
+            expect(beforeSendMock).toBeCalledTimes(0)
+
+            // opt in
+            posthog.opt_in_capturing()
+
+            expect(beforeSendMock).toBeCalledTimes(2)
+            const optInEvent = beforeSendMock.mock.calls[0][0]
+            expect(optInEvent.event).toBe('$opt_in')
+
+            const eventBeforeOptIn = beforeSendMock.mock.calls[1][0]
+            expect(eventBeforeOptIn.event).toBe('$pageview') // initial pageview
+            expect(eventBeforeOptIn.properties.distinct_id).toMatch(uuidV7Pattern)
+            expect(eventBeforeOptIn.properties.$anon_distinct_id).toBe(undefined)
+            expect(eventBeforeOptIn.properties.$device_id).toMatch(uuidV7Pattern)
+            expect(eventBeforeOptIn.properties.$session_id).toMatch(uuidV7Pattern)
+            expect(eventBeforeOptIn.properties.$window_id).toMatch(uuidV7Pattern)
+            expect(eventBeforeOptIn.properties.$cookieless_mode).toEqual(undefined)
+            expect(document.cookie).toContain('distinct_id')
         })
 
-        posthog.capture(eventName, eventProperties)
-        expect(beforeSendMock).toBeCalledTimes(1)
-        let event = beforeSendMock.mock.calls[0][0]
-        expect(event.properties.distinct_id).toBe('$posthog_cookieless')
-        expect(event.properties.$anon_distinct_id).toBe(undefined)
-        expect(event.properties.$device_id).toBe(null)
-        expect(event.properties.$session_id).toBe(undefined)
-        expect(event.properties.$window_id).toBe(undefined)
-        expect(event.properties.$cookieless_mode).toEqual(true)
-        expect(document.cookie).toBe('')
+        it('should not send any events before opt out, then send cookieless events', async () => {
+            expect(document.cookie).toEqual('')
 
-        // simulate user giving cookie consent
-        posthog.set_config({ persistence: 'localStorage+cookie' })
+            const { posthog, beforeSendMock } = await setup({
+                cookieless_mode: 'on_reject',
+            })
+            posthog.capture('eventBeforeOptOut') // will be dropped
+            expect(beforeSendMock).toBeCalledTimes(0)
 
-        // send an event after consent
-        posthog.capture(eventName, eventProperties)
-        expect(beforeSendMock).toBeCalledTimes(2)
-        event = beforeSendMock.mock.calls[1][0]
-        expect(event.properties.distinct_id).toBe('$posthog_cookieless')
-        expect(event.properties.$anon_distinct_id).toBe(undefined)
-        expect(event.properties.$device_id).toBe(null)
-        expect(event.properties.$session_id).toBe(undefined)
-        expect(event.properties.$window_id).toBe(undefined)
-        expect(event.properties.$cookieless_mode).toEqual(true)
-        expect(document.cookie).not.toBe('')
+            // opt out
+            posthog.opt_out_capturing()
 
-        // a user identifying
-        posthog.identify(identifiedDistinctId)
-        expect(beforeSendMock).toBeCalledTimes(3)
-        event = beforeSendMock.mock.calls[2][0]
-        expect(event.properties.distinct_id).toBe(identifiedDistinctId)
-        expect(event.properties.$anon_distinct_id).toBe('$posthog_cookieless')
-        expect(event.properties.$device_id).toBe(null)
-        expect(event.properties.$session_id).toBe(undefined)
-        expect(event.properties.$window_id).toBe(undefined)
-        expect(event.properties.$cookieless_mode).toEqual(true)
+            posthog.capture('eventAfterOptOut')
 
-        // an event after identifying
-        posthog.capture(eventName, eventProperties)
-        expect(beforeSendMock).toBeCalledTimes(4)
-        event = beforeSendMock.mock.calls[3][0]
-        expect(event.properties.distinct_id).toBe(identifiedDistinctId)
-        expect(event.properties.$anon_distinct_id).toBe(undefined)
-        expect(event.properties.$device_id).toBe(null)
-        expect(event.properties.$session_id).toBe(undefined)
-        expect(event.properties.$window_id).toBe(undefined)
-        expect(event.properties.$cookieless_mode).toEqual(true)
+            expect(beforeSendMock).toBeCalledTimes(2)
+            const pageview = beforeSendMock.mock.calls[0][0]
+            expect(pageview.event).toBe('$pageview') // initial pageview
 
-        // reset
-        posthog.reset()
-        posthog.set_config({ persistence: 'memory' })
+            const eventBeforeOptIn = beforeSendMock.mock.calls[1][0]
+            expect(eventBeforeOptIn.event).toBe('eventAfterOptOut')
+            expect(eventBeforeOptIn.properties.distinct_id).toEqual('$posthog_cookieless')
+            expect(eventBeforeOptIn.properties.$anon_distinct_id).toEqual(undefined)
+            expect(eventBeforeOptIn.properties.$device_id).toBe(null)
+            expect(eventBeforeOptIn.properties.$session_id).toBe(undefined)
+            expect(eventBeforeOptIn.properties.$window_id).toBe(undefined)
+            expect(eventBeforeOptIn.properties.$cookieless_mode).toEqual(true)
+            expect(document.cookie).toEqual('') // Q: why isn't consent set here? A: it's stored in localStorage
+        })
 
-        // an event after reset
-        posthog.capture(eventName, eventProperties)
-        expect(beforeSendMock).toBeCalledTimes(5)
-        event = beforeSendMock.mock.calls[4][0]
-        expect(event.properties.distinct_id).toBe('$posthog_cookieless')
-        expect(event.properties.$anon_distinct_id).toBe(undefined)
-        expect(event.properties.$device_id).toBe(null)
-        expect(event.properties.$session_id).toBe(undefined)
-        expect(event.properties.$window_id).toBe(undefined)
-        expect(event.properties.$cookieless_mode).toEqual(true)
-        expect(document.cookie).toBe('')
+        it('it should pick up positive cookie consent on startup and start sending non-cookieless events', async () => {
+            const persistenceName = uuidv7()
+            const { posthog: previousPosthog } = await setup(
+                {
+                    cookieless_mode: 'on_reject',
+                    consent_persistence_name: persistenceName,
+                    persistence_name: persistenceName,
+                },
+                undefined
+            )
+            previousPosthog.opt_in_capturing()
+            const { beforeSendMock, posthog } = await setup(
+                {
+                    cookieless_mode: 'on_reject',
+                    consent_persistence_name: persistenceName,
+                    persistence_name: persistenceName,
+                },
+                undefined
+            )
+            posthog.capture('eventWithStoredCookieConsentConfirm')
+            expect(beforeSendMock).toBeCalledTimes(1)
+            const pageview = beforeSendMock.mock.calls[0][0]
+            expect(pageview.event).toBe('eventWithStoredCookieConsentConfirm')
+            expect(pageview.properties.distinct_id).toMatch(uuidV7Pattern)
+            expect(pageview.properties.$anon_distinct_id).toBe(undefined)
+            expect(pageview.properties.$device_id).toMatch(uuidV7Pattern)
+            expect(pageview.properties.$session_id).toMatch(uuidV7Pattern)
+            expect(pageview.properties.$window_id).toMatch(uuidV7Pattern)
+            expect(pageview.properties.$cookieless_mode).toEqual(undefined)
+        })
+
+        it('should pick up negative cookie consent on startup and start sending cookieless events', async () => {
+            const persistenceName = uuidv7()
+            const { posthog: previousPosthog } = await setup(
+                {
+                    cookieless_mode: 'on_reject',
+                    consent_persistence_name: persistenceName,
+                    persistence_name: persistenceName,
+                },
+                undefined
+            )
+            previousPosthog.opt_out_capturing()
+            const { beforeSendMock, posthog } = await setup(
+                {
+                    cookieless_mode: 'on_reject',
+                    consent_persistence_name: persistenceName,
+                    persistence_name: persistenceName,
+                },
+                undefined
+            )
+            posthog.capture('eventWithStoredCookieConsentConfirm')
+            expect(beforeSendMock).toBeCalledTimes(1)
+            const pageview = beforeSendMock.mock.calls[0][0]
+            expect(pageview.event).toBe('eventWithStoredCookieConsentConfirm')
+            expect(pageview.properties.distinct_id).toEqual('$posthog_cookieless')
+            expect(pageview.properties.$anon_distinct_id).toEqual(undefined)
+            expect(pageview.properties.$device_id).toBe(null)
+            expect(pageview.properties.$session_id).toBe(undefined)
+            expect(pageview.properties.$window_id).toBe(undefined)
+            expect(pageview.properties.$cookieless_mode).toEqual(true)
+        })
     })
 })

--- a/packages/browser/src/__tests__/cookieless.test.ts
+++ b/packages/browser/src/__tests__/cookieless.test.ts
@@ -108,14 +108,14 @@ describe('cookieless', () => {
             const optInEvent = beforeSendMock.mock.calls[0][0]
             expect(optInEvent.event).toBe('$opt_in')
 
-            const eventBeforeOptIn = beforeSendMock.mock.calls[1][0]
-            expect(eventBeforeOptIn.event).toBe('$pageview') // initial pageview
-            expect(eventBeforeOptIn.properties.distinct_id).toMatch(uuidV7Pattern)
-            expect(eventBeforeOptIn.properties.$anon_distinct_id).toBe(undefined)
-            expect(eventBeforeOptIn.properties.$device_id).toMatch(uuidV7Pattern)
-            expect(eventBeforeOptIn.properties.$session_id).toMatch(uuidV7Pattern)
-            expect(eventBeforeOptIn.properties.$window_id).toMatch(uuidV7Pattern)
-            expect(eventBeforeOptIn.properties.$cookieless_mode).toEqual(undefined)
+            const initialPageview = beforeSendMock.mock.calls[1][0]
+            expect(initialPageview.event).toBe('$pageview') // initial pageview
+            expect(initialPageview.properties.distinct_id).toMatch(uuidV7Pattern)
+            expect(initialPageview.properties.$anon_distinct_id).toBe(undefined)
+            expect(initialPageview.properties.$device_id).toMatch(uuidV7Pattern)
+            expect(initialPageview.properties.$session_id).toMatch(uuidV7Pattern)
+            expect(initialPageview.properties.$window_id).toMatch(uuidV7Pattern)
+            expect(initialPageview.properties.$cookieless_mode).toEqual(undefined)
             expect(document.cookie).toContain('distinct_id')
         })
 
@@ -137,14 +137,14 @@ describe('cookieless', () => {
             const pageview = beforeSendMock.mock.calls[0][0]
             expect(pageview.event).toBe('$pageview') // initial pageview
 
-            const eventBeforeOptIn = beforeSendMock.mock.calls[1][0]
-            expect(eventBeforeOptIn.event).toBe('eventAfterOptOut')
-            expect(eventBeforeOptIn.properties.distinct_id).toEqual('$posthog_cookieless')
-            expect(eventBeforeOptIn.properties.$anon_distinct_id).toEqual(undefined)
-            expect(eventBeforeOptIn.properties.$device_id).toBe(null)
-            expect(eventBeforeOptIn.properties.$session_id).toBe(undefined)
-            expect(eventBeforeOptIn.properties.$window_id).toBe(undefined)
-            expect(eventBeforeOptIn.properties.$cookieless_mode).toEqual(true)
+            const event = beforeSendMock.mock.calls[1][0]
+            expect(event.event).toBe('eventAfterOptOut')
+            expect(event.properties.distinct_id).toEqual('$posthog_cookieless')
+            expect(event.properties.$anon_distinct_id).toEqual(undefined)
+            expect(event.properties.$device_id).toBe(null)
+            expect(event.properties.$session_id).toBe(undefined)
+            expect(event.properties.$window_id).toBe(undefined)
+            expect(event.properties.$cookieless_mode).toEqual(true)
             expect(document.cookie).toEqual('') // Q: why isn't consent set here? A: it's stored in localStorage
         })
 
@@ -169,14 +169,14 @@ describe('cookieless', () => {
             )
             posthog.capture('eventWithStoredCookieConsentConfirm')
             expect(beforeSendMock).toBeCalledTimes(1)
-            const pageview = beforeSendMock.mock.calls[0][0]
-            expect(pageview.event).toBe('eventWithStoredCookieConsentConfirm')
-            expect(pageview.properties.distinct_id).toMatch(uuidV7Pattern)
-            expect(pageview.properties.$anon_distinct_id).toBe(undefined)
-            expect(pageview.properties.$device_id).toMatch(uuidV7Pattern)
-            expect(pageview.properties.$session_id).toMatch(uuidV7Pattern)
-            expect(pageview.properties.$window_id).toMatch(uuidV7Pattern)
-            expect(pageview.properties.$cookieless_mode).toEqual(undefined)
+            const event = beforeSendMock.mock.calls[0][0]
+            expect(event.event).toBe('eventWithStoredCookieConsentConfirm')
+            expect(event.properties.distinct_id).toMatch(uuidV7Pattern)
+            expect(event.properties.$anon_distinct_id).toBe(undefined)
+            expect(event.properties.$device_id).toMatch(uuidV7Pattern)
+            expect(event.properties.$session_id).toMatch(uuidV7Pattern)
+            expect(event.properties.$window_id).toMatch(uuidV7Pattern)
+            expect(event.properties.$cookieless_mode).toEqual(undefined)
         })
 
         it('should pick up negative cookie consent on startup and start sending cookieless events', async () => {
@@ -200,14 +200,14 @@ describe('cookieless', () => {
             )
             posthog.capture('eventWithStoredCookieConsentConfirm')
             expect(beforeSendMock).toBeCalledTimes(1)
-            const pageview = beforeSendMock.mock.calls[0][0]
-            expect(pageview.event).toBe('eventWithStoredCookieConsentConfirm')
-            expect(pageview.properties.distinct_id).toEqual('$posthog_cookieless')
-            expect(pageview.properties.$anon_distinct_id).toEqual(undefined)
-            expect(pageview.properties.$device_id).toBe(null)
-            expect(pageview.properties.$session_id).toBe(undefined)
-            expect(pageview.properties.$window_id).toBe(undefined)
-            expect(pageview.properties.$cookieless_mode).toEqual(true)
+            const event = beforeSendMock.mock.calls[0][0]
+            expect(event.event).toBe('eventWithStoredCookieConsentConfirm')
+            expect(event.properties.distinct_id).toEqual('$posthog_cookieless')
+            expect(event.properties.$anon_distinct_id).toEqual(undefined)
+            expect(event.properties.$device_id).toBe(null)
+            expect(event.properties.$session_id).toBe(undefined)
+            expect(event.properties.$window_id).toBe(undefined)
+            expect(event.properties.$cookieless_mode).toEqual(true)
         })
     })
 })

--- a/packages/browser/src/__tests__/cookieless.test.ts
+++ b/packages/browser/src/__tests__/cookieless.test.ts
@@ -148,7 +148,7 @@ describe('cookieless', () => {
             expect(document.cookie).toEqual('') // Q: why isn't consent set here? A: it's stored in localStorage
         })
 
-        it('it should pick up positive cookie consent on startup and start sending non-cookieless events', async () => {
+        it('should pick up positive cookie consent on startup and start sending non-cookieless events', async () => {
             const persistenceName = uuidv7()
             const { posthog: previousPosthog } = await setup(
                 {

--- a/packages/browser/src/__tests__/cookieless.test.ts
+++ b/packages/browser/src/__tests__/cookieless.test.ts
@@ -75,6 +75,7 @@ describe('cookieless', () => {
             const { posthog, beforeSendMock } = await setup({
                 cookieless_mode: 'always',
             })
+            expect(posthog.has_opted_in_capturing()).toBe(false)
             posthog.capture(eventName, eventProperties)
 
             expect(beforeSendMock).toBeCalledTimes(1)

--- a/packages/browser/src/consent.ts
+++ b/packages/browser/src/consent.ts
@@ -35,7 +35,7 @@ export class ConsentManager {
 
     public isOptedOut() {
         if (this._config.cookieless_mode === 'always') {
-            return false
+            return true
         }
         // we are opted out if:
         // * consent is explicitly denied

--- a/packages/browser/src/entrypoints/tracing-headers.ts
+++ b/packages/browser/src/entrypoints/tracing-headers.ts
@@ -2,6 +2,7 @@ import { SessionIdManager } from '../sessionid'
 import { patch } from '../extensions/replay/rrweb-plugins/patch'
 import { assignableWindow, window } from '../utils/globals'
 import { isArray } from '../utils/type-utils'
+import { COOKIELESS_SENTINEL_VALUE } from '../constants'
 
 const addTracingHeaders = (
     hostnames: string[],
@@ -29,7 +30,9 @@ const addTracingHeaders = (
         req.headers.set('X-POSTHOG-SESSION-ID', sessionId)
         req.headers.set('X-POSTHOG-WINDOW-ID', windowId)
     }
-    req.headers.set('X-POSTHOG-DISTINCT-ID', distinctId)
+    if (distinctId !== COOKIELESS_SENTINEL_VALUE) {
+        req.headers.set('X-POSTHOG-DISTINCT-ID', distinctId)
+    }
 }
 
 const patchFetch = (hostnames: string[], distinctId: string, sessionManager?: SessionIdManager): (() => void) => {

--- a/packages/browser/src/extensions/replay/sessionrecording.ts
+++ b/packages/browser/src/extensions/replay/sessionrecording.ts
@@ -454,8 +454,8 @@ export class SessionRecording {
             logger.error('started without valid sessionManager')
             throw new Error(LOGGER_PREFIX + ' started without valid sessionManager. This is a bug.')
         }
-        if (this._instance.config.__preview_experimental_cookieless_mode) {
-            throw new Error(LOGGER_PREFIX + ' cannot be used with __preview_experimental_cookieless_mode.')
+        if (this._instance.config.cookieless_mode === 'always') {
+            throw new Error(LOGGER_PREFIX + ' cannot be used with cookieless_mode="always"')
         }
 
         this._linkedFlagMatching = new LinkedFlagMatching(this._instance)

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -2496,6 +2496,21 @@ export class PostHog {
         return this.consent.isOptedOut()
     }
 
+    /**
+     * Checks whether the PostHog library is currently capturing events.
+     *
+     * Usually this means that the user has not opted out of capturing, but the exact behaviour can be controlled by
+     * some config options.
+     *
+     * Additionally, if the cookieless_mode is set to 'on_reject', we will capture events in cookieless mode if the
+     * user has explicitly opted out.
+     *
+     * @see {PostHogConfig.cookieless_mode}
+     * @see {PostHogConfig.opt_out_persistence_by_default}
+     * @see {PostHogConfig.respect_dnt}
+     *
+     * @returns {boolean} whether the posthog library is capturing events
+     */
     is_capturing(): boolean {
         if (this.config.cookieless_mode === 'on_reject') {
             return this.consent.isExplicitlyOptedOut() || this.consent.isOptedIn()

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -2531,6 +2531,9 @@ export class PostHog {
      * @returns {boolean} whether the posthog library is capturing events
      */
     is_capturing(): boolean {
+        if (this.config.cookieless_mode === 'always') {
+            return true
+        }
         if (this.config.cookieless_mode === 'on_reject') {
             return this.consent.isExplicitlyOptedOut() || this.consent.isOptedIn()
         } else {

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -170,6 +170,7 @@ export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     opt_out_persistence_by_default: false,
     opt_out_useragent_filter: false,
     opt_out_capturing_persistence_type: 'localStorage',
+    consent_persistence_name: null,
     opt_out_capturing_cookie_prefix: null,
     opt_in_site_apps: false,
     property_denylist: [],
@@ -508,7 +509,11 @@ export class PostHog {
         this._retryQueue = new RetryQueue(this)
         this.__request_queue = []
 
-        if (!this.config.__preview_experimental_cookieless_mode) {
+        const startInCookielessMode =
+            this.config.cookieless_mode === 'always' ||
+            (this.config.cookieless_mode === 'on_reject' && this.consent.isExplicitlyOptedOut())
+
+        if (!startInCookielessMode) {
             this.sessionManager = new SessionIdManager(this)
             this.sessionPropsManager = new SessionPropsManager(this, this.sessionManager, this.persistence)
         }
@@ -518,7 +523,7 @@ export class PostHog {
         this.siteApps = new SiteApps(this)
         this.siteApps?.init()
 
-        if (!this.config.__preview_experimental_cookieless_mode) {
+        if (!startInCookielessMode) {
             this.sessionRecording = new SessionRecording(this)
             this.sessionRecording.startIfEnabledOrStop()
         }
@@ -591,7 +596,7 @@ export class PostHog {
             this.featureFlags.receivedFeatureFlags({ featureFlags: activeFlags, featureFlagPayloads })
         }
 
-        if (this.config.__preview_experimental_cookieless_mode) {
+        if (startInCookielessMode) {
             this.register_once(
                 {
                     distinct_id: COOKIELESS_SENTINEL_VALUE,
@@ -708,7 +713,7 @@ export class PostHog {
     }
 
     _start_queue_if_opted_in(): void {
-        if (!this.has_opted_out_capturing()) {
+        if (this.is_capturing()) {
             if (this.config.request_batching) {
                 this._requestQueue?.enable()
             }
@@ -716,7 +721,7 @@ export class PostHog {
     }
 
     _dom_loaded(): void {
-        if (!this.has_opted_out_capturing()) {
+        if (this.is_capturing()) {
             eachArray(this.__request_queue, (item) => this._send_retriable_request(item))
         }
 
@@ -909,7 +914,7 @@ export class PostHog {
             return
         }
 
-        if (this.consent.isOptedOut()) {
+        if (!this.is_capturing()) {
             return
         }
 
@@ -1069,7 +1074,10 @@ export class PostHog {
         properties['token'] = this.config.token
         properties['$config_defaults'] = this.config.defaults
 
-        if (this.config.__preview_experimental_cookieless_mode) {
+        if (
+            this.config.cookieless_mode == 'always' ||
+            (this.config.cookieless_mode == 'on_reject' && this.consent.isExplicitlyOptedOut())
+        ) {
             // Set a flag to tell the plugin server to use cookieless server hash mode
             properties[COOKIELESS_MODE_FLAG_PROPERTY] = true
         }
@@ -1933,7 +1941,7 @@ export class PostHog {
         this.persistence?.set_property(USER_STATE, 'anonymous')
         this.sessionManager?.resetSessionId()
         this._cachedPersonProperties = null
-        if (this.config.__preview_experimental_cookieless_mode) {
+        if (this.config.cookieless_mode === 'always') {
             this.register_once(
                 {
                     distinct_id: COOKIELESS_SENTINEL_VALUE,
@@ -2330,8 +2338,12 @@ export class PostHog {
     }
 
     private _is_persistence_disabled(): boolean {
+        if (this.config.cookieless_mode === 'always') {
+            return true
+        }
         const isOptedOut = this.consent.isOptedOut()
-        const defaultPersistenceDisabled = this.config.opt_out_persistence_by_default
+        const defaultPersistenceDisabled =
+            this.config.opt_out_persistence_by_default || this.config.cookieless_mode === 'on_reject'
 
         // TRICKY: We want a deterministic state for persistence so that a new pageload has the same persistence
         return this.config.disable_persistence || (isOptedOut && !!defaultPersistenceDisabled)
@@ -2389,6 +2401,11 @@ export class PostHog {
         captureEventName?: EventName | null | false /** event name to be used for capturing the opt-in action */
         captureProperties?: Properties /** set of properties to be captured along with the opt-in action */
     }): void {
+        if (this.config.cookieless_mode === 'always') {
+            logger.warn('Consent opt in/out is not valid with cookieless_mode="always" and will be ignored')
+            return
+        }
+
         this.consent.optInOut(true)
         this._sync_opt_out_with_persistence()
 
@@ -2418,8 +2435,23 @@ export class PostHog {
      * @public
      */
     opt_out_capturing(): void {
+        if (this.config.cookieless_mode === 'always') {
+            logger.warn('Consent opt in/out is not valid with cookieless_mode="always" and will be ignored')
+            return
+        }
+
         this.consent.optInOut(false)
         this._sync_opt_out_with_persistence()
+
+        if (this.config.cookieless_mode === 'on_reject') {
+            // If cookieless_mode is 'on_reject', we start capturing events in cookieless mode
+            this.register({
+                distinct_id: COOKIELESS_SENTINEL_VALUE,
+                $device_id: null,
+            })
+            this.sessionManager = undefined
+            this._captureInitialPageview()
+        }
     }
 
     /**
@@ -2462,6 +2494,14 @@ export class PostHog {
      */
     has_opted_out_capturing(): boolean {
         return this.consent.isOptedOut()
+    }
+
+    is_capturing(): boolean {
+        if (this.config.cookieless_mode === 'on_reject') {
+            return this.consent.isExplicitlyOptedOut() || this.consent.isOptedIn()
+        } else {
+            return !this.has_opted_out_capturing()
+        }
     }
 
     /**

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -73,6 +73,7 @@ export class PostHogSurveys {
             return
         }
         if (this._instance.config.cookieless_mode) {
+            logger.info('Not loading surveys in cookieless mode.')
             return
         }
 

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -72,6 +72,9 @@ export class PostHogSurveys {
             logger.info('Disabled. Not loading surveys.')
             return
         }
+        if (this._instance.config.cookieless_mode) {
+            return
+        }
 
         const phExtensions = assignableWindow?.__PosthogExtensions__
         if (!phExtensions) {

--- a/packages/browser/src/sessionid.ts
+++ b/packages/browser/src/sessionid.ts
@@ -41,8 +41,8 @@ export class SessionIdManager {
         if (!instance.persistence) {
             throw new Error('SessionIdManager requires a PostHogPersistence instance')
         }
-        if (instance.config.__preview_experimental_cookieless_mode) {
-            throw new Error('SessionIdManager cannot be used with __preview_experimental_cookieless_mode')
+        if (instance.config.cookieless_mode === 'always') {
+            throw new Error('SessionIdManager cannot be used with cookieless_mode="always"')
         }
 
         this._config = instance.config
@@ -233,10 +233,8 @@ export class SessionIdManager {
      * @param {Number} timestamp (optional) Defaults to the current time. The timestamp to be stored with the sessionId (used when determining if a new sessionId should be generated)
      */
     checkAndGetSessionAndWindowId(readOnly = false, _timestamp: number | null = null) {
-        if (this._config.__preview_experimental_cookieless_mode) {
-            throw new Error(
-                'checkAndGetSessionAndWindowId should not be called in __preview_experimental_cookieless_mode'
-            )
+        if (this._config.cookieless_mode === 'always') {
+            throw new Error('checkAndGetSessionAndWindowId should not be called with cookieless_mode="always"')
         }
         const timestamp = _timestamp || new Date().getTime()
 

--- a/packages/browser/src/storage.ts
+++ b/packages/browser/src/storage.ts
@@ -170,6 +170,9 @@ export const cookieStore: PersistentStore = {
     },
 
     _remove: function (name, cross_subdomain) {
+        if (!document?.cookie) {
+            return
+        }
         try {
             cookieStore._set(name, '', -1, cross_subdomain)
         } catch {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -575,13 +575,17 @@ export interface PostHogConfig {
      */
     opt_out_useragent_filter: boolean
 
+    /** @deprecated Use `consent_persistence_name` instead. This will be removed in a future major version. **/
+    opt_out_capturing_cookie_prefix: string | null
+
     /**
-     * Determines the prefix for the cookie used to store the information about whether users are opted out of capturing.
-     * When `null`, it falls back to the default prefix found in `consent.ts`.
+     * Determines the key for the cookie / local storage used to store the information about whether users are opted in/out of capturing.
+     * When `null`, we used a key based on your token.
      *
      * @default null
+     * @see `ConsentManager._storageKey`
      */
-    opt_out_capturing_cookie_prefix: string | null
+    consent_persistence_name: string | null
 
     /**
      * Determines if users should be opted in to site apps.
@@ -972,6 +976,16 @@ export interface PostHogConfig {
      */
     integrations?: Record<ExternalIntegrationKind, boolean>
 
+    /**
+     * Enables cookieless mode. In this mode, PostHog will not set any cookies, or use session or local storage. User
+     * identity is handled by generating a privacy-preserving hash on PostHog's servers.
+     * - 'always' - enable cookieless mode immediately on startup, use this if you do not intend to show a cookie banner
+     * - 'on_reject' - enable cookieless mode only if the user rejects cookies, use this if you want to show a cookie banner. If the user accepts cookies, cookieless mode will not be used, and PostHog will use cookies and local storage as usual.
+     *
+     * Note that you MUST enable cookieless mode in your PostHog project's settings, otherwise all your cookieless events will be ignored. We plan to remove this requirement in the future.
+     * */
+    cookieless_mode?: 'always' | 'on_reject'
+
     // ------- PREVIEW CONFIGS -------
 
     /**
@@ -986,12 +1000,6 @@ export interface PostHogConfig {
      * Enables the new RemoteConfig approach to loading config instead of /flags?v=2&config=true
      * */
     __preview_remote_config?: boolean
-
-    /**
-     * PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION
-     * Whether to send a sentinel value for distinct id, device id, and session id, which will be replaced server-side by a cookieless hash
-     * */
-    __preview_experimental_cookieless_mode?: boolean
 
     /**
      * PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION


### PR DESCRIPTION
## Problem

Cookieless mode took a bit of effort to use, this makes it much simpler.

## Changes

Split cookieless into 2 modes. Copied from a comment:

```tsx
    /**
     * Enables cookieless mode. In this mode, PostHog will not set any cookies, or use session or local storage. User
     * identity is handled by generating a privacy-preserving hash on PostHog's servers.
     * - 'always' - enable cookieless mode immediately on startup, use this if you do not intend to show a cookie banner
     * - 'on_reject' - enable cookieless mode only if the user rejects cookies, use this if you want to show a cookie banner. If the user accepts cookies, cookieless mode will not be used, and PostHog will use cookies and local storage as usual.
     *
     * Note that you MUST enable cookieless mode in your PostHog project's settings, otherwise all your cookieless events will be ignored. We plan to remove this requirement in the future.
     * */
```

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
