### PR TITLE
fix(posthog-node): fix node crash handling

### DIFF
--- a/packages/node/src/extensions/error-tracking/autocapture.ts
+++ b/packages/node/src/extensions/error-tracking/autocapture.ts
@@ -7,7 +7,7 @@ type ErrorHandler = { _posthogErrorHandler: boolean } & ((error: Error) => void)
 
 function makeUncaughtExceptionHandler(
   captureFn: (exception: Error, hint: EventHint) => void,
-  onFatalFn: () => void
+  onFatalFn: (exception: Error) => void
 ): ErrorHandler {
   let calledFatalError: boolean = false
 
@@ -39,7 +39,7 @@ function makeUncaughtExceptionHandler(
 
       if (!calledFatalError && processWouldExit) {
         calledFatalError = true
-        onFatalFn()
+        onFatalFn(error)
       }
     },
     { _posthogErrorHandler: true }
@@ -48,14 +48,14 @@ function makeUncaughtExceptionHandler(
 
 export function addUncaughtExceptionListener(
   captureFn: (exception: Error, hint: EventHint) => void,
-  onFatalFn: () => void
+  onFatalFn: (exception: Error) => void
 ): void {
   global.process.on('uncaughtException', makeUncaughtExceptionHandler(captureFn, onFatalFn))
 }
 
 export function addUnhandledRejectionListener(captureFn: (exception: unknown, hint: EventHint) => void): void {
   global.process.on('unhandledRejection', (reason: unknown) => {
-    captureFn(reason, {
+    return captureFn(reason, {
       mechanism: {
         type: 'onunhandledrejection',
         handled: false,

--- a/packages/node/src/extensions/error-tracking/chunk-ids.ts
+++ b/packages/node/src/extensions/error-tracking/chunk-ids.ts
@@ -12,11 +12,10 @@ let parsedStackResults: Record<StackString, CachedResult> | undefined
 let lastKeysCount: number | undefined
 let cachedFilenameChunkIds: ChunkIdMapType | undefined
 
-export function getFilenameToChunkIdMap(stackParser: StackParser): ChunkIdMapType {
+export function getFilenameToChunkIdMap(stackParser: StackParser): ChunkIdMapType | null {
   const chunkIdMap = (globalThis as any)._posthogChunkIds as ChunkIdMapType | undefined
   if (!chunkIdMap) {
-    console.error('No chunk id map found')
-    return {}
+    return null
   }
 
   const chunkIdKeys = Object.keys(chunkIdMap)

--- a/packages/node/src/extensions/error-tracking/error-conversion.ts
+++ b/packages/node/src/extensions/error-tracking/error-conversion.ts
@@ -282,7 +282,7 @@ function parseStackFrames(stackParser: StackParser, error: Error): StackFrame[] 
 export function applyChunkIds(frames: StackFrame[], parser: StackParser): StackFrame[] {
   const filenameChunkIdMap = getFilenameToChunkIdMap(parser)
   frames.forEach((frame) => {
-    if (frame.filename) {
+    if (frame.filename && filenameChunkIdMap) {
       frame.chunk_id = filenameChunkIdMap[frame.filename]
     }
   })

--- a/packages/node/src/extensions/error-tracking/index.ts
+++ b/packages/node/src/extensions/error-tracking/index.ts
@@ -54,14 +54,15 @@ export default class ErrorTracking {
     }
   }
 
-  private onException(exception: unknown, hint: EventHint): void {
-    void ErrorTracking.buildEventMessage(exception, hint).then((msg) => {
-      this.client.capture(msg)
-    })
+  private async onException(exception: unknown, hint: EventHint): Promise<void> {
+    const eventMessage = await ErrorTracking.buildEventMessage(exception, hint)
+    this.client.capture(eventMessage)
   }
 
-  private async onFatalError(): Promise<void> {
+  private async onFatalError(exception: Error): Promise<void> {
+    console.error(exception)
     await this.client.shutdown(SHUTDOWN_TIMEOUT)
+    process.exit(1)
   }
 
   isEnabled(): boolean {


### PR DESCRIPTION
## Problem

Fix https://github.com/PostHog/posthog-js/issues/2220
Fix https://github.com/PostHog/posthog-js/issues/2221
Fix https://github.com/PostHog/posthog-js/issues/2222

## Changes

- flush exception on shutdown
- log error on fatal error
- exit process with status code 1 on fatal error

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
