### PR TITLE
fix: pause survey timer when page is hidden

### DIFF
--- a/.changeset/fair-buttons-love.md
+++ b/.changeset/fair-buttons-love.md
@@ -2,4 +2,4 @@
 'posthog-js': patch
 ---
 
-fix: don't poll surveys while the page is hhidden
+fix: don't poll surveys while the page is hidden

--- a/.changeset/fair-buttons-love.md
+++ b/.changeset/fair-buttons-love.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: don't poll surveys while the page is hhidden

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -700,10 +700,35 @@ export function generateSurveys(posthog: PostHog, isSurveysEnabled: boolean | un
 
     surveyManager.callSurveysAndEvaluateDisplayLogic(true)
 
-    // recalculate surveys every second to check if URL or selectors have changed
-    setInterval(() => {
-        surveyManager.callSurveysAndEvaluateDisplayLogic(false)
-    }, 1000)
+    let intervalId: number | undefined
+
+    const startInterval = () => {
+        if (!isUndefined(intervalId)) {
+            return
+        }
+        intervalId = setInterval(() => {
+            surveyManager.callSurveysAndEvaluateDisplayLogic(false)
+        }, 1000) as unknown as number
+    }
+
+    const stopInterval = () => {
+        if (!isUndefined(intervalId)) {
+            clearInterval(intervalId)
+            intervalId = undefined
+        }
+    }
+
+    startInterval()
+
+    addEventListener(document, 'visibilitychange', () => {
+        if (document.hidden) {
+            stopInterval()
+        } else {
+            surveyManager.callSurveysAndEvaluateDisplayLogic(false)
+            startInterval()
+        }
+    })
+
     return surveyManager
 }
 


### PR DESCRIPTION
When the page is hidden we don't need to check if we should display a survey

we can pause and then resume when the page is visible again

(really we should wrap history and run an intersection observer so that this check is reactive instead of active but that's not _essential_