### PR TITLE
fix(llma): price override should not multiply by tokens

### DIFF
--- a/.changeset/clean-moons-kiss.md
+++ b/.changeset/clean-moons-kiss.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+fix price override params

--- a/packages/ai/src/gemini/index.ts
+++ b/packages/ai/src/gemini/index.ts
@@ -70,9 +70,7 @@ export class WrappedModels {
         usage: {
           inputTokens: metadata?.promptTokenCount ?? 0,
           outputTokens: metadata?.candidatesTokenCount ?? 0,
-          reasoningTokens:
-            (metadata as GenerateContentResponseUsageMetadata & { thoughtsTokenCount?: number })?.thoughtsTokenCount ??
-            0,
+          reasoningTokens: metadata?.thoughtsTokenCount ?? 0,
           cacheReadInputTokens: metadata?.cachedContentTokenCount ?? 0,
         },
         tools: availableTools,
@@ -170,8 +168,7 @@ export class WrappedModels {
           usage = {
             inputTokens: metadata.promptTokenCount ?? 0,
             outputTokens: metadata.candidatesTokenCount ?? 0,
-            reasoningTokens:
-              (metadata as GenerateContentResponseUsageMetadata & { thoughtsTokenCount?: number }).thoughtsTokenCount ??
+            reasoningTokens: metadata.thoughtsTokenCount ??
               0,
             cacheReadInputTokens: metadata.cachedContentTokenCount ?? 0,
           }

--- a/packages/ai/src/gemini/index.ts
+++ b/packages/ai/src/gemini/index.ts
@@ -168,8 +168,7 @@ export class WrappedModels {
           usage = {
             inputTokens: metadata.promptTokenCount ?? 0,
             outputTokens: metadata.candidatesTokenCount ?? 0,
-            reasoningTokens: metadata.thoughtsTokenCount ??
-              0,
+            reasoningTokens: metadata.thoughtsTokenCount ?? 0,
             cacheReadInputTokens: metadata.cachedContentTokenCount ?? 0,
           }
         }

--- a/packages/ai/src/openai/utils.ts
+++ b/packages/ai/src/openai/utils.ts
@@ -9,7 +9,6 @@ const POSTHOG_PARAMS_MAP: Record<keyof MonitoringParams, string> = {
   posthogGroups: 'groups',
   posthogModelOverride: 'modelOverride',
   posthogProviderOverride: 'providerOverride',
-  posthogCostOverride: 'costOverride',
   posthogCaptureImmediate: 'captureImmediate',
 }
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -55,7 +55,7 @@ export interface FormattedMessage {
 export interface TokenUsage {
   inputTokens?: number
   outputTokens?: number
-  reasoningTokens?: unknown // Use unknown since various providers return different types
-  cacheReadInputTokens?: unknown // Use unknown for provider flexibility
-  cacheCreationInputTokens?: unknown // Use unknown for provider flexibility
+  reasoningTokens?: number
+  cacheReadInputTokens?: number
+  cacheCreationInputTokens?: number
 }

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -25,7 +25,6 @@ export interface MonitoringEventPropertiesWithDefaults {
   groups?: Record<string, any>
   modelOverride?: string
   providerOverride?: string
-  costOverride?: CostOverride
   captureImmediate?: boolean
 }
 
@@ -35,10 +34,6 @@ export type MonitoringParams = {
   [K in keyof MonitoringEventProperties as `posthog${Capitalize<string & K>}`]: MonitoringEventProperties[K]
 }
 
-export interface CostOverride {
-  inputCost: number
-  outputCost: number
-}
 
 export const getModelParams = (
   params:
@@ -420,18 +415,6 @@ export const sendEventToPosthog = async ({
     }
   }
 
-  let costOverrideData = {}
-
-  if (params.posthogCostOverride) {
-    const inputCostUSD = params.posthogCostOverride.inputCost ?? 0
-    const outputCostUSD = params.posthogCostOverride.outputCost ?? 0
-
-    costOverrideData = {
-      $ai_input_cost_usd: inputCostUSD,
-      $ai_output_cost_usd: outputCostUSD,
-      $ai_total_cost_usd: inputCostUSD + outputCostUSD,
-    }
-  }
 
   const additionalTokenValues = {
     ...(usage.reasoningTokens ? { $ai_reasoning_tokens: usage.reasoningTokens } : {}),
@@ -458,7 +441,6 @@ export const sendEventToPosthog = async ({
     ...(distinctId ? {} : { $process_person_profile: false }),
     ...(tools ? { $ai_tools: tools } : {}),
     ...errorData,
-    ...costOverrideData,
   }
 
   const event = {

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -412,16 +412,20 @@ export const sendEventToPosthog = async ({
   const safeError = sanitizeValues(error)
 
   let errorData = {}
+
   if (isError) {
     errorData = {
       $ai_is_error: true,
       $ai_error: safeError,
     }
   }
+
   let costOverrideData = {}
+
   if (params.posthogCostOverride) {
-    const inputCostUSD = (params.posthogCostOverride.inputCost ?? 0) * (usage.inputTokens ?? 0)
-    const outputCostUSD = (params.posthogCostOverride.outputCost ?? 0) * (usage.outputTokens ?? 0)
+    const inputCostUSD = params.posthogCostOverride.inputCost ?? 0
+    const outputCostUSD = params.posthogCostOverride.outputCost ?? 0
+
     costOverrideData = {
       $ai_input_cost_usd: inputCostUSD,
       $ai_output_cost_usd: outputCostUSD,

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -42,10 +42,10 @@ interface PostHogInput {
   role: string
   type?: string
   content?:
-  | string
-  | {
-    [key: string]: any
-  }
+    | string
+    | {
+        [key: string]: any
+      }
 }
 
 // Content types for the output array
@@ -279,14 +279,16 @@ export const createInstrumentationMiddleware = (
         const content = mapVercelOutput(result.content)
         const latency = (Date.now() - startTime) / 1000
 
-        const anthropicCacheCreationInputTokens: JSONValue | undefined = result.providerMetadata?.anthropic?.cacheCreationInputTokens
+        const anthropicCacheCreationInputTokens: JSONValue | undefined =
+          result.providerMetadata?.anthropic?.cacheCreationInputTokens
 
         const usage: TokenUsage = {
           inputTokens: result.usage.inputTokens,
           outputTokens: result.usage.outputTokens,
           reasoningTokens: result.usage.reasoningTokens,
           cacheReadInputTokens: result.usage.cachedInputTokens,
-          cacheCreationInputTokens: typeof anthropicCacheCreationInputTokens === 'number' ? anthropicCacheCreationInputTokens : undefined,
+          cacheCreationInputTokens:
+            typeof anthropicCacheCreationInputTokens === 'number' ? anthropicCacheCreationInputTokens : undefined,
         }
 
         await sendEventToPosthog({
@@ -401,14 +403,16 @@ export const createInstrumentationMiddleware = (
             }
 
             if (chunk.type === 'finish') {
-              const anthropicCacheCreationInputTokens: JSONValue | undefined = chunk.providerMetadata?.anthropic?.cacheCreationInputTokens
+              const anthropicCacheCreationInputTokens: JSONValue | undefined =
+                chunk.providerMetadata?.anthropic?.cacheCreationInputTokens
 
               usage = {
                 inputTokens: chunk.usage?.inputTokens,
                 outputTokens: chunk.usage?.outputTokens,
                 reasoningTokens: chunk.usage?.reasoningTokens,
                 cacheReadInputTokens: chunk.usage?.cachedInputTokens,
-                cacheCreationInputTokens: typeof anthropicCacheCreationInputTokens === 'number' ? anthropicCacheCreationInputTokens : undefined,
+                cacheCreationInputTokens:
+                  typeof anthropicCacheCreationInputTokens === 'number' ? anthropicCacheCreationInputTokens : undefined,
               }
             }
             controller.enqueue(chunk)
@@ -443,11 +447,11 @@ export const createInstrumentationMiddleware = (
             const output =
               content.length > 0
                 ? [
-                  {
-                    role: 'assistant',
-                    content: content.length === 1 && content[0].type === 'text' ? content[0].text : content,
-                  },
-                ]
+                    {
+                      role: 'assistant',
+                      content: content.length === 1 && content[0].type === 'text' ? content[0].text : content,
+                    },
+                  ]
                 : []
 
             await sendEventToPosthog({

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -8,7 +8,7 @@ import type {
 } from '@ai-sdk/provider'
 import { v4 as uuidv4 } from 'uuid'
 import { PostHog } from 'posthog-node'
-import { CostOverride, sendEventToPosthog, truncate, MAX_OUTPUT_SIZE, extractAvailableToolCalls } from '../utils'
+import { sendEventToPosthog, truncate, MAX_OUTPUT_SIZE, extractAvailableToolCalls } from '../utils'
 import { Buffer } from 'buffer'
 import { redactBase64DataUrl } from '../sanitization'
 import { isString } from '../typeGuards'
@@ -22,7 +22,6 @@ interface ClientOptions {
   posthogGroups?: Record<string, any>
   posthogModelOverride?: string
   posthogProviderOverride?: string
-  posthogCostOverride?: CostOverride
   posthogCaptureImmediate?: boolean
 }
 
@@ -34,7 +33,6 @@ interface CreateInstrumentationMiddlewareOptions {
   posthogGroups?: Record<string, any>
   posthogModelOverride?: string
   posthogProviderOverride?: string
-  posthogCostOverride?: CostOverride
   posthogCaptureImmediate?: boolean
 }
 

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -1,4 +1,4 @@
-import { wrapLanguageModel } from 'ai'
+import { JSONValue, wrapLanguageModel } from 'ai'
 import type {
   LanguageModelV2,
   LanguageModelV2Content,
@@ -12,6 +12,7 @@ import { CostOverride, sendEventToPosthog, truncate, MAX_OUTPUT_SIZE, extractAva
 import { Buffer } from 'buffer'
 import { redactBase64DataUrl } from '../sanitization'
 import { isString } from '../typeGuards'
+import { TokenUsage } from '../types'
 
 interface ClientOptions {
   posthogDistinctId?: string
@@ -41,10 +42,10 @@ interface PostHogInput {
   role: string
   type?: string
   content?:
-    | string
-    | {
-        [key: string]: any
-      }
+  | string
+  | {
+    [key: string]: any
+  }
 }
 
 // Content types for the output array
@@ -277,21 +278,17 @@ export const createInstrumentationMiddleware = (
         const baseURL = '' // cannot currently get baseURL from vercel
         const content = mapVercelOutput(result.content)
         const latency = (Date.now() - startTime) / 1000
-        const providerMetadata = result.providerMetadata
-        const additionalTokenValues = {
-          ...(providerMetadata?.anthropic
-            ? {
-                cacheCreationInputTokens: providerMetadata.anthropic.cacheCreationInputTokens,
-              }
-            : {}),
-        }
-        const usage = {
+
+        const anthropicCacheCreationInputTokens: JSONValue | undefined = result.providerMetadata?.anthropic?.cacheCreationInputTokens
+
+        const usage: TokenUsage = {
           inputTokens: result.usage.inputTokens,
           outputTokens: result.usage.outputTokens,
           reasoningTokens: result.usage.reasoningTokens,
           cacheReadInputTokens: result.usage.cachedInputTokens,
-          ...additionalTokenValues,
+          cacheCreationInputTokens: typeof anthropicCacheCreationInputTokens === 'number' ? anthropicCacheCreationInputTokens : undefined,
         }
+
         await sendEventToPosthog({
           client: phClient,
           distinctId: options.posthogDistinctId,
@@ -341,13 +338,7 @@ export const createInstrumentationMiddleware = (
       const startTime = Date.now()
       let generatedText = ''
       let reasoningText = ''
-      let usage: {
-        inputTokens?: number
-        outputTokens?: number
-        reasoningTokens?: any
-        cacheReadInputTokens?: any
-        cacheCreationInputTokens?: any
-      } = {}
+      let usage: TokenUsage = {}
       const mergedParams = {
         ...options,
         ...mapVercelParams(params),
@@ -410,20 +401,14 @@ export const createInstrumentationMiddleware = (
             }
 
             if (chunk.type === 'finish') {
-              const providerMetadata = chunk.providerMetadata
-              const additionalTokenValues = {
-                ...(providerMetadata?.anthropic
-                  ? {
-                      cacheCreationInputTokens: providerMetadata.anthropic.cacheCreationInputTokens,
-                    }
-                  : {}),
-              }
+              const anthropicCacheCreationInputTokens: JSONValue | undefined = chunk.providerMetadata?.anthropic?.cacheCreationInputTokens
+
               usage = {
                 inputTokens: chunk.usage?.inputTokens,
                 outputTokens: chunk.usage?.outputTokens,
                 reasoningTokens: chunk.usage?.reasoningTokens,
                 cacheReadInputTokens: chunk.usage?.cachedInputTokens,
-                ...additionalTokenValues,
+                cacheCreationInputTokens: typeof anthropicCacheCreationInputTokens === 'number' ? anthropicCacheCreationInputTokens : undefined,
               }
             }
             controller.enqueue(chunk)
@@ -458,11 +443,11 @@ export const createInstrumentationMiddleware = (
             const output =
               content.length > 0
                 ? [
-                    {
-                      role: 'assistant',
-                      content: content.length === 1 && content[0].type === 'text' ? content[0].text : content,
-                    },
-                  ]
+                  {
+                    role: 'assistant',
+                    content: content.length === 1 && content[0].type === 'text' ? content[0].text : content,
+                  },
+                ]
                 : []
 
             await sendEventToPosthog({

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -901,41 +901,4 @@ describe('PostHogAnthropic', () => {
     })
   })
 
-  test('Cost Override - passes costs directly without multiplication', async () => {
-    await client.messages.create({
-      model: 'claude-3-opus-20240229',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 100,
-      posthogDistinctId: 'test-user',
-      posthogCostOverride: {
-        inputCost: 0.03,
-        outputCost: 0.06,
-      },
-    })
-
-    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    const { properties } = captureArgs[0]
-
-    expect(properties['$ai_input_cost_usd']).toBe(0.03)
-    expect(properties['$ai_output_cost_usd']).toBe(0.06)
-    expect(properties['$ai_total_cost_usd']).toBeCloseTo(0.09)
-    expect(properties['$ai_input_tokens']).toBeDefined()
-    expect(properties['$ai_output_tokens']).toBeDefined()
-  })
-
-  test('Cost Override - no cost properties when override not provided', async () => {
-    await client.messages.create({
-      model: 'claude-3-opus-20240229',
-      messages: [{ role: 'user', content: 'Hello' }],
-      max_tokens: 100,
-      posthogDistinctId: 'test-user',
-    })
-
-    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    const { properties } = captureArgs[0]
-
-    expect(properties['$ai_input_cost_usd']).toBeUndefined()
-    expect(properties['$ai_output_cost_usd']).toBeUndefined()
-    expect(properties['$ai_total_cost_usd']).toBeUndefined()
-  })
 })

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -790,11 +790,13 @@ describe('PostHogAnthropic', () => {
       })
 
       // Try to consume the stream (it should throw)
-      await expect((async () => {
-        for await (const _chunk of stream) {
-          // Should throw before getting here
-        }
-      })()).rejects.toThrow('Stream Error')
+      await expect(
+        (async () => {
+          for await (const _chunk of stream) {
+            // Should throw before getting here
+          }
+        })()
+      ).rejects.toThrow('Stream Error')
 
       // Allow async error capture to complete
       await new Promise(process.nextTick)

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -766,13 +766,21 @@ describe('PostHogAnthropic', () => {
       const errorStream = {
         tee: jest.fn().mockReturnValue([
           {
-            async *[Symbol.asyncIterator]() {
-              throw streamError
+            [Symbol.asyncIterator]() {
+              return {
+                async next() {
+                  throw streamError
+                },
+              }
             },
           },
           {
-            async *[Symbol.asyncIterator]() {
-              throw streamError
+            [Symbol.asyncIterator]() {
+              return {
+                async next() {
+                  throw streamError
+                },
+              }
             },
           },
         ]),

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -766,12 +766,12 @@ describe('PostHogAnthropic', () => {
       const errorStream = {
         tee: jest.fn().mockReturnValue([
           {
-            [Symbol.asyncIterator]: async function* () {
+            async *[Symbol.asyncIterator]() {
               throw streamError
             },
           },
           {
-            [Symbol.asyncIterator]: async function* () {
+            async *[Symbol.asyncIterator]() {
               throw streamError
             },
           },

--- a/packages/ai/tests/gemini.test.ts
+++ b/packages/ai/tests/gemini.test.ts
@@ -49,7 +49,6 @@ describe('PostHogGemini - Jest test suite', () => {
   let client: PostHogGemini
 
   beforeEach(() => {
-
     jest.clearAllMocks()
 
     // Reset the default mocks

--- a/packages/ai/tests/gemini.test.ts
+++ b/packages/ai/tests/gemini.test.ts
@@ -517,39 +517,4 @@ describe('PostHogGemini - Jest test suite', () => {
     expect(properties['$process_person_profile']).toBeUndefined()
   })
 
-  test('Cost Override - passes costs directly without multiplication', async () => {
-    await client.models.generateContent({
-      model: 'gemini-2.0-flash-001',
-      contents: 'Hello',
-      posthogDistinctId: 'test-user',
-      posthogCostOverride: {
-        inputCost: 0.02,
-        outputCost: 0.04,
-      },
-    })
-
-    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    const { properties } = captureArgs[0]
-
-    expect(properties['$ai_input_cost_usd']).toBe(0.02)
-    expect(properties['$ai_output_cost_usd']).toBe(0.04)
-    expect(properties['$ai_total_cost_usd']).toBeCloseTo(0.06)
-    expect(properties['$ai_input_tokens']).toBeDefined()
-    expect(properties['$ai_output_tokens']).toBeDefined()
-  })
-
-  test('Cost Override - no cost properties when override not provided', async () => {
-    await client.models.generateContent({
-      model: 'gemini-2.0-flash-001',
-      contents: 'Hello',
-      posthogDistinctId: 'test-user',
-    })
-
-    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    const { properties } = captureArgs[0]
-
-    expect(properties['$ai_input_cost_usd']).toBeUndefined()
-    expect(properties['$ai_output_cost_usd']).toBeUndefined()
-    expect(properties['$ai_total_cost_usd']).toBeUndefined()
-  })
 })

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -1178,43 +1178,4 @@ describe('PostHogOpenAI - Jest test suite', () => {
     ;(ChatMock.Completions as any).prototype.create = originalCreate
   })
 
-  test('Cost Override - passes costs directly without multiplication', async () => {
-    await client.chat.completions.create({
-      model: 'gpt-4',
-      messages: [{ role: 'user', content: 'Hello' }],
-      posthogDistinctId: 'test-id',
-      posthogCostOverride: {
-        inputCost: 0.05,
-        outputCost: 0.1,
-      },
-    })
-
-    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
-    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    const { properties } = captureArgs[0]
-
-    // Cost override values are passed directly (not multiplied by tokens)
-    expect(properties['$ai_input_cost_usd']).toBe(0.05)
-    expect(properties['$ai_output_cost_usd']).toBe(0.1)
-    expect(properties['$ai_total_cost_usd']).toBeCloseTo(0.15)
-
-    // Token counts are still present
-    expect(properties['$ai_input_tokens']).toBe(20)
-    expect(properties['$ai_output_tokens']).toBe(10)
-  })
-
-  test('Cost Override - no cost properties when override not provided', async () => {
-    await client.chat.completions.create({
-      model: 'gpt-4',
-      messages: [{ role: 'user', content: 'Hello' }],
-      posthogDistinctId: 'test-id',
-    })
-
-    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    const { properties } = captureArgs[0]
-
-    expect(properties['$ai_input_cost_usd']).toBeUndefined()
-    expect(properties['$ai_output_cost_usd']).toBeUndefined()
-    expect(properties['$ai_total_cost_usd']).toBeUndefined()
-  })
 })

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -370,7 +370,6 @@ describe('PostHogOpenAI - Jest test suite', () => {
     EmbeddingsMock.prototype.create = jest.fn().mockResolvedValue(mockOpenAiEmbeddingResponse)
   })
 
-
   test('basic completion', async () => {
     // We ensure calls to create a completion return our mock
     // This is handled by the inherited Chat.Completions mock in openai
@@ -1186,7 +1185,7 @@ describe('PostHogOpenAI - Jest test suite', () => {
       posthogDistinctId: 'test-id',
       posthogCostOverride: {
         inputCost: 0.05,
-        outputCost: 0.10,
+        outputCost: 0.1,
       },
     })
 
@@ -1196,9 +1195,9 @@ describe('PostHogOpenAI - Jest test suite', () => {
 
     // Cost override values are passed directly (not multiplied by tokens)
     expect(properties['$ai_input_cost_usd']).toBe(0.05)
-    expect(properties['$ai_output_cost_usd']).toBe(0.10)
+    expect(properties['$ai_output_cost_usd']).toBe(0.1)
     expect(properties['$ai_total_cost_usd']).toBeCloseTo(0.15)
-    
+
     // Token counts are still present
     expect(properties['$ai_input_tokens']).toBe(20)
     expect(properties['$ai_output_tokens']).toBe(10)

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -850,45 +850,4 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
     })
   })
 
-  test('Cost Override - passes costs directly without multiplication', async () => {
-    const model = createMockModel('test-model')
-    const wrappedModel = withTracing(model, mockPostHogClient, {
-      posthogDistinctId: 'test-user',
-      posthogCostOverride: {
-        inputCost: 0.05,
-        outputCost: 0.1,
-      },
-    })
-
-    await wrappedModel.doGenerate({
-      prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Hello' }] }],
-    })
-
-    const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    const { properties } = captureCall[0]
-
-    expect(properties.$ai_input_cost_usd).toBe(0.05)
-    expect(properties.$ai_output_cost_usd).toBe(0.1)
-    expect(properties.$ai_total_cost_usd).toBeCloseTo(0.15)
-    expect(properties.$ai_input_tokens).toBe(5)
-    expect(properties.$ai_output_tokens).toBe(1)
-  })
-
-  test('Cost Override - no cost properties when override not provided', async () => {
-    const model = createMockModel('test-model')
-    const wrappedModel = withTracing(model, mockPostHogClient, {
-      posthogDistinctId: 'test-user',
-    })
-
-    await wrappedModel.doGenerate({
-      prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Hello' }] }],
-    })
-
-    const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
-    const { properties } = captureCall[0]
-
-    expect(properties.$ai_input_cost_usd).toBeUndefined()
-    expect(properties.$ai_output_cost_usd).toBeUndefined()
-    expect(properties.$ai_total_cost_usd).toBeUndefined()
-  })
 })

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -47,7 +47,13 @@ jest.mock('ai', () => ({
           model,
         })
       },
-      doStream: model.doStream,
+      doStream: async (params: any) => {
+        return middleware.wrapStream({
+          doStream: async () => model.doStream(params),
+          params,
+          model,
+        })
+      },
     }
     return wrappedModel
   }),
@@ -842,5 +848,47 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
         },
       ])
     })
+  })
+
+  test('Cost Override - passes costs directly without multiplication', async () => {
+    const model = createMockModel('test-model')
+    const wrappedModel = withTracing(model, mockPostHogClient, {
+      posthogDistinctId: 'test-user',
+      posthogCostOverride: {
+        inputCost: 0.05,
+        outputCost: 0.10,
+      },
+    })
+
+    await wrappedModel.doGenerate({
+      prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Hello' }] }],
+    })
+
+    const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    const { properties } = captureCall[0]
+
+    expect(properties.$ai_input_cost_usd).toBe(0.05)
+    expect(properties.$ai_output_cost_usd).toBe(0.10)
+    expect(properties.$ai_total_cost_usd).toBeCloseTo(0.15)
+    expect(properties.$ai_input_tokens).toBe(5)
+    expect(properties.$ai_output_tokens).toBe(1)
+  })
+
+  test('Cost Override - no cost properties when override not provided', async () => {
+    const model = createMockModel('test-model')
+    const wrappedModel = withTracing(model, mockPostHogClient, {
+      posthogDistinctId: 'test-user',
+    })
+
+    await wrappedModel.doGenerate({
+      prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Hello' }] }],
+    })
+
+    const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    const { properties } = captureCall[0]
+
+    expect(properties.$ai_input_cost_usd).toBeUndefined()
+    expect(properties.$ai_output_cost_usd).toBeUndefined()
+    expect(properties.$ai_total_cost_usd).toBeUndefined()
   })
 })

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -856,7 +856,7 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
       posthogDistinctId: 'test-user',
       posthogCostOverride: {
         inputCost: 0.05,
-        outputCost: 0.10,
+        outputCost: 0.1,
       },
     })
 
@@ -868,7 +868,7 @@ describe('Vercel AI SDK v5 Middleware - End User Usage', () => {
     const { properties } = captureCall[0]
 
     expect(properties.$ai_input_cost_usd).toBe(0.05)
-    expect(properties.$ai_output_cost_usd).toBe(0.10)
+    expect(properties.$ai_output_cost_usd).toBe(0.1)
     expect(properties.$ai_total_cost_usd).toBeCloseTo(0.15)
     expect(properties.$ai_input_tokens).toBe(5)
     expect(properties.$ai_output_tokens).toBe(1)


### PR DESCRIPTION
## Problem

When users are passing us `posthogCostOverride`, we want to take it as in, not multiply it by the number of tokens.

## Changes

- This removes the multiplication.
- This also removes the `conditionalTest` from the affected test suites, to make sure they are run in the CI.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
