### PR TITLE
fix(llma): various bug fixes related to tools for streaming providers

### DIFF
--- a/.changeset/whole-candles-ask.md
+++ b/.changeset/whole-candles-ask.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Fixes tool calls for streaming providers

--- a/packages/ai/src/openai/azure.ts
+++ b/packages/ai/src/openai/azure.ts
@@ -5,6 +5,7 @@ import { formatResponseOpenAI, MonitoringParams, sendEventToPosthog } from '../u
 import type { APIPromise } from 'openai'
 import type { Stream } from 'openai/streaming'
 import type { ParsedResponse } from 'openai/resources/responses/responses'
+import type { FormattedMessage, FormattedContent, FormattedFunctionCall } from '../types'
 
 type ChatCompletion = OpenAIOrignal.ChatCompletion
 type ChatCompletionChunk = OpenAIOrignal.ChatCompletionChunk
@@ -97,6 +98,7 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
           const [stream1, stream2] = value.tee()
           ;(async () => {
             try {
+              const contentBlocks: FormattedContent = []
               let accumulatedContent = ''
               let usage: {
                 inputTokens?: number
@@ -108,9 +110,56 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                 outputTokens: 0,
               }
 
+              // Map to track in-progress tool calls
+              const toolCallsInProgress = new Map<number, {
+                id: string
+                name: string
+                arguments: string
+              }>()
+
               for await (const chunk of stream1) {
-                const delta = chunk?.choices?.[0]?.delta?.content ?? ''
-                accumulatedContent += delta
+                const choice = chunk?.choices?.[0]
+                
+                // Handle text content
+                const deltaContent = choice?.delta?.content
+                if (deltaContent) {
+                  accumulatedContent += deltaContent
+                }
+
+                // Handle tool calls
+                const deltaToolCalls = choice?.delta?.tool_calls
+                if (deltaToolCalls && Array.isArray(deltaToolCalls)) {
+                  for (const toolCall of deltaToolCalls) {
+                    const index = toolCall.index
+                    
+                    if (index !== undefined) {
+                      if (!toolCallsInProgress.has(index)) {
+                        // New tool call
+                        toolCallsInProgress.set(index, {
+                          id: toolCall.id || '',
+                          name: toolCall.function?.name || '',
+                          arguments: ''
+                        })
+                      }
+                      
+                      const inProgressCall = toolCallsInProgress.get(index)
+                      if (inProgressCall) {
+                        // Update tool call data
+                        if (toolCall.id) {
+                          inProgressCall.id = toolCall.id
+                        }
+                        if (toolCall.function?.name) {
+                          inProgressCall.name = toolCall.function.name
+                        }
+                        if (toolCall.function?.arguments) {
+                          inProgressCall.arguments += toolCall.function.arguments
+                        }
+                      }
+                    }
+                  }
+                }
+
+                // Handle usage information
                 if (chunk.usage) {
                   usage = {
                     inputTokens: chunk.usage.prompt_tokens ?? 0,
@@ -121,6 +170,36 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                 }
               }
 
+              // Build final content blocks
+              if (accumulatedContent) {
+                contentBlocks.push({ type: 'text', text: accumulatedContent })
+              }
+
+              // Add completed tool calls to content blocks
+              for (const toolCall of toolCallsInProgress.values()) {
+                if (toolCall.name) {
+                  contentBlocks.push({
+                    type: 'function',
+                    id: toolCall.id,
+                    function: {
+                      name: toolCall.name,
+                      arguments: toolCall.arguments
+                    }
+                  } as FormattedFunctionCall)
+                }
+              }
+
+              // Format output to match non-streaming version
+              const formattedOutput: FormattedMessage[] = contentBlocks.length > 0
+                ? [{
+                    role: 'assistant',
+                    content: contentBlocks
+                  }]
+                : [{
+                    role: 'assistant',
+                    content: [{ type: 'text', text: '' }]
+                  }]
+
               const latency = (Date.now() - startTime) / 1000
               await sendEventToPosthog({
                 client: this.phClient,
@@ -129,7 +208,7 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                 model: openAIParams.model,
                 provider: 'azure',
                 input: openAIParams.messages,
-                output: [{ content: accumulatedContent, role: 'assistant' }],
+                output: formattedOutput,
                 latency,
                 baseURL: (this as any).baseURL ?? '',
                 params: body,
@@ -137,7 +216,11 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                 usage,
                 captureImmediate: posthogCaptureImmediate,
               })
-            } catch (error: any) {
+            } catch (error: unknown) {
+              const httpStatus = error && typeof error === 'object' && 'status' in error 
+                ? (error as { status?: number }).status ?? 500 
+                : 500
+              
               await sendEventToPosthog({
                 client: this.phClient,
                 distinctId: posthogDistinctId,
@@ -149,7 +232,7 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                 latency: 0,
                 baseURL: (this as any).baseURL ?? '',
                 params: body,
-                httpStatus: error?.status ? error.status : 500,
+                httpStatus,
                 usage: { inputTokens: 0, outputTokens: 0 },
                 isError: true,
                 error: JSON.stringify(error),
@@ -191,7 +274,11 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
           }
           return result
         },
-        async (error: any) => {
+        async (error: unknown) => {
+          const httpStatus = error && typeof error === 'object' && 'status' in error 
+            ? (error as { status?: number }).status ?? 500 
+            : 500
+          
           await sendEventToPosthog({
             client: this.phClient,
             distinctId: posthogDistinctId,
@@ -203,7 +290,7 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
             latency: 0,
             baseURL: (this as any).baseURL ?? '',
             params: body,
-            httpStatus: error?.status ? error.status : 500,
+            httpStatus,
             usage: {
               inputTokens: 0,
               outputTokens: 0,
@@ -321,7 +408,11 @@ export class WrappedResponses extends AzureOpenAI.Responses {
                 usage,
                 captureImmediate: posthogCaptureImmediate,
               })
-            } catch (error: any) {
+            } catch (error: unknown) {
+              const httpStatus = error && typeof error === 'object' && 'status' in error 
+                ? (error as { status?: number }).status ?? 500 
+                : 500
+              
               await sendEventToPosthog({
                 client: this.phClient,
                 distinctId: posthogDistinctId,
@@ -334,7 +425,7 @@ export class WrappedResponses extends AzureOpenAI.Responses {
                 latency: 0,
                 baseURL: (this as any).baseURL ?? '',
                 params: body,
-                httpStatus: error?.status ? error.status : 500,
+                httpStatus,
                 usage: { inputTokens: 0, outputTokens: 0 },
                 isError: true,
                 error: JSON.stringify(error),
@@ -376,7 +467,11 @@ export class WrappedResponses extends AzureOpenAI.Responses {
           }
           return result
         },
-        async (error: any) => {
+        async (error: unknown) => {
+          const httpStatus = error && typeof error === 'object' && 'status' in error 
+            ? (error as { status?: number }).status ?? 500 
+            : 500
+          
           await sendEventToPosthog({
             client: this.phClient,
             distinctId: posthogDistinctId,
@@ -389,7 +484,7 @@ export class WrappedResponses extends AzureOpenAI.Responses {
             latency: 0,
             baseURL: (this as any).baseURL ?? '',
             params: body,
-            httpStatus: error?.status ? error.status : 500,
+            httpStatus,
             usage: {
               inputTokens: 0,
               outputTokens: 0,

--- a/packages/ai/src/openai/azure.ts
+++ b/packages/ai/src/openai/azure.ts
@@ -111,15 +111,18 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
               }
 
               // Map to track in-progress tool calls
-              const toolCallsInProgress = new Map<number, {
-                id: string
-                name: string
-                arguments: string
-              }>()
+              const toolCallsInProgress = new Map<
+                number,
+                {
+                  id: string
+                  name: string
+                  arguments: string
+                }
+              >()
 
               for await (const chunk of stream1) {
                 const choice = chunk?.choices?.[0]
-                
+
                 // Handle text content
                 const deltaContent = choice?.delta?.content
                 if (deltaContent) {
@@ -131,17 +134,17 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                 if (deltaToolCalls && Array.isArray(deltaToolCalls)) {
                   for (const toolCall of deltaToolCalls) {
                     const index = toolCall.index
-                    
+
                     if (index !== undefined) {
                       if (!toolCallsInProgress.has(index)) {
                         // New tool call
                         toolCallsInProgress.set(index, {
                           id: toolCall.id || '',
                           name: toolCall.function?.name || '',
-                          arguments: ''
+                          arguments: '',
                         })
                       }
-                      
+
                       const inProgressCall = toolCallsInProgress.get(index)
                       if (inProgressCall) {
                         // Update tool call data
@@ -183,22 +186,27 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                     id: toolCall.id,
                     function: {
                       name: toolCall.name,
-                      arguments: toolCall.arguments
-                    }
+                      arguments: toolCall.arguments,
+                    },
                   } as FormattedFunctionCall)
                 }
               }
 
               // Format output to match non-streaming version
-              const formattedOutput: FormattedMessage[] = contentBlocks.length > 0
-                ? [{
-                    role: 'assistant',
-                    content: contentBlocks
-                  }]
-                : [{
-                    role: 'assistant',
-                    content: [{ type: 'text', text: '' }]
-                  }]
+              const formattedOutput: FormattedMessage[] =
+                contentBlocks.length > 0
+                  ? [
+                      {
+                        role: 'assistant',
+                        content: contentBlocks,
+                      },
+                    ]
+                  : [
+                      {
+                        role: 'assistant',
+                        content: [{ type: 'text', text: '' }],
+                      },
+                    ]
 
               const latency = (Date.now() - startTime) / 1000
               await sendEventToPosthog({
@@ -217,10 +225,11 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
                 captureImmediate: posthogCaptureImmediate,
               })
             } catch (error: unknown) {
-              const httpStatus = error && typeof error === 'object' && 'status' in error 
-                ? (error as { status?: number }).status ?? 500 
-                : 500
-              
+              const httpStatus =
+                error && typeof error === 'object' && 'status' in error
+                  ? ((error as { status?: number }).status ?? 500)
+                  : 500
+
               await sendEventToPosthog({
                 client: this.phClient,
                 distinctId: posthogDistinctId,
@@ -275,10 +284,11 @@ export class WrappedCompletions extends AzureOpenAI.Chat.Completions {
           return result
         },
         async (error: unknown) => {
-          const httpStatus = error && typeof error === 'object' && 'status' in error 
-            ? (error as { status?: number }).status ?? 500 
-            : 500
-          
+          const httpStatus =
+            error && typeof error === 'object' && 'status' in error
+              ? ((error as { status?: number }).status ?? 500)
+              : 500
+
           await sendEventToPosthog({
             client: this.phClient,
             distinctId: posthogDistinctId,
@@ -409,10 +419,11 @@ export class WrappedResponses extends AzureOpenAI.Responses {
                 captureImmediate: posthogCaptureImmediate,
               })
             } catch (error: unknown) {
-              const httpStatus = error && typeof error === 'object' && 'status' in error 
-                ? (error as { status?: number }).status ?? 500 
-                : 500
-              
+              const httpStatus =
+                error && typeof error === 'object' && 'status' in error
+                  ? ((error as { status?: number }).status ?? 500)
+                  : 500
+
               await sendEventToPosthog({
                 client: this.phClient,
                 distinctId: posthogDistinctId,
@@ -468,10 +479,11 @@ export class WrappedResponses extends AzureOpenAI.Responses {
           return result
         },
         async (error: unknown) => {
-          const httpStatus = error && typeof error === 'object' && 'status' in error 
-            ? (error as { status?: number }).status ?? 500 
-            : 500
-          
+          const httpStatus =
+            error && typeof error === 'object' && 'status' in error
+              ? ((error as { status?: number }).status ?? 500)
+              : 500
+
           await sendEventToPosthog({
             client: this.phClient,
             distinctId: posthogDistinctId,

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -118,15 +118,18 @@ export class WrappedCompletions extends Completions {
               }
 
               // Map to track in-progress tool calls
-              const toolCallsInProgress = new Map<number, {
-                id: string
-                name: string
-                arguments: string
-              }>()
+              const toolCallsInProgress = new Map<
+                number,
+                {
+                  id: string
+                  name: string
+                  arguments: string
+                }
+              >()
 
               for await (const chunk of stream1) {
                 const choice = chunk?.choices?.[0]
-                
+
                 // Handle text content
                 const deltaContent = choice?.delta?.content
                 if (deltaContent) {
@@ -138,17 +141,17 @@ export class WrappedCompletions extends Completions {
                 if (deltaToolCalls && Array.isArray(deltaToolCalls)) {
                   for (const toolCall of deltaToolCalls) {
                     const index = toolCall.index
-                    
+
                     if (index !== undefined) {
                       if (!toolCallsInProgress.has(index)) {
                         // New tool call
                         toolCallsInProgress.set(index, {
                           id: toolCall.id || '',
                           name: toolCall.function?.name || '',
-                          arguments: ''
+                          arguments: '',
                         })
                       }
-                      
+
                       const inProgressCall = toolCallsInProgress.get(index)
                       if (inProgressCall) {
                         // Update tool call data
@@ -190,22 +193,27 @@ export class WrappedCompletions extends Completions {
                     id: toolCall.id,
                     function: {
                       name: toolCall.name,
-                      arguments: toolCall.arguments
-                    }
+                      arguments: toolCall.arguments,
+                    },
                   } as FormattedFunctionCall)
                 }
               }
 
               // Format output to match non-streaming version
-              const formattedOutput: FormattedMessage[] = contentBlocks.length > 0
-                ? [{
-                    role: 'assistant',
-                    content: contentBlocks
-                  }]
-                : [{
-                    role: 'assistant',
-                    content: [{ type: 'text', text: '' }]
-                  }]
+              const formattedOutput: FormattedMessage[] =
+                contentBlocks.length > 0
+                  ? [
+                      {
+                        role: 'assistant',
+                        content: contentBlocks,
+                      },
+                    ]
+                  : [
+                      {
+                        role: 'assistant',
+                        content: [{ type: 'text', text: '' }],
+                      },
+                    ]
 
               const latency = (Date.now() - startTime) / 1000
               const availableTools = extractAvailableToolCalls('openai', openAIParams)
@@ -226,10 +234,11 @@ export class WrappedCompletions extends Completions {
                 captureImmediate: posthogCaptureImmediate,
               })
             } catch (error: unknown) {
-              const httpStatus = error && typeof error === 'object' && 'status' in error 
-                ? (error as { status?: number }).status ?? 500 
-                : 500
-              
+              const httpStatus =
+                error && typeof error === 'object' && 'status' in error
+                  ? ((error as { status?: number }).status ?? 500)
+                  : 500
+
               await sendEventToPosthog({
                 client: this.phClient,
                 distinctId: posthogDistinctId,
@@ -286,10 +295,11 @@ export class WrappedCompletions extends Completions {
           return result
         },
         async (error: unknown) => {
-          const httpStatus = error && typeof error === 'object' && 'status' in error 
-            ? (error as { status?: number }).status ?? 500 
-            : 500
-          
+          const httpStatus =
+            error && typeof error === 'object' && 'status' in error
+              ? ((error as { status?: number }).status ?? 500)
+              : 500
+
           await sendEventToPosthog({
             client: this.phClient,
             distinctId: posthogDistinctId,
@@ -422,10 +432,11 @@ export class WrappedResponses extends Responses {
                 captureImmediate: posthogCaptureImmediate,
               })
             } catch (error: unknown) {
-              const httpStatus = error && typeof error === 'object' && 'status' in error 
-                ? (error as { status?: number }).status ?? 500 
-                : 500
-              
+              const httpStatus =
+                error && typeof error === 'object' && 'status' in error
+                  ? ((error as { status?: number }).status ?? 500)
+                  : 500
+
               await sendEventToPosthog({
                 client: this.phClient,
                 distinctId: posthogDistinctId,
@@ -483,10 +494,11 @@ export class WrappedResponses extends Responses {
           return result
         },
         async (error: unknown) => {
-          const httpStatus = error && typeof error === 'object' && 'status' in error 
-            ? (error as { status?: number }).status ?? 500 
-            : 500
-          
+          const httpStatus =
+            error && typeof error === 'object' && 'status' in error
+              ? ((error as { status?: number }).status ?? 500)
+              : 500
+
           await sendEventToPosthog({
             client: this.phClient,
             distinctId: posthogDistinctId,
@@ -570,10 +582,11 @@ export class WrappedResponses extends Responses {
           return result
         },
         async (error: unknown) => {
-          const httpStatus = error && typeof error === 'object' && 'status' in error 
-            ? (error as { status?: number }).status ?? 500 
-            : 500
-          
+          const httpStatus =
+            error && typeof error === 'object' && 'status' in error
+              ? ((error as { status?: number }).status ?? 500)
+              : 500
+
           await sendEventToPosthog({
             client: this.phClient,
             distinctId: posthogDistinctId,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -19,7 +19,7 @@ export interface FormattedFunctionCall {
   id?: string
   function: {
     name: string
-    arguments: string | Record<string, any>
+    arguments: string | Record<string, unknown>
   }
 }
 
@@ -46,7 +46,7 @@ export type FormattedContent = FormattedContentItem[]
  */
 export interface FormattedMessage {
   role: string
-  content: FormattedContent | any // Keep any for backward compatibility with raw content
+  content: FormattedContent | unknown // Use unknown for better type safety with raw content
 }
 
 /**
@@ -55,7 +55,7 @@ export interface FormattedMessage {
 export interface TokenUsage {
   inputTokens?: number
   outputTokens?: number
-  reasoningTokens?: any // Keep as any since various providers return different types
-  cacheReadInputTokens?: any // Keep as any for provider flexibility
-  cacheCreationInputTokens?: any // Keep as any for provider flexibility
+  reasoningTokens?: unknown // Use unknown since various providers return different types
+  cacheReadInputTokens?: unknown // Use unknown for provider flexibility
+  cacheCreationInputTokens?: unknown // Use unknown for provider flexibility
 }

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -296,9 +296,8 @@ export const extractAvailableToolCalls = (
 
     return null
   } else if (provider === 'vercel') {
-    // Vercel AI SDK stores tools in params.mode.tools when mode type is 'regular'
-    if (params.mode?.type === 'regular' && params.mode.tools) {
-      return params.mode.tools
+    if (params.tools) {
+      return params.tools
     }
 
     return null

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -107,12 +107,12 @@ const createMockResponse = (options: MockAnthropicResponseOptions = {}): Anthrop
     content.push(
       ...options.tools.map(
         (tool) =>
-        ({
-          type: 'tool_use',
-          id: tool.id,
-          name: tool.name,
-          input: tool.input,
-        } as AnthropicOriginal.Messages.ToolUseBlock)
+          ({
+            type: 'tool_use',
+            id: tool.id,
+            name: tool.name,
+            input: tool.input,
+          }) as AnthropicOriginal.Messages.ToolUseBlock
       )
     )
   }
@@ -149,7 +149,7 @@ const createMockStreamChunks = (options: MockAnthropicResponseOptions = {}): Moc
         input_tokens: options.usage?.input_tokens || 20,
         cache_creation_input_tokens: options.usage?.cache_creation_input_tokens || 0,
         cache_read_input_tokens: options.usage?.cache_read_input_tokens || 0,
-        output_tokens: 0
+        output_tokens: 0,
       },
     },
   })
@@ -157,7 +157,11 @@ const createMockStreamChunks = (options: MockAnthropicResponseOptions = {}): Moc
   // Add text content chunks
   if (options.content) {
     chunks.push(
-      { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } as AnthropicOriginal.Messages.TextBlock },
+      {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text', text: '' } as AnthropicOriginal.Messages.TextBlock,
+      },
       ...options.content.split(' ').map((word, i, arr) => ({
         type: 'content_block_delta' as const,
         index: 0,
@@ -320,18 +324,18 @@ describe('PostHogAnthropic', () => {
 
     // Mock the create method
     const MessagesMock = AnthropicOriginal.Messages as jest.MockedClass<typeof AnthropicOriginal.Messages>
-      ; (MessagesMock.prototype.create as jest.Mock) = jest.fn().mockImplementation((params: any) => {
-        if (params.stream) {
-          // Return a mock stream
-          const mockStream = {
-            tee: jest
-              .fn()
-              .mockReturnValue([createMockAsyncIterator(mockStreamChunks), createMockAsyncIterator(mockStreamChunks)]),
-          }
-          return Promise.resolve(mockStream)
+    ;(MessagesMock.prototype.create as jest.Mock) = jest.fn().mockImplementation((params: any) => {
+      if (params.stream) {
+        // Return a mock stream
+        const mockStream = {
+          tee: jest
+            .fn()
+            .mockReturnValue([createMockAsyncIterator(mockStreamChunks), createMockAsyncIterator(mockStreamChunks)]),
         }
-        return Promise.resolve(mockResponse)
-      })
+        return Promise.resolve(mockStream)
+      }
+      return Promise.resolve(mockResponse)
+    })
   })
 
   // Wrap each test with conditional skip
@@ -626,7 +630,7 @@ describe('PostHogAnthropic', () => {
 
     conditionalTest('should respect global privacy mode', async () => {
       // Set global privacy mode
-      ; (mockPostHogClient as any).privacy_mode = true
+      ;(mockPostHogClient as any).privacy_mode = true
 
       await client.messages.create({
         model: 'claude-3-opus-20240229',
@@ -734,7 +738,7 @@ describe('PostHogAnthropic', () => {
       apiError.status = 429
 
       const MessagesMock = AnthropicOriginal.Messages as jest.MockedClass<typeof AnthropicOriginal.Messages>
-        ; (MessagesMock.prototype.create as jest.Mock) = jest.fn().mockRejectedValue(apiError)
+      ;(MessagesMock.prototype.create as jest.Mock) = jest.fn().mockRejectedValue(apiError)
 
       await expect(
         client.messages.create({
@@ -779,7 +783,7 @@ describe('PostHogAnthropic', () => {
       }
 
       const MessagesMock = AnthropicOriginal.Messages as jest.MockedClass<typeof AnthropicOriginal.Messages>
-        ; (MessagesMock.prototype.create as jest.Mock) = jest.fn().mockResolvedValue(errorStream)
+      ;(MessagesMock.prototype.create as jest.Mock) = jest.fn().mockResolvedValue(errorStream)
 
       const stream = await client.messages.create({
         model: 'claude-3-opus-20240229',

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -1,0 +1,893 @@
+import { PostHog } from 'posthog-node'
+import PostHogAnthropic from '../src/anthropic'
+import AnthropicOriginal from '@anthropic-ai/sdk'
+
+// Type definitions
+interface MockAnthropicResponseOptions {
+  content?: string
+  tools?: Array<{
+    id: string
+    name: string
+    input: Record<string, any>
+  }>
+  usage?: {
+    input_tokens: number
+    output_tokens: number
+    cache_creation_input_tokens?: number
+    cache_read_input_tokens?: number
+  }
+  model?: string
+  id?: string
+  stopReason?: string
+}
+
+interface MockStreamChunk {
+  type: string
+  content_block?: AnthropicOriginal.Messages.ContentBlock
+  delta?: {
+    type: string
+    text?: string
+    partial_json?: string
+    stop_reason?: string
+  }
+  index?: number
+  message?: Partial<AnthropicOriginal.Messages.Message>
+  usage?: Partial<AnthropicOriginal.Messages.Usage>
+}
+
+interface CaptureExpectations {
+  distinctId?: string
+  event?: string
+  provider?: string
+  model?: string
+  inputTokens?: number
+  outputTokens?: number
+  cacheReadInputTokens?: number
+  cacheCreationInputTokens?: number
+  httpStatus?: number
+  hasInput?: boolean
+  hasOutput?: boolean
+  properties?: Record<string, any>
+  groups?: Record<string, any>
+}
+
+interface MockAsyncIterator<T> {
+  [Symbol.asyncIterator](): AsyncIterator<T>
+}
+
+jest.mock('posthog-node', () => {
+  return {
+    PostHog: jest.fn().mockImplementation(() => {
+      return {
+        capture: jest.fn(),
+        captureImmediate: jest.fn(),
+        privacy_mode: false, // Note: This is the correct property name per PostHog Node SDK
+      }
+    }),
+  }
+})
+
+jest.mock('@anthropic-ai/sdk', () => {
+  // Mock Messages class
+  class MockMessages {
+    create(..._args: any[]): any {
+      /* will be stubbed in tests */
+      return undefined
+    }
+  }
+
+  // Mock Anthropic class
+  class MockAnthropic {
+    messages: any
+    constructor() {
+      this.messages = new MockMessages()
+    }
+    static Messages = MockMessages
+  }
+
+  return {
+    __esModule: true,
+    default: MockAnthropic,
+  }
+})
+
+/**
+ * Creates a mock Anthropic message response for testing
+ * @param options - Configuration for the mock response including content, tools, usage, etc.
+ * @returns A fully formed mock Message object
+ */
+const createMockResponse = (options: MockAnthropicResponseOptions = {}): AnthropicOriginal.Messages.Message => {
+  const content: AnthropicOriginal.Messages.ContentBlock[] = []
+
+  if (options.content) {
+    content.push({ type: 'text', text: options.content } as AnthropicOriginal.Messages.TextBlock)
+  }
+
+  if (options.tools) {
+    content.push(
+      ...options.tools.map(
+        (tool) =>
+        ({
+          type: 'tool_use',
+          id: tool.id,
+          name: tool.name,
+          input: tool.input,
+        } as AnthropicOriginal.Messages.ToolUseBlock)
+      )
+    )
+  }
+
+  return {
+    id: options.id || 'msg_test_123',
+    type: 'message',
+    role: 'assistant',
+    model: options.model || 'claude-3-opus-20240229',
+    content,
+    stop_reason: options.stopReason || 'end_turn',
+    stop_sequence: null,
+    usage: options.usage || { input_tokens: 20, output_tokens: 10 },
+  } as AnthropicOriginal.Messages.Message
+}
+
+/**
+ * Creates mock stream chunks that simulate Anthropic's streaming response format
+ * @param options - Configuration for the mock stream response
+ * @returns Array of mock stream chunks in the order they would be received
+ */
+const createMockStreamChunks = (options: MockAnthropicResponseOptions = {}): MockStreamChunk[] => {
+  const chunks: MockStreamChunk[] = []
+
+  // Message start
+  chunks.push({
+    type: 'message_start',
+    message: {
+      id: options.id || 'msg_test_123',
+      type: 'message',
+      role: 'assistant',
+      model: options.model || 'claude-3-opus-20240229',
+      usage: {
+        input_tokens: options.usage?.input_tokens || 20,
+        cache_creation_input_tokens: options.usage?.cache_creation_input_tokens || 0,
+        cache_read_input_tokens: options.usage?.cache_read_input_tokens || 0,
+        output_tokens: 0
+      },
+    },
+  })
+
+  // Add text content chunks
+  if (options.content) {
+    chunks.push(
+      { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } as AnthropicOriginal.Messages.TextBlock },
+      ...options.content.split(' ').map((word, i, arr) => ({
+        type: 'content_block_delta' as const,
+        index: 0,
+        delta: { type: 'text_delta', text: word + (i < arr.length - 1 ? ' ' : '') },
+      })),
+      { type: 'content_block_stop', index: 0 }
+    )
+  }
+
+  // Add tool chunks
+  if (options.tools) {
+    options.tools.forEach((tool, toolIndex) => {
+      const blockIndex = options.content ? 1 + toolIndex : toolIndex
+      const inputString = JSON.stringify(tool.input)
+      const chunkSize = Math.ceil(inputString.length / 3)
+
+      chunks.push(
+        {
+          type: 'content_block_start',
+          index: blockIndex,
+          content_block: { type: 'tool_use', id: tool.id, name: tool.name } as AnthropicOriginal.Messages.ToolUseBlock,
+        },
+        ...Array.from({ length: Math.ceil(inputString.length / chunkSize) }, (_, i) => ({
+          type: 'content_block_delta' as const,
+          index: blockIndex,
+          delta: { type: 'input_json_delta', partial_json: inputString.slice(i * chunkSize, (i + 1) * chunkSize) },
+        })),
+        { type: 'content_block_stop', index: blockIndex }
+      )
+    })
+  }
+
+  // Message end
+  chunks.push(
+    {
+      type: 'message_delta',
+      delta: {
+        stop_reason: options.stopReason || 'end_turn',
+        type: 'stop_reason',
+      },
+      usage: { output_tokens: options.usage?.output_tokens || 10 },
+    },
+    { type: 'message_stop' }
+  )
+
+  return chunks
+}
+
+/**
+ * Asserts that PostHog capture was called with expected parameters
+ * @param mockClient - The mocked PostHog client
+ * @param expectations - Object containing expected values for the capture call
+ */
+const assertPostHogCapture = (mockClient: PostHog, expectations: CaptureExpectations): void => {
+  const captureMock = mockClient.capture as jest.Mock
+  expect(captureMock).toHaveBeenCalledTimes(1)
+
+  const [captureArgs] = captureMock.mock.calls
+  const { distinctId, event, properties, groups } = captureArgs[0]
+
+  // Map of expectation keys to property keys
+  const propertyMap: Record<string, string> = {
+    provider: '$ai_provider',
+    model: '$ai_model',
+    inputTokens: '$ai_input_tokens',
+    outputTokens: '$ai_output_tokens',
+    cacheReadInputTokens: '$ai_cache_read_input_tokens',
+    cacheCreationInputTokens: '$ai_cache_creation_input_tokens',
+    httpStatus: '$ai_http_status',
+  }
+
+  // Check simple expectations
+  if (expectations.distinctId !== undefined) expect(distinctId).toBe(expectations.distinctId)
+  if (expectations.event !== undefined) expect(event).toBe(expectations.event)
+  if (expectations.groups !== undefined) expect(groups).toEqual(expectations.groups)
+
+  // Check mapped properties
+  Object.entries(propertyMap).forEach(([key, propKey]) => {
+    if (expectations[key as keyof CaptureExpectations] !== undefined) {
+      expect(properties[propKey]).toBe(expectations[key as keyof CaptureExpectations])
+    }
+  })
+
+  // Check input/output presence
+  if (expectations.hasInput !== undefined) {
+    if (expectations.hasInput) {
+      expect(properties['$ai_input']).toBeDefined()
+      expect(properties['$ai_input']).not.toBeNull()
+    } else {
+      expect(properties['$ai_input']).toBeNull()
+    }
+  }
+
+  if (expectations.hasOutput !== undefined) {
+    if (expectations.hasOutput) {
+      expect(properties['$ai_output_choices']).toBeDefined()
+      expect(properties['$ai_output_choices']).not.toBeNull()
+    } else {
+      expect(properties['$ai_output_choices']).toBeNull()
+    }
+  }
+
+  // Check custom properties
+  if (expectations.properties) {
+    Object.entries(expectations.properties).forEach(([key, value]) => {
+      expect(properties[key]).toBe(value)
+    })
+  }
+
+  // Always check that latency is a number
+  expect(typeof properties['$ai_latency']).toBe('number')
+}
+
+describe('PostHogAnthropic', () => {
+  let mockPostHogClient: PostHog
+  let client: PostHogAnthropic
+  let mockResponse: AnthropicOriginal.Messages.Message
+  let mockStreamChunks: MockStreamChunk[]
+
+  // Helper to wait for async operations to complete
+  const waitForAsyncCapture = () => new Promise(process.nextTick)
+
+  // Helper to create async iterator from chunks
+  const createMockAsyncIterator = <T>(chunks: T[]): MockAsyncIterator<T> => {
+    let index = 0
+    return {
+      async *[Symbol.asyncIterator]() {
+        while (index < chunks.length) {
+          yield chunks[index++]
+        }
+      },
+    }
+  }
+
+  beforeAll(() => {
+    if (!process.env.ANTHROPIC_API_KEY) {
+      console.warn('⚠️ Skipping Anthropic tests: No ANTHROPIC_API_KEY environment variable set')
+    }
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    // Reset the default mocks
+    mockPostHogClient = new (PostHog as any)()
+    client = new PostHogAnthropic({
+      apiKey: process.env.ANTHROPIC_API_KEY || '',
+      posthog: mockPostHogClient as any,
+    })
+
+    // Set up default mock response
+    mockResponse = createMockResponse({
+      content: 'Hello from Claude!',
+    })
+
+    // Set up default mock stream chunks
+    mockStreamChunks = createMockStreamChunks({
+      content: 'Hello from Claude!',
+    })
+
+    // Mock the create method
+    const MessagesMock = AnthropicOriginal.Messages as jest.MockedClass<typeof AnthropicOriginal.Messages>
+      ; (MessagesMock.prototype.create as jest.Mock) = jest.fn().mockImplementation((params: any) => {
+        if (params.stream) {
+          // Return a mock stream
+          const mockStream = {
+            tee: jest
+              .fn()
+              .mockReturnValue([createMockAsyncIterator(mockStreamChunks), createMockAsyncIterator(mockStreamChunks)]),
+          }
+          return Promise.resolve(mockStream)
+        }
+        return Promise.resolve(mockResponse)
+      })
+  })
+
+  // Wrap each test with conditional skip
+  const conditionalTest = process.env.ANTHROPIC_API_KEY ? test : test.skip
+
+  describe('Message Creation', () => {
+    conditionalTest('should handle non-streaming message creation', async () => {
+      const response = await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Hello Claude' }],
+        max_tokens: 100,
+        posthogDistinctId: 'test-user-123',
+        posthogProperties: { custom_prop: 'test_value' },
+      })
+
+      expect(response).toEqual(mockResponse)
+
+      assertPostHogCapture(mockPostHogClient, {
+        distinctId: 'test-user-123',
+        event: '$ai_generation',
+        provider: 'anthropic',
+        model: 'claude-3-opus-20240229',
+        inputTokens: 20,
+        outputTokens: 10,
+        httpStatus: 200,
+        hasInput: true,
+        hasOutput: true,
+        properties: { custom_prop: 'test_value' },
+      })
+    })
+
+    conditionalTest('should handle system prompts correctly', async () => {
+      mockResponse = createMockResponse({
+        content: 'I am a helpful assistant.',
+      })
+
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        system: 'You are a helpful assistant.',
+        messages: [{ role: 'user', content: 'Who are you?' }],
+        max_tokens: 100,
+        posthogDistinctId: 'test-user-123',
+      })
+
+      const captureMock = mockPostHogClient.capture as jest.Mock
+      const [captureArgs] = captureMock.mock.calls
+      const { properties } = captureArgs[0]
+
+      // Check that system prompt is included in input
+      expect(properties['$ai_input']).toEqual([
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'Who are you?' },
+      ])
+    })
+
+    conditionalTest('should handle multi-turn conversations', async () => {
+      const messages = [
+        { role: 'user' as const, content: 'Hello' },
+        { role: 'assistant' as const, content: 'Hi there!' },
+        { role: 'user' as const, content: 'How are you?' },
+      ]
+
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages,
+        max_tokens: 100,
+        posthogDistinctId: 'test-user-123',
+      })
+
+      const captureMock = mockPostHogClient.capture as jest.Mock
+      const [captureArgs] = captureMock.mock.calls
+      const { properties } = captureArgs[0]
+
+      expect(properties['$ai_input']).toEqual(messages)
+    })
+  })
+
+  describe('Streaming Responses', () => {
+    conditionalTest('should handle streaming responses', async () => {
+      const stream = await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 100,
+        stream: true,
+        posthogDistinctId: 'test-user-123',
+      })
+
+      // Consume the stream
+      const chunks = []
+      for await (const chunk of stream) {
+        chunks.push(chunk)
+      }
+
+      // Allow async capture to complete
+      await waitForAsyncCapture()
+
+      assertPostHogCapture(mockPostHogClient, {
+        distinctId: 'test-user-123',
+        event: '$ai_generation',
+        provider: 'anthropic',
+        model: 'claude-3-opus-20240229',
+        inputTokens: 20,
+        outputTokens: 10,
+        httpStatus: 200,
+        hasInput: true,
+        hasOutput: true,
+      })
+    })
+
+    conditionalTest('should handle streaming with tool calls', async () => {
+      mockStreamChunks = createMockStreamChunks({
+        content: 'I will check the weather for you.',
+        tools: [
+          {
+            id: 'tool_123',
+            name: 'get_weather',
+            input: { location: 'San Francisco', units: 'celsius' },
+          },
+        ],
+      })
+
+      const stream = await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'What is the weather?' }],
+        tools: [
+          {
+            name: 'get_weather',
+            description: 'Get the weather',
+            input_schema: {
+              type: 'object',
+              properties: {
+                location: { type: 'string' },
+                units: { type: 'string' },
+              },
+            },
+          },
+        ] as AnthropicOriginal.Tool[],
+        max_tokens: 100,
+        stream: true,
+        posthogDistinctId: 'test-user-123',
+      })
+
+      // Consume the stream
+      for await (const _chunk of stream) {
+        // Just consume
+      }
+
+      // Allow async capture to complete
+      await waitForAsyncCapture()
+
+      const captureMock = mockPostHogClient.capture as jest.Mock
+      const [captureArgs] = captureMock.mock.calls
+      const { properties } = captureArgs[0]
+
+      // Check that tools are captured
+      expect(properties['$ai_tools']).toBeDefined()
+      expect(properties['$ai_output_choices']).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'I will check the weather for you.' },
+            {
+              type: 'function',
+              id: 'tool_123',
+              function: {
+                name: 'get_weather',
+                arguments: { location: 'San Francisco', units: 'celsius' },
+              },
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe('Tool Usage', () => {
+    conditionalTest('should handle tool calls in non-streaming mode', async () => {
+      mockResponse = createMockResponse({
+        content: 'I will search for that information.',
+        tools: [
+          {
+            id: 'tool_456',
+            name: 'search',
+            input: { query: 'PostHog features' },
+          },
+        ],
+      })
+
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Tell me about PostHog' }],
+        tools: [
+          {
+            name: 'search',
+            description: 'Search for information',
+            input_schema: {
+              type: 'object',
+              properties: {
+                query: { type: 'string' },
+              },
+            },
+          },
+        ] as AnthropicOriginal.Tool[],
+        max_tokens: 100,
+        posthogDistinctId: 'test-user-123',
+      })
+
+      const captureMock = mockPostHogClient.capture as jest.Mock
+      const [captureArgs] = captureMock.mock.calls
+      const { properties } = captureArgs[0]
+
+      expect(properties['$ai_tools']).toBeDefined()
+      expect(properties['$ai_output_choices']).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'I will search for that information.' },
+            {
+              type: 'function',
+              id: 'tool_456',
+              function: {
+                name: 'search',
+                arguments: { query: 'PostHog features' },
+              },
+            },
+          ],
+        },
+      ])
+    })
+
+    conditionalTest('should handle multiple tool calls', async () => {
+      mockResponse = createMockResponse({
+        content: 'Let me check both of those for you.',
+        tools: [
+          {
+            id: 'tool_1',
+            name: 'get_weather',
+            input: { location: 'New York' },
+          },
+          {
+            id: 'tool_2',
+            name: 'get_weather',
+            input: { location: 'London' },
+          },
+        ],
+      })
+
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Weather in New York and London?' }],
+        tools: [
+          {
+            name: 'get_weather',
+            description: 'Get weather',
+            input_schema: {
+              type: 'object',
+              properties: {
+                location: { type: 'string' },
+              },
+            },
+          },
+        ] as AnthropicOriginal.Tool[],
+        max_tokens: 100,
+        posthogDistinctId: 'test-user-123',
+      })
+
+      const captureMock = mockPostHogClient.capture as jest.Mock
+      const [captureArgs] = captureMock.mock.calls
+      const { properties } = captureArgs[0]
+
+      const outputChoices = properties['$ai_output_choices'][0]
+      expect(outputChoices.content).toHaveLength(3) // 1 text + 2 tool calls
+      expect(outputChoices.content.filter((c: any) => c.type === 'function')).toHaveLength(2)
+    })
+  })
+
+  describe('Privacy Mode', () => {
+    conditionalTest('should respect local privacy mode', async () => {
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Sensitive information' }],
+        max_tokens: 100,
+        posthogDistinctId: 'test-user-123',
+        posthogPrivacyMode: true,
+      })
+
+      assertPostHogCapture(mockPostHogClient, {
+        hasInput: false,
+        hasOutput: false,
+      })
+    })
+
+    conditionalTest('should respect global privacy mode', async () => {
+      // Set global privacy mode
+      ; (mockPostHogClient as any).privacy_mode = true
+
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Sensitive information' }],
+        max_tokens: 100,
+        posthogDistinctId: 'test-user-123',
+        posthogPrivacyMode: false, // Try to override, but global should take precedence
+      })
+
+      assertPostHogCapture(mockPostHogClient, {
+        hasInput: false,
+        hasOutput: false,
+      })
+    })
+  })
+
+  describe('Token Tracking', () => {
+    conditionalTest('should track standard token usage', async () => {
+      mockResponse = createMockResponse({
+        content: 'Response',
+        usage: {
+          input_tokens: 50,
+          output_tokens: 25,
+        },
+      })
+
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 100,
+        posthogDistinctId: 'test-user-123',
+      })
+
+      assertPostHogCapture(mockPostHogClient, {
+        inputTokens: 50,
+        outputTokens: 25,
+      })
+    })
+
+    conditionalTest('should track cache tokens', async () => {
+      mockResponse = createMockResponse({
+        content: 'Response',
+        usage: {
+          input_tokens: 100,
+          output_tokens: 30,
+          cache_creation_input_tokens: 20,
+          cache_read_input_tokens: 15,
+        },
+      })
+
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 100,
+        posthogDistinctId: 'test-user-123',
+      })
+
+      assertPostHogCapture(mockPostHogClient, {
+        inputTokens: 100,
+        outputTokens: 30,
+        cacheCreationInputTokens: 20,
+        cacheReadInputTokens: 15,
+      })
+    })
+
+    conditionalTest('should track tokens in streaming mode', async () => {
+      mockStreamChunks = createMockStreamChunks({
+        content: 'Streaming response',
+        usage: {
+          input_tokens: 75,
+          output_tokens: 40,
+          cache_creation_input_tokens: 10,
+          cache_read_input_tokens: 5,
+        },
+      })
+
+      const stream = await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 100,
+        stream: true,
+        posthogDistinctId: 'test-user-123',
+      })
+
+      // Consume the stream
+      for await (const _chunk of stream) {
+        // Just consume
+      }
+
+      // Allow async capture to complete
+      await waitForAsyncCapture()
+
+      assertPostHogCapture(mockPostHogClient, {
+        inputTokens: 75,
+        outputTokens: 40,
+        cacheCreationInputTokens: 10,
+        cacheReadInputTokens: 5,
+      })
+    })
+  })
+
+  describe('Error Handling', () => {
+    conditionalTest('should handle API errors', async () => {
+      const apiError = new Error('API Error') as Error & { status: number }
+      apiError.status = 429
+
+      const MessagesMock = AnthropicOriginal.Messages as jest.MockedClass<typeof AnthropicOriginal.Messages>
+        ; (MessagesMock.prototype.create as jest.Mock) = jest.fn().mockRejectedValue(apiError)
+
+      await expect(
+        client.messages.create({
+          model: 'claude-3-opus-20240229',
+          messages: [{ role: 'user', content: 'Hello' }],
+          max_tokens: 100,
+          posthogDistinctId: 'test-user-123',
+        })
+      ).rejects.toThrow('API Error')
+
+      assertPostHogCapture(mockPostHogClient, {
+        httpStatus: 429,
+        inputTokens: 0,
+        outputTokens: 0,
+      })
+
+      const captureMock = mockPostHogClient.capture as jest.Mock
+      const [captureArgs] = captureMock.mock.calls
+      const { properties } = captureArgs[0]
+
+      expect(properties['$ai_error']).toBeDefined()
+    })
+
+    conditionalTest('should handle streaming errors', async () => {
+      const streamError = new Error('Stream Error') as Error & { status: number }
+      streamError.status = 500
+
+      // Create a mock stream that throws an error
+      const errorStream = {
+        tee: jest.fn().mockReturnValue([
+          {
+            [Symbol.asyncIterator]: async function* () {
+              throw streamError
+            },
+          },
+          {
+            [Symbol.asyncIterator]: async function* () {
+              throw streamError
+            },
+          },
+        ]),
+      }
+
+      const MessagesMock = AnthropicOriginal.Messages as jest.MockedClass<typeof AnthropicOriginal.Messages>
+        ; (MessagesMock.prototype.create as jest.Mock) = jest.fn().mockResolvedValue(errorStream)
+
+      const stream = await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 100,
+        stream: true,
+        posthogDistinctId: 'test-user-123',
+      })
+
+      // Try to consume the stream (it should throw)
+      await expect(async () => {
+        for await (const _chunk of stream) {
+          // Should throw before getting here
+        }
+      }).rejects.toThrow('Stream Error')
+
+      // Allow async error capture to complete
+      await new Promise(process.nextTick)
+
+      assertPostHogCapture(mockPostHogClient, {
+        httpStatus: 500,
+        inputTokens: 0,
+        outputTokens: 0,
+      })
+    })
+  })
+
+  describe('Additional Features', () => {
+    conditionalTest('should handle groups', async () => {
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 100,
+        posthogDistinctId: 'test-user-123',
+        posthogGroups: { company: 'acme-corp', team: 'engineering' },
+      })
+
+      assertPostHogCapture(mockPostHogClient, {
+        groups: { company: 'acme-corp', team: 'engineering' },
+      })
+    })
+
+    conditionalTest('should use captureImmediate when flag is set', async () => {
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 100,
+        posthogDistinctId: 'test-user-123',
+        posthogCaptureImmediate: true,
+      })
+
+      const captureImmediateMock = mockPostHogClient.captureImmediate as jest.Mock
+      expect(captureImmediateMock).toHaveBeenCalledTimes(1)
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(0)
+    })
+
+    conditionalTest('should track model parameters', async () => {
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 100,
+        temperature: 0.7,
+        top_p: 0.9,
+        posthogDistinctId: 'test-user-123',
+      })
+
+      const captureMock = mockPostHogClient.capture as jest.Mock
+      const [captureArgs] = captureMock.mock.calls
+      const { properties } = captureArgs[0]
+
+      expect(properties['$ai_model_parameters']).toEqual({
+        max_tokens: 100,
+        temperature: 0.7,
+        top_p: 0.9,
+      })
+    })
+
+    conditionalTest('should handle anonymous users with trace ID', async () => {
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 100,
+        posthogTraceId: 'trace-789',
+      })
+
+      const captureMock = mockPostHogClient.capture as jest.Mock
+      const [captureArgs] = captureMock.mock.calls
+      const { distinctId, properties } = captureArgs[0]
+
+      expect(distinctId).toBe('trace-789')
+      expect(properties['$process_person_profile']).toBe(false)
+    })
+
+    conditionalTest('should handle identified users without setting $process_person_profile', async () => {
+      await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 100,
+        posthogDistinctId: 'user-456',
+        posthogTraceId: 'trace-789',
+      })
+
+      const captureMock = mockPostHogClient.capture as jest.Mock
+      const [captureArgs] = captureMock.mock.calls
+      const { distinctId, properties } = captureArgs[0]
+
+      expect(distinctId).toBe('user-456')
+      expect(properties['$process_person_profile']).toBeUndefined()
+    })
+  })
+})

