### PR TITLE
fix(nextjs-config): fix windows execution

### DIFF
--- a/.changeset/thin-hoops-fix.md
+++ b/.changeset/thin-hoops-fix.md
@@ -1,0 +1,5 @@
+---
+'@posthog/nextjs-config': patch
+---
+
+fix posthog-cli execution on windows

--- a/packages/nextjs-config/src/utils.ts
+++ b/packages/nextjs-config/src/utils.ts
@@ -91,6 +91,7 @@ async function callPosthogCli(args: string[], env: NodeJS.ProcessEnv, verbose: b
   }
 
   const child = spawn(binaryLocation, [...args], {
+    shell: true,
     stdio: verbose ? 'inherit' : 'ignore',
     env,
     cwd: process.cwd(),


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog-js/issues/2333

## Changes

- add shell option to spawn to support windows execution

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [x] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
