### PR TITLE
fix: Use `token` on `checkout` step

### DIFF
--- a/.github/workflows/generate-references.yml
+++ b/.github/workflows/generate-references.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
         with:
           fetch-depth: 0
+          token: ${{ secrets.POSTHOG_BOT_PAT }}
+
       - name: Setup environment
         uses: ./.github/actions/setup
         with:
@@ -53,4 +55,3 @@ jobs:
         with:
           commit_message: "Update generated references"
           file_pattern: "packages/*/references/**"
-          token: ${{ secrets.POSTHOG_BOT_PAT }}


### PR DESCRIPTION
Docs in https://github.com/stefanzweifel/git-auto-commit-action/tree/778341af668090896ca464160c2def5d1d1a3eb0/?tab=readme-ov-file#push-to-protected-branches tell us we should use the `token` on the `checkout` step rather than the `git-auto-commit` one