### PR TITLE
feat: add React helpers

### DIFF
--- a/.changeset/ripe-snails-peel.md
+++ b/.changeset/ripe-snails-peel.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react': minor
+---
+
+feat: added helper method for React 19 error callbacks

--- a/packages/react/src/helpers/error-helpers.ts
+++ b/packages/react/src/helpers/error-helpers.ts
@@ -1,0 +1,14 @@
+import type { ErrorInfo } from 'react'
+import { PostHog } from '../context'
+
+export const setupReactErrorHandler = (
+    client: PostHog,
+    callback?: (event: any, error: any, errorInfo: ErrorInfo) => void
+) => {
+    return (error: any, errorInfo: ErrorInfo): void => {
+        const event = client.captureException(error)
+        if (callback) {
+            callback(event, error, errorInfo)
+        }
+    }
+}

--- a/packages/react/src/helpers/error-helpers.ts
+++ b/packages/react/src/helpers/error-helpers.ts
@@ -1,9 +1,10 @@
 import type { ErrorInfo } from 'react'
 import { PostHog } from '../context'
+import { CaptureResult } from 'posthog-js'
 
 export const setupReactErrorHandler = (
     client: PostHog,
-    callback?: (event: any, error: any, errorInfo: ErrorInfo) => void
+    callback?: (event: CaptureResult | undefined, error: any, errorInfo: ErrorInfo) => void
 ) => {
     return (error: any, errorInfo: ErrorInfo): void => {
         const event = client.captureException(error)

--- a/packages/react/src/helpers/index.ts
+++ b/packages/react/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './error-helpers'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,4 @@
 export * from './context'
 export * from './hooks'
 export * from './components'
+export * from './helpers'


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/37142 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/39231)

## Changes

Customer asked for a helper that handles the new error callbacks added in React 19 (https://react.dev/reference/react-dom/client/createRoot#parameters)

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
