### PR TITLE
Add turbopack support to nextjs-config package

### DIFF
--- a/packages/nextjs-config/README.md
+++ b/packages/nextjs-config/README.md
@@ -23,6 +23,7 @@ export default withPostHogConfig(nextConfig, {
     project: "my-application", // (optional) Project name, defaults to repository name
     version: "1.0.0", // (optional) Release version, defaults to current git commit
     deleteAfterUpload: true, // (optional) Delete sourcemaps after upload, defaults to true
+    failOnError: false, // (optional) Fail on error, defaults to false
   },
 });
 ```

--- a/packages/nextjs-config/package.json
+++ b/packages/nextjs-config/package.json
@@ -23,7 +23,8 @@
     "build": "rslib build",
     "test:unit": "jest",
     "dev": "rslib build --watch",
-    "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz"
+    "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz",
+    "prepare": "pnpm build"
   },
   "exports": {
     ".": {

--- a/packages/nextjs-config/src/config.ts
+++ b/packages/nextjs-config/src/config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from 'next'
 import { SourcemapWebpackPlugin } from './webpack-plugin'
+import { processTurbopackSourcemaps } from './turbopack-handler'
 
 type NextFuncConfig = (phase: string, { defaultConfig }: { defaultConfig: NextConfig }) => NextConfig
 type NextAsyncConfig = (phase: string, { defaultConfig }: { defaultConfig: NextConfig }) => Promise<NextConfig>
@@ -15,6 +16,7 @@ export type PostHogNextConfig = {
     project?: string
     version?: string
     deleteAfterUpload?: boolean
+    failOnError?: boolean
   }
 }
 
@@ -28,36 +30,70 @@ export type PostHogNextConfigComplete = {
     project?: string
     version?: string
     deleteAfterUpload: boolean
+    failOnError: boolean
   }
 }
 
 export function withPostHogConfig(userNextConfig: UserProvidedConfig, posthogConfig: PostHogNextConfig): NextConfig {
   const posthogNextConfigComplete = resolvePostHogConfig(posthogConfig)
   return async (phase: string, { defaultConfig }: { defaultConfig: NextConfig }) => {
-    const {
-      webpack: userWebPackConfig,
-      distDir,
-      ...userConfig
-    } = await resolveUserConfig(userNextConfig, phase, defaultConfig)
-    const defaultWebpackConfig = userWebPackConfig || ((config: any) => config)
+    const resolvedUserConfig = await resolveUserConfig(userNextConfig, phase, defaultConfig)
     const sourceMapEnabled = posthogNextConfigComplete.sourcemaps.enabled
-    return {
-      ...userConfig,
-      distDir,
-      productionBrowserSourceMaps: sourceMapEnabled,
-      webpack: (config: any, options: any) => {
-        const webpackConfig = defaultWebpackConfig(config, options)
-        if (webpackConfig && options.isServer && sourceMapEnabled) {
-          webpackConfig.devtool = 'source-map'
-        }
-        if (sourceMapEnabled) {
-          webpackConfig.plugins = webpackConfig.plugins || []
-          webpackConfig.plugins.push(
-            new SourcemapWebpackPlugin(posthogNextConfigComplete, options.isServer, options.nextRuntime, distDir)
-          )
-        }
-        return webpackConfig
-      },
+
+    // Check if Turbopack is being used
+    // Turbopack can be enabled via:
+    // 1. --turbo flag in CLI (sets TURBOPACK env var)
+    // 2. experimental.turbo in config (Next.js 13+)
+    // 3. turbo: true in config (Next.js 14+)
+    const isTurbopack = isTurbopackEnabled(resolvedUserConfig)
+
+    if (isTurbopack) {
+      // For Turbopack, use Next.js build hooks to process sourcemaps after build
+      return {
+        ...resolvedUserConfig,
+        productionBrowserSourceMaps: sourceMapEnabled,
+        ...(sourceMapEnabled && process.env.NODE_ENV === 'production'
+          ? {
+              runAfterProductionCompile: async () => {
+                // Call user's hook first if it exists
+                if (resolvedUserConfig.runAfterProductionCompile) {
+                  await resolvedUserConfig.runAfterProductionCompile()
+                }
+                // Then process sourcemaps
+                await processTurbopackSourcemaps(posthogNextConfigComplete, resolvedUserConfig.distDir)
+              },
+            }
+          : {}),
+      }
+    } else {
+      // For Webpack, add our plugin to the webpack config
+      const { webpack: userWebpackConfig, ...configWithoutWebpack } = resolvedUserConfig
+
+      return {
+        ...configWithoutWebpack,
+        productionBrowserSourceMaps: sourceMapEnabled,
+        webpack: (config: any, options: any) => {
+          // Call user's webpack config if they have one, otherwise just pass through
+          const webpackConfig = userWebpackConfig ? userWebpackConfig(config, options) : config
+
+          if (sourceMapEnabled) {
+            if (webpackConfig && options.isServer) {
+              webpackConfig.devtool = 'source-map'
+            }
+            webpackConfig.plugins = webpackConfig.plugins || []
+            webpackConfig.plugins.push(
+              new SourcemapWebpackPlugin(
+                posthogNextConfigComplete,
+                options.isServer,
+                options.nextRuntime,
+                resolvedUserConfig.distDir
+              )
+            )
+          }
+
+          return webpackConfig
+        },
+      }
     }
   }
 }
@@ -83,6 +119,15 @@ function resolveUserConfig(
 
 function resolvePostHogConfig(posthogProvidedConfig: PostHogNextConfig): PostHogNextConfigComplete {
   const { personalApiKey, envId, host, verbose, sourcemaps = {} } = posthogProvidedConfig
+
+  // Validate required configuration
+  if (!personalApiKey) {
+    throw new Error('PostHog: Personal API key not provided. Please set personalApiKey in your PostHog config.')
+  }
+  if (!envId) {
+    throw new Error('PostHog: Environment ID not provided. Please set envId in your PostHog config.')
+  }
+
   return {
     personalApiKey,
     envId,
@@ -93,6 +138,19 @@ function resolvePostHogConfig(posthogProvidedConfig: PostHogNextConfig): PostHog
       project: sourcemaps.project,
       version: sourcemaps.version,
       deleteAfterUpload: sourcemaps.deleteAfterUpload ?? true,
+      failOnError: sourcemaps.failOnError ?? false,
     },
   }
+}
+
+// Helper to detect if Turbopack is enabled
+function isTurbopackEnabled(resolvedUserConfig: NextConfig): boolean {
+  return (
+    // CLI flag (--turbo/--turbopack) injects TURBOPACK=1 at runtime
+    process.env.TURBOPACK === '1' ||
+    // Next.js 13+ experimental config: { experimental: { turbo: true } }
+    (resolvedUserConfig.experimental as any)?.turbo ||
+    // Next.js 14+ stable config: { turbo: true }
+    (resolvedUserConfig as any).turbo === true
+  )
 }

--- a/packages/nextjs-config/src/sourcemap-processor.ts
+++ b/packages/nextjs-config/src/sourcemap-processor.ts
@@ -1,0 +1,72 @@
+import { PostHogNextConfigComplete } from './config'
+import { callPosthogCli } from './utils'
+
+/**
+ * Process sourcemaps in a directory by injecting and uploading them
+ */
+export async function processSourcemaps(
+  directory: string,
+  posthogOptions: PostHogNextConfigComplete,
+  isServer: boolean
+): Promise<void> {
+  try {
+    // Run inject
+    await runInject(directory, posthogOptions)
+
+    // Run upload
+    await runUpload(directory, posthogOptions, isServer)
+
+    if (posthogOptions.verbose) {
+      console.log(`PostHog: Successfully processed sourcemaps in ${directory}`)
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    console.error(`Error processing PostHog sourcemaps in ${directory}:`, errorMessage)
+    if (posthogOptions.sourcemaps.failOnError) {
+      throw error
+    }
+    // Continue silently if failOnError is false
+  }
+}
+
+async function runInject(directory: string, posthogOptions: PostHogNextConfigComplete): Promise<void> {
+  const cliOptions = ['sourcemap', 'inject', '--directory', directory]
+  await callPosthogCli(cliOptions, process.env, posthogOptions.verbose)
+}
+
+async function runUpload(
+  directory: string,
+  posthogOptions: PostHogNextConfigComplete,
+  isServer: boolean
+): Promise<void> {
+  const cliOptions = []
+
+  if (posthogOptions.host) {
+    cliOptions.push('--host', posthogOptions.host)
+  }
+
+  cliOptions.push('sourcemap', 'upload')
+  cliOptions.push('--directory', directory)
+
+  if (posthogOptions.sourcemaps.project) {
+    cliOptions.push('--project', posthogOptions.sourcemaps.project)
+  }
+
+  if (posthogOptions.sourcemaps.version) {
+    cliOptions.push('--version', posthogOptions.sourcemaps.version)
+  }
+
+  // Only delete sourcemaps after upload for client builds. Server sourcemaps are retained to avoid unintended data loss or for debugging purposes.
+  if (posthogOptions.sourcemaps.deleteAfterUpload && !isServer) {
+    cliOptions.push('--delete-after')
+  }
+
+  // Add env variables
+  const envVars = {
+    ...process.env,
+    POSTHOG_CLI_TOKEN: posthogOptions.personalApiKey,
+    POSTHOG_CLI_ENV_ID: posthogOptions.envId,
+  }
+
+  await callPosthogCli(cliOptions, envVars, posthogOptions.verbose)
+}

--- a/packages/nextjs-config/src/turbopack-handler.ts
+++ b/packages/nextjs-config/src/turbopack-handler.ts
@@ -1,0 +1,35 @@
+import { PostHogNextConfigComplete } from './config'
+import * as path from 'path'
+import * as fs from 'fs'
+import { processSourcemaps } from './sourcemap-processor'
+
+/**
+ * Process sourcemaps for Turbopack builds
+ * This is called by the runAfterProductionCompile hook
+ */
+export async function processTurbopackSourcemaps(
+  posthogOptions: PostHogNextConfigComplete,
+  distDir?: string
+): Promise<void> {
+  const resolvedDistDir = path.resolve(distDir ?? '.next')
+
+  // Process both server and client sourcemaps
+  const serverDir = path.join(resolvedDistDir, 'server')
+  const clientDir = path.join(resolvedDistDir, 'static/chunks')
+
+  // Check if directories exist
+  const serverExists = fs.existsSync(serverDir)
+  const clientExists = fs.existsSync(clientDir)
+
+  if (serverExists) {
+    await processSourcemaps(serverDir, posthogOptions, true)
+  }
+
+  if (clientExists) {
+    await processSourcemaps(clientDir, posthogOptions, false)
+  }
+
+  if (!serverExists && !clientExists && posthogOptions.verbose) {
+    console.log('PostHog: No build directories found, skipping sourcemap processing')
+  }
+}

--- a/packages/nextjs-config/src/webpack-plugin.ts
+++ b/packages/nextjs-config/src/webpack-plugin.ts
@@ -1,6 +1,6 @@
 import { PostHogNextConfigComplete } from './config'
-import path from 'path'
-import { callPosthogCli } from './utils'
+import * as path from 'path'
+import { processSourcemaps } from './sourcemap-processor'
 
 type NextRuntime = 'edge' | 'nodejs' | undefined
 
@@ -14,16 +14,6 @@ export class SourcemapWebpackPlugin {
     distDir?: string
   ) {
     const resolvedDistDir = path.resolve(distDir ?? '.next')
-    if (!this.posthogOptions.personalApiKey) {
-      throw new Error(
-        `Personal API key not provided. If you are using turbo, make sure to add env variables to your turbo config`
-      )
-    }
-    if (!this.posthogOptions.envId) {
-      throw new Error(
-        `Environment ID not provided. If you are using turbo, make sure to add env variables to your turbo config`
-      )
-    }
     this.directory = this.isServer ? path.join(resolvedDistDir, 'server') : path.join(resolvedDistDir, 'static/chunks')
   }
 
@@ -36,13 +26,7 @@ export class SourcemapWebpackPlugin {
 
     const onDone = async (_: any, callback: any): Promise<void> => {
       callback = callback || (() => {})
-      try {
-        await this.runInject()
-        await this.runUpload()
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : error
-        return console.error('Error running PostHog sourcemap plugin:', errorMessage)
-      }
+      await this.processSourcemaps()
       return callback()
     }
 
@@ -53,34 +37,7 @@ export class SourcemapWebpackPlugin {
     }
   }
 
-  async runInject(): Promise<void> {
-    const cliOptions = []
-    cliOptions.push('sourcemap', 'inject', '--directory', this.directory)
-    await callPosthogCli(cliOptions, process.env, this.posthogOptions.verbose)
-  }
-
-  async runUpload(): Promise<void> {
-    const cliOptions = []
-    if (this.posthogOptions.host) {
-      cliOptions.push('--host', this.posthogOptions.host)
-    }
-    cliOptions.push('sourcemap', 'upload')
-    cliOptions.push('--directory', this.directory)
-    if (this.posthogOptions.sourcemaps.project) {
-      cliOptions.push('--project', this.posthogOptions.sourcemaps.project)
-    }
-    if (this.posthogOptions.sourcemaps.version) {
-      cliOptions.push('--version', this.posthogOptions.sourcemaps.version)
-    }
-    if (this.posthogOptions.sourcemaps.deleteAfterUpload && !this.isServer) {
-      cliOptions.push('--delete-after')
-    }
-    // Add env variables
-    const envVars = {
-      ...process.env,
-      POSTHOG_CLI_TOKEN: this.posthogOptions.personalApiKey,
-      POSTHOG_CLI_ENV_ID: this.posthogOptions.envId,
-    }
-    await callPosthogCli(cliOptions, envVars, this.posthogOptions.verbose)
+  async processSourcemaps(): Promise<void> {
+    await processSourcemaps(this.directory, this.posthogOptions, this.isServer)
   }
 }


### PR DESCRIPTION
## Problem

Turbopack is the successor to webpack, and `@posthog/nextjs-config` does not yet have support for it. 

## Changes

This PR adds turbopack support to the nextjs-config package. It uses the relatively new `runAfterProductionCompile` nextjs hook,  so we should ensure the correct version of nextjs. Does posthog-js have a standardised approach?

It also adds a `failOnError` parameter to fail a build if source maps are not uploaded.

The code is partially AI generated using Claude Code, but has been reviewed both manually and by CodeRabbit.

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [X] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [X] Accounted for the impact of any changes across different platforms
- [X] Accounted for backwards compatibility of any changes (no breaking changes!)
- [X] Took care not to unnecessarily increase the bundle size