### PR TITLE
fix: always set surveySeen on local storage for old posthog-js versions

### DIFF
--- a/.changeset/plain-onions-hide.md
+++ b/.changeset/plain-onions-hide.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: always set surveySeen on local storage for old posthog-js versions

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -76,7 +76,7 @@ import { getPersonPropertiesHash } from './utils/property-utils'
 import { RequestRouter, RequestRouterRegion } from './utils/request-router'
 import { SimpleEventEmitter } from './utils/simple-event-emitter'
 import { includes, isDistinctIdStringLike } from './utils/string-utils'
-import { getSurveyInteractionProperty, getSurveySeenKey } from './utils/survey-utils'
+import { getSurveyInteractionProperty, setSurveySeenOnLocalStorage } from './utils/survey-utils'
 import {
     isArray,
     isEmptyObject,
@@ -994,7 +994,7 @@ export class PostHog {
         if (event_name === SurveyEventName.DISMISSED || event_name === SurveyEventName.SENT) {
             const surveyId = properties?.[SurveyEventProperties.SURVEY_ID]
             const surveyIteration = properties?.[SurveyEventProperties.SURVEY_ITERATION]
-            localStorage.setItem(getSurveySeenKey({ id: surveyId, current_iteration: surveyIteration }), 'true')
+            setSurveySeenOnLocalStorage({ id: surveyId, current_iteration: surveyIteration })
             data.$set = {
                 ...data.$set,
                 [getSurveyInteractionProperty(

--- a/packages/browser/src/utils/survey-utils.ts
+++ b/packages/browser/src/utils/survey-utils.ts
@@ -39,6 +39,16 @@ export const getSurveySeenKey = (survey: Pick<Survey, 'id' | 'current_iteration'
     return surveySeenKey
 }
 
+export const setSurveySeenOnLocalStorage = (survey: Pick<Survey, 'id' | 'current_iteration'>) => {
+    const isSurveySeen = localStorage.getItem(getSurveySeenKey(survey))
+    // if survey is already seen, no need to set it again
+    if (isSurveySeen) {
+        return
+    }
+
+    localStorage.setItem(getSurveySeenKey(survey), 'true')
+}
+
 // These surveys are relevant for the getActiveMatchingSurveys method. They are used to
 // display surveys in our customer's application. Any new in-app survey type should be added here.
 export const IN_APP_SURVEY_TYPES = [SurveyType.Popover, SurveyType.Widget, SurveyType.API]


### PR DESCRIPTION
## Problem

[This PR](https://github.com/PostHog/posthog-js/pull/1987) introduced a change: the local storage `surveySeen` key was moved from the survey extensions to `posthog-core`.

However, this caused an issue: any versions prior to `1.249.2` got an issue where the survey was popping up repeatedly for the same user. This happened because we introduced a breaking change that now requires all customers to update their posthog-js version to remove this bug.

This happens because the extensions are always downloaded from the lastest version, so a customer on a version prior to this no longer sets the local storage. But because they might not have updated `posthog-js`, their `posthog-core` will also not set it up, causing the survey to show multiple times.

## Changes

This PR re-adds setting the local storage key to survey-extension-utils, and it still keeps the same functionality in posthog-core.

This way, even older versions will also work as expected without the need to upgrade.

It also adds a helper function to ensure we don't need to set the local storage multiple times if it's already set.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code -> all tests passing
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
