### PR TITLE
chore: retry periodically flakey tests

### DIFF
--- a/packages/browser/src/__tests__/consent.test.ts
+++ b/packages/browser/src/__tests__/consent.test.ts
@@ -22,6 +22,9 @@ function deleteAllCookies() {
     }
 }
 
+// periodically flakes because of unexpected console logging
+jest.retryTimes(3)
+
 describe('consentManager', () => {
     const createPostHog = async (config: Partial<PostHogConfig> = {}) => {
         const posthog = await new Promise<PostHog>(


### PR DESCRIPTION
we've updated jest so now we can use `jest.retryTimes` for flakey tests

so, let's attack this particular flake

yes, i should figure out how to deflake it but i also don't have the kreplets for that