### PR TITLE
chore: remove given from posthog/react

### DIFF
--- a/packages/react/jest.config.cjs
+++ b/packages/react/jest.config.cjs
@@ -3,5 +3,4 @@ module.exports = {
     testPathIgnorePatterns: ['/node_modules/', 'dist'],
     clearMocks: true,
     testEnvironment: 'jsdom',
-    setupFilesAfterEnv: ['given2/setup'],
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -49,7 +49,6 @@
         "@types/react": "^17.0.0",
         "@types/testing-library__react-hooks": "^4.0.0",
         "cross-env": "^7.0.3",
-        "given2": "^2.1.7",
         "jest": "catalog:",
         "jest-environment-jsdom": "catalog:",
         "posthog-js": "workspace:*",

--- a/packages/react/src/components/__tests__/PostHogErrorBoundary.test.jsx
+++ b/packages/react/src/components/__tests__/PostHogErrorBoundary.test.jsx
@@ -10,25 +10,25 @@ describe('PostHogErrorBoundary component', () => {
     mockFunction(console, 'warn')
     mockFunction(posthog, 'captureException')
 
-    given('render_with_error', () => (props) => render(<RenderWithError {...props} />))
-    given('render_without_error', () => (props) => render(<RenderWithoutError {...props} />))
+    const renderWithError = (props) => render(<RenderWithError {...props} />)
+    const renderWithoutError = (props) => render(<RenderWithoutError {...props} />)
 
     it('should call captureException with error message', () => {
-        const { container } = given.render_with_error({ message: 'Test error', fallback: <div></div> })
+        const { container } = renderWithError({ message: 'Test error', fallback: <div></div> })
         expect(posthog.captureException).toHaveBeenCalledWith(new Error('Test error'), undefined)
         expect(container.innerHTML).toBe('<div></div>')
         expect(console.error).toHaveBeenCalledTimes(2)
     })
 
     it('should warn user when fallback is null', () => {
-        const { container } = given.render_with_error({ fallback: null })
+        const { container } = renderWithError({ fallback: null })
         expect(posthog.captureException).toHaveBeenCalledWith(new Error('Error'), undefined)
         expect(container.innerHTML).toBe('')
         expect(console.warn).toHaveBeenCalledWith(__POSTHOG_ERROR_MESSAGES.INVALID_FALLBACK)
     })
 
     it('should warn user when fallback is a string', () => {
-        const { container } = given.render_with_error({ fallback: 'hello' })
+        const { container } = renderWithError({ fallback: 'hello' })
         expect(posthog.captureException).toHaveBeenCalledWith(new Error('Error'), undefined)
         expect(container.innerHTML).toBe('')
         expect(console.warn).toHaveBeenCalledWith(__POSTHOG_ERROR_MESSAGES.INVALID_FALLBACK)
@@ -36,13 +36,13 @@ describe('PostHogErrorBoundary component', () => {
 
     it('should add additional properties before sending event (as object)', () => {
         const props = { team_id: '1234' }
-        given.render_with_error({ message: 'Kaboom', additionalProperties: props })
+        renderWithError({ message: 'Kaboom', additionalProperties: props })
         expect(posthog.captureException).toHaveBeenCalledWith(new Error('Kaboom'), props)
     })
 
     it('should add additional properties before sending event (as function)', () => {
         const props = { team_id: '1234' }
-        given.render_with_error({
+        renderWithError({
             message: 'Kaboom',
             additionalProperties: (err) => {
                 expect(err.message).toBe('Kaboom')
@@ -53,7 +53,7 @@ describe('PostHogErrorBoundary component', () => {
     })
 
     it('should render children without errors', () => {
-        const { container } = given.render_without_error()
+        const { container } = renderWithoutError()
         expect(container.innerHTML).toBe('<div>Amazing content</div>')
     })
 })
@@ -63,10 +63,10 @@ describe('captureException processing', () => {
     mockFunction(console, 'warn')
     mockFunction(posthog, 'capture')
 
-    given('render_with_error', () => (props) => render(<RenderWithError {...props} />))
+    const renderWithError = (props) => render(<RenderWithError {...props} />)
 
     it('should call capture with a stacktrace', () => {
-        given.render_with_error({ message: 'Kaboom', fallback: <div></div>, additionalProperties: {} })
+        renderWithError({ message: 'Kaboom', fallback: <div></div>, additionalProperties: {} })
         const captureCalls = posthog.capture.mock.calls
         expect(captureCalls.length).toBe(1)
         const exceptionList = captureCalls[0][1].$exception_list

--- a/packages/react/src/context/__tests__/PostHogContext.test.jsx
+++ b/packages/react/src/context/__tests__/PostHogContext.test.jsx
@@ -3,28 +3,28 @@ import { render } from '@testing-library/react'
 import { PostHogProvider } from '..'
 
 describe('PostHogContext component', () => {
-    given(
-        'render',
-        () => () =>
-            render(
-                <PostHogProvider client={given.posthog}>
-                    <div>Hello</div>
-                </PostHogProvider>
-            )
-    )
-    given('posthog', () => ({}))
+    let posthog = {}
 
     it('should return a client instance from the context if available', () => {
-        given.render()
+        render(
+            <PostHogProvider client={posthog}>
+                <div>Hello</div>
+            </PostHogProvider>
+        )
     })
 
     it("should not throw error if a client instance can't be found in the context", () => {
-        given('posthog', () => undefined) // it might not exist in SSR for example
-
         // eslint-disable-next-line no-console
         console.warn = jest.fn()
 
-        expect(() => given.render()).not.toThrow()
+        expect(() => {
+            render(
+                // it might not exist in SSR for example
+                <PostHogProvider client={undefined}>
+                    <div>Hello</div>
+                </PostHogProvider>
+            )
+        }).not.toThrow()
 
         // eslint-disable-next-line no-console
         expect(console.warn).toHaveBeenCalledWith(

--- a/packages/react/src/hooks/__tests__/usePostHog.test.jsx
+++ b/packages/react/src/hooks/__tests__/usePostHog.test.jsx
@@ -8,15 +8,9 @@ jest.useFakeTimers()
 const posthog = { posthog_client: true }
 
 describe('usePostHog hook', () => {
-    given('renderProvider', () => ({ children }) => (
-        <PostHogProvider client={given.posthog}>{children}</PostHogProvider>
-    ))
-
-    given('posthog', () => posthog)
-
     it('should return the client', () => {
         let { result } = renderHook(() => usePostHog(), {
-            wrapper: given.renderProvider,
+            wrapper: ({ children }) => <PostHogProvider client={posthog}>{children}</PostHogProvider>,
         })
         expect(result.current).toEqual(posthog)
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,9 +531,6 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
-      given2:
-        specifier: ^2.1.7
-        version: 2.1.7
       jest:
         specifier: 'catalog:'
         version: 29.7.0(@types/node@22.17.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
@@ -7183,9 +7180,6 @@ packages:
 
   git-url-parse@16.1.0:
     resolution: {integrity: sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==}
-
-  given2@2.1.7:
-    resolution: {integrity: sha512-fI3VamsjN2euNVguGpSt2uExyDSMfJoK+SwDxbmV+Thf3v4oF6KKZAFE3LHHuT+PYyMwCsJYXO01TW3euFdPGA==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -21710,8 +21704,6 @@ snapshots:
   git-url-parse@16.1.0:
     dependencies:
       git-up: 8.1.1
-
-  given2@2.1.7: {}
 
   glob-parent@5.1.2:
     dependencies:


### PR DESCRIPTION
i didn't realise we still had given2
it hides so much from us by insisting on all the indirection in tests

let's remove it

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
