### PR TITLE
fix: Bump version

### DIFF
--- a/.changeset/public-pants-beam.md
+++ b/.changeset/public-pants-beam.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix https://github.com/PostHog/posthog-js/issues/2471


### PR DESCRIPTION
## Problem

Bump version after revert of a PR that introduced a bug

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
