### PR TITLE
fix(flags): `isFeatureEnabled` discerns missing feature flags in return value

### DIFF
--- a/.changeset/shiny-bushes-stare.md
+++ b/.changeset/shiny-bushes-stare.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+`isFeatureEnabled` now returns `undefined` (instead of `false`) for missing or disabled feature flags, aligning with the documentation. Previously, `undefined` was returned only before flags had loaded, and missing/disabled flags returned `false`. This change clarifies the difference between flags that exist but don't match (`false`) and flags that don’t exist or are disabled (`undefined`).

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -163,7 +163,7 @@ describe('featureflags', () => {
             'disabled-flag': false,
         })
         expect(featureFlags.isFeatureEnabled('beta-feature')).toEqual(true)
-        expect(featureFlags.isFeatureEnabled('random')).toEqual(false)
+        expect(featureFlags.isFeatureEnabled('random')).toEqual(undefined)
         expect(featureFlags.isFeatureEnabled('multivariate-flag')).toEqual(true)
 
         expect(instance.capture).toHaveBeenCalledTimes(3)
@@ -214,7 +214,7 @@ describe('featureflags', () => {
             $enabled_feature_flags: { x: 'y' },
         })
         expect(featureFlags.getFlagVariants()).toEqual({ x: 'y' })
-        expect(featureFlags.isFeatureEnabled('beta-feature')).toEqual(false)
+        expect(featureFlags.isFeatureEnabled('beta-feature')).toEqual(undefined)
         expect(instance.capture).toHaveBeenCalledTimes(2)
 
         instance.persistence.register({
@@ -245,6 +245,15 @@ describe('featureflags', () => {
         expect(featureFlags.getFeatureFlagPayload('alpha-feature-2')).toEqual(200)
         expect(featureFlags.getFeatureFlagPayload('multivariate-flag')).toEqual(undefined)
         expect(instance.capture).not.toHaveBeenCalled()
+    })
+
+    it('returns undefined for non-existent or disabled flags', () => {
+        featureFlags._hasLoadedFlags = true
+
+        expect(featureFlags.isFeatureEnabled('non-existent-flag')).toEqual(undefined)
+
+        // Despite being non-existent, the event will still be captured
+        expect(instance.capture).toHaveBeenCalled()
     })
 
     describe('feature flag overrides', () => {

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -591,22 +591,25 @@ export class PostHogFeatureFlags {
         })
     }
 
-    /*
+    /**
      * See if feature flag is enabled for user.
      *
      * ### Usage:
      *
      *     if(posthog.isFeatureEnabled('beta-feature')) { // do something }
      *
-     * @param {Object|String} key Key of the feature flag.
-     * @param {Object|String} options (optional) If {send_event: false}, we won't send an $feature_flag_call event to PostHog.
+     * @param key Key of the feature flag.
+     * @param [options] If {send_event: false}, we won't send an $feature_flag_call event to PostHog.
+     * @returns A boolean value indicating whether or not the specified feature flag is enabled. If flag information has not yet been loaded,
+     *          or if the specified feature flag is disabled or does not exist, returns undefined.
      */
     isFeatureEnabled(key: string, options: { send_event?: boolean } = {}): boolean | undefined {
         if (!this._hasLoadedFlags && !(this.getFlags() && this.getFlags().length > 0)) {
             logger.warn('isFeatureEnabled for key "' + key + '" failed. Feature flags didn\'t load in time.')
             return undefined
         }
-        return !!this.getFeatureFlag(key, options)
+        const flagValue = this.getFeatureFlag(key, options)
+        return isUndefined(flagValue) ? undefined : !!flagValue
     }
 
     addFeatureFlagsHandler(handler: FeatureFlagsCallback): void {


### PR DESCRIPTION
## Problem

`isFeatureEnabled` currently returns `false` in cases where the specified feature flag is disabled or does not exist. This means cases where the feature flag exists but has not matched conditions cannot be differentiated.

## Changes

`isFeatureEnabled` now correctly returns `undefined` in cases where if the specified feature flag does not exist or is disabled.

Resolves #2247

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
