### PR TITLE
Extend Gemini configuration options in order to allow Vertex AI authentication via googleAuthOptions

### DIFF
--- a/packages/ai/src/gemini/index.ts
+++ b/packages/ai/src/gemini/index.ts
@@ -4,6 +4,7 @@ import {
   GenerateContentParameters,
   Part,
   GenerateContentResponseUsageMetadata,
+  GoogleGenAIOptions,
 } from '@google/genai'
 import { PostHog } from 'posthog-node'
 import {
@@ -18,7 +19,7 @@ import { sanitizeGemini } from '../sanitization'
 import type { TokenUsage, FormattedContent, FormattedContentItem, FormattedMessage } from '../types'
 import { isString } from '../typeGuards'
 
-interface MonitoringGeminiConfig {
+interface MonitoringGeminiConfig extends GoogleGenAIOptions {
   apiKey?: string
   vertexai?: boolean
   project?: string


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

I ran into an issue instrumenting the Gemini SDK with PostHog since I'm using Vertex AI and that doesn't support authentication via API Key, but instead via `googleAuthOptions`.

This config option wasn't exposed, so typescript would fail, but since all options are already passed directly into the Gemini client for initialization, it was really just a type issue and not any other code changes required.

I've extended the config options using the client's `GoogleGenAIOptions`, which should ensure that changes to the Gemini SDK in the future are immediately exposed and available to consumers using the `@posthog/ai` wrapper.

Relevant thread in the PostHog docs https://posthog.com/questions/vertex-ai-support

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

Extended the Gemini wrappers `MonitoringGeminiConfig` config with `GoogleGenAIOptions` which ensures all client configuration is available, and unblocks Vertex AI usage.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
