### PR TITLE
fix: don't mangle to $

### DIFF
--- a/.changeset/clever-rings-itch.md
+++ b/.changeset/clever-rings-itch.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: don't mangle variables to `$`

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -247,6 +247,10 @@ const plugins = (es5, noExternal) => [
                               '_map',
                           ],
                       },
+                      reserved: [
+                          // we don't want to emit $ since that clashes with jquery
+                          '$',
+                      ],
                   },
     }),
     {


### PR DESCRIPTION
see private slack thread: https://posthog.slack.com/archives/C040PJN7011/p1756503041390999

terser had started mangling one of our variables to `$`
using terser's `reserved` lets us avoid doing that
so lets