### PR TITLE
fix: send custom event to replay on trigger matched

### DIFF
--- a/packages/browser/src/extensions/replay/sessionrecording.ts
+++ b/packages/browser/src/extensions/replay/sessionrecording.ts
@@ -1369,7 +1369,10 @@ export class SessionRecording {
             $session_recording_start_reason: startReason,
         })
         logger.info(startReason.replace('_', ' '), tagPayload)
-        if (!includes(['recording_initialized', 'session_id_changed'], startReason)) {
+        if (
+            !includes(['recording_initialized', 'session_id_changed'], startReason) ||
+            startReason.includes('trigger_matched')
+        ) {
             this._tryAddCustomEvent(startReason, tagPayload)
         }
     }


### PR DESCRIPTION
it's hard to show a user that a session is waiting to start recording
when in the replayer

it means they are sometimes confused about why a recording has an event in the timeline before the recording starts

so, let's show a custom event in the timeline when a trigger matches to make this easier to see