### PR TITLE
fix(nextjs-config): Fix TypeScript module resolution error

### DIFF
--- a/packages/nextjs-config/package.json
+++ b/packages/nextjs-config/package.json
@@ -28,7 +28,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.mts",
+        "types": "./dist/index.d.ts",
         "default": "./dist/index.mjs"
       },
       "require": {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

`@posthog/nextjs-config` fails with TypeScript due to missing `index.d.mts` file:

```
error TS7016: Could not find a declaration file for module '@posthog/nextjs-config'
```

Package.json points to non-existent file:
```json
"import": {
  "types": "./dist/index.d.mts",  // <- Doesn't exist
  "default": "./dist/index.mjs"
}
```

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

Updated `packages/nextjs-config/package.json` to point both module formats to the existing `.d.ts` file:

```diff
- "types": "./dist/index.d.mts",
+ "types": "./dist/index.d.ts",
```1

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [x] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
