### PR TITLE
fix: flappy console logging in test

### DIFF
--- a/packages/browser/src/__tests__/surveys.test.ts
+++ b/packages/browser/src/__tests__/surveys.test.ts
@@ -20,7 +20,7 @@ import {
     SurveyQuestionType,
     SurveyType,
 } from '../posthog-surveys-types'
-import { FlagsResponse, PostHogConfig, Properties } from '../types'
+import { FlagsResponse, PostHogConfig, Properties, RemoteConfig } from '../types'
 import * as globals from '../utils/globals'
 import { assignableWindow, window } from '../utils/globals'
 import { RequestRouter } from '../utils/request-router'
@@ -1535,6 +1535,35 @@ describe('surveys', () => {
             ] as unknown as SurveyQuestion[]
             expect(() => getNextSurveyStep(survey, 0, '2')).toThrow('The response type must be an integer')
             expect(() => getNextSurveyStep(survey, 0, 'some_string')).toThrow('The response type must be an integer')
+        })
+    })
+
+    describe('is enabled', () => {
+        it('starts effectively disabled', () => {
+            expect(surveys['_isSurveysEnabled']).toBe(undefined)
+        })
+
+        it('is disabled by having no results in onRemoteConfig', () => {
+            surveys.onRemoteConfig({
+                surveys: [],
+            } as Partial<RemoteConfig> as RemoteConfig)
+            expect(surveys['_isSurveysEnabled']).toBe(false)
+        })
+
+        it('is enabled by having results in onRemoteConfig', () => {
+            expect(surveys['_isSurveysEnabled']).toBe(undefined)
+            surveys.onRemoteConfig({
+                surveys: ['example' as unknown as Survey],
+            } as Partial<RemoteConfig> as RemoteConfig)
+            expect(surveys['_isSurveysEnabled']).toBe(true)
+        })
+
+        it('can be disabled by config despite results of onRemoteConfig', () => {
+            surveys['_instance'].config.disable_surveys = true
+            surveys.onRemoteConfig({
+                surveys: ['example' as unknown as Survey],
+            } as Partial<RemoteConfig> as RemoteConfig)
+            expect(surveys['_isSurveysEnabled']).toBe(undefined)
         })
     })
 })

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -35,11 +35,11 @@ export class PostHogSurveys {
     }
 
     onRemoteConfig(response: RemoteConfig) {
+        // only load surveys if they are enabled and there are surveys to load
         if (this._instance.config.disable_surveys) {
             return
         }
 
-        // only load surveys if they are enabled and there are surveys to load
         const surveys = response['surveys']
         if (isNullish(surveys)) {
             return logger.warn('Flags not loaded yet. Not loading surveys.')

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -37,7 +37,7 @@ export class PostHogSurveys {
     onRemoteConfig(response: RemoteConfig) {
         // only load surveys if they are enabled and there are surveys to load
         const surveys = response['surveys']
-        if (isNullish(surveys)) {
+        if (isNullish(surveys) && !this._instance.config.disable_surveys) {
             return logger.warn('Flags not loaded yet. Not loading surveys.')
         }
         const isArrayResponse = isArray(surveys)

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -35,9 +35,13 @@ export class PostHogSurveys {
     }
 
     onRemoteConfig(response: RemoteConfig) {
+        if (this._instance.config.disable_surveys) {
+            return
+        }
+
         // only load surveys if they are enabled and there are surveys to load
         const surveys = response['surveys']
-        if (isNullish(surveys) && !this._instance.config.disable_surveys) {
+        if (isNullish(surveys)) {
             return logger.warn('Flags not loaded yet. Not loading surveys.')
         }
         const isArrayResponse = isArray(surveys)


### PR DESCRIPTION
every so often the segment integration tests fail because of unexpected console logging

this is the result of a race where the posthog instance in the test is actually trying to load surveys
and cannot, and then logs if it manages to fail to load surveys before the test assertions run

in the test in question we are explicitly disabling surveys but ignoring that when logging in onRemoteConfig

there is imho a bigger bug here that this test exposes by accident, but at least to fix the flap, there is no point logging that we aren't loading surveys when client config has told us to disable surveys