### PR TITLE
fix: Add error when trying to import node packages into posthog-js

### DIFF
--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -299,7 +299,7 @@ const plugins = (es5, noExternal) => [
                 // See https://posthog.slack.com/archives/C03P7NL6RMW/p1761119028457109 for context
                 // Please don't fix this by adding a polyfill, instead use an approach which keeps the bundle size small, even if it means doing something bespoke.
                 throw new Error(
-                    `Node.js protocol import detected: "${source}". This will cause issues in browser/edge environments. Check the comments in rollup.config.js for details.`
+                    `Node.js protocol import detected: "${source}". This will cause issues in browser/edge environments. Check the comments in rollup.config.mjs for details.`
                 )
             }
             return null


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C03P7NL6RMW/p1761119028457109

## Changes

Add a rollup plugin which causes this to fail in CI, rather than failing in customers' builds.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
