### PR TITLE
fix: script loader can race and confuse caller

### DIFF
--- a/packages/browser/src/entrypoints/external-scripts-loader.ts
+++ b/packages/browser/src/entrypoints/external-scripts-loader.ts
@@ -16,8 +16,22 @@ const loadScript = (posthog: PostHog, url: string, callback: (error?: string | E
     if (existingScripts) {
         for (let i = 0; i < existingScripts.length; i++) {
             if (existingScripts[i].src === url) {
-                // Script already exists, we still call the callback, they have to be idempotent
-                return callback()
+                const alreadyExistingScriptTag = existingScripts[i]
+
+                if ((alreadyExistingScriptTag as any).__posthog_loading_callback_fired) {
+                    // script already exists and fired its load event,
+                    // we call the callback again, they need to be idempotent
+                    return callback()
+                }
+
+                alreadyExistingScriptTag.onload = (event) => {
+                    // it hasn't already loaded
+                    // we probably called loadScript twice in quick succession,
+                    // so we attach a callback to the onload event
+                    ;(alreadyExistingScriptTag as any).__posthog_loading_callback_fired = true
+                    callback(undefined, event)
+                }
+                alreadyExistingScriptTag.onerror = (error) => callback(error)
             }
         }
     }


### PR DESCRIPTION
in https://github.com/PostHog/posthog-js/pull/2246 we observed that 
we can call `loadExternalDependency` twice in quick succession
the second call can run after the script has been added to the DOM
but _before_ the script processing has finished (i.e. before the load event has fired)
so it calls the callback before the load event which should call it
since the callback should be idempotent
we can add a marker for the load event having fired
and if that is not present register for `onLoad`