### PR TITLE
fix: add @types/jest to @posthog/core devDependencies (#2358)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@posthog-tooling/tsconfig-base": "workspace:*",
     "@rslib/core": "catalog:",
+    "@types/jest": "^29.5.0",
     "jest": "catalog:"
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes issue #2358 by adding `@types/jest` as a devDependency to the `@posthog/core` package.

**Original Issue**: https://github.com/PostHog/posthog-js/issues/2358

## Problem

The `@posthog/core` package exports testing utilities (via `./testing` export) that reference Jest types (`jest.Mock`), but doesn't include `@types/jest` in its devDependencies. This causes TypeScript build errors in downstream packages like `posthog-node` when users don't have Jest installed:

```
error TS2503: Cannot find namespace 'jest'.
```

## Solution

Added `@types/jest` to the devDependencies of `@posthog/core` to ensure the exported type definitions are valid.

## Changes Made

- Added `@types/jest: ^29.5.0` to `packages/core/package.json` devDependencies

## Testing

- [ ] Build succeeds without Jest-related TypeScript errors
- [ ] Downstream packages (posthog-node) can compile successfully
- [ ] No breaking changes to existing functionality

🤖 Generated with Claude Code
Closes #2358