### PR TITLE
chore: correct changelog and 'alert' on release failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,11 +97,11 @@ jobs:
             event: 'posthog-js-github-release-pr-status'
             properties: >-
                 {
-                  "prUrl": "${{ github.event.pull_request.html_url }}",
+                  "commitSha": "${{ github.sha }}",
                   "jobStatus": "${{ job.status }}",
-                  "prTitle": "${{ github.event.pull_request.title }}",
-                  "prNumber": "${{ github.event.pull_request.number }}",
-                  "prState": "${{ github.event.pull_request.mergeable_state }}",
+                  "commitMessage": "${{ github.event.head_commit.message }}",
+                  "commitAuthor": "${{ github.event.head_commit.author.name }}",
+                  "ref": "${{ github.ref }}",
                   "matrixPackage": "${{ matrix.package.name }}",
                   "packageVersion": "${{ steps.check-package-version.outputs.committed-version }}"
                 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,3 +87,21 @@ jobs:
                    "package_version": "${{ steps.check-package-version.outputs.committed-version }}"
                  }
                }'
+
+      # a CDP destination is set-up to alert when we get this event
+      - name: Send Automerge Event to PostHog
+        if: ${{ failure() }}
+        uses: PostHog/posthog-github-action@v0.1
+        with:
+            posthog-token: '${{ secrets.POSTHOG_API_TOKEN }}'
+            event: 'posthog-js-github-release-pr-status'
+            properties: >-
+                {
+                  "prUrl": "${{ github.event.pull_request.html_url }}",
+                  "jobStatus": "${{ job.status }}",
+                  "prTitle": "${{ github.event.pull_request.title }}",
+                  "prNumber": "${{ github.event.pull_request.number }}",
+                  "prState": "${{ github.event.pull_request.mergeable_state }}",
+                  "matrixPackage": "${{ matrix.package.name }}",
+                  "packageVersion": "${{ steps.check-package-version.outputs.committed-version }}"
+                }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,12 +89,12 @@ jobs:
                }'
 
       # a CDP destination is set-up to alert when we get this event
-      - name: Send Automerge Event to PostHog
+      - name: Send failure event to PostHog
         if: ${{ failure() }}
         uses: PostHog/posthog-github-action@v0.1
         with:
             posthog-token: '${{ secrets.POSTHOG_API_TOKEN }}'
-            event: 'posthog-js-github-release-pr-status'
+            event: 'posthog-js-github-release-workflow-failure'
             properties: >-
                 {
                   "commitSha": "${{ github.sha }}",

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -6,17 +6,22 @@
 
 - [#2369](https://github.com/PostHog/posthog-js/pull/2369) [`2a6ea65`](https://github.com/PostHog/posthog-js/commit/2a6ea65333460027f163d186ab6b241488c4c750) Thanks [@dmarticus](https://github.com/dmarticus)! - This PR implements support for evaluation environments in the posthog-js SDK, allowing users to specify which environment tags their SDK instance should use when evaluating feature flags.
 
-## 1.268.11
-
 ### Patch Changes
 
 - [#2381](https://github.com/PostHog/posthog-js/pull/2381) [`06a79f9`](https://github.com/PostHog/posthog-js/commit/06a79f99e7bebcbf669e9ce37ef4441224339e9a) Thanks [@pauldambra](https://github.com/pauldambra)! - fix: remove xhr event listener when handling it to avoid potential memory leak
+- [#2374](https://github.com/PostHog/posthog-js/pull/2374) [`5af6e2d`](https://github.com/PostHog/posthog-js/commit/5af6e2d1fb1694cecfa4ef515cac192fb194fa4e) Thanks [@hpouillot](https://github.com/hpouillot)! - fix react sourcemaps
+
+## 1.268.11
+
+- failed release due to an error in CI, included in 1.269.0
+
+* [#2381](https://github.com/PostHog/posthog-js/pull/2381) [`06a79f9`](https://github.com/PostHog/posthog-js/commit/06a79f99e7bebcbf669e9ce37ef4441224339e9a) Thanks [@pauldambra](https://github.com/pauldambra)! - fix: remove xhr event listener when handling it to avoid potential memory leak
 
 ## 1.268.10
 
-### Patch Changes
+- failed release due to an error in CI, included in 1.269.0
 
-- [#2374](https://github.com/PostHog/posthog-js/pull/2374) [`5af6e2d`](https://github.com/PostHog/posthog-js/commit/5af6e2d1fb1694cecfa4ef515cac192fb194fa4e) Thanks [@hpouillot](https://github.com/hpouillot)! - fix react sourcemaps
+* [#2374](https://github.com/PostHog/posthog-js/pull/2374) [`5af6e2d`](https://github.com/PostHog/posthog-js/commit/5af6e2d1fb1694cecfa4ef515cac192fb194fa4e) Thanks [@hpouillot](https://github.com/hpouillot)! - fix react sourcemaps
 
 ## 1.268.9
 


### PR DESCRIPTION
we had a silent npm release failure for three posthog-js releases
let's correct the changelog so folks don't think there are releases that don't exist
and let's send an event to posthog if it happens in future
so we can alert with CDP