### PR TITLE
chore: extend from GoogleGenAIOptions interface

### DIFF
--- a/.changeset/clear-cups-carry.md
+++ b/.changeset/clear-cups-carry.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+chore: make `MonitoringGeminiConfig` extend `GoogleGenAIOptions` to expose additional configuration options like `googleAuthOptions` for proper `GoogleGenAI` initialization

--- a/packages/ai/src/gemini/index.ts
+++ b/packages/ai/src/gemini/index.ts
@@ -4,6 +4,7 @@ import {
   GenerateContentParameters,
   Part,
   GenerateContentResponseUsageMetadata,
+  GoogleGenAIOptions,
 } from '@google/genai'
 import { PostHog } from 'posthog-node'
 import {
@@ -17,12 +18,7 @@ import { sanitizeGemini } from '../sanitization'
 import type { TokenUsage, FormattedContent, FormattedContentItem, FormattedMessage } from '../types'
 import { isString } from '../typeGuards'
 
-interface MonitoringGeminiConfig {
-  apiKey?: string
-  vertexai?: boolean
-  project?: string
-  location?: string
-  apiVersion?: string
+interface MonitoringGeminiConfig extends GoogleGenAIOptions {
   posthog: PostHog
 }
 


### PR DESCRIPTION
## Problem

The `MonitoringGeminiConfig` interface exported by `@posthog/ai` did not include important configuration fields such as `googleAuthOptions`.  
This prevented users from properly configuring the `GoogleGenAI` constructor when running in Node environments.

## Changes

Updated the `MonitoringGeminiConfig` interface to extend from `GoogleGenAIOptions`.
This change adds the optional fields `googleAuthOptions` and `httpOptions` to the existing interface, enabling full configuration support for the `GoogleGenAI` client.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
