### PR TITLE
fix: use named import for Anthropic SDK instead of default import (#2379)

### DIFF
--- a/packages/ai/src/anthropic/index.ts
+++ b/packages/ai/src/anthropic/index.ts
@@ -1,4 +1,4 @@
-import AnthropicOriginal, { APIPromise } from '@anthropic-ai/sdk'
+import { Anthropic as AnthropicOriginal, APIPromise } from '@anthropic-ai/sdk'
 import { PostHog } from 'posthog-node'
 import {
   formatResponseAnthropic,


### PR DESCRIPTION
## Summary

This PR fixes issue #2379 by correcting the import statement for the Anthropic SDK.

**Original Issue**: https://github.com/PostHog/posthog-js/issues/2379

## Problem

When importing `@posthog/ai` with only OpenAI usage, users encountered:
```
TypeError: Class extends value undefined is not a constructor or null
    at Object.<anonymous> (node_modules/@posthog/ai/src/anthropic/index.ts:46:56)
```

This happened because the code was using a default import:
```typescript
import AnthropicOriginal from '@anthropic-ai/sdk'
```

However, `@anthropic-ai/sdk` exports `Anthropic` as a **named export**, not a default export. This resulted in `AnthropicOriginal` being `undefined`, causing the error when `PostHogAnthropic` tried to extend it.

## Solution

Changed the import to use the correct named export:
```typescript
import { Anthropic as AnthropicOriginal } from '@anthropic-ai/sdk'
```

## Changes Made

- Updated `packages/ai/src/anthropic/index.ts` line 1 to use named import

## Testing

- [ ] Import `@posthog/ai` with only OpenAI usage - no errors
- [ ] Anthropic functionality still works correctly
- [ ] Build succeeds

🤖 Generated with Claude Code
Closes #2379