### PR TITLE
fix(err): upgrade posthog/cli version

### DIFF
--- a/.changeset/slick-spoons-search.md
+++ b/.changeset/slick-spoons-search.md
@@ -1,0 +1,5 @@
+---
+'@posthog/nextjs-config': patch
+---
+
+bump @posthog/cli version

--- a/packages/nextjs-config/package.json
+++ b/packages/nextjs-config/package.json
@@ -42,7 +42,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@posthog/cli": "^0.4.2",
+    "@posthog/cli": "^0.4.4",
     "semver": "^7.7.2"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,8 +409,8 @@ importers:
   packages/nextjs-config:
     dependencies:
       '@posthog/cli':
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: ^0.4.4
+        version: 0.4.4
       semver:
         specifier: ^7.7.2
         version: 7.7.2
@@ -2478,8 +2478,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@posthog/cli@0.4.2':
-    resolution: {integrity: sha512-5I8YnjObWc55tU1ICNzg2Uc3s6IArXSyfWR8EdnjLt2MLhdFdp1U9byamUnxOHk3MKGF3Gb/DU3jrI/BduHbDg==}
+  '@posthog/cli@0.4.4':
+    resolution: {integrity: sha512-8tW73Wg+qA7YgB1DkdlVL50cZHa9/w+gsDbI84nrxUTQ0F3xPj3FlZXvIjKcpgPADK1IHrnSh2e1KCjUjmmTWg==}
     engines: {node: '>=14', npm: '>=6'}
     hasBin: true
 
@@ -13439,7 +13439,7 @@ snapshots:
     dependencies:
       playwright: 1.52.0
 
-  '@posthog/cli@0.4.2':
+  '@posthog/cli@0.4.4':
     dependencies:
       axios: 1.10.0
       axios-proxy-builder: 0.1.2


### PR DESCRIPTION
## Changes

- bump posthog/cli version to include batch processing

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [x] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
