### PR TITLE
fix: use node 20 for gh actions and nextjs config

### DIFF
--- a/.github/workflows/posthog-com-upgrade.yml
+++ b/.github/workflows/posthog-com-upgrade.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
 
       - name: Install new package version in PostHog.com repo

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: pnpm
 
       - name: Install new package version in main repo

--- a/packages/browser/playground/nuxtjs/package.json
+++ b/packages/browser/playground/nuxtjs/package.json
@@ -9,7 +9,7 @@
         "postinstall": "nuxt prepare"
     },
     "devDependencies": {
-        "@types/node": "^18",
+        "@types/node": "^20",
         "nuxt": "^3.16.2"
     },
     "dependencies": {

--- a/packages/nextjs-config/package.json
+++ b/packages/nextjs-config/package.json
@@ -38,7 +38,7 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog-js/actions/runs/17432485962/job/49493912304
CI (install new package version in posthog.com repo) fails with:
> error posthog.com@1.0.0: The engine "node" is incompatible with this module. Expected version "20.x". Got "18.20.8"

next config and nuxt sample still use node 18

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [X] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
