### PR TITLE
fix: prevent cascading local evaluation requests

### DIFF
--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -468,8 +468,6 @@ class FeatureFlagsPoller {
       this.poller = undefined
     }
 
-    this.poller = setTimeout(() => this._loadFeatureFlags(), this.getPollingInterval())
-
     try {
       const res = await this._requestFeatureFlagDefinitions()
 
@@ -556,6 +554,10 @@ class FeatureFlagsPoller {
     } catch (err) {
       if (err instanceof ClientError) {
         this.onError?.(err)
+      }
+    } finally {
+      if (!this.poller) {
+        this.poller = setTimeout(() => this._loadFeatureFlags(), this.getPollingInterval())
       }
     }
   }


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
