### PR TITLE
fix: slightly safer replay status reporting

### DIFF
--- a/.changeset/curly-foxes-repeat.md
+++ b/.changeset/curly-foxes-repeat.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: rely on 'state' less when reporting replay status

--- a/packages/browser/src/extensions/replay/sessionrecording-wrapper.ts
+++ b/packages/browser/src/extensions/replay/sessionrecording-wrapper.ts
@@ -37,11 +37,15 @@ export class SessionRecordingWrapper {
      * once a flags response is received status can be disabled, active or sampled
      */
     get status(): SessionRecordingStatus {
+        if (this._lazyLoadedSessionRecording) {
+            return this._lazyLoadedSessionRecording.status
+        }
+
         if (this._receivedFlags && !this._isRecordingEnabled) {
             return DISABLED
         }
 
-        return this._lazyLoadedSessionRecording?.status || LAZY_LOADING
+        return LAZY_LOADING
     }
 
     constructor(private readonly _instance: PostHog) {


### PR DESCRIPTION
if we have a lazy recorder we can return its status no matter what
so, it's safer to do that
than risk a state tracking problem with the "received flags" boolean