### PR TITLE
fix: extendUrlParams should always replace unless the caller says otherwise

### DIFF
--- a/.changeset/cold-glasses-exist.md
+++ b/.changeset/cold-glasses-exist.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: extendUrlParams should always replace unless the caller says otherwise

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -28,7 +28,14 @@ type EncodedBody = {
     estimatedSize: number
 }
 
-export const extendURLParams = (url: string, params: Record<string, any>, replace: boolean = false): string => {
+/**
+ * Extends a URL with additional query parameters
+ * @param url - The URL to extend
+ * @param params - The parameters to add
+ * @param replace - When true (default), new params overwrite existing ones with same key. When false, existing params are preserved.
+ * @returns The URL with extended parameters
+ */
+export const extendURLParams = (url: string, params: Record<string, any>, replace: boolean = true): string => {
     const [baseUrl, search] = url.split('?')
     const newParams = { ...params }
 

--- a/packages/browser/src/retry-queue.ts
+++ b/packages/browser/src/retry-queue.ts
@@ -69,7 +69,7 @@ export class RetryQueue {
 
     retriableRequest({ retriesPerformedSoFar, ...options }: RetriableRequestWithOptions): void {
         if (isNumber(retriesPerformedSoFar) && retriesPerformedSoFar > 0) {
-            options.url = extendURLParams(options.url, { retry_count: retriesPerformedSoFar }, true)
+            options.url = extendURLParams(options.url, { retry_count: retriesPerformedSoFar })
         }
 
         this._instance._send_request({


### PR DESCRIPTION
in posthog-js we were using `extendUrlParams`  as if it would replace but it doesn't

so, let's switch the default to replacing but allow the option of not  
  
this is spicier since we're changing the behaviour  
  
but..  
  
this is only used in 4 places  
  


1. request.ts:261-265 - Main request handler
\- Adds: _ (timestamp), ver (lib version), compression
(compression type)
2. request.ts:213-215 - sendBeacon handler
\- Adds: beacon=1 flag
3. posthog-core.ts:780-783 - Core request sender
\- Adds: ip (whether to detect IP info)
4. retry-queue.ts:72 - Retry mechanism
\- Adds: retry_count (number of retries performed)

in each case it either doesn't matter that it is being replaced or imho is better that it is replaced

