### PR TITLE
fix: over eager rename of onRemoteConfig

### DIFF
--- a/.changeset/chatty-planets-rescue.md
+++ b/.changeset/chatty-planets-rescue.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: over eager rename left a couple of old versions trying to call onRemoteConfig that doesn't exist

--- a/packages/browser/src/extensions/replay/triggerMatching.ts
+++ b/packages/browser/src/extensions/replay/triggerMatching.ts
@@ -142,6 +142,13 @@ export class URLTriggerMatching implements TriggerStatusMatching {
             (isEagerLoadedConfig(config) ? config.sessionRecording?.urlBlocklist : config?.urlBlocklist) || []
     }
 
+    /**
+     * @deprecated Use onConfig instead
+     */
+    onRemoteConfig(response: RemoteConfig) {
+        this.onConfig(response)
+    }
+
     private _urlTriggerStatus(sessionId: string): TriggerStatus {
         if (this._urlTriggers.length === 0) {
             return TRIGGER_DISABLED
@@ -245,6 +252,13 @@ export class LinkedFlagMatching implements TriggerStatusMatching {
         }
     }
 
+    /**
+     * @deprecated Use onConfig instead
+     */
+    onRemoteConfig(response: RemoteConfig, onStarted: (flag: string, variant: string | null) => void) {
+        this.onConfig(response, onStarted)
+    }
+
     stop(): void {
         this._flaglistenerCleanup()
     }
@@ -258,6 +272,13 @@ export class EventTriggerMatching implements TriggerStatusMatching {
     onConfig(config: ReplayConfigType) {
         this._eventTriggers =
             (isEagerLoadedConfig(config) ? config.sessionRecording?.eventTriggers : config?.eventTriggers) || []
+    }
+
+    /**
+     * @deprecated Use onConfig instead
+     */
+    onRemoteConfig(response: RemoteConfig) {
+        this.onConfig(response)
     }
 
     private _eventTriggerStatus(sessionId: string): TriggerStatus {


### PR DESCRIPTION
see https://github.com/PostHog/posthog-js/issues/2361

as we rolled lazy loaded replay out and then had to roll it back a rename has been added to simplify the code that will eventually be released

but folk who are pinned to the original lazy loaded version can end up calling code that doesn't exist any more 🫠

this puts those methods back and just delegates straight through to the renamed "current" methods