### PR TITLE
feat: Add `flags_api_host` config option

### DIFF
--- a/.changeset/tiny-views-shop.md
+++ b/.changeset/tiny-views-shop.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+feat: Add `flags_api_host` config option

--- a/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -3,6 +3,11 @@
 exports[`config snapshot for PostHogConfig 1`] = `
 "{
   "api_host": "string",
+  "flags_api_host": [
+    "undefined",
+    "null",
+    "string"
+  ],
   "ui_host": [
     "null",
     "string"

--- a/packages/browser/src/__tests__/utils/request-router.test.ts
+++ b/packages/browser/src/__tests__/utils/request-router.test.ts
@@ -80,4 +80,68 @@ describe('request-router', () => {
         mockPostHog.config.api_host = 'https://eu.posthog.com'
         expect(router.endpointFor('api')).toEqual('https://eu.i.posthog.com')
     })
+
+    describe('flags_api_host configuration', () => {
+        it('should use flags_api_host when set', () => {
+            const mockPostHog = {
+                config: {
+                    api_host: 'https://app.posthog.com',
+                    flags_api_host: 'https://example.com/feature-flags',
+                },
+            }
+            const router = new RequestRouter(mockPostHog as any)
+
+            expect(router.endpointFor('flags', '/flags/?v=2')).toEqual('https://example.com/feature-flags/flags/?v=2')
+        })
+
+        it('should fall back to api_host when flags_api_host is not set', () => {
+            const mockPostHog = {
+                config: {
+                    api_host: 'https://app.posthog.com',
+                },
+            }
+            const router = new RequestRouter(mockPostHog as any)
+
+            expect(router.endpointFor('flags', '/flags/?v=2')).toEqual('https://us.i.posthog.com/flags/?v=2')
+        })
+
+        it('should trim trailing slashes from flags_api_host', () => {
+            const mockPostHog = {
+                config: {
+                    api_host: 'https://app.posthog.com',
+                    flags_api_host: 'https://flags.example.com/',
+                },
+            }
+            const router = new RequestRouter(mockPostHog as any)
+
+            expect(router.endpointFor('flags', '/flags/?v=2')).toEqual('https://flags.example.com/flags/?v=2')
+        })
+
+        it('should react to flags_api_host config changes', () => {
+            const mockPostHog = {
+                config: {
+                    api_host: 'https://app.posthog.com',
+                    flags_api_host: 'https://flags1.example.com',
+                },
+            }
+            const router = new RequestRouter(mockPostHog as any)
+
+            expect(router.endpointFor('flags', '/flags/?v=2')).toEqual('https://flags1.example.com/flags/?v=2')
+
+            mockPostHog.config.flags_api_host = 'https://flags2.example.com'
+            expect(router.endpointFor('flags', '/flags/?v=2')).toEqual('https://flags2.example.com/flags/?v=2')
+        })
+
+        it('should use flags_api_host even when api_host is a custom domain', () => {
+            const mockPostHog = {
+                config: {
+                    api_host: 'https://my-proxy.com',
+                    flags_api_host: 'https://flags.example.com',
+                },
+            }
+            const router = new RequestRouter(mockPostHog as any)
+
+            expect(router.endpointFor('flags', '/flags/?v=2')).toEqual('https://flags.example.com/flags/?v=2')
+        })
+    })
 })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -149,6 +149,7 @@ let ENQUEUE_REQUESTS = !SUPPORTS_REQUEST && userAgent?.indexOf('MSIE') === -1 &&
 // NOTE²: This shouldn't ever change because we try very hard to be backwards-compatible
 export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     api_host: 'https://us.i.posthog.com',
+    flags_api_host: null,
     ui_host: null,
     token: '',
     autocapture: true,

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -425,7 +425,7 @@ export class PostHogFeatureFlags {
             ? '&only_evaluate_survey_feature_flags=true'
             : ''
 
-        const url = this._instance.requestRouter.endpointFor('api', flagsRoute + queryParams)
+        const url = this._instance.requestRouter.endpointFor('flags', flagsRoute + queryParams)
 
         if (useRemoteConfigWithFlags) {
             data.timezone = getTimezone()
@@ -611,7 +611,7 @@ export class PostHogFeatureFlags {
 
         this._instance._send_request({
             method: 'POST',
-            url: this._instance.requestRouter.endpointFor('api', '/flags/?v=2&config=true'),
+            url: this._instance.requestRouter.endpointFor('flags', '/flags/?v=2&config=true'),
             data,
             compression: this._instance.config.disable_compression ? undefined : Compression.Base64,
             timeout: this._instance.config.feature_flag_request_timeout_ms,

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -286,6 +286,15 @@ export interface PostHogConfig {
     api_host: string
 
     /**
+     * URL to use for feature flag requests specifically.
+     * If not set, feature flag requests will use the URL derived from `api_host`.
+     * This is useful when you want to route feature flag requests to a different endpoint than other analytic APIs.
+     *
+     * @default null
+     */
+    flags_api_host?: string | null
+
+    /**
      * If using a reverse proxy for `api_host` then this should be the actual PostHog app URL (e.g. https://us.posthog.com).
      * This ensures that links to PostHog point to the correct host.
      *

--- a/packages/browser/src/utils/request-router.ts
+++ b/packages/browser/src/utils/request-router.ts
@@ -12,7 +12,7 @@ export enum RequestRouterRegion {
     CUSTOM = 'custom',
 }
 
-export type RequestRouterTarget = 'api' | 'ui' | 'assets'
+export type RequestRouterTarget = 'api' | 'ui' | 'assets' | 'flags'
 
 const ingestionDomain = 'i.posthog.com'
 
@@ -31,6 +31,16 @@ export class RequestRouter {
         }
         return host
     }
+
+    get flagsApiHost(): string {
+        const customHost = this.instance.config.flags_api_host
+        if (customHost) {
+            return customHost.trim().replace(/\/$/, '')
+        }
+        // Backwards compatibility: if no custom flags_api_host is set, fall back to the regular apiHost
+        return this.apiHost
+    }
+
     get uiHost(): string | undefined {
         let host = this.instance.config.ui_host?.replace(/\/$/, '')
 
@@ -68,6 +78,10 @@ export class RequestRouter {
 
         if (target === 'ui') {
             return this.uiHost + path
+        }
+
+        if (target === 'flags') {
+            return this.flagsApiHost + path
         }
 
         if (this.region === RequestRouterRegion.CUSTOM) {


### PR DESCRIPTION
## Problem

This allows the client to specify a separate route for the flags API. This supports the logical distinction that feature flags control application behavior rather than collect analytics data. Ideally, in cases where PostHog is blocked by an ad blocker, this allows feature flags to remain intact.

## Changes

A `flags_api_host` is added to the client configuration. This URL is used only when constructing flags requests. Note that this does not include `/api/early_access_features`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

