### PR TITLE
Fix initial pageview not firing on cookieless_mode: always

### DIFF
--- a/.changeset/twelve-buses-heal.md
+++ b/.changeset/twelve-buses-heal.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix initial pageview not firing when using cookieless_mode: "always"

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -708,7 +708,7 @@ export class PostHog {
             // NOTE: We want to fire this on the next tick as the previous implementation had this side effect
             // and some clients may rely on it
             setTimeout(() => {
-                if (this.consent.isOptedIn()) {
+                if (this.consent.isOptedIn() || this.config.cookieless_mode === 'always') {
                     this._captureInitialPageview()
                 }
             }, 1)


### PR DESCRIPTION
## Changes

Fix a bug where we might not send the initial pageview event when using `cookieless_mode: 'always'`

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