--- a/packages/ai/tests/gemini.test.ts
+++ b/packages/ai/tests/gemini.test.ts
@@ -129,10 +129,12 @@ describe('PostHogGemini - Jest test suite', () => {
     ;(client as any).client.models.generateContent = jest.fn().mockResolvedValue(mockGeminiResponse)
 
     // Mock the generateContentStream method
-    ;(client as any).client.models.generateContentStream = jest.fn().mockImplementation(async function* () {
-      for (const chunk of mockGeminiStreamResponse) {
-        yield chunk
-      }
+    ;(client as any).client.models.generateContentStream = jest.fn().mockImplementation(() => {
+      return (async function* () {
+        for (const chunk of mockGeminiStreamResponse) {
+          yield chunk
+        }
+      })()
     })
   })
 
@@ -159,7 +161,12 @@ describe('PostHogGemini - Jest test suite', () => {
     expect(properties['$ai_provider']).toBe('gemini')
     expect(properties['$ai_model']).toBe('gemini-2.0-flash-001')
     expect(properties['$ai_input']).toEqual([{ role: 'user', content: 'Hello' }])
-    expect(properties['$ai_output_choices']).toEqual([{ role: 'assistant', content: 'Hello from Gemini!' }])
+    expect(properties['$ai_output_choices']).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello from Gemini!' }],
+      },
+    ])
     expect(properties['$ai_input_tokens']).toBe(15)
     expect(properties['$ai_output_tokens']).toBe(8)
     expect(properties['$ai_http_status']).toBe(200)
@@ -194,7 +201,12 @@ describe('PostHogGemini - Jest test suite', () => {
     expect(properties['$ai_provider']).toBe('gemini')
     expect(properties['$ai_model']).toBe('gemini-2.0-flash-001')
     expect(properties['$ai_input']).toEqual([{ role: 'user', content: 'Write a short poem' }])
-    expect(properties['$ai_output_choices']).toEqual([{ content: 'Hello from Gemini!', role: 'assistant' }])
+    expect(properties['$ai_output_choices']).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello from Gemini!' }],
+      },
+    ])
     expect(properties['$ai_input_tokens']).toBe(15)
     expect(properties['$ai_output_tokens']).toBe(8)
     expect(properties['$ai_http_status']).toBe(200)
