### PR TITLE
feat: allow ignoring rageclick by css selector

### DIFF
--- a/.changeset/loud-eels-tan.md
+++ b/.changeset/loud-eels-tan.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+feat: allow ignoring rageclicks on elements by css selector

--- a/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -51,7 +51,13 @@ exports[`config snapshot for PostHogConfig 1`] = `
   ],
   \\"rageclick\\": [
     \\"false\\",
-    \\"true\\"
+    \\"true\\",
+    {
+      \\"css_selector_ignorelist\\": [
+        \\"undefined\\",
+        \\"string[]\\"
+      ]
+    }
   ],
   \\"cross_subdomain_cookie\\": [
     \\"false\\",

--- a/packages/browser/src/__tests__/autocapture.test.ts
+++ b/packages/browser/src/__tests__/autocapture.test.ts
@@ -408,6 +408,80 @@ describe('Autocapture system', () => {
             ])
         })
 
+        it('should not capture rageclick if ph-no-capture', () => {
+            const elTarget = document.createElement('img')
+            const elParent = document.createElement('span')
+            elParent.className = 'ph-no-capture'
+            elParent.appendChild(elTarget)
+            const elGrandparent = document.createElement('a')
+            elGrandparent.setAttribute('href', 'https://test.com')
+            elGrandparent.appendChild(elParent)
+            const fakeEvent = makeMouseEvent({
+                target: elTarget,
+                clientX: 5,
+                clientY: 5,
+            })
+            Object.setPrototypeOf(fakeEvent, MouseEvent.prototype)
+            autocapture['_captureEvent'](fakeEvent)
+            autocapture['_captureEvent'](fakeEvent)
+            autocapture['_captureEvent'](fakeEvent)
+
+            expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual([])
+        })
+
+        it('should not capture rageclick if ph-no-rageclick', () => {
+            const elTarget = document.createElement('img')
+            const elParent = document.createElement('span')
+            elParent.className = 'ph-no-rageclick'
+            elParent.appendChild(elTarget)
+            const elGrandparent = document.createElement('a')
+            elGrandparent.setAttribute('href', 'https://test.com')
+            elGrandparent.appendChild(elParent)
+            const fakeEvent = makeMouseEvent({
+                target: elTarget,
+                clientX: 5,
+                clientY: 5,
+            })
+            Object.setPrototypeOf(fakeEvent, MouseEvent.prototype)
+            autocapture['_captureEvent'](fakeEvent)
+            autocapture['_captureEvent'](fakeEvent)
+            autocapture['_captureEvent'](fakeEvent)
+
+            expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual([
+                '$autocapture',
+                '$autocapture',
+                '$autocapture',
+            ])
+        })
+
+        it('should not capture rageclick if ignorelist configured', () => {
+            posthog.config.rageclick = {
+                css_selector_ignorelist: ['.ignore-rage-click'],
+            }
+            const elTarget = document.createElement('img')
+            const elParent = document.createElement('span')
+            elParent.className = 'ignore-rage-click'
+            elParent.appendChild(elTarget)
+            const elGrandparent = document.createElement('a')
+            elGrandparent.setAttribute('href', 'https://test.com')
+            elGrandparent.appendChild(elParent)
+            const fakeEvent = makeMouseEvent({
+                target: elTarget,
+                clientX: 5,
+                clientY: 5,
+            })
+            Object.setPrototypeOf(fakeEvent, MouseEvent.prototype)
+            autocapture['_captureEvent'](fakeEvent)
+            autocapture['_captureEvent'](fakeEvent)
+            autocapture['_captureEvent'](fakeEvent)
+
+            expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual([
+                '$autocapture',
+                '$autocapture',
+                '$autocapture',
+            ])
+        })
+
         describe('clipboard autocapture', () => {
             let elTarget: HTMLDivElement
 

--- a/packages/browser/src/__tests__/autocapture.test.ts
+++ b/packages/browser/src/__tests__/autocapture.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../autocapture'
 import { shouldCaptureDomEvent } from '../autocapture-utils'
 import { AUTOCAPTURE_DISABLED_SERVER_SIDE } from '../constants'
-import { AutocaptureConfig, FlagsResponse } from '../types'
+import { AutocaptureConfig, FlagsResponse, PostHogConfig } from '../types'
 import { PostHog } from '../posthog-core'
 import { window } from '../utils/globals'
 import { createPosthogInstance } from './helpers/posthog-instance'
@@ -383,104 +383,64 @@ describe('Autocapture system', () => {
             autocapture.onRemoteConfig({} as FlagsResponse)
         })
 
-        it('should capture rageclick', () => {
-            const elTarget = document.createElement('img')
-            const elParent = document.createElement('span')
-            elParent.appendChild(elTarget)
-            const elGrandparent = document.createElement('a')
-            elGrandparent.setAttribute('href', 'https://test.com')
-            elGrandparent.appendChild(elParent)
-            const fakeEvent = makeMouseEvent({
-                target: elTarget,
-                clientX: 5,
-                clientY: 5,
-            })
-            Object.setPrototypeOf(fakeEvent, MouseEvent.prototype)
-            autocapture['_captureEvent'](fakeEvent)
-            autocapture['_captureEvent'](fakeEvent)
-            autocapture['_captureEvent'](fakeEvent)
+        test.each([
+            [
+                'rageclick detection is active',
+                true,
+                null,
+                ['$autocapture', '$autocapture', '$rageclick', '$autocapture'],
+            ],
+            ['rageclick detection is inactive', false, null, ['$autocapture', '$autocapture', '$autocapture']],
+            ['rageclick detection with ph-no-capture', true, 'ph-no-capture', []],
+            [
+                'rageclick detection with ph-no-rageclick',
+                true,
+                'ph-no-rageclick',
+                ['$autocapture', '$autocapture', '$autocapture'],
+            ],
+            [
+                'rageclick detection with custom classname overrides default',
+                {
+                    css_selector_ignorelist: ['.custom-rageclick'],
+                },
+                'ph-no-rageclick',
+                ['$autocapture', '$autocapture', '$rageclick', '$autocapture'],
+            ],
+            [
+                'rageclick detection with custom classname',
+                {
+                    css_selector_ignorelist: ['.custom-rageclick'],
+                },
+                'custom-rageclick',
+                ['$autocapture', '$autocapture', '$autocapture'],
+            ],
+        ])(
+            'autocapture and rageclick testcase: %s',
+            (_title, rageclickConfig: PostHogConfig['rageclick'], parentClassname: string, expectedCaptured) => {
+                posthog.config.rageclick = rageclickConfig
 
-            expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual([
-                '$autocapture',
-                '$autocapture',
-                '$rageclick',
-                '$autocapture',
-            ])
-        })
+                const elTarget = document.createElement('img')
+                const elParent = document.createElement('span')
+                if (parentClassname) {
+                    elParent.className = parentClassname
+                }
+                elParent.appendChild(elTarget)
+                const elGrandparent = document.createElement('a')
+                elGrandparent.setAttribute('href', 'https://test.com')
+                elGrandparent.appendChild(elParent)
+                const fakeEvent = makeMouseEvent({
+                    target: elTarget,
+                    clientX: 5,
+                    clientY: 5,
+                })
+                Object.setPrototypeOf(fakeEvent, MouseEvent.prototype)
+                autocapture['_captureEvent'](fakeEvent)
+                autocapture['_captureEvent'](fakeEvent)
+                autocapture['_captureEvent'](fakeEvent)
 
-        it('should not capture rageclick if ph-no-capture', () => {
-            const elTarget = document.createElement('img')
-            const elParent = document.createElement('span')
-            elParent.className = 'ph-no-capture'
-            elParent.appendChild(elTarget)
-            const elGrandparent = document.createElement('a')
-            elGrandparent.setAttribute('href', 'https://test.com')
-            elGrandparent.appendChild(elParent)
-            const fakeEvent = makeMouseEvent({
-                target: elTarget,
-                clientX: 5,
-                clientY: 5,
-            })
-            Object.setPrototypeOf(fakeEvent, MouseEvent.prototype)
-            autocapture['_captureEvent'](fakeEvent)
-            autocapture['_captureEvent'](fakeEvent)
-            autocapture['_captureEvent'](fakeEvent)
-
-            expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual([])
-        })
-
-        it('should not capture rageclick if ph-no-rageclick', () => {
-            const elTarget = document.createElement('img')
-            const elParent = document.createElement('span')
-            elParent.className = 'ph-no-rageclick'
-            elParent.appendChild(elTarget)
-            const elGrandparent = document.createElement('a')
-            elGrandparent.setAttribute('href', 'https://test.com')
-            elGrandparent.appendChild(elParent)
-            const fakeEvent = makeMouseEvent({
-                target: elTarget,
-                clientX: 5,
-                clientY: 5,
-            })
-            Object.setPrototypeOf(fakeEvent, MouseEvent.prototype)
-            autocapture['_captureEvent'](fakeEvent)
-            autocapture['_captureEvent'](fakeEvent)
-            autocapture['_captureEvent'](fakeEvent)
-
-            expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual([
-                '$autocapture',
-                '$autocapture',
-                '$autocapture',
-            ])
-        })
-
-        it('should not capture rageclick if ignorelist configured', () => {
-            posthog.config.rageclick = {
-                css_selector_ignorelist: ['.ignore-rage-click'],
+                expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual(expectedCaptured)
             }
-            const elTarget = document.createElement('img')
-            const elParent = document.createElement('span')
-            elParent.className = 'ignore-rage-click'
-            elParent.appendChild(elTarget)
-            const elGrandparent = document.createElement('a')
-            elGrandparent.setAttribute('href', 'https://test.com')
-            elGrandparent.appendChild(elParent)
-            const fakeEvent = makeMouseEvent({
-                target: elTarget,
-                clientX: 5,
-                clientY: 5,
-            })
-            Object.setPrototypeOf(fakeEvent, MouseEvent.prototype)
-            autocapture['_captureEvent'](fakeEvent)
-            autocapture['_captureEvent'](fakeEvent)
-            autocapture['_captureEvent'](fakeEvent)
-
-            expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual([
-                '$autocapture',
-                '$autocapture',
-                '$autocapture',
-            ])
-        })
+        )
 
         describe('clipboard autocapture', () => {
             let elTarget: HTMLDivElement

--- a/packages/browser/src/autocapture-utils.ts
+++ b/packages/browser/src/autocapture-utils.ts
@@ -171,11 +171,8 @@ export function shouldCaptureRageclick(el: Element | null, _config: PostHogConfi
     }
 
     const { targetElementList } = getElementAndParentsForElement(el, false)
-    if (checkIfElementsMatchCSSSelector(targetElementList, selectorIgnoreList)) {
-        // we don't capture if we match the ignore list
-        return false
-    }
-    return true
+    // we don't capture if we match the ignore list
+    return !checkIfElementsMatchCSSSelector(targetElementList, selectorIgnoreList)
 }
 
 const cannotCheckForAutocapture = (el: Element | null) => {
@@ -189,7 +186,6 @@ const getElementAndParentsForElement = (el: Element, captureOnAnyElement: false 
 
     let parentIsUsefulElement = false
     const targetElementList: Element[] = [el]
-    let parentNode: Element | boolean = true
     let curEl: Element = el
     while (curEl.parentNode && !isTag(curEl, 'body')) {
         // If element is a shadow root, we skip it
@@ -198,7 +194,7 @@ const getElementAndParentsForElement = (el: Element, captureOnAnyElement: false 
             curEl = (curEl.parentNode as any).host
             continue
         }
-        parentNode = getParentElement(curEl)
+        const parentNode = getParentElement(curEl)
         if (!parentNode) break
         if (captureOnAnyElement || autocaptureCompatibleElements.indexOf(parentNode.tagName.toLowerCase()) > -1) {
             parentIsUsefulElement = true

--- a/packages/browser/src/autocapture-utils.ts
+++ b/packages/browser/src/autocapture-utils.ts
@@ -132,19 +132,16 @@ function checkIfElementTreePassesElementAllowList(
  */
 function checkIfElementsMatchCSSSelector(elements: Element[], selectorList: string[] | undefined): boolean {
     if (isUndefined(selectorList)) {
-        // everything is allowed, when there is no allow list
+        // everything is allowed, when there is no selector list
         return true
     }
 
-    // check each element in the tree
-    // if any of the elements are in the allow list, then the tree is allowed
     for (const el of elements) {
         if (selectorList.some((selector) => el.matches(selector))) {
             return true
         }
     }
 
-    // otherwise there is an allow list and this element tree didn't match it
     return false
 }
 

--- a/packages/browser/src/autocapture-utils.ts
+++ b/packages/browser/src/autocapture-utils.ts
@@ -169,7 +169,7 @@ export function shouldCaptureRageclick(el: Element | null, _config: PostHogConfi
         return false
     }
 
-    const { targetElementList } = getElementsTreeForElement(el, false)
+    const { targetElementList } = getElementAndParentsForElement(el, false)
     if (checkIfElementsMatchCSSSelector(targetElementList, selectorIgnoreList || undefined)) {
         // we don't capture if we match the ignore list
         return false
@@ -181,7 +181,7 @@ const cannotCheckForAutocapture = (el: Element | null) => {
     return !el || isTag(el, 'html') || !isElementNode(el)
 }
 
-const getElementsTreeForElement = (el: Element, captureOnAnyElement: false | true | undefined) => {
+const getElementAndParentsForElement = (el: Element, captureOnAnyElement: false | true | undefined) => {
     if (!window || cannotCheckForAutocapture(el)) {
         return { parentIsUsefulElement: false, targetElementList: [] }
     }
@@ -256,7 +256,7 @@ export function shouldCaptureDomEvent(
         }
     }
 
-    const { parentIsUsefulElement, targetElementList } = getElementsTreeForElement(el, captureOnAnyElement)
+    const { parentIsUsefulElement, targetElementList } = getElementAndParentsForElement(el, captureOnAnyElement)
 
     if (!checkIfElementTreePassesElementAllowList(targetElementList, autocaptureConfig)) {
         return false

--- a/packages/browser/src/autocapture-utils.ts
+++ b/packages/browser/src/autocapture-utils.ts
@@ -159,11 +159,12 @@ export function shouldCaptureRageclick(el: Element | null, _config: PostHogConfi
         return false
     }
 
-    const selectorIgnoreList = isBoolean(_config)
-        ? _config
-            ? DEFAULT_RAGE_CLICK_IGNORE_LIST
-            : false
-        : (_config?.css_selector_ignorelist ?? DEFAULT_RAGE_CLICK_IGNORE_LIST)
+    let selectorIgnoreList: string[] | boolean
+    if (isBoolean(_config)) {
+        selectorIgnoreList = _config ? DEFAULT_RAGE_CLICK_IGNORE_LIST : false
+    } else {
+        selectorIgnoreList = _config?.css_selector_ignorelist ?? DEFAULT_RAGE_CLICK_IGNORE_LIST
+    }
 
     if (selectorIgnoreList === false) {
         return false
@@ -291,7 +292,7 @@ export function shouldCaptureDomEvent(
 }
 
 /*
- * Check whether a DOM element should be "captured" or if it may contain sentitive data
+ * Check whether a DOM element should be "captured" or if it may contain sensitive data
  * using a variety of heuristics.
  * @param {Element} el - element to check
  * @returns {boolean} whether the element should be captured

--- a/packages/browser/src/autocapture-utils.ts
+++ b/packages/browser/src/autocapture-utils.ts
@@ -153,7 +153,7 @@ export function getParentElement(curEl: Element): Element | false {
 
 // autocapture check will already filter for ph-no-capture,
 // but we include it here to protect against future changes accidentally removing that check
-const defaultRageClickIgnoreList = ['.ph-no-rageclick', '.ph-no-capture']
+const DEFAULT_RAGE_CLICK_IGNORE_LIST = ['.ph-no-rageclick', '.ph-no-capture']
 export function shouldCaptureRageclick(el: Element | null, _config: PostHogConfig['rageclick']) {
     if (!window || cannotCheckForAutocapture(el)) {
         return false
@@ -161,9 +161,9 @@ export function shouldCaptureRageclick(el: Element | null, _config: PostHogConfi
 
     const selectorIgnoreList = isBoolean(_config)
         ? _config
-            ? defaultRageClickIgnoreList
+            ? DEFAULT_RAGE_CLICK_IGNORE_LIST
             : false
-        : (_config?.css_selector_ignorelist ?? defaultRageClickIgnoreList)
+        : (_config?.css_selector_ignorelist ?? DEFAULT_RAGE_CLICK_IGNORE_LIST)
 
     if (selectorIgnoreList === false) {
         return false

--- a/packages/browser/src/autocapture-utils.ts
+++ b/packages/browser/src/autocapture-utils.ts
@@ -170,7 +170,7 @@ export function shouldCaptureRageclick(el: Element | null, _config: PostHogConfi
     }
 
     const { targetElementList } = getElementAndParentsForElement(el, false)
-    if (checkIfElementsMatchCSSSelector(targetElementList, selectorIgnoreList || undefined)) {
+    if (checkIfElementsMatchCSSSelector(targetElementList, selectorIgnoreList)) {
         // we don't capture if we match the ignore list
         return false
     }

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -11,6 +11,7 @@ import {
     makeSafeText,
     shouldCaptureDomEvent,
     shouldCaptureElement,
+    shouldCaptureRageclick,
     shouldCaptureValue,
     splitClassString,
 } from './autocapture-utils'
@@ -353,10 +354,12 @@ export class Autocapture {
 
         if (eventName === '$autocapture' && e.type === 'click' && e instanceof MouseEvent) {
             if (
-                this.instance.config.rageclick &&
+                !!this.instance.config.rageclick &&
                 this.rageclicks?.isRageClick(e.clientX, e.clientY, new Date().getTime())
             ) {
-                this._captureEvent(e, '$rageclick')
+                if (shouldCaptureRageclick(target, this.instance.config.rageclick)) {
+                    this._captureEvent(e, '$rageclick')
+                }
             }
         }
 

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -120,7 +120,7 @@ export interface RageclickConfig {
      * we consider the tree of elements from the root to the target element of the click event
      * so for the tree div > div > button > svg
      * and ignore list config `['[id]']`
-     * we will capture the click if the click-target or its parents has any id
+     * we will ignore the rageclick if the click-target or its parents has any id
      *
      * Nothing is ignored when there's an empty ignorelist, e.g. []
      * If no ignorelist is set, we default to ignoring .ph-no-rageclick

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -113,6 +113,22 @@ export interface AutocaptureConfig {
     capture_copied_text?: boolean
 }
 
+export interface RageclickConfig {
+    /**
+     * List of CSS selectors to ignore rageclicks on
+     * e.g. ['.my-calendar-button']
+     * we consider the tree of elements from the root to the target element of the click event
+     * so for the tree div > div > button > svg
+     * and allow list config `['[id]']`
+     * we will capture the click if the click-target or its parents has any id
+     *
+     * Everything is allowed when there's an empty ignorelist, e.g. []
+     * If no ignorelist is set, we default to ignoring .ph-no-rageclick
+     * If an element has .ph-no-capture, it will always be ignored by rageclick and autocapture
+     */
+    css_selector_ignorelist?: string[]
+}
+
 export interface BootstrapConfig {
     distinctID?: string
     isIdentifiedID?: boolean
@@ -310,7 +326,7 @@ export interface PostHogConfig {
      *
      * @default true
      */
-    rageclick: boolean
+    rageclick: boolean | RageclickConfig
 
     /**
      * Determines if cookie should be set on the top level domain (example.com).

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -119,10 +119,10 @@ export interface RageclickConfig {
      * e.g. ['.my-calendar-button']
      * we consider the tree of elements from the root to the target element of the click event
      * so for the tree div > div > button > svg
-     * and allow list config `['[id]']`
+     * and ignore list config `['[id]']`
      * we will capture the click if the click-target or its parents has any id
      *
-     * Everything is allowed when there's an empty ignorelist, e.g. []
+     * Nothing is ignored when there's an empty ignorelist, e.g. []
      * If no ignorelist is set, we default to ignoring .ph-no-rageclick
      * If an element has .ph-no-capture, it will always be ignored by rageclick and autocapture
      */
@@ -317,6 +317,7 @@ export interface PostHogConfig {
      * Determines whether PostHog should autocapture events.
      * This setting does not affect capturing pageview events (see `capture_pageview`).
      *
+     * by default autocapture is ignored on elements that match a `ph-no-capture` css class on the element or a parent
      * @default true
      */
     autocapture: boolean | AutocaptureConfig
@@ -324,6 +325,7 @@ export interface PostHogConfig {
     /**
      * Determines whether PostHog should capture rage clicks.
      *
+     * by default rageclicks are ignored on elements that match a `ph-no-capture` or `ph-no-rageclick` css class on the element or a parent
      * @default true
      */
     rageclick: boolean | RageclickConfig


### PR DESCRIPTION
sometimes we want to allow autocapture on an element
but we know we don't want rageclicks

for example "previous" and "next" buttons are often clicked quickly and show up as rageclicks when they shouldn't

let's support a new default of `.ph-no-rageclick` to mirror the existing `.ph-no-capture`
and allow a custom list of selectors - since some sites will have an existing set of selectors that already make sense

when `.ph-no-rageclick` or the configured selector ignorelist is matched we don't capture a rageclick