### PR TITLE
fix: hosted surveys should always render

### DIFF
--- a/.changeset/fancy-files-train.md
+++ b/.changeset/fancy-files-train.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: hosted surveys should ignore any delays

--- a/packages/browser/src/__tests__/extensions/surveys/survey-popup.test.tsx
+++ b/packages/browser/src/__tests__/extensions/surveys/survey-popup.test.tsx
@@ -282,4 +282,23 @@ describe('SurveyPopup', () => {
 
         expect(mockedDismissedSurveyEvent).toHaveBeenCalledWith(mockSurvey, mockPosthog, false)
     })
+
+    test('always shows external surveys even if millisecondDelay is set', () => {
+        const survey = {
+            ...mockSurvey,
+            type: SurveyType.ExternalSurvey,
+            appearance: {
+                surveyPopupDelaySeconds: 1000,
+            },
+        }
+        render(
+            <SurveyPopup
+                survey={survey}
+                removeSurveyFromFocus={mockRemoveSurveyFromFocus}
+                isPopup={true}
+                posthog={mockPosthog as any}
+            />
+        )
+        expect(screen.getByRole('textbox')).toBeVisible()
+    })
 })

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -782,7 +782,9 @@ export function usePopupVisibility(
     removeSurveyFromFocus: (survey: SurveyWithTypeAndAppearance) => void,
     surveyContainerRef?: React.RefObject<HTMLDivElement>
 ) {
-    const [isPopupVisible, setIsPopupVisible] = useState(isPreviewMode || millisecondDelay === 0)
+    const [isPopupVisible, setIsPopupVisible] = useState(
+        isPreviewMode || millisecondDelay === 0 || survey.type === SurveyType.ExternalSurvey
+    )
     const [isSurveySent, setIsSurveySent] = useState(false)
 
     const hidePopupWithViewTransition = () => {
@@ -907,6 +909,10 @@ function getPopoverPosition(
     position: SurveyPosition = SurveyPosition.Right,
     surveyWidgetType?: SurveyWidgetType
 ) {
+    if (type === SurveyType.ExternalSurvey) {
+        return {}
+    }
+
     switch (position) {
         case SurveyPosition.TopLeft:
             return { top: '0', left: '0', transform: 'translate(30px, 30px)' }


### PR DESCRIPTION
- **fix: hosted surveys should always render even if delay**
- **add test**

## Problem

Hosted surveys that are saved with a delay are not showing.

## Changes

Ignore the delay when setting the survey popup visibility. Plus remove any style position changes from them.

I'll also change the function that sanitizes the survey payload to remove the delay if the survey is hosted, however, let's also make the change in the SDK so it works regardless.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
