### PR TITLE
fix: retry count never updated in query params

### DIFF
--- a/.changeset/four-lemons-wink.md
+++ b/.changeset/four-lemons-wink.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: correctly update the retry count URL parameter

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "scripts": {
         "build-rollup": "pnpm --filter=posthog-js build-rollup",
         "clean": "turbo clean",
+        "clean:dep": "rm -rf node_modules && pnpm -r exec rm -rf node_modules",
         "lint": "turbo lint",
         "lint:fix": "turbo lint:fix",
         "test": "turbo test",

--- a/packages/browser/playwright/mocked/retry-queue.spec.ts
+++ b/packages/browser/playwright/mocked/retry-queue.spec.ts
@@ -1,0 +1,191 @@
+import { expect, test } from './utils/posthog-playwright-test-base'
+import { start } from './utils/setup'
+import { Request } from '@playwright/test'
+
+const startOptions = {
+    options: {},
+    url: '/playground/cypress/index.html',
+}
+
+test.describe('retry queue', () => {
+    test('retries failed capture requests and stops after success', async ({ page, context }) => {
+        const captureRequests: Request[] = []
+        let errorResponseCount = 0
+        const maxErrorResponses = 3
+
+        // Mock the capture endpoint to fail initially, then succeed
+        await context.route('**/e/**', async (route) => {
+            const request = route.request()
+            captureRequests.push(request)
+
+            if (errorResponseCount < maxErrorResponses) {
+                errorResponseCount++
+                await route.fulfill({
+                    status: 500,
+                    contentType: 'text/plain',
+                    body: 'Internal Server Error',
+                })
+            } else {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ status: 'ok' }),
+                })
+            }
+        })
+
+        // Initialize PostHog without pageview to avoid extra requests
+        await start({ ...startOptions, options: { capture_pageview: false } }, page, context)
+
+        // Capture a custom event which will initially fail
+        await page.evaluate(() => {
+            window.posthog.capture('test-retry-event', { test: 'data' })
+        })
+
+        // Wait for the initial request and the retries
+        // The retry queue polls every 3 seconds with exponential backoff
+        // First retry: ~3-9 seconds
+        // Second retry: ~6-18 seconds
+        // Third retry: ~12-36 seconds
+        await page.waitForTimeout(20000)
+
+        // After this wait, we should have:
+        // 1. Initial request (failed with 500)
+        // 2. First retry with retry_count=1 (failed with 500)
+        // 3. Second retry with retry_count=2 (failed with 500)
+        // 4. Third retry with retry_count=3 (succeeded with 200)
+
+        // Check that we got multiple requests
+        expect(captureRequests.length).toBeGreaterThanOrEqual(3)
+
+        // Verify the first request had no retry_count
+        const firstRequest = captureRequests[0]
+        expect(firstRequest.url()).not.toContain('retry_count')
+
+        // Verify retry_count increments
+        const retryCountMatches = captureRequests
+            .map((req) => {
+                const match = req.url().match(/retry_count=(\d+)/)
+                return match ? parseInt(match[1]) : null
+            })
+            .filter((count) => count !== null)
+
+        // Should see incrementing retry counts
+        expect(retryCountMatches.length).toBeGreaterThanOrEqual(2)
+        expect(retryCountMatches).toContain(1)
+        expect(retryCountMatches).toContain(2)
+        // Verify counts are actually incrementing (not stuck at 1)
+        const uniqueCounts = Array.from(new Set(retryCountMatches))
+        expect(uniqueCounts.length).toBeGreaterThan(1)
+
+        // Wait additional time to ensure no more requests are made after success
+        const requestCountAfterSuccess = captureRequests.length
+        await page.waitForTimeout(5000)
+
+        // Assert no additional requests were made after success
+        expect(captureRequests.length).toBe(requestCountAfterSuccess)
+    })
+
+    test('stops retrying after 10 attempts', async ({ page, context }) => {
+        const captureRequests: Request[] = []
+
+        // Mock the capture endpoint to always fail
+        await context.route('**/e/**', async (route) => {
+            captureRequests.push(route.request())
+            await route.fulfill({
+                status: 500,
+                contentType: 'text/plain',
+                body: 'Internal Server Error',
+            })
+        })
+
+        // Initialize PostHog without pageview
+        await start({ ...startOptions, options: { capture_pageview: false } }, page, context)
+
+        // Capture a custom event which will fail
+        await page.evaluate(() => {
+            window.posthog.capture('test-max-retries-event', { test: 'data' })
+        })
+
+        // Wait for several retries
+        // The backoff increases exponentially: 3s, 6s, 12s, 24s, etc.
+        // We'll wait long enough to see at least 3-4 retries
+        await page.waitForTimeout(25000)
+
+        // Extract all retry counts
+        const retryCountMatches = captureRequests
+            .map((req) => {
+                const match = req.url().match(/retry_count=(\d+)/)
+                return match ? parseInt(match[1]) : null
+            })
+            .filter((count) => count !== null)
+            .sort((a, b) => a! - b!)
+
+        // Should have some retries but not exceed 10
+        expect(retryCountMatches.length).toBeGreaterThan(0)
+        const maxRetryCount = Math.max(...(retryCountMatches as number[]))
+        expect(maxRetryCount).toBeLessThanOrEqual(10)
+
+        // Verify counts are incrementing
+        expect(retryCountMatches).toContain(1)
+        expect(retryCountMatches).toContain(2)
+    }, 60000)
+
+    test('immediately retries when coming back online', async ({ page, context }) => {
+        const captureRequests: Request[] = []
+
+        // Mock the capture endpoint to fail initially
+        let shouldSucceed = false
+        await context.route('**/e/**', async (route) => {
+            captureRequests.push(route.request())
+            if (shouldSucceed) {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ status: 'ok' }),
+                })
+            } else {
+                await route.fulfill({
+                    status: 500,
+                    contentType: 'text/plain',
+                    body: 'Internal Server Error',
+                })
+            }
+        })
+
+        // Initialize PostHog without pageview
+        await start({ ...startOptions, options: { capture_pageview: false } }, page, context)
+
+        // Capture an event that will fail
+        await page.evaluate(() => {
+            window.posthog.capture('test-offline-event', { test: 'data' })
+        })
+
+        // Wait for initial request to be queued and sent
+        await page.waitForTimeout(3000)
+
+        // Simulate going offline
+        await context.setOffline(true)
+
+        // Wait a bit while offline (less than retry interval)
+        await page.waitForTimeout(3000)
+
+        // Should not have made many more requests while offline
+        const requestsWhileOffline = captureRequests.length
+
+        // Switch to success mode and come back online
+        shouldSucceed = true
+        await context.setOffline(false)
+
+        // Trigger the online event
+        await page.evaluate(() => {
+            window.dispatchEvent(new Event('online'))
+        })
+
+        // Wait for the retry to happen after coming online
+        await page.waitForTimeout(3000)
+
+        // Should have made at least one more request after coming online
+        expect(captureRequests.length).toBeGreaterThan(requestsWhileOffline)
+    })
+})

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -28,19 +28,24 @@ type EncodedBody = {
     estimatedSize: number
 }
 
