### PR TITLE
chore: support survey flag variant

### DIFF
--- a/.changeset/huge-rocks-smell.md
+++ b/.changeset/huge-rocks-smell.md
@@ -1,0 +1,6 @@
+---
+'posthog-react-native': minor
+'posthog-js': minor
+---
+
+survey support for feature flag variants

--- a/packages/browser/src/__tests__/posthog-surveys.test.ts
+++ b/packages/browser/src/__tests__/posthog-surveys.test.ts
@@ -228,6 +228,16 @@ describe('posthog-surveys', () => {
                 survey.conditions.linkedFlagVariant = undefined
             })
 
+            it('can render survey if linkedFlagVariant is any', () => {
+                flagsResponse.featureFlags[survey.targeting_flag_key] = true
+                flagsResponse.featureFlags[survey.internal_targeting_flag_key] = true
+                flagsResponse.featureFlags[survey.linked_flag_key] = 'variant'
+                survey.conditions.linkedFlagVariant = 'any'
+                const result = surveys['_checkSurveyEligibility'](survey.id)
+                expect(result.eligible).toBeTruthy()
+                survey.conditions.linkedFlagVariant = undefined
+            })
+
             it('can render if survey can activate repeatedly', () => {
                 flagsResponse.featureFlags[survey.targeting_flag_key] = true
                 flagsResponse.featureFlags[survey.linked_flag_key] = true

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -386,7 +386,7 @@ export class SurveyManager {
         )
     }
 
-    private _isSurveyFeatureFlagEnabled(flagKey: string | null, flagVariant: string | null = null) {
+    private _isSurveyFeatureFlagEnabled(flagKey: string | null, flagVariant: string | undefined = undefined) {
         if (!flagKey) {
             return true
         }

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -395,8 +395,8 @@ export class SurveyManager {
         })
         let flagVariantCheck = true
         if (flagVariant) {
-            flagVariantCheck =
-                this._posthog.featureFlags.getFeatureFlag(flagKey, { send_event: false }) === (flagVariant || 'any')
+            const flagVariantValue = this._posthog.featureFlags.getFeatureFlag(flagKey, { send_event: false })
+            flagVariantCheck = flagVariantValue === flagVariant || flagVariant === 'any'
         }
         return isFeatureEnabled && flagVariantCheck
     }

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -431,9 +431,14 @@ export class SurveyManager {
             return eligibility
         }
 
-        if (!this._isSurveyFeatureFlagEnabled(survey.linked_flag_key, survey.conditions?.linkedFlagVariant)) {
+        const linkedFlagVariant = survey.conditions?.linkedFlagVariant
+        if (!this._isSurveyFeatureFlagEnabled(survey.linked_flag_key, linkedFlagVariant)) {
             eligibility.eligible = false
-            eligibility.reason = `Survey linked feature flag is not enabled`
+            if (!linkedFlagVariant) {
+                eligibility.reason = `Survey linked feature flag is not enabled`
+            } else {
+                eligibility.reason = `Survey linked feature flag is not enabled for variant ${linkedFlagVariant}`
+            }
             return eligibility
         }
 

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -206,14 +206,14 @@ export interface Survey {
         } | null
         deviceTypes?: string[]
         deviceTypesMatchType?: PropertyMatchType
-        linkedFlagVariant: string | null
+        linkedFlagVariant?: string
     } | null
     start_date: string | null
     end_date: string | null
     current_iteration: number | null
     current_iteration_start_date: string | null
     schedule?: SurveySchedule | null
-    enable_partial_responses: boolean | null
+    enable_partial_responses?: boolean | null
 }
 
 export type SurveyWithTypeAndAppearance = Pick<Survey, 'id' | 'type' | 'appearance'>

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -182,8 +182,11 @@ export interface Survey {
               value?: string
           }[]
         | null
+    // the linked flag key is the flag key that is used to link the survey to a flag
     linked_flag_key: string | null
     targeting_flag_key: string | null
+    // the internal targeting flag key is the flag key that is used to target users who have seen the survey
+    // eg survey-targeting-<survey-id>
     internal_targeting_flag_key: string | null
     questions: SurveyQuestion[]
     appearance: SurveyAppearance | null
