### PR TITLE
feat: Support bootstrapping feature flags during SSR in ReactJS

### DIFF
--- a/packages/react/src/context/PostHogContext.ts
+++ b/packages/react/src/context/PostHogContext.ts
@@ -1,6 +1,9 @@
-import posthogJs from 'posthog-js'
+import posthogJs, { BootstrapConfig } from 'posthog-js'
 import { createContext } from 'react'
 
 export type PostHog = typeof posthogJs
 
-export const PostHogContext = createContext<{ client: PostHog }>({ client: posthogJs })
+export const PostHogContext = createContext<{ client: PostHog; bootstrap?: BootstrapConfig }>({
+    client: posthogJs,
+    bootstrap: undefined,
+})

--- a/packages/react/src/context/PostHogProvider.tsx
+++ b/packages/react/src/context/PostHogProvider.tsx
@@ -124,5 +124,9 @@ export function PostHogProvider({ children, client, apiKey, options }: WithOptio
         }
     }, [client, apiKey, JSON.stringify(options)]) // Stringify options to be a stable reference
 
-    return <PostHogContext.Provider value={{ client: posthog }}>{children}</PostHogContext.Provider>
+    return (
+        <PostHogContext.Provider value={{ client: posthog, bootstrap: options?.bootstrap ?? client?.config?.bootstrap }}>
+            {children}
+        </PostHogContext.Provider>
+    )
 }

--- a/packages/react/src/hooks/useActiveFeatureFlags.ts
+++ b/packages/react/src/hooks/useActiveFeatureFlags.ts
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react'
-import { usePostHog } from './usePostHog'
+import { useContext, useEffect, useState } from 'react'
+import { PostHogContext } from '../context'
 
 export function useActiveFeatureFlags(): string[] {
-    const client = usePostHog()
+    const { client, bootstrap } = useContext(PostHogContext)
 
     const [featureFlags, setFeatureFlags] = useState<string[]>(() => client.featureFlags.getFlags())
 
@@ -11,6 +11,11 @@ export function useActiveFeatureFlags(): string[] {
             setFeatureFlags(flags)
         })
     }, [client])
+
+    // if the client is not loaded yet and we have a bootstraped value, use it
+    if (featureFlags.length === 0 && bootstrap?.featureFlags) {
+        return Object.keys(bootstrap.featureFlags)
+    }
 
     return featureFlags
 }

--- a/packages/react/src/hooks/useActiveFeatureFlags.ts
+++ b/packages/react/src/hooks/useActiveFeatureFlags.ts
@@ -12,7 +12,7 @@ export function useActiveFeatureFlags(): string[] {
         })
     }, [client])
 
-    // if the client is not loaded yet and we have a bootstraped value, use it
+    // if the client is not loaded yet and we have a bootstrapped value, use it
     if (featureFlags.length === 0 && bootstrap?.featureFlags) {
         return Object.keys(bootstrap.featureFlags)
     }

--- a/packages/react/src/hooks/useFeatureFlagEnabled.ts
+++ b/packages/react/src/hooks/useFeatureFlagEnabled.ts
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
-import { usePostHog } from './usePostHog'
+import { useContext, useEffect, useState } from 'react'
+import { PostHogContext } from '../context'
+import { isUndefined } from '../utils/type-utils'
 
 export function useFeatureFlagEnabled(flag: string): boolean | undefined {
-    const client = usePostHog()
+    const { client, bootstrap } = useContext(PostHogContext)
 
     const [featureEnabled, setFeatureEnabled] = useState<boolean | undefined>(() => client.isFeatureEnabled(flag))
 
@@ -11,6 +12,13 @@ export function useFeatureFlagEnabled(flag: string): boolean | undefined {
             setFeatureEnabled(client.isFeatureEnabled(flag))
         })
     }, [client, flag])
+
+    const bootstrapped = bootstrap?.featureFlags?.[flag]
+
+    // if the client is not loaded yet, check if we have a bootstrapped value and then true/false it
+    if (isUndefined(featureEnabled)) {
+        return isUndefined(bootstrapped) ? undefined : !!bootstrapped
+    }
 
     return featureEnabled
 }

--- a/packages/react/src/hooks/useFeatureFlagPayload.ts
+++ b/packages/react/src/hooks/useFeatureFlagPayload.ts
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react'
 import { JsonType } from 'posthog-js'
-import { usePostHog } from './usePostHog'
+import { useContext, useEffect, useState } from 'react'
+import { PostHogContext } from '../context'
+import { isUndefined } from '../utils/type-utils'
 
 export function useFeatureFlagPayload(flag: string): JsonType {
-    const client = usePostHog()
+    const { client, bootstrap } = useContext(PostHogContext)
 
     const [featureFlagPayload, setFeatureFlagPayload] = useState<JsonType>(() => client.getFeatureFlagPayload(flag))
 
@@ -12,6 +13,11 @@ export function useFeatureFlagPayload(flag: string): JsonType {
             setFeatureFlagPayload(client.getFeatureFlagPayload(flag))
         })
     }, [client, flag])
+
+    // if the client is not loaded yet, use the bootstrapped value
+    if (isUndefined(featureFlagPayload)) {
+        return bootstrap?.featureFlagPayloads?.[flag]
+    }
 
     return featureFlagPayload
 }

--- a/packages/react/src/hooks/useFeatureFlagVariantKey.ts
+++ b/packages/react/src/hooks/useFeatureFlagVariantKey.ts
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
-import { usePostHog } from './usePostHog'
+import { useContext, useEffect, useState } from 'react'
+import { PostHogContext } from '../context'
+import { isUndefined } from '../utils/type-utils'
 
 export function useFeatureFlagVariantKey(flag: string): string | boolean | undefined {
-    const client = usePostHog()
+    const { client, bootstrap } = useContext(PostHogContext)
 
     const [featureFlagVariantKey, setFeatureFlagVariantKey] = useState<string | boolean | undefined>(() =>
         client.getFeatureFlag(flag)
@@ -13,6 +14,10 @@ export function useFeatureFlagVariantKey(flag: string): string | boolean | undef
             setFeatureFlagVariantKey(client.getFeatureFlag(flag))
         })
     }, [client, flag])
+
+    if (isUndefined(featureFlagVariantKey)) {
+        return bootstrap?.featureFlags?.[flag]
+    }
 
     return featureFlagVariantKey
 }


### PR DESCRIPTION
## Problem

For customers using the newer "Server Side Rendering" (SSR) technique in ReactJS can run into the "flickering" problem when using the `posthog-js/react` hooks intended for `"use client"` components. See issue #2250

Here is a video showing the before/after. As you can see after this change the server rendered instance of the component matches the bootstrapped state.

https://github.com/user-attachments/assets/a7138884-5118-436c-9c96-f4a352ff4d66

Things to note in the video:

- The values after `posthog:` are _always_ the default values for the functions in the rendered HTML
- The values after `posthog:` flicker in really quickly (it is bootstrapped so its almost instant, but it is still noticeable. Especially when the flag is an A/B test for something more drastic like a homepage.

## Changes

This PR updates the `PostHogContext` to store not just the pointer to the current client but the bootstrapped configuration as well.

It then updates the relevant hooks (`useActiveFeatureFlags`, `useFeatureFlagEnabled`, `useFeatureFlagPayload` and `useFeatureFlagVariantKey`) to _fallback_ to this value. This allows the toolbar, https://github.com/PostHog/posthog/issues/28517 (when merged) and `reloadFeatureFlags` to override the bootstrapped value while still allowing the user to receive HTML in line with the configured feature flag.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
