### PR TITLE
chore: show bug with failing test

### DIFF
--- a/packages/browser/src/__tests__/surveys.test.ts
+++ b/packages/browser/src/__tests__/surveys.test.ts
@@ -1561,7 +1561,7 @@ describe('surveys', () => {
         it('can be disabled by config despite results of onRemoteConfig', () => {
             surveys['_instance'].config.disable_surveys = true
             surveys.onRemoteConfig({
-                surveys: false,
+                surveys: ['example'],
             } as Partial<RemoteConfig> as RemoteConfig)
             expect(surveys['_isSurveysEnabled']).toBe(false)
         })

--- a/packages/browser/src/__tests__/surveys.test.ts
+++ b/packages/browser/src/__tests__/surveys.test.ts
@@ -1555,7 +1555,7 @@ describe('surveys', () => {
             surveys.onRemoteConfig({
                 surveys: false,
             } as Partial<RemoteConfig> as RemoteConfig)
-            expect(surveys['_isSurveysEnabled']).toBe(true)
+            expect(surveys['_isSurveysEnabled']).toBe(false)
         })
 
         it('can be disabled by config despite results of onRemoteConfig', () => {

--- a/packages/browser/src/__tests__/surveys.test.ts
+++ b/packages/browser/src/__tests__/surveys.test.ts
@@ -1546,7 +1546,7 @@ describe('surveys', () => {
         it('is enabled by having results in onRemoteConfig', () => {
             expect(surveys['_isSurveysEnabled']).toBe(undefined)
             surveys.onRemoteConfig({
-                surveys: true,
+                surveys: ['example'],
             } as Partial<RemoteConfig> as RemoteConfig)
             expect(surveys['_isSurveysEnabled']).toBe(true)
         })

--- a/packages/browser/src/__tests__/surveys.test.ts
+++ b/packages/browser/src/__tests__/surveys.test.ts
@@ -20,7 +20,7 @@ import {
     SurveyQuestionType,
     SurveyType,
 } from '../posthog-surveys-types'
-import { FlagsResponse, PostHogConfig, Properties } from '../types'
+import { FlagsResponse, PostHogConfig, Properties, RemoteConfig } from '../types'
 import * as globals from '../utils/globals'
 import { assignableWindow, window } from '../utils/globals'
 import { RequestRouter } from '../utils/request-router'
@@ -1535,6 +1535,35 @@ describe('surveys', () => {
             ] as unknown as SurveyQuestion[]
             expect(() => getNextSurveyStep(survey, 0, '2')).toThrow('The response type must be an integer')
             expect(() => getNextSurveyStep(survey, 0, 'some_string')).toThrow('The response type must be an integer')
+        })
+    })
+
+    describe('is enabled', () => {
+        it('starts effectively disabled', () => {
+            expect(surveys['_isSurveysEnabled']).toBe(undefined)
+        })
+
+        it('is enabled by having results in onRemoteConfig', () => {
+            expect(surveys['_isSurveysEnabled']).toBe(undefined)
+            surveys.onRemoteConfig({
+                surveys: true,
+            } as Partial<RemoteConfig> as RemoteConfig)
+            expect(surveys['_isSurveysEnabled']).toBe(true)
+        })
+
+        it('is disabled by having no results in onRemoteConfig', () => {
+            surveys.onRemoteConfig({
+                surveys: false,
+            } as Partial<RemoteConfig> as RemoteConfig)
+            expect(surveys['_isSurveysEnabled']).toBe(true)
+        })
+
+        it('can be disabled by config despite results of onRemoteConfig', () => {
+            surveys['_instance'].config.disable_surveys = true
+            surveys.onRemoteConfig({
+                surveys: false,
+            } as Partial<RemoteConfig> as RemoteConfig)
+            expect(surveys['_isSurveysEnabled']).toBe(false)
         })
     })
 })


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog-js/pull/2279

surveys has a private isEnabled field
it is set to true if the remote config response has surveys in it

this ignores the `disable_surveys` config on client config
but it probably shouldn't

it showed up as a failing test in the linked PR
i have no idea if it actually surfaces as user experienced difference