### PR TITLE
fix: node onException autocapture safely access the exception_List

### DIFF
--- a/.changeset/cruel-bananas-slide.md
+++ b/.changeset/cruel-bananas-slide.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': patch
+---
+
+fix: node onException autocapture safely access the exception_List

--- a/packages/node/src/extensions/error-tracking/index.ts
+++ b/packages/node/src/extensions/error-tracking/index.ts
@@ -74,7 +74,7 @@ export default class ErrorTracking {
       (async () => {
         const eventMessage = await ErrorTracking.buildEventMessage(exception, hint)
         const exceptionProperties = eventMessage.properties
-        const exceptionType = exceptionProperties?.$exception_list[0].type ?? 'Exception'
+        const exceptionType = exceptionProperties?.$exception_list[0]?.type ?? 'Exception'
         const isRateLimited = this._rateLimiter.consumeRateLimit(exceptionType)
         if (isRateLimited) {
           this._logger.info('Skipping exception capture because of client rate limiting.', {


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/38262 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/39883)
Not really solving that ticket becuase its a browser issue but it could happen on node as well

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [X] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
