### PR TITLE
fix: start queue after opting in

### DIFF
--- a/.changeset/seven-dodos-do.md
+++ b/.changeset/seven-dodos-do.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+Fixes an issue where the event queue was not started until a page reload after calling `opt_in_capturing()`

--- a/packages/browser/src/__tests__/cookieless.test.ts
+++ b/packages/browser/src/__tests__/cookieless.test.ts
@@ -78,6 +78,7 @@ describe('cookieless', () => {
     beforeEach(() => {
         mockURLGetter.mockImplementation(() => 'http://localhost')
         mockedCookieBox.cookie = ''
+        mockedFetch.mockResolvedValue({ status: 200, text: () => Promise.resolve('{"flags": {}}') })
     })
 
     describe('always mode', () => {
@@ -316,7 +317,6 @@ describe('cookieless', () => {
 
         it('should restart the request queue when opting in', async () => {
             // we're testing the interaction with the request queue, so we need to mock fetch rather than relying on before_send
-            mockedFetch.mockResolvedValue({ status: 200, text: () => Promise.resolve('{}') })
             jest.useFakeTimers()
             const { posthog } = await setup({
                 cookieless_mode: 'on_reject',

--- a/packages/browser/src/__tests__/cookieless.test.ts
+++ b/packages/browser/src/__tests__/cookieless.test.ts
@@ -8,11 +8,13 @@ jest.mock('../utils/globals', () => {
     const mockURLGetter = jest.fn()
     const mockReferrerGetter = jest.fn()
     const mockedCookieBox = { cookie: '' }
+    const mockedFetch = jest.fn()
     return {
         ...orig,
         mockURLGetter,
         mockReferrerGetter,
         mockedCookieBox: mockedCookieBox,
+        mockedFetch,
         document: {
             ...orig.document,
             createElement: (...args: any[]) => orig.document.createElement(...args),
@@ -49,11 +51,12 @@ jest.mock('../utils/globals', () => {
             send: jest.fn(),
             setRequestHeader: jest.fn(),
         }),
+        fetch: mockedFetch,
     }
 })
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { mockURLGetter, mockedCookieBox, document } = require('../utils/globals')
+const { mockURLGetter, mockedCookieBox, mockedFetch, document } = require('../utils/globals')
 
 const delay = (timeoutMs: number) => new Promise((resolve) => setTimeout(resolve, timeoutMs))
 
@@ -309,6 +312,28 @@ describe('cookieless', () => {
             expect(beforeSendMock.mock.calls[3][0].properties.$window_id).toBe(undefined)
             expect(beforeSendMock.mock.calls[3][0].properties.$cookieless_mode).toEqual(true)
             expect(posthog.sessionRecording).toBeFalsy()
+        })
+
+        it('should restart the request queue when opting in', async () => {
+            // we're testing the interaction with the request queue, so we need to mock fetch rather than relying on before_send
+            mockedFetch.mockResolvedValue({ status: 200, text: () => Promise.resolve('{}') })
+            jest.useFakeTimers()
+            const { posthog } = await setup({
+                cookieless_mode: 'on_reject',
+                request_batching: true,
+            })
+            expect(mockedFetch).toBeCalledTimes(1) // flags
+            expect(mockedFetch.mock.calls[0][0]).toContain('/flags/')
+
+            posthog.opt_in_capturing()
+            expect(mockedFetch).toBeCalledTimes(3) // flags + opt in + pageview
+            expect(JSON.parse(mockedFetch.mock.calls[1][1].body).event).toEqual('$opt_in')
+            expect(JSON.parse(mockedFetch.mock.calls[2][1].body).event).toEqual('$pageview')
+
+            posthog.capture('custom event')
+            jest.runOnlyPendingTimers() // allows the batch queue to flush
+            expect(mockedFetch).toBeCalledTimes(4) // flags + opt in + pageview + custom event
+            expect(JSON.parse(mockedFetch.mock.calls[3][1].body)[0].event).toEqual('custom event')
         })
     })
 })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -2921,6 +2921,9 @@ export class PostHog {
         this.consent.optInOut(true)
         this._sync_opt_out_with_persistence()
 
+        // Start queue after opting in
+        this._start_queue_if_opted_in()
+
         // Reinitialize surveys if we're in cookieless mode and just opted in
         if (this.config.cookieless_mode == 'on_reject') {
             this.surveys.loadIfEnabled()


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog-js/issues/2401

## Changes

Starts the queue immediately when opting in.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js

Assuming this is the case, as it's a change in posthog-core.

## Checklist

- [ ] Tests for new code - not yet, having trouble to access the request queue from playwright
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
