### PR TITLE
feat: Add config option for partitioned cookies

### DIFF
--- a/.changeset/sad-yaks-unite.md
+++ b/.changeset/sad-yaks-unite.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+Add support for partitioned cookies

--- a/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -155,6 +155,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"false\\",
     \\"true\\"
   ],
+  \\"partitioned_cookie\\": [
+    \\"false\\",
+    \\"true\\"
+  ],
   \\"opt_out_capturing_by_default\\": [
     \\"false\\",
     \\"true\\"

--- a/packages/browser/src/consent.ts
+++ b/packages/browser/src/consent.ts
@@ -62,7 +62,8 @@ export class ConsentManager {
             isOptedIn ? 1 : 0,
             this._config.cookie_expiration,
             this._config.cross_subdomain_cookie,
-            this._config.secure_cookie
+            this._config.secure_cookie,
+            this._config.partitioned_cookie
         )
     }
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -167,6 +167,7 @@ export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     disable_external_dependency_loading: false,
     enable_recording_console_log: undefined, // When undefined, it falls back to the server-side setting
     secure_cookie: window?.location?.protocol === 'https:',
+    partitioned_cookie: false,
     ip: false,
     opt_out_capturing_by_default: false,
     opt_out_persistence_by_default: false,

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -56,6 +56,7 @@ export class PostHogPersistence {
     private readonly _name: string
     _disabled: boolean | undefined
     private _secure: boolean | undefined
+    private _partitioned: boolean | undefined
     private _expire_days: number | undefined
     private _default_expiry: number | undefined
     private _cross_subdomain: boolean | undefined
@@ -160,6 +161,7 @@ export class PostHogPersistence {
             this._expire_days,
             this._cross_subdomain,
             this._secure,
+            this._partitioned,
             this._config.debug
         )
     }
@@ -321,6 +323,7 @@ export class PostHogPersistence {
         this.set_disabled(config['disable_persistence'] || !!isDisabled)
         this.set_cross_subdomain(config['cross_subdomain_cookie'])
         this.set_secure(config['secure_cookie'])
+        this.set_partitioned(config['partitioned_cookie'])
 
         if (config.persistence !== oldConfig.persistence) {
             // If the persistence type has changed, we need to migrate the data.
@@ -356,6 +359,14 @@ export class PostHogPersistence {
     set_secure(secure: boolean): void {
         if (secure !== this._secure) {
             this._secure = secure
+            this.remove()
+            this.save()
+        }
+    }
+
+    set_partitioned(partitioned: boolean): void {
+        if (partitioned !== this._partitioned) {
+            this._partitioned = partitioned
             this.remove()
             this.save()
         }

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -521,6 +521,13 @@ export interface PostHogConfig {
     secure_cookie: boolean
 
     /**
+     * Determines whether PostHog should use partitioned cookies.
+     * @see https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies
+     * @default false
+     */
+    partitioned_cookie: boolean
+
+    /**
      * Determines if users should be opted out of PostHog tracking by default,
      * requiring additional logic to opt them into capturing by calling `posthog.opt_in_capturing()`.
      *
@@ -1576,6 +1583,7 @@ export interface PersistentStore {
         expire_days?: number | null,
         cross_subdomain?: boolean,
         secure?: boolean,
+        partitioned?: boolean,
         debug?: boolean
     ) => void
     _remove: (name: string, cross_subdomain?: boolean) => void

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -199,6 +199,7 @@
         "_override_warning",
         "_pageViewFallBack",
         "_parse",
+        "_partitioned",
         "_pauseRecording",
         "_pendingRemoteConfig",
         "_persistFlagsOnSessionListener",


### PR DESCRIPTION
## Problem

Our cookies are not partioned.

This means that if the user visits posthog.com, then visits customer.com, when the posthog-js library on customer.com calls api.posthog.com, the browser will attempt to include those cookies. This can trip up some customers with strict cookie rules.

See this ticket: https://posthoghelp.zendesk.com/agent/tickets/37096 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/39016)

## Changes

We can use used Partitioned cookies (see https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies)

This would mean that cookies set on posthog.com are stored in a different cookie jar to those set on customer.com.

This doesn't affect cross-subdomain tracking, so posthog.com and app.posthog.com should still be able to share cookies.

This is pretty hard to test, I am relying on rolling this out to posthog.com first, and then making sure the issue in the above ticket is fixed.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