@@ -203,13 +206,14 @@ export interface Survey {
         } | null
         deviceTypes?: string[]
         deviceTypesMatchType?: PropertyMatchType
+        linkedFlagVariant: string | null
     } | null
     start_date: string | null
     end_date: string | null
     current_iteration: number | null
     current_iteration_start_date: string | null
     schedule?: SurveySchedule | null
-    enable_partial_responses?: boolean | null
+    enable_partial_responses: boolean | null
 }
 
 export type SurveyWithTypeAndAppearance = Pick<Survey, 'id' | 'type' | 'appearance'>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -473,7 +473,7 @@ export type Survey = {
     }
     deviceTypes?: string[]
     deviceTypesMatchType?: SurveyMatchType
-    linkedFlagVariant?: string | null
+    linkedFlagVariant: string | null
   }
   start_date?: string
   end_date?: string

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -473,6 +473,7 @@ export type Survey = {
     }
     deviceTypes?: string[]
     deviceTypesMatchType?: SurveyMatchType
+    linkedFlagVariant?: string | null
   }
   start_date?: string
   end_date?: string

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -473,7 +473,7 @@ export type Survey = {
     }
     deviceTypes?: string[]
     deviceTypesMatchType?: SurveyMatchType
-    linkedFlagVariant: string | null
+    linkedFlagVariant?: string
   }
   start_date?: string
   end_date?: string

--- a/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
+++ b/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
@@ -97,13 +97,13 @@ export function getActiveMatchingSurveys(
       return true
     }
 
-    const linkedFlagCheck = survey.linked_flag_key ? flags[survey.linked_flag_key] === true : true
+    const linkedFlagCheck = survey.linked_flag_key ? !!flags[survey.linked_flag_key] === true : true
 
     const linkedFlagVariant = survey.conditions?.linkedFlagVariant
     let linkedFlagVariantCheck = true
     if (linkedFlagVariant) {
       linkedFlagVariantCheck = survey.linked_flag_key
-        ? flags[survey.linked_flag_key] === (linkedFlagVariant || 'any')
+        ? flags[survey.linked_flag_key] === linkedFlagVariant || linkedFlagVariant === 'any'
         : true
     }
 

--- a/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
+++ b/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
@@ -107,17 +107,17 @@ export function getActiveMatchingSurveys(
         : true
     }
 
-    const targetingFlagCheck = survey.targeting_flag_key ? flags[survey.targeting_flag_key] === true : true
+    const targetingFlagCheck = survey.targeting_flag_key ? !!flags[survey.targeting_flag_key] === true : true
 
     const eventBasedTargetingFlagCheck = hasEvents(survey) ? activatedSurveys.has(survey.id) : true
 
     const internalTargetingFlagCheck =
       survey.internal_targeting_flag_key && !canActivateRepeatedly(survey)
-        ? flags[survey.internal_targeting_flag_key] === true
+        ? !!flags[survey.internal_targeting_flag_key] === true
         : true
     const flagsCheck = survey.feature_flag_keys?.length
       ? survey.feature_flag_keys.every(({ key, value }: { key: string; value?: string }) => {
-          return !key || !value || flags[value] === true
+          return !key || !value || !!flags[value] === true
         })
       : true
 

--- a/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
+++ b/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
@@ -102,7 +102,9 @@ export function getActiveMatchingSurveys(
     const linkedFlagVariant = survey.conditions?.linkedFlagVariant
     let linkedFlagVariantCheck = true
     if (linkedFlagVariant) {
-      linkedFlagVariantCheck = flags[survey.linked_flag_key] === (linkedFlagVariant || 'any')
+      linkedFlagVariantCheck = survey.linked_flag_key
+        ? flags[survey.linked_flag_key] === (linkedFlagVariant || 'any')
+        : true
     }
 
     const targetingFlagCheck = survey.targeting_flag_key ? flags[survey.targeting_flag_key] === true : true

--- a/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
+++ b/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
@@ -98,6 +98,13 @@ export function getActiveMatchingSurveys(
     }
 
     const linkedFlagCheck = survey.linked_flag_key ? flags[survey.linked_flag_key] === true : true
+
+    const linkedFlagVariant = survey.conditions?.linkedFlagVariant
+    let linkedFlagVariantCheck = true
+    if (linkedFlagVariant) {
+      linkedFlagVariantCheck = flags[survey.linked_flag_key] === (linkedFlagVariant || 'any')
+    }
+
     const targetingFlagCheck = survey.targeting_flag_key ? flags[survey.targeting_flag_key] === true : true
 
     const eventBasedTargetingFlagCheck = hasEvents(survey) ? activatedSurveys.has(survey.id) : true
@@ -113,7 +120,12 @@ export function getActiveMatchingSurveys(
       : true
 
     return (
-      linkedFlagCheck && targetingFlagCheck && internalTargetingFlagCheck && eventBasedTargetingFlagCheck && flagsCheck
+      linkedFlagCheck &&
+      linkedFlagVariantCheck &&
+      targetingFlagCheck &&
+      internalTargetingFlagCheck &&
+      eventBasedTargetingFlagCheck &&
+      flagsCheck
     )
   })
 }

