### PR TITLE
fix(node): don't sort condition sets with variant overrides to the top

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # posthog-node
 
+## 5.8.7
+
+### Patch Changes
+
+- fix: don't sort condition sets with variant overrides to the top - conditions are now evaluated in their original order to match server-side logic
+
 ## 5.8.6
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-node",
-  "version": "5.8.6",
+  "version": "5.8.7",
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -419,24 +419,7 @@ class FeatureFlagsPoller {
     let isInconclusive = false
     let result = undefined
 
-    // # Stable sort conditions with variant overrides to the top. This ensures that if overrides are present, they are
-    // # evaluated first, and the variant override is applied to the first matching condition.
-    const sortedFlagConditions = [...flagConditions].sort((conditionA, conditionB) => {
-      const AHasVariantOverride = !!conditionA.variant
-      const BHasVariantOverride = !!conditionB.variant
-
-      if (AHasVariantOverride && BHasVariantOverride) {
-        return 0
-      } else if (AHasVariantOverride) {
-        return -1
-      } else if (BHasVariantOverride) {
-        return 1
-      } else {
-        return 0
-      }
-    })
-
-    for (const condition of sortedFlagConditions) {
+    for (const condition of flagConditions) {
       try {
         if (await this.isConditionMatch(flag, distinctId, condition, properties, evaluationCache)) {
           const variantOverride = condition.variant


### PR DESCRIPTION
## Problem

Feature flag condition sets with variant overrides were sorted to the top which was confusing and not how customers expected them to work.

https://github.com/PostHog/posthog/issues/37854

## Changes

Remove sorting condition sets with variant overrides to the top to match server logic.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [na] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [na] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
