### PR TITLE
fix(react): fix react sourcemap

### DIFF
--- a/.changeset/strong-trams-see.md
+++ b/.changeset/strong-trams-see.md
@@ -1,0 +1,6 @@
+---
+'@posthog/react': patch
+'posthog-js': patch
+---
+
+fix react sourcemaps

--- a/packages/browser/.gitignore
+++ b/packages/browser/.gitignore
@@ -22,6 +22,7 @@ yalc*
 cypress/videos
 coverage
 react/dist
+react/src
 test-result.json
 yarn-error.log
 stats.html

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,8 +25,8 @@
     "module": "dist/esm/index.js",
     "types": "dist/types/index.d.ts",
     "files": [
-        "dist/*",
-        "README.md"
+        "dist",
+        "src"
     ],
     "peerDependencies": {
         "@types/react": ">=16.8.0",

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -66,7 +66,10 @@ const buildTypes = {
         dts(),
         copy({
             hook: 'writeBundle',
-            targets: [{ src: 'dist/*', dest: '../browser/react/dist' }],
+            targets: [
+                { src: 'dist/*', dest: '../browser/react/dist' },
+                { src: 'src/*', dest: '../browser/react/src' },
+            ],
         }),
     ],
 }


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog-js/pull/2374

## Changes

- copy react/src alongside react/dist
- gitignore react/src
- add src to react package

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
