### PR TITLE
feat: Add option for xhr credentials and to disable sendBeacon

### DIFF
--- a/.changeset/chubby-dolls-nail.md
+++ b/.changeset/chubby-dolls-nail.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Add option to disable sendBeacon and xhr credentials

--- a/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -554,6 +554,16 @@ exports[`config snapshot for PostHogConfig 1`] = `
     \\"false\\",
     \\"true\\"
   ],
+  \\"__preview_disable_beacon\\": [
+    \\"undefined\\",
+    \\"false\\",
+    \\"true\\"
+  ],
+  \\"__preview_disable_xhr_credentials\\": [
+    \\"undefined\\",
+    \\"false\\",
+    \\"true\\"
+  ],
   \\"__preview_lazy_load_replay\\": [
     \\"undefined\\",
     \\"false\\",

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -46,6 +46,7 @@ describe('request', () => {
         readyState: 4,
         responseText: JSON.stringify('something here'),
         status: 200,
+        withCredentials: false,
     }
 
     const now = 1700000000000
@@ -115,6 +116,15 @@ describe('request', () => {
                 json: undefined,
                 text: '{wat',
             })
+        })
+
+        it('respects disableXHRCredentials=true', () => {
+            request(createRequest({ disableXHRCredentials: true }))
+            expect(mockedXHR.withCredentials).toBe(false)
+        })
+        it('respects disableXHRCredentials=false', () => {
+            request(createRequest({ disableXHRCredentials: false }))
+            expect(mockedXHR.withCredentials).toBe(true)
         })
     })
 
@@ -271,6 +281,15 @@ describe('request', () => {
                     )
                 }
             )
+        })
+        it('is used as a fallback when the requested transport is disabled', async () => {
+            request(
+                createRequest({
+                    transport: 'sendBeacon',
+                    disableTransport: ['sendBeacon'],
+                })
+            )
+            expect(mockedFetch).toHaveBeenCalled()
         })
     })
 

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -38,7 +38,7 @@ describe('request', () => {
     const mockedFetch: jest.MockedFunction<any> = fetch as jest.MockedFunction<any>
     const mockedXMLHttpRequest: jest.MockedFunction<any> = XMLHttpRequest as jest.MockedFunction<any>
     const mockedNavigator: jest.Mocked<typeof navigator> = navigator as jest.Mocked<typeof navigator>
-    const mockedXHR = {
+    let mockedXHR = {
         open: jest.fn(),
         setRequestHeader: jest.fn(),
         onreadystatechange: jest.fn(),
@@ -56,7 +56,16 @@ describe('request', () => {
     let transport: RequestWithOptions['transport']
 
     beforeEach(() => {
-        mockedXHR.open.mockClear()
+        mockedXHR = {
+            open: jest.fn(),
+            setRequestHeader: jest.fn(),
+            onreadystatechange: jest.fn(),
+            send: jest.fn(),
+            readyState: 4,
+            responseText: JSON.stringify('something here'),
+            status: 200,
+            withCredentials: false,
+        }
         mockedXMLHttpRequest.mockImplementation(() => mockedXHR)
 
         jest.useFakeTimers()

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -774,6 +774,7 @@ export class PostHog {
             ...this.config.request_headers,
         }
         options.compression = options.compression === 'best-available' ? this.compression : options.compression
+        options.disableXHRCredentials = this.config.__preview_disable_xhr_credentials
 
         // Specially useful if you're doing SSR with NextJS
         // Users must be careful when tweaking `cache` because they might get out-of-date feature flags

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -775,6 +775,9 @@ export class PostHog {
         }
         options.compression = options.compression === 'best-available' ? this.compression : options.compression
         options.disableXHRCredentials = this.config.__preview_disable_xhr_credentials
+        if (this.config.__preview_disable_beacon) {
+            options.disableTransport = ['sendBeacon']
+        }
 
         // Specially useful if you're doing SSR with NextJS
         // Users must be careful when tweaking `cache` because they might get out-of-date feature flags

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -106,9 +106,11 @@ const xhr = (options: RequestWithOptions) => {
     if (options.timeout) {
         req.timeout = options.timeout
     }
-    // send the ph_optout cookie
-    // withCredentials cannot be modified until after calling .open on Android and Mobile Safari
-    req.withCredentials = true
+    if (!options.disableXHRCredentials) {
+        // send the ph_optout cookie
+        // withCredentials cannot be modified until after calling .open on Android and Mobile Safari
+        req.withCredentials = true
+    }
     req.onreadystatechange = () => {
         // XMLHttpRequest.DONE == 4, except in safari 4
         if (req.readyState === 4) {
@@ -256,8 +258,12 @@ export const request = (_options: RequestWithOptions) => {
 
     const transport = options.transport ?? 'fetch'
 
+    const availableTransports = AVAILABLE_TRANSPORTS.filter(
+        (t) => !options.disableTransport || !t.transport || !options.disableTransport.includes(t.transport)
+    )
+
     const transportMethod =
-        find(AVAILABLE_TRANSPORTS, (t) => t.transport === transport)?.method ?? AVAILABLE_TRANSPORTS[0].method
+        find(availableTransports, (t) => t.transport === transport)?.method ?? availableTransports[0].method
 
     if (!transportMethod) {
         throw new Error('No available transport method')

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -992,6 +992,17 @@ export interface PostHogConfig {
      * */
     __preview_eager_load_replay?: boolean
 
+    /**
+     * Prevents posthog-js from using the `navigator.sendBeacon` API to send events.
+     * Enabling this option may hurt the reliability of sending $pageleave events
+     */
+    __preview_disable_beacon?: boolean
+
+    /**
+     * Disables sending credentials when using XHR requests.
+     */
+    __preview_disable_xhr_credentials?: boolean
+
     // ------- RETIRED CONFIGS - NO REPLACEMENT OR USAGE -------
 
     /**
@@ -1237,6 +1248,8 @@ export interface RequestWithOptions {
     callback?: RequestCallback
     timeout?: number
     noRetries?: boolean
+    disableTransport?: ('XHR' | 'fetch' | 'sendBeacon')[]
+    disableXHRCredentials?: boolean
     compression?: Compression | 'best-available'
     fetchOptions?: {
         cache?: RequestInit['cache']


### PR DESCRIPTION
## Problem

This ticket: https://posthoghelp.zendesk.com/agent/tickets/37096 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/39016)

As part of trying to debug this, I noticed that we send credentials (cookies) with xhr requests. We should probably not do this. Whilst Chrome filters these cookies out, it means that sites try to send cookies from posthog.com along with xhr requests.

From looking at the capture code, I couldn't see anywhere where we used cookies.

I also asked @benjackwhite if he knew why it was added here https://github.com/PostHog/posthog-js/pull/1055/files#diff-b1a2ab03a3672e105afeaab6615ad625365cd8459d592a840d925f132af62b35R107 and he didn't

We should be safe to remove it, but just in case, let's remove it for ourselves first.

Additionally, `sendBeacon` doesn't even have an option to remove credentials, and they are sent by default. IMO, this is insane, but I didn't write the spec. I've added an option to remove sendBeacon calls, which I'll suggest this user can try out

## Changes

Add options to disable credentials on xhr and to disable sendBeacon

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
