### PR TITLE
chore: mark persistence isDisabled as potentially undefined

### DIFF
--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -81,7 +81,6 @@ export class PostHogPersistence {
     /**
      * Returns whether persistence is disabled. Only available in SDKs > 1.257.1. Do not use on extensions, otherwise
      * it'll break backwards compatibility for any version before 1.257.1.
-     * @returns
      */
     public isDisabled?(): boolean {
         return !!this._disabled


### PR DESCRIPTION
## Problem

this ended up causing an incident, so marking this function as potentially undefined to prevent it from happening if someone decides to use it

## Changes

makes the method `isDisabled` in `PostHogPersistence` potentially undefined. this is relevant specifically for extensions - as otherwise one of them might call `isDisabled` in a version where it's not defined yet.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)