@@ -309,6 +321,185 @@ describe('PostHogGemini - Jest test suite', () => {
 
     expect(vertexClient).toBeInstanceOf(PostHogGemini)
     expect(vertexClient.models).toBeDefined()
+  })
+
+  conditionalTest('streaming with function calls', async () => {
+    // Mock streaming response with function calls
+    const mockStreamWithFunctions = [
+      {
+        text: 'I can help with that. ',
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'I can help with that. ' }],
+            },
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 20,
+          candidatesTokenCount: 5,
+        },
+      },
+      {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: 'searchWeather',
+                    args: { location: 'New York', units: 'celsius' },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 20,
+          candidatesTokenCount: 10,
+        },
+      },
+      {
+        text: 'The weather is sunny.',
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'The weather is sunny.' }],
+            },
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 20,
+          candidatesTokenCount: 15,
+        },
+      },
+    ]
+
+    // Update mock to use function call stream
+    ;(client as any).client.models.generateContentStream = jest.fn().mockImplementation(() => {
+      return (async function* () {
+        for (const chunk of mockStreamWithFunctions) {
+          yield chunk
+        }
+      })()
+    })
+
+    const stream = client.models.generateContentStream({
+      model: 'gemini-2.0-flash-001',
+      contents: 'What is the weather?',
+      posthogDistinctId: 'test-id',
+    })
+
+    let accumulatedText = ''
+    const functionCalls: any[] = []
+
+    for await (const chunk of stream) {
+      if (chunk.text) {
+        accumulatedText += chunk.text
+      }
+      if (chunk.candidates) {
+        for (const candidate of chunk.candidates) {
+          if (candidate.content?.parts) {
+            for (const part of candidate.content.parts) {
+              if ('functionCall' in part) {
+                functionCalls.push(part.functionCall)
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(accumulatedText).toBe('I can help with that. The weather is sunny.')
+    expect(functionCalls).toHaveLength(1)
+    expect(functionCalls[0]).toEqual({
+      name: 'searchWeather',
+      args: { location: 'New York', units: 'celsius' },
+    })
+
+    // Check PostHog capture
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    const { properties } = captureArgs[0]
+
+    expect(properties['$ai_output_choices']).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'I can help with that. The weather is sunny.' },
+          {
+            type: 'function',
+            function: {
+              name: 'searchWeather',
+              arguments: { location: 'New York', units: 'celsius' },
+            },
+          },
+        ],
+      },
+    ])
+    expect(properties['$ai_input_tokens']).toBe(20)
+    expect(properties['$ai_output_tokens']).toBe(15)
+  })
+
+  conditionalTest('streaming with multiple text chunks accumulation', async () => {
+    // Mock streaming response with multiple text chunks
+    const mockMultipleTextChunks = [
+      {
+        text: 'The ',
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 1 },
+      },
+      {
+        text: 'quick ',
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 2 },
+      },
+      {
+        text: 'brown ',
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 3 },
+      },
+      {
+        text: 'fox.',
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 4 },
+      },
+    ]
+
+    // Update mock
+    ;(client as any).client.models.generateContentStream = jest.fn().mockImplementation(() => {
+      return (async function* () {
+        for (const chunk of mockMultipleTextChunks) {
+          yield chunk
+        }
+      })()
+    })
+
+    const stream = client.models.generateContentStream({
+      model: 'gemini-2.0-flash-001',
+      contents: 'Tell me a story',
+      posthogDistinctId: 'test-id',
+    })
+
+    let accumulatedText = ''
+    for await (const chunk of stream) {
+      if (chunk.text) {
+        accumulatedText += chunk.text
+      }
+    }
+
+    expect(accumulatedText).toBe('The quick brown fox.')
+
+    // Check PostHog capture for proper text accumulation
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    const { properties } = captureArgs[0]
+
+    // Should have a single text item with all accumulated text
+    expect(properties['$ai_output_choices']).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'The quick brown fox.' }],
+      },
+    ])
+    expect(properties['$ai_output_tokens']).toBe(4)
   })
 
   conditionalTest('anonymous user - $process_person_profile set to false', async () => {

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -1,9 +1,17 @@
 import { PostHog } from 'posthog-node'
 import PostHogOpenAI from '../src/openai'
 import openaiModule from 'openai'
+import type { ChatCompletion, ChatCompletionChunk } from 'openai/resources/chat/completions'
+import type { ParsedResponse } from 'openai/resources/responses/responses'
 
-let mockOpenAiChatResponse: any = {}
-let mockOpenAiParsedResponse: any = {}
+// Test-specific helper interface for async iteration
+interface MockAsyncIterator<T> {
+  [Symbol.asyncIterator](): AsyncIterator<T>
+}
+
+let mockOpenAiChatResponse: ChatCompletion = {} as ChatCompletion
+let mockOpenAiParsedResponse: ParsedResponse<any> = {} as ParsedResponse<any>
+let mockStreamChunks: ChatCompletionChunk[] = []
 
 jest.mock('posthog-node', () => {
   return {
@@ -36,14 +44,17 @@ jest.mock('openai', () => {
     static Completions = MockCompletions
   }
 
-  // Mock Responses class
+  // Mock Responses class with parse method that will be called by super.parse()
   class MockResponses {
     constructor() {}
-    create = jest.fn()
+    // These need to be on the prototype for super.parse() to work
+    create() {
+      return Promise.resolve({})
+    }
+    parse() {
+      return Promise.resolve({})
+    }
   }
-
-  // Add parse to prototype instead of instance
-  ;(MockResponses.prototype as any).parse = jest.fn()
 
   // Mock OpenAI class
   class MockOpenAI {
@@ -76,6 +87,140 @@ jest.mock('openai', () => {
   }
 })
 
+/**
+ * Helper function to create an async iterator from stream chunks
+ * Used to simulate OpenAI's streaming response behavior
+ */
+const createMockAsyncIterator = <T>(chunks: T[]): MockAsyncIterator<T> => {
+  let index = 0
+  return {
+    async *[Symbol.asyncIterator]() {
+      while (index < chunks.length) {
+        yield chunks[index++]
+      }
+    },
+  }
+}
+
+/**
+ * Creates mock stream chunks for testing streaming completions
+ * @param options Configuration for the mock stream response
+ * @returns Array of properly typed ChatCompletionChunk objects
+ */
+const createMockStreamChunks = (options: {
+  content?: string
+  includeToolCalls?: boolean
+  toolCallName?: string
+  toolCallArguments?: string
+  includeUsage?: boolean
+}): ChatCompletionChunk[] => {
+  const chunks: ChatCompletionChunk[] = []
+  const baseChunk: Partial<ChatCompletionChunk> = {
+    id: 'chatcmpl-test',
+    model: 'gpt-4',
+    object: 'chat.completion.chunk',
+    created: Date.now() / 1000,
+  }
+
+  if (options.content) {
+    // Split content into multiple chunks to simulate real streaming
+    const words = options.content.split(' ')
+    for (let i = 0; i < words.length; i++) {
+      chunks.push({
+        ...baseChunk,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: words[i] + (i < words.length - 1 ? ' ' : ''),
+            },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+      } as ChatCompletionChunk)
+    }
+  }
+
+  if (options.includeToolCalls) {
+    // Tool call chunks come in sequence: id/name first, then arguments in parts
+    chunks.push({
+      ...baseChunk,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: 'call_abc123',
+                type: 'function',
+                function: {
+                  name: options.toolCallName || 'get_weather',
+                  arguments: '',
+                },
+              },
+            ],
+          },
+          finish_reason: null,
+          logprobs: null,
+        },
+      ],
+    } as ChatCompletionChunk)
+
+    // Stream the arguments in parts
+    const args = options.toolCallArguments || '{"location": "San Francisco", "unit": "celsius"}'
+    const argChunks = [args.slice(0, 10), args.slice(10, 30), args.slice(30)]
+    
+    for (const argChunk of argChunks) {
+      chunks.push({
+        ...baseChunk,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  function: {
+                    arguments: argChunk,
+                  },
+                },
+              ],
+            },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+      } as ChatCompletionChunk)
+    }
+  }
+
+  // Add final chunk with finish reason and optional usage
+  const finalChunk: ChatCompletionChunk = {
+    ...baseChunk,
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: 'stop',
+        logprobs: null,
+      },
+    ],
+  } as ChatCompletionChunk
+
+  if (options.includeUsage) {
+    finalChunk.usage = {
+      prompt_tokens: 25,
+      completion_tokens: 15,
+      total_tokens: 40,
+    }
+  }
+
+  chunks.push(finalChunk)
+  return chunks
+}
+
 describe('PostHogOpenAI - Jest test suite', () => {
   let mockPostHogClient: PostHog
   let client: PostHogOpenAI
@@ -101,7 +246,7 @@ describe('PostHogOpenAI - Jest test suite', () => {
       posthog: mockPostHogClient as any,
     })
 
-    // Some default chat completion mock
+    // Default chat completion mock for non-streaming responses
     mockOpenAiChatResponse = {
       id: 'test-response-id',
       model: 'gpt-4',
@@ -114,7 +259,9 @@ describe('PostHogOpenAI - Jest test suite', () => {
           message: {
             role: 'assistant',
             content: 'Hello from OpenAI!',
+            refusal: null,
           },
+          logprobs: null,
         },
       ],
       usage: {
@@ -133,9 +280,16 @@ describe('PostHogOpenAI - Jest test suite', () => {
       status: 'completed',
       output: [
         {
-          type: 'output_text',
-          text: '{"name": "Science Fair", "date": "Friday", "participants": ["Alice", "Bob"]}',
-        },
+          id: 'msg-001',
+          type: 'message',
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: '{"name": "Science Fair", "date": "Friday", "participants": ["Alice", "Bob"]}',
+            },
+          ],
+        } as any,
       ],
       output_parsed: {
         name: 'Science Fair',
@@ -149,17 +303,52 @@ describe('PostHogOpenAI - Jest test suite', () => {
         output_tokens_details: { reasoning_tokens: 5 },
         total_tokens: 35,
       },
-    }
+      // Additional required fields for ParsedResponse
+      output_text: '',
+      error: null,
+      incomplete_details: null,
+      instructions: '',
+      input: [],
+      metadata: null,
+      response_id: 'test-parsed-response-id',
+      service_tier: null,
+      system_fingerprint: null,
+      queue_time: null,
+      parallel_tool_calls: true,
+      temperature: 1.0,
+      tool_choice: 'auto',
+      tools: [],
+      top_p: 1.0,
+    } as unknown as ParsedResponse<any>
+
+    // Default stream chunks for streaming tests
+    mockStreamChunks = createMockStreamChunks({
+      content: 'Hello from streaming OpenAI!',
+      includeUsage: true,
+    })
 
     const ChatMock: any = openaiModule.Chat
-    ;(ChatMock.Completions as any).prototype.create = jest.fn().mockResolvedValue(mockOpenAiChatResponse)
+    ;(ChatMock.Completions as any).prototype.create = jest.fn().mockImplementation((params: any) => {
+      if (params.stream) {
+        // Return a mock stream with tee() method
+        const mockStream = {
+          tee: jest.fn().mockReturnValue([
+            createMockAsyncIterator(mockStreamChunks),
+            createMockAsyncIterator(mockStreamChunks),
+          ]),
+        }
+        return Promise.resolve(mockStream)
+      }
+      return Promise.resolve(mockOpenAiChatResponse)
+    })
 
-    // Mock responses.parse using the same pattern as chat completions
+    // Mock the Responses.prototype.parse method that super.parse() will call
     const ResponsesMock: any = openaiModule.Responses
-    ResponsesMock.prototype.parse.mockResolvedValue(mockOpenAiParsedResponse)
+    ResponsesMock.prototype.parse = jest.fn().mockResolvedValue(mockOpenAiParsedResponse)
+    ResponsesMock.prototype.create = jest.fn().mockResolvedValue(mockOpenAiParsedResponse)
   })
 
-  // Wrap each test with conditional skip
+  // Conditionally run tests based on API key availability
   const conditionalTest = process.env.OPENAI_API_KEY ? test : test.skip
 
   conditionalTest('basic completion', async () => {
@@ -184,7 +373,18 @@ describe('PostHogOpenAI - Jest test suite', () => {
     expect(properties['$ai_provider']).toBe('openai')
     expect(properties['$ai_model']).toBe('gpt-4')
     expect(properties['$ai_input']).toEqual([{ role: 'user', content: 'Hello' }])
-    expect(properties['$ai_output_choices']).toEqual([{ role: 'assistant', content: 'Hello from OpenAI!' }])
+    // Updated to match new formatted output structure
+    expect(properties['$ai_output_choices']).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Hello from OpenAI!',
+          },
+        ],
+      },
+    ])
     expect(properties['$ai_input_tokens']).toBe(20)
     expect(properties['$ai_output_tokens']).toBe(10)
     expect(properties['$ai_http_status']).toBe(200)
