### PR TITLE
fix: set survey person properties on SDK older than 1.249.2

### DIFF
--- a/.changeset/grumpy-numbers-ring.md
+++ b/.changeset/grumpy-numbers-ring.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: set survey person properties on SDK <1.249.2

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../posthog-surveys-types'
 import { document as _document, window as _window, userAgent } from '../../utils/globals'
 import {
+    getSurveyInteractionProperty,
     getSurveySeenKey,
     SURVEY_LOGGER as logger,
     setSurveySeenOnLocalStorage,
@@ -417,6 +418,9 @@ export const sendSurveyEvent = ({
         [SurveyEventProperties.SURVEY_COMPLETED]: isSurveyCompleted,
         sessionRecordingUrl: posthog.get_session_replay_url?.(),
         ...responses,
+        $set: {
+            [getSurveyInteractionProperty(survey, 'responded')]: true,
+        },
     })
     if (isSurveyCompleted) {
         // Only dispatch PHSurveySent if the survey is completed, as that removes the survey from focus
@@ -451,6 +455,9 @@ export const dismissedSurveyEvent = (survey: Survey, posthog?: PostHog, readOnly
             question: question.question,
             response: getSurveyResponseValue(inProgressSurvey?.responses || {}, question.id),
         })),
+        $set: {
+            [getSurveyInteractionProperty(survey, 'dismissed')]: true,
+        },
     })
     // Clear in-progress state on dismissal
     clearInProgressSurveyState(survey)


### PR DESCRIPTION
## Problem

[follow up of this PR](https://github.com/PostHog/posthog-js/pull/2215).

Last PR made sure we're setting the localStorage changes, but, for versions older than `1.249.2`, we are not setting the person properties.

## Changes

Also sets the person properties when capturing survey_sent/survey_dismissed events.

This works because the extensions are always downloaded in the latest version for most installations. For people who bundle all the functionality, it should be working as expected in all cases regardless

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code -> all tests passing
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