-export const extendURLParams = (url: string, params: Record<string, any>): string => {
+export const extendURLParams = (url: string, params: Record<string, any>, replace: boolean = false): string => {
     const [baseUrl, search] = url.split('?')
     const newParams = { ...params }
 
-    search?.split('&').forEach((pair) => {
-        const [key] = pair.split('=')
-        delete newParams[key]
-    })
+    const updatedSearch =
+        search?.split('&').map((pair) => {
+            const [key, origValue] = pair.split('=')
+            const value = replace ? (newParams[key] ?? origValue) : origValue
+            delete newParams[key]
+            return `${key}=${value}`
+        }) ?? []
 
-    let newSearch = formDataToQuery(newParams)
-    newSearch = newSearch ? (search ? search + '&' : '') + newSearch : search
+    const remaining = formDataToQuery(newParams)
+    if (remaining) {
+        updatedSearch.push(remaining)
+    }
 
-    return `${baseUrl}?${newSearch}`
+    return `${baseUrl}?${updatedSearch.join('&')}`
 }
 
 export const jsonStringify = (data: any, space?: string | number): string => {

--- a/packages/browser/src/retry-queue.ts
+++ b/packages/browser/src/retry-queue.ts
@@ -69,7 +69,7 @@ export class RetryQueue {
 
     retriableRequest({ retriesPerformedSoFar, ...options }: RetriableRequestWithOptions): void {
         if (isNumber(retriesPerformedSoFar) && retriesPerformedSoFar > 0) {
-            options.url = extendURLParams(options.url, { retry_count: retriesPerformedSoFar })
+            options.url = extendURLParams(options.url, { retry_count: retriesPerformedSoFar }, true)
         }
 
         this._instance._send_request({


### PR DESCRIPTION
noticed while testing something else

retry count wasn't incrementing in the URL at least which is confusing