### PR TITLE
fix: potential memory leak in xhr network plugin

### DIFF
--- a/.changeset/khaki-shirts-tell.md
+++ b/.changeset/khaki-shirts-tell.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: remove xhr event listener when handling it to avoid potential memory leak

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -8,7 +8,7 @@
 // however, in the PR, it throws when the performance observer data is not available
 // and assumes it is running in a browser with the Request API (i.e. not IE11)
 // copying here so that we can use it before rrweb adopt it
-import { addEventListener } from './utils'
+
 import type { IWindow, listenerHandler, RecordPlugin } from '@rrweb/types'
 import { CapturedNetworkRequest, Headers, InitiatorType, NetworkRecordOptions } from '../../../types'
 import { isArray, isBoolean, isFormData, isNull, isNullish, isString, isUndefined, isObject } from '@posthog/core'
@@ -292,9 +292,6 @@ function initXhrObserver(cb: networkCallback, win: IWindow, options: Required<Ne
                     return originalSend(body)
                 }
 
-                // This is very tricky code, and making it passive won't bring many performance benefits,
-                // so let's ignore the rule here.
-                // eslint-disable-next-line posthog-js/no-add-event-listener
                 const readyStateListener = () => {
                     if (xhr.readyState !== xhr.DONE) {
                         return
@@ -346,7 +343,11 @@ function initXhrObserver(cb: networkCallback, win: IWindow, options: Required<Ne
                             //
                         })
                 }
-                addEventListener(xhr, 'readystatechange', readyStateListener)
+
+                // This is very tricky code, and making it passive won't bring many performance benefits,
+                // so let's ignore the rule here.
+                // eslint-disable-next-line posthog-js/no-add-event-listener
+                xhr.addEventListener('readystatechange', readyStateListener)
 
                 originalOpen.call(xhr, method, url, async, username, password)
             }


### PR DESCRIPTION
trying to see any obvious leaks in this code that could cause a recorder to hold on to data or dom elements

the xhr wrapper registers an event listener but never clears it

_maybe_ this could cause a circular reference, so let's unregister the listener when we're handling it
to make it a one time listener