### PR TITLE
fix: Mask cookie campaign params

### DIFF
--- a/packages/browser/src/__tests__/utils/event-utils.test.ts
+++ b/packages/browser/src/__tests__/utils/event-utils.test.ts
@@ -1,11 +1,14 @@
 import {
     getBrowserLanguage,
     getBrowserLanguagePrefix,
+    getCampaignParams,
     getEventProperties,
     getTimezone,
     getTimezoneOffset,
 } from '../../utils/event-utils'
 import * as globals from '../../utils/globals'
+import { cookieStore } from '../../storage'
+import { PostHogConfig } from '../../types'
 
 describe(`event-utils`, () => {
     describe('properties', () => {
@@ -84,6 +87,18 @@ describe(`event-utils`, () => {
         it('should compute browser language prefix', () => {
             const languagePrefix = getBrowserLanguagePrefix()
             expect(languagePrefix).toBe('pt')
+        })
+    })
+
+    describe('getCampaignParams', () => {
+        it('should mask cookie params', () => {
+            const mockedCookieStore = jest.spyOn(cookieStore, '_get')
+            mockedCookieStore.mockReturnValue('SOME_SECRET')
+            const params = getCampaignParams({ mask_personal_data_properties: true } as PostHogConfig)
+            // li_fat_id should come from cookie
+            expect(params['li_fat_id']).toEqual('<masked>')
+            // gclid does not come from cookie
+            expect(params['gclid']).toEqual(null)
         })
     })
 })

--- a/packages/browser/src/customizations/setAllPersonProfilePropertiesAsPersonPropertiesForFlags.ts
+++ b/packages/browser/src/customizations/setAllPersonProfilePropertiesAsPersonPropertiesForFlags.ts
@@ -16,11 +16,7 @@ export const setAllPersonProfilePropertiesAsPersonPropertiesForFlags = (posthog:
             posthog.config.mask_personal_data_properties,
             posthog.config.custom_personal_data_properties
         ),
-        getCampaignParams(
-            posthog.config.custom_campaign_params,
-            posthog.config.mask_personal_data_properties,
-            posthog.config.custom_personal_data_properties
-        ),
+        getCampaignParams(posthog.config),
         getReferrerInfo()
     )
     const personProperties: Record<string, string> = {}

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -97,7 +97,9 @@ export class PostHogPersistence {
         let store: PersistentStore
         // We handle storage type in a case-insensitive way for backwards compatibility
         const storage_type = config['persistence'].toLowerCase() as Lowercase<PostHogConfig['persistence']>
-        if (storage_type === 'localstorage' && localStore._is_supported()) {
+        if (config.cookieless_mode === 'always') {
+            store = memoryStore
+        } else if (storage_type === 'localstorage' && localStore._is_supported()) {
             store = localStore
         } else if (storage_type === 'localstorage+cookie' && localPlusCookieStore._is_supported()) {
             store = localPlusCookieStore
@@ -243,11 +245,7 @@ export class PostHogPersistence {
 
     update_campaign_params(): void {
         if (!this._campaign_params_saved) {
-            const campaignParams = getCampaignParams(
-                this._config.custom_campaign_params,
-                this._config.mask_personal_data_properties,
-                this._config.custom_personal_data_properties
-            )
+            const campaignParams = getCampaignParams(this._config)
             // only save campaign params if there were any
             if (!isEmptyObject(stripEmptyProperties(campaignParams))) {
                 this.register(campaignParams)

--- a/packages/browser/src/utils/event-utils.ts
+++ b/packages/browser/src/utils/event-utils.ts
@@ -78,17 +78,17 @@ export const COOKIE_CAMPAIGN_PARAMS = [
     'li_fat_id', // linkedin
 ]
 
-export function getCampaignParams(config: PostHogConfig): Record<string, string> {
+export function getCampaignParams(config?: PostHogConfig): Record<string, string> {
     if (!document) {
         return {}
     }
 
-    const paramsToMask = config.mask_personal_data_properties
-        ? extendArray([], PERSONAL_DATA_CAMPAIGN_PARAMS, config.custom_personal_data_properties || [])
+    const paramsToMask = config?.mask_personal_data_properties
+        ? extendArray([], PERSONAL_DATA_CAMPAIGN_PARAMS, config?.custom_personal_data_properties || [])
         : []
 
     // Initially get campaign params from the URL
-    const urlCampaignParams = _getCampaignParamsFromUrl(document.URL, config.custom_campaign_params)
+    const urlCampaignParams = _getCampaignParamsFromUrl(document.URL, config?.custom_campaign_params)
 
     // But we can also get some of them from the cookie store
     // For example: https://learn.microsoft.com/en-us/linkedin/marketing/conversions/enabling-first-party-cookies?view=li-lms-2025-05#reading-li_fat_id-from-cookies

--- a/packages/browser/src/utils/request-utils.ts
+++ b/packages/browser/src/utils/request-utils.ts
@@ -74,7 +74,7 @@ export const getQueryParam = function (url: string, param: string): string {
     }
 }
 
-// replace any query params in the url with the provided mask value. Tries to keep the URL as instant as possible,
+// replace any query params in the url with the provided mask value. Tries to keep the URL as intact as possible,
 // including preserving malformed text in most cases
 export const maskQueryParams = function <T extends string | undefined>(
     url: T,
@@ -117,6 +117,22 @@ export const maskQueryParams = function <T extends string | undefined>(
     }
 
     return result as any
+}
+
+export function maskParams(
+    params: Record<string, string>,
+    maskedParams: string[] | undefined,
+    mask: string
+): Record<string, string> {
+    const newParams: Record<string, string> = {}
+    each(params, function (value: string, key: string) {
+        if (maskedParams && maskedParams.includes(key) && value) {
+            newParams[key] = mask
+        } else {
+            newParams[key] = value
+        }
+    })
+    return newParams
 }
 
 export const _getHashParam = function (hash: string, param: string): string | null {


### PR DESCRIPTION
## Problem

I noticed that the code to mask campaign params was not being applied to the params from cookies.

## Changes

Mask cookie params as well

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
