### PR TITLE
chore(llma): include ai lib version in event

### DIFF
--- a/.changeset/old-ideas-yawn.md
+++ b/.changeset/old-ideas-yawn.md
@@ -1,5 +1,5 @@
 ---
-'@posthog/ai': patch
+'@posthog/ai': minor
 ---
 
 send ai library version in events

--- a/.changeset/wise-pants-nail.md
+++ b/.changeset/wise-pants-nail.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+send ai library version in events

--- a/packages/ai/src/langchain/callbacks.ts
+++ b/packages/ai/src/langchain/callbacks.ts
@@ -1,6 +1,7 @@
 import { PostHog } from 'posthog-node'
 import { withPrivacyMode, getModelParams } from '../utils'
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base'
+import { version } from '../../package.json'
 import type { Serialized } from '@langchain/core/load/serializable'
 import type { ChainValues } from '@langchain/core/utils/types'
 import type { LLMResult } from '@langchain/core/outputs'
@@ -361,6 +362,8 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
     const eventName = parentRunId ? '$ai_span' : '$ai_trace'
     const latency = run.endTime ? (run.endTime - run.startTime) / 1000 : 0
     const eventProperties: Record<string, any> = {
+      $ai_lib: 'posthog-ai',
+      $ai_lib_version: version,
       $ai_trace_id: traceId,
       $ai_input_state: withPrivacyMode(this.client, this.privacyMode, run.input),
       $ai_latency: latency,
@@ -414,6 +417,8 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
   ): void {
     const latency = run.endTime ? (run.endTime - run.startTime) / 1000 : 0
     const eventProperties: Record<string, any> = {
+      $ai_lib: 'posthog-ai',
+      $ai_lib_version: version,
       $ai_trace_id: traceId,
       $ai_span_id: runId,
       $ai_span_name: run.name,

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -5,6 +5,7 @@ import AnthropicOriginal from '@anthropic-ai/sdk'
 import type { ChatCompletionTool } from 'openai/resources/chat/completions'
 import type { Tool as GeminiTool } from '@google/genai'
 import type { FormattedMessage, FormattedContent, TokenUsage } from './types'
+import { version } from '../package.json'
 
 type ChatCompletionCreateParamsBase = OpenAIOrignal.Chat.Completions.ChatCompletionCreateParams
 type MessageCreateParams = AnthropicOriginal.Messages.MessageCreateParams
@@ -391,6 +392,8 @@ export const sendEventToPosthog = async ({
   }
 
   const properties = {
+    $ai_lib: 'posthog-ai',
+    $ai_lib_version: version,
     $ai_provider: params.posthogProviderOverride ?? provider,
     $ai_model: params.posthogModelOverride ?? model,
     $ai_model_parameters: getModelParams(params),

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -274,7 +274,7 @@ const assertPostHogCapture = (mockClient: PostHog, expectations: CaptureExpectat
 
   // Always check that latency is a number
   expect(typeof properties['$ai_latency']).toBe('number')
-  
+
   // Always check $ai_lib and $ai_lib_version
   expect(properties['$ai_lib']).toBe('posthog-ai')
   expect(properties['$ai_lib_version']).toBe(version)

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -1,6 +1,7 @@
 import { PostHog } from 'posthog-node'
 import PostHogAnthropic from '../src/anthropic'
 import AnthropicOriginal from '@anthropic-ai/sdk'
+import { version } from '../package.json'
 
 // Type definitions
 interface MockAnthropicResponseOptions {
@@ -273,6 +274,10 @@ const assertPostHogCapture = (mockClient: PostHog, expectations: CaptureExpectat
 
   // Always check that latency is a number
   expect(typeof properties['$ai_latency']).toBe('number')
+  
+  // Always check $ai_lib and $ai_lib_version
+  expect(properties['$ai_lib']).toBe('posthog-ai')
+  expect(properties['$ai_lib_version']).toBe(version)
 }
 
 describe('PostHogAnthropic', () => {

--- a/packages/ai/tests/callbacks.test.ts
+++ b/packages/ai/tests/callbacks.test.ts
@@ -30,11 +30,11 @@ describe('LangChainCallbackHandler', () => {
     const parentRunId = 'parent_lib'
     const metadata = { ls_model_name: 'gpt-4', ls_provider: 'openai' }
     // Need to provide extraParams with invocation_params to set up modelParams
-    const extraParams = { 
-      invocation_params: { 
+    const extraParams = {
+      invocation_params: {
         temperature: 0.7,
-        max_tokens: 100
-      } 
+        max_tokens: 100,
+      },
     }
 
     // Start LLM with extraParams
@@ -69,7 +69,7 @@ describe('LangChainCallbackHandler', () => {
     // Check $ai_lib and $ai_lib_version
     expect(captureCall[0].properties['$ai_lib']).toBe('posthog-ai')
     expect(captureCall[0].properties['$ai_lib_version']).toBe(version)
-    
+
     // Check other expected properties
     expect(captureCall[0].event).toBe('$ai_generation')
     expect(captureCall[0].properties.$ai_model).toBe('gpt-4')

--- a/packages/ai/tests/callbacks.test.ts
+++ b/packages/ai/tests/callbacks.test.ts
@@ -1,6 +1,7 @@
 import { LangChainCallbackHandler } from '../src/langchain/callbacks'
 import { PostHog } from 'posthog-node'
 import { AIMessage } from '@langchain/core/messages'
+import { version } from '../package.json'
 
 const mockPostHogClient = {
   capture: jest.fn(),
@@ -14,6 +15,65 @@ describe('LangChainCallbackHandler', () => {
       client: mockPostHogClient,
     })
     jest.clearAllMocks()
+  })
+
+  it('should include $ai_lib and $ai_lib_version in captured events', async () => {
+    const serialized = {
+      lc: 1,
+      type: 'constructor' as const,
+      id: ['langchain', 'llms', 'openai', 'OpenAI'],
+      kwargs: { openai_api_base: 'https://api.openai.com/v1' },
+    }
+
+    const prompts = ['Test prompt for library version']
+    const runId = 'run_lib_test'
+    const parentRunId = 'parent_lib'
+    const metadata = { ls_model_name: 'gpt-4', ls_provider: 'openai' }
+    // Need to provide extraParams with invocation_params to set up modelParams
+    const extraParams = { 
+      invocation_params: { 
+        temperature: 0.7,
+        max_tokens: 100
+      } 
+    }
+
+    // Start LLM with extraParams
+    handler.handleLLMStart(serialized, prompts, runId, parentRunId, extraParams, undefined, metadata)
+
+    // Mock LLM response
+    const llmResult = {
+      generations: [
+        [
+          {
+            text: 'Test response',
+            message: new AIMessage('Test response'),
+          },
+        ],
+      ],
+      llmOutput: {
+        tokenUsage: {
+          promptTokens: 10,
+          completionTokens: 3,
+          totalTokens: 13,
+        },
+      },
+    }
+
+    // End LLM
+    handler.handleLLMEnd(llmResult, runId)
+
+    // Verify capture was called
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+    const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+
+    // Check $ai_lib and $ai_lib_version
+    expect(captureCall[0].properties['$ai_lib']).toBe('posthog-ai')
+    expect(captureCall[0].properties['$ai_lib_version']).toBe(version)
+    
+    // Check other expected properties
+    expect(captureCall[0].event).toBe('$ai_generation')
+    expect(captureCall[0].properties.$ai_model).toBe('gpt-4')
+    expect(captureCall[0].properties.$ai_provider).toBe('openai')
   })
 
   it('should convert AIMessage with tool calls to dict format', () => {

--- a/packages/ai/tests/gemini.test.ts
+++ b/packages/ai/tests/gemini.test.ts
@@ -1,5 +1,6 @@
 import { PostHog } from 'posthog-node'
 import PostHogGemini from '../src/gemini'
+import { version } from '../package.json'
 
 let mockGeminiResponse: any = {}
 let mockGeminiStreamResponse: any = {}
@@ -163,6 +164,8 @@ describe('PostHogGemini - Jest test suite', () => {
 
     expect(distinctId).toBe('test-id')
     expect(event).toBe('$ai_generation')
+    expect(properties['$ai_lib']).toBe('posthog-ai')
+    expect(properties['$ai_lib_version']).toBe(version)
     expect(properties['$ai_provider']).toBe('gemini')
     expect(properties['$ai_model']).toBe('gemini-2.0-flash-001')
     expect(properties['$ai_input']).toEqual([{ role: 'user', content: 'Hello' }])
@@ -203,6 +206,8 @@ describe('PostHogGemini - Jest test suite', () => {
 
     expect(distinctId).toBe('test-id')
     expect(event).toBe('$ai_generation')
+    expect(properties['$ai_lib']).toBe('posthog-ai')
+    expect(properties['$ai_lib_version']).toBe(version)
     expect(properties['$ai_provider']).toBe('gemini')
     expect(properties['$ai_model']).toBe('gemini-2.0-flash-001')
     expect(properties['$ai_input']).toEqual([{ role: 'user', content: 'Write a short poem' }])

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -4,6 +4,7 @@ import openaiModule from 'openai'
 import type { ChatCompletion, ChatCompletionChunk } from 'openai/resources/chat/completions'
 import type { ParsedResponse } from 'openai/resources/responses/responses'
 import { flushPromises } from './test-utils'
+import { version } from '../package.json'
 
 // Test-specific helper interface for async iteration
 interface MockAsyncIterator<T> {
@@ -370,6 +371,8 @@ describe('PostHogOpenAI - Jest test suite', () => {
 
     expect(distinctId).toBe('test-id')
     expect(event).toBe('$ai_generation')
+    expect(properties['$ai_lib']).toBe('posthog-ai')
+    expect(properties['$ai_lib_version']).toBe(version)
     expect(properties['$ai_provider']).toBe('openai')
     expect(properties['$ai_model']).toBe('gpt-4')
     expect(properties['$ai_input']).toEqual([{ role: 'user', content: 'Hello' }])
@@ -555,6 +558,8 @@ describe('PostHogOpenAI - Jest test suite', () => {
 
     expect(distinctId).toBe('test-id')
     expect(event).toBe('$ai_generation')
+    expect(properties['$ai_lib']).toBe('posthog-ai')
+    expect(properties['$ai_lib_version']).toBe(version)
     expect(properties['$ai_provider']).toBe('openai')
     expect(properties['$ai_model']).toBe('gpt-4o-2024-08-06')
     expect(properties['$ai_input']).toEqual([
@@ -637,6 +642,8 @@ describe('PostHogOpenAI - Jest test suite', () => {
 
       expect(distinctId).toBe('test-stream-user')
       expect(event).toBe('$ai_generation')
+      expect(properties['$ai_lib']).toBe('posthog-ai')
+      expect(properties['$ai_lib_version']).toBe(version)
       expect(properties['$ai_provider']).toBe('openai')
       expect(properties['$ai_model']).toBe('gpt-4')
 

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -127,11 +127,11 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
       // Verify PostHog was called
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
       const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
-      
+
       // Verify $ai_lib and $ai_lib_version
       expect(captureCall[0].properties['$ai_lib']).toBe('posthog-ai')
       expect(captureCall[0].properties['$ai_lib_version']).toBe(version)
-      
+
       expect(captureCall[0]).toEqual({
         distinctId: 'test-user',
         event: '$ai_generation',
@@ -225,7 +225,7 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
       // Check that PostHog capture was called
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
       const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
-      
+
       // Verify $ai_lib and $ai_lib_version
       expect(captureCall[0].properties['$ai_lib']).toBe('posthog-ai')
       expect(captureCall[0].properties['$ai_lib_version']).toBe(version)
@@ -282,7 +282,7 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
       // Verify error was tracked
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
       const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
-      
+
       // Verify $ai_lib and $ai_lib_version
       expect(captureCall[0].properties['$ai_lib']).toBe('posthog-ai')
       expect(captureCall[0].properties['$ai_lib_version']).toBe(version)
@@ -375,7 +375,7 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
       // Verify PostHog was called with tools
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
       const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
-      
+
       // Verify $ai_lib and $ai_lib_version
       expect(captureCall[0].properties['$ai_lib']).toBe('posthog-ai')
       expect(captureCall[0].properties['$ai_lib_version']).toBe(version)

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -3,6 +3,7 @@ import { withTracing } from '../src/index'
 import { generateText, wrapLanguageModel } from 'ai'
 import type { LanguageModelV2, LanguageModelV2CallOptions, LanguageModelV2StreamPart } from '@ai-sdk/provider'
 import { flushPromises } from './test-utils'
+import { version } from '../package.json'
 
 // Mock PostHog
 jest.mock('posthog-node', () => {
@@ -126,6 +127,11 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
       // Verify PostHog was called
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
       const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      
+      // Verify $ai_lib and $ai_lib_version
+      expect(captureCall[0].properties['$ai_lib']).toBe('posthog-ai')
+      expect(captureCall[0].properties['$ai_lib_version']).toBe(version)
+      
       expect(captureCall[0]).toEqual({
         distinctId: 'test-user',
         event: '$ai_generation',
@@ -187,10 +193,12 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
       // Verify PostHog was called 3 times
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(3)
 
-      // Verify each call had the correct trace ID
+      // Verify each call had the correct trace ID and library properties
       const calls = (mockPostHogClient.capture as jest.Mock).mock.calls
       calls.forEach((call) => {
         expect(call[0].properties.$ai_trace_id).toBe('test123')
+        expect(call[0].properties['$ai_lib']).toBe('posthog-ai')
+        expect(call[0].properties['$ai_lib_version']).toBe(version)
       })
     })
 
@@ -217,6 +225,10 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
       // Check that PostHog capture was called
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
       const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      
+      // Verify $ai_lib and $ai_lib_version
+      expect(captureCall[0].properties['$ai_lib']).toBe('posthog-ai')
+      expect(captureCall[0].properties['$ai_lib_version']).toBe(version)
 
       expect(captureCall[0]).toEqual({
         distinctId: 'test-user',
@@ -270,6 +282,10 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
       // Verify error was tracked
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
       const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      
+      // Verify $ai_lib and $ai_lib_version
+      expect(captureCall[0].properties['$ai_lib']).toBe('posthog-ai')
+      expect(captureCall[0].properties['$ai_lib_version']).toBe(version)
 
       expect(captureCall[0].properties).toEqual(
         expect.objectContaining({
@@ -359,6 +375,10 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
       // Verify PostHog was called with tools
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
       const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      
+      // Verify $ai_lib and $ai_lib_version
+      expect(captureCall[0].properties['$ai_lib']).toBe('posthog-ai')
+      expect(captureCall[0].properties['$ai_lib_version']).toBe(version)
 
       expect(captureCall[0].properties).toEqual(
         expect.objectContaining({


### PR DESCRIPTION
## Problem

In the Python SDK, we can clearly see the SDK version because the LLM Analytics related code is part of the same library as the rest, whereas in the Node SDK it is not. We only see the posthog-node version in the event, which makes it hard to easily see what posthog-ai library version was used to send an event.

## Changes

This sends two new properties in the LLM Events: `$ai_lib` and `$ai_lib_version`.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
