### PR TITLE
fix: order of operations when replay does pageview fallback

### DIFF
--- a/.changeset/stale-taxes-unite.md
+++ b/.changeset/stale-taxes-unite.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: order of operations when replay does pageview fallback

--- a/packages/browser/src/__tests__/segment.test.ts
+++ b/packages/browser/src/__tests__/segment.test.ts
@@ -30,6 +30,8 @@ const initPostHogInAPromise = (
                 segment: segment,
                 loaded: resolve,
                 disable_surveys: true,
+                // want to avoid flags code logging during tests
+                advanced_disable_feature_flags: true,
                 ...(config || {}),
             },
             posthogName

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -521,8 +521,8 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         }
         const currentUrl = this._maskUrl(window.location.href)
         if (this._lastHref !== currentUrl) {
-            this._tryAddCustomEvent('$url_changed', { href: currentUrl })
             this._lastHref = currentUrl
+            this._tryAddCustomEvent('$url_changed', { href: currentUrl })
         }
     }
 


### PR DESCRIPTION
when replay is running and pageview capture is disabled
we have simple url tracking which gets emitted to the replay events table as metadata

we say 

* when emitting an event that is not a meta event
 * if rrwebEvent url is not the same as privately tracked `lastUrl`
 * then emit a `urlChanged` custom event that holds the url
 * and then update the privately tracked `lastUrl`

but if the custom event is emitted before the tracking variable is updated then we'll emit _another_ url 
and that might cause us to...

etc

instead let's update the privately tracked `lastUrl` and then emit the rrweb custom event