### PR TITLE
fix(posthog-js): fix posthog.com upgrade workflow

### DIFF
--- a/.github/workflows/posthog-com-upgrade.yml
+++ b/.github/workflows/posthog-com-upgrade.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
 
       - name: Install new package version in PostHog.com repo


### PR DESCRIPTION
## Problem

- posthog.com uses node 22
- https://github.com/PostHog/posthog-js/actions/workflows/posthog-com-upgrade.yml

## Changes

- increase node version for upgrade workflow

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
