### PR TITLE
chore: add prepare script to package.json for build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "build": "turbo build",
         "dev": "turbo dev",
         "package": "export PACKAGE_DEST=$(pwd)/target && turbo package",
-        "package:watch": "export PACKAGE_DEST=$(pwd)/target && turbo watch package"
+        "package:watch": "export PACKAGE_DEST=$(pwd)/target && turbo watch package",
+        "prepare": "pnpm build"
     },
     "pnpm": {
         "patchedDependencies": {


### PR DESCRIPTION
Add a build script so that the build can be performed after the dependencies are installed.

This allows you to get TypeScript hints when reading other source code, otherwise, you won't be able to find types in other packages.