### PR TITLE
chore: skip test that fails frequently on firefox

### DIFF
--- a/packages/browser/playwright/mocked/session-recording/session-recording-network-recorder.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-recording-network-recorder.spec.ts
@@ -105,6 +105,11 @@ test.beforeEach(async ({ context }) => {
         })
         ;['fetch', 'xhr'].forEach((networkType) => {
             test('it captures ' + networkType, async ({ page, browserName }) => {
+                test.skip(
+                    browserName === 'firefox',
+                    'We are trying to misbehave in order to test things, but it looks like Firefox does not let us... good firefox'
+                )
+
                 await page.waitingForNetworkCausedBy({
                     urlPatternsToWaitFor: ['**/ses/*', 'https://example.com/'],
                     action: async () => {

--- a/packages/browser/playwright/mocked/tracing-headers.spec.ts
+++ b/packages/browser/playwright/mocked/tracing-headers.spec.ts
@@ -46,9 +46,11 @@ test.describe('tracing headers', () => {
         const request = fetchRequests[0]
         const headers = request.headers()
 
-        expect(headers['x-posthog-distinct-id']).toBeTruthy()
-        expect(headers['x-posthog-session-id']).toBeTruthy()
-        expect(headers['x-posthog-window-id']).toBeTruthy()
+        expect(headers).toMatchObject({
+            'x-posthog-distinct-id': expect.any(String),
+            'x-posthog-session-id': expect.any(String),
+            'x-posthog-window-id': expect.any(String),
+        })
     })
 
     // XHR test fails... needs more testing
@@ -143,7 +145,9 @@ test.describe('tracing headers', () => {
         const request = fetchRequests[0]
         const headers = request.headers()
 
-        expect(headers['x-posthog-distinct-id']).toBeTruthy()
+        expect(headers).toMatchObject({
+            'x-posthog-distinct-id': expect.any(String),
+        })
     })
 
     test('does NOT add tracing headers to unlisted domains', async ({ page, context }) => {


### PR DESCRIPTION
i think firefox is being too spec compliant here and not letting me misbehave

let's skip on firefox