### PR TITLE
fix: ensure event capture is awaited inside `captureImmediate`

### DIFF
--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -263,9 +263,9 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
         // Something went wrong getting the flag info - we should capture the event anyways
         return {}
       })
-      .then((additionalProperties) => {
+      .then(async (additionalProperties) => {
         // No matter what - capture the event
-        _capture({
+        await _capture({
           ...additionalProperties,
           ...(eventMessage.properties || {}),
           $groups: eventMessage.groups || groups,


### PR DESCRIPTION
Fixes posthog/posthog-js#2225

## Problem

#2225 

## Changes

`await` the `_capture` call inside `captureImmediate` method.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

