### PR TITLE
fix(llma): dependabot changeset permissions

### DIFF
--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -4,6 +4,8 @@ jobs:
   changeset:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This is necessary because GitHub removed write permissions from Dependabot PR actions for security reasons, this re-enables them for this workflow.