### PR TITLE
fix: Revert "feat: Add config option for partitioned cookies"

### DIFF
--- a/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -155,10 +155,6 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"false\\",
     \\"true\\"
   ],
-  \\"partitioned_cookie\\": [
-    \\"false\\",
-    \\"true\\"
-  ],
   \\"opt_out_capturing_by_default\\": [
     \\"false\\",
     \\"true\\"

--- a/packages/browser/src/consent.ts
+++ b/packages/browser/src/consent.ts
@@ -62,8 +62,7 @@ export class ConsentManager {
             isOptedIn ? 1 : 0,
             this._config.cookie_expiration,
             this._config.cross_subdomain_cookie,
-            this._config.secure_cookie,
-            this._config.partitioned_cookie
+            this._config.secure_cookie
         )
     }
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -167,7 +167,6 @@ export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     disable_external_dependency_loading: false,
     enable_recording_console_log: undefined, // When undefined, it falls back to the server-side setting
     secure_cookie: window?.location?.protocol === 'https:',
-    partitioned_cookie: false,
     ip: false,
     opt_out_capturing_by_default: false,
     opt_out_persistence_by_default: false,

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -56,7 +56,6 @@ export class PostHogPersistence {
     private readonly _name: string
     _disabled: boolean | undefined
     private _secure: boolean | undefined
-    private _partitioned: boolean | undefined
     private _expire_days: number | undefined
     private _default_expiry: number | undefined
     private _cross_subdomain: boolean | undefined
@@ -161,7 +160,6 @@ export class PostHogPersistence {
             this._expire_days,
             this._cross_subdomain,
             this._secure,
-            this._partitioned,
             this._config.debug
         )
     }
@@ -323,7 +321,6 @@ export class PostHogPersistence {
         this.set_disabled(config['disable_persistence'] || !!isDisabled)
         this.set_cross_subdomain(config['cross_subdomain_cookie'])
         this.set_secure(config['secure_cookie'])
-        this.set_partitioned(config['partitioned_cookie'])
 
         if (config.persistence !== oldConfig.persistence) {
             // If the persistence type has changed, we need to migrate the data.
@@ -359,14 +356,6 @@ export class PostHogPersistence {
     set_secure(secure: boolean): void {
         if (secure !== this._secure) {
             this._secure = secure
-            this.remove()
-            this.save()
-        }
-    }
-
-    set_partitioned(partitioned: boolean): void {
-        if (partitioned !== this._partitioned) {
-            this._partitioned = partitioned
             this.remove()
             this.save()
         }

--- a/packages/browser/src/storage.ts
+++ b/packages/browser/src/storage.ts
@@ -128,14 +128,13 @@ export const cookieStore: PersistentStore = {
         return cookie
     },
 
-    _set: function (name, value, days, cross_subdomain, is_secure, is_partitioned?: boolean) {
+    _set: function (name, value, days, cross_subdomain, is_secure) {
         if (!document) {
             return
         }
         try {
             let expires = '',
-                secure = '',
-                partition = ''
+                secure = ''
 
             const cdomain = chooseCookieDomain(document.location.hostname, cross_subdomain)
 
@@ -149,10 +148,6 @@ export const cookieStore: PersistentStore = {
                 secure = '; secure'
             }
 
-            if (is_partitioned) {
-                partition = '; partitioned'
-            }
-
             const new_cookie_val =
                 name +
                 '=' +
@@ -160,8 +155,7 @@ export const cookieStore: PersistentStore = {
                 expires +
                 '; SameSite=Lax; path=/' +
                 cdomain +
-                secure +
-                partition
+                secure
 
             // 4096 bytes is the size at which some browsers (e.g. firefox) will not store a cookie, warn slightly before that
             if (new_cookie_val.length > 4096 * 0.9) {
@@ -290,9 +284,9 @@ export const localPlusCookieStore: PersistentStore = {
         return null
     },
 
-    _set: function (name, value, days, cross_subdomain, is_secure, is_partitioned, debug) {
+    _set: function (name, value, days, cross_subdomain, is_secure, debug) {
         try {
-            localStore._set(name, value, undefined, undefined, undefined, debug)
+            localStore._set(name, value, undefined, undefined, debug)
             const cookiePersistedProperties: Record<string, any> = {}
             COOKIE_PERSISTED_PROPERTIES.forEach((key) => {
                 if (value[key]) {
@@ -301,15 +295,7 @@ export const localPlusCookieStore: PersistentStore = {
             })
 
             if (Object.keys(cookiePersistedProperties).length) {
-                cookieStore._set(
-                    name,
-                    cookiePersistedProperties,
-                    days,
-                    cross_subdomain,
-                    is_secure,
-                    is_partitioned,
-                    debug
-                )
+                cookieStore._set(name, cookiePersistedProperties, days, cross_subdomain, is_secure, debug)
             }
         } catch (err) {
             localStore._error(err)

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -521,13 +521,6 @@ export interface PostHogConfig {
     secure_cookie: boolean
 
     /**
-     * Determines whether PostHog should use partitioned cookies.
-     * @see https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies
-     * @default false
-     */
-    partitioned_cookie: boolean
-
-    /**
      * Determines if users should be opted out of PostHog tracking by default,
      * requiring additional logic to opt them into capturing by calling `posthog.opt_in_capturing()`.
      *
@@ -1583,7 +1576,6 @@ export interface PersistentStore {
         expire_days?: number | null,
         cross_subdomain?: boolean,
         secure?: boolean,
-        partitioned?: boolean,
         debug?: boolean
     ) => void
     _remove: (name: string, cross_subdomain?: boolean) => void

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -199,7 +199,6 @@
         "_override_warning",
         "_pageViewFallBack",
         "_parse",
-        "_partitioned",
         "_pauseRecording",
         "_pendingRemoteConfig",
         "_persistFlagsOnSessionListener",


### PR DESCRIPTION
Reverts PostHog/posthog-js#2310

This doesn't work as intended