### PR TITLE
refactor(flags): Unify method to compute flag value and payload

### DIFF
--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -428,20 +428,25 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
 
     const localEvaluationEnabled = this.featureFlagsPoller !== undefined
     if (localEvaluationEnabled) {
-      // Try to get match value locally if not provided
-      if (!matchValue) {
-        matchValue = await this.getFeatureFlag(key, distinctId, {
-          ...options,
-          onlyEvaluateLocally: true,
-          sendFeatureFlagEvents: false,
-        })
-      }
+      // Ensure flags are loaded before checking for the specific flag
+      await this.featureFlagsPoller?.loadFeatureFlags()
 
-      if (matchValue) {
-        response = await this.featureFlagsPoller?.computeFeatureFlagPayloadLocally(key, matchValue)
+      const flag = this.featureFlagsPoller?.featureFlagsByKey[key]
+      if (flag) {
+        const result = await this.featureFlagsPoller?.computeFlagAndPayloadLocally(
+          flag,
+          distinctId,
+          groups,
+          personProperties,
+          groupProperties,
+          matchValue
+        )
+        if (result) {
+          matchValue = result.value
+          response = result.payload
+        }
       }
     }
-    //}
 
     // set defaults
     if (onlyEvaluateLocally == undefined) {

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -456,11 +456,6 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       sendFeatureFlagEvents = true
     }
 
-    // set defaults
-    if (onlyEvaluateLocally == undefined) {
-      onlyEvaluateLocally = false
-    }
-
     const payloadWasLocallyEvaluated = response !== undefined
 
     if (!payloadWasLocallyEvaluated && !onlyEvaluateLocally) {

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -272,7 +272,7 @@ class FeatureFlagsPoller {
   private getFeatureFlagPayload(key: string, flagValue: FeatureFlagValue): JsonType | null {
     let payload: JsonType | null = null
 
-    if (flagValue !== false) {
+    if (flagValue !== false && flagValue !== null && flagValue !== undefined) {
       if (typeof flagValue == 'boolean') {
         payload = this.featureFlagsByKey?.[key]?.filters?.payloads?.[flagValue.toString()] || null
       } else if (typeof flagValue == 'string') {


### PR DESCRIPTION
This refactors both `compute*Locally` methods into a single one.

## Problem

Two separate methods for what is essentially the same operation is going to cause headaches down the line.

For example, while working on [local evaluation support for flag dependencies](https://github.com/PostHog/posthog-python/pull/288), I ended up having two code paths for dependency evaluation. First to evaluate the flag value in a dependency-aware manner. Then I had to evaluate flag payloads. This was confusing and brittle.

## Changes

* Wrote a new `computeFlagAndPayloadLocally` method that computes the flag value and payload
  - This method accepts an optional provided `matchValue` and skips flag value evaluation if provided and uses that value to get the payload.
* Update `client.ts` to use the new method.
* Removed `computeFeatureFlagPayloadLocally` and `computeFlagLocally`.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

This change doesn't need to be released right away.

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
