### PR TITLE
chore: Add missing doc comment label + example syntax

### DIFF
--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1802,21 +1802,31 @@ export class PostHog {
      * @param {DisplaySurveyOptions} options - Display configuration
      *
      * @example
+     * ```js
      * // Display as popover (respects all conditions defined in the dashboard)
      * posthog.displaySurvey('survey-id-123')
+     * ```
      *
+     * @example
+     * ```js
      * // Display inline in a specific element
      * posthog.displaySurvey('survey-id-123', {
      *   displayType: DisplaySurveyType.Inline,
      *   selector: '#survey-container'
      * })
+     * ```
      *
+     * @example
+     * ```js
      * // Force display ignoring conditions and delays
      * posthog.displaySurvey('survey-id-123', {
      *   displayType: DisplaySurveyType.Popover,
      *   ignoreConditions: true,
      *   ignoreDelay: true
      * })
+     * ```
+     * 
+     * {@label Surveys}
      */
     displaySurvey(surveyId: string, options: DisplaySurveyOptions = DEFAULT_DISPLAY_SURVEY_OPTIONS): void {
         this.surveys.displaySurvey(surveyId, options)


### PR DESCRIPTION
## Problem

Some doc comments missing labels

## Changes

Updates doc comments

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

Manually generated specs and checked