### PR TITLE
Chore: Add docs comments and code for react native specs

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -235,6 +235,31 @@ export abstract class PostHogCoreStateless {
     return this._events.on(event, cb)
   }
 
+  /**
+   * Enables or disables debug mode for detailed logging.
+   *
+   * @remarks
+   * Debug mode logs all PostHog calls to the console for troubleshooting.
+   * This is useful during development to understand what data is being sent.
+   *
+   * {@label Initialization}
+   *
+   * @example
+   * ```js
+   * // enable debug mode
+   * posthog.debug(true)
+   * ```
+   *
+   * @example
+   * ```js
+   * // disable debug mode
+   * posthog.debug(false)
+   * ```
+   *
+   * @public
+   *
+   * @param {boolean} [debug] If true, will enable debug mode.
+   */
   debug(enabled: boolean = true): void {
     this.removeDebugCallback?.()
 
@@ -923,7 +948,7 @@ export abstract class PostHogCoreStateless {
   }
 
   /**
-   * Flushes the queue
+   * Flushes the queue of pending events.
    *
    * This function will return a promise that will resolve when the flush is complete,
    * or reject if there was an error (for example if the server or network is down).
@@ -932,13 +957,19 @@ export abstract class PostHogCoreStateless {
    *
    * It's recommended to do error handling in the callback of the promise.
    *
+   * {@label Initialization}
+   *
    * @example
+   * ```js
+   * // flush with error handling
    * posthog.flush().then(() => {
    *   console.log('Flush complete')
    * }).catch((err) => {
    *   console.error('Flush failed', err)
    * })
+   * ```
    *
+   * @public
    *
    * @throws PostHogFetchHttpError
    * @throws PostHogFetchNetworkError
@@ -1175,9 +1206,27 @@ export abstract class PostHogCoreStateless {
   }
 
   /**
-   *  Call shutdown() once before the node process exits, so ensure that all events have been sent and all promises
-   *  have resolved. Do not use this function if you intend to keep using this PostHog instance after calling it.
-   * @param shutdownTimeoutMs
+   * Shuts down the PostHog instance and ensures all events are sent.
+   *
+   * Call shutdown() once before the process exits to ensure that all events have been sent and all promises
+   * have resolved. Do not use this function if you intend to keep using this PostHog instance after calling it.
+   * Use flush() for per-request cleanup instead.
+   *
+   * {@label Initialization}
+   *
+   * @example
+   * ```js
+   * // shutdown before process exit
+   * process.on('SIGINT', async () => {
+   *   await posthog.shutdown()
+   *   process.exit(0)
+   * })
+   * ```
+   *
+   * @public
+   *
+   * @param {number} [shutdownTimeoutMs=30000] Maximum time to wait for shutdown in milliseconds
+   * @returns {Promise<void>} A promise that resolves when shutdown is complete
    */
   async shutdown(shutdownTimeoutMs: number = 30000): Promise<void> {
     if (this.shutdownPromise) {
@@ -1322,7 +1371,17 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   }
 
   /**
-   * * @returns {string} The stored session ID for the current session. This may be an empty string if the client is not yet fully initialized.
+   * Returns the current session_id.
+   *
+   * @remarks
+   * This should only be used for informative purposes.
+   * Any actual internal use case for the session_id should be handled by the sessionManager.
+   *
+   * {@label Session replay}
+   *
+   * @public
+   *
+   * @returns The current session_id
    */
   getSessionId(): string {
     if (!this._isInitialized) {
@@ -1358,7 +1417,23 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   }
 
   /**
-   * * @returns {string} The stored anonymous ID. This may be an empty string if the client is not yet fully initialized.
+   * Returns the current anonymous ID.
+   *
+   * This is the ID assigned to users before they are identified. It's used to track
+   * anonymous users and link them to identified users when they sign up.
+   *
+   * {@label Identification}
+   *
+   * @example
+   * ```js
+   * // get the anonymous ID
+   * const anonId = posthog.getAnonymousId()
+   * console.log('Anonymous ID:', anonId)
+   * ```
+   *
+   * @public
+   *
+   * @returns {string} The stored anonymous ID. This may be an empty string if the client is not yet fully initialized.
    */
   getAnonymousId(): string {
     if (!this._isInitialized) {
@@ -1398,6 +1473,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   /***
    *** TRACKING
    ***/
+  
   identify(distinctId?: string, properties?: PostHogEventProperties, options?: PostHogCaptureOptions): void {
     this.wrap(() => {
       const previousDistinctId = this.getDistinctId()
@@ -2006,9 +2082,37 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     })
   }
 
-  /***
-   *** ERROR TRACKING
-   ***/
+  /**
+   * Capture a caught exception manually
+   *
+   * {@label Error tracking}
+   *
+   * @public
+   *
+   * @example
+   * ```js
+   * // Capture a caught exception
+   * try {
+   *   // something that might throw
+   * } catch (error) {
+   *   posthog.captureException(error)
+   * }
+   * ```
+   *
+   * @example
+   * ```js
+   * // With additional properties
+   * posthog.captureException(error, {
+   *   customProperty: 'value',
+   *   anotherProperty: ['I', 'can be a list'],
+   *   ...
+   * })
+   * ```
+   *
+   * @param {Error} error The error to capture
+   * @param {Object} [additionalProperties] Any additional properties to add to the error event
+   * @returns {CaptureResult} The result of the capture
+   */
   captureException(error: unknown, additionalProperties?: PostHogEventProperties): void {
     const properties: { [key: string]: any } = {
       $exception_level: 'error',
@@ -2035,6 +2139,11 @@ export abstract class PostHogCore extends PostHogCoreStateless {
 
   /**
    * Capture written user feedback for a LLM trace. Numeric values are converted to strings.
+   *
+   * {@label LLM analytics}
+   *
+   * @public
+   *
    * @param traceId The trace ID to capture feedback for.
    * @param userFeedback The feedback to capture.
    */
@@ -2047,6 +2156,11 @@ export abstract class PostHogCore extends PostHogCoreStateless {
 
   /**
    * Capture a metric for a LLM trace. Numeric values are converted to strings.
+   *
+   * {@label LLM analytics}
+   *
+   * @public
+   *
    * @param traceId The trace ID to capture the metric for.
    * @param metricName The name of the metric to capture.
    * @param metricValue The value of the metric to capture.

--- a/packages/react-native/.gitignore
+++ b/packages/react-native/.gitignore
@@ -1,1 +1,2 @@
 src/version.ts
+docs/

--- a/packages/react-native/api-extractor.json
+++ b/packages/react-native/api-extractor.json
@@ -1,0 +1,455 @@
+/**
+ * Config file for API Extractor.  For more info, please visit: https://api-extractor.com
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+
+  /**
+   * Optionally specifies another JSON config file that this file extends from.  This provides a way for
+   * standard settings to be shared across multiple projects.
+   *
+   * If the path starts with "./" or "../", the path is resolved relative to the folder of the file that contains
+   * the "extends" field.  Otherwise, the first path segment is interpreted as an NPM package name, and will be
+   * resolved using NodeJS require().
+   *
+   * SUPPORTED TOKENS: none
+   * DEFAULT VALUE: ""
+   */
+  // "extends": "./shared/api-extractor-base.json"
+  // "extends": "my-package/include/api-extractor-base.json"
+
+  /**
+   * Determines the "<projectFolder>" token that can be used with other config file settings.  The project folder
+   * typically contains the tsconfig.json and package.json config files, but the path is user-defined.
+   *
+   * The path is resolved relative to the folder of the config file that contains the setting.
+   *
+   * The default value for "projectFolder" is the token "<lookup>", which means the folder is determined by traversing
+   * parent folders, starting from the folder containing api-extractor.json, and stopping at the first folder
+   * that contains a tsconfig.json file.  If a tsconfig.json file cannot be found in this way, then an error
+   * will be reported.
+   *
+   * SUPPORTED TOKENS: <lookup>
+   * DEFAULT VALUE: "<lookup>"
+   */
+  // "projectFolder": "..",
+
+  /**
+   * (REQUIRED) Specifies the .d.ts file to be used as the starting point for analysis.  API Extractor
+   * analyzes the symbols exported by this module.
+   *
+   * The file extension must be ".d.ts" and not ".ts".
+   *
+   * The path is resolved relative to the folder of the config file that contains the setting; to change this,
+   * prepend a folder token such as "<projectFolder>".
+   *
+   * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
+   */
+  "mainEntryPointFilePath": "<projectFolder>/dist/index.d.ts",
+
+  /**
+   * A list of NPM package names whose exports should be treated as part of this package.
+   *
+   * For example, suppose that Webpack is used to generate a distributed bundle for the project "library1",
+   * and another NPM package "library2" is embedded in this bundle.  Some types from library2 may become part
+   * of the exported API for library1, but by default API Extractor would generate a .d.ts rollup that explicitly
+   * imports library2.  To avoid this, we might specify:
+   *
+   *   "bundledPackages": [ "library2" ],
+   *
+   * This would direct API Extractor to embed those types directly in the .d.ts rollup, as if they had been
+   * local files for library1.
+   *
+   * The "bundledPackages" elements may specify glob patterns using minimatch syntax.  To ensure deterministic
+   * output, globs are expanded by matching explicitly declared top-level dependencies only.  For example,
+   * the pattern below will NOT match "@my-company/example" unless it appears in a field such as "dependencies"
+   * or "devDependencies" of the project's package.json file:
+   *
+   *   "bundledPackages": [ "@my-company/*" ],
+   */
+  "bundledPackages": ["@posthog/core"],
+
+  /**
+   * Specifies what type of newlines API Extractor should use when writing output files.  By default, the output files
+   * will be written with Windows-style newlines.  To use POSIX-style newlines, specify "lf" instead.
+   * To use the OS's default newline kind, specify "os".
+   *
+   * DEFAULT VALUE: "crlf"
+   */
+  // "newlineKind": "crlf",
+
+  /**
+   * Specifies how API Extractor sorts members of an enum when generating the .api.json file. By default, the output
+   * files will be sorted alphabetically, which is "by-name". To keep the ordering in the source code, specify
+   * "preserve".
+   *
+   * DEFAULT VALUE: "by-name"
+   */
+  // "enumMemberOrder": "by-name",
+
+  /**
+   * Set to true when invoking API Extractor's test harness. When `testMode` is true, the `toolVersion` field in the
+   * .api.json file is assigned an empty string to prevent spurious diffs in output files tracked for tests.
+   *
+   * DEFAULT VALUE: "false"
+   */
+  // "testMode": false,
+
+  /**
+   * Determines how the TypeScript compiler engine will be invoked by API Extractor.
+   */
+  "compiler": {
+    /**
+     * Specifies the path to the tsconfig.json file to be used by API Extractor when analyzing the project.
+     *
+     * The path is resolved relative to the folder of the config file that contains the setting; to change this,
+     * prepend a folder token such as "<projectFolder>".
+     *
+     * Note: This setting will be ignored if "overrideTsconfig" is used.
+     *
+     * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
+     * DEFAULT VALUE: "<projectFolder>/tsconfig.json"
+     */
+    // "tsconfigFilePath": "<projectFolder>/tsconfig.json",
+    /**
+     * Provides a compiler configuration that will be used instead of reading the tsconfig.json file from disk.
+     * The object must conform to the TypeScript tsconfig schema:
+     *
+     * http://json.schemastore.org/tsconfig
+     *
+     * If omitted, then the tsconfig.json file will be read from the "projectFolder".
+     *
+     * DEFAULT VALUE: no overrideTsconfig section
+     */
+    // "overrideTsconfig": {
+    //   . . .
+    // }
+    /**
+     * This option causes the compiler to be invoked with the --skipLibCheck option. This option is not recommended
+     * and may cause API Extractor to produce incomplete or incorrect declarations, but it may be required when
+     * dependencies contain declarations that are incompatible with the TypeScript engine that API Extractor uses
+     * for its analysis.  Where possible, the underlying issue should be fixed rather than relying on skipLibCheck.
+     *
+     * DEFAULT VALUE: false
+     */
+    // "skipLibCheck": true,
+  },
+
+  /**
+   * Configures how the API report file (*.api.md) will be generated.
+   */
+  "apiReport": {
+    /**
+     * (REQUIRED) Whether to generate an API report.
+     */
+    "enabled": true,
+
+    /**
+     * The base filename for the API report files, to be combined with "reportFolder" or "reportTempFolder"
+     * to produce the full file path.  The "reportFileName" should not include any path separators such as
+     * "\" or "/".  The "reportFileName" should not include a file extension, since API Extractor will automatically
+     * append an appropriate file extension such as ".api.md".  If the "reportVariants" setting is used, then the
+     * file extension includes the variant name, for example "my-report.public.api.md" or "my-report.beta.api.md".
+     * The "complete" variant always uses the simple extension "my-report.api.md".
+     *
+     * Previous versions of API Extractor required "reportFileName" to include the ".api.md" extension explicitly;
+     * for backwards compatibility, that is still accepted but will be discarded before applying the above rules.
+     *
+     * SUPPORTED TOKENS: <packageName>, <unscopedPackageName>
+     * DEFAULT VALUE: "<unscopedPackageName>"
+     */
+    // "reportFileName": "<unscopedPackageName>",
+
+    /**
+     * To support different approval requirements for different API levels, multiple "variants" of the API report can
+     * be generated.  The "reportVariants" setting specifies a list of variants to be generated.  If omitted,
+     * by default only the "complete" variant will be generated, which includes all @internal, @alpha, @beta,
+     * and @public items.  Other possible variants are "alpha" (@alpha + @beta + @public), "beta" (@beta + @public),
+     * and "public" (@public only).
+     *
+     * DEFAULT VALUE: [ "complete" ]
+     */
+    // "reportVariants": ["public", "beta"],
+
+    /**
+     * Specifies the folder where the API report file is written.  The file name portion is determined by
+     * the "reportFileName" setting.
+     *
+     * The API report file is normally tracked by Git.  Changes to it can be used to trigger a branch policy,
+     * e.g. for an API review.
+     *
+     * The path is resolved relative to the folder of the config file that contains the setting; to change this,
+     * prepend a folder token such as "<projectFolder>".
+     *
+     * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
+     * DEFAULT VALUE: "<projectFolder>/etc/"
+     */
+    "reportFolder": "<projectFolder>/docs/",
+
+    /**
+     * Specifies the folder where the temporary report file is written.  The file name portion is determined by
+     * the "reportFileName" setting.
+     *
+     * After the temporary file is written to disk, it is compared with the file in the "reportFolder".
+     * If they are different, a production build will fail.
+     *
+     * The path is resolved relative to the folder of the config file that contains the setting; to change this,
+     * prepend a folder token such as "<projectFolder>".
+     *
+     * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
+     * DEFAULT VALUE: "<projectFolder>/temp/"
+     */
+    "reportTempFolder": "<projectFolder>/docs/"
+
+    /**
+     * Whether "forgotten exports" should be included in the API report file. Forgotten exports are declarations
+     * flagged with `ae-forgotten-export` warnings. See https://api-extractor.com/pages/messages/ae-forgotten-export/ to
+     * learn more.
+     *
+     * DEFAULT VALUE: "false"
+     */
+    // "includeForgottenExports": false
+  },
+
+  /**
+   * Configures how the doc model file (*.api.json) will be generated.
+   */
+  "docModel": {
+    /**
+     * (REQUIRED) Whether to generate a doc model file.
+     */
+    "enabled": true,
+    
+
+    /**
+     * The output path for the doc model file.  The file extension should be ".api.json".
+     *
+     * The path is resolved relative to the folder of the config file that contains the setting; to change this,
+     * prepend a folder token such as "<projectFolder>".
+     *
+     * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
+     * DEFAULT VALUE: "<projectFolder>/temp/<unscopedPackageName>.api.json"
+     */
+    "apiJsonFilePath": "<projectFolder>/docs/<unscopedPackageName>.api.json",
+
+    /**
+     * Whether "forgotten exports" should be included in the doc model file. Forgotten exports are declarations
+     * flagged with `ae-forgotten-export` warnings. See https://api-extractor.com/pages/messages/ae-forgotten-export/ to
+     * learn more.
+     *
+     * DEFAULT VALUE: "false"
+     */
+    "includeForgottenExports": true,
+
+    /**
+     * The base URL where the project's source code can be viewed on a website such as GitHub or
+     * Azure DevOps. This URL path corresponds to the `<projectFolder>` path on disk.
+     *
+     * This URL is concatenated with the file paths serialized to the doc model to produce URL file paths to individual API items.
+     * For example, if the `projectFolderUrl` is "https://github.com/microsoft/rushstack/tree/main/apps/api-extractor" and an API
+     * item's file path is "api/ExtractorConfig.ts", the full URL file path would be
+     * "https://github.com/microsoft/rushstack/tree/main/apps/api-extractor/api/ExtractorConfig.js".
+     *
+     * This setting can be omitted if you don't need source code links in your API documentation reference.
+     *
+     * SUPPORTED TOKENS: none
+     * DEFAULT VALUE: ""
+     */
+    // "projectFolderUrl": "http://github.com/path/to/your/projectFolder"
+  },
+
+  /**
+   * Configures how the .d.ts rollup file will be generated.
+   */
+  "dtsRollup": {
+    /**
+     * (REQUIRED) Whether to generate the .d.ts rollup file.
+     */
+    "enabled": true,
+
+    /**
+     * Specifies the output path for a .d.ts rollup file to be generated without any trimming.
+     * This file will include all declarations that are exported by the main entry point.
+     *
+     * If the path is an empty string, then this file will not be written.
+     *
+     * The path is resolved relative to the folder of the config file that contains the setting; to change this,
+     * prepend a folder token such as "<projectFolder>".
+     *
+     * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
+     * DEFAULT VALUE: "<projectFolder>/dist/<unscopedPackageName>.d.ts"
+     */
+    // "untrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>.d.ts",
+
+    /**
+     * Specifies the output path for a .d.ts rollup file to be generated with trimming for an "alpha" release.
+     * This file will include only declarations that are marked as "@public", "@beta", or "@alpha".
+     *
+     * If the path is an empty string, then this file will not be written.
+     *
+     * The path is resolved relative to the folder of the config file that contains the setting; to change this,
+     * prepend a folder token such as "<projectFolder>".
+     *
+     * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
+     * DEFAULT VALUE: ""
+     */
+    // "alphaTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-alpha.d.ts",
+
+    /**
+     * Specifies the output path for a .d.ts rollup file to be generated with trimming for a "beta" release.
+     * This file will include only declarations that are marked as "@public" or "@beta".
+     *
+     * If the path is an empty string, then this file will not be written.
+     *
+     * The path is resolved relative to the folder of the config file that contains the setting; to change this,
+     * prepend a folder token such as "<projectFolder>".
+     *
+     * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
+     * DEFAULT VALUE: ""
+     */
+    // "betaTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-beta.d.ts",
+
+    /**
+     * Specifies the output path for a .d.ts rollup file to be generated with trimming for a "public" release.
+     * This file will include only declarations that are marked as "@public".
+     *
+     * If the path is an empty string, then this file will not be written.
+     *
+     * The path is resolved relative to the folder of the config file that contains the setting; to change this,
+     * prepend a folder token such as "<projectFolder>".
+     *
+     * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
+     * DEFAULT VALUE: ""
+     */
+    // "publicTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-public.d.ts",
+
+    /**
+     * When a declaration is trimmed, by default it will be replaced by a code comment such as
+     * "Excluded from this release type: exampleMember".  Set "omitTrimmingComments" to true to remove the
+     * declaration completely.
+     *
+     * DEFAULT VALUE: false
+     */
+    // "omitTrimmingComments": true
+  },
+
+  /**
+   * Configures how the tsdoc-metadata.json file will be generated.
+   */
+  "tsdocMetadata": {
+    /**
+     * Whether to generate the tsdoc-metadata.json file.
+     *
+     * DEFAULT VALUE: true
+     */
+    // "enabled": true,
+    /**
+     * Specifies where the TSDoc metadata file should be written.
+     *
+     * The path is resolved relative to the folder of the config file that contains the setting; to change this,
+     * prepend a folder token such as "<projectFolder>".
+     *
+     * The default value is "<lookup>", which causes the path to be automatically inferred from the "tsdocMetadata",
+     * "typings" or "main" fields of the project's package.json.  If none of these fields are set, the lookup
+     * falls back to "tsdoc-metadata.json" in the package folder.
+     *
+     * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
+     * DEFAULT VALUE: "<lookup>"
+     */
+    // "tsdocMetadataFilePath": "<projectFolder>/dist/tsdoc-metadata.json"
+  },
+
+  /**
+   * Configures how API Extractor reports error and warning messages produced during analysis.
+   *
+   * There are three sources of messages:  compiler messages, API Extractor messages, and TSDoc messages.
+   */
+  "messages": {
+    /**
+     * Configures handling of diagnostic messages reported by the TypeScript compiler engine while analyzing
+     * the input .d.ts files.
+     *
+     * TypeScript message identifiers start with np"TS" followed by an integer.  For example: "TS2551"
+     *
+     * DEFAULT VALUE:  A single "default" entry with logLevel=warning.
+     */
+    "compilerMessageReporting": {
+      /**
+       * Configures the default routing for messages that don't match an explicit rule in this table.
+       */
+      "default": {
+        /**
+         * Specifies whether the message should be written to the the tool's output log.  Note that
+         * the "addToApiReportFile" property may supersede this option.
+         *
+         * Possible values: "error", "warning", "none"
+         *
+         * Errors cause the build to fail and return a nonzero exit code.  Warnings cause a production build fail
+         * and return a nonzero exit code.  For a non-production build (e.g. when "api-extractor run" includes
+         * the "--local" option), the warning is displayed but the build will not fail.
+         *
+         * DEFAULT VALUE: "warning"
+         */
+        "logLevel": "warning"
+
+        /**
+         * When addToApiReportFile is true:  If API Extractor is configured to write an API report file (.api.md),
+         * then the message will be written inside that file; otherwise, the message is instead logged according to
+         * the "logLevel" option.
+         *
+         * DEFAULT VALUE: false
+         */
+        // "addToApiReportFile": false
+      }
+
+      // "TS2551": {
+      //   "logLevel": "warning",
+      //   "addToApiReportFile": true
+      // },
+      //
+      // . . .
+    },
+
+    /**
+     * Configures handling of messages reported by API Extractor during its analysis.
+     *
+     * API Extractor message identifiers start with "ae-".  For example: "ae-extra-release-tag"
+     *
+     * DEFAULT VALUE: See api-extractor-defaults.json for the complete table of extractorMessageReporting mappings
+     */
+    "extractorMessageReporting": {
+      "default": {
+        "logLevel": "warning"
+        // "addToApiReportFile": false
+      }
+
+      // "ae-extra-release-tag": {
+      //   "logLevel": "warning",
+      //   "addToApiReportFile": true
+      // },
+      //
+      // . . .
+    },
+
+    /**
+     * Configures handling of messages reported by the TSDoc parser when analyzing code comments.
+     *
+     * TSDoc message identifiers start with "tsdoc-".  For example: "tsdoc-link-tag-unescaped-text"
+     *
+     * DEFAULT VALUE:  A single "default" entry with logLevel=warning.
+     */
+    "tsdocMessageReporting": {
+      "default": {
+        "logLevel": "warning"
+        // "addToApiReportFile": false
+      }
+
+      // "tsdoc-link-tag-unescaped-text": {
+      //   "logLevel": "warning",
+      //   "addToApiReportFile": true
+      // },
+      //
+      // . . .
+    }
+  }
+}

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -20,7 +20,9 @@
     "prepublishOnly": "pnpm lint && pnpm test:unit && pnpm build",
     "prebuild": "node -p \"'export const version = ' + JSON.stringify(require('./package.json').version)\" > src/version.ts",
     "build": "tsc -b && babel ./dist --out-dir dist --extensions '.js'",
-    "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz"
+    "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz",
+    "gen-specs": "pnpm exec tsc && pnpm exec api-extractor run --config ./api-extractor.json --local",
+    "parse-specs": "node scripts/generate-docs.js"
   },
   "dependencies": {
     "@posthog/core": "workspace:*"

--- a/packages/react-native/scripts/generate-docs.js
+++ b/packages/react-native/scripts/generate-docs.js
@@ -1,0 +1,43 @@
+const path = require('path');
+const { generateApiSpecs } = require('../../../scripts/docs/parser');
+const { HOG_REF } = require('../../../scripts/docs/constants');
+
+// Node-specific configuration
+const REACT_NATIVE_SPEC_INFO = {
+    id: 'posthog-react-native',
+    title: 'PostHog React Native SDK',
+    description: 'PostHog React Native SDK allows you to capture events and send them to PostHog from your React Native applications.',
+    slugPrefix: 'posthog-react-native',
+    specUrl: 'https://github.com/PostHog/posthog-js'
+};
+
+// Node-specific type examples (can be customized as needed)
+const REACT_NATIVE_TYPE_EXAMPLES = {
+    Properties: `// Properties for React Native events
+{
+    event: 'user_signed_up',
+    userId: 'user123',
+    timestamp: new Date().toISOString(),
+    distinct_id: 'user123',
+    $set: {
+        email: 'user@example.com',
+        name: 'John Doe'
+    }
+}`,
+    Property: `// React Native property value
+"user@example.com" | { name: "John", age: 25 }`
+};
+
+const config = {
+    packageDir: path.resolve(__dirname, '..'),  // packages/react-native
+    apiJsonPath: path.resolve(__dirname, '../docs/posthog-react-native.api.json'),
+    outputPath: path.resolve(__dirname, '../docs/posthog-react-native-references.json'),
+    id: REACT_NATIVE_SPEC_INFO.id,
+    hogRef: HOG_REF,
+    specInfo: REACT_NATIVE_SPEC_INFO,
+    typeExamples: REACT_NATIVE_TYPE_EXAMPLES,
+    parentClass: 'PostHog',
+    extraMethods: ['PostHogProvider']
+};
+
+generateApiSpecs(config);

--- a/packages/react-native/src/PostHogProvider.tsx
+++ b/packages/react-native/src/PostHogProvider.tsx
@@ -7,15 +7,29 @@ import { PostHogContext } from './PostHogContext'
 import { PostHogAutocaptureOptions } from './types'
 import { defaultPostHogLabelProp } from './autocapture'
 
+/**
+ * Props for the PostHogProvider component.
+ *
+ * @public
+ */
 export interface PostHogProviderProps {
+  /** The child components to render within the PostHog context */
   children: React.ReactNode
+  /** PostHog configuration options */
   options?: PostHogOptions
+  /** Your PostHog API key */
   apiKey?: string
+  /** An existing PostHog client instance */
   client?: PostHog
+  /** Autocapture configuration - can be a boolean or detailed options */
   autocapture?: boolean | PostHogAutocaptureOptions
+  /** Enable debug mode for additional logging */
   debug?: boolean
+  /** Custom styles for the provider wrapper View */
   style?: StyleProp<ViewStyle>
 }
+
+
 
 function PostHogNavigationHook({
   options,
@@ -28,6 +42,66 @@ function PostHogNavigationHook({
   return null
 }
 
+/**
+ * PostHogProvider is a React component that provides PostHog functionality to your React Native app. You can find all configuration options in the [React Native SDK docs](https://posthog.com/docs/libraries/react-native#configuration-options).
+ * 
+ * Autocapturing navigation requires further configuration. See the [React Native SDK navigation docs](https://posthog.com/docs/libraries/react-native#capturing-screen-views) 
+ * for more information about autocapturing navigation.
+ *
+ * This is the recommended way to set up PostHog for React Native. This utilizes the Context API to pass the PostHog client around, enable autocapture, and ensure that the queue is flushed at the right time.
+ *
+ * {@label Initialization}
+ *
+ * @example
+ * ```jsx
+ * // Add to App.(js|ts)
+ * import { usePostHog, PostHogProvider } from 'posthog-react-native'
+ * 
+ * export function MyApp() {
+ *     return (
+ *         <PostHogProvider apiKey="<ph_project_api_key>" options={{
+ *             host: '<ph_client_api_host>', 
+ *         }}>
+ *             <MyComponent />
+ *         </PostHogProvider>
+ *     )
+ * }
+ * 
+ * // And access the PostHog client via the usePostHog hook
+ * import { usePostHog } from 'posthog-react-native'
+ *
+ * const MyComponent = () => {
+ *     const posthog = usePostHog()
+ * 
+ *     useEffect(() => {
+ *         posthog.capture("event_name")
+ *     }, [posthog])
+ * }
+ * 
+ * ```
+ *
+ * @example
+ * ```jsx
+ * // Using with existing client
+ * import { PostHog } from 'posthog-react-native'
+ * 
+ * const posthog = new PostHog('<ph_project_api_key>', {
+ *     host: '<ph_client_api_host>'
+ * })
+ * 
+ * export function MyApp() {
+ *     return (
+ *         <PostHogProvider client={posthog}>
+ *             <MyComponent />
+ *         </PostHogProvider>
+ *     )
+ * }
+ * ```
+ *
+ * @public
+ *
+ * @param props - The PostHogProvider props
+ */
 export const PostHogProvider = ({
   children,
   client,

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -79,6 +79,40 @@ export class PostHog extends PostHogCore {
   private _disableSurveys: boolean
   private _disableRemoteConfig: boolean
 
+  /**
+   * Creates a new PostHog instance for React Native. You can find all configuration options in the [React Native SDK docs](https://posthog.com/docs/libraries/react-native#configuration-options).
+   *
+   * If you prefer not to use the PostHogProvider, you can initialize PostHog in its own file and import the instance from there.
+   *
+   * {@label Initialization}
+   *
+   * @example
+   * ```ts
+   * // posthog.ts
+   * import PostHog from 'posthog-react-native'
+   * 
+   * export const posthog = new PostHog('<ph_project_api_key>', {
+   *   host: '<ph_client_api_host>' 
+   * })
+   * 
+   * // Then you can access PostHog by importing your instance
+   * // Another file:
+   * import { posthog } from './posthog'
+   * 
+   * export function MyApp1() {
+   *     useEffect(async () => {
+   *         posthog.capture('event_name')
+   *     }, [posthog])
+   * 
+   *     return <View>Your app code</View>
+   * }
+   * ```
+   *
+   * @public
+   *
+   * @param apiKey - Your PostHog API key
+   * @param options - PostHog configuration options
+   */
   constructor(apiKey: string, options?: PostHogOptions) {
     super(apiKey, options)
     this._isInitialized = false
@@ -167,7 +201,11 @@ export class PostHog extends PostHogCore {
     }
   }
 
-  // NOTE: This is purely a helper method for testing purposes or those who wish to be certain the SDK is fully initialised
+  /**
+   * 
+   * @internal
+   *
+   */
   public async ready(): Promise<void> {
     await this._initPromise
   }
@@ -187,6 +225,7 @@ export class PostHog extends PostHogCore {
   getLibraryId(): string {
     return 'posthog-react-native'
   }
+
   getLibraryVersion(): string {
     return version
   }
@@ -206,7 +245,431 @@ export class PostHog extends PostHogCore {
     }
   }
 
-  // Custom methods
+  /**
+   * Registers super properties that are sent with every event.
+   *
+   * Super properties are properties associated with events that are set once and then sent with every capture call.
+   * They persist across sessions and are stored locally.
+   *
+   * {@label Capture}
+   *
+   * @example
+   * ```js
+   * // register super properties
+   * posthog.register({
+   *     'icecream pref': 'vanilla',
+   *     team_id: 22,
+   * })
+   * ```
+   *
+   * @public
+   *
+   * @param properties An associative array of properties to store about the user
+   */
+  register(properties: PostHogEventProperties): Promise<void> {
+    return super.register(properties)
+  }
+
+  /**
+   * Removes a super property so it won't be sent with future events.
+   *
+   * Super Properties are persisted across sessions so you have to explicitly remove them if they are no longer relevant.
+   *
+   * {@label Capture}
+   *
+   * @example
+   * ```js
+   * // remove a super property
+   * posthog.unregister('icecream pref')
+   * ```
+   *
+   * @public
+   *
+   * @param property The name of the super property to remove
+   */
+  unregister(property: string): Promise<void> {
+    return super.unregister(property)
+  }
+
+  /**
+   * Resets the user's ID and anonymous ID after logout.
+   *
+   * To reset the user's ID and anonymous ID, call reset. Usually you would do this right after the user logs out.
+   * This also clears all stored super properties and more.
+   *
+   * {@label Identification}
+   *
+   * @example
+   * ```js
+   * // reset after logout
+   * posthog.reset()
+   * ```
+   *
+   * @public
+   */
+  reset(): void {
+    super.reset()
+  }
+
+  /**
+   * Manually flushes the event queue.
+   *
+   * You can set the number of events in the configuration that should queue before flushing.
+   * Setting this to 1 will send events immediately and will use more battery. This is set to 20 by default.
+   * You can also manually flush the queue. If a flush is already in progress it returns a promise for the existing flush.
+   *
+   * {@label Capture}
+   *
+   * @example
+   * ```js
+   * // manually flush the queue
+   * await posthog.flush()
+   * ```
+   *
+   * @public
+   *
+   * @returns Promise that resolves when the flush is complete
+   */
+  flush(): Promise<void> {
+    return super.flush()
+  }
+
+  /**
+   * Opts the user in to data capture.
+   *
+   * By default, PostHog has tracking enabled unless it is forcefully disabled by default using the option { defaultOptIn: false }.
+   * Once this has been called it is persisted and will be respected until optOut is called again or the reset function is called.
+   *
+   * {@label Privacy}
+   *
+   * @example
+   * ```js
+   * // opt in to tracking
+   * posthog.optIn()
+   * ```
+   *
+   * @public
+   */
+  optIn(): Promise<void> {
+    return super.optIn()
+  }
+
+  /**
+   * Opts the user out of data capture.
+   *
+   * You can completely opt-out users from data capture. Once this has been called it is persisted and will be respected until optIn is called again or the reset function is called.
+   *
+   * {@label Privacy}
+   *
+   * @example
+   * ```js
+   * // opt out of tracking
+   * posthog.optOut()
+   * ```
+   *
+   * @public
+   */
+  optOut(): Promise<void> {
+    return super.optOut()
+  }
+
+
+  /**
+   * Checks if a feature flag is enabled for the current user.
+   *
+   * Defaults to undefined if not loaded yet or if there was a problem loading.
+   *
+   * {@label Feature flags}
+   *
+   * @example
+   * ```js
+   * // check if feature flag is enabled
+   * const isEnabled = posthog.isFeatureEnabled('key-for-your-boolean-flag')
+   * ```
+   *
+   * @public
+   *
+   * @param key The feature flag key
+   * @returns True if enabled, false if disabled, undefined if not loaded
+   */
+  isFeatureEnabled(key: string): boolean | undefined {
+    return super.isFeatureEnabled(key)
+  }
+
+  /**
+   * Gets the value of a feature flag for the current user.
+   *
+   * Defaults to undefined if not loaded yet or if there was a problem loading.
+   * Multivariant feature flags are returned as a string.
+   *
+   * {@label Feature flags}
+   *
+   * @example
+   * ```js
+   * // get feature flag value
+   * const value = posthog.getFeatureFlag('key-for-your-boolean-flag')
+   * ```
+   *
+   * @public
+   *
+   * @param key The feature flag key
+   * @returns The feature flag value or undefined if not loaded
+   */
+  getFeatureFlag(key: string): boolean | string | undefined {
+    return super.getFeatureFlag(key)
+  }
+
+  /**
+   * Gets the payload of a feature flag for the current user.
+   *
+   * Returns JsonType or undefined if not loaded yet or if there was a problem loading.
+   *
+   * {@label Feature flags}
+   *
+   * @example
+   * ```js
+   * // get feature flag payload
+   * const payload = posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+   * ```
+   *
+   * @public
+   *
+   * @param key The feature flag key
+   * @returns The feature flag payload or undefined if not loaded
+   */
+  getFeatureFlagPayload(key: string): JsonType | undefined {
+    return super.getFeatureFlagPayload(key)
+  }
+
+  /**
+   * Reloads feature flags from the server.
+   *
+   * PostHog loads feature flags when instantiated and refreshes whenever methods are called that affect the flag.
+   * If you want to manually trigger a refresh, you can call this method.
+   *
+   * {@label Feature flags}
+   *
+   * @example
+   * ```js
+   * // reload feature flags
+   * posthog.reloadFeatureFlags()
+   * ```
+   *
+   * @public
+   */
+  reloadFeatureFlags(): void {
+    super.reloadFeatureFlags()
+  }
+
+  /**
+   * Reloads feature flags from the server asynchronously.
+   *
+   * PostHog loads feature flags when instantiated and refreshes whenever methods are called that affect the flag.
+   * If you want to manually trigger a refresh and get the result, you can call this method.
+   *
+   * {@label Feature flags}
+   *
+   * @example
+   * ```js
+   * // reload feature flags and get result
+   * posthog.reloadFeatureFlagsAsync().then((refreshedFlags) => console.log(refreshedFlags))
+   * ```
+   *
+   * @public
+   *
+   * @returns Promise that resolves with the refreshed flags
+   */
+  reloadFeatureFlagsAsync(): Promise<Record<string, boolean | string> | undefined> {
+    return super.reloadFeatureFlagsAsync()
+  }
+
+  /**
+   * Associates the current user with a group.
+   *
+   * Group analytics allows you to associate the events for that person's session with a group (e.g. teams, organizations, etc.).
+   * This is a paid feature and is not available on the open-source or free cloud plan.
+   *
+   * {@label Group analytics}
+   *
+   * @example
+   * ```js
+   * // associate with a group
+   * posthog.group('company', 'company_id_in_your_db')
+   * ```
+   *
+   * @example
+   * ```js
+   * // associate with a group and update properties
+   * posthog.group('company', 'company_id_in_your_db', {
+   *   name: 'Awesome Inc.',
+   *   employees: 11,
+   * })
+   * ```
+   *
+   * @public
+   *
+   * @param groupType The type of group (e.g. 'company', 'team')
+   * @param groupKey The unique identifier for the group
+   * @param properties Optional properties to set for the group
+   */
+  group(groupType: string, groupKey: string, properties?: PostHogEventProperties): void {
+    super.group(groupType, groupKey, properties)
+  }
+
+  /**
+   * Assigns an alias to the current user.
+   *
+   * Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible.
+   * For example, if a distinct ID used on the frontend is not available in your backend.
+   *
+   * {@label Identification}
+   *
+   * @example
+   * ```js
+   * // set alias for current user
+   * posthog.alias('distinct_id')
+   * ```
+   *
+   * @public
+   *
+   * @param alias The alias to assign to the current user
+   */
+  alias(alias: string): void {
+    super.alias(alias)
+  }
+
+  /**
+   * Gets the current user's distinct ID.
+   *
+   * You may find it helpful to get the current user's distinct ID. For example, to check whether you've already called identify for a user or not.
+   * This returns either the ID automatically generated by PostHog or the ID that has been passed by a call to identify().
+   *
+   * {@label Identification}
+   *
+   * @example
+   * ```js
+   * // get current distinct ID
+   * const distinctId = posthog.getDistinctId()
+   * ```
+   *
+   * @public
+   *
+   * @returns The current user's distinct ID
+   */
+  getDistinctId(): string {
+    return super.getDistinctId()
+  }
+
+  /**
+   * Sets person properties for feature flag evaluation.
+   *
+   * Sometimes, you might want to evaluate feature flags using properties that haven't been ingested yet, or were set incorrectly earlier.
+   * You can do so by setting properties the flag depends on with this call. These are set for the entire session.
+   * Successive calls are additive: all properties you set are combined together and sent for flag evaluation.
+   *
+   * {@label Feature flags}
+   *
+   * @example
+   * ```js
+   * // set person properties for flags
+   * posthog.setPersonPropertiesForFlags({'property1': 'value', property2: 'value2'})
+   * ```
+   *
+   * @public
+   *
+   * @param properties The person properties to set for flag evaluation
+   */
+  setPersonPropertiesForFlags(properties: Record<string, string>): void {
+    super.setPersonPropertiesForFlags(properties)
+  }
+
+  /**
+   * Resets person properties for feature flag evaluation.
+   *
+   *
+   * {@label Feature flags}
+   *
+   * @example
+   * ```js
+   * // reset person properties for flags
+   * posthog.resetPersonPropertiesForFlags()
+   * ```
+   *
+   * @public
+   */
+  resetPersonPropertiesForFlags(): void {
+    super.resetPersonPropertiesForFlags()
+  }
+
+  /**
+   * Sets group properties for feature flag evaluation.
+   *
+   * These properties are automatically attached to the current group (set via posthog.group()).
+   * When you change the group, these properties are reset.
+   *
+   * {@label Feature flags}
+   *
+   * @example
+   * ```js
+   * // set group properties for flags
+   * posthog.setGroupPropertiesForFlags({'company': {'property1': 'value', property2: 'value2'}})
+   * ```
+   *
+   * @public
+   *
+   * @param properties The group properties to set for flag evaluation
+   */
+  setGroupPropertiesForFlags(properties: Record<string, Record<string, string>>): void {
+    super.setGroupPropertiesForFlags(properties)
+  }
+
+  /**
+   * Resets group properties for feature flag evaluation.
+   *
+   * {@label Feature flags}
+   *
+   * @example
+   * ```js
+   * // reset group properties for flags
+   * posthog.resetGroupPropertiesForFlags()
+   * ```
+   *
+   * @public
+   */
+  resetGroupPropertiesForFlags(): void {
+    super.resetGroupPropertiesForFlags()
+  }
+
+  /**
+   * Captures a screen view event.
+   *
+   * @remarks
+   * This function requires a name. You may also pass in an optional properties object.
+   * Screen name is automatically registered for the session and will be included in subsequent events.
+   *
+   * {@label Capture}
+   *
+   * @example
+   * ```js
+   * // Basic screen capture
+   * posthog.screen('dashboard')
+   * ```
+   *
+   * @example
+   * ```js
+   * // Screen capture with properties
+   * posthog.screen('dashboard', {
+   *     background: 'blue',
+   *     hero: 'superhog',
+   * })
+   * ```
+   *
+   * @public
+   *
+   * @param name - The name of the screen
+   * @param properties - Optional properties to include with the screen event
+   * @param options - Optional capture options
+   */
   async screen(name: string, properties?: PostHogEventProperties, options?: PostHogCaptureOptions): Promise<void> {
     await this._initPromise
     // Screen name is good to know for all other subsequent events
@@ -283,6 +746,40 @@ export class PostHog extends PostHogCore {
     }
   }
 
+  /**
+   * Associates events with a specific user. Learn more about [identifying users](https://posthog.com/docs/product-analytics/identify)
+   *
+   * {@label Identification}
+   *
+   * @example
+   * ```js
+   * // Basic identify
+   * posthog.identify('distinctID', {
+   *   email: 'user@posthog.com',
+   *   name: 'My Name'
+   * })
+   * ```
+   *
+   * @example
+   * ```js
+   * // Using $set and $set_once
+   * posthog.identify('distinctID', {
+   *   $set: {
+   *     email: 'user@posthog.com',
+   *     name: 'My Name'
+   *   },
+   *   $set_once: {
+   *     date_of_first_log_in: '2024-03-01'
+   *   }
+   * })
+   * ```
+   *
+   * @public
+   *
+   * @param distinctId - A unique identifier for your user. Typically either their email or database ID.
+   * @param properties - Optional dictionary with key:value pairs to set the person properties
+   * @param options - Optional capture options
+   */
   identify(distinctId?: string, properties?: PostHogEventProperties, options?: PostHogCaptureOptions): void {
     const previousDistinctId = this.getDistinctId()
     super.identify(distinctId, properties, options)

--- a/packages/react-native/tsdoc.json
+++ b/packages/react-native/tsdoc.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+    "tagDefinitions": [
+      {
+        "tagName": "@category",
+        "syntaxKind": "inline"
+      }
+    ],
+    "supportForTags": {
+        "@category": true
+    },
+    "extends": [ "@microsoft/api-extractor/extends/tsdoc-base.json" ]
+  }


### PR DESCRIPTION
## Problem

We need comments for react native specs, see: https://github.com/PostHog/posthog.com/pull/12720

Similar to [these references](https://posthog.com/docs/references/posthog-js) for posthog-js

Would love your help to make sure these comments are accurate

## Changes

Adds docs comment. Adds a special case to include specific methods that aren't part of the posthog class like the posthogprovider

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## How to test these changes

This PR uses the generated specs.: https://github.com/PostHog/posthog.com/pull/12720