### PR TITLE
chore: Help getting local dev nextjs example working

### DIFF
--- a/packages/browser/playground/README.md
+++ b/packages/browser/playground/README.md
@@ -1,5 +1,5 @@
-A collection of examples for showing how to use PostHog's JS SDK
+A collection of examples for showing how to use PostHog's JS SDK or for testing features of it.
 
-Or for testing features of it
+Nextjs is the most commonly used inside PostHog.
 
-Inside each folder you need to run `pnpm i --ignore-workspace` to install dependencies
+Note: these folders are be excluded from the main workspace in this repo. You will need to install dependencies in each folder separately. They are excluded to keep a separation between the dependencies of our production SDKs and misc code examples.

--- a/packages/browser/playground/README.md
+++ b/packages/browser/playground/README.md
@@ -1,5 +1,5 @@
-A collection of examples for showing how to use PostHog's JS SDK or for testing features of it.
+A collection of examples for showing how to use PostHog's JS SDK, or for testing features of it.
 
-Nextjs is the most commonly used inside PostHog.
+`playground/nextjs` is the most commonly used inside PostHog.
 
-Note: these folders are be excluded from the main workspace in this repo. You will need to install dependencies in each folder separately. They are excluded to keep a separation between the dependencies of our production SDKs and misc code examples.
+Note: these folders are excluded from the main workspace in this repo. You will need to install dependencies in each folder separately. They are excluded to keep a separation between the dependencies of our production SDKs and misc code examples.

--- a/packages/browser/playground/nextjs/README.md
+++ b/packages/browser/playground/nextjs/README.md
@@ -1,27 +1,26 @@
 ## PostHog demo project
 
-From the posthog-js root folder, run:
-```bash
-pnpm package:watch
-```
-It will watch for package changes and recreate local tarballs inside the `target` folder
+### Testing local changes to packages
 
-In another terminal window, from the nextjs directory, run:
+This is a simple porject used to test local changes to the PostHog JS SDK packages.
+
+Ensure that you can have already installed and built the packages in this monorepo. From the root of the repo, run:
+
 ```bash
 pnpm install
+pnpm build
 ```
-All posthog packages will be resolved from the local tarball folder using the `.pnpmfile.cjs`
 
-Then start the development server:
+Then you can run
+
 ```bash
-NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' pnpm dev
+pnpm dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-### Testing local changes to packages
-
 Update your files, wait for the package script to finish, then, from this folder, run:
+
 ```bash
 pnpm install
 NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' pnpm dev
@@ -31,6 +30,12 @@ If you need to provide environment variables, you can do so:
 
 ```bash
 NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' NEXT_PUBLIC_POSTHOG_HOST='http://localhost:8010' pnpm dev
+```
+
+To rebuild posthog-js after making changes, you can run:
+
+```bash
+pnpm run build-posthog-js && NEXT_PUBLIC_POSTHOG_KEY='<your-local-api-key>' NEXT_PUBLIC_POSTHOG_HOST='http://localhost:8010' pnpm dev
 ```
 
 ### Testing cross-subdomain tracking

--- a/packages/browser/playground/nextjs/package.json
+++ b/packages/browser/playground/nextjs/package.json
@@ -9,7 +9,8 @@
         "dev-crossdomain": "NEXT_PUBLIC_CROSSDOMAIN=1 next dev --experimental-https",
         "build": "next build --no-lint",
         "start": "next start",
-        "lint": "next lint"
+        "lint": "next lint",
+        "build-posthog-js": "cd ../../ && NODE_ENV=dev pnpm i && pnpm run build && cd playground/nextjs"
     },
     "dependencies": {
         "@lottiefiles/react-lottie-player": "^3.5.4",
@@ -19,8 +20,8 @@
         "cookie": "^0.7.2",
         "eslint": "^8.57.1",
         "hls.js": "^1.5.15",
-        "next": "14.2.30",
-        "posthog-js": "*",
+        "next": "14.2.33",
+        "posthog-js": "file:../../dist",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "socket.io": "^4.8.1",

--- a/packages/browser/playground/nextjs/pnpm-workspace.yaml
+++ b/packages/browser/playground/nextjs/pnpm-workspace.yaml
@@ -1,3 +1,1 @@
-pnpmfile: ../.pnpmfile.cjs
-packages:
-  - "." # TODO delete this file and make the root workspace's file respect exclusion rules for this folder - weirdly tricky to do so
+# this file is intentionally empty, so that running `pnpm install` in this directory doesn't install dependencies for the workspace at the repo root

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - packages/*
   - tooling/*
+  - '!**/playground/**'
+  - '!**/examples/**'
+
 
 catalog:
   tsup: ^8.5.0


### PR DESCRIPTION
## Problem

The nextjs playground doesn't point to the locally built posthog-js by default

## Changes

* Point to local posthog-js
* Make pnpm-workspace.yaml empty
* Add (very redundant, we already exclude these) exclusion rules to exclude playground and examples directories from pnpm workspace (we don't need this change at all, I'm just paranoid about future refactors)
* Update comment


## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
