### PR TITLE
fix: codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,12 +4,12 @@ packages/browser/src/entrypoints/recorder.ts           @PostHog/team-replay
 # Surveys
 packages/browser/src/extensions/surveys/               @PostHog/team-surveys
 packages/browser/src/extensions/surveys.tsx            @PostHog/team-surveys
-packages/browser/src/extensions/surveys-widget.ts      @PostHog/team-surveys
 packages/browser/src/entrypoints/surveys.ts            @PostHog/team-surveys
 packages/browser/src/entrypoints/surveys-preview.es.ts @PostHog/team-surveys
 packages/browser/src/posthog-surveys-types.ts          @PostHog/team-surveys
 packages/browser/src/posthog-surveys.ts                @PostHog/team-surveys
 packages/browser/src/utils/survey-event-receiver.ts    @PostHog/team-surveys
+packages/browser/src/utils/survey-utils.ts             @PostHog/team-surveys
 
 # Mobile
 packages/react-native/                                 @PostHog/team-mobile


### PR DESCRIPTION
## Problem
codeowners file should be under .github folder

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
