### PR TITLE
fix: autocapture crash when encountering non-Element DOM nodes

### DIFF
--- a/.changeset/fix-autocapture-non-element-nodes.md
+++ b/.changeset/fix-autocapture-non-element-nodes.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix autocapture crash when encountering non-Element DOM nodes (text nodes, comment nodes, etc.) that don't have a tagName property

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -159,6 +159,9 @@ export function autocapturePropertiesForElement(
             curEl = (curEl.parentNode as any).host
             continue
         }
+        if (!isElementNode(curEl.parentNode)) {
+            break
+        }
         targetElementList.push(curEl.parentNode as Element)
         curEl = curEl.parentNode as Element
     }
@@ -169,12 +172,16 @@ export function autocapturePropertiesForElement(
     let explicitNoCapture = false
 
     each(targetElementList, (el) => {
+        if (!isElementNode(el)) {
+            return
+        }
+
         const shouldCaptureEl = shouldCaptureElement(el)
 
         // if the element or a parent element is an anchor tag
         // include the href as a property
         if (el.tagName.toLowerCase() === 'a') {
-            href = el.getAttribute('href')
+            href = el.getAttribute('href') || false
             href = shouldCaptureEl && href && shouldCaptureValue(href) && href
         }
 


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/38691

## Changes


Added validation to skip non-Element DOM nodes in `autocapturePropertiesForElement`. The code was trying to access `.tagName` on nodes that don't have this property (text nodes, comment nodes, etc), causing crashes

Two checks added:
- Check `parentNode` is an Element before adding it to the list
- Skip non-Element nodes when iterating using the existing `isElementNode()` helper

Also fixed a type mismatch where `getAttribute('href')` returns `string | null` but the code expected `string | false`, causing a TypeScript error

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

