### PR TITLE
WIP Persist SDK references

### DIFF
--- a/.changeset/chatty-planets-rescue.md
+++ b/.changeset/chatty-planets-rescue.md
@@ -1,5 +1,0 @@
----
-'posthog-js': patch
----
-
-fix: over eager rename left a couple of old versions trying to call onRemoteConfig that doesn't exist

--- a/.github/workflows/generate-references.yml
+++ b/.github/workflows/generate-references.yml
@@ -1,0 +1,43 @@
+name: "Generate References"
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  generate-references:
+    name: Generate SDK references
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup environment
+        uses: ./.github/actions/setup
+        with:
+          build: false
+
+      - name: Build packages
+        run: pnpm build
+        
+      - name: Generate SDK references
+        run: pnpm generate-references
+
+      - name: Check for changes in references
+        id: changes
+        run: |
+          if [ -n "$(git status --porcelain packages/*/references/)" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "New references generated in packages references directories:"
+            git status --porcelain packages/*/references/
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No new references generated in packages references directories"
+          fi
+      - uses: stefanzweifel/git-auto-commit-action@v6
+        if: steps.changes.outputs.changed == 'true'
+        with:
+          commit_message: "Update generated references"
+          file_pattern: "packages/*/references/**"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "build": "turbo build",
         "dev": "turbo dev",
         "package": "export PACKAGE_DEST=$(pwd)/target && turbo package",
-        "package:watch": "export PACKAGE_DEST=$(pwd)/target && turbo watch package"
+        "package:watch": "export PACKAGE_DEST=$(pwd)/target && turbo watch package",
+        "generate-references": "turbo posthog-js#generate-references posthog-node#generate-references posthog-react-native#generate-references"
     },
     "pnpm": {
         "patchedDependencies": {

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # posthog-js
 
+## 1.268.5
+
+### Patch Changes
+
+- [#2362](https://github.com/PostHog/posthog-js/pull/2362) [`8b570b8`](https://github.com/PostHog/posthog-js/commit/8b570b832532d2827fd03a7da0d5554028ce7d77) Thanks [@pauldambra](https://github.com/pauldambra)! - fix: over eager rename left a couple of old versions trying to call onRemoteConfig that doesn't exist
+
 ## 1.268.4
 
 ### Patch Changes

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-js",
-    "version": "1.268.4",
+    "version": "1.268.5",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "hey@posthog.com",
@@ -37,8 +37,7 @@
         "check-testcafe-results": "ts-node testcafe/check-testcafe-results.js",
         "run-testcafe-localhost": "node scripts/run-testcafe-localhost.mjs",
         "write-mangled-property-names": "WRITE_MANGLED_PROPERTIES=1 pnpm build",
-        "gen-specs": "pnpm exec tsc && pnpm exec api-extractor run --config ./api-extractor.json --local",
-        "parse-specs": "node scripts/generate-docs.js"
+        "generate-references": "pnpm exec api-extractor run --config ./api-extractor.json --local && node scripts/generate-docs.js"
     },
     "main": "dist/main.js",
     "module": "dist/module.js",

--- a/packages/browser/references/posthog-js-references-1.268.5.json
+++ b/packages/browser/references/posthog-js-references-1.268.5.json
@@ -1,0 +1,4256 @@
+{
+  "id": "posthog-js",
+  "hogRef": "0.3",
+  "info": {
+    "version": "1.268.5",
+    "id": "posthog-js",
+    "title": "PostHog JavaScript Web SDK",
+    "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
+    "slugPrefix": "posthog-js",
+    "specUrl": "https://github.com/PostHog/posthog-js"
+  },
+  "classes": [
+    {
+      "description": "This is the SDK reference for the PostHog JavaScript Web SDK. You can learn more about example usage in the [JavaScript Web SDK documentation](/docs/libraries/js). You can also follow [framework specific guides](/docs/frameworks) to integrate PostHog into your project.\nThis SDK is designed for browser environments. Use the PostHog [Node.js SDK](/docs/libraries/node) for server-side usage.",
+      "id": "PostHog",
+      "title": "PostHog",
+      "functions": [
+        {
+          "category": "",
+          "description": "Constructs a new instance of the `PostHog` class",
+          "details": null,
+          "id": "PostHog",
+          "showDocs": true,
+          "title": "PostHog",
+          "examples": [
+            {
+              "id": "posthog",
+              "name": "Generated example for PostHog",
+              "code": "// Generated example for PostHog\nposthog.PostHog();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "any",
+            "name": "any"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Creates an alias linking two distinct user identifiers. Learn more about [identifying users](/docs/product-analytics/identify)",
+          "details": "PostHog will use this to link two distinct_ids going forward (not retroactively). Call this when a user signs up to connect their anonymous session with their account.",
+          "id": "alias",
+          "showDocs": true,
+          "title": "alias",
+          "examples": [
+            {
+              "id": "link_anonymous_user_to_account_on_signup",
+              "name": "link anonymous user to account on signup",
+              "code": "\n\n// link anonymous user to account on signup\nposthog.alias('user_12345')\n\n\n"
+            },
+            {
+              "id": "explicit_alias_with_original_id",
+              "name": "explicit alias with original ID",
+              "code": "\n\n// explicit alias with original ID\nposthog.alias('user_12345', 'anonymous_abc123')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "A unique identifier that you want to use for this user in the future.",
+              "isOptional": false,
+              "type": "string",
+              "name": "alias"
+            },
+            {
+              "description": "The current identifier being used for this user.",
+              "isOptional": true,
+              "type": "string",
+              "name": "original"
+            }
+          ],
+          "returnType": {
+            "id": "CaptureResult | void | number",
+            "name": "CaptureResult | void | number"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Checks the feature flags associated with this Survey to see if the survey can be rendered. This method is deprecated because it's synchronous and won't return the correct result if surveys are not loaded. Use `canRenderSurveyAsync` instead.",
+          "details": null,
+          "id": "canRenderSurvey",
+          "showDocs": true,
+          "title": "canRenderSurvey",
+          "examples": [
+            {
+              "id": "canrendersurvey",
+              "name": "Generated example for canRenderSurvey",
+              "code": "// Generated example for canRenderSurvey\nposthog.canRenderSurvey();"
+            }
+          ],
+          "releaseTag": "deprecated",
+          "params": [
+            {
+              "description": "The ID of the survey to check.",
+              "isOptional": false,
+              "type": "string",
+              "name": "surveyId"
+            }
+          ],
+          "returnType": {
+            "id": "SurveyRenderReason | null",
+            "name": "SurveyRenderReason | null"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Checks the feature flags associated with this Survey to see if the survey can be rendered.",
+          "details": null,
+          "id": "canRenderSurveyAsync",
+          "showDocs": true,
+          "title": "canRenderSurveyAsync",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.canRenderSurveyAsync(surveyId).then((result) => {\n    if (result.visible) {\n        // Survey can be rendered\n        console.log('Survey can be rendered')\n    } else {\n        // Survey cannot be rendered\n        console.log('Survey cannot be rendered:', result.disabledReason)\n    }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The ID of the survey to check.",
+              "isOptional": false,
+              "type": "string",
+              "name": "surveyId"
+            },
+            {
+              "description": "If true, the survey will be reloaded from the server, Default: false",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "forceReload"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<SurveyRenderReason>",
+            "name": "Promise<SurveyRenderReason>"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Captures an event with optional properties and configuration.",
+          "details": "You can capture arbitrary object-like values as events. [Learn about capture best practices](/docs/product-analytics/capture-events)",
+          "id": "capture",
+          "showDocs": true,
+          "title": "capture",
+          "examples": [
+            {
+              "id": "basic_event_capture",
+              "name": "basic event capture",
+              "code": "\n\n// basic event capture\nposthog.capture('cta-button-clicked', {\n    button_name: 'Get Started',\n    page: 'homepage'\n})\n\n\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the event (e.g., 'Sign Up', 'Button Click', 'Purchase')",
+              "isOptional": false,
+              "type": "EventName",
+              "name": "event_name"
+            },
+            {
+              "description": "Properties to include with the event describing the user or event details",
+              "isOptional": true,
+              "type": "Properties | null",
+              "name": "properties"
+            },
+            {
+              "description": "Optional configuration for the capture request",
+              "isOptional": true,
+              "type": "CaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "CaptureResult | undefined",
+            "name": "CaptureResult | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Error tracking",
+          "description": "Capture a caught exception manually",
+          "details": null,
+          "id": "captureException",
+          "showDocs": true,
+          "title": "captureException",
+          "examples": [
+            {
+              "id": "capture_a_caught_exception",
+              "name": "Capture a caught exception",
+              "code": "\n\n// Capture a caught exception\ntry {\n  // something that might throw\n} catch (error) {\n  posthog.captureException(error)\n}\n\n\n"
+            },
+            {
+              "id": "with_additional_properties",
+              "name": "With additional properties",
+              "code": "\n\n// With additional properties\nposthog.captureException(error, {\n  customProperty: 'value',\n  anotherProperty: ['I', 'can be a list'],\n  ...\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The error to capture",
+              "isOptional": false,
+              "type": "unknown",
+              "name": "error"
+            },
+            {
+              "description": "Any additional properties to add to the error event",
+              "isOptional": true,
+              "type": "Properties",
+              "name": "additionalProperties"
+            }
+          ],
+          "returnType": {
+            "id": "CaptureResult | undefined",
+            "name": "CaptureResult | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "LLM analytics",
+          "description": "Capture written user feedback for a LLM trace. Numeric values are converted to strings.",
+          "details": null,
+          "id": "captureTraceFeedback",
+          "showDocs": true,
+          "title": "captureTraceFeedback",
+          "examples": [
+            {
+              "id": "capturetracefeedback",
+              "name": "Generated example for captureTraceFeedback",
+              "code": "// Generated example for captureTraceFeedback\nposthog.captureTraceFeedback();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The trace ID to capture feedback for.",
+              "isOptional": false,
+              "type": "string | number",
+              "name": "traceId"
+            },
+            {
+              "description": "The feedback to capture.",
+              "isOptional": false,
+              "type": "string",
+              "name": "userFeedback"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "LLM analytics",
+          "description": "Capture a metric for a LLM trace. Numeric values are converted to strings.",
+          "details": null,
+          "id": "captureTraceMetric",
+          "showDocs": true,
+          "title": "captureTraceMetric",
+          "examples": [
+            {
+              "id": "capturetracemetric",
+              "name": "Generated example for captureTraceMetric",
+              "code": "// Generated example for captureTraceMetric\nposthog.captureTraceMetric();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The trace ID to capture the metric for.",
+              "isOptional": false,
+              "type": "string | number",
+              "name": "traceId"
+            },
+            {
+              "description": "The name of the metric to capture.",
+              "isOptional": false,
+              "type": "string",
+              "name": "metricName"
+            },
+            {
+              "description": "The value of the metric to capture.",
+              "isOptional": false,
+              "type": "string | number | boolean",
+              "name": "metricValue"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Clear the user's opt in/out status of data capturing and cookies/localstorage for this PostHog instance",
+          "details": null,
+          "id": "clear_opt_in_out_capturing",
+          "showDocs": true,
+          "title": "clear_opt_in_out_capturing",
+          "examples": [
+            {
+              "id": "clear_opt_in_out_capturing",
+              "name": "Generated example for clear_opt_in_out_capturing",
+              "code": "// Generated example for clear_opt_in_out_capturing\nposthog.clear_opt_in_out_capturing();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Creates a person profile for the current user, if they don't already have one and config.person_profiles is set to 'identified_only'. Produces a warning and does not create a profile if config.person_profiles is set to 'never'. Learn more about [person profiles](/docs/product-analytics/identify)",
+          "details": null,
+          "id": "createPersonProfile",
+          "showDocs": true,
+          "title": "createPersonProfile",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.createPersonProfile()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Enables or disables debug mode for detailed logging.",
+          "details": "Debug mode logs all PostHog calls to the browser console for troubleshooting. Can also be enabled by adding `?__posthog_debug=true` to the URL.",
+          "id": "debug",
+          "showDocs": true,
+          "title": "debug",
+          "examples": [
+            {
+              "id": "enable_debug_mode",
+              "name": "enable debug mode",
+              "code": "\n\n// enable debug mode\nposthog.debug(true)\n\n\n"
+            },
+            {
+              "id": "disable_debug_mode",
+              "name": "disable debug mode",
+              "code": "\n\n// disable debug mode\nposthog.debug(false)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "If true, will enable debug mode.",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "debug"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Display a survey programmatically as either a popover or inline element.",
+          "details": null,
+          "id": "displaySurvey",
+          "showDocs": true,
+          "title": "displaySurvey",
+          "examples": [
+            {
+              "id": "display_as_popover_(respects_all_conditions_defined_in_the_dashboard)",
+              "name": "Display as popover (respects all conditions defined in the dashboard)",
+              "code": "\n\n// Display as popover (respects all conditions defined in the dashboard)\nposthog.displaySurvey('survey-id-123')\n\n\n"
+            },
+            {
+              "id": "display_inline_in_a_specific_element",
+              "name": "Display inline in a specific element",
+              "code": "\n\n// Display inline in a specific element\nposthog.displaySurvey('survey-id-123', {\n  displayType: DisplaySurveyType.Inline,\n  selector: '#survey-container'\n})\n\n\n"
+            },
+            {
+              "id": "force_display_ignoring_conditions_and_delays",
+              "name": "Force display ignoring conditions and delays",
+              "code": "\n\n// Force display ignoring conditions and delays\nposthog.displaySurvey('survey-id-123', {\n  displayType: DisplaySurveyType.Popover,\n  ignoreConditions: true,\n  ignoreDelay: true\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The survey ID to display",
+              "isOptional": false,
+              "type": "string",
+              "name": "surveyId"
+            },
+            {
+              "description": "Display configuration",
+              "isOptional": true,
+              "type": "DisplaySurveyOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Returns the current distinct ID for the user.",
+          "details": "This is either the auto-generated ID or the ID set via `identify()`. The distinct ID is used to associate events with users in PostHog.",
+          "id": "get_distinct_id",
+          "showDocs": true,
+          "title": "get_distinct_id",
+          "examples": [
+            {
+              "id": "get_the_current_user_id",
+              "name": "get the current user ID",
+              "code": "\n\n// get the current user ID\nconst userId = posthog.get_distinct_id()\nconsole.log('Current user:', userId)\n\n\n"
+            },
+            {
+              "id": "use_in_loaded_callback",
+              "name": "use in loaded callback",
+              "code": "\n\n// use in loaded callback\nposthog.init('token', {\n    loaded: (posthog) => {\n        const id = posthog.get_distinct_id()\n        // use the ID\n    }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "",
+          "description": "Returns the explicit consent status of the user.",
+          "details": "This can be used to check if the user has explicitly opted in or out of data capturing, or neither. This does not take the default config options into account, only whether the user has made an explicit choice, so this can be used to determine whether to show an initial cookie banner or not.",
+          "id": "get_explicit_consent_status",
+          "showDocs": true,
+          "title": "get_explicit_consent_status",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nconst consentStatus = posthog.get_explicit_consent_status()\nif (consentStatus === \"granted\") {\n    // user has explicitly opted in\n} else if (consentStatus === \"denied\") {\n    // user has explicitly opted out\n} else if (consentStatus === \"pending\"){\n    // user has not made a choice, show consent banner\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "'granted' | 'denied' | 'pending'",
+            "name": "'granted' | 'denied' | 'pending'"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Returns the value of a super property. Returns undefined if the property doesn't exist.",
+          "details": "get_property() can only be called after the PostHog library has finished loading. init() has a loaded function available to handle this automatically.",
+          "id": "get_property",
+          "showDocs": true,
+          "title": "get_property",
+          "examples": [
+            {
+              "id": "grab_value_for_'$user_id'_after_the_posthog_library_has_loaded",
+              "name": "grab value for '$user_id' after the posthog library has loaded",
+              "code": "\n\n// grab value for '$user_id' after the posthog library has loaded\nposthog.init('<YOUR PROJECT TOKEN>', {\n    loaded: function(posthog) {\n        user_id = posthog.get_property('$user_id');\n    }\n});\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the super property you want to retrieve",
+              "isOptional": false,
+              "type": "string",
+              "name": "property_name"
+            }
+          ],
+          "returnType": {
+            "id": "Property | undefined",
+            "name": "Property | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "",
+          "description": "Returns the current session_id.",
+          "details": "This should only be used for informative purposes. Any actual internal use case for the session_id should be handled by the sessionManager.",
+          "id": "get_session_id",
+          "showDocs": true,
+          "title": "get_session_id",
+          "examples": [
+            {
+              "id": "get_session_id",
+              "name": "Generated example for get_session_id",
+              "code": "// Generated example for get_session_id\nposthog.get_session_id();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Session replay",
+          "description": "Returns the Replay url for the current session.",
+          "details": null,
+          "id": "get_session_replay_url",
+          "showDocs": true,
+          "title": "get_session_replay_url",
+          "examples": [
+            {
+              "id": "basic_usage",
+              "name": "basic usage",
+              "code": "\n\n// basic usage\nposthog.get_session_replay_url()\n\n@example\n\njs // timestamp posthog.get_session_replay_url({ withTimestamp: true })\n\n\n@example\n\njs // timestamp and lookback posthog.get_session_replay_url({ withTimestamp: true, timestampLookBack: 30 // look back 30 seconds }) ```\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Options for the url",
+              "isOptional": true,
+              "type": "{\n        withTimestamp?: boolean;\n        timestampLookBack?: number;\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Get surveys that should be enabled for the current user. See [fetching surveys documentation](/docs/surveys/implementing-custom-surveys#fetching-surveys-manually) for more details.",
+          "details": null,
+          "id": "getActiveMatchingSurveys",
+          "showDocs": true,
+          "title": "getActiveMatchingSurveys",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.getActiveMatchingSurveys((surveys) => {\n     // do something\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The callback function will be called when the surveys are loaded or updated.",
+              "isOptional": false,
+              "type": "SurveyCallback",
+              "name": "callback"
+            },
+            {
+              "description": "Whether to force a reload of the surveys.",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "forceReload"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get the list of early access features. To check enrollment status, use `isFeatureEnabled`. [Learn more in the docs](/docs/feature-flags/early-access-feature-management#option-2-custom-implementation)",
+          "details": null,
+          "id": "getEarlyAccessFeatures",
+          "showDocs": true,
+          "title": "getEarlyAccessFeatures",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nconst posthog = usePostHog()\nconst activeFlags = useActiveFeatureFlags()\n\nconst [activeBetas, setActiveBetas] = useState([])\nconst [inactiveBetas, setInactiveBetas] = useState([])\nconst [comingSoonFeatures, setComingSoonFeatures] = useState([])\n\nuseEffect(() => {\n  posthog.getEarlyAccessFeatures((features) => {\n    // Filter features by stage\n    const betaFeatures = features.filter(feature => feature.stage === 'beta')\n    const conceptFeatures = features.filter(feature => feature.stage === 'concept')\n\n    setComingSoonFeatures(conceptFeatures)\n\n    if (!activeFlags || activeFlags.length === 0) {\n      setInactiveBetas(betaFeatures)\n      return\n    }\n\n    const activeBetas = betaFeatures.filter(\n            beta => activeFlags.includes(beta.flagKey)\n        );\n    const inactiveBetas = betaFeatures.filter(\n            beta => !activeFlags.includes(beta.flagKey)\n        );\n    setActiveBetas(activeBetas)\n    setInactiveBetas(inactiveBetas)\n  }, true, ['concept', 'beta'])\n}, [activeFlags])\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The callback function will be called when the early access features are loaded.",
+              "isOptional": false,
+              "type": "EarlyAccessFeatureCallback",
+              "name": "callback"
+            },
+            {
+              "description": "Whether to force a reload of the early access features.",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "force_reload"
+            },
+            {
+              "description": "The stages of the early access features to load.",
+              "isOptional": true,
+              "type": "EarlyAccessFeatureStage[]",
+              "name": "stages"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Gets the value of a feature flag for the current user.",
+          "details": "Returns the feature flag value which can be a boolean, string, or undefined. Supports multivariate flags that can return custom string values.",
+          "id": "getFeatureFlag",
+          "showDocs": true,
+          "title": "getFeatureFlag",
+          "examples": [
+            {
+              "id": "check_boolean_flag",
+              "name": "check boolean flag",
+              "code": "\n\n// check boolean flag\nif (posthog.getFeatureFlag('new-feature')) {\n    // show new feature\n}\n\n\n"
+            },
+            {
+              "id": "check_multivariate_flag",
+              "name": "check multivariate flag",
+              "code": "\n\n// check multivariate flag\nconst variant = posthog.getFeatureFlag('button-color')\nif (variant === 'red') {\n    // show red button\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "(optional) If send_event: false, we won't send an $feature_flag_call event to PostHog.",
+              "isOptional": true,
+              "type": "{\n        send_event?: boolean;\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "boolean | string | undefined",
+            "name": "boolean | string | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get feature flag payload value matching key for user (supports multivariate flags).",
+          "details": null,
+          "id": "getFeatureFlagPayload",
+          "showDocs": true,
+          "title": "getFeatureFlagPayload",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nif(posthog.getFeatureFlag('beta-feature') === 'some-value') {\n     const someValue = posthog.getFeatureFlagPayload('beta-feature')\n     // do something\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            }
+          ],
+          "returnType": {
+            "id": "JsonType",
+            "name": "JsonType"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Returns the current groups.",
+          "details": null,
+          "id": "getGroups",
+          "showDocs": true,
+          "title": "getGroups",
+          "examples": [
+            {
+              "id": "getgroups",
+              "name": "Generated example for getGroups",
+              "code": "// Generated example for getGroups\nposthog.getGroups();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Record<string, any>",
+            "name": "Record<string, any>"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Returns the current page view ID.",
+          "details": null,
+          "id": "getPageViewId",
+          "showDocs": true,
+          "title": "getPageViewId",
+          "examples": [
+            {
+              "id": "getpageviewid",
+              "name": "Generated example for getPageViewId",
+              "code": "// Generated example for getPageViewId\nposthog.getPageViewId();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string | undefined",
+            "name": "string | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Returns the value of the session super property named property_name. If no such property is set, getSessionProperty() will return the undefined value.",
+          "details": "This is based on browser-level `sessionStorage`, NOT the PostHog session. getSessionProperty() can only be called after the PostHog library has finished loading. init() has a loaded function available to handle this automatically.",
+          "id": "getSessionProperty",
+          "showDocs": true,
+          "title": "getSessionProperty",
+          "examples": [
+            {
+              "id": "grab_value_for_'user_id'_after_the_posthog_library_has_loaded",
+              "name": "grab value for 'user_id' after the posthog library has loaded",
+              "code": "\n\n// grab value for 'user_id' after the posthog library has loaded\nposthog.init('YOUR PROJECT TOKEN', {\n    loaded: function(posthog) {\n        user_id = posthog.getSessionProperty('user_id');\n    }\n});\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the session super property you want to retrieve",
+              "isOptional": false,
+              "type": "string",
+              "name": "property_name"
+            }
+          ],
+          "returnType": {
+            "id": "Property | undefined",
+            "name": "Property | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Get list of all surveys.",
+          "details": null,
+          "id": "getSurveys",
+          "showDocs": true,
+          "title": "getSurveys",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nfunction callback(surveys, context) {\n  // do something\n}\n\nposthog.getSurveys(callback, false)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Function that receives the array of surveys",
+              "isOptional": false,
+              "type": "SurveyCallback",
+              "name": "callback"
+            },
+            {
+              "description": "Optional boolean to force an API call for updated surveys",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "forceReload"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Associates the user with a group for group-based analytics. Learn more about [groups](/docs/product-analytics/group-analytics)",
+          "details": "Groups allow you to analyze users collectively (e.g., by organization, team, or account). This sets the group association for all subsequent events and reloads feature flags.",
+          "id": "group",
+          "showDocs": true,
+          "title": "group",
+          "examples": [
+            {
+              "id": "associate_user_with_an_organization",
+              "name": "associate user with an organization",
+              "code": "\n\n// associate user with an organization\nposthog.group('organization', 'org_12345', {\n    name: 'Acme Corp',\n    plan: 'enterprise'\n})\n\n\n"
+            },
+            {
+              "id": "associate_with_multiple_group_types",
+              "name": "associate with multiple group types",
+              "code": "\n\n// associate with multiple group types\nposthog.group('organization', 'org_12345')\nposthog.group('team', 'team_67890')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Group type (example: 'organization')",
+              "isOptional": false,
+              "type": "string",
+              "name": "groupType"
+            },
+            {
+              "description": "Group key (example: 'org::5')",
+              "isOptional": false,
+              "type": "string",
+              "name": "groupKey"
+            },
+            {
+              "description": "Optional properties to set for group",
+              "isOptional": true,
+              "type": "Properties",
+              "name": "groupPropertiesToSet"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Checks if the user has opted into data capturing.",
+          "details": "Returns the current consent status for event tracking and data persistence.",
+          "id": "has_opted_in_capturing",
+          "showDocs": true,
+          "title": "has_opted_in_capturing",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nif (posthog.has_opted_in_capturing()) {\n    // show analytics features\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Checks if the user has opted out of data capturing.",
+          "details": "Returns the current consent status for event tracking and data persistence.",
+          "id": "has_opted_out_capturing",
+          "showDocs": true,
+          "title": "has_opted_out_capturing",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nif (posthog.has_opted_out_capturing()) {\n    // disable analytics features\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Associates a user with a unique identifier instead of an auto-generated ID. Learn more about [identifying users](/docs/product-analytics/identify)",
+          "details": "By default, PostHog assigns each user a randomly generated `distinct_id`. Use this method to replace that ID with your own unique identifier (like a user ID from your database).",
+          "id": "identify",
+          "showDocs": true,
+          "title": "identify",
+          "examples": [
+            {
+              "id": "basic_identification",
+              "name": "basic identification",
+              "code": "\n\n// basic identification\nposthog.identify('user_12345')\n\n\n"
+            },
+            {
+              "id": "identify_with_user_properties",
+              "name": "identify with user properties",
+              "code": "\n\n// identify with user properties\nposthog.identify('user_12345', {\n    email: 'user@example.com',\n    plan: 'premium'\n})\n\n\n"
+            },
+            {
+              "id": "identify_with_set_and_set_once_properties",
+              "name": "identify with set and set_once properties",
+              "code": "\n\n// identify with set and set_once properties\nposthog.identify('user_12345',\n    { last_login: new Date() },  // updates every time\n    { signup_date: new Date() }  // sets only once\n)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.",
+              "isOptional": true,
+              "type": "string",
+              "name": "new_distinct_id"
+            },
+            {
+              "description": "Optional: An associative array of properties to store about the user. Note: For feature flag evaluations, if the same key is present in the userPropertiesToSetOnce, it will be overwritten by the value in userPropertiesToSet.",
+              "isOptional": true,
+              "type": "Properties",
+              "name": "userPropertiesToSet"
+            },
+            {
+              "description": "Optional: An associative array of properties to store about the user. If property is previously set, this does not override that value.",
+              "isOptional": true,
+              "type": "Properties",
+              "name": "userPropertiesToSetOnce"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Initializes a new instance of the PostHog capturing object.",
+          "details": "All new instances are added to the main posthog object as sub properties (such as `posthog.library_name`) and also returned by this function. [Learn more about configuration options](https://github.com/posthog/posthog-js/blob/6e0e873/src/posthog-core.js#L57-L91)",
+          "id": "init",
+          "showDocs": true,
+          "title": "init",
+          "examples": [
+            {
+              "id": "basic_initialization",
+              "name": "basic initialization",
+              "code": "\n\n// basic initialization\nposthog.init('<ph_project_api_key>', {\n    api_host: '<ph_client_api_host>'\n})\n\n\n"
+            },
+            {
+              "id": "multiple_instances",
+              "name": "multiple instances",
+              "code": "\n\n// multiple instances\nposthog.init('<ph_project_api_key>', {}, 'project1')\nposthog.init('<ph_project_api_key>', {}, 'project2')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Your PostHog API token",
+              "isOptional": false,
+              "type": "string",
+              "name": "token"
+            },
+            {
+              "description": "A dictionary of config options to override",
+              "isOptional": true,
+              "type": "OnlyValidKeys<Partial<PostHogConfig>, Partial<PostHogConfig>>",
+              "name": "config"
+            },
+            {
+              "description": "The name for the new posthog instance that you want created",
+              "isOptional": true,
+              "type": "string",
+              "name": "name"
+            }
+          ],
+          "returnType": {
+            "id": "PostHog",
+            "name": "PostHog"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Checks whether the PostHog library is currently capturing events.\nUsually this means that the user has not opted out of capturing, but the exact behaviour can be controlled by some config options.\nAdditionally, if the cookieless_mode is set to 'on_reject', we will capture events in cookieless mode if the user has explicitly opted out.",
+          "details": null,
+          "id": "is_capturing",
+          "showDocs": true,
+          "title": "is_capturing",
+          "examples": [
+            {
+              "id": "is_capturing",
+              "name": "Generated example for is_capturing",
+              "code": "// Generated example for is_capturing\nposthog.is_capturing();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Checks if a feature flag is enabled for the current user.",
+          "details": "Returns true if the flag is enabled, false if disabled, or undefined if not found. This is a convenience method that treats any truthy value as enabled.",
+          "id": "isFeatureEnabled",
+          "showDocs": true,
+          "title": "isFeatureEnabled",
+          "examples": [
+            {
+              "id": "simple_feature_flag_check",
+              "name": "simple feature flag check",
+              "code": "\n\n// simple feature flag check\nif (posthog.isFeatureEnabled('new-checkout')) {\n    showNewCheckout()\n}\n\n\n"
+            },
+            {
+              "id": "disable_event_tracking",
+              "name": "disable event tracking",
+              "code": "\n\n// disable event tracking\nif (posthog.isFeatureEnabled('feature', { send_event: false })) {\n    // flag checked without sending $feature_flag_call event\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "(optional) If send_event: false, we won't send an $feature_flag_call event to PostHog.",
+              "isOptional": true,
+              "type": "{\n        send_event: boolean;\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "boolean | undefined",
+            "name": "boolean | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Toolbar",
+          "description": "returns a boolean indicating whether the [toolbar](/docs/toolbar) loaded",
+          "details": null,
+          "id": "loadToolbar",
+          "showDocs": true,
+          "title": "loadToolbar",
+          "examples": [
+            {
+              "id": "loadtoolbar",
+              "name": "Generated example for loadToolbar",
+              "code": "// Generated example for loadToolbar\nposthog.loadToolbar();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "ToolbarParams",
+              "name": "params"
+            }
+          ],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Exposes a set of events that PostHog will emit. e.g. `eventCaptured` is emitted immediately before trying to send an event\nUnlike `onFeatureFlags` and `onSessionId` these are not called when the listener is registered, the first callback will be the next event _after_ registering a listener",
+          "details": null,
+          "id": "on",
+          "showDocs": true,
+          "title": "on",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.on('eventCaptured', (event) => {\n  console.log(event)\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The event to listen for.",
+              "isOptional": false,
+              "type": "'eventCaptured'",
+              "name": "event"
+            },
+            {
+              "description": "The callback function to call when the event is emitted.",
+              "isOptional": false,
+              "type": "(...args: any[]) => void",
+              "name": "cb"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Register an event listener that runs when feature flags become available or when they change. If there are flags, the listener is called immediately in addition to being called on future changes. Note that this is not called only when we fetch feature flags from the server, but also when they change in the browser.",
+          "details": null,
+          "id": "onFeatureFlags",
+          "showDocs": true,
+          "title": "onFeatureFlags",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.onFeatureFlags(function(featureFlags, featureFlagsVariants, { errorsLoading }) {\n    // do something\n})\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The callback function will be called once the feature flags are ready or when they are updated. It'll return a list of feature flags enabled for the user, the variants, and also a context object indicating whether we succeeded to fetch the flags or not.",
+              "isOptional": false,
+              "type": "FeatureFlagsCallback",
+              "name": "callback"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Register an event listener that runs whenever the session id or window id change. If there is already a session id, the listener is called immediately in addition to being called on future changes.\nCan be used, for example, to sync the PostHog session id with a backend session.",
+          "details": null,
+          "id": "onSessionId",
+          "showDocs": true,
+          "title": "onSessionId",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.onSessionId(function(sessionId, windowId) { // do something })\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The callback function will be called once a session id is present or when it or the window id are updated.",
+              "isOptional": false,
+              "type": "SessionIdChangedCallback",
+              "name": "callback"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Register an event listener that runs when surveys are loaded.\nCallback parameters: - surveys: Survey[]: An array containing all survey objects fetched from PostHog using the getSurveys method - context:  isLoaded: boolean, error?: string : An object indicating if the surveys were loaded successfully",
+          "details": null,
+          "id": "onSurveysLoaded",
+          "showDocs": true,
+          "title": "onSurveysLoaded",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.onSurveysLoaded((surveys, context) => { // do something })\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The callback function will be called when surveys are loaded or updated.",
+              "isOptional": false,
+              "type": "SurveyCallback",
+              "name": "callback"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Opts the user into data capturing and persistence.",
+          "details": "Enables event tracking and data persistence (cookies/localStorage) for this PostHog instance. By default, captures an `$opt_in` event unless disabled.",
+          "id": "opt_in_capturing",
+          "showDocs": true,
+          "title": "opt_in_capturing",
+          "examples": [
+            {
+              "id": "simple_opt-in",
+              "name": "simple opt-in",
+              "code": "\n\n// simple opt-in\nposthog.opt_in_capturing()\n\n\n"
+            },
+            {
+              "id": "opt-in_with_custom_event_and_properties",
+              "name": "opt-in with custom event and properties",
+              "code": "\n\n// opt-in with custom event and properties\nposthog.opt_in_capturing({\n    captureEventName: 'Privacy Accepted',\n    captureProperties: { source: 'banner' }\n})\n\n\n"
+            },
+            {
+              "id": "opt-in_without_capturing_event",
+              "name": "opt-in without capturing event",
+              "code": "\n\n// opt-in without capturing event\nposthog.opt_in_capturing({\n    captureEventName: false\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "{\n        captureEventName?: EventName | null | false; /** event name to be used for capturing the opt-in action */\n        captureProperties?: Properties; /** set of properties to be captured along with the opt-in action */\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Opts the user out of data capturing and persistence.",
+          "details": "Disables event tracking and data persistence (cookies/localStorage) for this PostHog instance. If `opt_out_persistence_by_default` is true, SDK persistence will also be disabled.",
+          "id": "opt_out_capturing",
+          "showDocs": true,
+          "title": "opt_out_capturing",
+          "examples": [
+            {
+              "id": "opt_user_out_(e.g.,_on_privacy_settings_page)",
+              "name": "opt user out (e.g., on privacy settings page)",
+              "code": "\n\n// opt user out (e.g., on privacy settings page)\nposthog.opt_out_capturing()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "",
+          "description": "push() keeps the standard async-array-push behavior around after the lib is loaded. This is only useful for external integrations that do not wish to rely on our convenience methods (created in the snippet).",
+          "details": null,
+          "id": "push",
+          "showDocs": true,
+          "title": "push",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.push(['register', { a: 'b' }]);\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "A [function_name, args...] array to be executed",
+              "isOptional": false,
+              "type": "SnippetArrayItem",
+              "name": "item"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Registers super properties for the current session only.",
+          "details": "Session super properties are automatically added to all events during the current browser session. Unlike regular super properties, these are cleared when the session ends and are stored in sessionStorage.",
+          "id": "register_for_session",
+          "showDocs": true,
+          "title": "register_for_session",
+          "examples": [
+            {
+              "id": "register_session-specific_properties",
+              "name": "register session-specific properties",
+              "code": "\n\n// register session-specific properties\nposthog.register_for_session({\n    current_page_type: 'checkout',\n    ab_test_variant: 'control'\n})\n\n\n"
+            },
+            {
+              "id": "register_properties_for_user_flow_tracking",
+              "name": "register properties for user flow tracking",
+              "code": "\n\n// register properties for user flow tracking\nposthog.register_for_session({\n    selected_plan: 'pro',\n    completed_steps: 3,\n    flow_id: 'signup_flow_v2'\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "An associative array of properties to store about the user",
+              "isOptional": false,
+              "type": "Properties",
+              "name": "properties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Registers super properties only if they haven't been set before.",
+          "details": "Unlike `register()`, this method will not overwrite existing super properties. Use this for properties that should only be set once, like signup date or initial referrer.",
+          "id": "register_once",
+          "showDocs": true,
+          "title": "register_once",
+          "examples": [
+            {
+              "id": "register_once-only_properties",
+              "name": "register once-only properties",
+              "code": "\n\n// register once-only properties\nposthog.register_once({\n    first_login_date: new Date().toISOString(),\n    initial_referrer: document.referrer\n})\n\n\n"
+            },
+            {
+              "id": "override_existing_value_if_it_matches_default",
+              "name": "override existing value if it matches default",
+              "code": "\n\n// override existing value if it matches default\nposthog.register_once(\n    { user_type: 'premium' },\n    'unknown'  // overwrite if current value is 'unknown'\n)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "An associative array of properties to store about the user",
+              "isOptional": false,
+              "type": "Properties",
+              "name": "properties"
+            },
+            {
+              "description": "Value to override if already set in super properties (ex: 'False') Default: 'None'",
+              "isOptional": true,
+              "type": "Property",
+              "name": "default_value"
+            },
+            {
+              "description": "How many days since the users last visit to store the super properties",
+              "isOptional": true,
+              "type": "number",
+              "name": "days"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Registers super properties that are included with all events.",
+          "details": "Super properties are stored in persistence and automatically added to every event you capture. These values will overwrite any existing super properties with the same keys.",
+          "id": "register",
+          "showDocs": true,
+          "title": "register",
+          "examples": [
+            {
+              "id": "register_a_single_property",
+              "name": "register a single property",
+              "code": "\n\n// register a single property\nposthog.register({ plan: 'premium' })\n\n\n\n\n"
+            },
+            {
+              "id": "register_multiple_properties",
+              "name": "register multiple properties",
+              "code": "\n\n// register multiple properties\nposthog.register({\n    email: 'user@example.com',\n    account_type: 'business',\n    signup_date: '2023-01-15'\n})\n\n\n"
+            },
+            {
+              "id": "register_with_custom_expiration",
+              "name": "register with custom expiration",
+              "code": "\n\n// register with custom expiration\nposthog.register({ campaign: 'summer_sale' }, 7) // expires in 7 days\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "properties to store about the user",
+              "isOptional": false,
+              "type": "Properties",
+              "name": "properties"
+            },
+            {
+              "description": "How many days since the user's last visit to store the super properties",
+              "isOptional": true,
+              "type": "number",
+              "name": "days"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Feature flag values are cached. If something has changed with your user and you'd like to refetch their flag values, call this method.",
+          "details": null,
+          "id": "reloadFeatureFlags",
+          "showDocs": true,
+          "title": "reloadFeatureFlags",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.reloadFeatureFlags()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Although we recommend using popover surveys and display conditions, if you want to show surveys programmatically without setting up all the extra logic needed for API surveys, you can render surveys programmatically with the renderSurvey method.\nThis takes a survey ID and an HTML selector to render an unstyled survey.",
+          "details": null,
+          "id": "renderSurvey",
+          "showDocs": true,
+          "title": "renderSurvey",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.renderSurvey(coolSurveyID, '#survey-container')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "deprecated",
+          "params": [
+            {
+              "description": "The ID of the survey to render.",
+              "isOptional": false,
+              "type": "string",
+              "name": "surveyId"
+            },
+            {
+              "description": "The selector of the HTML element to render the survey on.",
+              "isOptional": false,
+              "type": "string",
+              "name": "selector"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Resets all user data and starts a fresh session.\n⚠️ **Warning**: Only call this when a user logs out. Calling at the wrong time can cause split sessions.\nThis clears: - Session ID and super properties - User identification (sets new random distinct_id) - Cached data and consent settings",
+          "details": null,
+          "id": "reset",
+          "showDocs": true,
+          "title": "reset",
+          "examples": [
+            {
+              "id": "reset_on_user_logout",
+              "name": "reset on user logout",
+              "code": "\n\n// reset on user logout\nfunction logout() {\n    posthog.reset()\n    // redirect to login page\n}\n\n\n"
+            },
+            {
+              "id": "reset_and_generate_new_device_id",
+              "name": "reset and generate new device ID",
+              "code": "\n\n// reset and generate new device ID\nposthog.reset(true)  // also resets device_id\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "reset_device_id"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Resets the group properties for feature flags.",
+          "details": null,
+          "id": "resetGroupPropertiesForFlags",
+          "showDocs": true,
+          "title": "resetGroupPropertiesForFlags",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.resetGroupPropertiesForFlags()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "string",
+              "name": "group_type"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Resets only the group properties of the user currently logged in. Learn more about [groups](/docs/product-analytics/group-analytics)",
+          "details": null,
+          "id": "resetGroups",
+          "showDocs": true,
+          "title": "resetGroups",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.resetGroups()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Resets the person properties for feature flags.",
+          "details": null,
+          "id": "resetPersonPropertiesForFlags",
+          "showDocs": true,
+          "title": "resetPersonPropertiesForFlags",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.resetPersonPropertiesForFlags()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Session replay",
+          "description": "returns a boolean indicating whether session recording is currently running",
+          "details": null,
+          "id": "sessionRecordingStarted",
+          "showDocs": true,
+          "title": "sessionRecordingStarted",
+          "examples": [
+            {
+              "id": "stop_session_recording_if_it's_running",
+              "name": "Stop session recording if it's running",
+              "code": "\n\n// Stop session recording if it's running\nif (posthog.sessionRecordingStarted()) {\n  posthog.stopSessionRecording()\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Updates the configuration of the PostHog instance.",
+          "details": null,
+          "id": "set_config",
+          "showDocs": true,
+          "title": "set_config",
+          "examples": [
+            {
+              "id": "set_config",
+              "name": "Generated example for set_config",
+              "code": "// Generated example for set_config\nposthog.set_config();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "A dictionary of new configuration values to update",
+              "isOptional": false,
+              "type": "Partial<PostHogConfig>",
+              "name": "config"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Set override group properties for feature flags. This is used when dealing with new groups / where you don't want to wait for ingestion to update properties. Takes in an object, the key of which is the group type.",
+          "details": null,
+          "id": "setGroupPropertiesForFlags",
+          "showDocs": true,
+          "title": "setGroupPropertiesForFlags",
+          "examples": [
+            {
+              "id": "set_properties_with_reload",
+              "name": "Set properties with reload",
+              "code": "\n\n// Set properties with reload\nposthog.setGroupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } })\n\n\n"
+            },
+            {
+              "id": "set_properties_without_reload",
+              "name": "Set properties without reload",
+              "code": "\n\n// Set properties without reload\nposthog.setGroupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } }, false)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The properties to override, the key of which is the group type.",
+              "isOptional": false,
+              "type": "{\n        [type: string]: Properties;\n    }",
+              "name": "properties"
+            },
+            {
+              "description": "Whether to reload feature flags.",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "reloadFeatureFlags"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Sets properties on the person profile associated with the current `distinct_id`. Learn more about [identifying users](/docs/product-analytics/identify)",
+          "details": "Updates user properties that are stored with the person profile in PostHog. If `person_profiles` is set to `identified_only` and no profile exists, this will create one.",
+          "id": "setPersonProperties",
+          "showDocs": true,
+          "title": "setPersonProperties",
+          "examples": [
+            {
+              "id": "set_user_properties",
+              "name": "set user properties",
+              "code": "\n\n// set user properties\nposthog.setPersonProperties({\n    email: 'user@example.com',\n    plan: 'premium'\n})\n\n\n"
+            },
+            {
+              "id": "set_properties",
+              "name": "set properties",
+              "code": "\n\n// set properties\nposthog.setPersonProperties(\n    { name: 'Max Hedgehog' },  // $set properties\n    { initial_url: '/blog' }   // $set_once properties\n)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Optional: An associative array of properties to store about the user. Note: For feature flag evaluations, if the same key is present in the userPropertiesToSetOnce, it will be overwritten by the value in userPropertiesToSet.",
+              "isOptional": true,
+              "type": "Properties",
+              "name": "userPropertiesToSet"
+            },
+            {
+              "description": "Optional: An associative array of properties to store about the user. If property is previously set, this does not override that value.",
+              "isOptional": true,
+              "type": "Properties",
+              "name": "userPropertiesToSetOnce"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Sometimes, you might want to evaluate feature flags using properties that haven't been ingested yet, or were set incorrectly earlier. You can do so by setting properties the flag depends on with these calls:",
+          "details": null,
+          "id": "setPersonPropertiesForFlags",
+          "showDocs": true,
+          "title": "setPersonPropertiesForFlags",
+          "examples": [
+            {
+              "id": "set_properties",
+              "name": "Set properties",
+              "code": "\n\n// Set properties\nposthog.setPersonPropertiesForFlags({'property1': 'value', property2: 'value2'})\n\n\n"
+            },
+            {
+              "id": "set_properties_without_reloading",
+              "name": "Set properties without reloading",
+              "code": "\n\n// Set properties without reloading\nposthog.setPersonPropertiesForFlags({'property1': 'value', property2: 'value2'}, false)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The properties to override.",
+              "isOptional": false,
+              "type": "Properties",
+              "name": "properties"
+            },
+            {
+              "description": "Whether to reload feature flags.",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "reloadFeatureFlags"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Session replay",
+          "description": "turns session recording on, and updates the config option `disable_session_recording` to false",
+          "details": null,
+          "id": "startSessionRecording",
+          "showDocs": true,
+          "title": "startSessionRecording",
+          "examples": [
+            {
+              "id": "start_and_ignore_controls",
+              "name": "Start and ignore controls",
+              "code": "\n\n// Start and ignore controls\nposthog.startSessionRecording(true)\n\n\n"
+            },
+            {
+              "id": "start_and_override_controls",
+              "name": "Start and override controls",
+              "code": "\n\n// Start and override controls\nposthog.startSessionRecording({\n  // you don't have to send all of these\n  sampling: true || false,\n  linked_flag: true || false,\n  url_trigger: true || false,\n  event_trigger: true || false\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "optional boolean to override the default sampling behavior - ensures the next session recording to start will not be skipped by sampling or linked_flag config. `true` is shorthand for  sampling: true, linked_flag: true",
+              "isOptional": true,
+              "type": "{\n        sampling?: boolean;\n        linked_flag?: boolean;\n        url_trigger?: true;\n        event_trigger?: true;\n    } | true",
+              "name": "override"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Session replay",
+          "description": "turns session recording off, and updates the config option disable_session_recording to true",
+          "details": null,
+          "id": "stopSessionRecording",
+          "showDocs": true,
+          "title": "stopSessionRecording",
+          "examples": [
+            {
+              "id": "stop_session_recording",
+              "name": "Stop session recording",
+              "code": "\n\n// Stop session recording\nposthog.stopSessionRecording()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Removes a session super property from the current session.",
+          "details": "This will stop the property from being automatically included in future events for this session. The property is removed from sessionStorage.",
+          "id": "unregister_for_session",
+          "showDocs": true,
+          "title": "unregister_for_session",
+          "examples": [
+            {
+              "id": "remove_a_session_property",
+              "name": "remove a session property",
+              "code": "\n\n// remove a session property\nposthog.unregister_for_session('current_flow')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the session super property to remove",
+              "isOptional": false,
+              "type": "string",
+              "name": "property"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Removes a super property from persistent storage.",
+          "details": "This will stop the property from being automatically included in future events. The property will be permanently removed from the user's profile.",
+          "id": "unregister",
+          "showDocs": true,
+          "title": "unregister",
+          "examples": [
+            {
+              "id": "remove_a_super_property",
+              "name": "remove a super property",
+              "code": "\n\n// remove a super property\nposthog.unregister('plan_type')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the super property to remove",
+              "isOptional": false,
+              "type": "string",
+              "name": "property"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Opt the user in or out of an early access feature. [Learn more in the docs](/docs/feature-flags/early-access-feature-management#option-2-custom-implementation)",
+          "details": null,
+          "id": "updateEarlyAccessFeatureEnrollment",
+          "showDocs": true,
+          "title": "updateEarlyAccessFeatureEnrollment",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nconst toggleBeta = (betaKey) => {\n  if (activeBetas.some(\n    beta => beta.flagKey === betaKey\n  )) {\n    posthog.updateEarlyAccessFeatureEnrollment(\n      betaKey,\n      false\n    )\n    setActiveBetas(\n      prevActiveBetas => prevActiveBetas.filter(\n        item => item.flagKey !== betaKey\n      )\n    );\n    return\n  }\n\n  posthog.updateEarlyAccessFeatureEnrollment(\n    betaKey,\n    true\n  )\n  setInactiveBetas(\n    prevInactiveBetas => prevInactiveBetas.filter(\n      item => item.flagKey !== betaKey\n    )\n  );\n}\n\nconst registerInterest = (featureKey) => {\n  posthog.updateEarlyAccessFeatureEnrollment(\n    featureKey,\n    true\n  )\n  // Update UI to show user has registered\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The key of the feature flag to update.",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "Whether the user is enrolled in the feature.",
+              "isOptional": false,
+              "type": "boolean",
+              "name": "isEnrolled"
+            },
+            {
+              "description": "The stage of the feature flag to update.",
+              "isOptional": true,
+              "type": "string",
+              "name": "stage"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        }
+      ]
+    }
+  ],
+  "types": [
+    {
+      "id": "ActionStepStringMatching",
+      "name": "ActionStepStringMatching",
+      "properties": [],
+      "path": "lib/src/posthog-surveys-types.d.ts",
+      "example": "\"contains\" | \"exact\" | \"regex\""
+    },
+    {
+      "id": "ActionStepType",
+      "name": "ActionStepType",
+      "properties": [
+        {
+          "type": "string | null",
+          "name": "event"
+        },
+        {
+          "description": "ActionStepStringMatching.Exact",
+          "type": "ActionStepStringMatching | null",
+          "name": "href_matching"
+        },
+        {
+          "type": "string | null",
+          "name": "href"
+        },
+        {
+          "type": "string | null",
+          "name": "selector"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "name": "tag_name"
+        },
+        {
+          "description": "StringMatching.Exact",
+          "type": "ActionStepStringMatching | null",
+          "name": "text_matching"
+        },
+        {
+          "type": "string | null",
+          "name": "text"
+        },
+        {
+          "description": "StringMatching.Contains",
+          "type": "ActionStepStringMatching | null",
+          "name": "url_matching"
+        },
+        {
+          "type": "string | null",
+          "name": "url"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "AutocaptureCompatibleElement",
+      "name": "AutocaptureCompatibleElement",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"a\" | \"button\" | \"form\" | \"input\" | \"select\" | \"textarea\" | \"label\""
+    },
+    {
+      "id": "AutocaptureConfig",
+      "name": "AutocaptureConfig",
+      "properties": [
+        {
+          "description": "When set to true, autocapture will capture the text of any element that is cut or copied.",
+          "type": "boolean",
+          "name": "capture_copied_text"
+        },
+        {
+          "description": "List of CSS selectors to allow autocapture on e.g. ['[ph-capture]'] we consider the tree of elements from the root to the target element of the click event so for the tree div  div  button  svg and allow list config `['[id]']` we will capture the click if the click-target or its parents has any id\nEverything is allowed when there's no allowlist",
+          "type": "string[]",
+          "name": "css_selector_allowlist"
+        },
+        {
+          "description": "List of DOM events to allow autocapture on e.g. ['click', 'change', 'submit']",
+          "type": "DomAutocaptureEvents[]",
+          "name": "dom_event_allowlist"
+        },
+        {
+          "description": "List of DOM elements to allow autocapture on e.g. ['a', 'button', 'form', 'input', 'select', 'textarea', 'label']\nWe consider the tree of elements from the root to the target element of the click event so for the tree `div > div > button > svg` if the allowlist has `button` then we allow the capture when the `button` or the `svg` is the click target but not if either of the `div`s are detected as the click target",
+          "type": "AutocaptureCompatibleElement[]",
+          "name": "element_allowlist"
+        },
+        {
+          "description": "Exclude certain element attributes from autocapture E.g. ['aria-label'] or [data-attr-pii]",
+          "type": "string[]",
+          "name": "element_attribute_ignorelist"
+        },
+        {
+          "description": "List of URLs to allow autocapture on, can be strings to match or regexes e.g. ['https://example.com', 'test.com/.*'] this is useful when you want to autocapture on specific pages only\nif you set both url_allowlist and url_ignorelist, we check the allowlist first and then the ignorelist. the ignorelist can override the allowlist",
+          "type": "(string | RegExp)[]",
+          "name": "url_allowlist"
+        },
+        {
+          "description": "List of URLs to not allow autocapture on, can be strings to match or regexes e.g. ['https://example.com', 'test.com/.*'] this is useful when you want to autocapture on most pages but not some specific ones\nif you set both url_allowlist and url_ignorelist, we check the allowlist first and then the ignorelist. the ignorelist can override the allowlist",
+          "type": "(string | RegExp)[]",
+          "name": "url_ignorelist"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "BasicSurveyQuestion",
+      "name": "BasicSurveyQuestion",
+      "properties": [
+        {
+          "type": "SurveyQuestionType.Open",
+          "name": "type"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "BeforeSendFn",
+      "name": "BeforeSendFn",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(cr: CaptureResult | null) => CaptureResult | null"
+    },
+    {
+      "id": "BootstrapConfig",
+      "name": "BootstrapConfig",
+      "properties": [
+        {
+          "type": "string",
+          "name": "distinctID"
+        },
+        {
+          "type": "Record<string, JsonType>",
+          "name": "featureFlagPayloads"
+        },
+        {
+          "type": "Record<string, boolean | string>",
+          "name": "featureFlags"
+        },
+        {
+          "type": "boolean",
+          "name": "isIdentifiedID"
+        },
+        {
+          "description": "Optionally provide a sessionID, this is so that you can provide an existing sessionID here to continue a user's session across a domain or device. It MUST be: - unique to this user - a valid UUID v7 - the timestamp part must be = the timestamp of the first event in the session - the timestamp of the last event in the session must be  the timestamp part + 24 hours *",
+          "type": "string",
+          "name": "sessionID"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "Breaker",
+      "name": "Breaker",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{}"
+    },
+    {
+      "id": "CapturedNetworkRequest",
+      "name": "CapturedNetworkRequest",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "Writable<Omit<PerformanceEntry, 'toJSON'>> & {\n    method?: string;\n    initiatorType?: InitiatorType;\n    status?: number;\n    timeOrigin?: number;\n    timestamp?: number;\n    startTime?: number;\n    endTime?: number;\n    requestHeaders?: Headers;\n    requestBody?: string | null;\n    responseHeaders?: Headers;\n    responseBody?: string | null;\n    isInitial?: boolean;\n}"
+    },
+    {
+      "id": "CaptureOptions",
+      "name": "CaptureOptions",
+      "properties": [
+        {
+          "description": "key of queue, e.g. 'sessionRecording' vs 'event'",
+          "type": "string",
+          "name": "_batchKey"
+        },
+        {
+          "description": "If set, overrides and disables config.properties_string_max_length",
+          "type": "boolean",
+          "name": "_noTruncate"
+        },
+        {
+          "description": "Used to override the desired endpoint for the captured event",
+          "type": "string",
+          "name": "_url"
+        },
+        {
+          "description": "Used when `$identify` is called Will set person properties but only once, it will NOT override previous values",
+          "type": "Properties",
+          "name": "$set_once"
+        },
+        {
+          "description": "Used when `$identify` is called Will set person properties overriding previous values",
+          "type": "Properties",
+          "name": "$set"
+        },
+        {
+          "description": "If set, skips the batched queue",
+          "type": "boolean",
+          "name": "send_instantly"
+        },
+        {
+          "description": "If set, skips the client side rate limiting",
+          "type": "boolean",
+          "name": "skip_client_rate_limiting"
+        },
+        {
+          "description": "If set, overrides the current timestamp",
+          "type": "Date",
+          "name": "timestamp"
+        },
+        {
+          "description": "If set, overrides the desired transport method",
+          "type": "RequestWithOptions['transport']",
+          "name": "transport"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "CaptureResult",
+      "name": "CaptureResult",
+      "properties": [
+        {
+          "type": "Properties",
+          "name": "$set_once"
+        },
+        {
+          "type": "Properties",
+          "name": "$set"
+        },
+        {
+          "type": "EventName",
+          "name": "event"
+        },
+        {
+          "type": "Properties",
+          "name": "properties"
+        },
+        {
+          "type": "Date",
+          "name": "timestamp"
+        },
+        {
+          "type": "string",
+          "name": "uuid"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "Compression",
+      "name": "Compression",
+      "properties": [
+        {
+          "type": "\"base64\"",
+          "name": "Base64"
+        },
+        {
+          "type": "\"gzip-js\"",
+          "name": "GZipJS"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "ConfigDefaults",
+      "name": "ConfigDefaults",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"2025-05-24\" | \"unset\""
+    },
+    {
+      "id": "DeadClickCandidate",
+      "name": "DeadClickCandidate",
+      "properties": [
+        {
+          "type": "number",
+          "name": "absoluteDelayMs"
+        },
+        {
+          "type": "number",
+          "name": "mutationDelayMs"
+        },
+        {
+          "type": "Element",
+          "name": "node"
+        },
+        {
+          "type": "MouseEvent",
+          "name": "originalEvent"
+        },
+        {
+          "type": "number",
+          "name": "scrollDelayMs"
+        },
+        {
+          "type": "number",
+          "name": "selectionChangedDelayMs"
+        },
+        {
+          "type": "number",
+          "name": "timestamp"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "DeadClicksAutoCaptureConfig",
+      "name": "DeadClicksAutoCaptureConfig",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    scroll_threshold_ms?: number;\n    selection_change_threshold_ms?: number;\n    mutation_threshold_ms?: number;\n    __onCapture?: ((click: DeadClickCandidate, properties: Properties) => void) | undefined;\n} & Pick<AutocaptureConfig, 'element_attribute_ignorelist'>"
+    },
+    {
+      "id": "DisplaySurveyOptions",
+      "name": "DisplaySurveyOptions",
+      "properties": [],
+      "path": "lib/src/posthog-surveys-types.d.ts",
+      "example": "DisplaySurveyPopoverOptions | DisplaySurveyInlineOptions"
+    },
+    {
+      "id": "DisplaySurveyType",
+      "name": "DisplaySurveyType",
+      "properties": [
+        {
+          "type": "\"inline\"",
+          "name": "Inline"
+        },
+        {
+          "type": "\"popover\"",
+          "name": "Popover"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "DomAutocaptureEvents",
+      "name": "DomAutocaptureEvents",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"click\" | \"change\" | \"submit\""
+    },
+    {
+      "id": "EarlyAccessFeature",
+      "name": "EarlyAccessFeature",
+      "properties": [
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "string | null",
+          "name": "documentationUrl"
+        },
+        {
+          "type": "string | null",
+          "name": "flagKey"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "'concept' | 'alpha' | 'beta'",
+          "name": "stage"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "EarlyAccessFeatureCallback",
+      "name": "EarlyAccessFeatureCallback",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(earlyAccessFeatures: EarlyAccessFeature[]) => void"
+    },
+    {
+      "id": "EarlyAccessFeatureResponse",
+      "name": "EarlyAccessFeatureResponse",
+      "properties": [
+        {
+          "type": "EarlyAccessFeature[]",
+          "name": "earlyAccessFeatures"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "EarlyAccessFeatureStage",
+      "name": "EarlyAccessFeatureStage",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"concept\" | \"alpha\" | \"beta\" | \"general-availability\""
+    },
+    {
+      "id": "ErrorEventArgs",
+      "name": "ErrorEventArgs",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "[\n    event: string | Event, source?: string | undefined, lineno?: number | undefined, colno?: number | undefined, error?: Error | undefined\n]"
+    },
+    {
+      "id": "ErrorTrackingOptions",
+      "name": "ErrorTrackingOptions",
+      "properties": [
+        {
+          "description": "ADVANCED: alters the bucket size for the token bucket mutation throttling Normally only altered alongside posthog support guidance. Accepts values between 0 and 100\n10",
+          "type": "number",
+          "name": "__exceptionRateLimiterBucketSize"
+        },
+        {
+          "description": "ADVANCED: alters the refill rate for the token bucket mutation throttling Normally only altered alongside posthog support guidance. Accepts values between 0 and 100\n1",
+          "type": "number",
+          "name": "__exceptionRateLimiterRefillRate"
+        },
+        {
+          "description": "Decide whether exceptions thrown by browser extensions should be captured\nfalse",
+          "type": "boolean",
+          "name": "captureExtensionExceptions"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "ErrorTrackingSuppressionRule",
+      "name": "ErrorTrackingSuppressionRule",
+      "properties": [
+        {
+          "type": "'AND' | 'OR'",
+          "name": "type"
+        },
+        {
+          "type": "ErrorTrackingSuppressionRuleValue[]",
+          "name": "values"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "ErrorTrackingSuppressionRuleValue",
+      "name": "ErrorTrackingSuppressionRuleValue",
+      "properties": [
+        {
+          "type": "'$exception_types' | '$exception_values'",
+          "name": "key"
+        },
+        {
+          "type": "PropertyMatchType",
+          "name": "operator"
+        },
+        {
+          "type": "string",
+          "name": "type"
+        },
+        {
+          "type": "string | string[]",
+          "name": "value"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "EvaluationReason",
+      "name": "EvaluationReason",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    code: string;\n    condition_index: number | undefined;\n    description: string | undefined;\n}"
+    },
+    {
+      "id": "EventHandler",
+      "name": "EventHandler",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(event: Event) => boolean | void"
+    },
+    {
+      "id": "EventName",
+      "name": "EventName",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"$pageview\" | \"$identify\" | \"custom_event\" | string"
+    },
+    {
+      "id": "ExceptionAutoCaptureConfig",
+      "name": "ExceptionAutoCaptureConfig",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    capture_unhandled_errors: boolean;\n    capture_unhandled_rejections: boolean;\n    capture_console_errors: boolean;\n}"
+    },
+    {
+      "id": "ExternalIntegrationKind",
+      "name": "ExternalIntegrationKind",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"intercom\" | \"crispChat\""
+    },
+    {
+      "id": "FeatureFlagDetail",
+      "name": "FeatureFlagDetail",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    key: string;\n    enabled: boolean;\n    original_enabled?: boolean | undefined;\n    variant: string | undefined;\n    original_variant?: string | undefined;\n    reason: EvaluationReason | undefined;\n    metadata: FeatureFlagMetadata | undefined;\n}"
+    },
+    {
+      "id": "FeatureFlagMetadata",
+      "name": "FeatureFlagMetadata",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    id: number;\n    version: number | undefined;\n    description: string | undefined;\n    payload: JsonType | undefined;\n    original_payload?: JsonType | undefined;\n}"
+    },
+    {
+      "id": "FeatureFlagsCallback",
+      "name": "FeatureFlagsCallback",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(flags: string[], variants: Record<string, string | boolean>, context?: {\n    errorsLoading?: boolean;\n}) => void"
+    },
+    {
+      "id": "FlagsResponse",
+      "name": "FlagsResponse",
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "errorsWhileComputingFlags"
+        },
+        {
+          "type": "Record<string, JsonType>",
+          "name": "featureFlagPayloads"
+        },
+        {
+          "type": "Record<string, string | boolean>",
+          "name": "featureFlags"
+        },
+        {
+          "type": "Record<string, FeatureFlagDetail>",
+          "name": "flags"
+        },
+        {
+          "type": "string",
+          "name": "requestId"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "FlagVariant",
+      "name": "FlagVariant",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    flag: string;\n    variant: string;\n}"
+    },
+    {
+      "id": "Headers_2",
+      "name": "Headers_2",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "Record<string, string>"
+    },
+    {
+      "id": "HeatmapConfig",
+      "name": "HeatmapConfig",
+      "properties": [
+        {
+          "description": "How often to send batched data in `$heatmap_data` events If set to 0 or not set, sends using the default interval of 1 second\n1000",
+          "type": "number",
+          "name": "flush_interval_milliseconds"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "InitiatorType",
+      "name": "InitiatorType",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"audio\" | \"beacon\" | \"body\" | \"css\" | \"early-hint\" | \"embed\" | \"fetch\" | \"frame\" | \"iframe\" | \"icon\" | \"image\" | \"img\" | \"input\" | \"link\" | \"navigation\" | \"object\" | \"ping\" | \"script\" | \"track\" | \"video\" | \"xmlhttprequest\""
+    },
+    {
+      "id": "JsonRecord",
+      "name": "JsonRecord",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    [key: string]: JsonType;\n}"
+    },
+    {
+      "id": "JsonType",
+      "name": "JsonType",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "string | number | boolean | null | undefined | JsonRecord | Array<JsonType>"
+    },
+    {
+      "id": "KnownEventName",
+      "name": "KnownEventName",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"$heatmaps_data\" | \"$opt_in\" | \"$exception\" | \"$$heatmap\" | \"$web_vitals\" | \"$dead_click\" | \"$autocapture\" | \"$rageclick\""
+    },
+    {
+      "id": "LinkSurveyQuestion",
+      "name": "LinkSurveyQuestion",
+      "properties": [
+        {
+          "type": "string | null",
+          "name": "link"
+        },
+        {
+          "type": "SurveyQuestionType.Link",
+          "name": "type"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "MultipleSurveyQuestion",
+      "name": "MultipleSurveyQuestion",
+      "properties": [
+        {
+          "type": "string[]",
+          "name": "choices"
+        },
+        {
+          "type": "boolean",
+          "name": "hasOpenChoice"
+        },
+        {
+          "type": "boolean",
+          "name": "shuffleOptions"
+        },
+        {
+          "type": "boolean",
+          "name": "skipSubmitButton"
+        },
+        {
+          "type": "SurveyQuestionType.SingleChoice | SurveyQuestionType.MultipleChoice",
+          "name": "type"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "NetworkRecordOptions",
+      "name": "NetworkRecordOptions",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    initiatorTypes?: InitiatorType[];\n    maskRequestFn?: (data: CapturedNetworkRequest) => CapturedNetworkRequest | undefined;\n    recordHeaders?: boolean | {\n        request: boolean;\n        response: boolean;\n    };\n    recordBody?: boolean | string[] | {\n        request: boolean | string[];\n        response: boolean | string[];\n    };\n    recordInitialRequests?: boolean;\n    recordPerformance?: boolean;\n    performanceEntryTypeToObserve: string[];\n    payloadSizeLimitBytes: number;\n    payloadHostDenyList?: string[];\n}"
+    },
+    {
+      "id": "NetworkRequest",
+      "name": "NetworkRequest",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    url: string;\n}"
+    },
+    {
+      "id": "PerformanceCaptureConfig",
+      "name": "PerformanceCaptureConfig",
+      "properties": [
+        {
+          "description": "We observe very large values reported by the Chrome web vitals library These outliers are likely not real, useful values, and we exclude them You can set this to 0 in order to include all values, NB this is not recommended\n15 * 60 * 1000 (15 minutes)",
+          "type": "number",
+          "name": "__web_vitals_max_value"
+        },
+        {
+          "description": "Works with session replay to use the browser's native performance observer to capture performance metrics",
+          "type": "boolean",
+          "name": "network_timing"
+        },
+        {
+          "description": "By default all 4 metrics are captured You can set this config to restrict which metrics are captured e.g. ['CLS', 'FCP'] to only capture those two metrics NB setting this does not override whether the capture is enabled\n['LCP', 'CLS', 'FCP', 'INP']",
+          "type": "SupportedWebVitalsMetrics[]",
+          "name": "web_vitals_allowed_metrics"
+        },
+        {
+          "description": "We delay flushing web vitals metrics to reduce the number of events we send This is the maximum time we will wait before sending the metrics\n5000",
+          "type": "number",
+          "name": "web_vitals_delayed_flush_ms"
+        },
+        {
+          "description": "Use chrome's web vitals library to wrap fetch and capture web vitals",
+          "type": "boolean",
+          "name": "web_vitals"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "PersistentStore",
+      "name": "PersistentStore",
+      "properties": [
+        {
+          "type": "(error: any) => void",
+          "name": "_error"
+        },
+        {
+          "type": "(name: string) => any",
+          "name": "_get"
+        },
+        {
+          "type": "() => boolean",
+          "name": "_is_supported"
+        },
+        {
+          "type": "(name: string) => any",
+          "name": "_parse"
+        },
+        {
+          "type": "(name: string, cross_subdomain?: boolean) => void",
+          "name": "_remove"
+        },
+        {
+          "type": "(name: string, value: any, expire_days?: number | null, cross_subdomain?: boolean, secure?: boolean, debug?: boolean) => void",
+          "name": "_set"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "PostHogConfig",
+      "name": "PostHogConfig",
+      "properties": [
+        {
+          "description": "PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION A list of hostnames for which to inject PostHog tracing headers to all requests (X-POSTHOG-DISTINCT-ID, X-POSTHOG-SESSION-ID, X-POSTHOG-WINDOW-ID)",
+          "type": "string[]",
+          "name": "__add_tracing_headers"
+        },
+        {
+          "description": "Prevents posthog-js from using the `navigator.sendBeacon` API to send events. Enabling this option may hurt the reliability of sending $pageleave events",
+          "type": "boolean",
+          "name": "__preview_disable_beacon"
+        },
+        {
+          "description": "Disables sending credentials when using XHR requests.",
+          "type": "boolean",
+          "name": "__preview_disable_xhr_credentials"
+        },
+        {
+          "description": "PREVIEW - MAY CHANGE WITHOUT WARNING - ONLY USE WHEN TALKING TO POSTHOG SUPPORT Enables deprecated eager loading of session recording code, not just rrweb and network plugin we are switching the default to lazy loading because the bundle will ultimately be 18% smaller then keeping this around for a few days in case there are unexpected consequences that testing did not uncover",
+          "type": "boolean",
+          "name": "__preview_eager_load_replay"
+        },
+        {
+          "description": "PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION Whether to use the new /flags/ endpoint",
+          "type": "boolean",
+          "name": "__preview_flags_v2"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "__preview_lazy_load_replay"
+        },
+        {
+          "description": "PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION Enables the new RemoteConfig approach to loading config instead of /flags?v=2&config=true",
+          "type": "boolean",
+          "name": "__preview_remote_config"
+        },
+        {
+          "description": "",
+          "type": "(eventName: string, eventData: CaptureResult) => void",
+          "name": "_onCapture"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "advanced_disable_decide"
+        },
+        {
+          "description": "Stops from firing feature flag requests on first page load. Only requests feature flags when user identity or properties are updated, or you manually request for flags to be loaded.\nfalse",
+          "type": "boolean",
+          "name": "advanced_disable_feature_flags_on_first_load"
+        },
+        {
+          "description": "Will keep /flags running, but without evaluating any feature flags. Useful for when you need to load the config data associated with the flags endpoint (e.g. /flags?v=2&config=true) without evaluating any feature flags. Most folks use this to save money on feature flag evaluation (by bootstrapping feature flags on the server side).\nfalse",
+          "type": "boolean",
+          "name": "advanced_disable_feature_flags"
+        },
+        {
+          "description": "One of the very first things the PostHog library does when init() is called is make a request to the /flags endpoint on PostHog's backend. This endpoint contains information on how to run the PostHog library so events are properly received in the backend, and it also contains feature flag evaluation information for the current user.\nThis endpoint is required to run most features of this library. However, if you're not using any of the described features, you may wish to turn off the call completely to avoid an extra request and reduce resource usage on both the client and the server.\nfalse",
+          "type": "boolean",
+          "name": "advanced_disable_flags"
+        },
+        {
+          "description": "Determines whether PostHog should disable toolbar metrics. This is our internal instrumentation for our toolbar in your website.\nfalse",
+          "type": "boolean",
+          "name": "advanced_disable_toolbar_metrics"
+        },
+        {
+          "description": "When this is enabled, surveys will always be initialized, regardless of the /flags response or remote config settings. This is useful if you want to use surveys but disable all other flag-dependent functionality. Used internally for displaying external surveys without making a /flags request.\nfalse",
+          "type": "boolean",
+          "name": "advanced_enable_surveys"
+        },
+        {
+          "description": "Determines whether PostHog should only evaluate feature flags for surveys. Useful for when you want to use this library to evaluate feature flags for surveys only but you have additional feature flags that you evaluate on the server side.\nfalse",
+          "type": "boolean",
+          "name": "advanced_only_evaluate_survey_feature_flags"
+        },
+        {
+          "description": "URL of your PostHog instance.\n'https://us.i.posthog.com'",
+          "type": "string",
+          "name": "api_host"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "name": "api_method"
+        },
+        {
+          "description": "The transport method to use for API requests.\n'fetch'",
+          "type": "'XHR' | 'fetch'",
+          "name": "api_transport"
+        },
+        {
+          "description": "Determines whether PostHog should autocapture events. This setting does not affect capturing pageview events (see `capture_pageview`).\nby default autocapture is ignored on elements that match a `ph-no-capture` css class on the element or a parent   true",
+          "type": "boolean | AutocaptureConfig",
+          "name": "autocapture"
+        },
+        {
+          "description": "This function or array of functions - if provided - are called immediately before sending data to the server. It allows you to edit data before it is sent, or choose not to send it all. if provided as an array the functions are called in the order they are provided any one function returning null means the event will not be sent",
+          "type": "BeforeSendFn | BeforeSendFn[]",
+          "name": "before_send"
+        },
+        {
+          "description": "An object containing the `distinctID`, `isIdentifiedID`, and `featureFlags` keys, where `distinctID` is a string, and `featureFlags` is an object of key-value pairs.\nSince there is a delay between initializing PostHog and fetching feature flags, feature flags are not always available immediately. This makes them unusable if you want to do something like redirecting a user to a different page based on a feature flag.\nYou can, therefore, fetch the feature flags in your server and pre-fill them here, allowing PostHog to know the feature flag values immediately.\nAfter the SDK fetches feature flags from PostHog, it will use those flag values instead of bootstrapped ones.",
+          "type": "BootstrapConfig",
+          "name": "bootstrap"
+        },
+        {
+          "description": "Determines whether to capture dead clicks.",
+          "type": "boolean | DeadClicksAutoCaptureConfig",
+          "name": "capture_dead_clicks"
+        },
+        {
+          "description": "Determines whether to capture exceptions.",
+          "type": "boolean | ExceptionAutoCaptureConfig",
+          "name": "capture_exceptions"
+        },
+        {
+          "description": "Determines whether to capture heatmaps.",
+          "type": "boolean | HeatmapConfig",
+          "name": "capture_heatmaps"
+        },
+        {
+          "description": "Determines whether PostHog should capture pageleave events. If set to `true`, it will capture pageleave events for all pages. If set to `'if_capture_pageview'`, it will only capture pageleave events if `capture_pageview` is also set to `true` or `'history_change'`.\n'if_capture_pageview'",
+          "type": "boolean | 'if_capture_pageview'",
+          "name": "capture_pageleave"
+        },
+        {
+          "description": "Determines whether PostHog should capture pageview events automatically. Can be: - `true`: Capture regular pageviews (default) - `false`: Don't capture any pageviews - `'history_change'`: Only capture pageviews on history API changes (pushState, replaceState, popstate)\ntrue",
+          "type": "boolean | 'history_change'",
+          "name": "capture_pageview"
+        },
+        {
+          "description": "Determines whether to capture performance metrics. These include Network Timing and Web Vitals.\nWhen `undefined`, fallback to the remote configuration. If `false`, neither network timing nor web vitals will work. If an object, that will override the remote configuration.",
+          "type": "boolean | PerformanceCaptureConfig",
+          "name": "capture_performance"
+        },
+        {
+          "description": "Determines the key for the cookie / local storage used to store the information about whether users are opted in/out of capturing. When `null`, we used a key based on your token.\nnull",
+          "type": "string | null",
+          "name": "consent_persistence_name"
+        },
+        {
+          "description": "Determines the number of days to store cookies for.\n365",
+          "type": "number",
+          "name": "cookie_expiration"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "name": "cookie_name"
+        },
+        {
+          "description": "Enables cookieless mode. In this mode, PostHog will not set any cookies, or use session or local storage. User identity is handled by generating a privacy-preserving hash on PostHog's servers. - 'always' - enable cookieless mode immediately on startup, use this if you do not intend to show a cookie banner - 'on_reject' - enable cookieless mode only if the user rejects cookies, use this if you want to show a cookie banner. If the user accepts cookies, cookieless mode will not be used, and PostHog will use cookies and local storage as usual.\nNote that you MUST enable cookieless mode in your PostHog project's settings, otherwise all your cookieless events will be ignored. We plan to remove this requirement in the future.",
+          "type": "'always' | 'on_reject'",
+          "name": "cookieless_mode"
+        },
+        {
+          "description": "Determines if cookie should be set on the top level domain (example.com). If PostHog-js is loaded on a subdomain (test.example.com), and `cross_subdomain_cookie` is set to false, it'll set the cookie on the subdomain only (test.example.com).\nNOTE: It will be set to `false` if we detect that the domain is a subdomain of a platform that is excluded from cross-subdomain cookie setting. The current list of excluded platforms is `herokuapp.com`, `vercel.app`, and `netlify.app`.",
+          "type": "boolean",
+          "name": "cross_subdomain_cookie"
+        },
+        {
+          "description": "Used to extend the list of user agents that are blocked by default.",
+          "type": "string[]",
+          "name": "custom_blocked_useragents"
+        },
+        {
+          "description": "Used to extend the list of campaign parameters that are saved by default.",
+          "type": "string[]",
+          "name": "custom_campaign_params"
+        },
+        {
+          "description": "Custom list of personal data properties to mask.\nE.g. if you added `email` to this list, then any `email` property in the URL will be masked. https://www.example.com/login?email=john.doe%40example.com = https://www.example.com/login?email=\n[]",
+          "type": "string[]",
+          "name": "custom_personal_data_properties"
+        },
+        {
+          "description": "Determines whether PostHog should be in debug mode. You can enable this to get more detailed logging.\nYou can also enable this on your website by appending `?__posthog_debug=true` at the end of your URL You can also call `posthog.debug()` in your code to enable debug mode\nfalse",
+          "type": "boolean",
+          "name": "debug"
+        },
+        {
+          "description": "Configuration defaults for breaking changes. When set to a specific date, enables new default behaviors that were introduced on that date.\n- `'unset'`: Use legacy default behaviors - `'2025-05-24'`: Use updated default behaviors (e.g. capture_pageview defaults to 'history_change')\n'unset'",
+          "type": "ConfigDefaults",
+          "name": "defaults"
+        },
+        {
+          "description": "Determines whether to disable compression when sending events to the server. WARNING: Should only be used for testing. Could negatively impact performance.\nfalse",
+          "type": "boolean",
+          "name": "disable_compression"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "disable_cookie"
+        },
+        {
+          "description": "Determines whether PostHog should disable any external dependency loading. This will prevent PostHog from requesting any external scripts such as those needed for Session Replay, Surveys or Site Apps.\nfalse",
+          "type": "boolean",
+          "name": "disable_external_dependency_loading"
+        },
+        {
+          "description": "Determines whether PostHog should disable persistence. If set to `true`, the library will not save any data to the browser. It will also delete any data previously saved to the browser.\nfalse",
+          "type": "boolean",
+          "name": "disable_persistence"
+        },
+        {
+          "description": "Determines whether to disable scroll properties. These allow you to keep track of how far down someone scrolled in your website.\nfalse",
+          "type": "boolean",
+          "name": "disable_scroll_properties"
+        },
+        {
+          "description": "Determines whether PostHog should disable session recording.\nfalse",
+          "type": "boolean",
+          "name": "disable_session_recording"
+        },
+        {
+          "description": "Determines whether PostHog should disable automatic display of surveys. If this is true, popup or widget surveys will not be shown when display conditions are met.\nfalse",
+          "type": "boolean",
+          "name": "disable_surveys_automatic_display"
+        },
+        {
+          "description": "Determines whether PostHog should disable all surveys functionality.\nfalse",
+          "type": "boolean",
+          "name": "disable_surveys"
+        },
+        {
+          "description": "Determines whether PostHog should disable web experiments.\nCurrently disabled while we're in BETA. It will be toggled to `true` in a future release.\ntrue",
+          "type": "boolean",
+          "name": "disable_web_experiments"
+        },
+        {
+          "type": "boolean",
+          "name": "enable_heatmaps"
+        },
+        {
+          "description": "Determines whether PostHog should enable recording console logs. When undefined, it falls back to the remote config setting.\nundefined",
+          "type": "boolean",
+          "name": "enable_recording_console_log"
+        },
+        {
+          "description": "Determines the error tracking options.",
+          "type": "ErrorTrackingOptions",
+          "name": "error_tracking"
+        },
+        {
+          "description": "Sets timeout for fetching feature flags\n3000",
+          "type": "number",
+          "name": "feature_flag_request_timeout_ms"
+        },
+        {
+          "description": "Used when sending data via `fetch`, use with care. This is intentionally meant to be used with NextJS `fetch`\nIncorrect `cache` usage may cause out-of-date data for feature flags, actions tracking, etc. See https://nextjs.org/docs/app/api-reference/functions/fetch#fetchurl-options",
+          "type": "{\n        cache?: RequestInit['cache'];\n        next_options?: NextOptions;\n    }",
+          "name": "fetch_options"
+        },
+        {
+          "description": "Function to get the device ID. This doesn't usually need to be set, but can be useful if you want to use a custom device ID.",
+          "type": "(uuid: string) => string",
+          "name": "get_device_id"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "inapp_link_new_window"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "name": "inapp_protocol"
+        },
+        {
+          "description": "Used to set-up external integrations with PostHog data - such as session replays, distinct id, etc.",
+          "type": "Record<ExternalIntegrationKind, boolean>",
+          "name": "integrations"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "ip"
+        },
+        {
+          "description": "A function to be called once the PostHog scripts have loaded successfully.",
+          "type": "(posthog_instance: PostHog) => void",
+          "name": "loaded"
+        },
+        {
+          "description": "Prevent autocapture from capturing any attribute names on elements.\nfalse",
+          "type": "boolean",
+          "name": "mask_all_element_attributes"
+        },
+        {
+          "description": "Prevent autocapture from capturing `textContent` on elements.\nfalse",
+          "type": "boolean",
+          "name": "mask_all_text"
+        },
+        {
+          "description": "Mask personal data properties from the current URL. This will mask personal data properties such as advertising IDs (gclid, fbclid, etc.), and you can also add custom properties to mask with `custom_personal_data_properties`.   false",
+          "type": "boolean",
+          "name": "mask_personal_data_properties"
+        },
+        {
+          "description": "The name this instance will be identified by. You don't need to set this most of the time, but can be useful if you have several Posthog instances running at the same time.\n'posthog'",
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "description": "A function that is called when a request to the PostHog API fails.",
+          "type": "(error: RequestResponse) => void",
+          "name": "on_request_error"
+        },
+        {
+          "description": "",
+          "type": "(failedRequest: XMLHttpRequest) => void",
+          "name": "on_xhr_error"
+        },
+        {
+          "description": "Determines if users should be opted in to site apps.\nfalse",
+          "type": "boolean",
+          "name": "opt_in_site_apps"
+        },
+        {
+          "description": "Determines if users should be opted out of PostHog tracking by default, requiring additional logic to opt them into capturing by calling `posthog.opt_in_capturing()`.\nfalse",
+          "type": "boolean",
+          "name": "opt_out_capturing_by_default"
+        },
+        {
+          "description": "",
+          "type": "string | null",
+          "name": "opt_out_capturing_cookie_prefix"
+        },
+        {
+          "description": "Determines where we'll save the information about whether users are opted out of capturing.\n'localStorage'",
+          "type": "'localStorage' | 'cookie'",
+          "name": "opt_out_capturing_persistence_type"
+        },
+        {
+          "description": "Determines if users should be opted out of browser data storage by this PostHog instance by default, requiring additional logic to opt them into capturing by calling `posthog.opt_in_capturing()`.\nfalse",
+          "type": "boolean",
+          "name": "opt_out_persistence_by_default"
+        },
+        {
+          "description": "Determines if users should be opted out of user agent filtering such as googlebot or other bots. If this is set to `true`, PostHog will set `$browser_type` to either `bot` or `browser` for all events, but will process all events as if they were from a browser.\nfalse",
+          "type": "boolean",
+          "name": "opt_out_useragent_filter"
+        },
+        {
+          "description": "The name for the super properties persistent store\n''",
+          "type": "string",
+          "name": "persistence_name"
+        },
+        {
+          "description": "Determines how PostHog stores information about the user. See [persistence](https://posthog.com/docs/libraries/js#persistence) for details.\n'localStorage+cookie'",
+          "type": "'localStorage' | 'cookie' | 'memory' | 'localStorage+cookie' | 'sessionStorage'",
+          "name": "persistence"
+        },
+        {
+          "description": "You can control whether events from PostHog-js have person processing enabled with the `person_profiles` config setting. There are three options: - `person_profiles: 'always'` - we will process persons data for all events - `person_profiles: 'never'` - we won't process persons for any event. This means that anonymous users will not be merged once they sign up or login, so you lose the ability to create funnels that track users from anonymous to identified. All events (including `$identify`) will be sent with `$process_person_profile: False`. - `person_profiles: 'identified_only'` _(default)_ - we will only process persons when you call `posthog.identify`, `posthog.alias`, `posthog.setPersonProperties`, `posthog.group`, `posthog.setPersonPropertiesForFlags` or `posthog.setGroupPropertiesForFlags` Anonymous users won't get person profiles.\n'identified_only'",
+          "type": "'always' | 'never' | 'identified_only'",
+          "name": "person_profiles"
+        },
+        {
+          "description": "A function to be called when a script is being loaded. This can be used to modify the script before it is loaded. This is useful for adding a nonce to the script, for example.",
+          "type": "(script: HTMLScriptElement) => HTMLScriptElement | null",
+          "name": "prepare_external_dependency_script"
+        },
+        {
+          "description": "A function to be called when a stylesheet is being loaded. This can be used to modify the stylesheet before it is loaded. This is useful for adding a nonce to the stylesheet, for example.",
+          "type": "(stylesheet: HTMLStyleElement) => HTMLStyleElement | null",
+          "name": "prepare_external_dependency_stylesheet"
+        },
+        {
+          "description": "",
+          "type": "'always' | 'never' | 'identified_only'",
+          "name": "process_person"
+        },
+        {
+          "description": "Determines the maximum length of the properties string that can be sent with capture calls.\n65535",
+          "type": "number",
+          "name": "properties_string_max_length"
+        },
+        {
+          "description": "",
+          "type": "string[]",
+          "name": "property_blacklist"
+        },
+        {
+          "description": "A list of properties that should never be sent with capture calls.\n[]",
+          "type": "string[]",
+          "name": "property_denylist"
+        },
+        {
+          "description": "Determines whether PostHog should capture rage clicks.\nby default rageclicks are ignored on elements that match a `ph-no-capture` or `ph-no-rageclick` css class on the element or a parent   true",
+          "type": "boolean | RageclickConfig",
+          "name": "rageclick"
+        },
+        {
+          "description": "Client side rate limiting",
+          "type": "{\n        events_per_second?: number;\n        events_burst_limit?: number;\n    }",
+          "name": "rate_limiting"
+        },
+        {
+          "description": "Determines whether PostHog should batch requests to the PostHog API.\ntrue",
+          "type": "boolean",
+          "name": "request_batching"
+        },
+        {
+          "description": "A list of headers that should be sent with requests to the PostHog API.",
+          "type": "{\n        [header_name: string]: string;\n    }",
+          "name": "request_headers"
+        },
+        {
+          "description": "Used to change the behavior of the request queue. This is an advanced feature and should be used with caution.",
+          "type": "RequestQueueConfig",
+          "name": "request_queue_config"
+        },
+        {
+          "description": "Determines whether PostHog should respect the Do Not Track header when computing consent in `ConsentManager`.",
+          "type": "boolean",
+          "name": "respect_dnt"
+        },
+        {
+          "description": "",
+          "type": "((properties: Properties, event_name: string) => Properties) | null",
+          "name": "sanitize_properties"
+        },
+        {
+          "description": "Determines whether PostHog should save marketing parameters. These are `utm_*` paramaters and friends.",
+          "type": "boolean",
+          "name": "save_campaign_params"
+        },
+        {
+          "description": "Determines whether PostHog should save referrer information.\ntrue",
+          "type": "boolean",
+          "name": "save_referrer"
+        },
+        {
+          "description": "Let the pageview scroll stats use a custom css selector for the root element, e.g. `main` It will use `window.document.documentElement` if not specified.",
+          "type": "string | string[]",
+          "name": "scroll_root_selector"
+        },
+        {
+          "description": "Determines whether PostHog should use secure cookies. If this is `true`, PostHog cookies will be marked as secure, meaning they will only be transmitted over HTTPS.\nwindow.location.protocol === 'https:'",
+          "type": "boolean",
+          "name": "secure_cookie"
+        },
+        {
+          "description": "The segment analytics object.",
+          "type": "SegmentAnalytics",
+          "name": "segment"
+        },
+        {
+          "description": "Determines the session idle timeout in seconds. Any new event that's happened after this timeout will create a new session.\n30 * 60 -- 30 minutes",
+          "type": "number",
+          "name": "session_idle_timeout_seconds"
+        },
+        {
+          "description": "Determines the session recording options.",
+          "type": "SessionRecordingOptions",
+          "name": "session_recording"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "store_google"
+        },
+        {
+          "description": "Sets timeout for fetching surveys\n10000",
+          "type": "number",
+          "name": "surveys_request_timeout_ms"
+        },
+        {
+          "description": "The token for your PostHog project. It should NOT be provided manually in the config, but rather passed as the first parameter to `posthog.init()`.",
+          "type": "string",
+          "name": "token"
+        },
+        {
+          "description": "If using a reverse proxy for `api_host` then this should be the actual PostHog app URL (e.g. https://us.posthog.com). This ensures that links to PostHog point to the correct host.\nnull",
+          "type": "string | null",
+          "name": "ui_host"
+        },
+        {
+          "description": "Determines whether PostHog should upgrade old cookies. If set to `true`, the library will check for a cookie from our old js library and import super properties from it, then the old cookie is deleted. This option only works in the initialization, so make sure you set it when you create the library.\nfalse",
+          "type": "boolean",
+          "name": "upgrade"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "verbose"
+        },
+        {
+          "description": "",
+          "type": "{\n        [header_name: string]: string;\n    }",
+          "name": "xhr_headers"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "Properties",
+      "name": "Properties",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "// Properties is a Record<string, Property> \n// Below are PostHog's default properties, you can add your own properties during capture\n{\n    $timestamp: '2024-05-29T17:32:07.202Z',\n    $os: 'Mac OS X',\n    $os_version: '10.15.7',\n    $browser: 'Chrome',\n    $browser_version: '125',\n    $device_type: 'Desktop',\n    $current_url: 'https://example.com/page',\n    $host: 'example.com',\n    $pathname: '/page',\n    $screen_height: 1080,\n    $screen_width: 1920,\n    $viewport_height: 950,\n    $viewport_width: 1903,\n    $lib: 'web',\n    $lib_version: '1.31.0',\n    $search_engine: 'google',\n    $referrer: 'https://google.com',\n    $referring_domain: 'www.google.com',\n    $active_feature_flags: ['beta_feature'],\n    $event_type: 'click',\n    $utm_source: 'newsletter',\n    $utm_medium: 'email',\n    $utm_campaign: 'product_launch',\n    $utm_term: 'new+product',\n    $utm_content: 'logolink',\n    $gclid: 'TeSter-123',\n    $gad_source: 'google_ads',\n    $gclsrc: 'dsa',\n    $dclid: 'testDclid123',\n    $wbraid: 'testWbraid123',\n    $gbraid: 'testGbraid123',\n    $fbclid: 'testFbclid123',\n    $msclkid: 'testMsclkid123',\n    $twclid: 'testTwclid123',\n    $li_fat_id: 'testLiFatId123',\n    $mc_cid: 'testMcCid123',\n    $igshid: 'testIgshid123',\n    $ttclid: 'testTtclid123',\n    $plugins_succeeded: ['GeoIP (56578)'],\n    $plugins_failed: ['plugin3'],\n    $plugins_deferred: ['plugin4'],\n    $ip: '192.168.1.1'\n}"
+    },
+    {
+      "id": "Property",
+      "name": "Property",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "// It can be a string\n\"max@example.com\"\n// It can be an object like field\n{\n    firstName: 'Max',\n    lastName: 'Hog',\n    isAdmin: true,\n}\n"
+    },
+    {
+      "id": "PropertyMatchType",
+      "name": "PropertyMatchType",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"regex\" | \"not_regex\" | \"exact\" | \"is_not\" | \"icontains\" | \"not_icontains\""
+    },
+    {
+      "id": "QueuedRequestWithOptions",
+      "name": "QueuedRequestWithOptions",
+      "properties": [
+        {
+          "description": "key of queue, e.g. 'sessionRecording' vs 'event'",
+          "type": "string",
+          "name": "batchKey"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RageclickConfig",
+      "name": "RageclickConfig",
+      "properties": [
+        {
+          "description": "List of CSS selectors to ignore rageclicks on e.g. ['.my-calendar-button'] we consider the tree of elements from the root to the target element of the click event so for the tree div  div  button  svg and ignore list config `['[id]']` we will ignore the rageclick if the click-target or its parents has any id\nNothing is ignored when there's an empty ignorelist, e.g. [] If no ignorelist is set, we default to ignoring .ph-no-rageclick If an element has .ph-no-capture, it will always be ignored by rageclick and autocapture",
+          "type": "string[]",
+          "name": "css_selector_ignorelist"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RatingSurveyQuestion",
+      "name": "RatingSurveyQuestion",
+      "properties": [
+        {
+          "type": "'number' | 'emoji'",
+          "name": "display"
+        },
+        {
+          "type": "string",
+          "name": "lowerBoundLabel"
+        },
+        {
+          "type": "3 | 5 | 7 | 10",
+          "name": "scale"
+        },
+        {
+          "type": "boolean",
+          "name": "skipSubmitButton"
+        },
+        {
+          "type": "SurveyQuestionType.Rating",
+          "name": "type"
+        },
+        {
+          "type": "string",
+          "name": "upperBoundLabel"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "RemoteConfig",
+      "name": "RemoteConfig",
+      "properties": [
+        {
+          "description": "Whether we should use a custom endpoint for analytics\nendpoint: \"/e\"",
+          "type": "{\n        endpoint?: string;\n    }",
+          "name": "analytics"
+        },
+        {
+          "description": "If set, disables autocapture",
+          "type": "boolean",
+          "name": "autocapture_opt_out"
+        },
+        {
+          "description": "This is currently in development and may have breaking changes without a major version bump",
+          "type": "boolean | {\n        endpoint?: string;\n    }",
+          "name": "autocaptureExceptions"
+        },
+        {
+          "description": "Whether to capture dead clicks",
+          "type": "boolean",
+          "name": "captureDeadClicks"
+        },
+        {
+          "description": "originally capturePerformance was replay only and so boolean true is equivalent to  network_timing: true  now capture performance can be separately enabled within replay and as a standalone web vitals tracker people can have them enabled separately they work standalone but enhance each other TODO: deprecate this so we make a new config that doesn't need this explanation",
+          "type": "boolean | PerformanceCaptureConfig",
+          "name": "capturePerformance"
+        },
+        {
+          "description": "Whether to only capture identified users by default",
+          "type": "boolean",
+          "name": "defaultIdentifiedOnly"
+        },
+        {
+          "description": "",
+          "type": "ToolbarParams",
+          "name": "editorParams"
+        },
+        {
+          "description": "Whether the `$elements_chain` property should be sent as a string or as an array\nfalse",
+          "type": "boolean",
+          "name": "elementsChainAsString"
+        },
+        {
+          "description": "Error tracking configuration options",
+          "type": "{\n        autocaptureExceptions?: boolean;\n        captureExtensionExceptions?: boolean;\n        suppressionRules?: ErrorTrackingSuppressionRule[];\n    }",
+          "name": "errorTracking"
+        },
+        {
+          "description": "Indicates if the team has any flags enabled (if not we don't need to load them)",
+          "type": "boolean",
+          "name": "hasFeatureFlags"
+        },
+        {
+          "description": "Whether heatmaps are enabled",
+          "type": "boolean",
+          "name": "heatmaps"
+        },
+        {
+          "description": "Whether the user is authenticated",
+          "type": "boolean",
+          "name": "isAuthenticated"
+        },
+        {
+          "description": "Session recording configuration options",
+          "type": "SessionRecordingRemoteConfig",
+          "name": "sessionRecording"
+        },
+        {
+          "description": "List of site apps with their IDs and URLs",
+          "type": "{\n        id: string;\n        url: string;\n    }[]",
+          "name": "siteApps"
+        },
+        {
+          "description": "Supported compression algorithms",
+          "type": "Compression[]",
+          "name": "supportedCompression"
+        },
+        {
+          "description": "Whether surveys are enabled",
+          "type": "boolean | Survey[]",
+          "name": "surveys"
+        },
+        {
+          "description": "Parameters for the toolbar",
+          "type": "ToolbarParams",
+          "name": "toolbarParams"
+        },
+        {
+          "description": "deprecated, moved to toolbarParams",
+          "type": "'toolbar'",
+          "name": "toolbarVersion"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RemoteConfigFeatureFlagCallback",
+      "name": "RemoteConfigFeatureFlagCallback",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(payload: JsonType) => void"
+    },
+    {
+      "id": "RequestCallback",
+      "name": "RequestCallback",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(response: RequestResponse) => void"
+    },
+    {
+      "id": "RequestQueueConfig",
+      "name": "RequestQueueConfig",
+      "properties": [
+        {
+          "description": "ADVANCED - alters the frequency which PostHog sends events to the server. generally speaking this is only set when apps have automatic page refreshes, or very short visits. Defaults to 3 seconds when not set Allowed values between 250 and 5000",
+          "type": "number",
+          "name": "flush_interval_ms"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RequestResponse",
+      "name": "RequestResponse",
+      "properties": [
+        {
+          "type": "any",
+          "name": "json"
+        },
+        {
+          "type": "number",
+          "name": "statusCode"
+        },
+        {
+          "type": "string",
+          "name": "text"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RequestWithOptions",
+      "name": "RequestWithOptions",
+      "properties": [
+        {
+          "type": "RequestCallback",
+          "name": "callback"
+        },
+        {
+          "type": "Compression | 'best-available'",
+          "name": "compression"
+        },
+        {
+          "type": "Record<string, any> | Record<string, any>[]",
+          "name": "data"
+        },
+        {
+          "type": "('XHR' | 'fetch' | 'sendBeacon')[]",
+          "name": "disableTransport"
+        },
+        {
+          "type": "boolean",
+          "name": "disableXHRCredentials"
+        },
+        {
+          "type": "{\n        cache?: RequestInit['cache'];\n        next?: NextOptions;\n    }",
+          "name": "fetchOptions"
+        },
+        {
+          "type": "Record<string, any>",
+          "name": "headers"
+        },
+        {
+          "type": "'POST' | 'GET'",
+          "name": "method"
+        },
+        {
+          "type": "boolean",
+          "name": "noRetries"
+        },
+        {
+          "type": "number",
+          "name": "timeout"
+        },
+        {
+          "type": "'XHR' | 'fetch' | 'sendBeacon'",
+          "name": "transport"
+        },
+        {
+          "type": "string",
+          "name": "url"
+        },
+        {
+          "type": "{\n        compression: Compression;\n    }",
+          "name": "urlQueryArgs"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RetriableRequestWithOptions",
+      "name": "RetriableRequestWithOptions",
+      "properties": [
+        {
+          "type": "number",
+          "name": "retriesPerformedSoFar"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "SessionIdChangedCallback",
+      "name": "SessionIdChangedCallback",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(sessionId: string, windowId: string | null | undefined, changeReason?: {\n    noSessionId: boolean;\n    activityTimeout: boolean;\n    sessionPastMaximumLength: boolean;\n}) => void"
+    },
+    {
+      "id": "SessionRecordingCanvasOptions",
+      "name": "SessionRecordingCanvasOptions",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    recordCanvas?: boolean | null;\n    canvasFps?: number | null;\n    canvasQuality?: string | null;\n}"
+    },
+    {
+      "id": "SessionRecordingOptions",
+      "name": "SessionRecordingOptions",
+      "properties": [
+        {
+          "description": "ADVANCED: alters the bucket size for the token bucket mutation throttling Normally only altered alongside posthog support guidance. Accepts values between 0 and 100\n100",
+          "type": "number",
+          "name": "__mutationThrottlerBucketSize"
+        },
+        {
+          "description": "ADVANCED: alters the refill rate for the token bucket mutation throttling Normally only altered alongside posthog support guidance. Accepts values between 0 and 100\n10",
+          "type": "number",
+          "name": "__mutationThrottlerRefillRate"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "string | RegExp",
+          "name": "blockClass"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "string | null",
+          "name": "blockSelector"
+        },
+        {
+          "description": "Allows local config to override remote canvas recording settings from the flags response",
+          "type": "SessionRecordingCanvasOptions",
+          "name": "captureCanvas"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "boolean",
+          "name": "collectFonts"
+        },
+        {
+          "description": "ADVANCED: whether to partially compress rrweb events before sending them to the server, defaults to true, can be set to false to disable partial compression NB requests are still compressed when sent to the server regardless of this setting\ntrue",
+          "type": "boolean",
+          "name": "compress_events"
+        },
+        {
+          "description": "ADVANCED: while a user is active we take a full snapshot of the browser every interval. For very few sites playback performance might be better with different interval. Set to 0 to disable\n1000 * 60 * 5 (5 minutes)",
+          "type": "number",
+          "name": "full_snapshot_interval_millis"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "string | RegExp",
+          "name": "ignoreClass"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "boolean",
+          "name": "inlineStylesheet"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "boolean",
+          "name": "maskAllInputs"
+        },
+        {
+          "description": "Modify the network request before it is captured. Returning null or undefined stops it being captured",
+          "type": "((data: CapturedNetworkRequest) => CapturedNetworkRequest | null | undefined) | null",
+          "name": "maskCapturedNetworkRequestFn"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "((text: string, element?: HTMLElement) => string) | null",
+          "name": "maskInputFn"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "recordOptions['maskInputOptions']",
+          "name": "maskInputOptions"
+        },
+        {
+          "description": "",
+          "type": "((data: NetworkRequest) => NetworkRequest | null | undefined) | null",
+          "name": "maskNetworkRequestFn"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "string | RegExp",
+          "name": "maskTextClass"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "((text: string, element?: HTMLElement) => string) | null",
+          "name": "maskTextFn"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "string | null",
+          "name": "maskTextSelector"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "boolean",
+          "name": "recordBody"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "boolean",
+          "name": "recordCrossOriginIframes"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "boolean",
+          "name": "recordHeaders"
+        },
+        {
+          "description": "ADVANCED: alters the threshold before a recording considers a user has become idle. Normally only altered alongside changes to session_idle_timeout_ms.\n1000 * 60 * 5 (5 minutes)",
+          "type": "number",
+          "name": "session_idle_threshold_ms"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "recordOptions['slimDOMOptions']",
+          "name": "slimDOMOptions"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "SessionRecordingPersistedConfig",
+      "name": "SessionRecordingPersistedConfig",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "Omit<SessionRecordingRemoteConfig, 'recordCanvas' | 'canvasFps' | 'canvasQuality' | 'networkPayloadCapture' | 'sampleRate' | 'minimumDurationMilliseconds'> & {\n    enabled: boolean;\n    networkPayloadCapture: SessionRecordingRemoteConfig['networkPayloadCapture'] & {\n        capturePerformance: RemoteConfig['capturePerformance'];\n    };\n    canvasRecording: {\n        enabled: SessionRecordingRemoteConfig['recordCanvas'];\n        fps: SessionRecordingRemoteConfig['canvasFps'];\n        quality: SessionRecordingRemoteConfig['canvasQuality'];\n    };\n    sampleRate: number | null;\n    minimumDurationMilliseconds: number | null | undefined;\n}"
+    },
+    {
+      "id": "SessionRecordingRemoteConfig",
+      "name": "SessionRecordingRemoteConfig",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "SessionRecordingCanvasOptions & {\n    endpoint?: string;\n    consoleLogRecordingEnabled?: boolean;\n    sampleRate?: string | null;\n    minimumDurationMilliseconds?: number;\n    linkedFlag?: string | FlagVariant | null;\n    networkPayloadCapture?: Pick<NetworkRecordOptions, 'recordBody' | 'recordHeaders'>;\n    masking?: Pick<SessionRecordingOptions, 'maskAllInputs' | 'maskTextSelector' | 'blockSelector'>;\n    urlTriggers?: SessionRecordingUrlTrigger[];\n    scriptConfig?: {\n        script?: string | undefined;\n    };\n    urlBlocklist?: SessionRecordingUrlTrigger[];\n    eventTriggers?: string[];\n    triggerMatchType?: 'any' | 'all';\n}"
+    },
+    {
+      "id": "SessionRecordingUrlTrigger",
+      "name": "SessionRecordingUrlTrigger",
+      "properties": [
+        {
+          "type": "'regex'",
+          "name": "matching"
+        },
+        {
+          "type": "string",
+          "name": "url"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "SessionStartReason",
+      "name": "SessionStartReason",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"sampling_overridden\" | \"recording_initialized\" | \"linked_flag_matched\" | \"linked_flag_overridden\" | \"session_id_changed\" | \"url_trigger_matched\" | \"event_trigger_matched\""
+    },
+    {
+      "id": "SeverityLevel",
+      "name": "SeverityLevel",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(typeof severityLevels)[number]"
+    },
+    {
+      "id": "SiteApp",
+      "name": "SiteApp",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    id: string;\n    loaded: boolean;\n    errored: boolean;\n    processedBuffer: boolean;\n    processEvent?: (globals: SiteAppGlobals) => void;\n}"
+    },
+    {
+      "id": "SiteAppGlobals",
+      "name": "SiteAppGlobals",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    event: {\n        uuid: string;\n        event: EventName;\n        properties: Properties;\n        timestamp?: Date;\n        elements_chain?: string;\n        distinct_id?: string;\n    };\n    person: {\n        properties: Properties;\n    };\n    groups: Record<string, {\n        id: string;\n        type: string;\n        properties: Properties;\n    }>;\n}"
+    },
+    {
+      "id": "SiteAppLoader",
+      "name": "SiteAppLoader",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    id: string;\n    init: (config: {\n        posthog: PostHog;\n        callback: (success: boolean) => void;\n    }) => {\n        processEvent?: (globals: SiteAppGlobals) => void;\n    };\n}"
+    },
+    {
+      "id": "SnippetArrayItem",
+      "name": "SnippetArrayItem",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "[method: string, ...args: any[]]"
+    },
+    {
+      "id": "SupportedWebVitalsMetrics",
+      "name": "SupportedWebVitalsMetrics",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"LCP\" | \"CLS\" | \"FCP\" | \"INP\""
+    },
+    {
+      "id": "Survey",
+      "name": "Survey",
+      "properties": [
+        {
+          "type": "SurveyAppearance | null",
+          "name": "appearance"
+        },
+        {
+          "type": "{\n        url?: string;\n        selector?: string;\n        seenSurveyWaitPeriodInDays?: number;\n        urlMatchType?: PropertyMatchType;\n        events: {\n            repeatedActivation?: boolean;\n            values: {\n                name: string;\n                propertyFilters?: {\n                    [propertyName: string]: {\n                        values: string[];\n                        operator: PropertyMatchType;\n                    };\n                };\n            }[];\n        } | null;\n        actions: {\n            values: SurveyActionType[];\n        } | null;\n        deviceTypes?: string[];\n        deviceTypesMatchType?: PropertyMatchType;\n        linkedFlagVariant?: string;\n    } | null",
+          "name": "conditions"
+        },
+        {
+          "type": "string | null",
+          "name": "current_iteration_start_date"
+        },
+        {
+          "type": "number | null",
+          "name": "current_iteration"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "boolean | null",
+          "name": "enable_partial_responses"
+        },
+        {
+          "type": "string | null",
+          "name": "end_date"
+        },
+        {
+          "type": "{\n        key: string;\n        value?: string;\n    }[] | null",
+          "name": "feature_flag_keys"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string | null",
+          "name": "internal_targeting_flag_key"
+        },
+        {
+          "type": "string | null",
+          "name": "linked_flag_key"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "SurveyQuestion[]",
+          "name": "questions"
+        },
+        {
+          "type": "SurveySchedule | null",
+          "name": "schedule"
+        },
+        {
+          "type": "string | null",
+          "name": "start_date"
+        },
+        {
+          "type": "string | null",
+          "name": "targeting_flag_key"
+        },
+        {
+          "type": "SurveyType",
+          "name": "type"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyActionType",
+      "name": "SurveyActionType",
+      "properties": [
+        {
+          "type": "number",
+          "name": "id"
+        },
+        {
+          "type": "string | null",
+          "name": "name"
+        },
+        {
+          "type": "ActionStepType[]",
+          "name": "steps"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyAppearance",
+      "name": "SurveyAppearance",
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "autoDisappear"
+        },
+        {
+          "type": "string",
+          "name": "backgroundColor"
+        },
+        {
+          "type": "string",
+          "name": "borderColor"
+        },
+        {
+          "type": "string",
+          "name": "boxPadding"
+        },
+        {
+          "type": "string",
+          "name": "descriptionTextColor"
+        },
+        {
+          "type": "string",
+          "name": "disabledButtonOpacity"
+        },
+        {
+          "type": "boolean",
+          "name": "displayThankYouMessage"
+        },
+        {
+          "type": "string",
+          "name": "fontFamily"
+        },
+        {
+          "type": "string",
+          "name": "maxWidth"
+        },
+        {
+          "type": "string",
+          "name": "placeholder"
+        },
+        {
+          "type": "SurveyPosition",
+          "name": "position"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonActiveColor"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonColor"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonHoverColor"
+        },
+        {
+          "type": "boolean",
+          "name": "shuffleQuestions"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonColor"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonText"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonTextColor"
+        },
+        {
+          "type": "number",
+          "name": "surveyPopupDelaySeconds"
+        },
+        {
+          "type": "string",
+          "name": "textColor"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageCloseButtonText"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageDescription"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "thankYouMessageDescriptionContentType"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageHeader"
+        },
+        {
+          "type": "boolean",
+          "name": "whiteLabel"
+        },
+        {
+          "type": "string",
+          "name": "widgetColor"
+        },
+        {
+          "type": "string",
+          "name": "widgetLabel"
+        },
+        {
+          "type": "string",
+          "name": "widgetSelector"
+        },
+        {
+          "type": "SurveyWidgetType",
+          "name": "widgetType"
+        },
+        {
+          "type": "string",
+          "name": "zIndex"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyCallback",
+      "name": "SurveyCallback",
+      "properties": [],
+      "path": "lib/src/posthog-surveys-types.d.ts",
+      "example": "(surveys: Survey[], context?: {\n    isLoaded: boolean;\n    error?: string;\n}) => void"
+    },
+    {
+      "id": "SurveyElement",
+      "name": "SurveyElement",
+      "properties": [
+        {
+          "type": "string",
+          "name": "$el_text"
+        },
+        {
+          "type": "string[]",
+          "name": "attr_class"
+        },
+        {
+          "type": "string",
+          "name": "attr_id"
+        },
+        {
+          "type": "Record<string, any>",
+          "name": "attributes"
+        },
+        {
+          "type": "number",
+          "name": "event_id"
+        },
+        {
+          "type": "number",
+          "name": "group_id"
+        },
+        {
+          "type": "string",
+          "name": "href"
+        },
+        {
+          "type": "number",
+          "name": "nth_child"
+        },
+        {
+          "type": "number",
+          "name": "nth_of_type"
+        },
+        {
+          "type": "number",
+          "name": "order"
+        },
+        {
+          "type": "string",
+          "name": "tag_name"
+        },
+        {
+          "type": "string",
+          "name": "text"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyEventName",
+      "name": "SurveyEventName",
+      "properties": [
+        {
+          "type": "\"survey dismissed\"",
+          "name": "DISMISSED"
+        },
+        {
+          "type": "\"survey sent\"",
+          "name": "SENT"
+        },
+        {
+          "type": "\"survey shown\"",
+          "name": "SHOWN"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyEventProperties",
+      "name": "SurveyEventProperties",
+      "properties": [
+        {
+          "type": "\"$survey_completed\"",
+          "name": "SURVEY_COMPLETED"
+        },
+        {
+          "type": "\"$survey_id\"",
+          "name": "SURVEY_ID"
+        },
+        {
+          "type": "\"$survey_iteration\"",
+          "name": "SURVEY_ITERATION"
+        },
+        {
+          "type": "\"$survey_iteration_start_date\"",
+          "name": "SURVEY_ITERATION_START_DATE"
+        },
+        {
+          "type": "\"$survey_name\"",
+          "name": "SURVEY_NAME"
+        },
+        {
+          "type": "\"$survey_partially_completed\"",
+          "name": "SURVEY_PARTIALLY_COMPLETED"
+        },
+        {
+          "type": "\"$survey_questions\"",
+          "name": "SURVEY_QUESTIONS"
+        },
+        {
+          "type": "\"$survey_response\"",
+          "name": "SURVEY_RESPONSE"
+        },
+        {
+          "type": "\"$survey_submission_id\"",
+          "name": "SURVEY_SUBMISSION_ID"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyPosition",
+      "name": "SurveyPosition",
+      "properties": [
+        {
+          "type": "\"center\"",
+          "name": "Center"
+        },
+        {
+          "type": "\"left\"",
+          "name": "Left"
+        },
+        {
+          "type": "\"middle_center\"",
+          "name": "MiddleCenter"
+        },
+        {
+          "type": "\"middle_left\"",
+          "name": "MiddleLeft"
+        },
+        {
+          "type": "\"middle_right\"",
+          "name": "MiddleRight"
+        },
+        {
+          "type": "\"next_to_trigger\"",
+          "name": "NextToTrigger"
+        },
+        {
+          "type": "\"right\"",
+          "name": "Right"
+        },
+        {
+          "type": "\"top_center\"",
+          "name": "TopCenter"
+        },
+        {
+          "type": "\"top_left\"",
+          "name": "TopLeft"
+        },
+        {
+          "type": "\"top_right\"",
+          "name": "TopRight"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyQuestion",
+      "name": "SurveyQuestion",
+      "properties": [],
+      "path": "lib/src/posthog-surveys-types.d.ts",
+      "example": "BasicSurveyQuestion | LinkSurveyQuestion | RatingSurveyQuestion | MultipleSurveyQuestion"
+    },
+    {
+      "id": "SurveyQuestionBranchingType",
+      "name": "SurveyQuestionBranchingType",
+      "properties": [
+        {
+          "type": "\"end\"",
+          "name": "End"
+        },
+        {
+          "type": "\"next_question\"",
+          "name": "NextQuestion"
+        },
+        {
+          "type": "\"response_based\"",
+          "name": "ResponseBased"
+        },
+        {
+          "type": "\"specific_question\"",
+          "name": "SpecificQuestion"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyQuestionDescriptionContentType",
+      "name": "SurveyQuestionDescriptionContentType",
+      "properties": [],
+      "path": "lib/src/posthog-surveys-types.d.ts",
+      "example": "\"html\" | \"text\""
+    },
+    {
+      "id": "SurveyQuestionType",
+      "name": "SurveyQuestionType",
+      "properties": [
+        {
+          "type": "\"link\"",
+          "name": "Link"
+        },
+        {
+          "type": "\"multiple_choice\"",
+          "name": "MultipleChoice"
+        },
+        {
+          "type": "\"open\"",
+          "name": "Open"
+        },
+        {
+          "type": "\"rating\"",
+          "name": "Rating"
+        },
+        {
+          "type": "\"single_choice\"",
+          "name": "SingleChoice"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyRenderReason",
+      "name": "SurveyRenderReason",
+      "properties": [
+        {
+          "type": "string",
+          "name": "disabledReason"
+        },
+        {
+          "type": "boolean",
+          "name": "visible"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveySchedule",
+      "name": "SurveySchedule",
+      "properties": [
+        {
+          "type": "\"always\"",
+          "name": "Always"
+        },
+        {
+          "type": "\"once\"",
+          "name": "Once"
+        },
+        {
+          "type": "\"recurring\"",
+          "name": "Recurring"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyType",
+      "name": "SurveyType",
+      "properties": [
+        {
+          "type": "\"api\"",
+          "name": "API"
+        },
+        {
+          "type": "\"external_survey\"",
+          "name": "ExternalSurvey"
+        },
+        {
+          "type": "\"popover\"",
+          "name": "Popover"
+        },
+        {
+          "type": "\"widget\"",
+          "name": "Widget"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyWidgetType",
+      "name": "SurveyWidgetType",
+      "properties": [
+        {
+          "type": "\"button\"",
+          "name": "Button"
+        },
+        {
+          "type": "\"selector\"",
+          "name": "Selector"
+        },
+        {
+          "type": "\"tab\"",
+          "name": "Tab"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyWithTypeAndAppearance",
+      "name": "SurveyWithTypeAndAppearance",
+      "properties": [],
+      "path": "lib/src/posthog-surveys-types.d.ts",
+      "example": "\"id\" | \"type\" | \"appearance\""
+    },
+    {
+      "id": "ToolbarParams",
+      "name": "ToolbarParams",
+      "properties": [
+        {
+          "type": "number",
+          "name": "actionId"
+        },
+        {
+          "type": "string[]",
+          "name": "dataAttributes"
+        },
+        {
+          "type": "string",
+          "name": "distinctId"
+        },
+        {
+          "type": "Record<string, string | boolean>",
+          "name": "featureFlags"
+        },
+        {
+          "type": "boolean",
+          "name": "instrument"
+        },
+        {
+          "type": "ToolbarSource",
+          "name": "source"
+        },
+        {
+          "type": "string",
+          "name": "temporaryToken"
+        },
+        {
+          "type": "string",
+          "name": "token"
+        },
+        {
+          "type": "ToolbarVersion",
+          "name": "toolbarVersion"
+        },
+        {
+          "type": "string",
+          "name": "userEmail"
+        },
+        {
+          "type": "ToolbarUserIntent",
+          "name": "userIntent"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "ToolbarSource",
+      "name": "ToolbarSource",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"url\" | \"localstorage\""
+    },
+    {
+      "id": "ToolbarUserIntent",
+      "name": "ToolbarUserIntent",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"add-action\" | \"edit-action\""
+    },
+    {
+      "id": "ToolbarVersion",
+      "name": "ToolbarVersion",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"toolbar\""
+    }
+  ],
+  "categories": [
+    "Initialization",
+    "Identification",
+    "Capture",
+    "Surveys",
+    "Error tracking",
+    "LLM analytics",
+    "Privacy",
+    "Session replay",
+    "Feature flags",
+    "Toolbar"
+  ]
+}

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -1,0 +1,4256 @@
+{
+  "id": "posthog-js",
+  "hogRef": "0.3",
+  "info": {
+    "version": "1.268.5",
+    "id": "posthog-js",
+    "title": "PostHog JavaScript Web SDK",
+    "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
+    "slugPrefix": "posthog-js",
+    "specUrl": "https://github.com/PostHog/posthog-js"
+  },
+  "classes": [
+    {
+      "description": "This is the SDK reference for the PostHog JavaScript Web SDK. You can learn more about example usage in the [JavaScript Web SDK documentation](/docs/libraries/js). You can also follow [framework specific guides](/docs/frameworks) to integrate PostHog into your project.\nThis SDK is designed for browser environments. Use the PostHog [Node.js SDK](/docs/libraries/node) for server-side usage.",
+      "id": "PostHog",
+      "title": "PostHog",
+      "functions": [
+        {
+          "category": "",
+          "description": "Constructs a new instance of the `PostHog` class",
+          "details": null,
+          "id": "PostHog",
+          "showDocs": true,
+          "title": "PostHog",
+          "examples": [
+            {
+              "id": "posthog",
+              "name": "Generated example for PostHog",
+              "code": "// Generated example for PostHog\nposthog.PostHog();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "any",
+            "name": "any"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Creates an alias linking two distinct user identifiers. Learn more about [identifying users](/docs/product-analytics/identify)",
+          "details": "PostHog will use this to link two distinct_ids going forward (not retroactively). Call this when a user signs up to connect their anonymous session with their account.",
+          "id": "alias",
+          "showDocs": true,
+          "title": "alias",
+          "examples": [
+            {
+              "id": "link_anonymous_user_to_account_on_signup",
+              "name": "link anonymous user to account on signup",
+              "code": "\n\n// link anonymous user to account on signup\nposthog.alias('user_12345')\n\n\n"
+            },
+            {
+              "id": "explicit_alias_with_original_id",
+              "name": "explicit alias with original ID",
+              "code": "\n\n// explicit alias with original ID\nposthog.alias('user_12345', 'anonymous_abc123')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "A unique identifier that you want to use for this user in the future.",
+              "isOptional": false,
+              "type": "string",
+              "name": "alias"
+            },
+            {
+              "description": "The current identifier being used for this user.",
+              "isOptional": true,
+              "type": "string",
+              "name": "original"
+            }
+          ],
+          "returnType": {
+            "id": "CaptureResult | void | number",
+            "name": "CaptureResult | void | number"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Checks the feature flags associated with this Survey to see if the survey can be rendered. This method is deprecated because it's synchronous and won't return the correct result if surveys are not loaded. Use `canRenderSurveyAsync` instead.",
+          "details": null,
+          "id": "canRenderSurvey",
+          "showDocs": true,
+          "title": "canRenderSurvey",
+          "examples": [
+            {
+              "id": "canrendersurvey",
+              "name": "Generated example for canRenderSurvey",
+              "code": "// Generated example for canRenderSurvey\nposthog.canRenderSurvey();"
+            }
+          ],
+          "releaseTag": "deprecated",
+          "params": [
+            {
+              "description": "The ID of the survey to check.",
+              "isOptional": false,
+              "type": "string",
+              "name": "surveyId"
+            }
+          ],
+          "returnType": {
+            "id": "SurveyRenderReason | null",
+            "name": "SurveyRenderReason | null"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Checks the feature flags associated with this Survey to see if the survey can be rendered.",
+          "details": null,
+          "id": "canRenderSurveyAsync",
+          "showDocs": true,
+          "title": "canRenderSurveyAsync",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.canRenderSurveyAsync(surveyId).then((result) => {\n    if (result.visible) {\n        // Survey can be rendered\n        console.log('Survey can be rendered')\n    } else {\n        // Survey cannot be rendered\n        console.log('Survey cannot be rendered:', result.disabledReason)\n    }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The ID of the survey to check.",
+              "isOptional": false,
+              "type": "string",
+              "name": "surveyId"
+            },
+            {
+              "description": "If true, the survey will be reloaded from the server, Default: false",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "forceReload"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<SurveyRenderReason>",
+            "name": "Promise<SurveyRenderReason>"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Captures an event with optional properties and configuration.",
+          "details": "You can capture arbitrary object-like values as events. [Learn about capture best practices](/docs/product-analytics/capture-events)",
+          "id": "capture",
+          "showDocs": true,
+          "title": "capture",
+          "examples": [
+            {
+              "id": "basic_event_capture",
+              "name": "basic event capture",
+              "code": "\n\n// basic event capture\nposthog.capture('cta-button-clicked', {\n    button_name: 'Get Started',\n    page: 'homepage'\n})\n\n\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the event (e.g., 'Sign Up', 'Button Click', 'Purchase')",
+              "isOptional": false,
+              "type": "EventName",
+              "name": "event_name"
+            },
+            {
+              "description": "Properties to include with the event describing the user or event details",
+              "isOptional": true,
+              "type": "Properties | null",
+              "name": "properties"
+            },
+            {
+              "description": "Optional configuration for the capture request",
+              "isOptional": true,
+              "type": "CaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "CaptureResult | undefined",
+            "name": "CaptureResult | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Error tracking",
+          "description": "Capture a caught exception manually",
+          "details": null,
+          "id": "captureException",
+          "showDocs": true,
+          "title": "captureException",
+          "examples": [
+            {
+              "id": "capture_a_caught_exception",
+              "name": "Capture a caught exception",
+              "code": "\n\n// Capture a caught exception\ntry {\n  // something that might throw\n} catch (error) {\n  posthog.captureException(error)\n}\n\n\n"
+            },
+            {
+              "id": "with_additional_properties",
+              "name": "With additional properties",
+              "code": "\n\n// With additional properties\nposthog.captureException(error, {\n  customProperty: 'value',\n  anotherProperty: ['I', 'can be a list'],\n  ...\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The error to capture",
+              "isOptional": false,
+              "type": "unknown",
+              "name": "error"
+            },
+            {
+              "description": "Any additional properties to add to the error event",
+              "isOptional": true,
+              "type": "Properties",
+              "name": "additionalProperties"
+            }
+          ],
+          "returnType": {
+            "id": "CaptureResult | undefined",
+            "name": "CaptureResult | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "LLM analytics",
+          "description": "Capture written user feedback for a LLM trace. Numeric values are converted to strings.",
+          "details": null,
+          "id": "captureTraceFeedback",
+          "showDocs": true,
+          "title": "captureTraceFeedback",
+          "examples": [
+            {
+              "id": "capturetracefeedback",
+              "name": "Generated example for captureTraceFeedback",
+              "code": "// Generated example for captureTraceFeedback\nposthog.captureTraceFeedback();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The trace ID to capture feedback for.",
+              "isOptional": false,
+              "type": "string | number",
+              "name": "traceId"
+            },
+            {
+              "description": "The feedback to capture.",
+              "isOptional": false,
+              "type": "string",
+              "name": "userFeedback"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "LLM analytics",
+          "description": "Capture a metric for a LLM trace. Numeric values are converted to strings.",
+          "details": null,
+          "id": "captureTraceMetric",
+          "showDocs": true,
+          "title": "captureTraceMetric",
+          "examples": [
+            {
+              "id": "capturetracemetric",
+              "name": "Generated example for captureTraceMetric",
+              "code": "// Generated example for captureTraceMetric\nposthog.captureTraceMetric();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The trace ID to capture the metric for.",
+              "isOptional": false,
+              "type": "string | number",
+              "name": "traceId"
+            },
+            {
+              "description": "The name of the metric to capture.",
+              "isOptional": false,
+              "type": "string",
+              "name": "metricName"
+            },
+            {
+              "description": "The value of the metric to capture.",
+              "isOptional": false,
+              "type": "string | number | boolean",
+              "name": "metricValue"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Clear the user's opt in/out status of data capturing and cookies/localstorage for this PostHog instance",
+          "details": null,
+          "id": "clear_opt_in_out_capturing",
+          "showDocs": true,
+          "title": "clear_opt_in_out_capturing",
+          "examples": [
+            {
+              "id": "clear_opt_in_out_capturing",
+              "name": "Generated example for clear_opt_in_out_capturing",
+              "code": "// Generated example for clear_opt_in_out_capturing\nposthog.clear_opt_in_out_capturing();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Creates a person profile for the current user, if they don't already have one and config.person_profiles is set to 'identified_only'. Produces a warning and does not create a profile if config.person_profiles is set to 'never'. Learn more about [person profiles](/docs/product-analytics/identify)",
+          "details": null,
+          "id": "createPersonProfile",
+          "showDocs": true,
+          "title": "createPersonProfile",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.createPersonProfile()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Enables or disables debug mode for detailed logging.",
+          "details": "Debug mode logs all PostHog calls to the browser console for troubleshooting. Can also be enabled by adding `?__posthog_debug=true` to the URL.",
+          "id": "debug",
+          "showDocs": true,
+          "title": "debug",
+          "examples": [
+            {
+              "id": "enable_debug_mode",
+              "name": "enable debug mode",
+              "code": "\n\n// enable debug mode\nposthog.debug(true)\n\n\n"
+            },
+            {
+              "id": "disable_debug_mode",
+              "name": "disable debug mode",
+              "code": "\n\n// disable debug mode\nposthog.debug(false)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "If true, will enable debug mode.",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "debug"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Display a survey programmatically as either a popover or inline element.",
+          "details": null,
+          "id": "displaySurvey",
+          "showDocs": true,
+          "title": "displaySurvey",
+          "examples": [
+            {
+              "id": "display_as_popover_(respects_all_conditions_defined_in_the_dashboard)",
+              "name": "Display as popover (respects all conditions defined in the dashboard)",
+              "code": "\n\n// Display as popover (respects all conditions defined in the dashboard)\nposthog.displaySurvey('survey-id-123')\n\n\n"
+            },
+            {
+              "id": "display_inline_in_a_specific_element",
+              "name": "Display inline in a specific element",
+              "code": "\n\n// Display inline in a specific element\nposthog.displaySurvey('survey-id-123', {\n  displayType: DisplaySurveyType.Inline,\n  selector: '#survey-container'\n})\n\n\n"
+            },
+            {
+              "id": "force_display_ignoring_conditions_and_delays",
+              "name": "Force display ignoring conditions and delays",
+              "code": "\n\n// Force display ignoring conditions and delays\nposthog.displaySurvey('survey-id-123', {\n  displayType: DisplaySurveyType.Popover,\n  ignoreConditions: true,\n  ignoreDelay: true\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The survey ID to display",
+              "isOptional": false,
+              "type": "string",
+              "name": "surveyId"
+            },
+            {
+              "description": "Display configuration",
+              "isOptional": true,
+              "type": "DisplaySurveyOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Returns the current distinct ID for the user.",
+          "details": "This is either the auto-generated ID or the ID set via `identify()`. The distinct ID is used to associate events with users in PostHog.",
+          "id": "get_distinct_id",
+          "showDocs": true,
+          "title": "get_distinct_id",
+          "examples": [
+            {
+              "id": "get_the_current_user_id",
+              "name": "get the current user ID",
+              "code": "\n\n// get the current user ID\nconst userId = posthog.get_distinct_id()\nconsole.log('Current user:', userId)\n\n\n"
+            },
+            {
+              "id": "use_in_loaded_callback",
+              "name": "use in loaded callback",
+              "code": "\n\n// use in loaded callback\nposthog.init('token', {\n    loaded: (posthog) => {\n        const id = posthog.get_distinct_id()\n        // use the ID\n    }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "",
+          "description": "Returns the explicit consent status of the user.",
+          "details": "This can be used to check if the user has explicitly opted in or out of data capturing, or neither. This does not take the default config options into account, only whether the user has made an explicit choice, so this can be used to determine whether to show an initial cookie banner or not.",
+          "id": "get_explicit_consent_status",
+          "showDocs": true,
+          "title": "get_explicit_consent_status",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nconst consentStatus = posthog.get_explicit_consent_status()\nif (consentStatus === \"granted\") {\n    // user has explicitly opted in\n} else if (consentStatus === \"denied\") {\n    // user has explicitly opted out\n} else if (consentStatus === \"pending\"){\n    // user has not made a choice, show consent banner\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "'granted' | 'denied' | 'pending'",
+            "name": "'granted' | 'denied' | 'pending'"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Returns the value of a super property. Returns undefined if the property doesn't exist.",
+          "details": "get_property() can only be called after the PostHog library has finished loading. init() has a loaded function available to handle this automatically.",
+          "id": "get_property",
+          "showDocs": true,
+          "title": "get_property",
+          "examples": [
+            {
+              "id": "grab_value_for_'$user_id'_after_the_posthog_library_has_loaded",
+              "name": "grab value for '$user_id' after the posthog library has loaded",
+              "code": "\n\n// grab value for '$user_id' after the posthog library has loaded\nposthog.init('<YOUR PROJECT TOKEN>', {\n    loaded: function(posthog) {\n        user_id = posthog.get_property('$user_id');\n    }\n});\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the super property you want to retrieve",
+              "isOptional": false,
+              "type": "string",
+              "name": "property_name"
+            }
+          ],
+          "returnType": {
+            "id": "Property | undefined",
+            "name": "Property | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "",
+          "description": "Returns the current session_id.",
+          "details": "This should only be used for informative purposes. Any actual internal use case for the session_id should be handled by the sessionManager.",
+          "id": "get_session_id",
+          "showDocs": true,
+          "title": "get_session_id",
+          "examples": [
+            {
+              "id": "get_session_id",
+              "name": "Generated example for get_session_id",
+              "code": "// Generated example for get_session_id\nposthog.get_session_id();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Session replay",
+          "description": "Returns the Replay url for the current session.",
+          "details": null,
+          "id": "get_session_replay_url",
+          "showDocs": true,
+          "title": "get_session_replay_url",
+          "examples": [
+            {
+              "id": "basic_usage",
+              "name": "basic usage",
+              "code": "\n\n// basic usage\nposthog.get_session_replay_url()\n\n@example\n\njs // timestamp posthog.get_session_replay_url({ withTimestamp: true })\n\n\n@example\n\njs // timestamp and lookback posthog.get_session_replay_url({ withTimestamp: true, timestampLookBack: 30 // look back 30 seconds }) ```\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Options for the url",
+              "isOptional": true,
+              "type": "{\n        withTimestamp?: boolean;\n        timestampLookBack?: number;\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Get surveys that should be enabled for the current user. See [fetching surveys documentation](/docs/surveys/implementing-custom-surveys#fetching-surveys-manually) for more details.",
+          "details": null,
+          "id": "getActiveMatchingSurveys",
+          "showDocs": true,
+          "title": "getActiveMatchingSurveys",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.getActiveMatchingSurveys((surveys) => {\n     // do something\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The callback function will be called when the surveys are loaded or updated.",
+              "isOptional": false,
+              "type": "SurveyCallback",
+              "name": "callback"
+            },
+            {
+              "description": "Whether to force a reload of the surveys.",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "forceReload"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get the list of early access features. To check enrollment status, use `isFeatureEnabled`. [Learn more in the docs](/docs/feature-flags/early-access-feature-management#option-2-custom-implementation)",
+          "details": null,
+          "id": "getEarlyAccessFeatures",
+          "showDocs": true,
+          "title": "getEarlyAccessFeatures",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nconst posthog = usePostHog()\nconst activeFlags = useActiveFeatureFlags()\n\nconst [activeBetas, setActiveBetas] = useState([])\nconst [inactiveBetas, setInactiveBetas] = useState([])\nconst [comingSoonFeatures, setComingSoonFeatures] = useState([])\n\nuseEffect(() => {\n  posthog.getEarlyAccessFeatures((features) => {\n    // Filter features by stage\n    const betaFeatures = features.filter(feature => feature.stage === 'beta')\n    const conceptFeatures = features.filter(feature => feature.stage === 'concept')\n\n    setComingSoonFeatures(conceptFeatures)\n\n    if (!activeFlags || activeFlags.length === 0) {\n      setInactiveBetas(betaFeatures)\n      return\n    }\n\n    const activeBetas = betaFeatures.filter(\n            beta => activeFlags.includes(beta.flagKey)\n        );\n    const inactiveBetas = betaFeatures.filter(\n            beta => !activeFlags.includes(beta.flagKey)\n        );\n    setActiveBetas(activeBetas)\n    setInactiveBetas(inactiveBetas)\n  }, true, ['concept', 'beta'])\n}, [activeFlags])\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The callback function will be called when the early access features are loaded.",
+              "isOptional": false,
+              "type": "EarlyAccessFeatureCallback",
+              "name": "callback"
+            },
+            {
+              "description": "Whether to force a reload of the early access features.",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "force_reload"
+            },
+            {
+              "description": "The stages of the early access features to load.",
+              "isOptional": true,
+              "type": "EarlyAccessFeatureStage[]",
+              "name": "stages"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Gets the value of a feature flag for the current user.",
+          "details": "Returns the feature flag value which can be a boolean, string, or undefined. Supports multivariate flags that can return custom string values.",
+          "id": "getFeatureFlag",
+          "showDocs": true,
+          "title": "getFeatureFlag",
+          "examples": [
+            {
+              "id": "check_boolean_flag",
+              "name": "check boolean flag",
+              "code": "\n\n// check boolean flag\nif (posthog.getFeatureFlag('new-feature')) {\n    // show new feature\n}\n\n\n"
+            },
+            {
+              "id": "check_multivariate_flag",
+              "name": "check multivariate flag",
+              "code": "\n\n// check multivariate flag\nconst variant = posthog.getFeatureFlag('button-color')\nif (variant === 'red') {\n    // show red button\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "(optional) If send_event: false, we won't send an $feature_flag_call event to PostHog.",
+              "isOptional": true,
+              "type": "{\n        send_event?: boolean;\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "boolean | string | undefined",
+            "name": "boolean | string | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get feature flag payload value matching key for user (supports multivariate flags).",
+          "details": null,
+          "id": "getFeatureFlagPayload",
+          "showDocs": true,
+          "title": "getFeatureFlagPayload",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nif(posthog.getFeatureFlag('beta-feature') === 'some-value') {\n     const someValue = posthog.getFeatureFlagPayload('beta-feature')\n     // do something\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            }
+          ],
+          "returnType": {
+            "id": "JsonType",
+            "name": "JsonType"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Returns the current groups.",
+          "details": null,
+          "id": "getGroups",
+          "showDocs": true,
+          "title": "getGroups",
+          "examples": [
+            {
+              "id": "getgroups",
+              "name": "Generated example for getGroups",
+              "code": "// Generated example for getGroups\nposthog.getGroups();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Record<string, any>",
+            "name": "Record<string, any>"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Returns the current page view ID.",
+          "details": null,
+          "id": "getPageViewId",
+          "showDocs": true,
+          "title": "getPageViewId",
+          "examples": [
+            {
+              "id": "getpageviewid",
+              "name": "Generated example for getPageViewId",
+              "code": "// Generated example for getPageViewId\nposthog.getPageViewId();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string | undefined",
+            "name": "string | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Returns the value of the session super property named property_name. If no such property is set, getSessionProperty() will return the undefined value.",
+          "details": "This is based on browser-level `sessionStorage`, NOT the PostHog session. getSessionProperty() can only be called after the PostHog library has finished loading. init() has a loaded function available to handle this automatically.",
+          "id": "getSessionProperty",
+          "showDocs": true,
+          "title": "getSessionProperty",
+          "examples": [
+            {
+              "id": "grab_value_for_'user_id'_after_the_posthog_library_has_loaded",
+              "name": "grab value for 'user_id' after the posthog library has loaded",
+              "code": "\n\n// grab value for 'user_id' after the posthog library has loaded\nposthog.init('YOUR PROJECT TOKEN', {\n    loaded: function(posthog) {\n        user_id = posthog.getSessionProperty('user_id');\n    }\n});\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the session super property you want to retrieve",
+              "isOptional": false,
+              "type": "string",
+              "name": "property_name"
+            }
+          ],
+          "returnType": {
+            "id": "Property | undefined",
+            "name": "Property | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Get list of all surveys.",
+          "details": null,
+          "id": "getSurveys",
+          "showDocs": true,
+          "title": "getSurveys",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nfunction callback(surveys, context) {\n  // do something\n}\n\nposthog.getSurveys(callback, false)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Function that receives the array of surveys",
+              "isOptional": false,
+              "type": "SurveyCallback",
+              "name": "callback"
+            },
+            {
+              "description": "Optional boolean to force an API call for updated surveys",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "forceReload"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Associates the user with a group for group-based analytics. Learn more about [groups](/docs/product-analytics/group-analytics)",
+          "details": "Groups allow you to analyze users collectively (e.g., by organization, team, or account). This sets the group association for all subsequent events and reloads feature flags.",
+          "id": "group",
+          "showDocs": true,
+          "title": "group",
+          "examples": [
+            {
+              "id": "associate_user_with_an_organization",
+              "name": "associate user with an organization",
+              "code": "\n\n// associate user with an organization\nposthog.group('organization', 'org_12345', {\n    name: 'Acme Corp',\n    plan: 'enterprise'\n})\n\n\n"
+            },
+            {
+              "id": "associate_with_multiple_group_types",
+              "name": "associate with multiple group types",
+              "code": "\n\n// associate with multiple group types\nposthog.group('organization', 'org_12345')\nposthog.group('team', 'team_67890')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Group type (example: 'organization')",
+              "isOptional": false,
+              "type": "string",
+              "name": "groupType"
+            },
+            {
+              "description": "Group key (example: 'org::5')",
+              "isOptional": false,
+              "type": "string",
+              "name": "groupKey"
+            },
+            {
+              "description": "Optional properties to set for group",
+              "isOptional": true,
+              "type": "Properties",
+              "name": "groupPropertiesToSet"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Checks if the user has opted into data capturing.",
+          "details": "Returns the current consent status for event tracking and data persistence.",
+          "id": "has_opted_in_capturing",
+          "showDocs": true,
+          "title": "has_opted_in_capturing",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nif (posthog.has_opted_in_capturing()) {\n    // show analytics features\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Checks if the user has opted out of data capturing.",
+          "details": "Returns the current consent status for event tracking and data persistence.",
+          "id": "has_opted_out_capturing",
+          "showDocs": true,
+          "title": "has_opted_out_capturing",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nif (posthog.has_opted_out_capturing()) {\n    // disable analytics features\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Associates a user with a unique identifier instead of an auto-generated ID. Learn more about [identifying users](/docs/product-analytics/identify)",
+          "details": "By default, PostHog assigns each user a randomly generated `distinct_id`. Use this method to replace that ID with your own unique identifier (like a user ID from your database).",
+          "id": "identify",
+          "showDocs": true,
+          "title": "identify",
+          "examples": [
+            {
+              "id": "basic_identification",
+              "name": "basic identification",
+              "code": "\n\n// basic identification\nposthog.identify('user_12345')\n\n\n"
+            },
+            {
+              "id": "identify_with_user_properties",
+              "name": "identify with user properties",
+              "code": "\n\n// identify with user properties\nposthog.identify('user_12345', {\n    email: 'user@example.com',\n    plan: 'premium'\n})\n\n\n"
+            },
+            {
+              "id": "identify_with_set_and_set_once_properties",
+              "name": "identify with set and set_once properties",
+              "code": "\n\n// identify with set and set_once properties\nposthog.identify('user_12345',\n    { last_login: new Date() },  // updates every time\n    { signup_date: new Date() }  // sets only once\n)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "A string that uniquely identifies a user. If not provided, the distinct_id currently in the persistent store (cookie or localStorage) will be used.",
+              "isOptional": true,
+              "type": "string",
+              "name": "new_distinct_id"
+            },
+            {
+              "description": "Optional: An associative array of properties to store about the user. Note: For feature flag evaluations, if the same key is present in the userPropertiesToSetOnce, it will be overwritten by the value in userPropertiesToSet.",
+              "isOptional": true,
+              "type": "Properties",
+              "name": "userPropertiesToSet"
+            },
+            {
+              "description": "Optional: An associative array of properties to store about the user. If property is previously set, this does not override that value.",
+              "isOptional": true,
+              "type": "Properties",
+              "name": "userPropertiesToSetOnce"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Initializes a new instance of the PostHog capturing object.",
+          "details": "All new instances are added to the main posthog object as sub properties (such as `posthog.library_name`) and also returned by this function. [Learn more about configuration options](https://github.com/posthog/posthog-js/blob/6e0e873/src/posthog-core.js#L57-L91)",
+          "id": "init",
+          "showDocs": true,
+          "title": "init",
+          "examples": [
+            {
+              "id": "basic_initialization",
+              "name": "basic initialization",
+              "code": "\n\n// basic initialization\nposthog.init('<ph_project_api_key>', {\n    api_host: '<ph_client_api_host>'\n})\n\n\n"
+            },
+            {
+              "id": "multiple_instances",
+              "name": "multiple instances",
+              "code": "\n\n// multiple instances\nposthog.init('<ph_project_api_key>', {}, 'project1')\nposthog.init('<ph_project_api_key>', {}, 'project2')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Your PostHog API token",
+              "isOptional": false,
+              "type": "string",
+              "name": "token"
+            },
+            {
+              "description": "A dictionary of config options to override",
+              "isOptional": true,
+              "type": "OnlyValidKeys<Partial<PostHogConfig>, Partial<PostHogConfig>>",
+              "name": "config"
+            },
+            {
+              "description": "The name for the new posthog instance that you want created",
+              "isOptional": true,
+              "type": "string",
+              "name": "name"
+            }
+          ],
+          "returnType": {
+            "id": "PostHog",
+            "name": "PostHog"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Checks whether the PostHog library is currently capturing events.\nUsually this means that the user has not opted out of capturing, but the exact behaviour can be controlled by some config options.\nAdditionally, if the cookieless_mode is set to 'on_reject', we will capture events in cookieless mode if the user has explicitly opted out.",
+          "details": null,
+          "id": "is_capturing",
+          "showDocs": true,
+          "title": "is_capturing",
+          "examples": [
+            {
+              "id": "is_capturing",
+              "name": "Generated example for is_capturing",
+              "code": "// Generated example for is_capturing\nposthog.is_capturing();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Checks if a feature flag is enabled for the current user.",
+          "details": "Returns true if the flag is enabled, false if disabled, or undefined if not found. This is a convenience method that treats any truthy value as enabled.",
+          "id": "isFeatureEnabled",
+          "showDocs": true,
+          "title": "isFeatureEnabled",
+          "examples": [
+            {
+              "id": "simple_feature_flag_check",
+              "name": "simple feature flag check",
+              "code": "\n\n// simple feature flag check\nif (posthog.isFeatureEnabled('new-checkout')) {\n    showNewCheckout()\n}\n\n\n"
+            },
+            {
+              "id": "disable_event_tracking",
+              "name": "disable event tracking",
+              "code": "\n\n// disable event tracking\nif (posthog.isFeatureEnabled('feature', { send_event: false })) {\n    // flag checked without sending $feature_flag_call event\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "(optional) If send_event: false, we won't send an $feature_flag_call event to PostHog.",
+              "isOptional": true,
+              "type": "{\n        send_event: boolean;\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "boolean | undefined",
+            "name": "boolean | undefined"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Toolbar",
+          "description": "returns a boolean indicating whether the [toolbar](/docs/toolbar) loaded",
+          "details": null,
+          "id": "loadToolbar",
+          "showDocs": true,
+          "title": "loadToolbar",
+          "examples": [
+            {
+              "id": "loadtoolbar",
+              "name": "Generated example for loadToolbar",
+              "code": "// Generated example for loadToolbar\nposthog.loadToolbar();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "ToolbarParams",
+              "name": "params"
+            }
+          ],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Exposes a set of events that PostHog will emit. e.g. `eventCaptured` is emitted immediately before trying to send an event\nUnlike `onFeatureFlags` and `onSessionId` these are not called when the listener is registered, the first callback will be the next event _after_ registering a listener",
+          "details": null,
+          "id": "on",
+          "showDocs": true,
+          "title": "on",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.on('eventCaptured', (event) => {\n  console.log(event)\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The event to listen for.",
+              "isOptional": false,
+              "type": "'eventCaptured'",
+              "name": "event"
+            },
+            {
+              "description": "The callback function to call when the event is emitted.",
+              "isOptional": false,
+              "type": "(...args: any[]) => void",
+              "name": "cb"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Register an event listener that runs when feature flags become available or when they change. If there are flags, the listener is called immediately in addition to being called on future changes. Note that this is not called only when we fetch feature flags from the server, but also when they change in the browser.",
+          "details": null,
+          "id": "onFeatureFlags",
+          "showDocs": true,
+          "title": "onFeatureFlags",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.onFeatureFlags(function(featureFlags, featureFlagsVariants, { errorsLoading }) {\n    // do something\n})\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The callback function will be called once the feature flags are ready or when they are updated. It'll return a list of feature flags enabled for the user, the variants, and also a context object indicating whether we succeeded to fetch the flags or not.",
+              "isOptional": false,
+              "type": "FeatureFlagsCallback",
+              "name": "callback"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Register an event listener that runs whenever the session id or window id change. If there is already a session id, the listener is called immediately in addition to being called on future changes.\nCan be used, for example, to sync the PostHog session id with a backend session.",
+          "details": null,
+          "id": "onSessionId",
+          "showDocs": true,
+          "title": "onSessionId",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.onSessionId(function(sessionId, windowId) { // do something })\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The callback function will be called once a session id is present or when it or the window id are updated.",
+              "isOptional": false,
+              "type": "SessionIdChangedCallback",
+              "name": "callback"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Register an event listener that runs when surveys are loaded.\nCallback parameters: - surveys: Survey[]: An array containing all survey objects fetched from PostHog using the getSurveys method - context:  isLoaded: boolean, error?: string : An object indicating if the surveys were loaded successfully",
+          "details": null,
+          "id": "onSurveysLoaded",
+          "showDocs": true,
+          "title": "onSurveysLoaded",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.onSurveysLoaded((surveys, context) => { // do something })\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The callback function will be called when surveys are loaded or updated.",
+              "isOptional": false,
+              "type": "SurveyCallback",
+              "name": "callback"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Opts the user into data capturing and persistence.",
+          "details": "Enables event tracking and data persistence (cookies/localStorage) for this PostHog instance. By default, captures an `$opt_in` event unless disabled.",
+          "id": "opt_in_capturing",
+          "showDocs": true,
+          "title": "opt_in_capturing",
+          "examples": [
+            {
+              "id": "simple_opt-in",
+              "name": "simple opt-in",
+              "code": "\n\n// simple opt-in\nposthog.opt_in_capturing()\n\n\n"
+            },
+            {
+              "id": "opt-in_with_custom_event_and_properties",
+              "name": "opt-in with custom event and properties",
+              "code": "\n\n// opt-in with custom event and properties\nposthog.opt_in_capturing({\n    captureEventName: 'Privacy Accepted',\n    captureProperties: { source: 'banner' }\n})\n\n\n"
+            },
+            {
+              "id": "opt-in_without_capturing_event",
+              "name": "opt-in without capturing event",
+              "code": "\n\n// opt-in without capturing event\nposthog.opt_in_capturing({\n    captureEventName: false\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "{\n        captureEventName?: EventName | null | false; /** event name to be used for capturing the opt-in action */\n        captureProperties?: Properties; /** set of properties to be captured along with the opt-in action */\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Opts the user out of data capturing and persistence.",
+          "details": "Disables event tracking and data persistence (cookies/localStorage) for this PostHog instance. If `opt_out_persistence_by_default` is true, SDK persistence will also be disabled.",
+          "id": "opt_out_capturing",
+          "showDocs": true,
+          "title": "opt_out_capturing",
+          "examples": [
+            {
+              "id": "opt_user_out_(e.g.,_on_privacy_settings_page)",
+              "name": "opt user out (e.g., on privacy settings page)",
+              "code": "\n\n// opt user out (e.g., on privacy settings page)\nposthog.opt_out_capturing()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "",
+          "description": "push() keeps the standard async-array-push behavior around after the lib is loaded. This is only useful for external integrations that do not wish to rely on our convenience methods (created in the snippet).",
+          "details": null,
+          "id": "push",
+          "showDocs": true,
+          "title": "push",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.push(['register', { a: 'b' }]);\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "A [function_name, args...] array to be executed",
+              "isOptional": false,
+              "type": "SnippetArrayItem",
+              "name": "item"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Registers super properties for the current session only.",
+          "details": "Session super properties are automatically added to all events during the current browser session. Unlike regular super properties, these are cleared when the session ends and are stored in sessionStorage.",
+          "id": "register_for_session",
+          "showDocs": true,
+          "title": "register_for_session",
+          "examples": [
+            {
+              "id": "register_session-specific_properties",
+              "name": "register session-specific properties",
+              "code": "\n\n// register session-specific properties\nposthog.register_for_session({\n    current_page_type: 'checkout',\n    ab_test_variant: 'control'\n})\n\n\n"
+            },
+            {
+              "id": "register_properties_for_user_flow_tracking",
+              "name": "register properties for user flow tracking",
+              "code": "\n\n// register properties for user flow tracking\nposthog.register_for_session({\n    selected_plan: 'pro',\n    completed_steps: 3,\n    flow_id: 'signup_flow_v2'\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "An associative array of properties to store about the user",
+              "isOptional": false,
+              "type": "Properties",
+              "name": "properties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Registers super properties only if they haven't been set before.",
+          "details": "Unlike `register()`, this method will not overwrite existing super properties. Use this for properties that should only be set once, like signup date or initial referrer.",
+          "id": "register_once",
+          "showDocs": true,
+          "title": "register_once",
+          "examples": [
+            {
+              "id": "register_once-only_properties",
+              "name": "register once-only properties",
+              "code": "\n\n// register once-only properties\nposthog.register_once({\n    first_login_date: new Date().toISOString(),\n    initial_referrer: document.referrer\n})\n\n\n"
+            },
+            {
+              "id": "override_existing_value_if_it_matches_default",
+              "name": "override existing value if it matches default",
+              "code": "\n\n// override existing value if it matches default\nposthog.register_once(\n    { user_type: 'premium' },\n    'unknown'  // overwrite if current value is 'unknown'\n)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "An associative array of properties to store about the user",
+              "isOptional": false,
+              "type": "Properties",
+              "name": "properties"
+            },
+            {
+              "description": "Value to override if already set in super properties (ex: 'False') Default: 'None'",
+              "isOptional": true,
+              "type": "Property",
+              "name": "default_value"
+            },
+            {
+              "description": "How many days since the users last visit to store the super properties",
+              "isOptional": true,
+              "type": "number",
+              "name": "days"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Registers super properties that are included with all events.",
+          "details": "Super properties are stored in persistence and automatically added to every event you capture. These values will overwrite any existing super properties with the same keys.",
+          "id": "register",
+          "showDocs": true,
+          "title": "register",
+          "examples": [
+            {
+              "id": "register_a_single_property",
+              "name": "register a single property",
+              "code": "\n\n// register a single property\nposthog.register({ plan: 'premium' })\n\n\n\n\n"
+            },
+            {
+              "id": "register_multiple_properties",
+              "name": "register multiple properties",
+              "code": "\n\n// register multiple properties\nposthog.register({\n    email: 'user@example.com',\n    account_type: 'business',\n    signup_date: '2023-01-15'\n})\n\n\n"
+            },
+            {
+              "id": "register_with_custom_expiration",
+              "name": "register with custom expiration",
+              "code": "\n\n// register with custom expiration\nposthog.register({ campaign: 'summer_sale' }, 7) // expires in 7 days\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "properties to store about the user",
+              "isOptional": false,
+              "type": "Properties",
+              "name": "properties"
+            },
+            {
+              "description": "How many days since the user's last visit to store the super properties",
+              "isOptional": true,
+              "type": "number",
+              "name": "days"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Feature flag values are cached. If something has changed with your user and you'd like to refetch their flag values, call this method.",
+          "details": null,
+          "id": "reloadFeatureFlags",
+          "showDocs": true,
+          "title": "reloadFeatureFlags",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.reloadFeatureFlags()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Surveys",
+          "description": "Although we recommend using popover surveys and display conditions, if you want to show surveys programmatically without setting up all the extra logic needed for API surveys, you can render surveys programmatically with the renderSurvey method.\nThis takes a survey ID and an HTML selector to render an unstyled survey.",
+          "details": null,
+          "id": "renderSurvey",
+          "showDocs": true,
+          "title": "renderSurvey",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.renderSurvey(coolSurveyID, '#survey-container')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "deprecated",
+          "params": [
+            {
+              "description": "The ID of the survey to render.",
+              "isOptional": false,
+              "type": "string",
+              "name": "surveyId"
+            },
+            {
+              "description": "The selector of the HTML element to render the survey on.",
+              "isOptional": false,
+              "type": "string",
+              "name": "selector"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Resets all user data and starts a fresh session.\n⚠️ **Warning**: Only call this when a user logs out. Calling at the wrong time can cause split sessions.\nThis clears: - Session ID and super properties - User identification (sets new random distinct_id) - Cached data and consent settings",
+          "details": null,
+          "id": "reset",
+          "showDocs": true,
+          "title": "reset",
+          "examples": [
+            {
+              "id": "reset_on_user_logout",
+              "name": "reset on user logout",
+              "code": "\n\n// reset on user logout\nfunction logout() {\n    posthog.reset()\n    // redirect to login page\n}\n\n\n"
+            },
+            {
+              "id": "reset_and_generate_new_device_id",
+              "name": "reset and generate new device ID",
+              "code": "\n\n// reset and generate new device ID\nposthog.reset(true)  // also resets device_id\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "reset_device_id"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Resets the group properties for feature flags.",
+          "details": null,
+          "id": "resetGroupPropertiesForFlags",
+          "showDocs": true,
+          "title": "resetGroupPropertiesForFlags",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.resetGroupPropertiesForFlags()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "string",
+              "name": "group_type"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Resets only the group properties of the user currently logged in. Learn more about [groups](/docs/product-analytics/group-analytics)",
+          "details": null,
+          "id": "resetGroups",
+          "showDocs": true,
+          "title": "resetGroups",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.resetGroups()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Resets the person properties for feature flags.",
+          "details": null,
+          "id": "resetPersonPropertiesForFlags",
+          "showDocs": true,
+          "title": "resetPersonPropertiesForFlags",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nposthog.resetPersonPropertiesForFlags()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Session replay",
+          "description": "returns a boolean indicating whether session recording is currently running",
+          "details": null,
+          "id": "sessionRecordingStarted",
+          "showDocs": true,
+          "title": "sessionRecordingStarted",
+          "examples": [
+            {
+              "id": "stop_session_recording_if_it's_running",
+              "name": "Stop session recording if it's running",
+              "code": "\n\n// Stop session recording if it's running\nif (posthog.sessionRecordingStarted()) {\n  posthog.stopSessionRecording()\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Updates the configuration of the PostHog instance.",
+          "details": null,
+          "id": "set_config",
+          "showDocs": true,
+          "title": "set_config",
+          "examples": [
+            {
+              "id": "set_config",
+              "name": "Generated example for set_config",
+              "code": "// Generated example for set_config\nposthog.set_config();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "A dictionary of new configuration values to update",
+              "isOptional": false,
+              "type": "Partial<PostHogConfig>",
+              "name": "config"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Set override group properties for feature flags. This is used when dealing with new groups / where you don't want to wait for ingestion to update properties. Takes in an object, the key of which is the group type.",
+          "details": null,
+          "id": "setGroupPropertiesForFlags",
+          "showDocs": true,
+          "title": "setGroupPropertiesForFlags",
+          "examples": [
+            {
+              "id": "set_properties_with_reload",
+              "name": "Set properties with reload",
+              "code": "\n\n// Set properties with reload\nposthog.setGroupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } })\n\n\n"
+            },
+            {
+              "id": "set_properties_without_reload",
+              "name": "Set properties without reload",
+              "code": "\n\n// Set properties without reload\nposthog.setGroupPropertiesForFlags({'organization': { name: 'CYZ', employees: '11' } }, false)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The properties to override, the key of which is the group type.",
+              "isOptional": false,
+              "type": "{\n        [type: string]: Properties;\n    }",
+              "name": "properties"
+            },
+            {
+              "description": "Whether to reload feature flags.",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "reloadFeatureFlags"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Sets properties on the person profile associated with the current `distinct_id`. Learn more about [identifying users](/docs/product-analytics/identify)",
+          "details": "Updates user properties that are stored with the person profile in PostHog. If `person_profiles` is set to `identified_only` and no profile exists, this will create one.",
+          "id": "setPersonProperties",
+          "showDocs": true,
+          "title": "setPersonProperties",
+          "examples": [
+            {
+              "id": "set_user_properties",
+              "name": "set user properties",
+              "code": "\n\n// set user properties\nposthog.setPersonProperties({\n    email: 'user@example.com',\n    plan: 'premium'\n})\n\n\n"
+            },
+            {
+              "id": "set_properties",
+              "name": "set properties",
+              "code": "\n\n// set properties\nposthog.setPersonProperties(\n    { name: 'Max Hedgehog' },  // $set properties\n    { initial_url: '/blog' }   // $set_once properties\n)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Optional: An associative array of properties to store about the user. Note: For feature flag evaluations, if the same key is present in the userPropertiesToSetOnce, it will be overwritten by the value in userPropertiesToSet.",
+              "isOptional": true,
+              "type": "Properties",
+              "name": "userPropertiesToSet"
+            },
+            {
+              "description": "Optional: An associative array of properties to store about the user. If property is previously set, this does not override that value.",
+              "isOptional": true,
+              "type": "Properties",
+              "name": "userPropertiesToSetOnce"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Sometimes, you might want to evaluate feature flags using properties that haven't been ingested yet, or were set incorrectly earlier. You can do so by setting properties the flag depends on with these calls:",
+          "details": null,
+          "id": "setPersonPropertiesForFlags",
+          "showDocs": true,
+          "title": "setPersonPropertiesForFlags",
+          "examples": [
+            {
+              "id": "set_properties",
+              "name": "Set properties",
+              "code": "\n\n// Set properties\nposthog.setPersonPropertiesForFlags({'property1': 'value', property2: 'value2'})\n\n\n"
+            },
+            {
+              "id": "set_properties_without_reloading",
+              "name": "Set properties without reloading",
+              "code": "\n\n// Set properties without reloading\nposthog.setPersonPropertiesForFlags({'property1': 'value', property2: 'value2'}, false)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The properties to override.",
+              "isOptional": false,
+              "type": "Properties",
+              "name": "properties"
+            },
+            {
+              "description": "Whether to reload feature flags.",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "reloadFeatureFlags"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Session replay",
+          "description": "turns session recording on, and updates the config option `disable_session_recording` to false",
+          "details": null,
+          "id": "startSessionRecording",
+          "showDocs": true,
+          "title": "startSessionRecording",
+          "examples": [
+            {
+              "id": "start_and_ignore_controls",
+              "name": "Start and ignore controls",
+              "code": "\n\n// Start and ignore controls\nposthog.startSessionRecording(true)\n\n\n"
+            },
+            {
+              "id": "start_and_override_controls",
+              "name": "Start and override controls",
+              "code": "\n\n// Start and override controls\nposthog.startSessionRecording({\n  // you don't have to send all of these\n  sampling: true || false,\n  linked_flag: true || false,\n  url_trigger: true || false,\n  event_trigger: true || false\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "optional boolean to override the default sampling behavior - ensures the next session recording to start will not be skipped by sampling or linked_flag config. `true` is shorthand for  sampling: true, linked_flag: true",
+              "isOptional": true,
+              "type": "{\n        sampling?: boolean;\n        linked_flag?: boolean;\n        url_trigger?: true;\n        event_trigger?: true;\n    } | true",
+              "name": "override"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Session replay",
+          "description": "turns session recording off, and updates the config option disable_session_recording to true",
+          "details": null,
+          "id": "stopSessionRecording",
+          "showDocs": true,
+          "title": "stopSessionRecording",
+          "examples": [
+            {
+              "id": "stop_session_recording",
+              "name": "Stop session recording",
+              "code": "\n\n// Stop session recording\nposthog.stopSessionRecording()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Removes a session super property from the current session.",
+          "details": "This will stop the property from being automatically included in future events for this session. The property is removed from sessionStorage.",
+          "id": "unregister_for_session",
+          "showDocs": true,
+          "title": "unregister_for_session",
+          "examples": [
+            {
+              "id": "remove_a_session_property",
+              "name": "remove a session property",
+              "code": "\n\n// remove a session property\nposthog.unregister_for_session('current_flow')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the session super property to remove",
+              "isOptional": false,
+              "type": "string",
+              "name": "property"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Removes a super property from persistent storage.",
+          "details": "This will stop the property from being automatically included in future events. The property will be permanently removed from the user's profile.",
+          "id": "unregister",
+          "showDocs": true,
+          "title": "unregister",
+          "examples": [
+            {
+              "id": "remove_a_super_property",
+              "name": "remove a super property",
+              "code": "\n\n// remove a super property\nposthog.unregister('plan_type')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the super property to remove",
+              "isOptional": false,
+              "type": "string",
+              "name": "property"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Opt the user in or out of an early access feature. [Learn more in the docs](/docs/feature-flags/early-access-feature-management#option-2-custom-implementation)",
+          "details": null,
+          "id": "updateEarlyAccessFeatureEnrollment",
+          "showDocs": true,
+          "title": "updateEarlyAccessFeatureEnrollment",
+          "examples": [
+            {
+              "id": "",
+              "name": "",
+              "code": "\n\nconst toggleBeta = (betaKey) => {\n  if (activeBetas.some(\n    beta => beta.flagKey === betaKey\n  )) {\n    posthog.updateEarlyAccessFeatureEnrollment(\n      betaKey,\n      false\n    )\n    setActiveBetas(\n      prevActiveBetas => prevActiveBetas.filter(\n        item => item.flagKey !== betaKey\n      )\n    );\n    return\n  }\n\n  posthog.updateEarlyAccessFeatureEnrollment(\n    betaKey,\n    true\n  )\n  setInactiveBetas(\n    prevInactiveBetas => prevInactiveBetas.filter(\n      item => item.flagKey !== betaKey\n    )\n  );\n}\n\nconst registerInterest = (featureKey) => {\n  posthog.updateEarlyAccessFeatureEnrollment(\n    featureKey,\n    true\n  )\n  // Update UI to show user has registered\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The key of the feature flag to update.",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "Whether the user is enrolled in the feature.",
+              "isOptional": false,
+              "type": "boolean",
+              "name": "isEnrolled"
+            },
+            {
+              "description": "The stage of the feature flag to update.",
+              "isOptional": true,
+              "type": "string",
+              "name": "stage"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "lib/src/posthog-core.d.ts"
+        }
+      ]
+    }
+  ],
+  "types": [
+    {
+      "id": "ActionStepStringMatching",
+      "name": "ActionStepStringMatching",
+      "properties": [],
+      "path": "lib/src/posthog-surveys-types.d.ts",
+      "example": "\"contains\" | \"exact\" | \"regex\""
+    },
+    {
+      "id": "ActionStepType",
+      "name": "ActionStepType",
+      "properties": [
+        {
+          "type": "string | null",
+          "name": "event"
+        },
+        {
+          "description": "ActionStepStringMatching.Exact",
+          "type": "ActionStepStringMatching | null",
+          "name": "href_matching"
+        },
+        {
+          "type": "string | null",
+          "name": "href"
+        },
+        {
+          "type": "string | null",
+          "name": "selector"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "name": "tag_name"
+        },
+        {
+          "description": "StringMatching.Exact",
+          "type": "ActionStepStringMatching | null",
+          "name": "text_matching"
+        },
+        {
+          "type": "string | null",
+          "name": "text"
+        },
+        {
+          "description": "StringMatching.Contains",
+          "type": "ActionStepStringMatching | null",
+          "name": "url_matching"
+        },
+        {
+          "type": "string | null",
+          "name": "url"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "AutocaptureCompatibleElement",
+      "name": "AutocaptureCompatibleElement",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"a\" | \"button\" | \"form\" | \"input\" | \"select\" | \"textarea\" | \"label\""
+    },
+    {
+      "id": "AutocaptureConfig",
+      "name": "AutocaptureConfig",
+      "properties": [
+        {
+          "description": "When set to true, autocapture will capture the text of any element that is cut or copied.",
+          "type": "boolean",
+          "name": "capture_copied_text"
+        },
+        {
+          "description": "List of CSS selectors to allow autocapture on e.g. ['[ph-capture]'] we consider the tree of elements from the root to the target element of the click event so for the tree div  div  button  svg and allow list config `['[id]']` we will capture the click if the click-target or its parents has any id\nEverything is allowed when there's no allowlist",
+          "type": "string[]",
+          "name": "css_selector_allowlist"
+        },
+        {
+          "description": "List of DOM events to allow autocapture on e.g. ['click', 'change', 'submit']",
+          "type": "DomAutocaptureEvents[]",
+          "name": "dom_event_allowlist"
+        },
+        {
+          "description": "List of DOM elements to allow autocapture on e.g. ['a', 'button', 'form', 'input', 'select', 'textarea', 'label']\nWe consider the tree of elements from the root to the target element of the click event so for the tree `div > div > button > svg` if the allowlist has `button` then we allow the capture when the `button` or the `svg` is the click target but not if either of the `div`s are detected as the click target",
+          "type": "AutocaptureCompatibleElement[]",
+          "name": "element_allowlist"
+        },
+        {
+          "description": "Exclude certain element attributes from autocapture E.g. ['aria-label'] or [data-attr-pii]",
+          "type": "string[]",
+          "name": "element_attribute_ignorelist"
+        },
+        {
+          "description": "List of URLs to allow autocapture on, can be strings to match or regexes e.g. ['https://example.com', 'test.com/.*'] this is useful when you want to autocapture on specific pages only\nif you set both url_allowlist and url_ignorelist, we check the allowlist first and then the ignorelist. the ignorelist can override the allowlist",
+          "type": "(string | RegExp)[]",
+          "name": "url_allowlist"
+        },
+        {
+          "description": "List of URLs to not allow autocapture on, can be strings to match or regexes e.g. ['https://example.com', 'test.com/.*'] this is useful when you want to autocapture on most pages but not some specific ones\nif you set both url_allowlist and url_ignorelist, we check the allowlist first and then the ignorelist. the ignorelist can override the allowlist",
+          "type": "(string | RegExp)[]",
+          "name": "url_ignorelist"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "BasicSurveyQuestion",
+      "name": "BasicSurveyQuestion",
+      "properties": [
+        {
+          "type": "SurveyQuestionType.Open",
+          "name": "type"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "BeforeSendFn",
+      "name": "BeforeSendFn",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(cr: CaptureResult | null) => CaptureResult | null"
+    },
+    {
+      "id": "BootstrapConfig",
+      "name": "BootstrapConfig",
+      "properties": [
+        {
+          "type": "string",
+          "name": "distinctID"
+        },
+        {
+          "type": "Record<string, JsonType>",
+          "name": "featureFlagPayloads"
+        },
+        {
+          "type": "Record<string, boolean | string>",
+          "name": "featureFlags"
+        },
+        {
+          "type": "boolean",
+          "name": "isIdentifiedID"
+        },
+        {
+          "description": "Optionally provide a sessionID, this is so that you can provide an existing sessionID here to continue a user's session across a domain or device. It MUST be: - unique to this user - a valid UUID v7 - the timestamp part must be = the timestamp of the first event in the session - the timestamp of the last event in the session must be  the timestamp part + 24 hours *",
+          "type": "string",
+          "name": "sessionID"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "Breaker",
+      "name": "Breaker",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{}"
+    },
+    {
+      "id": "CapturedNetworkRequest",
+      "name": "CapturedNetworkRequest",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "Writable<Omit<PerformanceEntry, 'toJSON'>> & {\n    method?: string;\n    initiatorType?: InitiatorType;\n    status?: number;\n    timeOrigin?: number;\n    timestamp?: number;\n    startTime?: number;\n    endTime?: number;\n    requestHeaders?: Headers;\n    requestBody?: string | null;\n    responseHeaders?: Headers;\n    responseBody?: string | null;\n    isInitial?: boolean;\n}"
+    },
+    {
+      "id": "CaptureOptions",
+      "name": "CaptureOptions",
+      "properties": [
+        {
+          "description": "key of queue, e.g. 'sessionRecording' vs 'event'",
+          "type": "string",
+          "name": "_batchKey"
+        },
+        {
+          "description": "If set, overrides and disables config.properties_string_max_length",
+          "type": "boolean",
+          "name": "_noTruncate"
+        },
+        {
+          "description": "Used to override the desired endpoint for the captured event",
+          "type": "string",
+          "name": "_url"
+        },
+        {
+          "description": "Used when `$identify` is called Will set person properties but only once, it will NOT override previous values",
+          "type": "Properties",
+          "name": "$set_once"
+        },
+        {
+          "description": "Used when `$identify` is called Will set person properties overriding previous values",
+          "type": "Properties",
+          "name": "$set"
+        },
+        {
+          "description": "If set, skips the batched queue",
+          "type": "boolean",
+          "name": "send_instantly"
+        },
+        {
+          "description": "If set, skips the client side rate limiting",
+          "type": "boolean",
+          "name": "skip_client_rate_limiting"
+        },
+        {
+          "description": "If set, overrides the current timestamp",
+          "type": "Date",
+          "name": "timestamp"
+        },
+        {
+          "description": "If set, overrides the desired transport method",
+          "type": "RequestWithOptions['transport']",
+          "name": "transport"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "CaptureResult",
+      "name": "CaptureResult",
+      "properties": [
+        {
+          "type": "Properties",
+          "name": "$set_once"
+        },
+        {
+          "type": "Properties",
+          "name": "$set"
+        },
+        {
+          "type": "EventName",
+          "name": "event"
+        },
+        {
+          "type": "Properties",
+          "name": "properties"
+        },
+        {
+          "type": "Date",
+          "name": "timestamp"
+        },
+        {
+          "type": "string",
+          "name": "uuid"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "Compression",
+      "name": "Compression",
+      "properties": [
+        {
+          "type": "\"base64\"",
+          "name": "Base64"
+        },
+        {
+          "type": "\"gzip-js\"",
+          "name": "GZipJS"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "ConfigDefaults",
+      "name": "ConfigDefaults",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"2025-05-24\" | \"unset\""
+    },
+    {
+      "id": "DeadClickCandidate",
+      "name": "DeadClickCandidate",
+      "properties": [
+        {
+          "type": "number",
+          "name": "absoluteDelayMs"
+        },
+        {
+          "type": "number",
+          "name": "mutationDelayMs"
+        },
+        {
+          "type": "Element",
+          "name": "node"
+        },
+        {
+          "type": "MouseEvent",
+          "name": "originalEvent"
+        },
+        {
+          "type": "number",
+          "name": "scrollDelayMs"
+        },
+        {
+          "type": "number",
+          "name": "selectionChangedDelayMs"
+        },
+        {
+          "type": "number",
+          "name": "timestamp"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "DeadClicksAutoCaptureConfig",
+      "name": "DeadClicksAutoCaptureConfig",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    scroll_threshold_ms?: number;\n    selection_change_threshold_ms?: number;\n    mutation_threshold_ms?: number;\n    __onCapture?: ((click: DeadClickCandidate, properties: Properties) => void) | undefined;\n} & Pick<AutocaptureConfig, 'element_attribute_ignorelist'>"
+    },
+    {
+      "id": "DisplaySurveyOptions",
+      "name": "DisplaySurveyOptions",
+      "properties": [],
+      "path": "lib/src/posthog-surveys-types.d.ts",
+      "example": "DisplaySurveyPopoverOptions | DisplaySurveyInlineOptions"
+    },
+    {
+      "id": "DisplaySurveyType",
+      "name": "DisplaySurveyType",
+      "properties": [
+        {
+          "type": "\"inline\"",
+          "name": "Inline"
+        },
+        {
+          "type": "\"popover\"",
+          "name": "Popover"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "DomAutocaptureEvents",
+      "name": "DomAutocaptureEvents",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"click\" | \"change\" | \"submit\""
+    },
+    {
+      "id": "EarlyAccessFeature",
+      "name": "EarlyAccessFeature",
+      "properties": [
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "string | null",
+          "name": "documentationUrl"
+        },
+        {
+          "type": "string | null",
+          "name": "flagKey"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "'concept' | 'alpha' | 'beta'",
+          "name": "stage"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "EarlyAccessFeatureCallback",
+      "name": "EarlyAccessFeatureCallback",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(earlyAccessFeatures: EarlyAccessFeature[]) => void"
+    },
+    {
+      "id": "EarlyAccessFeatureResponse",
+      "name": "EarlyAccessFeatureResponse",
+      "properties": [
+        {
+          "type": "EarlyAccessFeature[]",
+          "name": "earlyAccessFeatures"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "EarlyAccessFeatureStage",
+      "name": "EarlyAccessFeatureStage",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"concept\" | \"alpha\" | \"beta\" | \"general-availability\""
+    },
+    {
+      "id": "ErrorEventArgs",
+      "name": "ErrorEventArgs",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "[\n    event: string | Event, source?: string | undefined, lineno?: number | undefined, colno?: number | undefined, error?: Error | undefined\n]"
+    },
+    {
+      "id": "ErrorTrackingOptions",
+      "name": "ErrorTrackingOptions",
+      "properties": [
+        {
+          "description": "ADVANCED: alters the bucket size for the token bucket mutation throttling Normally only altered alongside posthog support guidance. Accepts values between 0 and 100\n10",
+          "type": "number",
+          "name": "__exceptionRateLimiterBucketSize"
+        },
+        {
+          "description": "ADVANCED: alters the refill rate for the token bucket mutation throttling Normally only altered alongside posthog support guidance. Accepts values between 0 and 100\n1",
+          "type": "number",
+          "name": "__exceptionRateLimiterRefillRate"
+        },
+        {
+          "description": "Decide whether exceptions thrown by browser extensions should be captured\nfalse",
+          "type": "boolean",
+          "name": "captureExtensionExceptions"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "ErrorTrackingSuppressionRule",
+      "name": "ErrorTrackingSuppressionRule",
+      "properties": [
+        {
+          "type": "'AND' | 'OR'",
+          "name": "type"
+        },
+        {
+          "type": "ErrorTrackingSuppressionRuleValue[]",
+          "name": "values"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "ErrorTrackingSuppressionRuleValue",
+      "name": "ErrorTrackingSuppressionRuleValue",
+      "properties": [
+        {
+          "type": "'$exception_types' | '$exception_values'",
+          "name": "key"
+        },
+        {
+          "type": "PropertyMatchType",
+          "name": "operator"
+        },
+        {
+          "type": "string",
+          "name": "type"
+        },
+        {
+          "type": "string | string[]",
+          "name": "value"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "EvaluationReason",
+      "name": "EvaluationReason",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    code: string;\n    condition_index: number | undefined;\n    description: string | undefined;\n}"
+    },
+    {
+      "id": "EventHandler",
+      "name": "EventHandler",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(event: Event) => boolean | void"
+    },
+    {
+      "id": "EventName",
+      "name": "EventName",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"$pageview\" | \"$identify\" | \"custom_event\" | string"
+    },
+    {
+      "id": "ExceptionAutoCaptureConfig",
+      "name": "ExceptionAutoCaptureConfig",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    capture_unhandled_errors: boolean;\n    capture_unhandled_rejections: boolean;\n    capture_console_errors: boolean;\n}"
+    },
+    {
+      "id": "ExternalIntegrationKind",
+      "name": "ExternalIntegrationKind",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"intercom\" | \"crispChat\""
+    },
+    {
+      "id": "FeatureFlagDetail",
+      "name": "FeatureFlagDetail",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    key: string;\n    enabled: boolean;\n    original_enabled?: boolean | undefined;\n    variant: string | undefined;\n    original_variant?: string | undefined;\n    reason: EvaluationReason | undefined;\n    metadata: FeatureFlagMetadata | undefined;\n}"
+    },
+    {
+      "id": "FeatureFlagMetadata",
+      "name": "FeatureFlagMetadata",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    id: number;\n    version: number | undefined;\n    description: string | undefined;\n    payload: JsonType | undefined;\n    original_payload?: JsonType | undefined;\n}"
+    },
+    {
+      "id": "FeatureFlagsCallback",
+      "name": "FeatureFlagsCallback",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(flags: string[], variants: Record<string, string | boolean>, context?: {\n    errorsLoading?: boolean;\n}) => void"
+    },
+    {
+      "id": "FlagsResponse",
+      "name": "FlagsResponse",
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "errorsWhileComputingFlags"
+        },
+        {
+          "type": "Record<string, JsonType>",
+          "name": "featureFlagPayloads"
+        },
+        {
+          "type": "Record<string, string | boolean>",
+          "name": "featureFlags"
+        },
+        {
+          "type": "Record<string, FeatureFlagDetail>",
+          "name": "flags"
+        },
+        {
+          "type": "string",
+          "name": "requestId"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "FlagVariant",
+      "name": "FlagVariant",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    flag: string;\n    variant: string;\n}"
+    },
+    {
+      "id": "Headers_2",
+      "name": "Headers_2",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "Record<string, string>"
+    },
+    {
+      "id": "HeatmapConfig",
+      "name": "HeatmapConfig",
+      "properties": [
+        {
+          "description": "How often to send batched data in `$heatmap_data` events If set to 0 or not set, sends using the default interval of 1 second\n1000",
+          "type": "number",
+          "name": "flush_interval_milliseconds"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "InitiatorType",
+      "name": "InitiatorType",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"audio\" | \"beacon\" | \"body\" | \"css\" | \"early-hint\" | \"embed\" | \"fetch\" | \"frame\" | \"iframe\" | \"icon\" | \"image\" | \"img\" | \"input\" | \"link\" | \"navigation\" | \"object\" | \"ping\" | \"script\" | \"track\" | \"video\" | \"xmlhttprequest\""
+    },
+    {
+      "id": "JsonRecord",
+      "name": "JsonRecord",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    [key: string]: JsonType;\n}"
+    },
+    {
+      "id": "JsonType",
+      "name": "JsonType",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "string | number | boolean | null | undefined | JsonRecord | Array<JsonType>"
+    },
+    {
+      "id": "KnownEventName",
+      "name": "KnownEventName",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"$heatmaps_data\" | \"$opt_in\" | \"$exception\" | \"$$heatmap\" | \"$web_vitals\" | \"$dead_click\" | \"$autocapture\" | \"$rageclick\""
+    },
+    {
+      "id": "LinkSurveyQuestion",
+      "name": "LinkSurveyQuestion",
+      "properties": [
+        {
+          "type": "string | null",
+          "name": "link"
+        },
+        {
+          "type": "SurveyQuestionType.Link",
+          "name": "type"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "MultipleSurveyQuestion",
+      "name": "MultipleSurveyQuestion",
+      "properties": [
+        {
+          "type": "string[]",
+          "name": "choices"
+        },
+        {
+          "type": "boolean",
+          "name": "hasOpenChoice"
+        },
+        {
+          "type": "boolean",
+          "name": "shuffleOptions"
+        },
+        {
+          "type": "boolean",
+          "name": "skipSubmitButton"
+        },
+        {
+          "type": "SurveyQuestionType.SingleChoice | SurveyQuestionType.MultipleChoice",
+          "name": "type"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "NetworkRecordOptions",
+      "name": "NetworkRecordOptions",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    initiatorTypes?: InitiatorType[];\n    maskRequestFn?: (data: CapturedNetworkRequest) => CapturedNetworkRequest | undefined;\n    recordHeaders?: boolean | {\n        request: boolean;\n        response: boolean;\n    };\n    recordBody?: boolean | string[] | {\n        request: boolean | string[];\n        response: boolean | string[];\n    };\n    recordInitialRequests?: boolean;\n    recordPerformance?: boolean;\n    performanceEntryTypeToObserve: string[];\n    payloadSizeLimitBytes: number;\n    payloadHostDenyList?: string[];\n}"
+    },
+    {
+      "id": "NetworkRequest",
+      "name": "NetworkRequest",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    url: string;\n}"
+    },
+    {
+      "id": "PerformanceCaptureConfig",
+      "name": "PerformanceCaptureConfig",
+      "properties": [
+        {
+          "description": "We observe very large values reported by the Chrome web vitals library These outliers are likely not real, useful values, and we exclude them You can set this to 0 in order to include all values, NB this is not recommended\n15 * 60 * 1000 (15 minutes)",
+          "type": "number",
+          "name": "__web_vitals_max_value"
+        },
+        {
+          "description": "Works with session replay to use the browser's native performance observer to capture performance metrics",
+          "type": "boolean",
+          "name": "network_timing"
+        },
+        {
+          "description": "By default all 4 metrics are captured You can set this config to restrict which metrics are captured e.g. ['CLS', 'FCP'] to only capture those two metrics NB setting this does not override whether the capture is enabled\n['LCP', 'CLS', 'FCP', 'INP']",
+          "type": "SupportedWebVitalsMetrics[]",
+          "name": "web_vitals_allowed_metrics"
+        },
+        {
+          "description": "We delay flushing web vitals metrics to reduce the number of events we send This is the maximum time we will wait before sending the metrics\n5000",
+          "type": "number",
+          "name": "web_vitals_delayed_flush_ms"
+        },
+        {
+          "description": "Use chrome's web vitals library to wrap fetch and capture web vitals",
+          "type": "boolean",
+          "name": "web_vitals"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "PersistentStore",
+      "name": "PersistentStore",
+      "properties": [
+        {
+          "type": "(error: any) => void",
+          "name": "_error"
+        },
+        {
+          "type": "(name: string) => any",
+          "name": "_get"
+        },
+        {
+          "type": "() => boolean",
+          "name": "_is_supported"
+        },
+        {
+          "type": "(name: string) => any",
+          "name": "_parse"
+        },
+        {
+          "type": "(name: string, cross_subdomain?: boolean) => void",
+          "name": "_remove"
+        },
+        {
+          "type": "(name: string, value: any, expire_days?: number | null, cross_subdomain?: boolean, secure?: boolean, debug?: boolean) => void",
+          "name": "_set"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "PostHogConfig",
+      "name": "PostHogConfig",
+      "properties": [
+        {
+          "description": "PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION A list of hostnames for which to inject PostHog tracing headers to all requests (X-POSTHOG-DISTINCT-ID, X-POSTHOG-SESSION-ID, X-POSTHOG-WINDOW-ID)",
+          "type": "string[]",
+          "name": "__add_tracing_headers"
+        },
+        {
+          "description": "Prevents posthog-js from using the `navigator.sendBeacon` API to send events. Enabling this option may hurt the reliability of sending $pageleave events",
+          "type": "boolean",
+          "name": "__preview_disable_beacon"
+        },
+        {
+          "description": "Disables sending credentials when using XHR requests.",
+          "type": "boolean",
+          "name": "__preview_disable_xhr_credentials"
+        },
+        {
+          "description": "PREVIEW - MAY CHANGE WITHOUT WARNING - ONLY USE WHEN TALKING TO POSTHOG SUPPORT Enables deprecated eager loading of session recording code, not just rrweb and network plugin we are switching the default to lazy loading because the bundle will ultimately be 18% smaller then keeping this around for a few days in case there are unexpected consequences that testing did not uncover",
+          "type": "boolean",
+          "name": "__preview_eager_load_replay"
+        },
+        {
+          "description": "PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION Whether to use the new /flags/ endpoint",
+          "type": "boolean",
+          "name": "__preview_flags_v2"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "__preview_lazy_load_replay"
+        },
+        {
+          "description": "PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION Enables the new RemoteConfig approach to loading config instead of /flags?v=2&config=true",
+          "type": "boolean",
+          "name": "__preview_remote_config"
+        },
+        {
+          "description": "",
+          "type": "(eventName: string, eventData: CaptureResult) => void",
+          "name": "_onCapture"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "advanced_disable_decide"
+        },
+        {
+          "description": "Stops from firing feature flag requests on first page load. Only requests feature flags when user identity or properties are updated, or you manually request for flags to be loaded.\nfalse",
+          "type": "boolean",
+          "name": "advanced_disable_feature_flags_on_first_load"
+        },
+        {
+          "description": "Will keep /flags running, but without evaluating any feature flags. Useful for when you need to load the config data associated with the flags endpoint (e.g. /flags?v=2&config=true) without evaluating any feature flags. Most folks use this to save money on feature flag evaluation (by bootstrapping feature flags on the server side).\nfalse",
+          "type": "boolean",
+          "name": "advanced_disable_feature_flags"
+        },
+        {
+          "description": "One of the very first things the PostHog library does when init() is called is make a request to the /flags endpoint on PostHog's backend. This endpoint contains information on how to run the PostHog library so events are properly received in the backend, and it also contains feature flag evaluation information for the current user.\nThis endpoint is required to run most features of this library. However, if you're not using any of the described features, you may wish to turn off the call completely to avoid an extra request and reduce resource usage on both the client and the server.\nfalse",
+          "type": "boolean",
+          "name": "advanced_disable_flags"
+        },
+        {
+          "description": "Determines whether PostHog should disable toolbar metrics. This is our internal instrumentation for our toolbar in your website.\nfalse",
+          "type": "boolean",
+          "name": "advanced_disable_toolbar_metrics"
+        },
+        {
+          "description": "When this is enabled, surveys will always be initialized, regardless of the /flags response or remote config settings. This is useful if you want to use surveys but disable all other flag-dependent functionality. Used internally for displaying external surveys without making a /flags request.\nfalse",
+          "type": "boolean",
+          "name": "advanced_enable_surveys"
+        },
+        {
+          "description": "Determines whether PostHog should only evaluate feature flags for surveys. Useful for when you want to use this library to evaluate feature flags for surveys only but you have additional feature flags that you evaluate on the server side.\nfalse",
+          "type": "boolean",
+          "name": "advanced_only_evaluate_survey_feature_flags"
+        },
+        {
+          "description": "URL of your PostHog instance.\n'https://us.i.posthog.com'",
+          "type": "string",
+          "name": "api_host"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "name": "api_method"
+        },
+        {
+          "description": "The transport method to use for API requests.\n'fetch'",
+          "type": "'XHR' | 'fetch'",
+          "name": "api_transport"
+        },
+        {
+          "description": "Determines whether PostHog should autocapture events. This setting does not affect capturing pageview events (see `capture_pageview`).\nby default autocapture is ignored on elements that match a `ph-no-capture` css class on the element or a parent   true",
+          "type": "boolean | AutocaptureConfig",
+          "name": "autocapture"
+        },
+        {
+          "description": "This function or array of functions - if provided - are called immediately before sending data to the server. It allows you to edit data before it is sent, or choose not to send it all. if provided as an array the functions are called in the order they are provided any one function returning null means the event will not be sent",
+          "type": "BeforeSendFn | BeforeSendFn[]",
+          "name": "before_send"
+        },
+        {
+          "description": "An object containing the `distinctID`, `isIdentifiedID`, and `featureFlags` keys, where `distinctID` is a string, and `featureFlags` is an object of key-value pairs.\nSince there is a delay between initializing PostHog and fetching feature flags, feature flags are not always available immediately. This makes them unusable if you want to do something like redirecting a user to a different page based on a feature flag.\nYou can, therefore, fetch the feature flags in your server and pre-fill them here, allowing PostHog to know the feature flag values immediately.\nAfter the SDK fetches feature flags from PostHog, it will use those flag values instead of bootstrapped ones.",
+          "type": "BootstrapConfig",
+          "name": "bootstrap"
+        },
+        {
+          "description": "Determines whether to capture dead clicks.",
+          "type": "boolean | DeadClicksAutoCaptureConfig",
+          "name": "capture_dead_clicks"
+        },
+        {
+          "description": "Determines whether to capture exceptions.",
+          "type": "boolean | ExceptionAutoCaptureConfig",
+          "name": "capture_exceptions"
+        },
+        {
+          "description": "Determines whether to capture heatmaps.",
+          "type": "boolean | HeatmapConfig",
+          "name": "capture_heatmaps"
+        },
+        {
+          "description": "Determines whether PostHog should capture pageleave events. If set to `true`, it will capture pageleave events for all pages. If set to `'if_capture_pageview'`, it will only capture pageleave events if `capture_pageview` is also set to `true` or `'history_change'`.\n'if_capture_pageview'",
+          "type": "boolean | 'if_capture_pageview'",
+          "name": "capture_pageleave"
+        },
+        {
+          "description": "Determines whether PostHog should capture pageview events automatically. Can be: - `true`: Capture regular pageviews (default) - `false`: Don't capture any pageviews - `'history_change'`: Only capture pageviews on history API changes (pushState, replaceState, popstate)\ntrue",
+          "type": "boolean | 'history_change'",
+          "name": "capture_pageview"
+        },
+        {
+          "description": "Determines whether to capture performance metrics. These include Network Timing and Web Vitals.\nWhen `undefined`, fallback to the remote configuration. If `false`, neither network timing nor web vitals will work. If an object, that will override the remote configuration.",
+          "type": "boolean | PerformanceCaptureConfig",
+          "name": "capture_performance"
+        },
+        {
+          "description": "Determines the key for the cookie / local storage used to store the information about whether users are opted in/out of capturing. When `null`, we used a key based on your token.\nnull",
+          "type": "string | null",
+          "name": "consent_persistence_name"
+        },
+        {
+          "description": "Determines the number of days to store cookies for.\n365",
+          "type": "number",
+          "name": "cookie_expiration"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "name": "cookie_name"
+        },
+        {
+          "description": "Enables cookieless mode. In this mode, PostHog will not set any cookies, or use session or local storage. User identity is handled by generating a privacy-preserving hash on PostHog's servers. - 'always' - enable cookieless mode immediately on startup, use this if you do not intend to show a cookie banner - 'on_reject' - enable cookieless mode only if the user rejects cookies, use this if you want to show a cookie banner. If the user accepts cookies, cookieless mode will not be used, and PostHog will use cookies and local storage as usual.\nNote that you MUST enable cookieless mode in your PostHog project's settings, otherwise all your cookieless events will be ignored. We plan to remove this requirement in the future.",
+          "type": "'always' | 'on_reject'",
+          "name": "cookieless_mode"
+        },
+        {
+          "description": "Determines if cookie should be set on the top level domain (example.com). If PostHog-js is loaded on a subdomain (test.example.com), and `cross_subdomain_cookie` is set to false, it'll set the cookie on the subdomain only (test.example.com).\nNOTE: It will be set to `false` if we detect that the domain is a subdomain of a platform that is excluded from cross-subdomain cookie setting. The current list of excluded platforms is `herokuapp.com`, `vercel.app`, and `netlify.app`.",
+          "type": "boolean",
+          "name": "cross_subdomain_cookie"
+        },
+        {
+          "description": "Used to extend the list of user agents that are blocked by default.",
+          "type": "string[]",
+          "name": "custom_blocked_useragents"
+        },
+        {
+          "description": "Used to extend the list of campaign parameters that are saved by default.",
+          "type": "string[]",
+          "name": "custom_campaign_params"
+        },
+        {
+          "description": "Custom list of personal data properties to mask.\nE.g. if you added `email` to this list, then any `email` property in the URL will be masked. https://www.example.com/login?email=john.doe%40example.com = https://www.example.com/login?email=\n[]",
+          "type": "string[]",
+          "name": "custom_personal_data_properties"
+        },
+        {
+          "description": "Determines whether PostHog should be in debug mode. You can enable this to get more detailed logging.\nYou can also enable this on your website by appending `?__posthog_debug=true` at the end of your URL You can also call `posthog.debug()` in your code to enable debug mode\nfalse",
+          "type": "boolean",
+          "name": "debug"
+        },
+        {
+          "description": "Configuration defaults for breaking changes. When set to a specific date, enables new default behaviors that were introduced on that date.\n- `'unset'`: Use legacy default behaviors - `'2025-05-24'`: Use updated default behaviors (e.g. capture_pageview defaults to 'history_change')\n'unset'",
+          "type": "ConfigDefaults",
+          "name": "defaults"
+        },
+        {
+          "description": "Determines whether to disable compression when sending events to the server. WARNING: Should only be used for testing. Could negatively impact performance.\nfalse",
+          "type": "boolean",
+          "name": "disable_compression"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "disable_cookie"
+        },
+        {
+          "description": "Determines whether PostHog should disable any external dependency loading. This will prevent PostHog from requesting any external scripts such as those needed for Session Replay, Surveys or Site Apps.\nfalse",
+          "type": "boolean",
+          "name": "disable_external_dependency_loading"
+        },
+        {
+          "description": "Determines whether PostHog should disable persistence. If set to `true`, the library will not save any data to the browser. It will also delete any data previously saved to the browser.\nfalse",
+          "type": "boolean",
+          "name": "disable_persistence"
+        },
+        {
+          "description": "Determines whether to disable scroll properties. These allow you to keep track of how far down someone scrolled in your website.\nfalse",
+          "type": "boolean",
+          "name": "disable_scroll_properties"
+        },
+        {
+          "description": "Determines whether PostHog should disable session recording.\nfalse",
+          "type": "boolean",
+          "name": "disable_session_recording"
+        },
+        {
+          "description": "Determines whether PostHog should disable automatic display of surveys. If this is true, popup or widget surveys will not be shown when display conditions are met.\nfalse",
+          "type": "boolean",
+          "name": "disable_surveys_automatic_display"
+        },
+        {
+          "description": "Determines whether PostHog should disable all surveys functionality.\nfalse",
+          "type": "boolean",
+          "name": "disable_surveys"
+        },
+        {
+          "description": "Determines whether PostHog should disable web experiments.\nCurrently disabled while we're in BETA. It will be toggled to `true` in a future release.\ntrue",
+          "type": "boolean",
+          "name": "disable_web_experiments"
+        },
+        {
+          "type": "boolean",
+          "name": "enable_heatmaps"
+        },
+        {
+          "description": "Determines whether PostHog should enable recording console logs. When undefined, it falls back to the remote config setting.\nundefined",
+          "type": "boolean",
+          "name": "enable_recording_console_log"
+        },
+        {
+          "description": "Determines the error tracking options.",
+          "type": "ErrorTrackingOptions",
+          "name": "error_tracking"
+        },
+        {
+          "description": "Sets timeout for fetching feature flags\n3000",
+          "type": "number",
+          "name": "feature_flag_request_timeout_ms"
+        },
+        {
+          "description": "Used when sending data via `fetch`, use with care. This is intentionally meant to be used with NextJS `fetch`\nIncorrect `cache` usage may cause out-of-date data for feature flags, actions tracking, etc. See https://nextjs.org/docs/app/api-reference/functions/fetch#fetchurl-options",
+          "type": "{\n        cache?: RequestInit['cache'];\n        next_options?: NextOptions;\n    }",
+          "name": "fetch_options"
+        },
+        {
+          "description": "Function to get the device ID. This doesn't usually need to be set, but can be useful if you want to use a custom device ID.",
+          "type": "(uuid: string) => string",
+          "name": "get_device_id"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "inapp_link_new_window"
+        },
+        {
+          "description": "",
+          "type": "string",
+          "name": "inapp_protocol"
+        },
+        {
+          "description": "Used to set-up external integrations with PostHog data - such as session replays, distinct id, etc.",
+          "type": "Record<ExternalIntegrationKind, boolean>",
+          "name": "integrations"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "ip"
+        },
+        {
+          "description": "A function to be called once the PostHog scripts have loaded successfully.",
+          "type": "(posthog_instance: PostHog) => void",
+          "name": "loaded"
+        },
+        {
+          "description": "Prevent autocapture from capturing any attribute names on elements.\nfalse",
+          "type": "boolean",
+          "name": "mask_all_element_attributes"
+        },
+        {
+          "description": "Prevent autocapture from capturing `textContent` on elements.\nfalse",
+          "type": "boolean",
+          "name": "mask_all_text"
+        },
+        {
+          "description": "Mask personal data properties from the current URL. This will mask personal data properties such as advertising IDs (gclid, fbclid, etc.), and you can also add custom properties to mask with `custom_personal_data_properties`.   false",
+          "type": "boolean",
+          "name": "mask_personal_data_properties"
+        },
+        {
+          "description": "The name this instance will be identified by. You don't need to set this most of the time, but can be useful if you have several Posthog instances running at the same time.\n'posthog'",
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "description": "A function that is called when a request to the PostHog API fails.",
+          "type": "(error: RequestResponse) => void",
+          "name": "on_request_error"
+        },
+        {
+          "description": "",
+          "type": "(failedRequest: XMLHttpRequest) => void",
+          "name": "on_xhr_error"
+        },
+        {
+          "description": "Determines if users should be opted in to site apps.\nfalse",
+          "type": "boolean",
+          "name": "opt_in_site_apps"
+        },
+        {
+          "description": "Determines if users should be opted out of PostHog tracking by default, requiring additional logic to opt them into capturing by calling `posthog.opt_in_capturing()`.\nfalse",
+          "type": "boolean",
+          "name": "opt_out_capturing_by_default"
+        },
+        {
+          "description": "",
+          "type": "string | null",
+          "name": "opt_out_capturing_cookie_prefix"
+        },
+        {
+          "description": "Determines where we'll save the information about whether users are opted out of capturing.\n'localStorage'",
+          "type": "'localStorage' | 'cookie'",
+          "name": "opt_out_capturing_persistence_type"
+        },
+        {
+          "description": "Determines if users should be opted out of browser data storage by this PostHog instance by default, requiring additional logic to opt them into capturing by calling `posthog.opt_in_capturing()`.\nfalse",
+          "type": "boolean",
+          "name": "opt_out_persistence_by_default"
+        },
+        {
+          "description": "Determines if users should be opted out of user agent filtering such as googlebot or other bots. If this is set to `true`, PostHog will set `$browser_type` to either `bot` or `browser` for all events, but will process all events as if they were from a browser.\nfalse",
+          "type": "boolean",
+          "name": "opt_out_useragent_filter"
+        },
+        {
+          "description": "The name for the super properties persistent store\n''",
+          "type": "string",
+          "name": "persistence_name"
+        },
+        {
+          "description": "Determines how PostHog stores information about the user. See [persistence](https://posthog.com/docs/libraries/js#persistence) for details.\n'localStorage+cookie'",
+          "type": "'localStorage' | 'cookie' | 'memory' | 'localStorage+cookie' | 'sessionStorage'",
+          "name": "persistence"
+        },
+        {
+          "description": "You can control whether events from PostHog-js have person processing enabled with the `person_profiles` config setting. There are three options: - `person_profiles: 'always'` - we will process persons data for all events - `person_profiles: 'never'` - we won't process persons for any event. This means that anonymous users will not be merged once they sign up or login, so you lose the ability to create funnels that track users from anonymous to identified. All events (including `$identify`) will be sent with `$process_person_profile: False`. - `person_profiles: 'identified_only'` _(default)_ - we will only process persons when you call `posthog.identify`, `posthog.alias`, `posthog.setPersonProperties`, `posthog.group`, `posthog.setPersonPropertiesForFlags` or `posthog.setGroupPropertiesForFlags` Anonymous users won't get person profiles.\n'identified_only'",
+          "type": "'always' | 'never' | 'identified_only'",
+          "name": "person_profiles"
+        },
+        {
+          "description": "A function to be called when a script is being loaded. This can be used to modify the script before it is loaded. This is useful for adding a nonce to the script, for example.",
+          "type": "(script: HTMLScriptElement) => HTMLScriptElement | null",
+          "name": "prepare_external_dependency_script"
+        },
+        {
+          "description": "A function to be called when a stylesheet is being loaded. This can be used to modify the stylesheet before it is loaded. This is useful for adding a nonce to the stylesheet, for example.",
+          "type": "(stylesheet: HTMLStyleElement) => HTMLStyleElement | null",
+          "name": "prepare_external_dependency_stylesheet"
+        },
+        {
+          "description": "",
+          "type": "'always' | 'never' | 'identified_only'",
+          "name": "process_person"
+        },
+        {
+          "description": "Determines the maximum length of the properties string that can be sent with capture calls.\n65535",
+          "type": "number",
+          "name": "properties_string_max_length"
+        },
+        {
+          "description": "",
+          "type": "string[]",
+          "name": "property_blacklist"
+        },
+        {
+          "description": "A list of properties that should never be sent with capture calls.\n[]",
+          "type": "string[]",
+          "name": "property_denylist"
+        },
+        {
+          "description": "Determines whether PostHog should capture rage clicks.\nby default rageclicks are ignored on elements that match a `ph-no-capture` or `ph-no-rageclick` css class on the element or a parent   true",
+          "type": "boolean | RageclickConfig",
+          "name": "rageclick"
+        },
+        {
+          "description": "Client side rate limiting",
+          "type": "{\n        events_per_second?: number;\n        events_burst_limit?: number;\n    }",
+          "name": "rate_limiting"
+        },
+        {
+          "description": "Determines whether PostHog should batch requests to the PostHog API.\ntrue",
+          "type": "boolean",
+          "name": "request_batching"
+        },
+        {
+          "description": "A list of headers that should be sent with requests to the PostHog API.",
+          "type": "{\n        [header_name: string]: string;\n    }",
+          "name": "request_headers"
+        },
+        {
+          "description": "Used to change the behavior of the request queue. This is an advanced feature and should be used with caution.",
+          "type": "RequestQueueConfig",
+          "name": "request_queue_config"
+        },
+        {
+          "description": "Determines whether PostHog should respect the Do Not Track header when computing consent in `ConsentManager`.",
+          "type": "boolean",
+          "name": "respect_dnt"
+        },
+        {
+          "description": "",
+          "type": "((properties: Properties, event_name: string) => Properties) | null",
+          "name": "sanitize_properties"
+        },
+        {
+          "description": "Determines whether PostHog should save marketing parameters. These are `utm_*` paramaters and friends.",
+          "type": "boolean",
+          "name": "save_campaign_params"
+        },
+        {
+          "description": "Determines whether PostHog should save referrer information.\ntrue",
+          "type": "boolean",
+          "name": "save_referrer"
+        },
+        {
+          "description": "Let the pageview scroll stats use a custom css selector for the root element, e.g. `main` It will use `window.document.documentElement` if not specified.",
+          "type": "string | string[]",
+          "name": "scroll_root_selector"
+        },
+        {
+          "description": "Determines whether PostHog should use secure cookies. If this is `true`, PostHog cookies will be marked as secure, meaning they will only be transmitted over HTTPS.\nwindow.location.protocol === 'https:'",
+          "type": "boolean",
+          "name": "secure_cookie"
+        },
+        {
+          "description": "The segment analytics object.",
+          "type": "SegmentAnalytics",
+          "name": "segment"
+        },
+        {
+          "description": "Determines the session idle timeout in seconds. Any new event that's happened after this timeout will create a new session.\n30 * 60 -- 30 minutes",
+          "type": "number",
+          "name": "session_idle_timeout_seconds"
+        },
+        {
+          "description": "Determines the session recording options.",
+          "type": "SessionRecordingOptions",
+          "name": "session_recording"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "store_google"
+        },
+        {
+          "description": "Sets timeout for fetching surveys\n10000",
+          "type": "number",
+          "name": "surveys_request_timeout_ms"
+        },
+        {
+          "description": "The token for your PostHog project. It should NOT be provided manually in the config, but rather passed as the first parameter to `posthog.init()`.",
+          "type": "string",
+          "name": "token"
+        },
+        {
+          "description": "If using a reverse proxy for `api_host` then this should be the actual PostHog app URL (e.g. https://us.posthog.com). This ensures that links to PostHog point to the correct host.\nnull",
+          "type": "string | null",
+          "name": "ui_host"
+        },
+        {
+          "description": "Determines whether PostHog should upgrade old cookies. If set to `true`, the library will check for a cookie from our old js library and import super properties from it, then the old cookie is deleted. This option only works in the initialization, so make sure you set it when you create the library.\nfalse",
+          "type": "boolean",
+          "name": "upgrade"
+        },
+        {
+          "description": "",
+          "type": "boolean",
+          "name": "verbose"
+        },
+        {
+          "description": "",
+          "type": "{\n        [header_name: string]: string;\n    }",
+          "name": "xhr_headers"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "Properties",
+      "name": "Properties",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "// Properties is a Record<string, Property> \n// Below are PostHog's default properties, you can add your own properties during capture\n{\n    $timestamp: '2024-05-29T17:32:07.202Z',\n    $os: 'Mac OS X',\n    $os_version: '10.15.7',\n    $browser: 'Chrome',\n    $browser_version: '125',\n    $device_type: 'Desktop',\n    $current_url: 'https://example.com/page',\n    $host: 'example.com',\n    $pathname: '/page',\n    $screen_height: 1080,\n    $screen_width: 1920,\n    $viewport_height: 950,\n    $viewport_width: 1903,\n    $lib: 'web',\n    $lib_version: '1.31.0',\n    $search_engine: 'google',\n    $referrer: 'https://google.com',\n    $referring_domain: 'www.google.com',\n    $active_feature_flags: ['beta_feature'],\n    $event_type: 'click',\n    $utm_source: 'newsletter',\n    $utm_medium: 'email',\n    $utm_campaign: 'product_launch',\n    $utm_term: 'new+product',\n    $utm_content: 'logolink',\n    $gclid: 'TeSter-123',\n    $gad_source: 'google_ads',\n    $gclsrc: 'dsa',\n    $dclid: 'testDclid123',\n    $wbraid: 'testWbraid123',\n    $gbraid: 'testGbraid123',\n    $fbclid: 'testFbclid123',\n    $msclkid: 'testMsclkid123',\n    $twclid: 'testTwclid123',\n    $li_fat_id: 'testLiFatId123',\n    $mc_cid: 'testMcCid123',\n    $igshid: 'testIgshid123',\n    $ttclid: 'testTtclid123',\n    $plugins_succeeded: ['GeoIP (56578)'],\n    $plugins_failed: ['plugin3'],\n    $plugins_deferred: ['plugin4'],\n    $ip: '192.168.1.1'\n}"
+    },
+    {
+      "id": "Property",
+      "name": "Property",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "// It can be a string\n\"max@example.com\"\n// It can be an object like field\n{\n    firstName: 'Max',\n    lastName: 'Hog',\n    isAdmin: true,\n}\n"
+    },
+    {
+      "id": "PropertyMatchType",
+      "name": "PropertyMatchType",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"regex\" | \"not_regex\" | \"exact\" | \"is_not\" | \"icontains\" | \"not_icontains\""
+    },
+    {
+      "id": "QueuedRequestWithOptions",
+      "name": "QueuedRequestWithOptions",
+      "properties": [
+        {
+          "description": "key of queue, e.g. 'sessionRecording' vs 'event'",
+          "type": "string",
+          "name": "batchKey"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RageclickConfig",
+      "name": "RageclickConfig",
+      "properties": [
+        {
+          "description": "List of CSS selectors to ignore rageclicks on e.g. ['.my-calendar-button'] we consider the tree of elements from the root to the target element of the click event so for the tree div  div  button  svg and ignore list config `['[id]']` we will ignore the rageclick if the click-target or its parents has any id\nNothing is ignored when there's an empty ignorelist, e.g. [] If no ignorelist is set, we default to ignoring .ph-no-rageclick If an element has .ph-no-capture, it will always be ignored by rageclick and autocapture",
+          "type": "string[]",
+          "name": "css_selector_ignorelist"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RatingSurveyQuestion",
+      "name": "RatingSurveyQuestion",
+      "properties": [
+        {
+          "type": "'number' | 'emoji'",
+          "name": "display"
+        },
+        {
+          "type": "string",
+          "name": "lowerBoundLabel"
+        },
+        {
+          "type": "3 | 5 | 7 | 10",
+          "name": "scale"
+        },
+        {
+          "type": "boolean",
+          "name": "skipSubmitButton"
+        },
+        {
+          "type": "SurveyQuestionType.Rating",
+          "name": "type"
+        },
+        {
+          "type": "string",
+          "name": "upperBoundLabel"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "RemoteConfig",
+      "name": "RemoteConfig",
+      "properties": [
+        {
+          "description": "Whether we should use a custom endpoint for analytics\nendpoint: \"/e\"",
+          "type": "{\n        endpoint?: string;\n    }",
+          "name": "analytics"
+        },
+        {
+          "description": "If set, disables autocapture",
+          "type": "boolean",
+          "name": "autocapture_opt_out"
+        },
+        {
+          "description": "This is currently in development and may have breaking changes without a major version bump",
+          "type": "boolean | {\n        endpoint?: string;\n    }",
+          "name": "autocaptureExceptions"
+        },
+        {
+          "description": "Whether to capture dead clicks",
+          "type": "boolean",
+          "name": "captureDeadClicks"
+        },
+        {
+          "description": "originally capturePerformance was replay only and so boolean true is equivalent to  network_timing: true  now capture performance can be separately enabled within replay and as a standalone web vitals tracker people can have them enabled separately they work standalone but enhance each other TODO: deprecate this so we make a new config that doesn't need this explanation",
+          "type": "boolean | PerformanceCaptureConfig",
+          "name": "capturePerformance"
+        },
+        {
+          "description": "Whether to only capture identified users by default",
+          "type": "boolean",
+          "name": "defaultIdentifiedOnly"
+        },
+        {
+          "description": "",
+          "type": "ToolbarParams",
+          "name": "editorParams"
+        },
+        {
+          "description": "Whether the `$elements_chain` property should be sent as a string or as an array\nfalse",
+          "type": "boolean",
+          "name": "elementsChainAsString"
+        },
+        {
+          "description": "Error tracking configuration options",
+          "type": "{\n        autocaptureExceptions?: boolean;\n        captureExtensionExceptions?: boolean;\n        suppressionRules?: ErrorTrackingSuppressionRule[];\n    }",
+          "name": "errorTracking"
+        },
+        {
+          "description": "Indicates if the team has any flags enabled (if not we don't need to load them)",
+          "type": "boolean",
+          "name": "hasFeatureFlags"
+        },
+        {
+          "description": "Whether heatmaps are enabled",
+          "type": "boolean",
+          "name": "heatmaps"
+        },
+        {
+          "description": "Whether the user is authenticated",
+          "type": "boolean",
+          "name": "isAuthenticated"
+        },
+        {
+          "description": "Session recording configuration options",
+          "type": "SessionRecordingRemoteConfig",
+          "name": "sessionRecording"
+        },
+        {
+          "description": "List of site apps with their IDs and URLs",
+          "type": "{\n        id: string;\n        url: string;\n    }[]",
+          "name": "siteApps"
+        },
+        {
+          "description": "Supported compression algorithms",
+          "type": "Compression[]",
+          "name": "supportedCompression"
+        },
+        {
+          "description": "Whether surveys are enabled",
+          "type": "boolean | Survey[]",
+          "name": "surveys"
+        },
+        {
+          "description": "Parameters for the toolbar",
+          "type": "ToolbarParams",
+          "name": "toolbarParams"
+        },
+        {
+          "description": "deprecated, moved to toolbarParams",
+          "type": "'toolbar'",
+          "name": "toolbarVersion"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RemoteConfigFeatureFlagCallback",
+      "name": "RemoteConfigFeatureFlagCallback",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(payload: JsonType) => void"
+    },
+    {
+      "id": "RequestCallback",
+      "name": "RequestCallback",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(response: RequestResponse) => void"
+    },
+    {
+      "id": "RequestQueueConfig",
+      "name": "RequestQueueConfig",
+      "properties": [
+        {
+          "description": "ADVANCED - alters the frequency which PostHog sends events to the server. generally speaking this is only set when apps have automatic page refreshes, or very short visits. Defaults to 3 seconds when not set Allowed values between 250 and 5000",
+          "type": "number",
+          "name": "flush_interval_ms"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RequestResponse",
+      "name": "RequestResponse",
+      "properties": [
+        {
+          "type": "any",
+          "name": "json"
+        },
+        {
+          "type": "number",
+          "name": "statusCode"
+        },
+        {
+          "type": "string",
+          "name": "text"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RequestWithOptions",
+      "name": "RequestWithOptions",
+      "properties": [
+        {
+          "type": "RequestCallback",
+          "name": "callback"
+        },
+        {
+          "type": "Compression | 'best-available'",
+          "name": "compression"
+        },
+        {
+          "type": "Record<string, any> | Record<string, any>[]",
+          "name": "data"
+        },
+        {
+          "type": "('XHR' | 'fetch' | 'sendBeacon')[]",
+          "name": "disableTransport"
+        },
+        {
+          "type": "boolean",
+          "name": "disableXHRCredentials"
+        },
+        {
+          "type": "{\n        cache?: RequestInit['cache'];\n        next?: NextOptions;\n    }",
+          "name": "fetchOptions"
+        },
+        {
+          "type": "Record<string, any>",
+          "name": "headers"
+        },
+        {
+          "type": "'POST' | 'GET'",
+          "name": "method"
+        },
+        {
+          "type": "boolean",
+          "name": "noRetries"
+        },
+        {
+          "type": "number",
+          "name": "timeout"
+        },
+        {
+          "type": "'XHR' | 'fetch' | 'sendBeacon'",
+          "name": "transport"
+        },
+        {
+          "type": "string",
+          "name": "url"
+        },
+        {
+          "type": "{\n        compression: Compression;\n    }",
+          "name": "urlQueryArgs"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "RetriableRequestWithOptions",
+      "name": "RetriableRequestWithOptions",
+      "properties": [
+        {
+          "type": "number",
+          "name": "retriesPerformedSoFar"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "SessionIdChangedCallback",
+      "name": "SessionIdChangedCallback",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(sessionId: string, windowId: string | null | undefined, changeReason?: {\n    noSessionId: boolean;\n    activityTimeout: boolean;\n    sessionPastMaximumLength: boolean;\n}) => void"
+    },
+    {
+      "id": "SessionRecordingCanvasOptions",
+      "name": "SessionRecordingCanvasOptions",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    recordCanvas?: boolean | null;\n    canvasFps?: number | null;\n    canvasQuality?: string | null;\n}"
+    },
+    {
+      "id": "SessionRecordingOptions",
+      "name": "SessionRecordingOptions",
+      "properties": [
+        {
+          "description": "ADVANCED: alters the bucket size for the token bucket mutation throttling Normally only altered alongside posthog support guidance. Accepts values between 0 and 100\n100",
+          "type": "number",
+          "name": "__mutationThrottlerBucketSize"
+        },
+        {
+          "description": "ADVANCED: alters the refill rate for the token bucket mutation throttling Normally only altered alongside posthog support guidance. Accepts values between 0 and 100\n10",
+          "type": "number",
+          "name": "__mutationThrottlerRefillRate"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "string | RegExp",
+          "name": "blockClass"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "string | null",
+          "name": "blockSelector"
+        },
+        {
+          "description": "Allows local config to override remote canvas recording settings from the flags response",
+          "type": "SessionRecordingCanvasOptions",
+          "name": "captureCanvas"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "boolean",
+          "name": "collectFonts"
+        },
+        {
+          "description": "ADVANCED: whether to partially compress rrweb events before sending them to the server, defaults to true, can be set to false to disable partial compression NB requests are still compressed when sent to the server regardless of this setting\ntrue",
+          "type": "boolean",
+          "name": "compress_events"
+        },
+        {
+          "description": "ADVANCED: while a user is active we take a full snapshot of the browser every interval. For very few sites playback performance might be better with different interval. Set to 0 to disable\n1000 * 60 * 5 (5 minutes)",
+          "type": "number",
+          "name": "full_snapshot_interval_millis"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "string | RegExp",
+          "name": "ignoreClass"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "boolean",
+          "name": "inlineStylesheet"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "boolean",
+          "name": "maskAllInputs"
+        },
+        {
+          "description": "Modify the network request before it is captured. Returning null or undefined stops it being captured",
+          "type": "((data: CapturedNetworkRequest) => CapturedNetworkRequest | null | undefined) | null",
+          "name": "maskCapturedNetworkRequestFn"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "((text: string, element?: HTMLElement) => string) | null",
+          "name": "maskInputFn"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "recordOptions['maskInputOptions']",
+          "name": "maskInputOptions"
+        },
+        {
+          "description": "",
+          "type": "((data: NetworkRequest) => NetworkRequest | null | undefined) | null",
+          "name": "maskNetworkRequestFn"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "string | RegExp",
+          "name": "maskTextClass"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "((text: string, element?: HTMLElement) => string) | null",
+          "name": "maskTextFn"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "string | null",
+          "name": "maskTextSelector"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "boolean",
+          "name": "recordBody"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "boolean",
+          "name": "recordCrossOriginIframes"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "boolean",
+          "name": "recordHeaders"
+        },
+        {
+          "description": "ADVANCED: alters the threshold before a recording considers a user has become idle. Normally only altered alongside changes to session_idle_timeout_ms.\n1000 * 60 * 5 (5 minutes)",
+          "type": "number",
+          "name": "session_idle_threshold_ms"
+        },
+        {
+          "description": "Derived from `rrweb.record` options",
+          "type": "recordOptions['slimDOMOptions']",
+          "name": "slimDOMOptions"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "SessionRecordingPersistedConfig",
+      "name": "SessionRecordingPersistedConfig",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "Omit<SessionRecordingRemoteConfig, 'recordCanvas' | 'canvasFps' | 'canvasQuality' | 'networkPayloadCapture' | 'sampleRate' | 'minimumDurationMilliseconds'> & {\n    enabled: boolean;\n    networkPayloadCapture: SessionRecordingRemoteConfig['networkPayloadCapture'] & {\n        capturePerformance: RemoteConfig['capturePerformance'];\n    };\n    canvasRecording: {\n        enabled: SessionRecordingRemoteConfig['recordCanvas'];\n        fps: SessionRecordingRemoteConfig['canvasFps'];\n        quality: SessionRecordingRemoteConfig['canvasQuality'];\n    };\n    sampleRate: number | null;\n    minimumDurationMilliseconds: number | null | undefined;\n}"
+    },
+    {
+      "id": "SessionRecordingRemoteConfig",
+      "name": "SessionRecordingRemoteConfig",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "SessionRecordingCanvasOptions & {\n    endpoint?: string;\n    consoleLogRecordingEnabled?: boolean;\n    sampleRate?: string | null;\n    minimumDurationMilliseconds?: number;\n    linkedFlag?: string | FlagVariant | null;\n    networkPayloadCapture?: Pick<NetworkRecordOptions, 'recordBody' | 'recordHeaders'>;\n    masking?: Pick<SessionRecordingOptions, 'maskAllInputs' | 'maskTextSelector' | 'blockSelector'>;\n    urlTriggers?: SessionRecordingUrlTrigger[];\n    scriptConfig?: {\n        script?: string | undefined;\n    };\n    urlBlocklist?: SessionRecordingUrlTrigger[];\n    eventTriggers?: string[];\n    triggerMatchType?: 'any' | 'all';\n}"
+    },
+    {
+      "id": "SessionRecordingUrlTrigger",
+      "name": "SessionRecordingUrlTrigger",
+      "properties": [
+        {
+          "type": "'regex'",
+          "name": "matching"
+        },
+        {
+          "type": "string",
+          "name": "url"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "SessionStartReason",
+      "name": "SessionStartReason",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"sampling_overridden\" | \"recording_initialized\" | \"linked_flag_matched\" | \"linked_flag_overridden\" | \"session_id_changed\" | \"url_trigger_matched\" | \"event_trigger_matched\""
+    },
+    {
+      "id": "SeverityLevel",
+      "name": "SeverityLevel",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "(typeof severityLevels)[number]"
+    },
+    {
+      "id": "SiteApp",
+      "name": "SiteApp",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    id: string;\n    loaded: boolean;\n    errored: boolean;\n    processedBuffer: boolean;\n    processEvent?: (globals: SiteAppGlobals) => void;\n}"
+    },
+    {
+      "id": "SiteAppGlobals",
+      "name": "SiteAppGlobals",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    event: {\n        uuid: string;\n        event: EventName;\n        properties: Properties;\n        timestamp?: Date;\n        elements_chain?: string;\n        distinct_id?: string;\n    };\n    person: {\n        properties: Properties;\n    };\n    groups: Record<string, {\n        id: string;\n        type: string;\n        properties: Properties;\n    }>;\n}"
+    },
+    {
+      "id": "SiteAppLoader",
+      "name": "SiteAppLoader",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "{\n    id: string;\n    init: (config: {\n        posthog: PostHog;\n        callback: (success: boolean) => void;\n    }) => {\n        processEvent?: (globals: SiteAppGlobals) => void;\n    };\n}"
+    },
+    {
+      "id": "SnippetArrayItem",
+      "name": "SnippetArrayItem",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "[method: string, ...args: any[]]"
+    },
+    {
+      "id": "SupportedWebVitalsMetrics",
+      "name": "SupportedWebVitalsMetrics",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"LCP\" | \"CLS\" | \"FCP\" | \"INP\""
+    },
+    {
+      "id": "Survey",
+      "name": "Survey",
+      "properties": [
+        {
+          "type": "SurveyAppearance | null",
+          "name": "appearance"
+        },
+        {
+          "type": "{\n        url?: string;\n        selector?: string;\n        seenSurveyWaitPeriodInDays?: number;\n        urlMatchType?: PropertyMatchType;\n        events: {\n            repeatedActivation?: boolean;\n            values: {\n                name: string;\n                propertyFilters?: {\n                    [propertyName: string]: {\n                        values: string[];\n                        operator: PropertyMatchType;\n                    };\n                };\n            }[];\n        } | null;\n        actions: {\n            values: SurveyActionType[];\n        } | null;\n        deviceTypes?: string[];\n        deviceTypesMatchType?: PropertyMatchType;\n        linkedFlagVariant?: string;\n    } | null",
+          "name": "conditions"
+        },
+        {
+          "type": "string | null",
+          "name": "current_iteration_start_date"
+        },
+        {
+          "type": "number | null",
+          "name": "current_iteration"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "boolean | null",
+          "name": "enable_partial_responses"
+        },
+        {
+          "type": "string | null",
+          "name": "end_date"
+        },
+        {
+          "type": "{\n        key: string;\n        value?: string;\n    }[] | null",
+          "name": "feature_flag_keys"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string | null",
+          "name": "internal_targeting_flag_key"
+        },
+        {
+          "type": "string | null",
+          "name": "linked_flag_key"
+        },
+        {
+          "type": "string",
+          "name": "name"
+        },
+        {
+          "type": "SurveyQuestion[]",
+          "name": "questions"
+        },
+        {
+          "type": "SurveySchedule | null",
+          "name": "schedule"
+        },
+        {
+          "type": "string | null",
+          "name": "start_date"
+        },
+        {
+          "type": "string | null",
+          "name": "targeting_flag_key"
+        },
+        {
+          "type": "SurveyType",
+          "name": "type"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyActionType",
+      "name": "SurveyActionType",
+      "properties": [
+        {
+          "type": "number",
+          "name": "id"
+        },
+        {
+          "type": "string | null",
+          "name": "name"
+        },
+        {
+          "type": "ActionStepType[]",
+          "name": "steps"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyAppearance",
+      "name": "SurveyAppearance",
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "autoDisappear"
+        },
+        {
+          "type": "string",
+          "name": "backgroundColor"
+        },
+        {
+          "type": "string",
+          "name": "borderColor"
+        },
+        {
+          "type": "string",
+          "name": "boxPadding"
+        },
+        {
+          "type": "string",
+          "name": "descriptionTextColor"
+        },
+        {
+          "type": "string",
+          "name": "disabledButtonOpacity"
+        },
+        {
+          "type": "boolean",
+          "name": "displayThankYouMessage"
+        },
+        {
+          "type": "string",
+          "name": "fontFamily"
+        },
+        {
+          "type": "string",
+          "name": "maxWidth"
+        },
+        {
+          "type": "string",
+          "name": "placeholder"
+        },
+        {
+          "type": "SurveyPosition",
+          "name": "position"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonActiveColor"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonColor"
+        },
+        {
+          "type": "string",
+          "name": "ratingButtonHoverColor"
+        },
+        {
+          "type": "boolean",
+          "name": "shuffleQuestions"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonColor"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonText"
+        },
+        {
+          "type": "string",
+          "name": "submitButtonTextColor"
+        },
+        {
+          "type": "number",
+          "name": "surveyPopupDelaySeconds"
+        },
+        {
+          "type": "string",
+          "name": "textColor"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageCloseButtonText"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageDescription"
+        },
+        {
+          "type": "SurveyQuestionDescriptionContentType",
+          "name": "thankYouMessageDescriptionContentType"
+        },
+        {
+          "type": "string",
+          "name": "thankYouMessageHeader"
+        },
+        {
+          "type": "boolean",
+          "name": "whiteLabel"
+        },
+        {
+          "type": "string",
+          "name": "widgetColor"
+        },
+        {
+          "type": "string",
+          "name": "widgetLabel"
+        },
+        {
+          "type": "string",
+          "name": "widgetSelector"
+        },
+        {
+          "type": "SurveyWidgetType",
+          "name": "widgetType"
+        },
+        {
+          "type": "string",
+          "name": "zIndex"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyCallback",
+      "name": "SurveyCallback",
+      "properties": [],
+      "path": "lib/src/posthog-surveys-types.d.ts",
+      "example": "(surveys: Survey[], context?: {\n    isLoaded: boolean;\n    error?: string;\n}) => void"
+    },
+    {
+      "id": "SurveyElement",
+      "name": "SurveyElement",
+      "properties": [
+        {
+          "type": "string",
+          "name": "$el_text"
+        },
+        {
+          "type": "string[]",
+          "name": "attr_class"
+        },
+        {
+          "type": "string",
+          "name": "attr_id"
+        },
+        {
+          "type": "Record<string, any>",
+          "name": "attributes"
+        },
+        {
+          "type": "number",
+          "name": "event_id"
+        },
+        {
+          "type": "number",
+          "name": "group_id"
+        },
+        {
+          "type": "string",
+          "name": "href"
+        },
+        {
+          "type": "number",
+          "name": "nth_child"
+        },
+        {
+          "type": "number",
+          "name": "nth_of_type"
+        },
+        {
+          "type": "number",
+          "name": "order"
+        },
+        {
+          "type": "string",
+          "name": "tag_name"
+        },
+        {
+          "type": "string",
+          "name": "text"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyEventName",
+      "name": "SurveyEventName",
+      "properties": [
+        {
+          "type": "\"survey dismissed\"",
+          "name": "DISMISSED"
+        },
+        {
+          "type": "\"survey sent\"",
+          "name": "SENT"
+        },
+        {
+          "type": "\"survey shown\"",
+          "name": "SHOWN"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyEventProperties",
+      "name": "SurveyEventProperties",
+      "properties": [
+        {
+          "type": "\"$survey_completed\"",
+          "name": "SURVEY_COMPLETED"
+        },
+        {
+          "type": "\"$survey_id\"",
+          "name": "SURVEY_ID"
+        },
+        {
+          "type": "\"$survey_iteration\"",
+          "name": "SURVEY_ITERATION"
+        },
+        {
+          "type": "\"$survey_iteration_start_date\"",
+          "name": "SURVEY_ITERATION_START_DATE"
+        },
+        {
+          "type": "\"$survey_name\"",
+          "name": "SURVEY_NAME"
+        },
+        {
+          "type": "\"$survey_partially_completed\"",
+          "name": "SURVEY_PARTIALLY_COMPLETED"
+        },
+        {
+          "type": "\"$survey_questions\"",
+          "name": "SURVEY_QUESTIONS"
+        },
+        {
+          "type": "\"$survey_response\"",
+          "name": "SURVEY_RESPONSE"
+        },
+        {
+          "type": "\"$survey_submission_id\"",
+          "name": "SURVEY_SUBMISSION_ID"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyPosition",
+      "name": "SurveyPosition",
+      "properties": [
+        {
+          "type": "\"center\"",
+          "name": "Center"
+        },
+        {
+          "type": "\"left\"",
+          "name": "Left"
+        },
+        {
+          "type": "\"middle_center\"",
+          "name": "MiddleCenter"
+        },
+        {
+          "type": "\"middle_left\"",
+          "name": "MiddleLeft"
+        },
+        {
+          "type": "\"middle_right\"",
+          "name": "MiddleRight"
+        },
+        {
+          "type": "\"next_to_trigger\"",
+          "name": "NextToTrigger"
+        },
+        {
+          "type": "\"right\"",
+          "name": "Right"
+        },
+        {
+          "type": "\"top_center\"",
+          "name": "TopCenter"
+        },
+        {
+          "type": "\"top_left\"",
+          "name": "TopLeft"
+        },
+        {
+          "type": "\"top_right\"",
+          "name": "TopRight"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyQuestion",
+      "name": "SurveyQuestion",
+      "properties": [],
+      "path": "lib/src/posthog-surveys-types.d.ts",
+      "example": "BasicSurveyQuestion | LinkSurveyQuestion | RatingSurveyQuestion | MultipleSurveyQuestion"
+    },
+    {
+      "id": "SurveyQuestionBranchingType",
+      "name": "SurveyQuestionBranchingType",
+      "properties": [
+        {
+          "type": "\"end\"",
+          "name": "End"
+        },
+        {
+          "type": "\"next_question\"",
+          "name": "NextQuestion"
+        },
+        {
+          "type": "\"response_based\"",
+          "name": "ResponseBased"
+        },
+        {
+          "type": "\"specific_question\"",
+          "name": "SpecificQuestion"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyQuestionDescriptionContentType",
+      "name": "SurveyQuestionDescriptionContentType",
+      "properties": [],
+      "path": "lib/src/posthog-surveys-types.d.ts",
+      "example": "\"html\" | \"text\""
+    },
+    {
+      "id": "SurveyQuestionType",
+      "name": "SurveyQuestionType",
+      "properties": [
+        {
+          "type": "\"link\"",
+          "name": "Link"
+        },
+        {
+          "type": "\"multiple_choice\"",
+          "name": "MultipleChoice"
+        },
+        {
+          "type": "\"open\"",
+          "name": "Open"
+        },
+        {
+          "type": "\"rating\"",
+          "name": "Rating"
+        },
+        {
+          "type": "\"single_choice\"",
+          "name": "SingleChoice"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyRenderReason",
+      "name": "SurveyRenderReason",
+      "properties": [
+        {
+          "type": "string",
+          "name": "disabledReason"
+        },
+        {
+          "type": "boolean",
+          "name": "visible"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveySchedule",
+      "name": "SurveySchedule",
+      "properties": [
+        {
+          "type": "\"always\"",
+          "name": "Always"
+        },
+        {
+          "type": "\"once\"",
+          "name": "Once"
+        },
+        {
+          "type": "\"recurring\"",
+          "name": "Recurring"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyType",
+      "name": "SurveyType",
+      "properties": [
+        {
+          "type": "\"api\"",
+          "name": "API"
+        },
+        {
+          "type": "\"external_survey\"",
+          "name": "ExternalSurvey"
+        },
+        {
+          "type": "\"popover\"",
+          "name": "Popover"
+        },
+        {
+          "type": "\"widget\"",
+          "name": "Widget"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyWidgetType",
+      "name": "SurveyWidgetType",
+      "properties": [
+        {
+          "type": "\"button\"",
+          "name": "Button"
+        },
+        {
+          "type": "\"selector\"",
+          "name": "Selector"
+        },
+        {
+          "type": "\"tab\"",
+          "name": "Tab"
+        }
+      ],
+      "path": "lib/src/posthog-surveys-types.d.ts"
+    },
+    {
+      "id": "SurveyWithTypeAndAppearance",
+      "name": "SurveyWithTypeAndAppearance",
+      "properties": [],
+      "path": "lib/src/posthog-surveys-types.d.ts",
+      "example": "\"id\" | \"type\" | \"appearance\""
+    },
+    {
+      "id": "ToolbarParams",
+      "name": "ToolbarParams",
+      "properties": [
+        {
+          "type": "number",
+          "name": "actionId"
+        },
+        {
+          "type": "string[]",
+          "name": "dataAttributes"
+        },
+        {
+          "type": "string",
+          "name": "distinctId"
+        },
+        {
+          "type": "Record<string, string | boolean>",
+          "name": "featureFlags"
+        },
+        {
+          "type": "boolean",
+          "name": "instrument"
+        },
+        {
+          "type": "ToolbarSource",
+          "name": "source"
+        },
+        {
+          "type": "string",
+          "name": "temporaryToken"
+        },
+        {
+          "type": "string",
+          "name": "token"
+        },
+        {
+          "type": "ToolbarVersion",
+          "name": "toolbarVersion"
+        },
+        {
+          "type": "string",
+          "name": "userEmail"
+        },
+        {
+          "type": "ToolbarUserIntent",
+          "name": "userIntent"
+        }
+      ],
+      "path": "lib/src/types.d.ts"
+    },
+    {
+      "id": "ToolbarSource",
+      "name": "ToolbarSource",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"url\" | \"localstorage\""
+    },
+    {
+      "id": "ToolbarUserIntent",
+      "name": "ToolbarUserIntent",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"add-action\" | \"edit-action\""
+    },
+    {
+      "id": "ToolbarVersion",
+      "name": "ToolbarVersion",
+      "properties": [],
+      "path": "lib/src/types.d.ts",
+      "example": "\"toolbar\""
+    }
+  ],
+  "categories": [
+    "Initialization",
+    "Identification",
+    "Capture",
+    "Surveys",
+    "Error tracking",
+    "LLM analytics",
+    "Privacy",
+    "Session replay",
+    "Feature flags",
+    "Toolbar"
+  ]
+}

--- a/packages/browser/scripts/generate-docs.js
+++ b/packages/browser/scripts/generate-docs.js
@@ -1,11 +1,17 @@
 const path = require('path');
+const fs = require('fs');
 const { generateApiSpecs } = require('../../../scripts/docs/parser');
 const { HOG_REF, PROPERTIES_EXAMPLE, PROPERTY_EXAMPLE } = require('../../../scripts/docs/constants');
+
+// Read package.json to get version
+const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8'));
+const version = packageJson.version;
 
 const config = {
     packageDir: path.resolve(__dirname, '..'),  // packages/browser
     apiJsonPath: path.resolve(__dirname, '../docs/posthog-js.api.json'),
-    outputPath: path.resolve(__dirname, '../docs/posthog-js-references.json'),
+    outputPath: path.resolve(__dirname, `../references/posthog-js-references-${version}.json`),
+    version: version,
     id: 'posthog-js',
     hogRef: HOG_REF,
     specInfo: {
@@ -22,4 +28,19 @@ const config = {
     parentClass: 'PostHog'
 };
 
-generateApiSpecs(config);
+// Ensure references directory exists
+const referencesDir = path.resolve(__dirname, '../references');
+if (!fs.existsSync(referencesDir)) {
+    fs.mkdirSync(referencesDir, { recursive: true });
+}
+
+// Generate versioned file
+const output = generateApiSpecs(config);
+
+// Write versioned file
+const versionedPath = path.resolve(__dirname, `../references/posthog-js-references-${version}.json`);
+fs.writeFileSync(versionedPath, JSON.stringify(output, null, 2));
+
+// Copy to latest file
+const latestPath = path.resolve(__dirname, '../references/posthog-js-references-latest.json');
+fs.writeFileSync(latestPath, JSON.stringify(output, null, 2));

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -17,8 +17,7 @@
     "dev": "rslib build -w",
     "prepublishOnly": "pnpm lint && pnpm test:unit && pnpm build",
     "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz",
-    "gen-specs": "pnpm build && pnpm exec api-extractor run --config ./api-extractor.jsonc --local",
-    "parse-specs": "node scripts/generate-docs.mjs"
+    "generate-references": "pnpm build && pnpm exec api-extractor run --config ./api-extractor.jsonc --local && node scripts/generate-docs.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/packages/node/references/posthog-node-references-5.9.1.json
+++ b/packages/node/references/posthog-node-references-5.9.1.json
@@ -1,0 +1,1221 @@
+{
+  "id": "posthog-node",
+  "hogRef": "0.3",
+  "info": {
+    "version": "5.9.1",
+    "id": "posthog-node",
+    "title": "PostHog Node.js SDK",
+    "description": "PostHog Node.js SDK allows you to capture events and send them to PostHog from your Node.js applications.",
+    "slugPrefix": "posthog-node",
+    "specUrl": "https://github.com/PostHog/posthog-js"
+  },
+  "classes": [
+    {
+      "id": "PostHog",
+      "title": "PostHog",
+      "functions": [
+        {
+          "category": "",
+          "details": null,
+          "id": "getLibraryId",
+          "showDocs": true,
+          "title": "getLibraryId",
+          "examples": [
+            {
+              "id": "getlibraryid",
+              "name": "Generated example for getLibraryId",
+              "code": "// Generated example for getLibraryId\nposthog.getLibraryId();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Initialize a new PostHog client instance.",
+          "details": null,
+          "id": "PostHog",
+          "showDocs": true,
+          "title": "PostHog",
+          "examples": [
+            {
+              "id": "basic_initialization",
+              "name": "Basic initialization",
+              "code": "\n\n// Basic initialization\nconst client = new PostHogBackendClient(\n  'your-api-key',\n  { host: 'https://app.posthog.com' }\n)\n\n\n"
+            },
+            {
+              "id": "with_personal_api_key",
+              "name": "With personal API key",
+              "code": "\n\n// With personal API key\nconst client = new PostHogBackendClient(\n  'your-api-key',\n  {\n    host: 'https://app.posthog.com',\n    personalApiKey: 'your-personal-api-key'\n  }\n)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Your PostHog project API key",
+              "isOptional": false,
+              "type": "string",
+              "name": "apiKey"
+            },
+            {
+              "description": "Configuration options for the client",
+              "isOptional": true,
+              "type": "PostHogOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "any",
+            "name": "any"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Create an alias to link two distinct IDs together.",
+          "details": null,
+          "id": "alias",
+          "showDocs": true,
+          "title": "alias",
+          "examples": [
+            {
+              "id": "link_an_anonymous_user_to_an_identified_user",
+              "name": "Link an anonymous user to an identified user",
+              "code": "\n\n// Link an anonymous user to an identified user\nclient.alias({\n  distinctId: 'anonymous_123',\n  alias: 'user_456'\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The alias data containing distinctId and alias",
+              "isOptional": false,
+              "type": "{\n        distinctId: string;\n        alias: string;\n        disableGeoip?: boolean;\n    }",
+              "name": "data"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Create an alias to link two distinct IDs together immediately (synchronously).",
+          "details": null,
+          "id": "aliasImmediate",
+          "showDocs": true,
+          "title": "aliasImmediate",
+          "examples": [
+            {
+              "id": "link_an_anonymous_user_to_an_identified_user_immediately",
+              "name": "Link an anonymous user to an identified user immediately",
+              "code": "\n\n// Link an anonymous user to an identified user immediately\nawait client.aliasImmediate({\n  distinctId: 'anonymous_123',\n  alias: 'user_456'\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The alias data containing distinctId and alias",
+              "isOptional": false,
+              "type": "{\n        distinctId: string;\n        alias: string;\n        disableGeoip?: boolean;\n    }",
+              "name": "data"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Capture an event manually.",
+          "details": null,
+          "id": "capture",
+          "showDocs": true,
+          "title": "capture",
+          "examples": [
+            {
+              "id": "basic_capture",
+              "name": "Basic capture",
+              "code": "\n\n// Basic capture\nclient.capture({\n  distinctId: 'user_123',\n  event: 'button_clicked',\n  properties: { button_color: 'red' }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The event properties",
+              "isOptional": false,
+              "type": "EventMessage",
+              "name": "props"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Error tracking",
+          "description": "Capture an error exception as an event.",
+          "details": null,
+          "id": "captureException",
+          "showDocs": true,
+          "title": "captureException",
+          "examples": [
+            {
+              "id": "capture_an_error_with_user_id",
+              "name": "Capture an error with user ID",
+              "code": "\n\n// Capture an error with user ID\ntry {\n  // Some risky operation\n  riskyOperation()\n} catch (error) {\n  client.captureException(error, 'user_123')\n}\n\n\n"
+            },
+            {
+              "id": "capture_with_additional_properties",
+              "name": "Capture with additional properties",
+              "code": "\n\n// Capture with additional properties\ntry {\n  apiCall()\n} catch (error) {\n  client.captureException(error, 'user_123', {\n    endpoint: '/api/users',\n    method: 'POST',\n    status_code: 500\n  })\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The error to capture",
+              "isOptional": false,
+              "type": "unknown",
+              "name": "error"
+            },
+            {
+              "description": "Optional user distinct ID",
+              "isOptional": true,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional additional properties to include",
+              "isOptional": true,
+              "type": "Record<string | number, any>",
+              "name": "additionalProperties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Error tracking",
+          "description": "Capture an error exception as an event immediately (synchronously).",
+          "details": null,
+          "id": "captureExceptionImmediate",
+          "showDocs": true,
+          "title": "captureExceptionImmediate",
+          "examples": [
+            {
+              "id": "capture_an_error_immediately_with_user_id",
+              "name": "Capture an error immediately with user ID",
+              "code": "\n\n// Capture an error immediately with user ID\ntry {\n  // Some risky operation\n  riskyOperation()\n} catch (error) {\n  await client.captureExceptionImmediate(error, 'user_123')\n}\n\n\n"
+            },
+            {
+              "id": "capture_with_additional_properties",
+              "name": "Capture with additional properties",
+              "code": "\n\n// Capture with additional properties\ntry {\n  apiCall()\n} catch (error) {\n  await client.captureExceptionImmediate(error, 'user_123', {\n    endpoint: '/api/users',\n    method: 'POST',\n    status_code: 500\n  })\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The error to capture",
+              "isOptional": false,
+              "type": "unknown",
+              "name": "error"
+            },
+            {
+              "description": "Optional user distinct ID",
+              "isOptional": true,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional additional properties to include",
+              "isOptional": true,
+              "type": "Record<string | number, any>",
+              "name": "additionalProperties"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Capture an event immediately (synchronously).",
+          "details": null,
+          "id": "captureImmediate",
+          "showDocs": true,
+          "title": "captureImmediate",
+          "examples": [
+            {
+              "id": "basic_immediate_capture",
+              "name": "Basic immediate capture",
+              "code": "\n\n// Basic immediate capture\nawait client.captureImmediate({\n  distinctId: 'user_123',\n  event: 'button_clicked',\n  properties: { button_color: 'red' }\n})\n\n\n"
+            },
+            {
+              "id": "with_feature_flags",
+              "name": "With feature flags",
+              "code": "\n\n// With feature flags\nawait client.captureImmediate({\n  distinctId: 'user_123',\n  event: 'user_action',\n  sendFeatureFlags: true\n})\n\n\n"
+            },
+            {
+              "id": "with_custom_feature_flags_options",
+              "name": "With custom feature flags options",
+              "code": "\n\n// With custom feature flags options\nawait client.captureImmediate({\n  distinctId: 'user_123',\n  event: 'user_action',\n  sendFeatureFlags: {\n    onlyEvaluateLocally: true,\n    personProperties: { plan: 'premium' },\n    groupProperties: { org: { tier: 'enterprise' } }\n    flagKeys: ['flag1', 'flag2']\n  }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The event properties",
+              "isOptional": false,
+              "type": "EventMessage",
+              "name": "props"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Enable or disable debug logging.",
+          "details": null,
+          "id": "debug",
+          "showDocs": true,
+          "title": "debug",
+          "examples": [
+            {
+              "id": "enable_debug_logging",
+              "name": "Enable debug logging",
+              "code": "\n\n// Enable debug logging\nclient.debug(true)\n\n\n"
+            },
+            {
+              "id": "disable_debug_logging",
+              "name": "Disable debug logging",
+              "code": "\n\n// Disable debug logging\nclient.debug(false)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Whether to enable debug logging",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "enabled"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Disable the PostHog client (opt-out).",
+          "details": null,
+          "id": "disable",
+          "showDocs": true,
+          "title": "disable",
+          "examples": [
+            {
+              "id": "disable_client",
+              "name": "Disable client",
+              "code": "\n\n// Disable client\nawait client.disable()\n// Client is now disabled and will not capture events\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Enable the PostHog client (opt-in).",
+          "details": null,
+          "id": "enable",
+          "showDocs": true,
+          "title": "enable",
+          "examples": [
+            {
+              "id": "enable_client",
+              "name": "Enable client",
+              "code": "\n\n// Enable client\nawait client.enable()\n// Client is now enabled and will capture events\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get all feature flag values for a specific user.",
+          "details": null,
+          "id": "getAllFlags",
+          "showDocs": true,
+          "title": "getAllFlags",
+          "examples": [
+            {
+              "id": "get_all_flags_for_a_user",
+              "name": "Get all flags for a user",
+              "code": "\n\n// Get all flags for a user\nconst allFlags = await client.getAllFlags('user_123')\nconsole.log('User flags:', allFlags)\n// Output: { 'flag-1': 'variant-a', 'flag-2': false, 'flag-3': 'variant-b' }\n\n\n"
+            },
+            {
+              "id": "with_specific_flag_keys",
+              "name": "With specific flag keys",
+              "code": "\n\n// With specific flag keys\nconst specificFlags = await client.getAllFlags('user_123', {\n  flagKeys: ['flag-1', 'flag-2']\n})\n\n\n"
+            },
+            {
+              "id": "with_groups_and_properties",
+              "name": "With groups and properties",
+              "code": "\n\n// With groups and properties\nconst orgFlags = await client.getAllFlags('user_123', {\n  groups: { organization: 'acme-corp' },\n  personProperties: { plan: 'enterprise' }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The user's distinct ID",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional configuration for flag evaluation",
+              "isOptional": true,
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        disableGeoip?: boolean;\n        flagKeys?: string[];\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<Record<string, FeatureFlagValue>>",
+            "name": "Promise<Record<string, FeatureFlagValue>>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get all feature flag values and payloads for a specific user.",
+          "details": null,
+          "id": "getAllFlagsAndPayloads",
+          "showDocs": true,
+          "title": "getAllFlagsAndPayloads",
+          "examples": [
+            {
+              "id": "get_all_flags_and_payloads_for_a_user",
+              "name": "Get all flags and payloads for a user",
+              "code": "\n\n// Get all flags and payloads for a user\nconst result = await client.getAllFlagsAndPayloads('user_123')\nconsole.log('Flags:', result.featureFlags)\nconsole.log('Payloads:', result.featureFlagPayloads)\n\n\n"
+            },
+            {
+              "id": "with_specific_flag_keys",
+              "name": "With specific flag keys",
+              "code": "\n\n// With specific flag keys\nconst result = await client.getAllFlagsAndPayloads('user_123', {\n  flagKeys: ['flag-1', 'flag-2']\n})\n\n\n"
+            },
+            {
+              "id": "only_evaluate_locally",
+              "name": "Only evaluate locally",
+              "code": "\n\n// Only evaluate locally\nconst result = await client.getAllFlagsAndPayloads('user_123', {\n  onlyEvaluateLocally: true\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The user's distinct ID",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional configuration for flag evaluation",
+              "isOptional": true,
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        disableGeoip?: boolean;\n        flagKeys?: string[];\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<PostHogFlagsAndPayloadsResponse>",
+            "name": "Promise<PostHogFlagsAndPayloadsResponse>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Get the custom user agent string for this client.",
+          "details": null,
+          "id": "getCustomUserAgent",
+          "showDocs": true,
+          "title": "getCustomUserAgent",
+          "examples": [
+            {
+              "id": "get_user_agent",
+              "name": "Get user agent",
+              "code": "\n\n// Get user agent\nconst userAgent = client.getCustomUserAgent()\n// Returns: \"posthog-node/5.7.0\"\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get the value of a feature flag for a specific user.",
+          "details": null,
+          "id": "getFeatureFlag",
+          "showDocs": true,
+          "title": "getFeatureFlag",
+          "examples": [
+            {
+              "id": "basic_feature_flag_check",
+              "name": "Basic feature flag check",
+              "code": "\n\n// Basic feature flag check\nconst flagValue = await client.getFeatureFlag('new-feature', 'user_123')\nif (flagValue === 'variant-a') {\n  // Show variant A\n} else if (flagValue === 'variant-b') {\n  // Show variant B\n} else {\n  // Flag is disabled or not found\n}\n\n\n"
+            },
+            {
+              "id": "with_groups_and_properties",
+              "name": "With groups and properties",
+              "code": "\n\n// With groups and properties\nconst flagValue = await client.getFeatureFlag('org-feature', 'user_123', {\n  groups: { organization: 'acme-corp' },\n  personProperties: { plan: 'enterprise' },\n  groupProperties: { organization: { tier: 'premium' } }\n})\n\n\n"
+            },
+            {
+              "id": "only_evaluate_locally",
+              "name": "Only evaluate locally",
+              "code": "\n\n// Only evaluate locally\nconst flagValue = await client.getFeatureFlag('local-flag', 'user_123', {\n  onlyEvaluateLocally: true\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "The user's distinct ID",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional configuration for flag evaluation",
+              "isOptional": true,
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        sendFeatureFlagEvents?: boolean;\n        disableGeoip?: boolean;\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<FeatureFlagValue | undefined>",
+            "name": "Promise<FeatureFlagValue | undefined>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get the payload for a feature flag.",
+          "details": null,
+          "id": "getFeatureFlagPayload",
+          "showDocs": true,
+          "title": "getFeatureFlagPayload",
+          "examples": [
+            {
+              "id": "get_payload_for_a_feature_flag",
+              "name": "Get payload for a feature flag",
+              "code": "\n\n// Get payload for a feature flag\nconst payload = await client.getFeatureFlagPayload('flag-key', 'user_123')\nif (payload) {\n  console.log('Flag payload:', payload)\n}\n\n\n"
+            },
+            {
+              "id": "get_payload_with_specific_match_value",
+              "name": "Get payload with specific match value",
+              "code": "\n\n// Get payload with specific match value\nconst payload = await client.getFeatureFlagPayload('flag-key', 'user_123', 'variant-a')\n\n\n"
+            },
+            {
+              "id": "with_groups_and_properties",
+              "name": "With groups and properties",
+              "code": "\n\n// With groups and properties\nconst payload = await client.getFeatureFlagPayload('org-flag', 'user_123', undefined, {\n  groups: { organization: 'acme-corp' },\n  personProperties: { plan: 'enterprise' }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "The user's distinct ID",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional match value to get payload for",
+              "isOptional": true,
+              "type": "FeatureFlagValue",
+              "name": "matchValue"
+            },
+            {
+              "description": "Optional configuration for flag evaluation",
+              "isOptional": true,
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        sendFeatureFlagEvents?: boolean;\n        disableGeoip?: boolean;\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<JsonType | undefined>",
+            "name": "Promise<JsonType | undefined>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Get the library version from package.json.",
+          "details": null,
+          "id": "getLibraryVersion",
+          "showDocs": true,
+          "title": "getLibraryVersion",
+          "examples": [
+            {
+              "id": "get_version",
+              "name": "Get version",
+              "code": "\n\n// Get version\nconst version = client.getLibraryVersion()\nconsole.log(`Using PostHog SDK version: ${version}`)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Get a persisted property value from memory storage.",
+          "details": null,
+          "id": "getPersistedProperty",
+          "showDocs": true,
+          "title": "getPersistedProperty",
+          "examples": [
+            {
+              "id": "get_user_id",
+              "name": "Get user ID",
+              "code": "\n\n// Get user ID\nconst userId = client.getPersistedProperty('userId')\n\n\n"
+            },
+            {
+              "id": "get_session_id",
+              "name": "Get session ID",
+              "code": "\n\n// Get session ID\nconst sessionId = client.getPersistedProperty('sessionId')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The property key to retrieve",
+              "isOptional": false,
+              "type": "PostHogPersistedProperty",
+              "name": "key"
+            }
+          ],
+          "returnType": {
+            "id": "any | undefined",
+            "name": "any | undefined"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get the remote config payload for a feature flag.",
+          "details": null,
+          "id": "getRemoteConfigPayload",
+          "showDocs": true,
+          "title": "getRemoteConfigPayload",
+          "examples": [
+            {
+              "id": "get_remote_config_payload",
+              "name": "Get remote config payload",
+              "code": "\n\n// Get remote config payload\nconst payload = await client.getRemoteConfigPayload('flag-key')\nif (payload) {\n  console.log('Remote config payload:', payload)\n}\n\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "flagKey"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<JsonType | undefined>",
+            "name": "Promise<JsonType | undefined>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Create or update a group and its properties.",
+          "details": null,
+          "id": "groupIdentify",
+          "showDocs": true,
+          "title": "groupIdentify",
+          "examples": [
+            {
+              "id": "create_a_company_group",
+              "name": "Create a company group",
+              "code": "\n\n// Create a company group\nclient.groupIdentify({\n  groupType: 'company',\n  groupKey: 'acme-corp',\n  properties: {\n    name: 'Acme Corporation',\n    industry: 'Technology',\n    employee_count: 500\n  },\n  distinctId: 'user_123'\n})\n\n\n"
+            },
+            {
+              "id": "update_organization_properties",
+              "name": "Update organization properties",
+              "code": "\n\n// Update organization properties\nclient.groupIdentify({\n  groupType: 'organization',\n  groupKey: 'org-456',\n  properties: {\n    plan: 'enterprise',\n    region: 'US-West'\n  }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "GroupIdentifyMessage",
+              "name": "{ groupType, groupKey, properties, distinctId, disableGeoip }"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Identify a user and set their properties.",
+          "details": null,
+          "id": "identify",
+          "showDocs": true,
+          "title": "identify",
+          "examples": [
+            {
+              "id": "basic_identify_with_properties",
+              "name": "Basic identify with properties",
+              "code": "\n\n// Basic identify with properties\nclient.identify({\n  distinctId: 'user_123',\n  properties: {\n    name: 'John Doe',\n    email: 'john@example.com',\n    plan: 'premium'\n  }\n})\n\n\n"
+            },
+            {
+              "id": "using_$set_and_$set_once",
+              "name": "Using $set and $set_once",
+              "code": "\n\n// Using $set and $set_once\nclient.identify({\n  distinctId: 'user_123',\n  properties: {\n    $set: { name: 'John Doe', email: 'john@example.com' },\n    $set_once: { first_login: new Date().toISOString() }\n  }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "IdentifyMessage",
+              "name": "{ distinctId, properties, disableGeoip }"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Identify a user and set their properties immediately (synchronously).",
+          "details": null,
+          "id": "identifyImmediate",
+          "showDocs": true,
+          "title": "identifyImmediate",
+          "examples": [
+            {
+              "id": "basic_immediate_identify",
+              "name": "Basic immediate identify",
+              "code": "\n\n// Basic immediate identify\nawait client.identifyImmediate({\n  distinctId: 'user_123',\n  properties: {\n    name: 'John Doe',\n    email: 'john@example.com'\n  }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "IdentifyMessage",
+              "name": "{ distinctId, properties, disableGeoip }"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Check if a feature flag is enabled for a specific user.",
+          "details": null,
+          "id": "isFeatureEnabled",
+          "showDocs": true,
+          "title": "isFeatureEnabled",
+          "examples": [
+            {
+              "id": "basic_feature_flag_check",
+              "name": "Basic feature flag check",
+              "code": "\n\n// Basic feature flag check\nconst isEnabled = await client.isFeatureEnabled('new-feature', 'user_123')\nif (isEnabled) {\n  // Feature is enabled\n  console.log('New feature is active')\n} else {\n  // Feature is disabled\n  console.log('New feature is not active')\n}\n\n\n"
+            },
+            {
+              "id": "with_groups_and_properties",
+              "name": "With groups and properties",
+              "code": "\n\n// With groups and properties\nconst isEnabled = await client.isFeatureEnabled('org-feature', 'user_123', {\n  groups: { organization: 'acme-corp' },\n  personProperties: { plan: 'enterprise' }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "The user's distinct ID",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional configuration for flag evaluation",
+              "isOptional": true,
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        sendFeatureFlagEvents?: boolean;\n        disableGeoip?: boolean;\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<boolean | undefined>",
+            "name": "Promise<boolean | undefined>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Check if local evaluation of feature flags is ready.",
+          "details": null,
+          "id": "isLocalEvaluationReady",
+          "showDocs": true,
+          "title": "isLocalEvaluationReady",
+          "examples": [
+            {
+              "id": "check_if_ready",
+              "name": "Check if ready",
+              "code": "\n\n// Check if ready\nif (client.isLocalEvaluationReady()) {\n  // Local evaluation is ready, can evaluate flags locally\n  const flag = await client.getFeatureFlag('flag-key', 'user_123')\n} else {\n  // Local evaluation not ready, will use remote evaluation\n  const flag = await client.getFeatureFlag('flag-key', 'user_123')\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "prepareEventMessage",
+          "showDocs": true,
+          "title": "prepareEventMessage",
+          "examples": [
+            {
+              "id": "prepareeventmessage",
+              "name": "Generated example for prepareEventMessage",
+              "code": "// Generated example for prepareEventMessage\nposthog.prepareEventMessage();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "EventMessage",
+              "name": "props"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<{\n        distinctId: string;\n        event: string;\n        properties: PostHogEventProperties;\n        options: PostHogCaptureOptions;\n    }>",
+            "name": "Promise<{\n        distinctId: string;\n        event: string;\n        properties: PostHogEventProperties;\n        options: PostHogCaptureOptions;\n    }>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Reload feature flag definitions from the server for local evaluation.",
+          "details": null,
+          "id": "reloadFeatureFlags",
+          "showDocs": true,
+          "title": "reloadFeatureFlags",
+          "examples": [
+            {
+              "id": "force_reload_of_feature_flags",
+              "name": "Force reload of feature flags",
+              "code": "\n\n// Force reload of feature flags\nawait client.reloadFeatureFlags()\nconsole.log('Feature flags reloaded')\n\n\n"
+            },
+            {
+              "id": "reload_before_checking_a_specific_flag",
+              "name": "Reload before checking a specific flag",
+              "code": "\n\n// Reload before checking a specific flag\nawait client.reloadFeatureFlags()\nconst flag = await client.getFeatureFlag('flag-key', 'user_123')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Set a persisted property value in memory storage.",
+          "details": null,
+          "id": "setPersistedProperty",
+          "showDocs": true,
+          "title": "setPersistedProperty",
+          "examples": [
+            {
+              "id": "set_user_id",
+              "name": "Set user ID",
+              "code": "\n\n// Set user ID\nclient.setPersistedProperty('userId', 'user_123')\n\n\n"
+            },
+            {
+              "id": "set_session_id",
+              "name": "Set session ID",
+              "code": "\n\n// Set session ID\nclient.setPersistedProperty('sessionId', 'session_456')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The property key to set",
+              "isOptional": false,
+              "type": "PostHogPersistedProperty",
+              "name": "key"
+            },
+            {
+              "description": "The value to store (null to remove)",
+              "isOptional": false,
+              "type": "any | null",
+              "name": "value"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Wait for local evaluation of feature flags to be ready.",
+          "details": null,
+          "id": "waitForLocalEvaluationReady",
+          "showDocs": true,
+          "title": "waitForLocalEvaluationReady",
+          "examples": [
+            {
+              "id": "wait_for_local_evaluation",
+              "name": "Wait for local evaluation",
+              "code": "\n\n// Wait for local evaluation\nconst isReady = await client.waitForLocalEvaluationReady()\nif (isReady) {\n  console.log('Local evaluation is ready')\n} else {\n  console.log('Local evaluation timed out')\n}\n\n\n"
+            },
+            {
+              "id": "wait_with_custom_timeout",
+              "name": "Wait with custom timeout",
+              "code": "\n\n// Wait with custom timeout\nconst isReady = await client.waitForLocalEvaluationReady(10000) // 10 seconds\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Timeout in milliseconds (default: 30000)",
+              "isOptional": true,
+              "type": "number",
+              "name": "timeoutMs"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<boolean>",
+            "name": "Promise<boolean>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        }
+      ]
+    }
+  ],
+  "types": [
+    {
+      "id": "_SentryEvent",
+      "name": "_SentryEvent",
+      "properties": [],
+      "path": "src/extensions/sentry-integration.ts"
+    },
+    {
+      "id": "_SentryEventProcessor",
+      "name": "_SentryEventProcessor",
+      "properties": [],
+      "path": "src/extensions/sentry-integration.ts"
+    },
+    {
+      "id": "_SentryHub",
+      "name": "_SentryHub",
+      "properties": [],
+      "path": "src/extensions/sentry-integration.ts"
+    },
+    {
+      "id": "_SentryIntegration",
+      "name": "_SentryIntegration",
+      "properties": [
+        {
+          "type": "string",
+          "name": "name"
+        }
+      ],
+      "path": "src/extensions/sentry-integration.ts"
+    },
+    {
+      "id": "_SentryIntegrationClass",
+      "name": "_SentryIntegrationClass",
+      "properties": [
+        {
+          "type": "string",
+          "name": "name"
+        }
+      ],
+      "path": "src/extensions/sentry-integration.ts"
+    },
+    {
+      "id": "BeforeSendFn",
+      "name": "BeforeSendFn",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "(event: EventMessage | null) => EventMessage | null"
+    },
+    {
+      "id": "EventMessage",
+      "name": "EventMessage",
+      "properties": [
+        {
+          "type": "string",
+          "name": "event"
+        },
+        {
+          "type": "Record<string, string | number>",
+          "name": "groups"
+        },
+        {
+          "type": "boolean | SendFeatureFlagsOptions",
+          "name": "sendFeatureFlags"
+        },
+        {
+          "type": "Date",
+          "name": "timestamp"
+        },
+        {
+          "type": "string",
+          "name": "uuid"
+        }
+      ],
+      "path": "src/types.ts"
+    },
+    {
+      "id": "ExpressErrorMiddleware",
+      "name": "ExpressErrorMiddleware",
+      "properties": [],
+      "path": "src/extensions/express.ts",
+      "example": "(error: MiddlewareError, req: http.IncomingMessage, res: http.ServerResponse, next: (error: MiddlewareError) => void) => void"
+    },
+    {
+      "id": "ExpressMiddleware",
+      "name": "ExpressMiddleware",
+      "properties": [],
+      "path": "src/extensions/express.ts",
+      "example": "(req: http.IncomingMessage, res: http.ServerResponse, next: () => void) => void"
+    },
+    {
+      "id": "FeatureFlagCondition",
+      "name": "FeatureFlagCondition",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "{\n    properties: FlagProperty[];\n    rollout_percentage?: number;\n    variant?: string;\n}"
+    },
+    {
+      "id": "FlagProperty",
+      "name": "FlagProperty",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "{\n    key: string;\n    type?: string;\n    value: FlagPropertyValue;\n    operator?: string;\n    negation?: boolean;\n    dependency_chain?: string[];\n}"
+    },
+    {
+      "id": "FlagPropertyValue",
+      "name": "FlagPropertyValue",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "string | number | (string | number)[] | boolean"
+    },
+    {
+      "id": "GroupIdentifyMessage",
+      "name": "GroupIdentifyMessage",
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "disableGeoip"
+        },
+        {
+          "type": "string",
+          "name": "distinctId"
+        },
+        {
+          "type": "string",
+          "name": "groupKey"
+        },
+        {
+          "type": "string",
+          "name": "groupType"
+        },
+        {
+          "type": "Record<string | number, any>",
+          "name": "properties"
+        }
+      ],
+      "path": "src/types.ts"
+    },
+    {
+      "id": "IdentifyMessage",
+      "name": "IdentifyMessage",
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "disableGeoip"
+        },
+        {
+          "type": "string",
+          "name": "distinctId"
+        },
+        {
+          "type": "Record<string | number, any>",
+          "name": "properties"
+        }
+      ],
+      "path": "src/types.ts"
+    },
+    {
+      "id": "IPostHog",
+      "name": "IPostHog",
+      "properties": [],
+      "path": "src/types.ts"
+    },
+    {
+      "id": "MiddlewareError",
+      "name": "MiddlewareError",
+      "properties": [
+        {
+          "type": "{\n        statusCode?: number | string;\n    }",
+          "name": "output"
+        },
+        {
+          "type": "number | string",
+          "name": "status_code"
+        },
+        {
+          "type": "number | string",
+          "name": "status"
+        },
+        {
+          "type": "number | string",
+          "name": "statusCode"
+        }
+      ],
+      "path": "src/extensions/express.ts"
+    },
+    {
+      "id": "PostHogFeatureFlag",
+      "name": "PostHogFeatureFlag",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "{\n    id: number;\n    name: string;\n    key: string;\n    filters?: {\n        aggregation_group_type_index?: number;\n        groups?: FeatureFlagCondition[];\n        multivariate?: {\n            variants: {\n                key: string;\n                rollout_percentage: number;\n            }[];\n        };\n        payloads?: Record<string, string>;\n    };\n    deleted: boolean;\n    active: boolean;\n    rollout_percentage: null | number;\n    ensure_experience_continuity: boolean;\n    experiment_set: number[];\n}"
+    },
+    {
+      "id": "PostHogOptions",
+      "name": "PostHogOptions",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "PostHogCoreOptions & {\n    persistence?: 'memory';\n    personalApiKey?: string;\n    privacyMode?: boolean;\n    enableExceptionAutocapture?: boolean;\n    featureFlagsPollingInterval?: number;\n    maxCacheSize?: number;\n    fetch?: (url: string, options: PostHogFetchOptions) => Promise<PostHogFetchResponse>;\n    enableLocalEvaluation?: boolean;\n    before_send?: BeforeSendFn | BeforeSendFn[];\n}"
+    },
+    {
+      "id": "PropertyGroup",
+      "name": "PropertyGroup",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "{\n    type: 'AND' | 'OR';\n    values: PropertyGroup[] | FlagProperty[];\n}"
+    },
+    {
+      "id": "SendFeatureFlagsOptions",
+      "name": "SendFeatureFlagsOptions",
+      "properties": [
+        {
+          "type": "string[]",
+          "name": "flagKeys"
+        },
+        {
+          "type": "Record<string, Record<string, any>>",
+          "name": "groupProperties"
+        },
+        {
+          "type": "boolean",
+          "name": "onlyEvaluateLocally"
+        },
+        {
+          "type": "Record<string, any>",
+          "name": "personProperties"
+        }
+      ],
+      "path": "src/types.ts"
+    },
+    {
+      "id": "SentryIntegrationOptions",
+      "name": "SentryIntegrationOptions",
+      "properties": [],
+      "path": "src/extensions/sentry-integration.ts",
+      "example": "{\n    organization?: string;\n    projectId?: number;\n    prefix?: string;\n    severityAllowList?: CoreErrorTracking.SeverityLevel[] | '*';\n    sendExceptionsToPostHog?: boolean;\n}"
+    }
+  ],
+  "categories": [
+    "Initialization",
+    "Identification",
+    "Capture",
+    "Error tracking",
+    "Privacy",
+    "Feature flags"
+  ]
+}

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -1,0 +1,1221 @@
+{
+  "id": "posthog-node",
+  "hogRef": "0.3",
+  "info": {
+    "version": "5.9.1",
+    "id": "posthog-node",
+    "title": "PostHog Node.js SDK",
+    "description": "PostHog Node.js SDK allows you to capture events and send them to PostHog from your Node.js applications.",
+    "slugPrefix": "posthog-node",
+    "specUrl": "https://github.com/PostHog/posthog-js"
+  },
+  "classes": [
+    {
+      "id": "PostHog",
+      "title": "PostHog",
+      "functions": [
+        {
+          "category": "",
+          "details": null,
+          "id": "getLibraryId",
+          "showDocs": true,
+          "title": "getLibraryId",
+          "examples": [
+            {
+              "id": "getlibraryid",
+              "name": "Generated example for getLibraryId",
+              "code": "// Generated example for getLibraryId\nposthog.getLibraryId();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Initialize a new PostHog client instance.",
+          "details": null,
+          "id": "PostHog",
+          "showDocs": true,
+          "title": "PostHog",
+          "examples": [
+            {
+              "id": "basic_initialization",
+              "name": "Basic initialization",
+              "code": "\n\n// Basic initialization\nconst client = new PostHogBackendClient(\n  'your-api-key',\n  { host: 'https://app.posthog.com' }\n)\n\n\n"
+            },
+            {
+              "id": "with_personal_api_key",
+              "name": "With personal API key",
+              "code": "\n\n// With personal API key\nconst client = new PostHogBackendClient(\n  'your-api-key',\n  {\n    host: 'https://app.posthog.com',\n    personalApiKey: 'your-personal-api-key'\n  }\n)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Your PostHog project API key",
+              "isOptional": false,
+              "type": "string",
+              "name": "apiKey"
+            },
+            {
+              "description": "Configuration options for the client",
+              "isOptional": true,
+              "type": "PostHogOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "any",
+            "name": "any"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Create an alias to link two distinct IDs together.",
+          "details": null,
+          "id": "alias",
+          "showDocs": true,
+          "title": "alias",
+          "examples": [
+            {
+              "id": "link_an_anonymous_user_to_an_identified_user",
+              "name": "Link an anonymous user to an identified user",
+              "code": "\n\n// Link an anonymous user to an identified user\nclient.alias({\n  distinctId: 'anonymous_123',\n  alias: 'user_456'\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The alias data containing distinctId and alias",
+              "isOptional": false,
+              "type": "{\n        distinctId: string;\n        alias: string;\n        disableGeoip?: boolean;\n    }",
+              "name": "data"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Create an alias to link two distinct IDs together immediately (synchronously).",
+          "details": null,
+          "id": "aliasImmediate",
+          "showDocs": true,
+          "title": "aliasImmediate",
+          "examples": [
+            {
+              "id": "link_an_anonymous_user_to_an_identified_user_immediately",
+              "name": "Link an anonymous user to an identified user immediately",
+              "code": "\n\n// Link an anonymous user to an identified user immediately\nawait client.aliasImmediate({\n  distinctId: 'anonymous_123',\n  alias: 'user_456'\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The alias data containing distinctId and alias",
+              "isOptional": false,
+              "type": "{\n        distinctId: string;\n        alias: string;\n        disableGeoip?: boolean;\n    }",
+              "name": "data"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Capture an event manually.",
+          "details": null,
+          "id": "capture",
+          "showDocs": true,
+          "title": "capture",
+          "examples": [
+            {
+              "id": "basic_capture",
+              "name": "Basic capture",
+              "code": "\n\n// Basic capture\nclient.capture({\n  distinctId: 'user_123',\n  event: 'button_clicked',\n  properties: { button_color: 'red' }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The event properties",
+              "isOptional": false,
+              "type": "EventMessage",
+              "name": "props"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Error tracking",
+          "description": "Capture an error exception as an event.",
+          "details": null,
+          "id": "captureException",
+          "showDocs": true,
+          "title": "captureException",
+          "examples": [
+            {
+              "id": "capture_an_error_with_user_id",
+              "name": "Capture an error with user ID",
+              "code": "\n\n// Capture an error with user ID\ntry {\n  // Some risky operation\n  riskyOperation()\n} catch (error) {\n  client.captureException(error, 'user_123')\n}\n\n\n"
+            },
+            {
+              "id": "capture_with_additional_properties",
+              "name": "Capture with additional properties",
+              "code": "\n\n// Capture with additional properties\ntry {\n  apiCall()\n} catch (error) {\n  client.captureException(error, 'user_123', {\n    endpoint: '/api/users',\n    method: 'POST',\n    status_code: 500\n  })\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The error to capture",
+              "isOptional": false,
+              "type": "unknown",
+              "name": "error"
+            },
+            {
+              "description": "Optional user distinct ID",
+              "isOptional": true,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional additional properties to include",
+              "isOptional": true,
+              "type": "Record<string | number, any>",
+              "name": "additionalProperties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Error tracking",
+          "description": "Capture an error exception as an event immediately (synchronously).",
+          "details": null,
+          "id": "captureExceptionImmediate",
+          "showDocs": true,
+          "title": "captureExceptionImmediate",
+          "examples": [
+            {
+              "id": "capture_an_error_immediately_with_user_id",
+              "name": "Capture an error immediately with user ID",
+              "code": "\n\n// Capture an error immediately with user ID\ntry {\n  // Some risky operation\n  riskyOperation()\n} catch (error) {\n  await client.captureExceptionImmediate(error, 'user_123')\n}\n\n\n"
+            },
+            {
+              "id": "capture_with_additional_properties",
+              "name": "Capture with additional properties",
+              "code": "\n\n// Capture with additional properties\ntry {\n  apiCall()\n} catch (error) {\n  await client.captureExceptionImmediate(error, 'user_123', {\n    endpoint: '/api/users',\n    method: 'POST',\n    status_code: 500\n  })\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The error to capture",
+              "isOptional": false,
+              "type": "unknown",
+              "name": "error"
+            },
+            {
+              "description": "Optional user distinct ID",
+              "isOptional": true,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional additional properties to include",
+              "isOptional": true,
+              "type": "Record<string | number, any>",
+              "name": "additionalProperties"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Capture an event immediately (synchronously).",
+          "details": null,
+          "id": "captureImmediate",
+          "showDocs": true,
+          "title": "captureImmediate",
+          "examples": [
+            {
+              "id": "basic_immediate_capture",
+              "name": "Basic immediate capture",
+              "code": "\n\n// Basic immediate capture\nawait client.captureImmediate({\n  distinctId: 'user_123',\n  event: 'button_clicked',\n  properties: { button_color: 'red' }\n})\n\n\n"
+            },
+            {
+              "id": "with_feature_flags",
+              "name": "With feature flags",
+              "code": "\n\n// With feature flags\nawait client.captureImmediate({\n  distinctId: 'user_123',\n  event: 'user_action',\n  sendFeatureFlags: true\n})\n\n\n"
+            },
+            {
+              "id": "with_custom_feature_flags_options",
+              "name": "With custom feature flags options",
+              "code": "\n\n// With custom feature flags options\nawait client.captureImmediate({\n  distinctId: 'user_123',\n  event: 'user_action',\n  sendFeatureFlags: {\n    onlyEvaluateLocally: true,\n    personProperties: { plan: 'premium' },\n    groupProperties: { org: { tier: 'enterprise' } }\n    flagKeys: ['flag1', 'flag2']\n  }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The event properties",
+              "isOptional": false,
+              "type": "EventMessage",
+              "name": "props"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Enable or disable debug logging.",
+          "details": null,
+          "id": "debug",
+          "showDocs": true,
+          "title": "debug",
+          "examples": [
+            {
+              "id": "enable_debug_logging",
+              "name": "Enable debug logging",
+              "code": "\n\n// Enable debug logging\nclient.debug(true)\n\n\n"
+            },
+            {
+              "id": "disable_debug_logging",
+              "name": "Disable debug logging",
+              "code": "\n\n// Disable debug logging\nclient.debug(false)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Whether to enable debug logging",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "enabled"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Disable the PostHog client (opt-out).",
+          "details": null,
+          "id": "disable",
+          "showDocs": true,
+          "title": "disable",
+          "examples": [
+            {
+              "id": "disable_client",
+              "name": "Disable client",
+              "code": "\n\n// Disable client\nawait client.disable()\n// Client is now disabled and will not capture events\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Enable the PostHog client (opt-in).",
+          "details": null,
+          "id": "enable",
+          "showDocs": true,
+          "title": "enable",
+          "examples": [
+            {
+              "id": "enable_client",
+              "name": "Enable client",
+              "code": "\n\n// Enable client\nawait client.enable()\n// Client is now enabled and will capture events\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get all feature flag values for a specific user.",
+          "details": null,
+          "id": "getAllFlags",
+          "showDocs": true,
+          "title": "getAllFlags",
+          "examples": [
+            {
+              "id": "get_all_flags_for_a_user",
+              "name": "Get all flags for a user",
+              "code": "\n\n// Get all flags for a user\nconst allFlags = await client.getAllFlags('user_123')\nconsole.log('User flags:', allFlags)\n// Output: { 'flag-1': 'variant-a', 'flag-2': false, 'flag-3': 'variant-b' }\n\n\n"
+            },
+            {
+              "id": "with_specific_flag_keys",
+              "name": "With specific flag keys",
+              "code": "\n\n// With specific flag keys\nconst specificFlags = await client.getAllFlags('user_123', {\n  flagKeys: ['flag-1', 'flag-2']\n})\n\n\n"
+            },
+            {
+              "id": "with_groups_and_properties",
+              "name": "With groups and properties",
+              "code": "\n\n// With groups and properties\nconst orgFlags = await client.getAllFlags('user_123', {\n  groups: { organization: 'acme-corp' },\n  personProperties: { plan: 'enterprise' }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The user's distinct ID",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional configuration for flag evaluation",
+              "isOptional": true,
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        disableGeoip?: boolean;\n        flagKeys?: string[];\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<Record<string, FeatureFlagValue>>",
+            "name": "Promise<Record<string, FeatureFlagValue>>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get all feature flag values and payloads for a specific user.",
+          "details": null,
+          "id": "getAllFlagsAndPayloads",
+          "showDocs": true,
+          "title": "getAllFlagsAndPayloads",
+          "examples": [
+            {
+              "id": "get_all_flags_and_payloads_for_a_user",
+              "name": "Get all flags and payloads for a user",
+              "code": "\n\n// Get all flags and payloads for a user\nconst result = await client.getAllFlagsAndPayloads('user_123')\nconsole.log('Flags:', result.featureFlags)\nconsole.log('Payloads:', result.featureFlagPayloads)\n\n\n"
+            },
+            {
+              "id": "with_specific_flag_keys",
+              "name": "With specific flag keys",
+              "code": "\n\n// With specific flag keys\nconst result = await client.getAllFlagsAndPayloads('user_123', {\n  flagKeys: ['flag-1', 'flag-2']\n})\n\n\n"
+            },
+            {
+              "id": "only_evaluate_locally",
+              "name": "Only evaluate locally",
+              "code": "\n\n// Only evaluate locally\nconst result = await client.getAllFlagsAndPayloads('user_123', {\n  onlyEvaluateLocally: true\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The user's distinct ID",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional configuration for flag evaluation",
+              "isOptional": true,
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        disableGeoip?: boolean;\n        flagKeys?: string[];\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<PostHogFlagsAndPayloadsResponse>",
+            "name": "Promise<PostHogFlagsAndPayloadsResponse>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Get the custom user agent string for this client.",
+          "details": null,
+          "id": "getCustomUserAgent",
+          "showDocs": true,
+          "title": "getCustomUserAgent",
+          "examples": [
+            {
+              "id": "get_user_agent",
+              "name": "Get user agent",
+              "code": "\n\n// Get user agent\nconst userAgent = client.getCustomUserAgent()\n// Returns: \"posthog-node/5.7.0\"\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get the value of a feature flag for a specific user.",
+          "details": null,
+          "id": "getFeatureFlag",
+          "showDocs": true,
+          "title": "getFeatureFlag",
+          "examples": [
+            {
+              "id": "basic_feature_flag_check",
+              "name": "Basic feature flag check",
+              "code": "\n\n// Basic feature flag check\nconst flagValue = await client.getFeatureFlag('new-feature', 'user_123')\nif (flagValue === 'variant-a') {\n  // Show variant A\n} else if (flagValue === 'variant-b') {\n  // Show variant B\n} else {\n  // Flag is disabled or not found\n}\n\n\n"
+            },
+            {
+              "id": "with_groups_and_properties",
+              "name": "With groups and properties",
+              "code": "\n\n// With groups and properties\nconst flagValue = await client.getFeatureFlag('org-feature', 'user_123', {\n  groups: { organization: 'acme-corp' },\n  personProperties: { plan: 'enterprise' },\n  groupProperties: { organization: { tier: 'premium' } }\n})\n\n\n"
+            },
+            {
+              "id": "only_evaluate_locally",
+              "name": "Only evaluate locally",
+              "code": "\n\n// Only evaluate locally\nconst flagValue = await client.getFeatureFlag('local-flag', 'user_123', {\n  onlyEvaluateLocally: true\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "The user's distinct ID",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional configuration for flag evaluation",
+              "isOptional": true,
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        sendFeatureFlagEvents?: boolean;\n        disableGeoip?: boolean;\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<FeatureFlagValue | undefined>",
+            "name": "Promise<FeatureFlagValue | undefined>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get the payload for a feature flag.",
+          "details": null,
+          "id": "getFeatureFlagPayload",
+          "showDocs": true,
+          "title": "getFeatureFlagPayload",
+          "examples": [
+            {
+              "id": "get_payload_for_a_feature_flag",
+              "name": "Get payload for a feature flag",
+              "code": "\n\n// Get payload for a feature flag\nconst payload = await client.getFeatureFlagPayload('flag-key', 'user_123')\nif (payload) {\n  console.log('Flag payload:', payload)\n}\n\n\n"
+            },
+            {
+              "id": "get_payload_with_specific_match_value",
+              "name": "Get payload with specific match value",
+              "code": "\n\n// Get payload with specific match value\nconst payload = await client.getFeatureFlagPayload('flag-key', 'user_123', 'variant-a')\n\n\n"
+            },
+            {
+              "id": "with_groups_and_properties",
+              "name": "With groups and properties",
+              "code": "\n\n// With groups and properties\nconst payload = await client.getFeatureFlagPayload('org-flag', 'user_123', undefined, {\n  groups: { organization: 'acme-corp' },\n  personProperties: { plan: 'enterprise' }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "The user's distinct ID",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional match value to get payload for",
+              "isOptional": true,
+              "type": "FeatureFlagValue",
+              "name": "matchValue"
+            },
+            {
+              "description": "Optional configuration for flag evaluation",
+              "isOptional": true,
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        sendFeatureFlagEvents?: boolean;\n        disableGeoip?: boolean;\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<JsonType | undefined>",
+            "name": "Promise<JsonType | undefined>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Get the library version from package.json.",
+          "details": null,
+          "id": "getLibraryVersion",
+          "showDocs": true,
+          "title": "getLibraryVersion",
+          "examples": [
+            {
+              "id": "get_version",
+              "name": "Get version",
+              "code": "\n\n// Get version\nconst version = client.getLibraryVersion()\nconsole.log(`Using PostHog SDK version: ${version}`)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Get a persisted property value from memory storage.",
+          "details": null,
+          "id": "getPersistedProperty",
+          "showDocs": true,
+          "title": "getPersistedProperty",
+          "examples": [
+            {
+              "id": "get_user_id",
+              "name": "Get user ID",
+              "code": "\n\n// Get user ID\nconst userId = client.getPersistedProperty('userId')\n\n\n"
+            },
+            {
+              "id": "get_session_id",
+              "name": "Get session ID",
+              "code": "\n\n// Get session ID\nconst sessionId = client.getPersistedProperty('sessionId')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The property key to retrieve",
+              "isOptional": false,
+              "type": "PostHogPersistedProperty",
+              "name": "key"
+            }
+          ],
+          "returnType": {
+            "id": "any | undefined",
+            "name": "any | undefined"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Get the remote config payload for a feature flag.",
+          "details": null,
+          "id": "getRemoteConfigPayload",
+          "showDocs": true,
+          "title": "getRemoteConfigPayload",
+          "examples": [
+            {
+              "id": "get_remote_config_payload",
+              "name": "Get remote config payload",
+              "code": "\n\n// Get remote config payload\nconst payload = await client.getRemoteConfigPayload('flag-key')\nif (payload) {\n  console.log('Remote config payload:', payload)\n}\n\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "flagKey"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<JsonType | undefined>",
+            "name": "Promise<JsonType | undefined>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Create or update a group and its properties.",
+          "details": null,
+          "id": "groupIdentify",
+          "showDocs": true,
+          "title": "groupIdentify",
+          "examples": [
+            {
+              "id": "create_a_company_group",
+              "name": "Create a company group",
+              "code": "\n\n// Create a company group\nclient.groupIdentify({\n  groupType: 'company',\n  groupKey: 'acme-corp',\n  properties: {\n    name: 'Acme Corporation',\n    industry: 'Technology',\n    employee_count: 500\n  },\n  distinctId: 'user_123'\n})\n\n\n"
+            },
+            {
+              "id": "update_organization_properties",
+              "name": "Update organization properties",
+              "code": "\n\n// Update organization properties\nclient.groupIdentify({\n  groupType: 'organization',\n  groupKey: 'org-456',\n  properties: {\n    plan: 'enterprise',\n    region: 'US-West'\n  }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "GroupIdentifyMessage",
+              "name": "{ groupType, groupKey, properties, distinctId, disableGeoip }"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Identify a user and set their properties.",
+          "details": null,
+          "id": "identify",
+          "showDocs": true,
+          "title": "identify",
+          "examples": [
+            {
+              "id": "basic_identify_with_properties",
+              "name": "Basic identify with properties",
+              "code": "\n\n// Basic identify with properties\nclient.identify({\n  distinctId: 'user_123',\n  properties: {\n    name: 'John Doe',\n    email: 'john@example.com',\n    plan: 'premium'\n  }\n})\n\n\n"
+            },
+            {
+              "id": "using_$set_and_$set_once",
+              "name": "Using $set and $set_once",
+              "code": "\n\n// Using $set and $set_once\nclient.identify({\n  distinctId: 'user_123',\n  properties: {\n    $set: { name: 'John Doe', email: 'john@example.com' },\n    $set_once: { first_login: new Date().toISOString() }\n  }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "IdentifyMessage",
+              "name": "{ distinctId, properties, disableGeoip }"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Identify a user and set their properties immediately (synchronously).",
+          "details": null,
+          "id": "identifyImmediate",
+          "showDocs": true,
+          "title": "identifyImmediate",
+          "examples": [
+            {
+              "id": "basic_immediate_identify",
+              "name": "Basic immediate identify",
+              "code": "\n\n// Basic immediate identify\nawait client.identifyImmediate({\n  distinctId: 'user_123',\n  properties: {\n    name: 'John Doe',\n    email: 'john@example.com'\n  }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "IdentifyMessage",
+              "name": "{ distinctId, properties, disableGeoip }"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Check if a feature flag is enabled for a specific user.",
+          "details": null,
+          "id": "isFeatureEnabled",
+          "showDocs": true,
+          "title": "isFeatureEnabled",
+          "examples": [
+            {
+              "id": "basic_feature_flag_check",
+              "name": "Basic feature flag check",
+              "code": "\n\n// Basic feature flag check\nconst isEnabled = await client.isFeatureEnabled('new-feature', 'user_123')\nif (isEnabled) {\n  // Feature is enabled\n  console.log('New feature is active')\n} else {\n  // Feature is disabled\n  console.log('New feature is not active')\n}\n\n\n"
+            },
+            {
+              "id": "with_groups_and_properties",
+              "name": "With groups and properties",
+              "code": "\n\n// With groups and properties\nconst isEnabled = await client.isFeatureEnabled('org-feature', 'user_123', {\n  groups: { organization: 'acme-corp' },\n  personProperties: { plan: 'enterprise' }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "The user's distinct ID",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional configuration for flag evaluation",
+              "isOptional": true,
+              "type": "{\n        groups?: Record<string, string>;\n        personProperties?: Record<string, string>;\n        groupProperties?: Record<string, Record<string, string>>;\n        onlyEvaluateLocally?: boolean;\n        sendFeatureFlagEvents?: boolean;\n        disableGeoip?: boolean;\n    }",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<boolean | undefined>",
+            "name": "Promise<boolean | undefined>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Check if local evaluation of feature flags is ready.",
+          "details": null,
+          "id": "isLocalEvaluationReady",
+          "showDocs": true,
+          "title": "isLocalEvaluationReady",
+          "examples": [
+            {
+              "id": "check_if_ready",
+              "name": "Check if ready",
+              "code": "\n\n// Check if ready\nif (client.isLocalEvaluationReady()) {\n  // Local evaluation is ready, can evaluate flags locally\n  const flag = await client.getFeatureFlag('flag-key', 'user_123')\n} else {\n  // Local evaluation not ready, will use remote evaluation\n  const flag = await client.getFeatureFlag('flag-key', 'user_123')\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "prepareEventMessage",
+          "showDocs": true,
+          "title": "prepareEventMessage",
+          "examples": [
+            {
+              "id": "prepareeventmessage",
+              "name": "Generated example for prepareEventMessage",
+              "code": "// Generated example for prepareEventMessage\nposthog.prepareEventMessage();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "EventMessage",
+              "name": "props"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<{\n        distinctId: string;\n        event: string;\n        properties: PostHogEventProperties;\n        options: PostHogCaptureOptions;\n    }>",
+            "name": "Promise<{\n        distinctId: string;\n        event: string;\n        properties: PostHogEventProperties;\n        options: PostHogCaptureOptions;\n    }>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Reload feature flag definitions from the server for local evaluation.",
+          "details": null,
+          "id": "reloadFeatureFlags",
+          "showDocs": true,
+          "title": "reloadFeatureFlags",
+          "examples": [
+            {
+              "id": "force_reload_of_feature_flags",
+              "name": "Force reload of feature flags",
+              "code": "\n\n// Force reload of feature flags\nawait client.reloadFeatureFlags()\nconsole.log('Feature flags reloaded')\n\n\n"
+            },
+            {
+              "id": "reload_before_checking_a_specific_flag",
+              "name": "Reload before checking a specific flag",
+              "code": "\n\n// Reload before checking a specific flag\nawait client.reloadFeatureFlags()\nconst flag = await client.getFeatureFlag('flag-key', 'user_123')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Set a persisted property value in memory storage.",
+          "details": null,
+          "id": "setPersistedProperty",
+          "showDocs": true,
+          "title": "setPersistedProperty",
+          "examples": [
+            {
+              "id": "set_user_id",
+              "name": "Set user ID",
+              "code": "\n\n// Set user ID\nclient.setPersistedProperty('userId', 'user_123')\n\n\n"
+            },
+            {
+              "id": "set_session_id",
+              "name": "Set session ID",
+              "code": "\n\n// Set session ID\nclient.setPersistedProperty('sessionId', 'session_456')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The property key to set",
+              "isOptional": false,
+              "type": "PostHogPersistedProperty",
+              "name": "key"
+            },
+            {
+              "description": "The value to store (null to remove)",
+              "isOptional": false,
+              "type": "any | null",
+              "name": "value"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Wait for local evaluation of feature flags to be ready.",
+          "details": null,
+          "id": "waitForLocalEvaluationReady",
+          "showDocs": true,
+          "title": "waitForLocalEvaluationReady",
+          "examples": [
+            {
+              "id": "wait_for_local_evaluation",
+              "name": "Wait for local evaluation",
+              "code": "\n\n// Wait for local evaluation\nconst isReady = await client.waitForLocalEvaluationReady()\nif (isReady) {\n  console.log('Local evaluation is ready')\n} else {\n  console.log('Local evaluation timed out')\n}\n\n\n"
+            },
+            {
+              "id": "wait_with_custom_timeout",
+              "name": "Wait with custom timeout",
+              "code": "\n\n// Wait with custom timeout\nconst isReady = await client.waitForLocalEvaluationReady(10000) // 10 seconds\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Timeout in milliseconds (default: 30000)",
+              "isOptional": true,
+              "type": "number",
+              "name": "timeoutMs"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<boolean>",
+            "name": "Promise<boolean>"
+          },
+          "path": "src/entrypoints/index.node.ts"
+        }
+      ]
+    }
+  ],
+  "types": [
+    {
+      "id": "_SentryEvent",
+      "name": "_SentryEvent",
+      "properties": [],
+      "path": "src/extensions/sentry-integration.ts"
+    },
+    {
+      "id": "_SentryEventProcessor",
+      "name": "_SentryEventProcessor",
+      "properties": [],
+      "path": "src/extensions/sentry-integration.ts"
+    },
+    {
+      "id": "_SentryHub",
+      "name": "_SentryHub",
+      "properties": [],
+      "path": "src/extensions/sentry-integration.ts"
+    },
+    {
+      "id": "_SentryIntegration",
+      "name": "_SentryIntegration",
+      "properties": [
+        {
+          "type": "string",
+          "name": "name"
+        }
+      ],
+      "path": "src/extensions/sentry-integration.ts"
+    },
+    {
+      "id": "_SentryIntegrationClass",
+      "name": "_SentryIntegrationClass",
+      "properties": [
+        {
+          "type": "string",
+          "name": "name"
+        }
+      ],
+      "path": "src/extensions/sentry-integration.ts"
+    },
+    {
+      "id": "BeforeSendFn",
+      "name": "BeforeSendFn",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "(event: EventMessage | null) => EventMessage | null"
+    },
+    {
+      "id": "EventMessage",
+      "name": "EventMessage",
+      "properties": [
+        {
+          "type": "string",
+          "name": "event"
+        },
+        {
+          "type": "Record<string, string | number>",
+          "name": "groups"
+        },
+        {
+          "type": "boolean | SendFeatureFlagsOptions",
+          "name": "sendFeatureFlags"
+        },
+        {
+          "type": "Date",
+          "name": "timestamp"
+        },
+        {
+          "type": "string",
+          "name": "uuid"
+        }
+      ],
+      "path": "src/types.ts"
+    },
+    {
+      "id": "ExpressErrorMiddleware",
+      "name": "ExpressErrorMiddleware",
+      "properties": [],
+      "path": "src/extensions/express.ts",
+      "example": "(error: MiddlewareError, req: http.IncomingMessage, res: http.ServerResponse, next: (error: MiddlewareError) => void) => void"
+    },
+    {
+      "id": "ExpressMiddleware",
+      "name": "ExpressMiddleware",
+      "properties": [],
+      "path": "src/extensions/express.ts",
+      "example": "(req: http.IncomingMessage, res: http.ServerResponse, next: () => void) => void"
+    },
+    {
+      "id": "FeatureFlagCondition",
+      "name": "FeatureFlagCondition",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "{\n    properties: FlagProperty[];\n    rollout_percentage?: number;\n    variant?: string;\n}"
+    },
+    {
+      "id": "FlagProperty",
+      "name": "FlagProperty",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "{\n    key: string;\n    type?: string;\n    value: FlagPropertyValue;\n    operator?: string;\n    negation?: boolean;\n    dependency_chain?: string[];\n}"
+    },
+    {
+      "id": "FlagPropertyValue",
+      "name": "FlagPropertyValue",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "string | number | (string | number)[] | boolean"
+    },
+    {
+      "id": "GroupIdentifyMessage",
+      "name": "GroupIdentifyMessage",
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "disableGeoip"
+        },
+        {
+          "type": "string",
+          "name": "distinctId"
+        },
+        {
+          "type": "string",
+          "name": "groupKey"
+        },
+        {
+          "type": "string",
+          "name": "groupType"
+        },
+        {
+          "type": "Record<string | number, any>",
+          "name": "properties"
+        }
+      ],
+      "path": "src/types.ts"
+    },
+    {
+      "id": "IdentifyMessage",
+      "name": "IdentifyMessage",
+      "properties": [
+        {
+          "type": "boolean",
+          "name": "disableGeoip"
+        },
+        {
+          "type": "string",
+          "name": "distinctId"
+        },
+        {
+          "type": "Record<string | number, any>",
+          "name": "properties"
+        }
+      ],
+      "path": "src/types.ts"
+    },
+    {
+      "id": "IPostHog",
+      "name": "IPostHog",
+      "properties": [],
+      "path": "src/types.ts"
+    },
+    {
+      "id": "MiddlewareError",
+      "name": "MiddlewareError",
+      "properties": [
+        {
+          "type": "{\n        statusCode?: number | string;\n    }",
+          "name": "output"
+        },
+        {
+          "type": "number | string",
+          "name": "status_code"
+        },
+        {
+          "type": "number | string",
+          "name": "status"
+        },
+        {
+          "type": "number | string",
+          "name": "statusCode"
+        }
+      ],
+      "path": "src/extensions/express.ts"
+    },
+    {
+      "id": "PostHogFeatureFlag",
+      "name": "PostHogFeatureFlag",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "{\n    id: number;\n    name: string;\n    key: string;\n    filters?: {\n        aggregation_group_type_index?: number;\n        groups?: FeatureFlagCondition[];\n        multivariate?: {\n            variants: {\n                key: string;\n                rollout_percentage: number;\n            }[];\n        };\n        payloads?: Record<string, string>;\n    };\n    deleted: boolean;\n    active: boolean;\n    rollout_percentage: null | number;\n    ensure_experience_continuity: boolean;\n    experiment_set: number[];\n}"
+    },
+    {
+      "id": "PostHogOptions",
+      "name": "PostHogOptions",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "PostHogCoreOptions & {\n    persistence?: 'memory';\n    personalApiKey?: string;\n    privacyMode?: boolean;\n    enableExceptionAutocapture?: boolean;\n    featureFlagsPollingInterval?: number;\n    maxCacheSize?: number;\n    fetch?: (url: string, options: PostHogFetchOptions) => Promise<PostHogFetchResponse>;\n    enableLocalEvaluation?: boolean;\n    before_send?: BeforeSendFn | BeforeSendFn[];\n}"
+    },
+    {
+      "id": "PropertyGroup",
+      "name": "PropertyGroup",
+      "properties": [],
+      "path": "src/types.ts",
+      "example": "{\n    type: 'AND' | 'OR';\n    values: PropertyGroup[] | FlagProperty[];\n}"
+    },
+    {
+      "id": "SendFeatureFlagsOptions",
+      "name": "SendFeatureFlagsOptions",
+      "properties": [
+        {
+          "type": "string[]",
+          "name": "flagKeys"
+        },
+        {
+          "type": "Record<string, Record<string, any>>",
+          "name": "groupProperties"
+        },
+        {
+          "type": "boolean",
+          "name": "onlyEvaluateLocally"
+        },
+        {
+          "type": "Record<string, any>",
+          "name": "personProperties"
+        }
+      ],
+      "path": "src/types.ts"
+    },
+    {
+      "id": "SentryIntegrationOptions",
+      "name": "SentryIntegrationOptions",
+      "properties": [],
+      "path": "src/extensions/sentry-integration.ts",
+      "example": "{\n    organization?: string;\n    projectId?: number;\n    prefix?: string;\n    severityAllowList?: CoreErrorTracking.SeverityLevel[] | '*';\n    sendExceptionsToPostHog?: boolean;\n}"
+    }
+  ],
+  "categories": [
+    "Initialization",
+    "Identification",
+    "Capture",
+    "Error tracking",
+    "Privacy",
+    "Feature flags"
+  ]
+}

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -21,8 +21,7 @@
     "prebuild": "node -p \"'export const version = ' + JSON.stringify(require('./package.json').version)\" > src/version.ts",
     "build": "tsc -b && babel ./dist --out-dir dist --extensions '.js'",
     "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz",
-    "gen-specs": "pnpm exec tsc && pnpm exec api-extractor run --config ./api-extractor.json --local",
-    "parse-specs": "node scripts/generate-docs.js"
+    "generate-references": "pnpm exec api-extractor run --config ./api-extractor.json --local && node scripts/generate-docs.js"
   },
   "dependencies": {
     "@posthog/core": "workspace:*"

--- a/packages/react-native/references/posthog-react-native-references-4.7.0.json
+++ b/packages/react-native/references/posthog-react-native-references-4.7.0.json
@@ -1,0 +1,3407 @@
+{
+  "id": "posthog-react-native",
+  "hogRef": "0.3",
+  "info": {
+    "version": "4.7.0",
+    "id": "posthog-react-native",
+    "title": "PostHog React Native SDK",
+    "description": "PostHog React Native SDK allows you to capture events and send them to PostHog from your React Native applications.",
+    "slugPrefix": "posthog-react-native",
+    "specUrl": "https://github.com/PostHog/posthog-js"
+  },
+  "classes": [
+    {
+      "id": "PostHog",
+      "title": "PostHog",
+      "functions": [
+        {
+          "category": "Initialization",
+          "description": "PostHogProvider is a React component that provides PostHog functionality to your React Native app. You can find all configuration options in the [React Native SDK docs](https://posthog.com/docs/libraries/react-native#configuration-options).\nAutocapturing navigation requires further configuration. See the [React Native SDK navigation docs](https://posthog.com/docs/libraries/react-native#capturing-screen-views) for more information about autocapturing navigation.\nThis is the recommended way to set up PostHog for React Native. This utilizes the Context API to pass the PostHog client around, enable autocapture.",
+          "details": null,
+          "id": "PostHogProvider",
+          "showDocs": true,
+          "title": "PostHogProvider",
+          "examples": [
+            {
+              "id": "add_to_app.(js|ts)",
+              "name": "Add to App.(js|ts)",
+              "code": "\n\n// Add to App.(js|ts)\nimport { usePostHog, PostHogProvider } from 'posthog-react-native'\n\nexport function MyApp() {\n    return (\n        <PostHogProvider apiKey=\"<ph_project_api_key>\" options={{\n            host: '<ph_client_api_host>',\n        }}>\n            <MyComponent />\n        </PostHogProvider>\n    )\n}\n\n// And access the PostHog client via the usePostHog hook\nimport { usePostHog } from 'posthog-react-native'\n\nconst MyComponent = () => {\n    const posthog = usePostHog()\n\n    useEffect(() => {\n        posthog.capture(\"event_name\")\n    }, [posthog])\n}\n\n\n\n"
+            },
+            {
+              "id": "using_with_existing_client",
+              "name": "Using with existing client",
+              "code": "\n\n// Using with existing client\nimport { PostHog } from 'posthog-react-native'\n\nconst posthog = new PostHog('<ph_project_api_key>', {\n    host: '<ph_client_api_host>'\n})\n\nexport function MyApp() {\n    return (\n        <PostHogProvider client={posthog}>\n            <MyComponent />\n        </PostHogProvider>\n    )\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogProviderProps",
+              "name": "{ children, client, options, apiKey, autocapture, style, debug, }"
+            }
+          ],
+          "returnType": {
+            "id": "JSX.Element | null",
+            "name": "JSX.Element | null"
+          }
+        },
+        {
+          "category": "Initialization",
+          "description": "Creates a new PostHog instance for React Native. You can find all configuration options in the [React Native SDK docs](https://posthog.com/docs/libraries/react-native#configuration-options).\nIf you prefer not to use the PostHogProvider, you can initialize PostHog in its own file and import the instance from there.",
+          "details": null,
+          "id": "PostHog",
+          "showDocs": true,
+          "title": "PostHog",
+          "examples": [
+            {
+              "id": "posthog.ts",
+              "name": "posthog.ts",
+              "code": "\n\n// posthog.ts\nimport PostHog from 'posthog-react-native'\n\nexport const posthog = new PostHog('<ph_project_api_key>', {\n  host: '<ph_client_api_host>'\n})\n\n// Then you can access PostHog by importing your instance\n// Another file:\nimport { posthog } from './posthog'\n\nexport function MyApp1() {\n    useEffect(async () => {\n        posthog.capture('event_name')\n    }, [posthog])\n\n    return <View>Your app code</View>\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Your PostHog API key",
+              "isOptional": false,
+              "type": "string",
+              "name": "apiKey"
+            },
+            {
+              "description": "PostHog configuration options",
+              "isOptional": true,
+              "type": "PostHogOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "any",
+            "name": "any"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Assigns an alias to the current user.\nSometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.",
+          "details": null,
+          "id": "alias",
+          "showDocs": true,
+          "title": "alias",
+          "examples": [
+            {
+              "id": "set_alias_for_current_user",
+              "name": "set alias for current user",
+              "code": "\n\n// set alias for current user\nposthog.alias('distinct_id')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The alias to assign to the current user",
+              "isOptional": false,
+              "type": "string",
+              "name": "alias"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "fetch",
+          "showDocs": true,
+          "title": "fetch",
+          "examples": [
+            {
+              "id": "fetch",
+              "name": "Generated example for fetch",
+              "code": "// Generated example for fetch\nposthog.fetch();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "url"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogFetchOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<PostHogFetchResponse>",
+            "name": "Promise<PostHogFetchResponse>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Manually flushes the event queue.\nYou can set the number of events in the configuration that should queue before flushing. Setting this to 1 will send events immediately and will use more battery. This is set to 20 by default. You can also manually flush the queue. If a flush is already in progress it returns a promise for the existing flush.",
+          "details": null,
+          "id": "flush",
+          "showDocs": true,
+          "title": "flush",
+          "examples": [
+            {
+              "id": "manually_flush_the_queue",
+              "name": "manually flush the queue",
+              "code": "\n\n// manually flush the queue\nawait posthog.flush()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getCommonEventProperties",
+          "showDocs": true,
+          "title": "getCommonEventProperties",
+          "examples": [
+            {
+              "id": "getcommoneventproperties",
+              "name": "Generated example for getCommonEventProperties",
+              "code": "// Generated example for getCommonEventProperties\nposthog.getCommonEventProperties();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "PostHogEventProperties",
+            "name": "PostHogEventProperties"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getCustomUserAgent",
+          "showDocs": true,
+          "title": "getCustomUserAgent",
+          "examples": [
+            {
+              "id": "getcustomuseragent",
+              "name": "Generated example for getCustomUserAgent",
+              "code": "// Generated example for getCustomUserAgent\nposthog.getCustomUserAgent();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Gets the current user's distinct ID.\nYou may find it helpful to get the current user's distinct ID. For example, to check whether you've already called identify for a user or not. This returns either the ID automatically generated by PostHog or the ID that has been passed by a call to identify().",
+          "details": null,
+          "id": "getDistinctId",
+          "showDocs": true,
+          "title": "getDistinctId",
+          "examples": [
+            {
+              "id": "get_current_distinct_id",
+              "name": "get current distinct ID",
+              "code": "\n\n// get current distinct ID\nconst distinctId = posthog.getDistinctId()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Gets the value of a feature flag for the current user.\nDefaults to undefined if not loaded yet or if there was a problem loading. Multivariant feature flags are returned as a string.",
+          "details": null,
+          "id": "getFeatureFlag",
+          "showDocs": true,
+          "title": "getFeatureFlag",
+          "examples": [
+            {
+              "id": "get_feature_flag_value",
+              "name": "get feature flag value",
+              "code": "\n\n// get feature flag value\nconst value = posthog.getFeatureFlag('key-for-your-boolean-flag')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            }
+          ],
+          "returnType": {
+            "id": "boolean | string | undefined",
+            "name": "boolean | string | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Gets the payload of a feature flag for the current user.\nReturns JsonType or undefined if not loaded yet or if there was a problem loading.",
+          "details": null,
+          "id": "getFeatureFlagPayload",
+          "showDocs": true,
+          "title": "getFeatureFlagPayload",
+          "examples": [
+            {
+              "id": "get_feature_flag_payload",
+              "name": "get feature flag payload",
+              "code": "\n\n// get feature flag payload\nconst payload = posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            }
+          ],
+          "returnType": {
+            "id": "JsonType | undefined",
+            "name": "JsonType | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getLibraryId",
+          "showDocs": true,
+          "title": "getLibraryId",
+          "examples": [
+            {
+              "id": "getlibraryid",
+              "name": "Generated example for getLibraryId",
+              "code": "// Generated example for getLibraryId\nposthog.getLibraryId();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getLibraryVersion",
+          "showDocs": true,
+          "title": "getLibraryVersion",
+          "examples": [
+            {
+              "id": "getlibraryversion",
+              "name": "Generated example for getLibraryVersion",
+              "code": "// Generated example for getLibraryVersion\nposthog.getLibraryVersion();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getPersistedProperty",
+          "showDocs": true,
+          "title": "getPersistedProperty",
+          "examples": [
+            {
+              "id": "getpersistedproperty",
+              "name": "Generated example for getPersistedProperty",
+              "code": "// Generated example for getPersistedProperty\nposthog.getPersistedProperty();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogPersistedProperty",
+              "name": "key"
+            }
+          ],
+          "returnType": {
+            "id": "T | undefined",
+            "name": "T | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getSessionId",
+          "showDocs": true,
+          "title": "getSessionId",
+          "examples": [
+            {
+              "id": "getsessionid",
+              "name": "Generated example for getSessionId",
+              "code": "// Generated example for getSessionId\nposthog.getSessionId();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getSurveys",
+          "showDocs": true,
+          "title": "getSurveys",
+          "examples": [
+            {
+              "id": "getsurveys",
+              "name": "Generated example for getSurveys",
+              "code": "// Generated example for getSurveys\nposthog.getSurveys();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<SurveyResponse['surveys']>",
+            "name": "Promise<SurveyResponse['surveys']>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Group analytics",
+          "description": "Associates the current user with a group.\nGroup analytics allows you to associate the events for that person's session with a group (e.g. teams, organizations, etc.). This is a paid feature and is not available on the open-source or free cloud plan.",
+          "details": null,
+          "id": "group",
+          "showDocs": true,
+          "title": "group",
+          "examples": [
+            {
+              "id": "associate_with_a_group",
+              "name": "associate with a group",
+              "code": "\n\n// associate with a group\nposthog.group('company', 'company_id_in_your_db')\n\n\n"
+            },
+            {
+              "id": "associate_with_a_group_and_update_properties",
+              "name": "associate with a group and update properties",
+              "code": "\n\n// associate with a group and update properties\nposthog.group('company', 'company_id_in_your_db', {\n  name: 'Awesome Inc.',\n  employees: 11,\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The type of group (e.g. 'company', 'team')",
+              "isOptional": false,
+              "type": "string",
+              "name": "groupType"
+            },
+            {
+              "description": "The unique identifier for the group",
+              "isOptional": false,
+              "type": "string",
+              "name": "groupKey"
+            },
+            {
+              "description": "Optional properties to set for the group",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Associates events with a specific user. Learn more about [identifying users](https://posthog.com/docs/product-analytics/identify)",
+          "details": null,
+          "id": "identify",
+          "showDocs": true,
+          "title": "identify",
+          "examples": [
+            {
+              "id": "basic_identify",
+              "name": "Basic identify",
+              "code": "\n\n// Basic identify\nposthog.identify('distinctID', {\n  email: 'user@posthog.com',\n  name: 'My Name'\n})\n\n\n"
+            },
+            {
+              "id": "using_$set_and_$set_once",
+              "name": "Using $set and $set_once",
+              "code": "\n\n// Using $set and $set_once\nposthog.identify('distinctID', {\n  $set: {\n    email: 'user@posthog.com',\n    name: 'My Name'\n  },\n  $set_once: {\n    date_of_first_log_in: '2024-03-01'\n  }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "A unique identifier for your user. Typically either their email or database ID.",
+              "isOptional": true,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional dictionary with key:value pairs to set the person properties",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "Optional capture options",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "initReactNativeNavigation",
+          "showDocs": true,
+          "title": "initReactNativeNavigation",
+          "examples": [
+            {
+              "id": "initreactnativenavigation",
+              "name": "Generated example for initReactNativeNavigation",
+              "code": "// Generated example for initReactNativeNavigation\nposthog.initReactNativeNavigation();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogAutocaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Checks if a feature flag is enabled for the current user.\nDefaults to undefined if not loaded yet or if there was a problem loading.",
+          "details": null,
+          "id": "isFeatureEnabled",
+          "showDocs": true,
+          "title": "isFeatureEnabled",
+          "examples": [
+            {
+              "id": "check_if_feature_flag_is_enabled",
+              "name": "check if feature flag is enabled",
+              "code": "\n\n// check if feature flag is enabled\nconst isEnabled = posthog.isFeatureEnabled('key-for-your-boolean-flag')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            }
+          ],
+          "returnType": {
+            "id": "boolean | undefined",
+            "name": "boolean | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Opts the user in to data capture.\nBy default, PostHog has tracking enabled unless it is forcefully disabled by default using the option  defaultOptIn: false . Once this has been called it is persisted and will be respected until optOut is called again or the reset function is called.",
+          "details": null,
+          "id": "optIn",
+          "showDocs": true,
+          "title": "optIn",
+          "examples": [
+            {
+              "id": "opt_in_to_tracking",
+              "name": "opt in to tracking",
+              "code": "\n\n// opt in to tracking\nposthog.optIn()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Opts the user out of data capture.\nYou can completely opt-out users from data capture. Once this has been called it is persisted and will be respected until optIn is called again or the reset function is called.",
+          "details": null,
+          "id": "optOut",
+          "showDocs": true,
+          "title": "optOut",
+          "examples": [
+            {
+              "id": "opt_out_of_tracking",
+              "name": "opt out of tracking",
+              "code": "\n\n// opt out of tracking\nposthog.optOut()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Registers super properties that are sent with every event.\nSuper properties are properties associated with events that are set once and then sent with every capture call. They persist across sessions and are stored locally.",
+          "details": null,
+          "id": "register",
+          "showDocs": true,
+          "title": "register",
+          "examples": [
+            {
+              "id": "register_super_properties",
+              "name": "register super properties",
+              "code": "\n\n// register super properties\nposthog.register({\n    'icecream pref': 'vanilla',\n    team_id: 22,\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "An associative array of properties to store about the user",
+              "isOptional": false,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Reloads feature flags from the server.\nPostHog loads feature flags when instantiated and refreshes whenever methods are called that affect the flag. If you want to manually trigger a refresh, you can call this method.",
+          "details": null,
+          "id": "reloadFeatureFlags",
+          "showDocs": true,
+          "title": "reloadFeatureFlags",
+          "examples": [
+            {
+              "id": "reload_feature_flags",
+              "name": "reload feature flags",
+              "code": "\n\n// reload feature flags\nposthog.reloadFeatureFlags()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Reloads feature flags from the server asynchronously.\nPostHog loads feature flags when instantiated and refreshes whenever methods are called that affect the flag. If you want to manually trigger a refresh and get the result, you can call this method.",
+          "details": null,
+          "id": "reloadFeatureFlagsAsync",
+          "showDocs": true,
+          "title": "reloadFeatureFlagsAsync",
+          "examples": [
+            {
+              "id": "reload_feature_flags_and_get_result",
+              "name": "reload feature flags and get result",
+              "code": "\n\n// reload feature flags and get result\nposthog.reloadFeatureFlagsAsync().then((refreshedFlags) => console.log(refreshedFlags))\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<Record<string, boolean | string> | undefined>",
+            "name": "Promise<Record<string, boolean | string> | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Resets the user's ID and anonymous ID after logout.\nTo reset the user's ID and anonymous ID, call reset. Usually you would do this right after the user logs out. This also clears all stored super properties and more.",
+          "details": null,
+          "id": "reset",
+          "showDocs": true,
+          "title": "reset",
+          "examples": [
+            {
+              "id": "reset_after_logout",
+              "name": "reset after logout",
+              "code": "\n\n// reset after logout\nposthog.reset()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Resets group properties for feature flag evaluation.",
+          "details": null,
+          "id": "resetGroupPropertiesForFlags",
+          "showDocs": true,
+          "title": "resetGroupPropertiesForFlags",
+          "examples": [
+            {
+              "id": "reset_group_properties_for_flags",
+              "name": "reset group properties for flags",
+              "code": "\n\n// reset group properties for flags\nposthog.resetGroupPropertiesForFlags()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Resets person properties for feature flag evaluation.",
+          "details": null,
+          "id": "resetPersonPropertiesForFlags",
+          "showDocs": true,
+          "title": "resetPersonPropertiesForFlags",
+          "examples": [
+            {
+              "id": "reset_person_properties_for_flags",
+              "name": "reset person properties for flags",
+              "code": "\n\n// reset person properties for flags\nposthog.resetPersonPropertiesForFlags()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "resetSessionId",
+          "showDocs": true,
+          "title": "resetSessionId",
+          "examples": [
+            {
+              "id": "resetsessionid",
+              "name": "Generated example for resetSessionId",
+              "code": "// Generated example for resetSessionId\nposthog.resetSessionId();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Captures a screen view event.",
+          "details": "This function requires a name. You may also pass in an optional properties object. Screen name is automatically registered for the session and will be included in subsequent events.",
+          "id": "screen",
+          "showDocs": true,
+          "title": "screen",
+          "examples": [
+            {
+              "id": "basic_screen_capture",
+              "name": "Basic screen capture",
+              "code": "\n\n// Basic screen capture\nposthog.screen('dashboard')\n\n\n"
+            },
+            {
+              "id": "screen_capture_with_properties",
+              "name": "Screen capture with properties",
+              "code": "\n\n// Screen capture with properties\nposthog.screen('dashboard', {\n    background: 'blue',\n    hero: 'superhog',\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the screen",
+              "isOptional": false,
+              "type": "string",
+              "name": "name"
+            },
+            {
+              "description": "Optional properties to include with the screen event",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "Optional capture options",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Sets group properties for feature flag evaluation.\nThese properties are automatically attached to the current group (set via posthog.group()). When you change the group, these properties are reset.",
+          "details": null,
+          "id": "setGroupPropertiesForFlags",
+          "showDocs": true,
+          "title": "setGroupPropertiesForFlags",
+          "examples": [
+            {
+              "id": "set_group_properties_for_flags",
+              "name": "set group properties for flags",
+              "code": "\n\n// set group properties for flags\nposthog.setGroupPropertiesForFlags({'company': {'property1': 'value', property2: 'value2'}})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The group properties to set for flag evaluation",
+              "isOptional": false,
+              "type": "Record<string, Record<string, string>>",
+              "name": "properties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "setPersistedProperty",
+          "showDocs": true,
+          "title": "setPersistedProperty",
+          "examples": [
+            {
+              "id": "setpersistedproperty",
+              "name": "Generated example for setPersistedProperty",
+              "code": "// Generated example for setPersistedProperty\nposthog.setPersistedProperty();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogPersistedProperty",
+              "name": "key"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "T | null",
+              "name": "value"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Sets person properties for feature flag evaluation.\nSometimes, you might want to evaluate feature flags using properties that haven't been ingested yet, or were set incorrectly earlier. You can do so by setting properties the flag depends on with this call. These are set for the entire session. Successive calls are additive: all properties you set are combined together and sent for flag evaluation.",
+          "details": null,
+          "id": "setPersonPropertiesForFlags",
+          "showDocs": true,
+          "title": "setPersonPropertiesForFlags",
+          "examples": [
+            {
+              "id": "set_person_properties_for_flags",
+              "name": "set person properties for flags",
+              "code": "\n\n// set person properties for flags\nposthog.setPersonPropertiesForFlags({'property1': 'value', property2: 'value2'})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The person properties to set for flag evaluation",
+              "isOptional": false,
+              "type": "Record<string, string>",
+              "name": "properties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Removes a super property so it won't be sent with future events.\nSuper Properties are persisted across sessions so you have to explicitly remove them if they are no longer relevant.",
+          "details": null,
+          "id": "unregister",
+          "showDocs": true,
+          "title": "unregister",
+          "examples": [
+            {
+              "id": "remove_a_super_property",
+              "name": "remove a super property",
+              "code": "\n\n// remove a super property\nposthog.unregister('icecream pref')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the super property to remove",
+              "isOptional": false,
+              "type": "string",
+              "name": "property"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "autocapture",
+          "showDocs": true,
+          "title": "autocapture",
+          "examples": [
+            {
+              "id": "autocapture",
+              "name": "Generated example for autocapture",
+              "code": "// Generated example for autocapture\nposthog.autocapture();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "eventType"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogAutocaptureElement[]",
+              "name": "elements"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "capture",
+          "showDocs": true,
+          "title": "capture",
+          "examples": [
+            {
+              "id": "capture",
+              "name": "Generated example for capture",
+              "code": "// Generated example for capture\nposthog.capture();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "event"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Error tracking",
+          "description": "Capture a caught exception manually",
+          "details": null,
+          "id": "captureException",
+          "showDocs": true,
+          "title": "captureException",
+          "examples": [
+            {
+              "id": "capture_a_caught_exception",
+              "name": "Capture a caught exception",
+              "code": "\n\n// Capture a caught exception\ntry {\n  // something that might throw\n} catch (error) {\n  posthog.captureException(error)\n}\n\n\n"
+            },
+            {
+              "id": "with_additional_properties",
+              "name": "With additional properties",
+              "code": "\n\n// With additional properties\nposthog.captureException(error, {\n  customProperty: 'value',\n  anotherProperty: ['I', 'can be a list'],\n  ...\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The error to capture",
+              "isOptional": false,
+              "type": "unknown",
+              "name": "error"
+            },
+            {
+              "description": "Any additional properties to add to the error event",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "additionalProperties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "LLM analytics",
+          "description": "Capture written user feedback for a LLM trace. Numeric values are converted to strings.",
+          "details": null,
+          "id": "captureTraceFeedback",
+          "showDocs": true,
+          "title": "captureTraceFeedback",
+          "examples": [
+            {
+              "id": "capturetracefeedback",
+              "name": "Generated example for captureTraceFeedback",
+              "code": "// Generated example for captureTraceFeedback\nposthog.captureTraceFeedback();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The trace ID to capture feedback for.",
+              "isOptional": false,
+              "type": "string | number",
+              "name": "traceId"
+            },
+            {
+              "description": "The feedback to capture.",
+              "isOptional": false,
+              "type": "string",
+              "name": "userFeedback"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "LLM analytics",
+          "description": "Capture a metric for a LLM trace. Numeric values are converted to strings.",
+          "details": null,
+          "id": "captureTraceMetric",
+          "showDocs": true,
+          "title": "captureTraceMetric",
+          "examples": [
+            {
+              "id": "capturetracemetric",
+              "name": "Generated example for captureTraceMetric",
+              "code": "// Generated example for captureTraceMetric\nposthog.captureTraceMetric();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The trace ID to capture the metric for.",
+              "isOptional": false,
+              "type": "string | number",
+              "name": "traceId"
+            },
+            {
+              "description": "The name of the metric to capture.",
+              "isOptional": false,
+              "type": "string",
+              "name": "metricName"
+            },
+            {
+              "description": "The value of the metric to capture.",
+              "isOptional": false,
+              "type": "string | number | boolean",
+              "name": "metricValue"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Returns the current anonymous ID.\nThis is the ID assigned to users before they are identified. It's used to track anonymous users and link them to identified users when they sign up.",
+          "details": null,
+          "id": "getAnonymousId",
+          "showDocs": true,
+          "title": "getAnonymousId",
+          "examples": [
+            {
+              "id": "get_the_anonymous_id",
+              "name": "get the anonymous ID",
+              "code": "\n\n// get the anonymous ID\nconst anonId = posthog.getAnonymousId()\nconsole.log('Anonymous ID:', anonId)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagDetails",
+          "showDocs": true,
+          "title": "getFeatureFlagDetails",
+          "examples": [
+            {
+              "id": "getfeatureflagdetails",
+              "name": "Generated example for getFeatureFlagDetails",
+              "code": "// Generated example for getFeatureFlagDetails\nposthog.getFeatureFlagDetails();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "PostHogFeatureFlagDetails | undefined",
+            "name": "PostHogFeatureFlagDetails | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagPayloads",
+          "showDocs": true,
+          "title": "getFeatureFlagPayloads",
+          "examples": [
+            {
+              "id": "getfeatureflagpayloads",
+              "name": "Generated example for getFeatureFlagPayloads",
+              "code": "// Generated example for getFeatureFlagPayloads\nposthog.getFeatureFlagPayloads();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "PostHogFlagsResponse['featureFlagPayloads'] | undefined",
+            "name": "PostHogFlagsResponse['featureFlagPayloads'] | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlags",
+          "showDocs": true,
+          "title": "getFeatureFlags",
+          "examples": [
+            {
+              "id": "getfeatureflags",
+              "name": "Generated example for getFeatureFlags",
+              "code": "// Generated example for getFeatureFlags\nposthog.getFeatureFlags();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "PostHogFlagsResponse['featureFlags'] | undefined",
+            "name": "PostHogFlagsResponse['featureFlags'] | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagsAndPayloads",
+          "showDocs": true,
+          "title": "getFeatureFlagsAndPayloads",
+          "examples": [
+            {
+              "id": "getfeatureflagsandpayloads",
+              "name": "Generated example for getFeatureFlagsAndPayloads",
+              "code": "// Generated example for getFeatureFlagsAndPayloads\nposthog.getFeatureFlagsAndPayloads();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "{\n        flags: PostHogFlagsResponse['featureFlags'] | undefined;\n        payloads: PostHogFlagsResponse['featureFlagPayloads'] | undefined;\n    }",
+            "name": "{\n        flags: PostHogFlagsResponse['featureFlags'] | undefined;\n        payloads: PostHogFlagsResponse['featureFlagPayloads'] | undefined;\n    }"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getKnownFeatureFlags",
+          "showDocs": true,
+          "title": "getKnownFeatureFlags",
+          "examples": [
+            {
+              "id": "getknownfeatureflags",
+              "name": "Generated example for getKnownFeatureFlags",
+              "code": "// Generated example for getKnownFeatureFlags\nposthog.getKnownFeatureFlags();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "PostHogFlagsResponse['featureFlags'] | undefined",
+            "name": "PostHogFlagsResponse['featureFlags'] | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "groupIdentify",
+          "showDocs": true,
+          "title": "groupIdentify",
+          "examples": [
+            {
+              "id": "groupidentify",
+              "name": "Generated example for groupIdentify",
+              "code": "// Generated example for groupIdentify\nposthog.groupIdentify();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "groupType"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string | number",
+              "name": "groupKey"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "description": "* ** GROUPS *",
+          "details": null,
+          "id": "groups",
+          "showDocs": true,
+          "title": "groups",
+          "examples": [
+            {
+              "id": "groups",
+              "name": "Generated example for groups",
+              "code": "// Generated example for groups\nposthog.groups();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogGroupProperties",
+              "name": "groups"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "on",
+          "showDocs": true,
+          "title": "on",
+          "examples": [
+            {
+              "id": "on",
+              "name": "Generated example for on",
+              "code": "// Generated example for on\nposthog.on();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "event"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "(...args: any[]) => void",
+              "name": "cb"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "onFeatureFlag",
+          "showDocs": true,
+          "title": "onFeatureFlag",
+          "examples": [
+            {
+              "id": "onfeatureflag",
+              "name": "Generated example for onFeatureFlag",
+              "code": "// Generated example for onFeatureFlag\nposthog.onFeatureFlag();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "(value: FeatureFlagValue) => void",
+              "name": "cb"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "onFeatureFlags",
+          "showDocs": true,
+          "title": "onFeatureFlags",
+          "examples": [
+            {
+              "id": "onfeatureflags",
+              "name": "Generated example for onFeatureFlags",
+              "code": "// Generated example for onFeatureFlags\nposthog.onFeatureFlags();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "(flags: PostHogFlagsResponse['featureFlags']) => void",
+              "name": "cb"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "overrideFeatureFlag",
+          "showDocs": true,
+          "title": "overrideFeatureFlag",
+          "examples": [
+            {
+              "id": "overridefeatureflag",
+              "name": "Generated example for overrideFeatureFlag",
+              "code": "// Generated example for overrideFeatureFlag\nposthog.overrideFeatureFlag();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogFlagsResponse['featureFlags'] | null",
+              "name": "flags"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "registerForSession",
+          "showDocs": true,
+          "title": "registerForSession",
+          "examples": [
+            {
+              "id": "registerforsession",
+              "name": "Generated example for registerForSession",
+              "code": "// Generated example for registerForSession\nposthog.registerForSession();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "reloadRemoteConfigAsync",
+          "showDocs": true,
+          "title": "reloadRemoteConfigAsync",
+          "examples": [
+            {
+              "id": "reloadremoteconfigasync",
+              "name": "Generated example for reloadRemoteConfigAsync",
+              "code": "// Generated example for reloadRemoteConfigAsync\nposthog.reloadRemoteConfigAsync();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<PostHogRemoteConfig | undefined>",
+            "name": "Promise<PostHogRemoteConfig | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "setupBootstrap",
+          "showDocs": true,
+          "title": "setupBootstrap",
+          "examples": [
+            {
+              "id": "setupbootstrap",
+              "name": "Generated example for setupBootstrap",
+              "code": "// Generated example for setupBootstrap\nposthog.setupBootstrap();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Partial<PostHogCoreOptions>",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "unregisterForSession",
+          "showDocs": true,
+          "title": "unregisterForSession",
+          "examples": [
+            {
+              "id": "unregisterforsession",
+              "name": "Generated example for unregisterForSession",
+              "code": "// Generated example for unregisterForSession\nposthog.unregisterForSession();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "property"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "addPendingPromise",
+          "showDocs": true,
+          "title": "addPendingPromise",
+          "examples": [
+            {
+              "id": "addpendingpromise",
+              "name": "Generated example for addPendingPromise",
+              "code": "// Generated example for addPendingPromise\nposthog.addPendingPromise();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "Promise<T>",
+              "name": "promise"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<T>",
+            "name": "Promise<T>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "aliasStateless",
+          "showDocs": true,
+          "title": "aliasStateless",
+          "examples": [
+            {
+              "id": "aliasstateless",
+              "name": "Generated example for aliasStateless",
+              "code": "// Generated example for aliasStateless\nposthog.aliasStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "alias"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "aliasStatelessImmediate",
+          "showDocs": true,
+          "title": "aliasStatelessImmediate",
+          "examples": [
+            {
+              "id": "aliasstatelessimmediate",
+              "name": "Generated example for aliasStatelessImmediate",
+              "code": "// Generated example for aliasStatelessImmediate\nposthog.aliasStatelessImmediate();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "alias"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "captureStateless",
+          "showDocs": true,
+          "title": "captureStateless",
+          "examples": [
+            {
+              "id": "capturestateless",
+              "name": "Generated example for captureStateless",
+              "code": "// Generated example for captureStateless\nposthog.captureStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "event"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "captureStatelessImmediate",
+          "showDocs": true,
+          "title": "captureStatelessImmediate",
+          "examples": [
+            {
+              "id": "capturestatelessimmediate",
+              "name": "Generated example for captureStatelessImmediate",
+              "code": "// Generated example for captureStatelessImmediate\nposthog.captureStatelessImmediate();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "event"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Enables or disables debug mode for detailed logging.",
+          "details": "Debug mode logs all PostHog calls to the console for troubleshooting. This is useful during development to understand what data is being sent.",
+          "id": "debug",
+          "showDocs": true,
+          "title": "debug",
+          "examples": [
+            {
+              "id": "enable_debug_mode",
+              "name": "enable debug mode",
+              "code": "\n\n// enable debug mode\nposthog.debug(true)\n\n\n"
+            },
+            {
+              "id": "disable_debug_mode",
+              "name": "disable debug mode",
+              "code": "\n\n// disable debug mode\nposthog.debug(false)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "enabled"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "description": "* ** QUEUEING AND FLUSHING *",
+          "details": null,
+          "id": "enqueue",
+          "showDocs": true,
+          "title": "enqueue",
+          "examples": [
+            {
+              "id": "enqueue",
+              "name": "Generated example for enqueue",
+              "code": "// Generated example for enqueue\nposthog.enqueue();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "type"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "any",
+              "name": "_message"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getCustomHeaders",
+          "showDocs": true,
+          "title": "getCustomHeaders",
+          "examples": [
+            {
+              "id": "getcustomheaders",
+              "name": "Generated example for getCustomHeaders",
+              "code": "// Generated example for getCustomHeaders\nposthog.getCustomHeaders();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "{\n        [key: string]: string;\n    }",
+            "name": "{\n        [key: string]: string;\n    }"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagDetailsStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagDetailsStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagdetailsstateless",
+              "name": "Generated example for getFeatureFlagDetailsStateless",
+              "code": "// Generated example for getFeatureFlagDetailsStateless\nposthog.getFeatureFlagDetailsStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string | number>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "string[]",
+              "name": "flagKeysToEvaluate"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<PostHogFeatureFlagDetails | undefined>",
+            "name": "Promise<PostHogFeatureFlagDetails | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagDetailStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagDetailStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagdetailstateless",
+              "name": "Generated example for getFeatureFlagDetailStateless",
+              "code": "// Generated example for getFeatureFlagDetailStateless\nposthog.getFeatureFlagDetailStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<{\n        response: FeatureFlagDetail | undefined;\n        requestId: string | undefined;\n    } | undefined>",
+            "name": "Promise<{\n        response: FeatureFlagDetail | undefined;\n        requestId: string | undefined;\n    } | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagPayloadsStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagPayloadsStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagpayloadsstateless",
+              "name": "Generated example for getFeatureFlagPayloadsStateless",
+              "code": "// Generated example for getFeatureFlagPayloadsStateless\nposthog.getFeatureFlagPayloadsStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "string[]",
+              "name": "flagKeysToEvaluate"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<PostHogFlagsResponse['featureFlagPayloads'] | undefined>",
+            "name": "Promise<PostHogFlagsResponse['featureFlagPayloads'] | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagPayloadStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagPayloadStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagpayloadstateless",
+              "name": "Generated example for getFeatureFlagPayloadStateless",
+              "code": "// Generated example for getFeatureFlagPayloadStateless\nposthog.getFeatureFlagPayloadStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<JsonType | undefined>",
+            "name": "Promise<JsonType | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagsAndPayloadsStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagsAndPayloadsStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagsandpayloadsstateless",
+              "name": "Generated example for getFeatureFlagsAndPayloadsStateless",
+              "code": "// Generated example for getFeatureFlagsAndPayloadsStateless\nposthog.getFeatureFlagsAndPayloadsStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string | number>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "string[]",
+              "name": "flagKeysToEvaluate"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<{\n        flags: PostHogFlagsResponse['featureFlags'] | undefined;\n        payloads: PostHogFlagsResponse['featureFlagPayloads'] | undefined;\n        requestId: PostHogFlagsResponse['requestId'] | undefined;\n    }>",
+            "name": "Promise<{\n        flags: PostHogFlagsResponse['featureFlags'] | undefined;\n        payloads: PostHogFlagsResponse['featureFlagPayloads'] | undefined;\n        requestId: PostHogFlagsResponse['requestId'] | undefined;\n    }>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagsStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagsStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagsstateless",
+              "name": "Generated example for getFeatureFlagsStateless",
+              "code": "// Generated example for getFeatureFlagsStateless\nposthog.getFeatureFlagsStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string | number>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "string[]",
+              "name": "flagKeysToEvaluate"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<{\n        flags: PostHogFlagsResponse['featureFlags'] | undefined;\n        payloads: PostHogFlagsResponse['featureFlagPayloads'] | undefined;\n        requestId: PostHogFlagsResponse['requestId'] | undefined;\n    }>",
+            "name": "Promise<{\n        flags: PostHogFlagsResponse['featureFlags'] | undefined;\n        payloads: PostHogFlagsResponse['featureFlagPayloads'] | undefined;\n        requestId: PostHogFlagsResponse['requestId'] | undefined;\n    }>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagstateless",
+              "name": "Generated example for getFeatureFlagStateless",
+              "code": "// Generated example for getFeatureFlagStateless\nposthog.getFeatureFlagStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<{\n        response: FeatureFlagValue | undefined;\n        requestId: string | undefined;\n    }>",
+            "name": "Promise<{\n        response: FeatureFlagValue | undefined;\n        requestId: string | undefined;\n    }>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "description": "* ** FEATURE FLAGS *",
+          "details": null,
+          "id": "getFlags",
+          "showDocs": true,
+          "title": "getFlags",
+          "examples": [
+            {
+              "id": "getflags",
+              "name": "Generated example for getFlags",
+              "code": "// Generated example for getFlags\nposthog.getFlags();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string | number>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, any>",
+              "name": "extraPayload"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<PostHogFlagsResponse | undefined>",
+            "name": "Promise<PostHogFlagsResponse | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getRemoteConfig",
+          "showDocs": true,
+          "title": "getRemoteConfig",
+          "examples": [
+            {
+              "id": "getremoteconfig",
+              "name": "Generated example for getRemoteConfig",
+              "code": "// Generated example for getRemoteConfig\nposthog.getRemoteConfig();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<PostHogRemoteConfig | undefined>",
+            "name": "Promise<PostHogRemoteConfig | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "description": "* ** SURVEYS *",
+          "details": null,
+          "id": "getSurveysStateless",
+          "showDocs": true,
+          "title": "getSurveysStateless",
+          "examples": [
+            {
+              "id": "getsurveysstateless",
+              "name": "Generated example for getSurveysStateless",
+              "code": "// Generated example for getSurveysStateless\nposthog.getSurveysStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<SurveyResponse['surveys']>",
+            "name": "Promise<SurveyResponse['surveys']>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "description": "* ** GROUPS *",
+          "details": null,
+          "id": "groupIdentifyStateless",
+          "showDocs": true,
+          "title": "groupIdentifyStateless",
+          "examples": [
+            {
+              "id": "groupidentifystateless",
+              "name": "Generated example for groupIdentifyStateless",
+              "code": "// Generated example for groupIdentifyStateless\nposthog.groupIdentifyStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "groupType"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string | number",
+              "name": "groupKey"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "eventProperties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "description": "* ** TRACKING *",
+          "details": null,
+          "id": "identifyStateless",
+          "showDocs": true,
+          "title": "identifyStateless",
+          "examples": [
+            {
+              "id": "identifystateless",
+              "name": "Generated example for identifyStateless",
+              "code": "// Generated example for identifyStateless\nposthog.identifyStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "identifyStatelessImmediate",
+          "showDocs": true,
+          "title": "identifyStatelessImmediate",
+          "examples": [
+            {
+              "id": "identifystatelessimmediate",
+              "name": "Generated example for identifyStatelessImmediate",
+              "code": "// Generated example for identifyStatelessImmediate\nposthog.identifyStatelessImmediate();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "logMsgIfDebug",
+          "showDocs": true,
+          "title": "logMsgIfDebug",
+          "examples": [
+            {
+              "id": "logmsgifdebug",
+              "name": "Generated example for logMsgIfDebug",
+              "code": "// Generated example for logMsgIfDebug\nposthog.logMsgIfDebug();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "() => void",
+              "name": "fn"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "sendImmediate",
+          "showDocs": true,
+          "title": "sendImmediate",
+          "examples": [
+            {
+              "id": "sendimmediate",
+              "name": "Generated example for sendImmediate",
+              "code": "// Generated example for sendImmediate\nposthog.sendImmediate();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "type"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "any",
+              "name": "_message"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Shuts down the PostHog instance and ensures all events are sent.\nCall shutdown() once before the process exits to ensure that all events have been sent and all promises have resolved. Do not use this function if you intend to keep using this PostHog instance after calling it. Use flush() for per-request cleanup instead.",
+          "details": null,
+          "id": "shutdown",
+          "showDocs": true,
+          "title": "shutdown",
+          "examples": [
+            {
+              "id": "shutdown_before_process_exit",
+              "name": "shutdown before process exit",
+              "code": "\n\n// shutdown before process exit\nprocess.on('SIGINT', async () => {\n  await posthog.shutdown()\n  process.exit(0)\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Maximum time to wait for shutdown in milliseconds",
+              "isOptional": true,
+              "type": "number",
+              "name": "shutdownTimeoutMs"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "wrap",
+          "showDocs": true,
+          "title": "wrap",
+          "examples": [
+            {
+              "id": "wrap",
+              "name": "Generated example for wrap",
+              "code": "// Generated example for wrap\nposthog.wrap();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "() => void",
+              "name": "fn"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        }
+      ]
+    }
+  ],
+  "types": [
+    {
+      "id": "ActionStepStringMatching",
+      "name": "ActionStepStringMatching",
+      "properties": [
+        {
+          "type": "\"contains\"",
+          "name": "Contains"
+        },
+        {
+          "type": "\"exact\"",
+          "name": "Exact"
+        },
+        {
+          "type": "\"regex\"",
+          "name": "Regex"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "ActionStepType",
+      "name": "ActionStepType",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    event?: string;\n    selector?: string;\n    text?: string;\n    text_matching?: ActionStepStringMatching;\n    href?: string;\n    href_matching?: ActionStepStringMatching;\n    url?: string;\n    url_matching?: ActionStepStringMatching;\n}"
+    },
+    {
+      "id": "BasicSurveyQuestion",
+      "name": "BasicSurveyQuestion",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.Open;\n}"
+    },
+    {
+      "id": "Compression",
+      "name": "Compression",
+      "properties": [
+        {
+          "type": "\"base64\"",
+          "name": "Base64"
+        },
+        {
+          "type": "\"gzip-js\"",
+          "name": "GZipJS"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "EndBranching",
+      "name": "EndBranching",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    type: SurveyQuestionBranchingType.End;\n}"
+    },
+    {
+      "id": "EvaluationReason",
+      "name": "EvaluationReason",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    code: string | undefined;\n    condition_index: number | undefined;\n    description: string | undefined;\n}"
+    },
+    {
+      "id": "FeatureFlagDetail",
+      "name": "FeatureFlagDetail",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    key: string;\n    enabled: boolean;\n    variant: string | undefined;\n    reason: EvaluationReason | undefined;\n    metadata: FeatureFlagMetadata | undefined;\n}"
+    },
+    {
+      "id": "FeatureFlagMetadata",
+      "name": "FeatureFlagMetadata",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    id: number | undefined;\n    version: number | undefined;\n    description: string | undefined;\n    payload: string | undefined;\n}"
+    },
+    {
+      "id": "FeatureFlagValue",
+      "name": "FeatureFlagValue",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "string | boolean"
+    },
+    {
+      "id": "FeatureFlagWithPayload",
+      "name": "FeatureFlagWithPayload",
+      "properties": [],
+      "path": "dist/hooks/useFeatureFlag.d.ts",
+      "example": "[FeatureFlagValue | undefined, JsonType | undefined]"
+    },
+    {
+      "id": "JsonType",
+      "name": "JsonType",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "string | number | boolean | null | {\n    [key: string]: JsonType;\n} | Array<JsonType> | JsonType[]"
+    },
+    {
+      "id": "LinkSurveyQuestion",
+      "name": "LinkSurveyQuestion",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.Link;\n    link?: string;\n}"
+    },
+    {
+      "id": "MultipleSurveyQuestion",
+      "name": "MultipleSurveyQuestion",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.SingleChoice | SurveyQuestionType.MultipleChoice;\n    choices: string[];\n    hasOpenChoice?: boolean;\n    shuffleOptions?: boolean;\n}"
+    },
+    {
+      "id": "NextQuestionBranching",
+      "name": "NextQuestionBranching",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    type: SurveyQuestionBranchingType.NextQuestion;\n}"
+    },
+    {
+      "id": "PartialWithRequired",
+      "name": "PartialWithRequired",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "keyof T> = {\n    [P in K]: T[P];\n} & {\n    [P in Exclude<keyof T, K>]?: T[P];\n}"
+    },
+    {
+      "id": "PostHogAutocaptureElement",
+      "name": "PostHogAutocaptureElement",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    $el_text?: string;\n    tag_name: string;\n    href?: string;\n    nth_child?: number;\n    nth_of_type?: number;\n    order?: number;\n} & PostHogEventProperties"
+    },
+    {
+      "id": "PostHogAutocaptureNavigationTrackerOptions",
+      "name": "PostHogAutocaptureNavigationTrackerOptions",
+      "properties": [],
+      "path": "dist/types.d.ts",
+      "example": "{\n    routeToName?: (name: string, params: any) => string;\n    routeToProperties?: (name: string, params: any) => Record<string, any>;\n}"
+    },
+    {
+      "id": "PostHogAutocaptureOptions",
+      "name": "PostHogAutocaptureOptions",
+      "properties": [],
+      "path": "dist/types.d.ts",
+      "example": "{\n    captureTouches?: boolean;\n    customLabelProp?: string;\n    noCaptureProp?: string;\n    maxElementsCaptured?: number;\n    ignoreLabels?: string[];\n    propsToCapture?: string[];\n    captureScreens?: boolean;\n    navigation?: PostHogAutocaptureNavigationTrackerOptions;\n    navigationRef?: PostHogNavigationRef;\n}"
+    },
+    {
+      "id": "PostHogCaptureOptions",
+      "name": "PostHogCaptureOptions",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    uuid?: string;\n    timestamp?: Date;\n    disableGeoip?: boolean;\n}"
+    },
+    {
+      "id": "PostHogCoreOptions",
+      "name": "PostHogCoreOptions",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    host?: string;\n    flushAt?: number;\n    flushInterval?: number;\n    maxBatchSize?: number;\n    maxQueueSize?: number;\n    disabled?: boolean;\n    defaultOptIn?: boolean;\n    sendFeatureFlagEvent?: boolean;\n    preloadFeatureFlags?: boolean;\n    disableRemoteConfig?: boolean;\n    disableSurveys?: boolean;\n    bootstrap?: {\n        distinctId?: string;\n        isIdentifiedId?: boolean;\n        featureFlags?: Record<string, FeatureFlagValue>;\n        featureFlagPayloads?: Record<string, JsonType>;\n    };\n    fetchRetryCount?: number;\n    fetchRetryDelay?: number;\n    requestTimeout?: number;\n    featureFlagsRequestTimeoutMs?: number;\n    remoteConfigRequestTimeoutMs?: number;\n    sessionExpirationTimeSeconds?: number;\n    disableCompression?: boolean;\n    disableGeoip?: boolean;\n    historicalMigration?: boolean;\n}"
+    },
+    {
+      "id": "PostHogCustomAppProperties",
+      "name": "PostHogCustomAppProperties",
+      "properties": [
+        {
+          "description": "Build number like \"1.2.2\" or \"122\"",
+          "type": "string | null",
+          "name": "$app_build"
+        },
+        {
+          "description": "Name of the app as displayed below the icon like \"PostHog\"",
+          "type": "string | null",
+          "name": "$app_name"
+        },
+        {
+          "description": "Namespace of the app usually like \"com.posthog.app\"",
+          "type": "string | null",
+          "name": "$app_namespace"
+        },
+        {
+          "description": "Human friendly app version like what a user would see in the app store like \"1.2.2\"",
+          "type": "string | null",
+          "name": "$app_version"
+        },
+        {
+          "description": "Manufacturer like \"Apple\", \"Samsung\" or \"Android\"",
+          "type": "string | null",
+          "name": "$device_manufacturer"
+        },
+        {
+          "description": "Model identifier like \"iPhone13,2\" or \"SM-S921B\"",
+          "type": "string | null",
+          "name": "$device_model"
+        },
+        {
+          "description": "Readable model name like \"iPhone 12\" or \"Samsung Galaxy S24\"",
+          "type": "string | null",
+          "name": "$device_name"
+        },
+        {
+          "description": "Device type (\"Mobile\" | \"Desktop\" | \"Web\")",
+          "type": "string | null",
+          "name": "$device_type"
+        },
+        {
+          "description": "Locale (language) of the device like \"en-US\"",
+          "type": "string | null",
+          "name": "$locale"
+        },
+        {
+          "description": "Operating system name like iOS or Android",
+          "type": "string | null",
+          "name": "$os_name"
+        },
+        {
+          "description": "Operating system version \"14.0\"",
+          "type": "string | null",
+          "name": "$os_version"
+        },
+        {
+          "description": "Timezone of the device like \"Europe/Berlin\"",
+          "type": "string | null",
+          "name": "$timezone"
+        }
+      ],
+      "path": "dist/types.d.ts"
+    },
+    {
+      "id": "PostHogCustomStorage",
+      "name": "PostHogCustomStorage",
+      "properties": [
+        {
+          "type": "(key: string) => string | null | Promise<string | null>",
+          "name": "getItem"
+        },
+        {
+          "type": "(key: string, value: string) => void | Promise<void>",
+          "name": "setItem"
+        }
+      ],
+      "path": "dist/types.d.ts"
+    },
+    {
+      "id": "PostHogEventProperties",
+      "name": "PostHogEventProperties",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "// Properties for React Native events\n{\n    event: 'user_signed_up',\n    userId: 'user123',\n    timestamp: new Date().toISOString(),\n    distinct_id: 'user123',\n    $set: {\n        email: 'user@example.com',\n        name: 'John Doe'\n    }\n}"
+    },
+    {
+      "id": "PostHogFeatureFlagDetails",
+      "name": "PostHogFeatureFlagDetails",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "\"flags\" | \"featureFlags\" | \"featureFlagPayloads\" | \"requestId\""
+    },
+    {
+      "id": "PostHogFetchOptions",
+      "name": "PostHogFetchOptions",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    method: 'GET' | 'POST' | 'PUT' | 'PATCH';\n    mode?: 'no-cors';\n    credentials?: 'omit';\n    headers: {\n        [key: string]: string;\n    };\n    body?: string | Blob;\n    signal?: AbortSignal;\n}"
+    },
+    {
+      "id": "PostHogFetchResponse",
+      "name": "PostHogFetchResponse",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    status: number;\n    text: () => Promise<string>;\n    json: () => Promise<any>;\n}"
+    },
+    {
+      "id": "PostHogFlagsResponse",
+      "name": "PostHogFlagsResponse",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "Omit<PostHogRemoteConfig, 'surveys' | 'hasFeatureFlags'> & {\n    featureFlags: {\n        [key: string]: FeatureFlagValue;\n    };\n    featureFlagPayloads: {\n        [key: string]: JsonType;\n    };\n    flags: {\n        [key: string]: FeatureFlagDetail;\n    };\n    errorsWhileComputingFlags: boolean;\n    sessionRecording?: boolean | {\n        [key: string]: JsonType;\n    };\n    quotaLimited?: string[];\n    requestId?: string;\n}"
+    },
+    {
+      "id": "PostHogGroupProperties",
+      "name": "PostHogGroupProperties",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    [type: string]: string | number;\n}"
+    },
+    {
+      "id": "PostHogNavigationRef",
+      "name": "PostHogNavigationRef",
+      "properties": [],
+      "path": "dist/types.d.ts",
+      "example": "{\n    getCurrentRoute(): any | undefined;\n    isReady: () => boolean;\n    current?: PostHogNavigationRef | any | undefined;\n}"
+    },
+    {
+      "id": "PostHogOptions",
+      "name": "PostHogOptions",
+      "properties": [],
+      "path": "dist/posthog-rn.d.ts",
+      "example": "PostHogCoreOptions & {\n    persistence?: 'memory' | 'file';\n    customAppProperties?: PostHogCustomAppProperties | ((properties: PostHogCustomAppProperties) => PostHogCustomAppProperties);\n    customStorage?: PostHogCustomStorage;\n    captureAppLifecycleEvents?: boolean;\n    enableSessionReplay?: boolean;\n    sessionReplayConfig?: PostHogSessionReplayConfig;\n    enablePersistSessionIdAcrossRestart?: boolean;\n}"
+    },
+    {
+      "id": "PostHogPersistedProperty",
+      "name": "PostHogPersistedProperty",
+      "properties": [
+        {
+          "type": "\"anonymous_id\"",
+          "name": "AnonymousId"
+        },
+        {
+          "type": "\"bootstrap_feature_flag_details\"",
+          "name": "BootstrapFeatureFlagDetails"
+        },
+        {
+          "type": "\"bootstrap_feature_flag_payloads\"",
+          "name": "BootstrapFeatureFlagPayloads"
+        },
+        {
+          "type": "\"bootstrap_feature_flags\"",
+          "name": "BootstrapFeatureFlags"
+        },
+        {
+          "type": "\"distinct_id\"",
+          "name": "DistinctId"
+        },
+        {
+          "type": "\"feature_flag_details\"",
+          "name": "FeatureFlagDetails"
+        },
+        {
+          "type": "\"feature_flag_payloads\"",
+          "name": "FeatureFlagPayloads"
+        },
+        {
+          "type": "\"feature_flags\"",
+          "name": "FeatureFlags"
+        },
+        {
+          "type": "\"flags_endpoint_was_hit\"",
+          "name": "FlagsEndpointWasHit"
+        },
+        {
+          "type": "\"group_properties\"",
+          "name": "GroupProperties"
+        },
+        {
+          "type": "\"installed_app_build\"",
+          "name": "InstalledAppBuild"
+        },
+        {
+          "type": "\"installed_app_version\"",
+          "name": "InstalledAppVersion"
+        },
+        {
+          "type": "\"opted_out\"",
+          "name": "OptedOut"
+        },
+        {
+          "type": "\"override_feature_flags\"",
+          "name": "OverrideFeatureFlags"
+        },
+        {
+          "type": "\"person_properties\"",
+          "name": "PersonProperties"
+        },
+        {
+          "type": "\"props\"",
+          "name": "Props"
+        },
+        {
+          "type": "\"queue\"",
+          "name": "Queue"
+        },
+        {
+          "type": "\"remote_config\"",
+          "name": "RemoteConfig"
+        },
+        {
+          "type": "\"session_id\"",
+          "name": "SessionId"
+        },
+        {
+          "type": "\"session_timestamp\"",
+          "name": "SessionLastTimestamp"
+        },
+        {
+          "type": "\"session_replay\"",
+          "name": "SessionReplay"
+        },
+        {
+          "type": "\"session_start_timestamp\"",
+          "name": "SessionStartTimestamp"
+        },
+        {
+          "type": "\"survey_last_seen_date\"",
+          "name": "SurveyLastSeenDate"
+        },
+        {
+          "type": "\"surveys\"",
+          "name": "Surveys"
+        },
+        {
+          "type": "\"surveys_seen\"",
+          "name": "SurveysSeen"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "PostHogProviderProps",
+      "name": "PostHogProviderProps",
+      "properties": [
+        {
+          "description": "Your PostHog API key",
+          "type": "string",
+          "name": "apiKey"
+        },
+        {
+          "description": "Autocapture configuration - can be a boolean or detailed options",
+          "type": "boolean | PostHogAutocaptureOptions",
+          "name": "autocapture"
+        },
+        {
+          "description": "The child components to render within the PostHog context",
+          "type": "React.ReactNode",
+          "name": "children"
+        },
+        {
+          "description": "An existing PostHog client instance",
+          "type": "PostHog",
+          "name": "client"
+        },
+        {
+          "description": "Enable debug mode for additional logging",
+          "type": "boolean",
+          "name": "debug"
+        },
+        {
+          "description": "PostHog configuration options",
+          "type": "PostHogOptions",
+          "name": "options"
+        },
+        {
+          "description": "Custom styles for the provider wrapper View",
+          "type": "StyleProp<ViewStyle>",
+          "name": "style"
+        }
+      ],
+      "path": "dist/PostHogProvider.d.ts"
+    },
+    {
+      "id": "PostHogRemoteConfig",
+      "name": "PostHogRemoteConfig",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    sessionRecording?: boolean | {\n        [key: string]: JsonType;\n    };\n    supportedCompression?: Compression[];\n    surveys?: boolean | Survey[];\n    hasFeatureFlags?: boolean;\n}"
+    },
+    {
+      "id": "PostHogSessionReplayConfig",
+      "name": "PostHogSessionReplayConfig",
+      "properties": [],
+      "path": "dist/types.d.ts",
+      "example": "{\n    maskAllTextInputs?: boolean;\n    maskAllImages?: boolean;\n    maskAllSandboxedViews?: boolean;\n    captureLog?: boolean;\n    iOSdebouncerDelayMs?: number;\n    androidDebouncerDelayMs?: number;\n    throttleDelayMs?: number;\n    captureNetworkTelemetry?: boolean;\n}"
+    },
+    {
+      "id": "PostHogSurveyProviderProps",
+      "name": "PostHogSurveyProviderProps",
+      "properties": [],
+      "path": "dist/surveys/PostHogSurveyProvider.d.ts",
+      "example": "{\n    defaultSurveyAppearance?: SurveyAppearance;\n    overrideAppearanceWithDefault?: boolean;\n    client?: PostHog;\n    children: React.ReactNode;\n}"
+    },
+    {
+      "id": "RatingSurveyQuestion",
+      "name": "RatingSurveyQuestion",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.Rating;\n    display: SurveyRatingDisplay;\n    scale: 3 | 5 | 7 | 10;\n    lowerBoundLabel: string;\n    upperBoundLabel: string;\n}"
+    },
+    {
+      "id": "ResponseBasedBranching",
+      "name": "ResponseBasedBranching",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    type: SurveyQuestionBranchingType.ResponseBased;\n    responseValues: Record<string, any>;\n}"
+    },
+    {
+      "id": "RetriableOptions",
+      "name": "RetriableOptions",
+      "properties": [
+        {
+          "type": "(err: unknown) => boolean",
+          "name": "retryCheck"
+        },
+        {
+          "type": "number",
+          "name": "retryCount"
+        },
+        {
+          "type": "number",
+          "name": "retryDelay"
+        }
+      ],
+      "path": "../core/src/utils/index.ts"
+    },
+    {
+      "id": "SpecificQuestionBranching",
+      "name": "SpecificQuestionBranching",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    type: SurveyQuestionBranchingType.SpecificQuestion;\n    index: number;\n}"
+    },
+    {
+      "id": "Survey",
+      "name": "Survey",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    id: string;\n    name: string;\n    description?: string;\n    type: SurveyType;\n    feature_flag_keys?: {\n        key: string;\n        value?: string;\n    }[];\n    linked_flag_key?: string;\n    targeting_flag_key?: string;\n    internal_targeting_flag_key?: string;\n    questions: SurveyQuestion[];\n    appearance?: SurveyAppearance;\n    conditions?: {\n        url?: string;\n        selector?: string;\n        seenSurveyWaitPeriodInDays?: number;\n        urlMatchType?: SurveyMatchType;\n        events?: {\n            repeatedActivation?: boolean;\n            values?: {\n                name: string;\n            }[];\n        };\n        actions?: {\n            values: SurveyActionType[];\n        };\n        deviceTypes?: string[];\n        deviceTypesMatchType?: SurveyMatchType;\n        linkedFlagVariant?: string;\n    };\n    start_date?: string;\n    end_date?: string;\n    current_iteration?: number;\n    current_iteration_start_date?: string;\n}"
+    },
+    {
+      "id": "SurveyActionType",
+      "name": "SurveyActionType",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    id: number;\n    name?: string;\n    steps?: ActionStepType[];\n}"
+    },
+    {
+      "id": "SurveyAppearance",
+      "name": "SurveyAppearance",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    backgroundColor?: string;\n    submitButtonColor?: string;\n    submitButtonText?: string;\n    submitButtonTextColor?: string;\n    ratingButtonColor?: string;\n    ratingButtonActiveColor?: string;\n    autoDisappear?: boolean;\n    displayThankYouMessage?: boolean;\n    thankYouMessageHeader?: string;\n    thankYouMessageDescription?: string;\n    thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType;\n    thankYouMessageCloseButtonText?: string;\n    borderColor?: string;\n    position?: SurveyPosition;\n    placeholder?: string;\n    shuffleQuestions?: boolean;\n    surveyPopupDelaySeconds?: number;\n    widgetType?: SurveyWidgetType;\n    widgetSelector?: string;\n    widgetLabel?: string;\n    widgetColor?: string;\n}"
+    },
+    {
+      "id": "SurveyAppearanceTheme",
+      "name": "SurveyAppearanceTheme",
+      "properties": [],
+      "path": "dist/surveys/surveys-utils.d.ts",
+      "example": "\"widgetSelector\" | \"widgetType\" | \"widgetColor\" | \"widgetLabel\" | \"shuffleQuestions\""
+    },
+    {
+      "id": "SurveyMatchType",
+      "name": "SurveyMatchType",
+      "properties": [
+        {
+          "type": "\"exact\"",
+          "name": "Exact"
+        },
+        {
+          "type": "\"icontains\"",
+          "name": "Icontains"
+        },
+        {
+          "type": "\"is_not\"",
+          "name": "IsNot"
+        },
+        {
+          "type": "\"not_icontains\"",
+          "name": "NotIcontains"
+        },
+        {
+          "type": "\"not_regex\"",
+          "name": "NotRegex"
+        },
+        {
+          "type": "\"regex\"",
+          "name": "Regex"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyModalProps",
+      "name": "SurveyModalProps",
+      "properties": [],
+      "path": "dist/surveys/components/SurveyModal.d.ts",
+      "example": "{\n    survey: Survey;\n    appearance: SurveyAppearanceTheme;\n    onShow: () => void;\n    onClose: (submitted: boolean) => void;\n}"
+    },
+    {
+      "id": "SurveyPosition",
+      "name": "SurveyPosition",
+      "properties": [
+        {
+          "type": "\"center\"",
+          "name": "Center"
+        },
+        {
+          "type": "\"left\"",
+          "name": "Left"
+        },
+        {
+          "type": "\"middle_center\"",
+          "name": "MiddleCenter"
+        },
+        {
+          "type": "\"middle_left\"",
+          "name": "MiddleLeft"
+        },
+        {
+          "type": "\"middle_right\"",
+          "name": "MiddleRight"
+        },
+        {
+          "type": "\"right\"",
+          "name": "Right"
+        },
+        {
+          "type": "\"top_center\"",
+          "name": "TopCenter"
+        },
+        {
+          "type": "\"top_left\"",
+          "name": "TopLeft"
+        },
+        {
+          "type": "\"top_right\"",
+          "name": "TopRight"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyQuestion",
+      "name": "SurveyQuestion",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "BasicSurveyQuestion | LinkSurveyQuestion | RatingSurveyQuestion | MultipleSurveyQuestion"
+    },
+    {
+      "id": "SurveyQuestionBase",
+      "name": "SurveyQuestionBase",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    question: string;\n    id: string;\n    description?: string;\n    descriptionContentType?: SurveyQuestionDescriptionContentType;\n    optional?: boolean;\n    buttonText?: string;\n    originalQuestionIndex: number;\n    branching?: NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching;\n}"
+    },
+    {
+      "id": "SurveyQuestionBranchingType",
+      "name": "SurveyQuestionBranchingType",
+      "properties": [
+        {
+          "type": "\"end\"",
+          "name": "End"
+        },
+        {
+          "type": "\"next_question\"",
+          "name": "NextQuestion"
+        },
+        {
+          "type": "\"response_based\"",
+          "name": "ResponseBased"
+        },
+        {
+          "type": "\"specific_question\"",
+          "name": "SpecificQuestion"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyQuestionDescriptionContentType",
+      "name": "SurveyQuestionDescriptionContentType",
+      "properties": [
+        {
+          "type": "\"html\"",
+          "name": "Html"
+        },
+        {
+          "type": "\"text\"",
+          "name": "Text"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyQuestionType",
+      "name": "SurveyQuestionType",
+      "properties": [
+        {
+          "type": "\"link\"",
+          "name": "Link"
+        },
+        {
+          "type": "\"multiple_choice\"",
+          "name": "MultipleChoice"
+        },
+        {
+          "type": "\"open\"",
+          "name": "Open"
+        },
+        {
+          "type": "\"rating\"",
+          "name": "Rating"
+        },
+        {
+          "type": "\"single_choice\"",
+          "name": "SingleChoice"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyRatingDisplay",
+      "name": "SurveyRatingDisplay",
+      "properties": [
+        {
+          "type": "\"emoji\"",
+          "name": "Emoji"
+        },
+        {
+          "type": "\"number\"",
+          "name": "Number"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyResponse",
+      "name": "SurveyResponse",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    surveys: Survey[];\n}"
+    },
+    {
+      "id": "SurveyType",
+      "name": "SurveyType",
+      "properties": [
+        {
+          "type": "\"api\"",
+          "name": "API"
+        },
+        {
+          "type": "\"external_survey\"",
+          "name": "ExternalSurvey"
+        },
+        {
+          "type": "\"popover\"",
+          "name": "Popover"
+        },
+        {
+          "type": "\"widget\"",
+          "name": "Widget"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyWidgetType",
+      "name": "SurveyWidgetType",
+      "properties": [
+        {
+          "type": "\"button\"",
+          "name": "Button"
+        },
+        {
+          "type": "\"selector\"",
+          "name": "Selector"
+        },
+        {
+          "type": "\"tab\"",
+          "name": "Tab"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    }
+  ],
+  "categories": [
+    "Initialization",
+    "Identification",
+    "Capture",
+    "Feature flags",
+    "Group analytics",
+    "Privacy",
+    "Error tracking",
+    "LLM analytics"
+  ]
+}

--- a/packages/react-native/references/posthog-react-native-references-latest.json
+++ b/packages/react-native/references/posthog-react-native-references-latest.json
@@ -1,0 +1,3407 @@
+{
+  "id": "posthog-react-native",
+  "hogRef": "0.3",
+  "info": {
+    "version": "4.7.0",
+    "id": "posthog-react-native",
+    "title": "PostHog React Native SDK",
+    "description": "PostHog React Native SDK allows you to capture events and send them to PostHog from your React Native applications.",
+    "slugPrefix": "posthog-react-native",
+    "specUrl": "https://github.com/PostHog/posthog-js"
+  },
+  "classes": [
+    {
+      "id": "PostHog",
+      "title": "PostHog",
+      "functions": [
+        {
+          "category": "Initialization",
+          "description": "PostHogProvider is a React component that provides PostHog functionality to your React Native app. You can find all configuration options in the [React Native SDK docs](https://posthog.com/docs/libraries/react-native#configuration-options).\nAutocapturing navigation requires further configuration. See the [React Native SDK navigation docs](https://posthog.com/docs/libraries/react-native#capturing-screen-views) for more information about autocapturing navigation.\nThis is the recommended way to set up PostHog for React Native. This utilizes the Context API to pass the PostHog client around, enable autocapture.",
+          "details": null,
+          "id": "PostHogProvider",
+          "showDocs": true,
+          "title": "PostHogProvider",
+          "examples": [
+            {
+              "id": "add_to_app.(js|ts)",
+              "name": "Add to App.(js|ts)",
+              "code": "\n\n// Add to App.(js|ts)\nimport { usePostHog, PostHogProvider } from 'posthog-react-native'\n\nexport function MyApp() {\n    return (\n        <PostHogProvider apiKey=\"<ph_project_api_key>\" options={{\n            host: '<ph_client_api_host>',\n        }}>\n            <MyComponent />\n        </PostHogProvider>\n    )\n}\n\n// And access the PostHog client via the usePostHog hook\nimport { usePostHog } from 'posthog-react-native'\n\nconst MyComponent = () => {\n    const posthog = usePostHog()\n\n    useEffect(() => {\n        posthog.capture(\"event_name\")\n    }, [posthog])\n}\n\n\n\n"
+            },
+            {
+              "id": "using_with_existing_client",
+              "name": "Using with existing client",
+              "code": "\n\n// Using with existing client\nimport { PostHog } from 'posthog-react-native'\n\nconst posthog = new PostHog('<ph_project_api_key>', {\n    host: '<ph_client_api_host>'\n})\n\nexport function MyApp() {\n    return (\n        <PostHogProvider client={posthog}>\n            <MyComponent />\n        </PostHogProvider>\n    )\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogProviderProps",
+              "name": "{ children, client, options, apiKey, autocapture, style, debug, }"
+            }
+          ],
+          "returnType": {
+            "id": "JSX.Element | null",
+            "name": "JSX.Element | null"
+          }
+        },
+        {
+          "category": "Initialization",
+          "description": "Creates a new PostHog instance for React Native. You can find all configuration options in the [React Native SDK docs](https://posthog.com/docs/libraries/react-native#configuration-options).\nIf you prefer not to use the PostHogProvider, you can initialize PostHog in its own file and import the instance from there.",
+          "details": null,
+          "id": "PostHog",
+          "showDocs": true,
+          "title": "PostHog",
+          "examples": [
+            {
+              "id": "posthog.ts",
+              "name": "posthog.ts",
+              "code": "\n\n// posthog.ts\nimport PostHog from 'posthog-react-native'\n\nexport const posthog = new PostHog('<ph_project_api_key>', {\n  host: '<ph_client_api_host>'\n})\n\n// Then you can access PostHog by importing your instance\n// Another file:\nimport { posthog } from './posthog'\n\nexport function MyApp1() {\n    useEffect(async () => {\n        posthog.capture('event_name')\n    }, [posthog])\n\n    return <View>Your app code</View>\n}\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Your PostHog API key",
+              "isOptional": false,
+              "type": "string",
+              "name": "apiKey"
+            },
+            {
+              "description": "PostHog configuration options",
+              "isOptional": true,
+              "type": "PostHogOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "any",
+            "name": "any"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Assigns an alias to the current user.\nSometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.",
+          "details": null,
+          "id": "alias",
+          "showDocs": true,
+          "title": "alias",
+          "examples": [
+            {
+              "id": "set_alias_for_current_user",
+              "name": "set alias for current user",
+              "code": "\n\n// set alias for current user\nposthog.alias('distinct_id')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The alias to assign to the current user",
+              "isOptional": false,
+              "type": "string",
+              "name": "alias"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "fetch",
+          "showDocs": true,
+          "title": "fetch",
+          "examples": [
+            {
+              "id": "fetch",
+              "name": "Generated example for fetch",
+              "code": "// Generated example for fetch\nposthog.fetch();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "url"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogFetchOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<PostHogFetchResponse>",
+            "name": "Promise<PostHogFetchResponse>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Manually flushes the event queue.\nYou can set the number of events in the configuration that should queue before flushing. Setting this to 1 will send events immediately and will use more battery. This is set to 20 by default. You can also manually flush the queue. If a flush is already in progress it returns a promise for the existing flush.",
+          "details": null,
+          "id": "flush",
+          "showDocs": true,
+          "title": "flush",
+          "examples": [
+            {
+              "id": "manually_flush_the_queue",
+              "name": "manually flush the queue",
+              "code": "\n\n// manually flush the queue\nawait posthog.flush()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getCommonEventProperties",
+          "showDocs": true,
+          "title": "getCommonEventProperties",
+          "examples": [
+            {
+              "id": "getcommoneventproperties",
+              "name": "Generated example for getCommonEventProperties",
+              "code": "// Generated example for getCommonEventProperties\nposthog.getCommonEventProperties();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "PostHogEventProperties",
+            "name": "PostHogEventProperties"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getCustomUserAgent",
+          "showDocs": true,
+          "title": "getCustomUserAgent",
+          "examples": [
+            {
+              "id": "getcustomuseragent",
+              "name": "Generated example for getCustomUserAgent",
+              "code": "// Generated example for getCustomUserAgent\nposthog.getCustomUserAgent();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Gets the current user's distinct ID.\nYou may find it helpful to get the current user's distinct ID. For example, to check whether you've already called identify for a user or not. This returns either the ID automatically generated by PostHog or the ID that has been passed by a call to identify().",
+          "details": null,
+          "id": "getDistinctId",
+          "showDocs": true,
+          "title": "getDistinctId",
+          "examples": [
+            {
+              "id": "get_current_distinct_id",
+              "name": "get current distinct ID",
+              "code": "\n\n// get current distinct ID\nconst distinctId = posthog.getDistinctId()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Gets the value of a feature flag for the current user.\nDefaults to undefined if not loaded yet or if there was a problem loading. Multivariant feature flags are returned as a string.",
+          "details": null,
+          "id": "getFeatureFlag",
+          "showDocs": true,
+          "title": "getFeatureFlag",
+          "examples": [
+            {
+              "id": "get_feature_flag_value",
+              "name": "get feature flag value",
+              "code": "\n\n// get feature flag value\nconst value = posthog.getFeatureFlag('key-for-your-boolean-flag')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            }
+          ],
+          "returnType": {
+            "id": "boolean | string | undefined",
+            "name": "boolean | string | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Gets the payload of a feature flag for the current user.\nReturns JsonType or undefined if not loaded yet or if there was a problem loading.",
+          "details": null,
+          "id": "getFeatureFlagPayload",
+          "showDocs": true,
+          "title": "getFeatureFlagPayload",
+          "examples": [
+            {
+              "id": "get_feature_flag_payload",
+              "name": "get feature flag payload",
+              "code": "\n\n// get feature flag payload\nconst payload = posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            }
+          ],
+          "returnType": {
+            "id": "JsonType | undefined",
+            "name": "JsonType | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getLibraryId",
+          "showDocs": true,
+          "title": "getLibraryId",
+          "examples": [
+            {
+              "id": "getlibraryid",
+              "name": "Generated example for getLibraryId",
+              "code": "// Generated example for getLibraryId\nposthog.getLibraryId();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getLibraryVersion",
+          "showDocs": true,
+          "title": "getLibraryVersion",
+          "examples": [
+            {
+              "id": "getlibraryversion",
+              "name": "Generated example for getLibraryVersion",
+              "code": "// Generated example for getLibraryVersion\nposthog.getLibraryVersion();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getPersistedProperty",
+          "showDocs": true,
+          "title": "getPersistedProperty",
+          "examples": [
+            {
+              "id": "getpersistedproperty",
+              "name": "Generated example for getPersistedProperty",
+              "code": "// Generated example for getPersistedProperty\nposthog.getPersistedProperty();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogPersistedProperty",
+              "name": "key"
+            }
+          ],
+          "returnType": {
+            "id": "T | undefined",
+            "name": "T | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getSessionId",
+          "showDocs": true,
+          "title": "getSessionId",
+          "examples": [
+            {
+              "id": "getsessionid",
+              "name": "Generated example for getSessionId",
+              "code": "// Generated example for getSessionId\nposthog.getSessionId();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getSurveys",
+          "showDocs": true,
+          "title": "getSurveys",
+          "examples": [
+            {
+              "id": "getsurveys",
+              "name": "Generated example for getSurveys",
+              "code": "// Generated example for getSurveys\nposthog.getSurveys();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<SurveyResponse['surveys']>",
+            "name": "Promise<SurveyResponse['surveys']>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Group analytics",
+          "description": "Associates the current user with a group.\nGroup analytics allows you to associate the events for that person's session with a group (e.g. teams, organizations, etc.). This is a paid feature and is not available on the open-source or free cloud plan.",
+          "details": null,
+          "id": "group",
+          "showDocs": true,
+          "title": "group",
+          "examples": [
+            {
+              "id": "associate_with_a_group",
+              "name": "associate with a group",
+              "code": "\n\n// associate with a group\nposthog.group('company', 'company_id_in_your_db')\n\n\n"
+            },
+            {
+              "id": "associate_with_a_group_and_update_properties",
+              "name": "associate with a group and update properties",
+              "code": "\n\n// associate with a group and update properties\nposthog.group('company', 'company_id_in_your_db', {\n  name: 'Awesome Inc.',\n  employees: 11,\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The type of group (e.g. 'company', 'team')",
+              "isOptional": false,
+              "type": "string",
+              "name": "groupType"
+            },
+            {
+              "description": "The unique identifier for the group",
+              "isOptional": false,
+              "type": "string",
+              "name": "groupKey"
+            },
+            {
+              "description": "Optional properties to set for the group",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Associates events with a specific user. Learn more about [identifying users](https://posthog.com/docs/product-analytics/identify)",
+          "details": null,
+          "id": "identify",
+          "showDocs": true,
+          "title": "identify",
+          "examples": [
+            {
+              "id": "basic_identify",
+              "name": "Basic identify",
+              "code": "\n\n// Basic identify\nposthog.identify('distinctID', {\n  email: 'user@posthog.com',\n  name: 'My Name'\n})\n\n\n"
+            },
+            {
+              "id": "using_$set_and_$set_once",
+              "name": "Using $set and $set_once",
+              "code": "\n\n// Using $set and $set_once\nposthog.identify('distinctID', {\n  $set: {\n    email: 'user@posthog.com',\n    name: 'My Name'\n  },\n  $set_once: {\n    date_of_first_log_in: '2024-03-01'\n  }\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "A unique identifier for your user. Typically either their email or database ID.",
+              "isOptional": true,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "Optional dictionary with key:value pairs to set the person properties",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "Optional capture options",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "initReactNativeNavigation",
+          "showDocs": true,
+          "title": "initReactNativeNavigation",
+          "examples": [
+            {
+              "id": "initreactnativenavigation",
+              "name": "Generated example for initReactNativeNavigation",
+              "code": "// Generated example for initReactNativeNavigation\nposthog.initReactNativeNavigation();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogAutocaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Checks if a feature flag is enabled for the current user.\nDefaults to undefined if not loaded yet or if there was a problem loading.",
+          "details": null,
+          "id": "isFeatureEnabled",
+          "showDocs": true,
+          "title": "isFeatureEnabled",
+          "examples": [
+            {
+              "id": "check_if_feature_flag_is_enabled",
+              "name": "check if feature flag is enabled",
+              "code": "\n\n// check if feature flag is enabled\nconst isEnabled = posthog.isFeatureEnabled('key-for-your-boolean-flag')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The feature flag key",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            }
+          ],
+          "returnType": {
+            "id": "boolean | undefined",
+            "name": "boolean | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Opts the user in to data capture.\nBy default, PostHog has tracking enabled unless it is forcefully disabled by default using the option  defaultOptIn: false . Once this has been called it is persisted and will be respected until optOut is called again or the reset function is called.",
+          "details": null,
+          "id": "optIn",
+          "showDocs": true,
+          "title": "optIn",
+          "examples": [
+            {
+              "id": "opt_in_to_tracking",
+              "name": "opt in to tracking",
+              "code": "\n\n// opt in to tracking\nposthog.optIn()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Privacy",
+          "description": "Opts the user out of data capture.\nYou can completely opt-out users from data capture. Once this has been called it is persisted and will be respected until optIn is called again or the reset function is called.",
+          "details": null,
+          "id": "optOut",
+          "showDocs": true,
+          "title": "optOut",
+          "examples": [
+            {
+              "id": "opt_out_of_tracking",
+              "name": "opt out of tracking",
+              "code": "\n\n// opt out of tracking\nposthog.optOut()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Registers super properties that are sent with every event.\nSuper properties are properties associated with events that are set once and then sent with every capture call. They persist across sessions and are stored locally.",
+          "details": null,
+          "id": "register",
+          "showDocs": true,
+          "title": "register",
+          "examples": [
+            {
+              "id": "register_super_properties",
+              "name": "register super properties",
+              "code": "\n\n// register super properties\nposthog.register({\n    'icecream pref': 'vanilla',\n    team_id: 22,\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "An associative array of properties to store about the user",
+              "isOptional": false,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Reloads feature flags from the server.\nPostHog loads feature flags when instantiated and refreshes whenever methods are called that affect the flag. If you want to manually trigger a refresh, you can call this method.",
+          "details": null,
+          "id": "reloadFeatureFlags",
+          "showDocs": true,
+          "title": "reloadFeatureFlags",
+          "examples": [
+            {
+              "id": "reload_feature_flags",
+              "name": "reload feature flags",
+              "code": "\n\n// reload feature flags\nposthog.reloadFeatureFlags()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Reloads feature flags from the server asynchronously.\nPostHog loads feature flags when instantiated and refreshes whenever methods are called that affect the flag. If you want to manually trigger a refresh and get the result, you can call this method.",
+          "details": null,
+          "id": "reloadFeatureFlagsAsync",
+          "showDocs": true,
+          "title": "reloadFeatureFlagsAsync",
+          "examples": [
+            {
+              "id": "reload_feature_flags_and_get_result",
+              "name": "reload feature flags and get result",
+              "code": "\n\n// reload feature flags and get result\nposthog.reloadFeatureFlagsAsync().then((refreshedFlags) => console.log(refreshedFlags))\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<Record<string, boolean | string> | undefined>",
+            "name": "Promise<Record<string, boolean | string> | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Resets the user's ID and anonymous ID after logout.\nTo reset the user's ID and anonymous ID, call reset. Usually you would do this right after the user logs out. This also clears all stored super properties and more.",
+          "details": null,
+          "id": "reset",
+          "showDocs": true,
+          "title": "reset",
+          "examples": [
+            {
+              "id": "reset_after_logout",
+              "name": "reset after logout",
+              "code": "\n\n// reset after logout\nposthog.reset()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Resets group properties for feature flag evaluation.",
+          "details": null,
+          "id": "resetGroupPropertiesForFlags",
+          "showDocs": true,
+          "title": "resetGroupPropertiesForFlags",
+          "examples": [
+            {
+              "id": "reset_group_properties_for_flags",
+              "name": "reset group properties for flags",
+              "code": "\n\n// reset group properties for flags\nposthog.resetGroupPropertiesForFlags()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Resets person properties for feature flag evaluation.",
+          "details": null,
+          "id": "resetPersonPropertiesForFlags",
+          "showDocs": true,
+          "title": "resetPersonPropertiesForFlags",
+          "examples": [
+            {
+              "id": "reset_person_properties_for_flags",
+              "name": "reset person properties for flags",
+              "code": "\n\n// reset person properties for flags\nposthog.resetPersonPropertiesForFlags()\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "resetSessionId",
+          "showDocs": true,
+          "title": "resetSessionId",
+          "examples": [
+            {
+              "id": "resetsessionid",
+              "name": "Generated example for resetSessionId",
+              "code": "// Generated example for resetSessionId\nposthog.resetSessionId();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Captures a screen view event.",
+          "details": "This function requires a name. You may also pass in an optional properties object. Screen name is automatically registered for the session and will be included in subsequent events.",
+          "id": "screen",
+          "showDocs": true,
+          "title": "screen",
+          "examples": [
+            {
+              "id": "basic_screen_capture",
+              "name": "Basic screen capture",
+              "code": "\n\n// Basic screen capture\nposthog.screen('dashboard')\n\n\n"
+            },
+            {
+              "id": "screen_capture_with_properties",
+              "name": "Screen capture with properties",
+              "code": "\n\n// Screen capture with properties\nposthog.screen('dashboard', {\n    background: 'blue',\n    hero: 'superhog',\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the screen",
+              "isOptional": false,
+              "type": "string",
+              "name": "name"
+            },
+            {
+              "description": "Optional properties to include with the screen event",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "Optional capture options",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Sets group properties for feature flag evaluation.\nThese properties are automatically attached to the current group (set via posthog.group()). When you change the group, these properties are reset.",
+          "details": null,
+          "id": "setGroupPropertiesForFlags",
+          "showDocs": true,
+          "title": "setGroupPropertiesForFlags",
+          "examples": [
+            {
+              "id": "set_group_properties_for_flags",
+              "name": "set group properties for flags",
+              "code": "\n\n// set group properties for flags\nposthog.setGroupPropertiesForFlags({'company': {'property1': 'value', property2: 'value2'}})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The group properties to set for flag evaluation",
+              "isOptional": false,
+              "type": "Record<string, Record<string, string>>",
+              "name": "properties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "setPersistedProperty",
+          "showDocs": true,
+          "title": "setPersistedProperty",
+          "examples": [
+            {
+              "id": "setpersistedproperty",
+              "name": "Generated example for setPersistedProperty",
+              "code": "// Generated example for setPersistedProperty\nposthog.setPersistedProperty();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogPersistedProperty",
+              "name": "key"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "T | null",
+              "name": "value"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Feature flags",
+          "description": "Sets person properties for feature flag evaluation.\nSometimes, you might want to evaluate feature flags using properties that haven't been ingested yet, or were set incorrectly earlier. You can do so by setting properties the flag depends on with this call. These are set for the entire session. Successive calls are additive: all properties you set are combined together and sent for flag evaluation.",
+          "details": null,
+          "id": "setPersonPropertiesForFlags",
+          "showDocs": true,
+          "title": "setPersonPropertiesForFlags",
+          "examples": [
+            {
+              "id": "set_person_properties_for_flags",
+              "name": "set person properties for flags",
+              "code": "\n\n// set person properties for flags\nposthog.setPersonPropertiesForFlags({'property1': 'value', property2: 'value2'})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The person properties to set for flag evaluation",
+              "isOptional": false,
+              "type": "Record<string, string>",
+              "name": "properties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Capture",
+          "description": "Removes a super property so it won't be sent with future events.\nSuper Properties are persisted across sessions so you have to explicitly remove them if they are no longer relevant.",
+          "details": null,
+          "id": "unregister",
+          "showDocs": true,
+          "title": "unregister",
+          "examples": [
+            {
+              "id": "remove_a_super_property",
+              "name": "remove a super property",
+              "code": "\n\n// remove a super property\nposthog.unregister('icecream pref')\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The name of the super property to remove",
+              "isOptional": false,
+              "type": "string",
+              "name": "property"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "autocapture",
+          "showDocs": true,
+          "title": "autocapture",
+          "examples": [
+            {
+              "id": "autocapture",
+              "name": "Generated example for autocapture",
+              "code": "// Generated example for autocapture\nposthog.autocapture();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "eventType"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogAutocaptureElement[]",
+              "name": "elements"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "capture",
+          "showDocs": true,
+          "title": "capture",
+          "examples": [
+            {
+              "id": "capture",
+              "name": "Generated example for capture",
+              "code": "// Generated example for capture\nposthog.capture();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "event"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Error tracking",
+          "description": "Capture a caught exception manually",
+          "details": null,
+          "id": "captureException",
+          "showDocs": true,
+          "title": "captureException",
+          "examples": [
+            {
+              "id": "capture_a_caught_exception",
+              "name": "Capture a caught exception",
+              "code": "\n\n// Capture a caught exception\ntry {\n  // something that might throw\n} catch (error) {\n  posthog.captureException(error)\n}\n\n\n"
+            },
+            {
+              "id": "with_additional_properties",
+              "name": "With additional properties",
+              "code": "\n\n// With additional properties\nposthog.captureException(error, {\n  customProperty: 'value',\n  anotherProperty: ['I', 'can be a list'],\n  ...\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The error to capture",
+              "isOptional": false,
+              "type": "unknown",
+              "name": "error"
+            },
+            {
+              "description": "Any additional properties to add to the error event",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "additionalProperties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "LLM analytics",
+          "description": "Capture written user feedback for a LLM trace. Numeric values are converted to strings.",
+          "details": null,
+          "id": "captureTraceFeedback",
+          "showDocs": true,
+          "title": "captureTraceFeedback",
+          "examples": [
+            {
+              "id": "capturetracefeedback",
+              "name": "Generated example for captureTraceFeedback",
+              "code": "// Generated example for captureTraceFeedback\nposthog.captureTraceFeedback();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The trace ID to capture feedback for.",
+              "isOptional": false,
+              "type": "string | number",
+              "name": "traceId"
+            },
+            {
+              "description": "The feedback to capture.",
+              "isOptional": false,
+              "type": "string",
+              "name": "userFeedback"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "LLM analytics",
+          "description": "Capture a metric for a LLM trace. Numeric values are converted to strings.",
+          "details": null,
+          "id": "captureTraceMetric",
+          "showDocs": true,
+          "title": "captureTraceMetric",
+          "examples": [
+            {
+              "id": "capturetracemetric",
+              "name": "Generated example for captureTraceMetric",
+              "code": "// Generated example for captureTraceMetric\nposthog.captureTraceMetric();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "The trace ID to capture the metric for.",
+              "isOptional": false,
+              "type": "string | number",
+              "name": "traceId"
+            },
+            {
+              "description": "The name of the metric to capture.",
+              "isOptional": false,
+              "type": "string",
+              "name": "metricName"
+            },
+            {
+              "description": "The value of the metric to capture.",
+              "isOptional": false,
+              "type": "string | number | boolean",
+              "name": "metricValue"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Identification",
+          "description": "Returns the current anonymous ID.\nThis is the ID assigned to users before they are identified. It's used to track anonymous users and link them to identified users when they sign up.",
+          "details": null,
+          "id": "getAnonymousId",
+          "showDocs": true,
+          "title": "getAnonymousId",
+          "examples": [
+            {
+              "id": "get_the_anonymous_id",
+              "name": "get the anonymous ID",
+              "code": "\n\n// get the anonymous ID\nconst anonId = posthog.getAnonymousId()\nconsole.log('Anonymous ID:', anonId)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "string",
+            "name": "string"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagDetails",
+          "showDocs": true,
+          "title": "getFeatureFlagDetails",
+          "examples": [
+            {
+              "id": "getfeatureflagdetails",
+              "name": "Generated example for getFeatureFlagDetails",
+              "code": "// Generated example for getFeatureFlagDetails\nposthog.getFeatureFlagDetails();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "PostHogFeatureFlagDetails | undefined",
+            "name": "PostHogFeatureFlagDetails | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagPayloads",
+          "showDocs": true,
+          "title": "getFeatureFlagPayloads",
+          "examples": [
+            {
+              "id": "getfeatureflagpayloads",
+              "name": "Generated example for getFeatureFlagPayloads",
+              "code": "// Generated example for getFeatureFlagPayloads\nposthog.getFeatureFlagPayloads();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "PostHogFlagsResponse['featureFlagPayloads'] | undefined",
+            "name": "PostHogFlagsResponse['featureFlagPayloads'] | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlags",
+          "showDocs": true,
+          "title": "getFeatureFlags",
+          "examples": [
+            {
+              "id": "getfeatureflags",
+              "name": "Generated example for getFeatureFlags",
+              "code": "// Generated example for getFeatureFlags\nposthog.getFeatureFlags();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "PostHogFlagsResponse['featureFlags'] | undefined",
+            "name": "PostHogFlagsResponse['featureFlags'] | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagsAndPayloads",
+          "showDocs": true,
+          "title": "getFeatureFlagsAndPayloads",
+          "examples": [
+            {
+              "id": "getfeatureflagsandpayloads",
+              "name": "Generated example for getFeatureFlagsAndPayloads",
+              "code": "// Generated example for getFeatureFlagsAndPayloads\nposthog.getFeatureFlagsAndPayloads();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "{\n        flags: PostHogFlagsResponse['featureFlags'] | undefined;\n        payloads: PostHogFlagsResponse['featureFlagPayloads'] | undefined;\n    }",
+            "name": "{\n        flags: PostHogFlagsResponse['featureFlags'] | undefined;\n        payloads: PostHogFlagsResponse['featureFlagPayloads'] | undefined;\n    }"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getKnownFeatureFlags",
+          "showDocs": true,
+          "title": "getKnownFeatureFlags",
+          "examples": [
+            {
+              "id": "getknownfeatureflags",
+              "name": "Generated example for getKnownFeatureFlags",
+              "code": "// Generated example for getKnownFeatureFlags\nposthog.getKnownFeatureFlags();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "PostHogFlagsResponse['featureFlags'] | undefined",
+            "name": "PostHogFlagsResponse['featureFlags'] | undefined"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "groupIdentify",
+          "showDocs": true,
+          "title": "groupIdentify",
+          "examples": [
+            {
+              "id": "groupidentify",
+              "name": "Generated example for groupIdentify",
+              "code": "// Generated example for groupIdentify\nposthog.groupIdentify();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "groupType"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string | number",
+              "name": "groupKey"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "description": "* ** GROUPS *",
+          "details": null,
+          "id": "groups",
+          "showDocs": true,
+          "title": "groups",
+          "examples": [
+            {
+              "id": "groups",
+              "name": "Generated example for groups",
+              "code": "// Generated example for groups\nposthog.groups();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogGroupProperties",
+              "name": "groups"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "on",
+          "showDocs": true,
+          "title": "on",
+          "examples": [
+            {
+              "id": "on",
+              "name": "Generated example for on",
+              "code": "// Generated example for on\nposthog.on();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "event"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "(...args: any[]) => void",
+              "name": "cb"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "onFeatureFlag",
+          "showDocs": true,
+          "title": "onFeatureFlag",
+          "examples": [
+            {
+              "id": "onfeatureflag",
+              "name": "Generated example for onFeatureFlag",
+              "code": "// Generated example for onFeatureFlag\nposthog.onFeatureFlag();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "(value: FeatureFlagValue) => void",
+              "name": "cb"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "onFeatureFlags",
+          "showDocs": true,
+          "title": "onFeatureFlags",
+          "examples": [
+            {
+              "id": "onfeatureflags",
+              "name": "Generated example for onFeatureFlags",
+              "code": "// Generated example for onFeatureFlags\nposthog.onFeatureFlags();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "(flags: PostHogFlagsResponse['featureFlags']) => void",
+              "name": "cb"
+            }
+          ],
+          "returnType": {
+            "id": "() => void",
+            "name": "() => void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "overrideFeatureFlag",
+          "showDocs": true,
+          "title": "overrideFeatureFlag",
+          "examples": [
+            {
+              "id": "overridefeatureflag",
+              "name": "Generated example for overrideFeatureFlag",
+              "code": "// Generated example for overrideFeatureFlag\nposthog.overrideFeatureFlag();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogFlagsResponse['featureFlags'] | null",
+              "name": "flags"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "registerForSession",
+          "showDocs": true,
+          "title": "registerForSession",
+          "examples": [
+            {
+              "id": "registerforsession",
+              "name": "Generated example for registerForSession",
+              "code": "// Generated example for registerForSession\nposthog.registerForSession();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "reloadRemoteConfigAsync",
+          "showDocs": true,
+          "title": "reloadRemoteConfigAsync",
+          "examples": [
+            {
+              "id": "reloadremoteconfigasync",
+              "name": "Generated example for reloadRemoteConfigAsync",
+              "code": "// Generated example for reloadRemoteConfigAsync\nposthog.reloadRemoteConfigAsync();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<PostHogRemoteConfig | undefined>",
+            "name": "Promise<PostHogRemoteConfig | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "setupBootstrap",
+          "showDocs": true,
+          "title": "setupBootstrap",
+          "examples": [
+            {
+              "id": "setupbootstrap",
+              "name": "Generated example for setupBootstrap",
+              "code": "// Generated example for setupBootstrap\nposthog.setupBootstrap();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Partial<PostHogCoreOptions>",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "unregisterForSession",
+          "showDocs": true,
+          "title": "unregisterForSession",
+          "examples": [
+            {
+              "id": "unregisterforsession",
+              "name": "Generated example for unregisterForSession",
+              "code": "// Generated example for unregisterForSession\nposthog.unregisterForSession();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "property"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "addPendingPromise",
+          "showDocs": true,
+          "title": "addPendingPromise",
+          "examples": [
+            {
+              "id": "addpendingpromise",
+              "name": "Generated example for addPendingPromise",
+              "code": "// Generated example for addPendingPromise\nposthog.addPendingPromise();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "Promise<T>",
+              "name": "promise"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<T>",
+            "name": "Promise<T>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "aliasStateless",
+          "showDocs": true,
+          "title": "aliasStateless",
+          "examples": [
+            {
+              "id": "aliasstateless",
+              "name": "Generated example for aliasStateless",
+              "code": "// Generated example for aliasStateless\nposthog.aliasStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "alias"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "aliasStatelessImmediate",
+          "showDocs": true,
+          "title": "aliasStatelessImmediate",
+          "examples": [
+            {
+              "id": "aliasstatelessimmediate",
+              "name": "Generated example for aliasStatelessImmediate",
+              "code": "// Generated example for aliasStatelessImmediate\nposthog.aliasStatelessImmediate();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "alias"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "captureStateless",
+          "showDocs": true,
+          "title": "captureStateless",
+          "examples": [
+            {
+              "id": "capturestateless",
+              "name": "Generated example for captureStateless",
+              "code": "// Generated example for captureStateless\nposthog.captureStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "event"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "captureStatelessImmediate",
+          "showDocs": true,
+          "title": "captureStatelessImmediate",
+          "examples": [
+            {
+              "id": "capturestatelessimmediate",
+              "name": "Generated example for captureStatelessImmediate",
+              "code": "// Generated example for captureStatelessImmediate\nposthog.captureStatelessImmediate();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "event"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Enables or disables debug mode for detailed logging.",
+          "details": "Debug mode logs all PostHog calls to the console for troubleshooting. This is useful during development to understand what data is being sent.",
+          "id": "debug",
+          "showDocs": true,
+          "title": "debug",
+          "examples": [
+            {
+              "id": "enable_debug_mode",
+              "name": "enable debug mode",
+              "code": "\n\n// enable debug mode\nposthog.debug(true)\n\n\n"
+            },
+            {
+              "id": "disable_debug_mode",
+              "name": "disable debug mode",
+              "code": "\n\n// disable debug mode\nposthog.debug(false)\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "enabled"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "description": "* ** QUEUEING AND FLUSHING *",
+          "details": null,
+          "id": "enqueue",
+          "showDocs": true,
+          "title": "enqueue",
+          "examples": [
+            {
+              "id": "enqueue",
+              "name": "Generated example for enqueue",
+              "code": "// Generated example for enqueue\nposthog.enqueue();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "type"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "any",
+              "name": "_message"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getCustomHeaders",
+          "showDocs": true,
+          "title": "getCustomHeaders",
+          "examples": [
+            {
+              "id": "getcustomheaders",
+              "name": "Generated example for getCustomHeaders",
+              "code": "// Generated example for getCustomHeaders\nposthog.getCustomHeaders();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "{\n        [key: string]: string;\n    }",
+            "name": "{\n        [key: string]: string;\n    }"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagDetailsStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagDetailsStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagdetailsstateless",
+              "name": "Generated example for getFeatureFlagDetailsStateless",
+              "code": "// Generated example for getFeatureFlagDetailsStateless\nposthog.getFeatureFlagDetailsStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string | number>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "string[]",
+              "name": "flagKeysToEvaluate"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<PostHogFeatureFlagDetails | undefined>",
+            "name": "Promise<PostHogFeatureFlagDetails | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagDetailStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagDetailStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagdetailstateless",
+              "name": "Generated example for getFeatureFlagDetailStateless",
+              "code": "// Generated example for getFeatureFlagDetailStateless\nposthog.getFeatureFlagDetailStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<{\n        response: FeatureFlagDetail | undefined;\n        requestId: string | undefined;\n    } | undefined>",
+            "name": "Promise<{\n        response: FeatureFlagDetail | undefined;\n        requestId: string | undefined;\n    } | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagPayloadsStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagPayloadsStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagpayloadsstateless",
+              "name": "Generated example for getFeatureFlagPayloadsStateless",
+              "code": "// Generated example for getFeatureFlagPayloadsStateless\nposthog.getFeatureFlagPayloadsStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "string[]",
+              "name": "flagKeysToEvaluate"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<PostHogFlagsResponse['featureFlagPayloads'] | undefined>",
+            "name": "Promise<PostHogFlagsResponse['featureFlagPayloads'] | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagPayloadStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagPayloadStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagpayloadstateless",
+              "name": "Generated example for getFeatureFlagPayloadStateless",
+              "code": "// Generated example for getFeatureFlagPayloadStateless\nposthog.getFeatureFlagPayloadStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<JsonType | undefined>",
+            "name": "Promise<JsonType | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagsAndPayloadsStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagsAndPayloadsStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagsandpayloadsstateless",
+              "name": "Generated example for getFeatureFlagsAndPayloadsStateless",
+              "code": "// Generated example for getFeatureFlagsAndPayloadsStateless\nposthog.getFeatureFlagsAndPayloadsStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string | number>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "string[]",
+              "name": "flagKeysToEvaluate"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<{\n        flags: PostHogFlagsResponse['featureFlags'] | undefined;\n        payloads: PostHogFlagsResponse['featureFlagPayloads'] | undefined;\n        requestId: PostHogFlagsResponse['requestId'] | undefined;\n    }>",
+            "name": "Promise<{\n        flags: PostHogFlagsResponse['featureFlags'] | undefined;\n        payloads: PostHogFlagsResponse['featureFlagPayloads'] | undefined;\n        requestId: PostHogFlagsResponse['requestId'] | undefined;\n    }>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagsStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagsStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagsstateless",
+              "name": "Generated example for getFeatureFlagsStateless",
+              "code": "// Generated example for getFeatureFlagsStateless\nposthog.getFeatureFlagsStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string | number>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "string[]",
+              "name": "flagKeysToEvaluate"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<{\n        flags: PostHogFlagsResponse['featureFlags'] | undefined;\n        payloads: PostHogFlagsResponse['featureFlagPayloads'] | undefined;\n        requestId: PostHogFlagsResponse['requestId'] | undefined;\n    }>",
+            "name": "Promise<{\n        flags: PostHogFlagsResponse['featureFlags'] | undefined;\n        payloads: PostHogFlagsResponse['featureFlagPayloads'] | undefined;\n        requestId: PostHogFlagsResponse['requestId'] | undefined;\n    }>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getFeatureFlagStateless",
+          "showDocs": true,
+          "title": "getFeatureFlagStateless",
+          "examples": [
+            {
+              "id": "getfeatureflagstateless",
+              "name": "Generated example for getFeatureFlagStateless",
+              "code": "// Generated example for getFeatureFlagStateless\nposthog.getFeatureFlagStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "key"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "boolean",
+              "name": "disableGeoip"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<{\n        response: FeatureFlagValue | undefined;\n        requestId: string | undefined;\n    }>",
+            "name": "Promise<{\n        response: FeatureFlagValue | undefined;\n        requestId: string | undefined;\n    }>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "description": "* ** FEATURE FLAGS *",
+          "details": null,
+          "id": "getFlags",
+          "showDocs": true,
+          "title": "getFlags",
+          "examples": [
+            {
+              "id": "getflags",
+              "name": "Generated example for getFlags",
+              "code": "// Generated example for getFlags\nposthog.getFlags();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string | number>",
+              "name": "groups"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, string>",
+              "name": "personProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, Record<string, string>>",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "Record<string, any>",
+              "name": "extraPayload"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<PostHogFlagsResponse | undefined>",
+            "name": "Promise<PostHogFlagsResponse | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "getRemoteConfig",
+          "showDocs": true,
+          "title": "getRemoteConfig",
+          "examples": [
+            {
+              "id": "getremoteconfig",
+              "name": "Generated example for getRemoteConfig",
+              "code": "// Generated example for getRemoteConfig\nposthog.getRemoteConfig();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<PostHogRemoteConfig | undefined>",
+            "name": "Promise<PostHogRemoteConfig | undefined>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "description": "* ** SURVEYS *",
+          "details": null,
+          "id": "getSurveysStateless",
+          "showDocs": true,
+          "title": "getSurveysStateless",
+          "examples": [
+            {
+              "id": "getsurveysstateless",
+              "name": "Generated example for getSurveysStateless",
+              "code": "// Generated example for getSurveysStateless\nposthog.getSurveysStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [],
+          "returnType": {
+            "id": "Promise<SurveyResponse['surveys']>",
+            "name": "Promise<SurveyResponse['surveys']>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "description": "* ** GROUPS *",
+          "details": null,
+          "id": "groupIdentifyStateless",
+          "showDocs": true,
+          "title": "groupIdentifyStateless",
+          "examples": [
+            {
+              "id": "groupidentifystateless",
+              "name": "Generated example for groupIdentifyStateless",
+              "code": "// Generated example for groupIdentifyStateless\nposthog.groupIdentifyStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "groupType"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string | number",
+              "name": "groupKey"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "groupProperties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "eventProperties"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "description": "* ** TRACKING *",
+          "details": null,
+          "id": "identifyStateless",
+          "showDocs": true,
+          "title": "identifyStateless",
+          "examples": [
+            {
+              "id": "identifystateless",
+              "name": "Generated example for identifyStateless",
+              "code": "// Generated example for identifyStateless\nposthog.identifyStateless();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "identifyStatelessImmediate",
+          "showDocs": true,
+          "title": "identifyStatelessImmediate",
+          "examples": [
+            {
+              "id": "identifystatelessimmediate",
+              "name": "Generated example for identifyStatelessImmediate",
+              "code": "// Generated example for identifyStatelessImmediate\nposthog.identifyStatelessImmediate();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "distinctId"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogEventProperties",
+              "name": "properties"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "logMsgIfDebug",
+          "showDocs": true,
+          "title": "logMsgIfDebug",
+          "examples": [
+            {
+              "id": "logmsgifdebug",
+              "name": "Generated example for logMsgIfDebug",
+              "code": "// Generated example for logMsgIfDebug\nposthog.logMsgIfDebug();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "() => void",
+              "name": "fn"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "sendImmediate",
+          "showDocs": true,
+          "title": "sendImmediate",
+          "examples": [
+            {
+              "id": "sendimmediate",
+              "name": "Generated example for sendImmediate",
+              "code": "// Generated example for sendImmediate\nposthog.sendImmediate();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "string",
+              "name": "type"
+            },
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "any",
+              "name": "_message"
+            },
+            {
+              "description": "",
+              "isOptional": true,
+              "type": "PostHogCaptureOptions",
+              "name": "options"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "Initialization",
+          "description": "Shuts down the PostHog instance and ensures all events are sent.\nCall shutdown() once before the process exits to ensure that all events have been sent and all promises have resolved. Do not use this function if you intend to keep using this PostHog instance after calling it. Use flush() for per-request cleanup instead.",
+          "details": null,
+          "id": "shutdown",
+          "showDocs": true,
+          "title": "shutdown",
+          "examples": [
+            {
+              "id": "shutdown_before_process_exit",
+              "name": "shutdown before process exit",
+              "code": "\n\n// shutdown before process exit\nprocess.on('SIGINT', async () => {\n  await posthog.shutdown()\n  process.exit(0)\n})\n\n\n\n"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "Maximum time to wait for shutdown in milliseconds",
+              "isOptional": true,
+              "type": "number",
+              "name": "shutdownTimeoutMs"
+            }
+          ],
+          "returnType": {
+            "id": "Promise<void>",
+            "name": "Promise<void>"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        },
+        {
+          "category": "",
+          "details": null,
+          "id": "wrap",
+          "showDocs": true,
+          "title": "wrap",
+          "examples": [
+            {
+              "id": "wrap",
+              "name": "Generated example for wrap",
+              "code": "// Generated example for wrap\nposthog.wrap();"
+            }
+          ],
+          "releaseTag": "public",
+          "params": [
+            {
+              "description": "",
+              "isOptional": false,
+              "type": "() => void",
+              "name": "fn"
+            }
+          ],
+          "returnType": {
+            "id": "void",
+            "name": "void"
+          },
+          "path": "dist/posthog-rn.d.ts"
+        }
+      ]
+    }
+  ],
+  "types": [
+    {
+      "id": "ActionStepStringMatching",
+      "name": "ActionStepStringMatching",
+      "properties": [
+        {
+          "type": "\"contains\"",
+          "name": "Contains"
+        },
+        {
+          "type": "\"exact\"",
+          "name": "Exact"
+        },
+        {
+          "type": "\"regex\"",
+          "name": "Regex"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "ActionStepType",
+      "name": "ActionStepType",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    event?: string;\n    selector?: string;\n    text?: string;\n    text_matching?: ActionStepStringMatching;\n    href?: string;\n    href_matching?: ActionStepStringMatching;\n    url?: string;\n    url_matching?: ActionStepStringMatching;\n}"
+    },
+    {
+      "id": "BasicSurveyQuestion",
+      "name": "BasicSurveyQuestion",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.Open;\n}"
+    },
+    {
+      "id": "Compression",
+      "name": "Compression",
+      "properties": [
+        {
+          "type": "\"base64\"",
+          "name": "Base64"
+        },
+        {
+          "type": "\"gzip-js\"",
+          "name": "GZipJS"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "EndBranching",
+      "name": "EndBranching",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    type: SurveyQuestionBranchingType.End;\n}"
+    },
+    {
+      "id": "EvaluationReason",
+      "name": "EvaluationReason",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    code: string | undefined;\n    condition_index: number | undefined;\n    description: string | undefined;\n}"
+    },
+    {
+      "id": "FeatureFlagDetail",
+      "name": "FeatureFlagDetail",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    key: string;\n    enabled: boolean;\n    variant: string | undefined;\n    reason: EvaluationReason | undefined;\n    metadata: FeatureFlagMetadata | undefined;\n}"
+    },
+    {
+      "id": "FeatureFlagMetadata",
+      "name": "FeatureFlagMetadata",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    id: number | undefined;\n    version: number | undefined;\n    description: string | undefined;\n    payload: string | undefined;\n}"
+    },
+    {
+      "id": "FeatureFlagValue",
+      "name": "FeatureFlagValue",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "string | boolean"
+    },
+    {
+      "id": "FeatureFlagWithPayload",
+      "name": "FeatureFlagWithPayload",
+      "properties": [],
+      "path": "dist/hooks/useFeatureFlag.d.ts",
+      "example": "[FeatureFlagValue | undefined, JsonType | undefined]"
+    },
+    {
+      "id": "JsonType",
+      "name": "JsonType",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "string | number | boolean | null | {\n    [key: string]: JsonType;\n} | Array<JsonType> | JsonType[]"
+    },
+    {
+      "id": "LinkSurveyQuestion",
+      "name": "LinkSurveyQuestion",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.Link;\n    link?: string;\n}"
+    },
+    {
+      "id": "MultipleSurveyQuestion",
+      "name": "MultipleSurveyQuestion",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.SingleChoice | SurveyQuestionType.MultipleChoice;\n    choices: string[];\n    hasOpenChoice?: boolean;\n    shuffleOptions?: boolean;\n}"
+    },
+    {
+      "id": "NextQuestionBranching",
+      "name": "NextQuestionBranching",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    type: SurveyQuestionBranchingType.NextQuestion;\n}"
+    },
+    {
+      "id": "PartialWithRequired",
+      "name": "PartialWithRequired",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "keyof T> = {\n    [P in K]: T[P];\n} & {\n    [P in Exclude<keyof T, K>]?: T[P];\n}"
+    },
+    {
+      "id": "PostHogAutocaptureElement",
+      "name": "PostHogAutocaptureElement",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    $el_text?: string;\n    tag_name: string;\n    href?: string;\n    nth_child?: number;\n    nth_of_type?: number;\n    order?: number;\n} & PostHogEventProperties"
+    },
+    {
+      "id": "PostHogAutocaptureNavigationTrackerOptions",
+      "name": "PostHogAutocaptureNavigationTrackerOptions",
+      "properties": [],
+      "path": "dist/types.d.ts",
+      "example": "{\n    routeToName?: (name: string, params: any) => string;\n    routeToProperties?: (name: string, params: any) => Record<string, any>;\n}"
+    },
+    {
+      "id": "PostHogAutocaptureOptions",
+      "name": "PostHogAutocaptureOptions",
+      "properties": [],
+      "path": "dist/types.d.ts",
+      "example": "{\n    captureTouches?: boolean;\n    customLabelProp?: string;\n    noCaptureProp?: string;\n    maxElementsCaptured?: number;\n    ignoreLabels?: string[];\n    propsToCapture?: string[];\n    captureScreens?: boolean;\n    navigation?: PostHogAutocaptureNavigationTrackerOptions;\n    navigationRef?: PostHogNavigationRef;\n}"
+    },
+    {
+      "id": "PostHogCaptureOptions",
+      "name": "PostHogCaptureOptions",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    uuid?: string;\n    timestamp?: Date;\n    disableGeoip?: boolean;\n}"
+    },
+    {
+      "id": "PostHogCoreOptions",
+      "name": "PostHogCoreOptions",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    host?: string;\n    flushAt?: number;\n    flushInterval?: number;\n    maxBatchSize?: number;\n    maxQueueSize?: number;\n    disabled?: boolean;\n    defaultOptIn?: boolean;\n    sendFeatureFlagEvent?: boolean;\n    preloadFeatureFlags?: boolean;\n    disableRemoteConfig?: boolean;\n    disableSurveys?: boolean;\n    bootstrap?: {\n        distinctId?: string;\n        isIdentifiedId?: boolean;\n        featureFlags?: Record<string, FeatureFlagValue>;\n        featureFlagPayloads?: Record<string, JsonType>;\n    };\n    fetchRetryCount?: number;\n    fetchRetryDelay?: number;\n    requestTimeout?: number;\n    featureFlagsRequestTimeoutMs?: number;\n    remoteConfigRequestTimeoutMs?: number;\n    sessionExpirationTimeSeconds?: number;\n    disableCompression?: boolean;\n    disableGeoip?: boolean;\n    historicalMigration?: boolean;\n}"
+    },
+    {
+      "id": "PostHogCustomAppProperties",
+      "name": "PostHogCustomAppProperties",
+      "properties": [
+        {
+          "description": "Build number like \"1.2.2\" or \"122\"",
+          "type": "string | null",
+          "name": "$app_build"
+        },
+        {
+          "description": "Name of the app as displayed below the icon like \"PostHog\"",
+          "type": "string | null",
+          "name": "$app_name"
+        },
+        {
+          "description": "Namespace of the app usually like \"com.posthog.app\"",
+          "type": "string | null",
+          "name": "$app_namespace"
+        },
+        {
+          "description": "Human friendly app version like what a user would see in the app store like \"1.2.2\"",
+          "type": "string | null",
+          "name": "$app_version"
+        },
+        {
+          "description": "Manufacturer like \"Apple\", \"Samsung\" or \"Android\"",
+          "type": "string | null",
+          "name": "$device_manufacturer"
+        },
+        {
+          "description": "Model identifier like \"iPhone13,2\" or \"SM-S921B\"",
+          "type": "string | null",
+          "name": "$device_model"
+        },
+        {
+          "description": "Readable model name like \"iPhone 12\" or \"Samsung Galaxy S24\"",
+          "type": "string | null",
+          "name": "$device_name"
+        },
+        {
+          "description": "Device type (\"Mobile\" | \"Desktop\" | \"Web\")",
+          "type": "string | null",
+          "name": "$device_type"
+        },
+        {
+          "description": "Locale (language) of the device like \"en-US\"",
+          "type": "string | null",
+          "name": "$locale"
+        },
+        {
+          "description": "Operating system name like iOS or Android",
+          "type": "string | null",
+          "name": "$os_name"
+        },
+        {
+          "description": "Operating system version \"14.0\"",
+          "type": "string | null",
+          "name": "$os_version"
+        },
+        {
+          "description": "Timezone of the device like \"Europe/Berlin\"",
+          "type": "string | null",
+          "name": "$timezone"
+        }
+      ],
+      "path": "dist/types.d.ts"
+    },
+    {
+      "id": "PostHogCustomStorage",
+      "name": "PostHogCustomStorage",
+      "properties": [
+        {
+          "type": "(key: string) => string | null | Promise<string | null>",
+          "name": "getItem"
+        },
+        {
+          "type": "(key: string, value: string) => void | Promise<void>",
+          "name": "setItem"
+        }
+      ],
+      "path": "dist/types.d.ts"
+    },
+    {
+      "id": "PostHogEventProperties",
+      "name": "PostHogEventProperties",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "// Properties for React Native events\n{\n    event: 'user_signed_up',\n    userId: 'user123',\n    timestamp: new Date().toISOString(),\n    distinct_id: 'user123',\n    $set: {\n        email: 'user@example.com',\n        name: 'John Doe'\n    }\n}"
+    },
+    {
+      "id": "PostHogFeatureFlagDetails",
+      "name": "PostHogFeatureFlagDetails",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "\"flags\" | \"featureFlags\" | \"featureFlagPayloads\" | \"requestId\""
+    },
+    {
+      "id": "PostHogFetchOptions",
+      "name": "PostHogFetchOptions",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    method: 'GET' | 'POST' | 'PUT' | 'PATCH';\n    mode?: 'no-cors';\n    credentials?: 'omit';\n    headers: {\n        [key: string]: string;\n    };\n    body?: string | Blob;\n    signal?: AbortSignal;\n}"
+    },
+    {
+      "id": "PostHogFetchResponse",
+      "name": "PostHogFetchResponse",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    status: number;\n    text: () => Promise<string>;\n    json: () => Promise<any>;\n}"
+    },
+    {
+      "id": "PostHogFlagsResponse",
+      "name": "PostHogFlagsResponse",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "Omit<PostHogRemoteConfig, 'surveys' | 'hasFeatureFlags'> & {\n    featureFlags: {\n        [key: string]: FeatureFlagValue;\n    };\n    featureFlagPayloads: {\n        [key: string]: JsonType;\n    };\n    flags: {\n        [key: string]: FeatureFlagDetail;\n    };\n    errorsWhileComputingFlags: boolean;\n    sessionRecording?: boolean | {\n        [key: string]: JsonType;\n    };\n    quotaLimited?: string[];\n    requestId?: string;\n}"
+    },
+    {
+      "id": "PostHogGroupProperties",
+      "name": "PostHogGroupProperties",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    [type: string]: string | number;\n}"
+    },
+    {
+      "id": "PostHogNavigationRef",
+      "name": "PostHogNavigationRef",
+      "properties": [],
+      "path": "dist/types.d.ts",
+      "example": "{\n    getCurrentRoute(): any | undefined;\n    isReady: () => boolean;\n    current?: PostHogNavigationRef | any | undefined;\n}"
+    },
+    {
+      "id": "PostHogOptions",
+      "name": "PostHogOptions",
+      "properties": [],
+      "path": "dist/posthog-rn.d.ts",
+      "example": "PostHogCoreOptions & {\n    persistence?: 'memory' | 'file';\n    customAppProperties?: PostHogCustomAppProperties | ((properties: PostHogCustomAppProperties) => PostHogCustomAppProperties);\n    customStorage?: PostHogCustomStorage;\n    captureAppLifecycleEvents?: boolean;\n    enableSessionReplay?: boolean;\n    sessionReplayConfig?: PostHogSessionReplayConfig;\n    enablePersistSessionIdAcrossRestart?: boolean;\n}"
+    },
+    {
+      "id": "PostHogPersistedProperty",
+      "name": "PostHogPersistedProperty",
+      "properties": [
+        {
+          "type": "\"anonymous_id\"",
+          "name": "AnonymousId"
+        },
+        {
+          "type": "\"bootstrap_feature_flag_details\"",
+          "name": "BootstrapFeatureFlagDetails"
+        },
+        {
+          "type": "\"bootstrap_feature_flag_payloads\"",
+          "name": "BootstrapFeatureFlagPayloads"
+        },
+        {
+          "type": "\"bootstrap_feature_flags\"",
+          "name": "BootstrapFeatureFlags"
+        },
+        {
+          "type": "\"distinct_id\"",
+          "name": "DistinctId"
+        },
+        {
+          "type": "\"feature_flag_details\"",
+          "name": "FeatureFlagDetails"
+        },
+        {
+          "type": "\"feature_flag_payloads\"",
+          "name": "FeatureFlagPayloads"
+        },
+        {
+          "type": "\"feature_flags\"",
+          "name": "FeatureFlags"
+        },
+        {
+          "type": "\"flags_endpoint_was_hit\"",
+          "name": "FlagsEndpointWasHit"
+        },
+        {
+          "type": "\"group_properties\"",
+          "name": "GroupProperties"
+        },
+        {
+          "type": "\"installed_app_build\"",
+          "name": "InstalledAppBuild"
+        },
+        {
+          "type": "\"installed_app_version\"",
+          "name": "InstalledAppVersion"
+        },
+        {
+          "type": "\"opted_out\"",
+          "name": "OptedOut"
+        },
+        {
+          "type": "\"override_feature_flags\"",
+          "name": "OverrideFeatureFlags"
+        },
+        {
+          "type": "\"person_properties\"",
+          "name": "PersonProperties"
+        },
+        {
+          "type": "\"props\"",
+          "name": "Props"
+        },
+        {
+          "type": "\"queue\"",
+          "name": "Queue"
+        },
+        {
+          "type": "\"remote_config\"",
+          "name": "RemoteConfig"
+        },
+        {
+          "type": "\"session_id\"",
+          "name": "SessionId"
+        },
+        {
+          "type": "\"session_timestamp\"",
+          "name": "SessionLastTimestamp"
+        },
+        {
+          "type": "\"session_replay\"",
+          "name": "SessionReplay"
+        },
+        {
+          "type": "\"session_start_timestamp\"",
+          "name": "SessionStartTimestamp"
+        },
+        {
+          "type": "\"survey_last_seen_date\"",
+          "name": "SurveyLastSeenDate"
+        },
+        {
+          "type": "\"surveys\"",
+          "name": "Surveys"
+        },
+        {
+          "type": "\"surveys_seen\"",
+          "name": "SurveysSeen"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "PostHogProviderProps",
+      "name": "PostHogProviderProps",
+      "properties": [
+        {
+          "description": "Your PostHog API key",
+          "type": "string",
+          "name": "apiKey"
+        },
+        {
+          "description": "Autocapture configuration - can be a boolean or detailed options",
+          "type": "boolean | PostHogAutocaptureOptions",
+          "name": "autocapture"
+        },
+        {
+          "description": "The child components to render within the PostHog context",
+          "type": "React.ReactNode",
+          "name": "children"
+        },
+        {
+          "description": "An existing PostHog client instance",
+          "type": "PostHog",
+          "name": "client"
+        },
+        {
+          "description": "Enable debug mode for additional logging",
+          "type": "boolean",
+          "name": "debug"
+        },
+        {
+          "description": "PostHog configuration options",
+          "type": "PostHogOptions",
+          "name": "options"
+        },
+        {
+          "description": "Custom styles for the provider wrapper View",
+          "type": "StyleProp<ViewStyle>",
+          "name": "style"
+        }
+      ],
+      "path": "dist/PostHogProvider.d.ts"
+    },
+    {
+      "id": "PostHogRemoteConfig",
+      "name": "PostHogRemoteConfig",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    sessionRecording?: boolean | {\n        [key: string]: JsonType;\n    };\n    supportedCompression?: Compression[];\n    surveys?: boolean | Survey[];\n    hasFeatureFlags?: boolean;\n}"
+    },
+    {
+      "id": "PostHogSessionReplayConfig",
+      "name": "PostHogSessionReplayConfig",
+      "properties": [],
+      "path": "dist/types.d.ts",
+      "example": "{\n    maskAllTextInputs?: boolean;\n    maskAllImages?: boolean;\n    maskAllSandboxedViews?: boolean;\n    captureLog?: boolean;\n    iOSdebouncerDelayMs?: number;\n    androidDebouncerDelayMs?: number;\n    throttleDelayMs?: number;\n    captureNetworkTelemetry?: boolean;\n}"
+    },
+    {
+      "id": "PostHogSurveyProviderProps",
+      "name": "PostHogSurveyProviderProps",
+      "properties": [],
+      "path": "dist/surveys/PostHogSurveyProvider.d.ts",
+      "example": "{\n    defaultSurveyAppearance?: SurveyAppearance;\n    overrideAppearanceWithDefault?: boolean;\n    client?: PostHog;\n    children: React.ReactNode;\n}"
+    },
+    {
+      "id": "RatingSurveyQuestion",
+      "name": "RatingSurveyQuestion",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "SurveyQuestionBase & {\n    type: SurveyQuestionType.Rating;\n    display: SurveyRatingDisplay;\n    scale: 3 | 5 | 7 | 10;\n    lowerBoundLabel: string;\n    upperBoundLabel: string;\n}"
+    },
+    {
+      "id": "ResponseBasedBranching",
+      "name": "ResponseBasedBranching",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    type: SurveyQuestionBranchingType.ResponseBased;\n    responseValues: Record<string, any>;\n}"
+    },
+    {
+      "id": "RetriableOptions",
+      "name": "RetriableOptions",
+      "properties": [
+        {
+          "type": "(err: unknown) => boolean",
+          "name": "retryCheck"
+        },
+        {
+          "type": "number",
+          "name": "retryCount"
+        },
+        {
+          "type": "number",
+          "name": "retryDelay"
+        }
+      ],
+      "path": "../core/src/utils/index.ts"
+    },
+    {
+      "id": "SpecificQuestionBranching",
+      "name": "SpecificQuestionBranching",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    type: SurveyQuestionBranchingType.SpecificQuestion;\n    index: number;\n}"
+    },
+    {
+      "id": "Survey",
+      "name": "Survey",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    id: string;\n    name: string;\n    description?: string;\n    type: SurveyType;\n    feature_flag_keys?: {\n        key: string;\n        value?: string;\n    }[];\n    linked_flag_key?: string;\n    targeting_flag_key?: string;\n    internal_targeting_flag_key?: string;\n    questions: SurveyQuestion[];\n    appearance?: SurveyAppearance;\n    conditions?: {\n        url?: string;\n        selector?: string;\n        seenSurveyWaitPeriodInDays?: number;\n        urlMatchType?: SurveyMatchType;\n        events?: {\n            repeatedActivation?: boolean;\n            values?: {\n                name: string;\n            }[];\n        };\n        actions?: {\n            values: SurveyActionType[];\n        };\n        deviceTypes?: string[];\n        deviceTypesMatchType?: SurveyMatchType;\n        linkedFlagVariant?: string;\n    };\n    start_date?: string;\n    end_date?: string;\n    current_iteration?: number;\n    current_iteration_start_date?: string;\n}"
+    },
+    {
+      "id": "SurveyActionType",
+      "name": "SurveyActionType",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    id: number;\n    name?: string;\n    steps?: ActionStepType[];\n}"
+    },
+    {
+      "id": "SurveyAppearance",
+      "name": "SurveyAppearance",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    backgroundColor?: string;\n    submitButtonColor?: string;\n    submitButtonText?: string;\n    submitButtonTextColor?: string;\n    ratingButtonColor?: string;\n    ratingButtonActiveColor?: string;\n    autoDisappear?: boolean;\n    displayThankYouMessage?: boolean;\n    thankYouMessageHeader?: string;\n    thankYouMessageDescription?: string;\n    thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType;\n    thankYouMessageCloseButtonText?: string;\n    borderColor?: string;\n    position?: SurveyPosition;\n    placeholder?: string;\n    shuffleQuestions?: boolean;\n    surveyPopupDelaySeconds?: number;\n    widgetType?: SurveyWidgetType;\n    widgetSelector?: string;\n    widgetLabel?: string;\n    widgetColor?: string;\n}"
+    },
+    {
+      "id": "SurveyAppearanceTheme",
+      "name": "SurveyAppearanceTheme",
+      "properties": [],
+      "path": "dist/surveys/surveys-utils.d.ts",
+      "example": "\"widgetSelector\" | \"widgetType\" | \"widgetColor\" | \"widgetLabel\" | \"shuffleQuestions\""
+    },
+    {
+      "id": "SurveyMatchType",
+      "name": "SurveyMatchType",
+      "properties": [
+        {
+          "type": "\"exact\"",
+          "name": "Exact"
+        },
+        {
+          "type": "\"icontains\"",
+          "name": "Icontains"
+        },
+        {
+          "type": "\"is_not\"",
+          "name": "IsNot"
+        },
+        {
+          "type": "\"not_icontains\"",
+          "name": "NotIcontains"
+        },
+        {
+          "type": "\"not_regex\"",
+          "name": "NotRegex"
+        },
+        {
+          "type": "\"regex\"",
+          "name": "Regex"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyModalProps",
+      "name": "SurveyModalProps",
+      "properties": [],
+      "path": "dist/surveys/components/SurveyModal.d.ts",
+      "example": "{\n    survey: Survey;\n    appearance: SurveyAppearanceTheme;\n    onShow: () => void;\n    onClose: (submitted: boolean) => void;\n}"
+    },
+    {
+      "id": "SurveyPosition",
+      "name": "SurveyPosition",
+      "properties": [
+        {
+          "type": "\"center\"",
+          "name": "Center"
+        },
+        {
+          "type": "\"left\"",
+          "name": "Left"
+        },
+        {
+          "type": "\"middle_center\"",
+          "name": "MiddleCenter"
+        },
+        {
+          "type": "\"middle_left\"",
+          "name": "MiddleLeft"
+        },
+        {
+          "type": "\"middle_right\"",
+          "name": "MiddleRight"
+        },
+        {
+          "type": "\"right\"",
+          "name": "Right"
+        },
+        {
+          "type": "\"top_center\"",
+          "name": "TopCenter"
+        },
+        {
+          "type": "\"top_left\"",
+          "name": "TopLeft"
+        },
+        {
+          "type": "\"top_right\"",
+          "name": "TopRight"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyQuestion",
+      "name": "SurveyQuestion",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "BasicSurveyQuestion | LinkSurveyQuestion | RatingSurveyQuestion | MultipleSurveyQuestion"
+    },
+    {
+      "id": "SurveyQuestionBase",
+      "name": "SurveyQuestionBase",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    question: string;\n    id: string;\n    description?: string;\n    descriptionContentType?: SurveyQuestionDescriptionContentType;\n    optional?: boolean;\n    buttonText?: string;\n    originalQuestionIndex: number;\n    branching?: NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching;\n}"
+    },
+    {
+      "id": "SurveyQuestionBranchingType",
+      "name": "SurveyQuestionBranchingType",
+      "properties": [
+        {
+          "type": "\"end\"",
+          "name": "End"
+        },
+        {
+          "type": "\"next_question\"",
+          "name": "NextQuestion"
+        },
+        {
+          "type": "\"response_based\"",
+          "name": "ResponseBased"
+        },
+        {
+          "type": "\"specific_question\"",
+          "name": "SpecificQuestion"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyQuestionDescriptionContentType",
+      "name": "SurveyQuestionDescriptionContentType",
+      "properties": [
+        {
+          "type": "\"html\"",
+          "name": "Html"
+        },
+        {
+          "type": "\"text\"",
+          "name": "Text"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyQuestionType",
+      "name": "SurveyQuestionType",
+      "properties": [
+        {
+          "type": "\"link\"",
+          "name": "Link"
+        },
+        {
+          "type": "\"multiple_choice\"",
+          "name": "MultipleChoice"
+        },
+        {
+          "type": "\"open\"",
+          "name": "Open"
+        },
+        {
+          "type": "\"rating\"",
+          "name": "Rating"
+        },
+        {
+          "type": "\"single_choice\"",
+          "name": "SingleChoice"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyRatingDisplay",
+      "name": "SurveyRatingDisplay",
+      "properties": [
+        {
+          "type": "\"emoji\"",
+          "name": "Emoji"
+        },
+        {
+          "type": "\"number\"",
+          "name": "Number"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyResponse",
+      "name": "SurveyResponse",
+      "properties": [],
+      "path": "../core/src/types.ts",
+      "example": "{\n    surveys: Survey[];\n}"
+    },
+    {
+      "id": "SurveyType",
+      "name": "SurveyType",
+      "properties": [
+        {
+          "type": "\"api\"",
+          "name": "API"
+        },
+        {
+          "type": "\"external_survey\"",
+          "name": "ExternalSurvey"
+        },
+        {
+          "type": "\"popover\"",
+          "name": "Popover"
+        },
+        {
+          "type": "\"widget\"",
+          "name": "Widget"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    },
+    {
+      "id": "SurveyWidgetType",
+      "name": "SurveyWidgetType",
+      "properties": [
+        {
+          "type": "\"button\"",
+          "name": "Button"
+        },
+        {
+          "type": "\"selector\"",
+          "name": "Selector"
+        },
+        {
+          "type": "\"tab\"",
+          "name": "Tab"
+        }
+      ],
+      "path": "../core/src/types.ts"
+    }
+  ],
+  "categories": [
+    "Initialization",
+    "Identification",
+    "Capture",
+    "Feature flags",
+    "Group analytics",
+    "Privacy",
+    "Error tracking",
+    "LLM analytics"
+  ]
+}

--- a/scripts/docs/parser.js
+++ b/scripts/docs/parser.js
@@ -6,9 +6,6 @@ const types = require('./types');
 const { writeFileSync, readFileSync } = require('fs');
 const path = require('path');
 
-const loadPackageInfo = (packageDir) => 
-    JSON.parse(readFileSync(path.resolve(packageDir, 'package.json'), 'utf8'));
-
 const loadApiPackage = (filePath) => 
     apiExtractor.ApiPackage.loadFromJsonFile(filePath);
 
@@ -80,11 +77,11 @@ const createClassDefinition = (posthogClass, functions) => ({
 });
 
 // Compose final output
-const composeOutput = (packageJson, posthogClass, functions, types, config) => ({
+const composeOutput = (posthogClass, functions, types, config) => ({
     id: config.id,
     hogRef: config.hogRef,
     info: {
-        version: packageJson.version,
+        version: config.version,
         ...config.specInfo
     },
     classes: [createClassDefinition(posthogClass, functions)],
@@ -94,7 +91,6 @@ const composeOutput = (packageJson, posthogClass, functions, types, config) => (
 });
 
 const generateApiSpecs = (config) => {
-    const packageJson = loadPackageInfo(config.packageDir);
     const apiPackage = loadApiPackage(config.apiJsonPath);
     const posthogClass = findPostHogClass(apiPackage, config.parentClass);
     
@@ -112,9 +108,7 @@ const generateApiSpecs = (config) => {
     // Combine regular methods with extra methods
     const allFunctions = [...providerMethods,...functions];
     
-    const output = composeOutput(packageJson, posthogClass, allFunctions, resolvedTypes, config);
-    
-    writeFileSync(config.outputPath, JSON.stringify(output, null, 2));
+    const output = composeOutput(posthogClass, allFunctions, resolvedTypes, config);
     
     return output;
 };

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,24 @@
             "outputs": ["dist/**", "lib/**", "react/**"],
             "env": ["WRITE_MANGLED_PROPERTIES"]
         },
+        "posthog-js#generate-references": {
+            "dependsOn": ["build"],
+            "inputs": ["dist/**", "package.json", "scripts/**", "docs/**"],
+            "outputs": ["references/**"],
+            "cache": false
+        },
+        "posthog-node#generate-references": {
+            "dependsOn": ["build"],
+            "inputs": ["dist/**", "package.json", "scripts/**", "docs/**"],
+            "outputs": ["references/**"],
+            "cache": false
+        },
+        "posthog-react-native#generate-references": {
+            "dependsOn": ["build"],
+            "inputs": ["dist/**", "package.json", "scripts/**", "docs/**"],
+            "outputs": ["references/**"],
+            "cache": false
+        },
         "package": {
             "cache": false,
             "dependsOn": ["^package", "build"],


### PR DESCRIPTION
## Problem

We want automatically updated, versioned, and persisted references for all SDKs.

See [related RFC](https://github.com/PostHog/meta/pull/368/files#diff-c5df39f9badac88d0947f3fc589c0061b7ef39cef8b84506feb327cfc3897d36R28)

## Changes

This PR does these things:
- Adds single generate-references command at root
- Add workflow to generate references and push on release
- Only changes in the references folder will be committed to master
- We will pull these in on build on the website later.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
