### PR TITLE
fix(react-native): fix react native resolution

### DIFF
--- a/examples/example-expo-53/pnpm-lock.yaml
+++ b/examples/example-expo-53/pnpm-lock.yaml
@@ -876,8 +876,8 @@ packages:
     engines: {node: '>=14'}
 
   '@posthog/core@file:../../target/posthog-core.tgz':
-    resolution: {integrity: sha512-3DFb9TcbGf4ISaf1ua8grADOutLbQ0xSpS2hu9kwajX3XzusEb3RzvNa8UaieW0Amt/l+UxQoFELB9Fm/3R9hw==, tarball: file:../../target/posthog-core.tgz}
-    version: 1.2.2
+    resolution: {integrity: sha512-L2BrCrJ+qurz6hueQjZsdnC6d2PtavX0NaXH8Db/7vS1Lbn0ZrtsSk+Sc6owDwecT6hxL3SNMLulVRjdOlSH7w==, tarball: file:../../target/posthog-core.tgz}
+    version: 1.3.0
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -3159,8 +3159,8 @@ packages:
       react-native: '*'
 
   posthog-react-native@file:../../target/posthog-react-native.tgz:
-    resolution: {integrity: sha512-bl/0Yku29CDM3SZNtStTpRCbTTQrn0IPXA1vvLhOzYtx3arXdjrC5fI3bVao8K/9eAXSHxbhx8mUVrAD4qqaYg==, tarball: file:../../target/posthog-react-native.tgz}
-    version: 4.8.0
+    resolution: {integrity: sha512-IkN6eFXBCkjkME/d42Dq4Iv0p8x0tp6zobas4OBLcclzUg1LfHjvZrtS+SCfEeWAFMkH4jlxEORfju2qZD4XDQ==, tarball: file:../../target/posthog-react-native.tgz}
+    version: 4.10.2
     peerDependencies:
       '@react-native-async-storage/async-storage': '>=1.0.0'
       '@react-navigation/native': '>= 5.0.0'

--- a/packages/react-native/tsconfig.json
+++ b/packages/react-native/tsconfig.json
@@ -8,7 +8,7 @@
     "incremental": false,
     "lib": ["ESNext"],
     "module": "ES2015",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "noEmitOnError": true,
     "outDir": "./dist",
     "skipLibCheck": true,


### PR DESCRIPTION
## Problem

- some users use a node moduleResolution in react-native projects which does not allow subpath imports

## Changes

- switch moduleResolution to node to avoid importing packages with sub path

## Tests

- diff folders using bundler and node resolution produced the exact same code

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
