### PR TITLE
fix: don't mangle to dollar in any build

### DIFF
--- a/.changeset/beige-corners-camp.md
+++ b/.changeset/beige-corners-camp.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: don't mangle to $ in no external or es5 builds

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -108,10 +108,16 @@ const plugins = (es5, noExternal) => [
             comments: false,
         },
         mangle:
-            // Don't mangle properties in no-external builds, as it is used in Browser extensions which have to go through a review process with e.g. Google, and they can be weird about obfuscated code.
-            // Don't mangle properties in the es5 build, as it relies on helpers which don't work well with mangling.
             noExternal || es5
-                ? true
+                ? {
+                      // Don't mangle properties in no-external builds, as it is used in Browser extensions which have to go through a review process with e.g. Google, and they can be weird about obfuscated code.
+                      // Don't mangle properties in the es5 build, as it relies on helpers which don't work well with mangling.
+                      properties: false,
+                      reserved: [
+                          // we don't want to emit $ since that clashes with jquery
+                          '$',
+                      ],
+                  }
                 : {
                       // Note:
                       // PROPERTY MANGLING CAN BREAK YOUR CODE


### PR DESCRIPTION
we don't want to mangle to $ ever
this updates so that the no external and es5 builds don't do that (previously they simply accepted the mangler defaults)

this won't fix every clash with jquery

since we rely on preact and chrome web vitals and at the time of writing they both mangle something to `$`

follows https://github.com/PostHog/posthog-js/pull/2266