### PR TITLE
fix: buffer rotation while pending

### DIFF
--- a/.changeset/wise-fans-mix.md
+++ b/.changeset/wise-fans-mix.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: rotating buffer while trigger pending

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -26,7 +26,6 @@ import {
 } from '../../../types'
 import { uuidv7 } from '../../../uuidv7'
 import { RECORDING_IDLE_THRESHOLD_MS, RECORDING_MAX_EVENT_SIZE } from '../../../extensions/replay/sessionrecording'
-import { TRIGGER_PENDING } from '../../../extensions/replay/triggerMatching'
 import { assignableWindow, window } from '../../../utils/globals'
 import { RequestRouter } from '../../../utils/request-router'
 import {
@@ -2179,22 +2178,13 @@ describe('Lazy SessionRecording', () => {
 
             expect(sessionRecording.status).toBe('buffering')
 
-            // Mock trigger status to be TRIGGER_PENDING
-            const mockTriggerStatus = jest.fn().mockReturnValue(TRIGGER_PENDING)
-            sessionRecording['_lazyLoadedSessionRecording']['_triggerMatching']['triggerStatus'] = mockTriggerStatus
-
-            // Mock _receivedFlags to true so buffer clearing can happen
-            sessionRecording['_lazyLoadedSessionRecording']['_receivedFlags'] = true
-
-            // Emit incremental event, then meta event, then custom event, then full snapshot
             _emit(createIncrementalSnapshot({ data: { source: 1 } }))
             _emit(createMetaSnapshot())
             _emit(createCustomSnapshot({}, { tag: 'test' }))
             _emit(createFullSnapshot())
 
-            // Buffer should only contain the meta event (the most recent meta event)
+            // Buffer should only data since (including) the meta event
             const bufferData = sessionRecording['_lazyLoadedSessionRecording']['_buffer'].data
-            expect(bufferData).toHaveLength(3)
             expect(bufferData).toEqual([
                 createMetaSnapshot(),
                 createCustomSnapshot({}, { tag: 'test' }),

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -835,7 +835,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             this._receivedFlags &&
             this._triggerMatching.triggerStatus(this.sessionId) === TRIGGER_PENDING
         ) {
-            this._clearBufferFromMostRecentMeta()
+            this._clearBufferBeforeMostRecentMeta()
         }
 
         const throttledEvent = this._mutationThrottler ? this._mutationThrottler.throttleMutations(rawEvent) : rawEvent
@@ -1027,7 +1027,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         return mostRecentSnapshot ? mostRecentSnapshot.timestamp - sessionStartTimestamp : null
     }
 
-    private _clearBufferFromMostRecentMeta(): SnapshotBuffer {
+    private _clearBufferBeforeMostRecentMeta(): SnapshotBuffer {
         if (!this._buffer || this._buffer.data.length === 0) {
             return this._clearBuffer()
         }

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -47,6 +47,7 @@
         "_checkStepUrl",
         "_checkSurveyEligibility",
         "_clearBuffer",
+        "_clearBufferBeforeMostRecentMeta",
         "_clearConditionalRecordingPersistence",
         "_clearDebouncer",
         "_clearFlushTimeout",


### PR DESCRIPTION
since i've been changing this code it's in my head

while i was looking at the meta event playback issue

my subconscious realised this code isn't correct

so even if it's unrelated we should fix it

---

when we're in a trigger pending state (e.g. waiting for a url or event trigger)
we take a full snapshot every minute (to keep the buffer size down)
when we get a fullsnapshot we clear the buffer
but before a fullsnapshot we get a meta event
and we have to keep the meta event for a recording to be playable

so we don't want to clear the buffer we want to clear everything from before the meta event

(this is implemented as if there could be events between the meta and the full snapshot, in practice there won't be but for safety...)