### PR TITLE
chore: switch to fine-grained PAT

### DIFF
--- a/.github/workflows/label-alpha-release.yml
+++ b/.github/workflows/label-alpha-release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
-          token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.POSTHOG_BOT_PAT }}
           fetch-depth: 0
 
       - uses: ./.github/actions/setup

--- a/.github/workflows/label-version-bump.yml
+++ b/.github/workflows/label-version-bump.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
-          token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.POSTHOG_BOT_PAT }}
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
@@ -39,4 +39,4 @@ jobs:
           add: "."
           branch: ${{ github.event.pull_request.base.ref }}
           message: "chore: update versions and lockfile"
-          github_token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+          github_token: ${{ secrets.POSTHOG_BOT_PAT }}

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -30,4 +30,4 @@ jobs:
               if: steps.is-shame-worthy.outputs.is-shame-worthy == 'true'
               run: |
                   SHAME_BODY="Hey @${{ github.actor }}! 👋\nThis pull request seems to contain no description. Please add useful context, rationale, and/or any other information that will help make sense of this change now and in the distant Mars-based future."
-                  curl -s -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }} -X POST -d "{ \"body\": \"$SHAME_BODY\" }" "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+                  curl -s -u posthog-bot:${{ secrets.POSTHOG_BOT_PAT }} -X POST -d "{ \"body\": \"$SHAME_BODY\" }" "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"

--- a/.github/workflows/posthog-com-upgrade.yml
+++ b/.github/workflows/posthog-com-upgrade.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: "PostHog/posthog.com"
-          token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.POSTHOG_BOT_PAT }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -61,7 +61,7 @@ jobs:
         id: com-repo-pr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.POSTHOG_BOT_PAT }}
           commit-message: "chore(deps): Update ${{ github.event.inputs.package_name }} to ${{ github.event.inputs.package_version }}"
           branch: ${{ steps.generate-branch-name.outputs.branch_name }}
           delete-branch: true

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: "PostHog/posthog"
-          token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.POSTHOG_BOT_PAT }}
 
       - uses: pnpm/action-setup@v4
 
@@ -67,7 +67,7 @@ jobs:
         id: main-repo-pr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.POSTHOG_BOT_PAT }}
           commit-message: "chore(deps): Update ${{ github.event.inputs.package_name }} to ${{ github.event.inputs.package_version }}"
           branch: ${{ steps.generate-branch-name.outputs.branch_name }}
           delete-branch: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
     stale:
-        # Only unleash the stale bot on PostHog/posthog, as there's no POSTHOG_BOT_GITHUB_TOKEN token on forks
+        # Only unleash the stale bot on PostHog/posthog, as there's no POSTHOG_BOT_PAT token on forks
         if: ${{ github.repository == 'PostHog/posthog-js' }}
         runs-on: ubuntu-22.04
         steps:
@@ -24,4 +24,4 @@ jobs:
                   stale-pr-label: stale
                   remove-pr-stale-when-updated: true
                   operations-per-run: 250
-                  repo-token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+                  repo-token: ${{ secrets.POSTHOG_BOT_PAT }}


### PR DESCRIPTION
Verified `new-pr.yml` and `posthog-upgrade.yml` both work, which should give us pretty high confidence that all Actions are working with the new PAT.

Context: https://posthog.slack.com/archives/C0113360FFV/p1760135796439999?thread_ts=1759419663.127389&cid=C0113360FFV