### PR TITLE
fix: mark renderSurvey as deprecated

### DIFF
--- a/.changeset/rude-memes-begin.md
+++ b/.changeset/rude-memes-begin.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+chore: mark renderSurvey as deprecated

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -3326,11 +3326,6 @@ const add_dom_loaded_handler = function () {
 }
 
 export function init_from_snippet(): void {
-    if (assignableWindow['posthog'] && assignableWindow['posthog'].__loaded) {
-        logger.warn('PostHog script loaded multiple times, skipping re-initialization')
-        return
-    }
-
     const posthogMain = (instances[PRIMARY_INSTANCE_NAME] = new PostHog())
 
     const snippetPostHog = assignableWindow['posthog']

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1786,6 +1786,8 @@ export class PostHog {
      * posthog.renderSurvey(coolSurveyID, '#survey-container')
      * ```
      *
+     * @deprecated Use displaySurvey instead - it's more complete and also supports popover surveys.
+     *
      * @public
      *
      * @param {String} surveyId The ID of the survey to render.
@@ -3324,6 +3326,11 @@ const add_dom_loaded_handler = function () {
 }
 
 export function init_from_snippet(): void {
+    if (assignableWindow['posthog'] && assignableWindow['posthog'].__loaded) {
+        logger.warn('PostHog script loaded multiple times, skipping re-initialization')
+        return
+    }
+
     const posthogMain = (instances[PRIMARY_INSTANCE_NAME] = new PostHog())
 
     const snippetPostHog = assignableWindow['posthog']


### PR DESCRIPTION
## Changes

mark `renderSurvey` as deprecated, since `displaySurvey` is released and it's an improved version of it

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] posthog-js (web)

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
