### PR TITLE
feat: expose rrweb custom event logging

### DIFF
--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1336,4 +1336,8 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             config: this._instance.config,
         })
     }
+
+    tryAddCustomEvent(tag: string, payload: any): boolean {
+        return this._tryAddCustomEvent(tag, payload)
+    }
 }

--- a/packages/browser/src/extensions/replay/sessionrecording-wrapper.ts
+++ b/packages/browser/src/extensions/replay/sessionrecording-wrapper.ts
@@ -223,4 +223,16 @@ export class SessionRecordingWrapper {
             }
         )
     }
+
+    /**
+     * This adds a custom event to the session recording
+     *
+     * It is not intended for arbitrary public use - playback only displays known custom events
+     * And is exposed on the public interface only so that other parts of the SDK are able to use it
+     *
+     * if you are calling this from client code, you're probably looking for `posthog.capture('$custom_event', {...})`
+     */
+    tryAddCustomEvent(tag: string, payload: any): boolean {
+        return !!this._lazyLoadedSessionRecording?.tryAddCustomEvent(tag, payload)
+    }
 }

--- a/packages/browser/src/utils/globals.ts
+++ b/packages/browser/src/utils/globals.ts
@@ -173,6 +173,7 @@ export interface LazyLoadedSessionRecordingInterface {
     overrideSampling: () => void
     overrideTrigger: (triggerType: TriggerType) => void
     isStarted: boolean
+    tryAddCustomEvent(tag: string, payload: any): boolean
 }
 
 export interface LazyLoadedDeadClicksAutocaptureInterface {


### PR DESCRIPTION
in order to add redux state logging without fighting the serialization in rrweb's console logger
let's expose rrweb custom event logging, since that already accepts arbitrary payloads

follow-up to https://github.com/PostHog/posthog-js/pull/2294