### PR TITLE
chore(core): update packaging process

### DIFF
--- a/packages/core/babel.config.mjs
+++ b/packages/core/babel.config.mjs
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
   presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
 }

--- a/packages/core/jest.config.mjs
+++ b/packages/core/jest.config.mjs
@@ -1,4 +1,7 @@
-module.exports = {
+export default {
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
   collectCoverage: true,
   clearMocks: true,
   fakeTimers: { enableGlobally: true },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,8 +15,8 @@
   ],
   "scripts": {
     "clean": "rimraf dist",
-    "lint": "eslint src test",
-    "lint:fix": "eslint src test --fix",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
     "build": "rslib build",
     "dev": "rslib build -w",
     "test:unit": "jest",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -5,4 +5,10 @@ export default defineConfig({
     { format: 'esm', syntax: 'es6', dts: true, bundle: false },
     { format: 'cjs', syntax: 'es6', dts: true, bundle: false },
   ],
+  source: {
+    entry: {
+      index: ['src/**/*', '!src/__tests__/**/*', '!src/**/*.spec.ts'],
+    },
+    tsconfigPath: './tsconfig.build.json',
+  },
 })

--- a/packages/core/src/__tests__/featureFlagUtils.spec.ts
+++ b/packages/core/src/__tests__/featureFlagUtils.spec.ts
@@ -4,8 +4,8 @@ import {
   getFlagDetailsFromFlagsAndPayloads,
   getFeatureFlagValue,
   normalizeFlagsResponse,
-} from '../src/featureFlagUtils'
-import { PostHogFlagsResponse, FeatureFlagDetail } from '../src/types'
+} from '@/featureFlagUtils'
+import { PostHogFlagsResponse, FeatureFlagDetail } from '@/types'
 
 describe('featureFlagUtils', () => {
   describe('getFeatureFlagValue', () => {

--- a/packages/core/src/__tests__/gzip.spec.ts
+++ b/packages/core/src/__tests__/gzip.spec.ts
@@ -1,4 +1,4 @@
-import { isGzipSupported, gzipCompress } from '../src/gzip'
+import { isGzipSupported, gzipCompress } from '@/gzip'
 import { gzip } from 'node:zlib'
 import { randomBytes, randomUUID } from 'node:crypto'
 import { promisify } from 'node:util'

--- a/packages/core/src/__tests__/posthog.ai.spec.ts
+++ b/packages/core/src/__tests__/posthog.ai.spec.ts
@@ -4,7 +4,7 @@ import {
   createTestClient,
   PostHogCoreTestClient,
   PostHogCoreTestClientMocks,
-} from '../src/testing'
+} from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.capture.spec.ts
+++ b/packages/core/src/__tests__/posthog.capture.spec.ts
@@ -4,8 +4,8 @@ import {
   createTestClient,
   PostHogCoreTestClient,
   PostHogCoreTestClientMocks,
-} from '../src/testing'
-import { uuidv7 } from '../src/vendor/uuidv7'
+} from '@/testing'
+import { uuidv7 } from '@/vendor/uuidv7'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.core.spec.ts
+++ b/packages/core/src/__tests__/posthog.core.spec.ts
@@ -1,4 +1,4 @@
-import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '../src/testing'
+import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.debug.spec.ts
+++ b/packages/core/src/__tests__/posthog.debug.spec.ts
@@ -1,4 +1,4 @@
-import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '../src/testing'
+import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.enqueue.spec.ts
+++ b/packages/core/src/__tests__/posthog.enqueue.spec.ts
@@ -1,5 +1,5 @@
-import { PostHogPersistedProperty } from '../src'
-import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '../src/testing'
+import { PostHogPersistedProperty } from '@/types'
+import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -1,12 +1,12 @@
-import { PostHogPersistedProperty, PostHogV2FlagsResponse } from '../src'
-import { normalizeFlagsResponse } from '../src/featureFlagUtils'
+import { PostHogPersistedProperty, PostHogV2FlagsResponse } from '@/types'
+import { normalizeFlagsResponse } from '@/featureFlagUtils'
 import {
   parseBody,
   waitForPromises,
   createTestClient,
   PostHogCoreTestClient,
   PostHogCoreTestClientMocks,
-} from '../src/testing'
+} from '@/testing'
 
 describe('PostHog Feature Flags v4', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.featureflags.v1.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.v1.spec.ts
@@ -1,12 +1,12 @@
-import { PostHogPersistedProperty, PostHogV1FlagsResponse } from '../src'
-import { normalizeFlagsResponse } from '../src/featureFlagUtils'
+import { PostHogPersistedProperty, PostHogV1FlagsResponse } from '@/types'
+import { normalizeFlagsResponse } from '@/featureFlagUtils'
 import {
   parseBody,
   waitForPromises,
   createTestClient,
   PostHogCoreTestClient,
   PostHogCoreTestClientMocks,
-} from '../src/testing'
+} from '@/testing'
 
 describe('PostHog Feature Flags v1', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.flush.spec.ts
+++ b/packages/core/src/__tests__/posthog.flush.spec.ts
@@ -1,11 +1,5 @@
-import {
-  delay,
-  waitForPromises,
-  createTestClient,
-  PostHogCoreTestClient,
-  PostHogCoreTestClientMocks,
-} from '../src/testing'
-import { PostHogPersistedProperty } from '../src'
+import { delay, waitForPromises, createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
+import { PostHogPersistedProperty } from '@/types'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.gdpr.spec.ts
+++ b/packages/core/src/__tests__/posthog.gdpr.spec.ts
@@ -1,5 +1,5 @@
-import { PostHogPersistedProperty } from '../src'
-import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '../src/testing'
+import { PostHogPersistedProperty } from '@/types'
+import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.groups.spec.ts
+++ b/packages/core/src/__tests__/posthog.groups.spec.ts
@@ -4,7 +4,7 @@ import {
   PostHogCoreTestClientMocks,
   parseBody,
   waitForPromises,
-} from '../src/testing'
+} from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.identify.spec.ts
+++ b/packages/core/src/__tests__/posthog.identify.spec.ts
@@ -4,8 +4,8 @@ import {
   createTestClient,
   PostHogCoreTestClient,
   PostHogCoreTestClientMocks,
-} from '../src/testing'
-import { PostHogPersistedProperty } from '../src'
+} from '@/testing'
+import { PostHogPersistedProperty } from '@/types'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.init.spec.ts
+++ b/packages/core/src/__tests__/posthog.init.spec.ts
@@ -1,4 +1,4 @@
-import { createTestClient, waitForPromises, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '../src/testing'
+import { createTestClient, waitForPromises, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.listeners.spec.ts
+++ b/packages/core/src/__tests__/posthog.listeners.spec.ts
@@ -1,4 +1,4 @@
-import { waitForPromises, createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '../src/testing'
+import { waitForPromises, createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.register.spec.ts
+++ b/packages/core/src/__tests__/posthog.register.spec.ts
@@ -1,5 +1,5 @@
-import { PostHogPersistedProperty } from '../src'
-import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '../src/testing'
+import { PostHogPersistedProperty } from '@/types'
+import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.reset.spec.ts
+++ b/packages/core/src/__tests__/posthog.reset.spec.ts
@@ -1,5 +1,5 @@
-import { PostHogPersistedProperty } from '../src'
-import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '../src/testing'
+import { PostHogPersistedProperty } from '@/types'
+import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.sessions.spec.ts
+++ b/packages/core/src/__tests__/posthog.sessions.spec.ts
@@ -1,5 +1,5 @@
-import { PostHogPersistedProperty } from '../src'
-import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '../src/testing'
+import { PostHogPersistedProperty } from '@/types'
+import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.setProperties.spec.ts
+++ b/packages/core/src/__tests__/posthog.setProperties.spec.ts
@@ -1,5 +1,5 @@
-import { PostHogPersistedProperty } from '../src'
-import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '../src/testing'
+import { PostHogPersistedProperty } from '@/types'
+import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/posthog.shutdown.spec.ts
+++ b/packages/core/src/__tests__/posthog.shutdown.spec.ts
@@ -1,4 +1,4 @@
-import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '../src/testing'
+import { createTestClient, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
 
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient

--- a/packages/core/src/__tests__/utils.spec.ts
+++ b/packages/core/src/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { assert, removeTrailingSlash, currentISOTime, currentTimestamp } from '../src/utils'
+import { assert, removeTrailingSlash, currentISOTime, currentTimestamp } from '@/utils'
 
 describe('utils', () => {
   describe('assert', () => {

--- a/packages/core/src/testing/test-utils.ts
+++ b/packages/core/src/testing/test-utils.ts
@@ -1,3 +1,5 @@
+import { Logger } from '@/types'
+
 export const wait = async (t: number): Promise<void> => {
   await new Promise((r) => setTimeout(r, t))
 }
@@ -30,4 +32,14 @@ export const delay = (ms: number): Promise<void> => {
   return new Promise((resolve) => {
     setTimeout(resolve, ms)
   })
+}
+
+export const mockLogger: Logger = {
+  _log: jest.fn(),
+  critical: jest.fn(),
+  uninitializedWarning: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  createLogger: () => mockLogger,
 }

--- a/packages/core/src/utils/bucketed-rate-limiter.spec.ts
+++ b/packages/core/src/utils/bucketed-rate-limiter.spec.ts
@@ -1,4 +1,5 @@
-import { BucketedRateLimiter } from '../../src/utils/bucketed-rate-limiter'
+import { Logger } from '@/types'
+import { BucketedRateLimiter } from './bucketed-rate-limiter'
 
 jest.useFakeTimers()
 
@@ -10,7 +11,7 @@ describe('BucketedRateLimiter', () => {
       bucketSize: 10,
       refillRate: 1,
       refillInterval: 1000,
-      _logger: {},
+      _logger: {} as unknown as Logger,
     })
   })
 

--- a/packages/core/src/utils/bucketed-rate-limiter.ts
+++ b/packages/core/src/utils/bucketed-rate-limiter.ts
@@ -1,4 +1,4 @@
-import { Logger } from 'types'
+import { Logger } from '../types'
 import { clampToRange } from './number-utils'
 
 export class BucketedRateLimiter<T extends string | number> {

--- a/packages/core/src/utils/number-utils.spec.ts
+++ b/packages/core/src/utils/number-utils.spec.ts
@@ -1,15 +1,5 @@
-import { clampToRange } from '../../src/utils/number-utils'
-import { Logger } from '../../src/types'
-
-const mockLogger: Logger = {
-  _log: jest.fn(),
-  critical: jest.fn(),
-  uninitializedWarning: jest.fn(),
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  createLogger: () => mockLogger,
-}
+import { mockLogger } from '@/testing'
+import { clampToRange } from './number-utils'
 
 describe('number-utils', () => {
   describe('clampToRange', () => {

--- a/packages/core/src/utils/number-utils.ts
+++ b/packages/core/src/utils/number-utils.ts
@@ -1,4 +1,4 @@
-import { Logger } from 'types'
+import { Logger } from '../types'
 import { isNumber } from './type-utils'
 
 /**

--- a/packages/core/src/utils/promise-queue.spec.ts
+++ b/packages/core/src/utils/promise-queue.spec.ts
@@ -1,4 +1,4 @@
-import { PromiseQueue } from '../../src/utils/promise-queue'
+import { PromiseQueue } from './promise-queue'
 
 function buildPromise(time: number): Promise<number> {
   return new Promise((res, rej) => setTimeout(() => res(42), time))

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["src/__tests__/**/*", "src/**/*.spec.ts"]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@posthog-tooling/tsconfig-base",
   "compilerOptions": {
     "rootDir": "./src",
-    "baseUrl": "./src",
     "outDir": "dist",
     "module": "CommonJS",
     "moduleResolution": "node",
@@ -10,8 +9,10 @@
     "composite": false,
     "declaration": true,
     "declarationMap": true,
-    "target": "ES2015"
+    "target": "ES2015",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
-  "include": ["src/**/*", "test/**/*"],
-  "exclude": ["node_modules", "test/**/*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Problem

- resolution inside jest did not work properly because it ignores the baseUrl from tsconfig
- unit tests close to the source file are exported in final package
- tests are not typechecked

## Changes

- move tests folder inside src
- remove baseURL from tsconfig
- create a path alias and jest map resolution to import from src easily
- create a separate tsconfig file for build process

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
