### PR TITLE
chore: Add doc comments to generate into specs.

### DIFF
--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -352,7 +352,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    *   sendFeatureFlags: true
    * })
    * ```
-   * 
+   *
    * @example
    * ```ts
    * // With custom feature flags options


### PR DESCRIPTION
## Problem

We don't have doc comments on exposed methods. We want these to generate specs. Stacked on https://github.com/PostHog/posthog-js/pull/2245

## Changes

Doc comments from the existing node.js docs.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
