### PR TITLE
chore(llma): fix automated PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,3 +16,6 @@ packages/react-native/                                 @PostHog/team-mobile
 examples/example_rn_macos/                             @PostHog/team-mobile
 packages/core/                                         @PostHog/team-mobile
 packages/example-expo-53/                              @PostHog/team-mobile
+
+# AI
+/packages/ai/package.json                              @PostHog/team-llm-analytics

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
       commit-message:
           prefix: 'chore(llma)'
       labels:
+          - dependencies
           - release
       directory: '/'
       schedule:
@@ -28,6 +29,7 @@ updates:
           - dependency-name: 'ai'
           - dependency-name: '@langchain/core'
           - dependency-name: 'langchain'
+      ignore:
+          - dependency-name: '*'
+            update-types: ['version-update:semver-major']
       open-pull-requests-limit: 1
-      reviewers:
-          - 'PostHog/team-llm-analytics'

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -1,0 +1,26 @@
+name: Dependabot Changesets
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  changeset:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+
+      - name: Generate changeset
+        uses: the-guild-org/changesets-dependencies-action@v1.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should hopefully get us where we can just fully automate the process:
- Does not suggest major upgrades
- Correctly tags us using code owners file instead of deprecated reviewers field
- Automatically generates the changeset contents

There are some major upgrades for the SDKs pending too, we should double check if they are breaking changes or not and decide what to do about them (might make sense to upgrade major).