--- a/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
+++ b/packages/react-native/src/surveys/getActiveMatchingSurveys.ts
@@ -2,6 +2,8 @@ import { canActivateRepeatedly, hasEvents } from './surveys-utils'
 import { currentDeviceType } from '../native-deps'
 import { FeatureFlagValue, Survey, SurveyMatchType } from '@posthog/core'
 
+const ANY_FLAG_VARIANT = 'any'
+
 const isMatchingRegex = function (value: string, pattern: string): boolean {
   if (!isValidRegex(pattern)) {
     return false
@@ -53,6 +55,10 @@ function doesSurveyDeviceTypesMatch(survey: Survey): boolean {
   )
 }
 
+function isSurveyFlagEnabled(flagKey: string | undefined, flags: Record<string, FeatureFlagValue>): boolean {
+  return flagKey ? !!flags[flagKey] === true : true
+}
+
 export function getActiveMatchingSurveys(
   surveys: Survey[],
   flags: Record<string, FeatureFlagValue>,
@@ -97,27 +103,27 @@ export function getActiveMatchingSurveys(
       return true
     }
 
-    const linkedFlagCheck = survey.linked_flag_key ? !!flags[survey.linked_flag_key] === true : true
+    const linkedFlagCheck = isSurveyFlagEnabled(survey.linked_flag_key, flags)
 
     const linkedFlagVariant = survey.conditions?.linkedFlagVariant
     let linkedFlagVariantCheck = true
     if (linkedFlagVariant) {
       linkedFlagVariantCheck = survey.linked_flag_key
-        ? flags[survey.linked_flag_key] === linkedFlagVariant || linkedFlagVariant === 'any'
+        ? flags[survey.linked_flag_key] === linkedFlagVariant || linkedFlagVariant === ANY_FLAG_VARIANT
         : true
     }
 
-    const targetingFlagCheck = survey.targeting_flag_key ? !!flags[survey.targeting_flag_key] === true : true
+    const targetingFlagCheck = isSurveyFlagEnabled(survey.targeting_flag_key, flags)
 
     const eventBasedTargetingFlagCheck = hasEvents(survey) ? activatedSurveys.has(survey.id) : true
 
     const internalTargetingFlagCheck =
       survey.internal_targeting_flag_key && !canActivateRepeatedly(survey)
-        ? !!flags[survey.internal_targeting_flag_key] === true
+        ? isSurveyFlagEnabled(survey.internal_targeting_flag_key, flags)
         : true
     const flagsCheck = survey.feature_flag_keys?.length
       ? survey.feature_flag_keys.every(({ key, value }: { key: string; value?: string }) => {
-          return !key || !value || !!flags[value] === true
+          return !key || !value || isSurveyFlagEnabled(value, flags)
         })
       : true
 

--- a/packages/react-native/test/getActiveMatchingSurveys.spec.ts
+++ b/packages/react-native/test/getActiveMatchingSurveys.spec.ts
@@ -1,0 +1,729 @@
+import { getActiveMatchingSurveys } from '../src/surveys/getActiveMatchingSurveys'
+import { Survey, SurveyMatchType, SurveyType } from '@posthog/core'
+import { FeatureFlagValue } from '@posthog/core'
+
+// Mock the native-deps module
+jest.mock('../src/native-deps', () => ({
+  currentDeviceType: 'Mobile',
+}))
+
+describe('getActiveMatchingSurveys', () => {
+  const mockFlags: Record<string, FeatureFlagValue> = {
+    'test-flag': true,
+    'test-flag-false': false,
+    'variant-flag': 'variant-a',
+    'targeting-flag': true,
+    'internal-flag': true,
+    'variant-flag-true': true,
+  }
+
+  const mockSeenSurveys: string[] = ['seen-survey-1', 'seen-survey-2']
+  const mockActivatedSurveys = new Set<string>(['activated-survey-1'])
+
+  const createMockSurvey = (overrides: Partial<Survey> = {}): Survey => ({
+    id: 'test-survey',
+    name: 'Test Survey',
+    description: 'Test Description',
+    type: SurveyType.Popover,
+    questions: [],
+    start_date: '2023-01-01T00:00:00Z',
+    end_date: undefined,
+    ...overrides,
+  })
+
+  describe('Basic filtering', () => {
+    it('should return surveys that are active (have start_date and no end_date)', () => {
+      const surveys = [
+        createMockSurvey({ id: 'active-1', start_date: '2023-01-01T00:00:00Z', end_date: undefined }),
+        createMockSurvey({ id: 'active-2', start_date: '2023-01-01T00:00:00Z', end_date: undefined }),
+        createMockSurvey({ id: 'inactive-1', start_date: undefined, end_date: undefined }),
+        createMockSurvey({ id: 'inactive-2', start_date: '2023-01-01T00:00:00Z', end_date: '2023-12-31T23:59:59Z' }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(2)
+      expect(result.map((s) => s.id)).toEqual(['active-1', 'active-2'])
+    })
+
+    it('should return surveys with no targeting conditions (targeting all users)', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'all-users-survey',
+          linked_flag_key: undefined,
+          targeting_flag_key: undefined,
+          internal_targeting_flag_key: undefined,
+          feature_flag_keys: [],
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('all-users-survey')
+    })
+  })
+
+  describe('Device type filtering', () => {
+    it('should include surveys with no device type conditions', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'no-device-conditions',
+          conditions: {},
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('no-device-conditions')
+    })
+
+    it('should include surveys that match current device type (Mobile)', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'mobile-survey',
+          conditions: {
+            deviceTypes: ['Mobile'],
+            deviceTypesMatchType: SurveyMatchType.Exact,
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('mobile-survey')
+    })
+
+    it('should exclude surveys that do not match current device type', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'desktop-survey',
+          conditions: {
+            deviceTypes: ['Desktop'],
+            deviceTypesMatchType: SurveyMatchType.Exact,
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should handle icontains match type for device types', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'mobile-icontains',
+          conditions: {
+            deviceTypes: ['Mobile', 'Tablet'],
+            deviceTypesMatchType: SurveyMatchType.Icontains,
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('mobile-icontains')
+    })
+
+    it('should handle not_icontains match type for device types', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'not-desktop',
+          conditions: {
+            deviceTypes: ['Desktop'],
+            deviceTypesMatchType: SurveyMatchType.NotIcontains,
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('not-desktop')
+    })
+
+    it('should handle not_icontains match type when device type is in the list', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'not-mobile',
+          conditions: {
+            deviceTypes: ['Mobile'],
+            deviceTypesMatchType: SurveyMatchType.NotIcontains,
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('Seen surveys filtering', () => {
+    it('should exclude surveys that have been seen and cannot be activated repeatedly', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'seen-survey-1',
+          conditions: {
+            events: {
+              values: [],
+              repeatedActivation: false,
+            },
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should include surveys that have been seen but can be activated repeatedly', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'seen-survey-1',
+          conditions: {
+            events: {
+              values: [{ name: 'test-event' }],
+              repeatedActivation: true,
+            },
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('seen-survey-1')
+    })
+
+    it('should include surveys that have not been seen', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'new-survey',
+          conditions: {
+            events: {
+              values: [],
+              repeatedActivation: false,
+            },
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('new-survey')
+    })
+  })
+
+  describe('Linked flag filtering', () => {
+    it('should include surveys when linked flag is true', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'linked-flag-true',
+          linked_flag_key: 'test-flag',
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('linked-flag-true')
+    })
+
+    it('should exclude surveys when linked flag is false', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'linked-flag-false',
+          linked_flag_key: 'test-flag-false',
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should include surveys when linked flag is not set', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'no-linked-flag',
+          linked_flag_key: undefined,
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('no-linked-flag')
+    })
+  })
+
+  describe('Linked flag variant filtering', () => {
+    it('should include surveys when linked flag variant matches', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'variant-match',
+          linked_flag_key: 'variant-flag-true',
+          conditions: {
+            linkedFlagVariant: 'any',
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('variant-match')
+    })
+
+    it('should include surveys when linked flag variant matches string value', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'variant-match-string',
+          linked_flag_key: 'variant-flag',
+          conditions: {
+            linkedFlagVariant: 'variant-a',
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('variant-match-string')
+    })
+
+    it('should exclude surveys when linked flag variant does not match', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'variant-no-match',
+          linked_flag_key: 'variant-flag',
+          conditions: {
+            linkedFlagVariant: 'variant-b',
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should include surveys when linked flag variant is "any"', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'variant-any',
+          linked_flag_key: 'variant-flag-true',
+          conditions: {
+            linkedFlagVariant: 'any',
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('variant-any')
+    })
+
+    it('should include surveys when no linked flag is set but variant is specified', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'no-flag-with-variant',
+          linked_flag_key: undefined,
+          conditions: {
+            linkedFlagVariant: 'variant-a',
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('no-flag-with-variant')
+    })
+  })
+
+  describe('Targeting flag filtering', () => {
+    it('should include surveys when targeting flag is true', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'targeting-flag-true',
+          targeting_flag_key: 'targeting-flag',
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('targeting-flag-true')
+    })
+
+    it('should exclude surveys when targeting flag is false', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'targeting-flag-false',
+          targeting_flag_key: 'test-flag-false',
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should include surveys when targeting flag is not set', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'no-targeting-flag',
+          targeting_flag_key: undefined,
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('no-targeting-flag')
+    })
+  })
+
+  describe('Event-based targeting filtering', () => {
+    it('should include surveys with events when they are in activated surveys', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'activated-survey-1',
+          conditions: {
+            events: {
+              values: [{ name: 'test-event' }],
+            },
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('activated-survey-1')
+    })
+
+    it('should include surveys with events when they are in activated surveys', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'activated-survey-1',
+          conditions: {
+            events: {
+              values: [{ name: 'test-event' }],
+            },
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('activated-survey-1')
+    })
+
+    it('should include surveys without events regardless of activated surveys', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'no-events-survey',
+          conditions: {
+            events: {
+              values: [],
+            },
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('no-events-survey')
+    })
+  })
+
+  describe('Internal targeting flag filtering', () => {
+    it('should include surveys when internal targeting flag is true and cannot be activated repeatedly', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'internal-flag-true',
+          internal_targeting_flag_key: 'internal-flag',
+          conditions: {
+            events: {
+              values: [],
+              repeatedActivation: false,
+            },
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('internal-flag-true')
+    })
+
+    it('should exclude surveys when internal targeting flag is false and cannot be activated repeatedly', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'internal-flag-false',
+          internal_targeting_flag_key: 'test-flag-false',
+          conditions: {
+            events: {
+              values: [],
+              repeatedActivation: false,
+            },
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should include surveys when internal targeting flag is not set and cannot be activated repeatedly', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'no-internal-flag',
+          internal_targeting_flag_key: undefined,
+          conditions: {
+            events: {
+              values: [],
+              repeatedActivation: false,
+            },
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('no-internal-flag')
+    })
+  })
+
+  describe('Feature flag keys filtering', () => {
+    it('should include surveys when all feature flags are true', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'all-flags-true',
+          feature_flag_keys: [
+            { key: 'flag1', value: 'test-flag' },
+            { key: 'flag2', value: 'targeting-flag' },
+          ],
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('all-flags-true')
+    })
+
+    it('should exclude surveys when any feature flag is false', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'one-flag-false',
+          feature_flag_keys: [
+            { key: 'flag1', value: 'test-flag' },
+            { key: 'flag2', value: 'test-flag-false' },
+          ],
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should include surveys when feature flag keys are empty', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'no-feature-flags',
+          feature_flag_keys: [],
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('no-feature-flags')
+    })
+
+    it('should include surveys when feature flag keys are not set', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'no-feature-flags-undefined',
+          feature_flag_keys: undefined,
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('no-feature-flags-undefined')
+    })
+
+    it('should handle feature flags with missing key or value', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'missing-key-value',
+          feature_flag_keys: [
+            { key: '', value: 'test-flag' },
+            { key: 'flag2', value: '' },
+            { key: 'flag3', value: undefined },
+          ],
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('missing-key-value')
+    })
+  })
+
+  describe('Complex combinations', () => {
+    it('should exclude surveys that fail any condition', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'complex-fail',
+          linked_flag_key: 'test-flag',
+          targeting_flag_key: 'test-flag-false', // This will fail
+          conditions: {
+            deviceTypes: ['Mobile'],
+            deviceTypesMatchType: SurveyMatchType.Exact,
+            linkedFlagVariant: 'any',
+            events: {
+              values: [{ name: 'test-event' }],
+              repeatedActivation: true,
+            },
+          },
+          feature_flag_keys: [{ key: 'flag1', value: 'test-flag' }],
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should handle multiple surveys with different conditions', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'survey-1',
+          linked_flag_key: 'test-flag',
+          conditions: {
+            deviceTypes: ['Mobile'],
+            deviceTypesMatchType: SurveyMatchType.Exact,
+          },
+        }),
+        createMockSurvey({
+          id: 'survey-2',
+          linked_flag_key: 'test-flag-false', // Will be excluded
+          conditions: {
+            deviceTypes: ['Mobile'],
+            deviceTypesMatchType: SurveyMatchType.Exact,
+          },
+        }),
+        createMockSurvey({
+          id: 'survey-3',
+          linked_flag_key: 'test-flag',
+          conditions: {
+            deviceTypes: ['Desktop'], // Will be excluded
+            deviceTypesMatchType: SurveyMatchType.Exact,
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('survey-1')
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should handle empty surveys array', () => {
+      const result = getActiveMatchingSurveys([], mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should handle empty flags object', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'no-flags-survey',
+          linked_flag_key: undefined,
+          targeting_flag_key: undefined,
+          internal_targeting_flag_key: undefined,
+          feature_flag_keys: [],
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, {}, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('no-flags-survey')
+    })
+
+    it('should handle empty seen surveys array', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'new-survey',
+          conditions: {
+            events: {
+              values: [],
+              repeatedActivation: false,
+            },
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, [], mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('new-survey')
+    })
+
+    it('should include surveys without events even with empty activated surveys set', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'no-events-survey',
+          conditions: {
+            events: {
+              values: [],
+            },
+          },
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, new Set())
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('no-events-survey')
+    })
+
+    it('should handle surveys with null/undefined conditions', () => {
+      const surveys = [
+        createMockSurvey({
+          id: 'null-conditions',
+          conditions: null as any,
+        }),
+      ]
+
+      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('null-conditions')
+    })
+  })
+})

--- a/packages/react-native/test/getActiveMatchingSurveys.spec.ts
+++ b/packages/react-native/test/getActiveMatchingSurveys.spec.ts
@@ -265,23 +265,6 @@ describe('getActiveMatchingSurveys', () => {
   })
 
   describe('Linked flag variant filtering', () => {
-    it('should include surveys when linked flag variant matches', () => {
-      const surveys = [
-        createMockSurvey({
-          id: 'variant-match',
-          linked_flag_key: 'variant-flag-true',
-          conditions: {
-            linkedFlagVariant: 'any',
-          },
-        }),
-      ]
-
-      const result = getActiveMatchingSurveys(surveys, mockFlags, mockSeenSurveys, mockActivatedSurveys)
-
-      expect(result).toHaveLength(1)
-      expect(result[0].id).toBe('variant-match')
-    })
-
     it('should include surveys when linked flag variant matches string value', () => {
       const surveys = [
         createMockSurvey({
@@ -319,7 +302,7 @@ describe('getActiveMatchingSurveys', () => {
       const surveys = [
         createMockSurvey({
           id: 'variant-any',
-          linked_flag_key: 'variant-flag-true',
+          linked_flag_key: 'variant-flag',
           conditions: {
             linkedFlagVariant: 'any',
           },


### PR DESCRIPTION
## Problem

follow up https://github.com/PostHog/posthog/pull/36200/

## Changes

SDK checks for feature flag variants when matching a survey linked flag

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [X] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [X] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
