### PR TITLE
chore: warn when no changeset or major browser bump

### DIFF
--- a/.github/workflows/check-posthog-major-version.yml
+++ b/.github/workflows/check-posthog-major-version.yml
@@ -1,0 +1,166 @@
+name: Check PostHog Major Version
+
+on:
+  pull_request:
+    paths:
+      - '.changeset/**'
+
+jobs:
+  check-major-version:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+        
+      - name: Check for major version bumps
+        id: check-major
+        run: |
+          # Get only added changeset files in this PR
+          changesets=$(git diff --name-only --diff-filter=A origin/${{ github.base_ref }}...HEAD | grep '^\.changeset/.*\.md$' | grep -v 'README.md' || true)
+          
+          if [ -z "$changesets" ]; then
+            echo "No new changesets found in this PR"
+            echo "no_changesets=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          echo "Found new changesets in this PR:"
+          echo "$changesets"
+          echo "no_changesets=false" >> $GITHUB_OUTPUT
+          
+          # Check each new changeset for major version bumps to posthog-js
+          for changeset in $changesets; do
+            echo "Checking $changeset"
+            
+            # Check if the file contains 'posthog-js': major
+            if grep -q "'posthog-js':[[:space:]]*major" "$changeset"; then
+              echo "❌ Error: Major version bump detected for 'posthog-js' in $changeset"
+              echo "The 'posthog-js' package is autoloaded by clients and must not have breaking changes."
+              echo "major_bump_found=true" >> $GITHUB_OUTPUT
+              echo "changeset_file=$changeset" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+          done
+          
+          echo "✅ No major version bumps found for 'posthog-js' in new changesets"
+          echo "major_bump_found=false" >> $GITHUB_OUTPUT
+      
+      - name: Comment on PR
+        if: failure() && steps.check-major.outputs.major_bump_found == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const comment = `## ⚠️ Major Version Bump Detected for posthog-js
+            
+            This PR contains a changeset with a **major version bump** for \`posthog-js\` in file: \`${{ steps.check-major.outputs.changeset_file }}\`
+            
+            ### Why is this blocked?
+            The \`posthog-js\` package is autoloaded by clients and **must not have breaking changes**. Major version bumps would break existing client integrations.
+            
+            ### What should you do?
+            - If this is a breaking change, please reconsider the implementation to maintain backwards compatibility
+            - Change the version bump to \`minor\` or \`patch\` in the changeset file
+            - You maybe want to change the `defaults` version of the config? 
+            
+            To update the changeset, run:
+            \`\`\`bash
+            npx changeset
+            \`\`\`
+            And select a non-breaking version bump for \`posthog-js\`.`;
+            
+            // Check if we already commented
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('Major Version Bump Detected for posthog-js')
+            );
+            
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: comment
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment
+              });
+            }
+      
+      - name: Comment about missing changeset
+        if: success() && steps.check-major.outputs.no_changesets == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const comment = `## 📝 No Changeset Found
+            
+            This PR doesn't include a changeset. Consider whether this PR requires a version bump.
+            
+            ### Should you add a changeset?
+            
+            **Add a changeset if this PR:**
+            - ✅ Adds a new feature
+            - ✅ Fixes a bug  
+            - ✅ Changes existing behavior
+            - ✅ Updates dependencies that affect the public API
+            
+            **Skip the changeset if this PR:**
+            - 📚 Only updates documentation
+            - 🧹 Only includes internal refactoring  
+            - 🧪 Only adds or updates tests
+            - 🔧 Only changes development tooling
+            
+            ### How to add a changeset
+            
+            Run this command and follow the prompts:
+            \`\`\`bash
+            npx changeset
+            \`\`\`
+            
+            **Remember:** Never use \`major\` version bumps for \`posthog-js\` as it's autoloaded by clients.`;
+            
+            // Check if we already commented about missing changeset
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('No Changeset Found')
+            );
+            
+            if (botComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: comment
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment
+              });
+            }


### PR DESCRIPTION
something like this which is right now zero read AI slop

* if no changeset in a PR prompt the user to maybe add one
* if a major change for posthog-js then fail the job and prompt the user why

computers should do this kind of work, not humans