### PR TITLE
feat(react-native): Add ability to pass custom headers to fetch calls

### DIFF
--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -68,6 +68,13 @@ export type PostHogOptions = PostHogCoreOptions & {
    * Defaults to false
    */
   enablePersistSessionIdAcrossRestart?: boolean
+
+  /**
+   * A list of headers that should be sent with requests to the PostHog API.
+   *
+   * @default {}
+   */
+  request_headers?: { [header_name: string]: string }
 }
 
 export class PostHog extends PostHogCore {
@@ -78,6 +85,7 @@ export class PostHog extends PostHogCore {
   private _enableSessionReplay?: boolean
   private _disableSurveys: boolean
   private _disableRemoteConfig: boolean
+  private _requestHeaders: { [header_name: string]: string }
 
   constructor(apiKey: string, options?: PostHogOptions) {
     super(apiKey, options)
@@ -85,6 +93,7 @@ export class PostHog extends PostHogCore {
     this._persistence = options?.persistence ?? 'file'
     this._disableSurveys = options?.disableSurveys ?? false
     this._disableRemoteConfig = options?.disableRemoteConfig ?? false
+    this._requestHeaders = options?.request_headers ?? {}
 
     // Either build the app properties from the existing ones
     this._appProperties =
@@ -181,7 +190,14 @@ export class PostHog extends PostHogCore {
   }
 
   fetch(url: string, options: PostHogFetchOptions): Promise<PostHogFetchResponse> {
-    return fetch(url, options)
+    const updatedOptions = {
+      ...options,
+      headers: {
+        ...this._requestHeaders,
+        ...options.headers,
+      },
+    }
+    return fetch(url, updatedOptions)
   }
 
   getLibraryId(): string {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
The browser package for PostHog permits the user to pass custom headers to the requests that the package makes. The react-native package did not support this. The main reason I'm adding this here is that my reverse proxy requires an Authorization header to be sent as we are only tracking logged in users.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->
- Adds the `request_headers` to the config
- Spreads this option with other existing headers
- Adds tests for `request_headers`

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