@@ -243,6 +443,7 @@ describe('PostHogOpenAI - Jest test suite', () => {
     mockOpenAiChatResponse.usage = {
       prompt_tokens: 20,
       completion_tokens: 10,
+      total_tokens: 30,
     }
 
     await client.chat.completions.create({
@@ -399,5 +600,401 @@ describe('PostHogOpenAI - Jest test suite', () => {
 
     expect(distinctId).toBe('user-456')
     expect(properties['$process_person_profile']).toBeUndefined()
+  })
+
+  describe('Streaming Responses', () => {
+    conditionalTest('handles basic streaming completion', async () => {
+      // Create a simple streaming response
+      mockStreamChunks = createMockStreamChunks({
+        content: 'This is a streaming response',
+        includeUsage: true,
+      })
+
+      const stream = await client.chat.completions.create({
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'Tell me about streaming' }],
+        stream: true,
+        posthogDistinctId: 'test-stream-user',
+        posthogProperties: { streamTest: true },
+      })
+
+      // Consume the stream to trigger the monitoring
+      const chunks = []
+      for await (const chunk of stream) {
+        chunks.push(chunk)
+      }
+
+      // Verify we received all chunks
+      expect(chunks.length).toBeGreaterThan(0)
+
+      // Wait a bit for async capture to complete
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Verify PostHog was called with correct data
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      const { distinctId, event, properties } = captureArgs[0]
+
+      expect(distinctId).toBe('test-stream-user')
+      expect(event).toBe('$ai_generation')
+      expect(properties['$ai_provider']).toBe('openai')
+      expect(properties['$ai_model']).toBe('gpt-4')
+      
+      // Check the formatted output structure
+      expect(properties['$ai_output_choices']).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'This is a streaming response',
+            },
+          ],
+        },
+      ])
+      
+      expect(properties['$ai_input_tokens']).toBe(25)
+      expect(properties['$ai_output_tokens']).toBe(15)
+      expect(properties['streamTest']).toBe(true)
+    })
+
+    conditionalTest('handles streaming with tool calls', async () => {
+      // Create stream chunks with tool calls
+      mockStreamChunks = createMockStreamChunks({
+        content: 'Let me check the weather for you.',
+        includeToolCalls: true,
+        toolCallName: 'get_current_weather',
+        toolCallArguments: '{"location": "New York", "unit": "fahrenheit"}',
+        includeUsage: true,
+      })
+
+      const stream = await client.chat.completions.create({
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'What is the weather?' }],
+        stream: true,
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'get_current_weather',
+              description: 'Get the current weather in a location',
+              parameters: {
+                type: 'object',
+                properties: {
+                  location: { type: 'string' },
+                  unit: { type: 'string', enum: ['celsius', 'fahrenheit'] },
+                },
+                required: ['location'],
+              },
+            },
+          },
+        ],
+        posthogDistinctId: 'test-tools-user',
+      })
+
+      // Consume the stream
+      for await (const _chunk of stream) {
+        // Just consume the chunks
+      }
+
+      // Wait for async capture
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Verify the capture includes tool calls in the formatted output
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      const { properties } = captureArgs[0]
+
+      // Check that output contains both text and function call
+      expect(properties['$ai_output_choices']).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'Let me check the weather for you.',
+            },
+            {
+              type: 'function',
+              id: 'call_abc123',
+              function: {
+                name: 'get_current_weather',
+                arguments: '{"location": "New York", "unit": "fahrenheit"}',
+              },
+            },
+          ],
+        },
+      ])
+
+      // Verify tools were captured
+      expect(properties['$ai_tools']).toBeDefined()
+      expect(properties['$ai_tools']).toHaveLength(1)
+      expect(properties['$ai_tools'][0].function.name).toBe('get_current_weather')
+    })
+
+    conditionalTest('handles multiple tool calls in streaming', async () => {
+      // Create custom chunks with multiple tool calls
+      const multiToolChunks: ChatCompletionChunk[] = [
+        {
+          id: 'chatcmpl-multi',
+          model: 'gpt-4',
+          object: 'chat.completion.chunk',
+          created: Date.now() / 1000,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: 'I will check both weather and news for you.',
+              },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+        } as ChatCompletionChunk,
+        // First tool call
+        {
+          id: 'chatcmpl-multi',
+          model: 'gpt-4',
+          object: 'chat.completion.chunk',
+          created: Date.now() / 1000,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: 'call_weather',
+                    type: 'function',
+                    function: {
+                      name: 'get_weather',
+                      arguments: '{"loc',
+                    },
+                  },
+                ],
+              },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+        } as ChatCompletionChunk,
+        {
+          id: 'chatcmpl-multi',
+          model: 'gpt-4',
+          object: 'chat.completion.chunk',
+          created: Date.now() / 1000,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    function: {
+                      arguments: 'ation": "NYC"}',
+                    },
+                  },
+                ],
+              },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+        } as ChatCompletionChunk,
+        // Second tool call
+        {
+          id: 'chatcmpl-multi',
+          model: 'gpt-4',
+          object: 'chat.completion.chunk',
+          created: Date.now() / 1000,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 1,
+                    id: 'call_news',
+                    type: 'function',
+                    function: {
+                      name: 'get_news',
+                      arguments: '{"topic": "technology"}',
+                    },
+                  },
+                ],
+              },
+              finish_reason: null,
+              logprobs: null,
+            },
+          ],
+        } as ChatCompletionChunk,
+        // Final chunk
+        {
+          id: 'chatcmpl-multi',
+          model: 'gpt-4',
+          object: 'chat.completion.chunk',
+          created: Date.now() / 1000,
+          choices: [
+            {
+              index: 0,
+              delta: {},
+              finish_reason: 'stop',
+              logprobs: null,
+            },
+          ],
+          usage: {
+            prompt_tokens: 30,
+            completion_tokens: 20,
+            total_tokens: 50,
+          },
+        } as ChatCompletionChunk,
+      ]
+
+      mockStreamChunks = multiToolChunks
+
+      const stream = await client.chat.completions.create({
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'Weather and news?' }],
+        stream: true,
+        posthogDistinctId: 'multi-tool-user',
+      })
+
+      // Consume the stream
+      for await (const _chunk of stream) {
+        // Just consume
+      }
+
+      // Wait for async capture
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      const { properties } = captureArgs[0]
+
+      // Verify both tool calls are in the output
+      const outputContent = properties['$ai_output_choices'][0].content
+      expect(outputContent).toHaveLength(3) // text + 2 function calls
+      expect(outputContent[0].type).toBe('text')
+      expect(outputContent[1].type).toBe('function')
+      expect(outputContent[1].function.name).toBe('get_weather')
+      expect(outputContent[2].type).toBe('function')
+      expect(outputContent[2].function.name).toBe('get_news')
+    })
+
+    conditionalTest('handles streaming errors gracefully', async () => {
+      // Mock a stream that throws an error
+      const errorStream = {
+        tee: jest.fn().mockReturnValue([
+          {
+            [Symbol.asyncIterator]: async function* () {
+              yield {
+                id: 'error-chunk',
+                model: 'gpt-4',
+                object: 'chat.completion.chunk',
+                created: Date.now() / 1000,
+                choices: [
+                  {
+                    index: 0,
+                    delta: { content: 'Starting...' },
+                    finish_reason: null,
+                  },
+                ],
+              }
+              const error = new Error('Stream interrupted') as Error & { status: number }
+              error.status = 503
+              throw error
+            },
+          },
+          {
+            [Symbol.asyncIterator]: async function* () {
+              const error = new Error('Stream interrupted') as Error & { status: number }
+              error.status = 503
+              throw error
+            },
+          },
+        ]),
+      }
+
+      const ChatMock: any = openaiModule.Chat
+      ;(ChatMock.Completions as any).prototype.create = jest.fn().mockResolvedValue(errorStream)
+
+      const stream = await client.chat.completions.create({
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'Test error' }],
+        stream: true,
+        posthogDistinctId: 'error-user',
+      })
+
+      // Try to consume the stream (should throw)
+      await expect(async () => {
+        for await (const _chunk of stream) {
+          // Should throw before completing
+        }
+      }).rejects.toThrow('Stream interrupted')
+
+      // Wait for error capture
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Verify error was captured
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      const { properties } = captureArgs[0]
+
+      expect(properties['$ai_http_status']).toBe(503)
+      expect(properties['$ai_error']).toBeDefined()
+      // Error is JSON stringified, so check for status code
+      expect(properties['$ai_error']).toContain('503')
+    })
+
+    conditionalTest('handles empty streaming response', async () => {
+      // Create chunks with no content
+      mockStreamChunks = [
+        {
+          id: 'empty-stream',
+          model: 'gpt-4',
+          object: 'chat.completion.chunk',
+          created: Date.now() / 1000,
+          choices: [
+            {
+              index: 0,
+              delta: {},
+              finish_reason: 'stop',
+              logprobs: null,
+            },
+          ],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 0,
+            total_tokens: 10,
+          },
+        } as ChatCompletionChunk,
+      ]
+
+      const stream = await client.chat.completions.create({
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'Empty test' }],
+        stream: true,
+        posthogDistinctId: 'empty-user',
+      })
+
+      // Consume the stream
+      for await (const _chunk of stream) {
+        // Just consume
+      }
+
+      // Wait for capture
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      const { properties } = captureArgs[0]
+
+      // Should have empty text content
+      expect(properties['$ai_output_choices']).toEqual([
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: '' }],
+        },
+      ])
+      expect(properties['$ai_output_tokens']).toBe(0)
+    })
   })
 })

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -171,7 +171,7 @@ const createMockStreamChunks = (options: {
     // Stream the arguments in parts
     const args = options.toolCallArguments || '{"location": "San Francisco", "unit": "celsius"}'
     const argChunks = [args.slice(0, 10), args.slice(10, 30), args.slice(30)]
-    
+
     for (const argChunk of argChunks) {
       chunks.push({
         ...baseChunk,
@@ -332,10 +332,9 @@ describe('PostHogOpenAI - Jest test suite', () => {
       if (params.stream) {
         // Return a mock stream with tee() method
         const mockStream = {
-          tee: jest.fn().mockReturnValue([
-            createMockAsyncIterator(mockStreamChunks),
-            createMockAsyncIterator(mockStreamChunks),
-          ]),
+          tee: jest
+            .fn()
+            .mockReturnValue([createMockAsyncIterator(mockStreamChunks), createMockAsyncIterator(mockStreamChunks)]),
         }
         return Promise.resolve(mockStream)
       }
@@ -639,7 +638,7 @@ describe('PostHogOpenAI - Jest test suite', () => {
       expect(event).toBe('$ai_generation')
       expect(properties['$ai_provider']).toBe('openai')
       expect(properties['$ai_model']).toBe('gpt-4')
-      
+
       // Check the formatted output structure
       expect(properties['$ai_output_choices']).toEqual([
         {
@@ -652,7 +651,7 @@ describe('PostHogOpenAI - Jest test suite', () => {
           ],
         },
       ])
-      
+
       expect(properties['$ai_input_tokens']).toBe(25)
       expect(properties['$ai_output_tokens']).toBe(15)
       expect(properties['streamTest']).toBe(true)

--- a/packages/ai/tests/tools.test.ts
+++ b/packages/ai/tests/tools.test.ts
@@ -84,47 +84,40 @@ describe('Tool Handling Tests', () => {
 
     it('should extract tools from Vercel AI SDK params', () => {
       const params = {
-        mode: {
-          type: 'regular',
-          tools: [
-            {
-              name: 'get_weather',
-              description: 'Get the weather for a location',
-              parameters: {
-                type: 'object',
-                properties: {
-                  location: { type: 'string' },
-                },
-                required: ['location'],
+        tools: [
+          {
+            name: 'get_weather',
+            description: 'Get the weather for a location',
+            parameters: {
+              type: 'object',
+              properties: {
+                location: { type: 'string' },
               },
+              required: ['location'],
             },
-            {
-              name: 'search',
-              description: 'Search for information',
-              parameters: {
-                type: 'object',
-                properties: {
-                  query: { type: 'string' },
-                },
-                required: ['query'],
+          },
+          {
+            name: 'search',
+            description: 'Search for information',
+            parameters: {
+              type: 'object',
+              properties: {
+                query: { type: 'string' },
               },
+              required: ['query'],
             },
-          ],
-        },
+          },
+        ],
         prompt: [],
         inputFormat: 'messages',
       }
 
       const tools = extractAvailableToolCalls('vercel', params)
-      expect(tools).toEqual(params.mode.tools)
+      expect(tools).toEqual(params.tools)
     })
 
-    it('should return null for Vercel AI SDK when mode is not regular', () => {
+    it('should return null for Vercel AI SDK when no tools are present', () => {
       const params = {
-        mode: {
-          type: 'object-json',
-          schema: { type: 'object' },
-        },
         prompt: [],
         inputFormat: 'messages',
       }
@@ -133,10 +126,11 @@ describe('Tool Handling Tests', () => {
       expect(tools).toBeNull()
     })
 
-    it('should return null for Vercel AI SDK when no mode is present', () => {
+    it('should return null for Vercel AI SDK when tools is undefined', () => {
       const params = {
         prompt: [],
         inputFormat: 'messages',
+        tools: undefined,
       }
 
       const tools = extractAvailableToolCalls('vercel', params)

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -1,7 +1,7 @@
 import { PostHog } from 'posthog-node'
 import { withTracing } from '../src/index'
-import { generateText, streamText } from 'ai'
-import type { LanguageModelV2, LanguageModelV2CallOptions } from '@ai-sdk/provider'
+import { generateText, streamText, wrapLanguageModel } from 'ai'
+import type { LanguageModelV2, LanguageModelV2CallOptions, LanguageModelV2StreamPart } from '@ai-sdk/provider'
 
 // Mock PostHog
 jest.mock('posthog-node', () => {
@@ -369,6 +369,457 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
           $ai_output_tokens: 5,
         })
       )
+    })
+  })
+
+  describe('streamText with tool calls', () => {
+    // Helper function to create a mock streaming model
+    const createMockStreamingModel = (
+      streamParts: LanguageModelV2StreamPart[]
+    ): LanguageModelV2 => {
+      return {
+        specificationVersion: 'v2' as const,
+        provider: 'test-provider',
+        modelId: 'test-streaming-model',
+        supportedUrls: {},
+        doGenerate: jest.fn(),
+        doStream: jest.fn().mockImplementation(async () => {
+          // Create a readable stream from the parts
+          const stream = new ReadableStream<LanguageModelV2StreamPart>({
+            async start(controller) {
+              for (const part of streamParts) {
+                controller.enqueue(part)
+              }
+              controller.close()
+            },
+          })
+
+          return {
+            stream,
+            response: { modelId: 'test-streaming-model' },
+          }
+        }),
+      } as LanguageModelV2
+    }
+
+    it('should capture single tool call in streaming', async () => {
+      const streamParts: LanguageModelV2StreamPart[] = [
+        { type: 'text-delta', id: 'text-1', delta: 'Let me check the weather ' },
+        { type: 'tool-input-start', id: 'tc-1', toolName: 'get_weather' },
+        { type: 'tool-input-delta', id: 'tc-1', delta: '{"location":"' },
+        { type: 'tool-input-delta', id: 'tc-1', delta: 'San Francisco"}' },
+        { type: 'tool-input-end', id: 'tc-1' },
+        { type: 'text-delta', id: 'text-2', delta: 'for you.' },
+        { 
+          type: 'finish', 
+          usage: { inputTokens: 20, outputTokens: 15, totalTokens: 35 },
+          finishReason: 'stop'
+        },
+      ]
+
+      const baseModel = createMockStreamingModel(streamParts)
+      const model = withTracing(baseModel, mockPostHogClient, {
+        posthogDistinctId: 'test-user',
+        posthogTraceId: 'test-stream-tool',
+      })
+
+      // Process the stream - need to mock doStream on the wrapped model
+      ;(model as any).doStream = async (params: any) => {
+        const middleware = (wrapLanguageModel as jest.Mock).mock.calls[0][0].middleware
+        return middleware.wrapStream({
+          doStream: async () => baseModel.doStream(params),
+          params,
+          model: baseModel,
+        })
+      }
+
+      const result = await model.doStream({ 
+        prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'What is the weather?' }] }] 
+      })
+      
+      // Read through the stream to trigger the transform and flush
+      const reader = result.stream.getReader()
+      while (!(await reader.read()).done) {
+        // Continue reading
+      }
+
+      // Wait for any async operations to complete
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      // Verify PostHog was called
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+
+      expect(captureCall[0].properties.$ai_output_choices).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Let me check the weather for you.' },
+            {
+              type: 'tool-call',
+              id: 'tc-1',
+              function: {
+                name: 'get_weather',
+                arguments: '{"location":"San Francisco"}',
+              },
+            },
+          ],
+        },
+      ])
+    })
+
+    it('should capture multiple tool calls in streaming', async () => {
+      const streamParts: LanguageModelV2StreamPart[] = [
+        { type: 'text-delta', id: 'text-1', delta: 'I will help you with multiple tasks. ' },
+        // First tool call
+        { type: 'tool-input-start', id: 'tc-1', toolName: 'get_weather' },
+        { type: 'tool-input-delta', id: 'tc-1', delta: '{"location":"NYC"}' },
+        { type: 'tool-input-end', id: 'tc-1' },
+        // Second tool call  
+        { type: 'tool-input-start', id: 'tc-2', toolName: 'web_search' },
+        { type: 'tool-input-delta', id: 'tc-2', delta: '{"query":"' },
+        { type: 'tool-input-delta', id: 'tc-2', delta: 'latest news"}' },
+        { type: 'tool-input-end', id: 'tc-2' },
+        { 
+          type: 'finish', 
+          usage: { inputTokens: 30, outputTokens: 25, totalTokens: 55 },
+          finishReason: 'stop'
+        },
+      ]
+
+      const baseModel = createMockStreamingModel(streamParts)
+      const model = withTracing(baseModel, mockPostHogClient, {
+        posthogDistinctId: 'test-user',
+        posthogTraceId: 'test-multi-tools',
+      })
+
+      // Process the stream - need to mock doStream on the wrapped model
+      ;(model as any).doStream = async (params: any) => {
+        const middleware = (wrapLanguageModel as jest.Mock).mock.calls[0][0].middleware
+        return middleware.wrapStream({
+          doStream: async () => baseModel.doStream(params),
+          params,
+          model: baseModel,
+        })
+      }
+
+      const result = await model.doStream({ 
+        prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Check weather and news' }] }] 
+      })
+      
+      const reader = result.stream.getReader()
+      while (!(await reader.read()).done) {
+        // Continue reading
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+
+      expect(captureCall[0].properties.$ai_output_choices).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'I will help you with multiple tasks. ' },
+            {
+              type: 'tool-call',
+              id: 'tc-1',
+              function: {
+                name: 'get_weather',
+                arguments: '{"location":"NYC"}',
+              },
+            },
+            {
+              type: 'tool-call',
+              id: 'tc-2',
+              function: {
+                name: 'web_search',
+                arguments: '{"query":"latest news"}',
+              },
+            },
+          ],
+        },
+      ])
+    })
+
+    it('should handle direct tool-call chunks in streaming', async () => {
+      const streamParts: LanguageModelV2StreamPart[] = [
+        { type: 'text-delta', id: 'text-1', delta: 'Processing your request. ' },
+        // Direct tool-call chunk (complete tool call in one chunk)
+        { 
+          type: 'tool-call', 
+          toolCallId: 'tc-direct',
+          toolName: 'calculate',
+          input: '{"operation":"add","a":5,"b":3}'
+        },
+        { 
+          type: 'finish', 
+          usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
+          finishReason: 'stop'
+        },
+      ]
+
+      const baseModel = createMockStreamingModel(streamParts)
+      const model = withTracing(baseModel, mockPostHogClient, {
+        posthogDistinctId: 'test-user',
+        posthogTraceId: 'test-direct-tool',
+      })
+
+      // Process the stream - need to mock doStream on the wrapped model
+      ;(model as any).doStream = async (params: any) => {
+        const middleware = (wrapLanguageModel as jest.Mock).mock.calls[0][0].middleware
+        return middleware.wrapStream({
+          doStream: async () => baseModel.doStream(params),
+          params,
+          model: baseModel,
+        })
+      }
+
+      const result = await model.doStream({ 
+        prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Calculate 5 + 3' }] }] 
+      })
+      
+      const reader = result.stream.getReader()
+      while (!(await reader.read()).done) {
+        // Continue reading
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+
+      expect(captureCall[0].properties.$ai_output_choices).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Processing your request. ' },
+            {
+              type: 'tool-call',
+              id: 'tc-direct',
+              function: {
+                name: 'calculate',
+                arguments: '{"operation":"add","a":5,"b":3}',
+              },
+            },
+          ],
+        },
+      ])
+    })
+
+    it('should handle mixed content with text, reasoning, and tool calls', async () => {
+      const streamParts: LanguageModelV2StreamPart[] = [
+        { type: 'reasoning-delta', id: 'reasoning-1', delta: 'User wants weather info. ' },
+        { type: 'reasoning-delta', id: 'reasoning-1', delta: 'I should use the weather tool.' },
+        { type: 'text-delta', id: 'text-1', delta: 'Let me check that for you. ' },
+        { type: 'tool-input-start', id: 'tc-1', toolName: 'get_weather' },
+        { type: 'tool-input-delta', id: 'tc-1', delta: '{"location":"London","units":"celsius"}' },
+        { type: 'tool-input-end', id: 'tc-1' },
+        { 
+          type: 'finish', 
+          usage: { 
+            inputTokens: 25, 
+            outputTokens: 20,
+            totalTokens: 45,
+            reasoningTokens: 10
+          },
+          finishReason: 'stop'
+        },
+      ]
+
+      const baseModel = createMockStreamingModel(streamParts)
+      const model = withTracing(baseModel, mockPostHogClient, {
+        posthogDistinctId: 'test-user',
+        posthogTraceId: 'test-mixed-content',
+      })
+
+      // Process the stream - need to mock doStream on the wrapped model
+      ;(model as any).doStream = async (params: any) => {
+        const middleware = (wrapLanguageModel as jest.Mock).mock.calls[0][0].middleware
+        return middleware.wrapStream({
+          doStream: async () => baseModel.doStream(params),
+          params,
+          model: baseModel,
+        })
+      }
+
+      const result = await model.doStream({ 
+        prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'What is the weather in London?' }] }] 
+      })
+      
+      const reader = result.stream.getReader()
+      while (!(await reader.read()).done) {
+        // Continue reading
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+
+      expect(captureCall[0].properties.$ai_output_choices).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'User wants weather info. I should use the weather tool.' },
+            { type: 'text', text: 'Let me check that for you. ' },
+            {
+              type: 'tool-call',
+              id: 'tc-1',
+              function: {
+                name: 'get_weather',
+                arguments: '{"location":"London","units":"celsius"}',
+              },
+            },
+          ],
+        },
+      ])
+
+      // Also verify reasoning tokens are captured
+      expect(captureCall[0].properties.$ai_reasoning_tokens).toBe(10)
+    })
+
+    it('should handle empty or incomplete tool calls gracefully', async () => {
+      const streamParts: LanguageModelV2StreamPart[] = [
+        { type: 'text-delta', id: 'text-1', delta: 'Here is the response. ' },
+        // Tool call without arguments
+        { type: 'tool-input-start', id: 'tc-1', toolName: 'empty_tool' },
+        { type: 'tool-input-end', id: 'tc-1' },
+        // Tool call with incomplete data (no name)
+        { 
+          type: 'tool-call', 
+          toolCallId: 'tc-incomplete',
+          toolName: '',
+          input: '{"data":"test"}'
+        },
+        { 
+          type: 'finish', 
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+          finishReason: 'stop'
+        },
+      ]
+
+      const baseModel = createMockStreamingModel(streamParts)
+      const model = withTracing(baseModel, mockPostHogClient, {
+        posthogDistinctId: 'test-user',
+        posthogTraceId: 'test-empty-tools',
+      })
+
+      // Process the stream - need to mock doStream on the wrapped model
+      ;(model as any).doStream = async (params: any) => {
+        const middleware = (wrapLanguageModel as jest.Mock).mock.calls[0][0].middleware
+        return middleware.wrapStream({
+          doStream: async () => baseModel.doStream(params),
+          params,
+          model: baseModel,
+        })
+      }
+
+      const result = await model.doStream({ 
+        prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Test empty tools' }] }] 
+      })
+      
+      const reader = result.stream.getReader()
+      while (!(await reader.read()).done) {
+        // Continue reading
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+
+      // Should only include valid tool calls (tc-1 with empty_tool name)
+      expect(captureCall[0].properties.$ai_output_choices).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Here is the response. ' },
+            {
+              type: 'tool-call',
+              id: 'tc-1',
+              function: {
+                name: 'empty_tool',
+                arguments: '',
+              },
+            },
+          ],
+        },
+      ])
+    })
+
+    it('should handle streaming with only tool calls and no text', async () => {
+      const streamParts: LanguageModelV2StreamPart[] = [
+        { type: 'tool-input-start', id: 'tc-1', toolName: 'function_a' },
+        { type: 'tool-input-delta', id: 'tc-1', delta: '{"param":"value"}' },
+        { type: 'tool-input-end', id: 'tc-1' },
+        { 
+          type: 'tool-call', 
+          toolCallId: 'tc-2',
+          toolName: 'function_b',
+          input: '{"x":10}'
+        },
+        { 
+          type: 'finish', 
+          usage: { inputTokens: 8, outputTokens: 4, totalTokens: 12 },
+          finishReason: 'stop'
+        },
+      ]
+
+      const baseModel = createMockStreamingModel(streamParts)
+      const model = withTracing(baseModel, mockPostHogClient, {
+        posthogDistinctId: 'test-user',
+        posthogTraceId: 'test-tools-only',
+      })
+
+      // Process the stream - need to mock doStream on the wrapped model
+      ;(model as any).doStream = async (params: any) => {
+        const middleware = (wrapLanguageModel as jest.Mock).mock.calls[0][0].middleware
+        return middleware.wrapStream({
+          doStream: async () => baseModel.doStream(params),
+          params,
+          model: baseModel,
+        })
+      }
+
+      const result = await model.doStream({ 
+        prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Execute functions' }] }] 
+      })
+      
+      const reader = result.stream.getReader()
+      while (!(await reader.read()).done) {
+        // Continue reading
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+
+      expect(captureCall[0].properties.$ai_output_choices).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              id: 'tc-1',
+              function: {
+                name: 'function_a',
+                arguments: '{"param":"value"}',
+              },
+            },
+            {
+              type: 'tool-call',
+              id: 'tc-2',
+              function: {
+                name: 'function_b',
+                arguments: '{"x":10}',
+              },
+            },
+          ],
+        },
+      ])
     })
   })
 })


### PR DESCRIPTION
## Problem

There are multiple bugs relating to tool for streaming providers, mostly where tool calls do not appear in the output messages, but also Vercel not showing available tools.

## Changes

Fixes:
- Anthropic Streaming missing tool call in output
- Gemini streaming missing tool call in output
- OpenAI Chat Completions API Streaming missing tool call in output
- Vercel missing tool call in output
- Vercel missing $ai_tools in both normal and streaming

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
