### PR TITLE
revert: "fix(react): fix react sourcemaps"

### DIFF
--- a/.changeset/four-bushes-fold.md
+++ b/.changeset/four-bushes-fold.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react': patch
+---
+
+revert: "fix(react): fix react sourcemaps"

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -66,10 +66,7 @@ const buildTypes = {
         dts(),
         copy({
             hook: 'writeBundle',
-            targets: [
-                { src: 'dist/*', dest: '../browser/react/dist' },
-                { src: 'src/*', dest: '../browser/react/src' },
-            ],
+            targets: [{ src: 'dist/*', dest: '../browser/react/dist' }],
         }),
     ],
 }


### PR DESCRIPTION
Reverts PostHog/posthog-js#2374

this breaks the release process by leaving many new files in packages/browser/react/src/ after a build