### PR TITLE
chore: Fix scripts to persist references

### DIFF
--- a/.github/workflows/generate-references.yml
+++ b/.github/workflows/generate-references.yml
@@ -1,11 +1,16 @@
 name: "Generate References"
 
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types:
-      - completed
   workflow_dispatch:
+    inputs:
+      package_name:
+        description: "Package name to generate references for"
+        required: true
+        type: string
+      package_path:
+        description: "Absolute path to the package directory (from repo root)"
+        required: true
+        type: string
 
 jobs:
   generate-references:
@@ -13,13 +18,6 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        package:
-          - name: posthog-js
-          - name: posthog-node
-          - name: posthog-react-native
 
     steps:
       - name: Checkout the repository
@@ -34,34 +32,22 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      - name: Get package path
-        id: get-package-path
-        run: |
-          PACKAGE_PATH=$(pnpm list --filter=${{ matrix.package.name }} --json | jq -r '.[0].path')
-          echo "path=$PACKAGE_PATH" >> "$GITHUB_OUTPUT"
-
-      - name: Check ${{ matrix.package.name }} version and detect an update
-        id: check-package-version
-        uses: PostHog/check-package-version@v2.1.0
-        with:
-          path: ${{ steps.get-package-path.outputs.path }}
-
-      - name: Generate references for ${{ matrix.package.name }}
-        if: steps.check-package-version.outputs.is-new-version == 'true'
-        run: pnpm exec turbo --filter="${{ matrix.package.name }}" generate-references
+      - name: Generate references for ${{ github.event.inputs.package_name }}
+        run: pnpm exec turbo --filter="${{ github.event.inputs.package_name }}" generate-references
 
       - name: Check for changes in references
         id: changes
         run: |
-          PACKAGE_DIR="${{ steps.get-package-path.outputs.path }}/references/"
+          PACKAGE_DIR="${{ github.event.inputs.package_path }}/references/"
           if [ -n "$(git status --porcelain "$PACKAGE_DIR")" ]; then
             echo "changed=true" >> $GITHUB_OUTPUT
-            echo "New references generated for ${{ matrix.package.name }}:"
+            echo "New references generated for ${{ github.event.inputs.package_name }}:"
             git status --porcelain "$PACKAGE_DIR"
           else
             echo "changed=false" >> $GITHUB_OUTPUT
-            echo "No new references generated for ${{ matrix.package.name }}"
+            echo "No new references generated for ${{ github.event.inputs.package_name }}"
           fi
+          
       - uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0
         if: steps.changes.outputs.changed == 'true'
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,16 @@ jobs:
           package_version: ${{ steps.check-package-version.outputs.committed-version }}
           npm_token: ${{ secrets.NPM_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Dispatch generate-references for ${{ matrix.package.name }}
+        if: steps.check-package-version.outputs.is-new-version == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run generate-references.yml \
+            --ref main \
+            --field package_name="${{ matrix.package.name }}" \
+            --field package_path="${{ steps.get-package-path.outputs.path }}"
 
       - name: Dispatch posthog upgrade for ${{ matrix.package.name }}
         if: matrix.package.name == 'posthog-js' && steps.check-package-version.outputs.is-new-version == 'true'


### PR DESCRIPTION
## Changes

The workflow wasn't triggering with `on: [publish]` so we just have it run right after release job. (**_Although, does the release job just run after every push to main? Am really looking for help here :D _**) 

thanks to @lricoy for help

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
…ain permissions

Co-authored-by: Copilot Autofix powered by AI <62310815+github-advanced-security[bot]@users.noreply.github.com>