### PR TITLE
feat: add bot detection playground

### DIFF
--- a/packages/browser/playground/bot-detection/.env.example
+++ b/packages/browser/playground/bot-detection/.env.example
@@ -1,0 +1,6 @@
+# PostHog Configuration
+# Copy this file to .env and fill in your values
+
+POSTHOG_TOKEN=your_posthog_project_api_key
+POSTHOG_API_HOST=https://us.i.posthog.com
+POSTHOG_UI_HOST=https://us.i.posthog.com

--- a/packages/browser/playground/bot-detection/.gitignore
+++ b/packages/browser/playground/bot-detection/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+package-lock.json
+.env
+*.log
+
+# TypeScript build artifacts
+dist/
+*.tsbuildinfo
+
+# Compiled React bundle (generated from src/client/*.tsx)
+static/bundle.js
+static/bundle.js.map

--- a/packages/browser/playground/bot-detection/README.md
+++ b/packages/browser/playground/bot-detection/README.md
@@ -1,0 +1,201 @@
+# Bot Detection Playground
+
+A simple playground for testing PostHog's bot detection and pageview collection features.
+
+## Features
+
+This playground demonstrates:
+
+- Bot detection using user agent filtering
+- `__preview_send_bot_pageviews` preview flag
+- `$bot_pageview` event generation for bot traffic
+- `$browser_type` property on bot pageviews
+- Interactive testing UI with buttons
+- Real-time console logging of all events
+
+## Setup
+
+### Environment Variables (Optional)
+
+Create a `.env` file in this directory:
+
+```bash
+POSTHOG_TOKEN=your_posthog_project_api_key
+POSTHOG_API_HOST=https://us.i.posthog.com
+POSTHOG_UI_HOST=https://us.i.posthog.com
+```
+
+If not provided, the app will use default test values that work locally.
+
+### Installation
+
+```bash
+npm install
+```
+
+### Building
+
+The playground is written in TypeScript. Build the project:
+
+```bash
+npm run build
+```
+
+## Running the Playground
+
+### Development Mode (with hot reload)
+
+```bash
+npm run dev
+```
+
+This uses `ts-node` to run the TypeScript directly.
+
+### Production Mode
+
+```bash
+npm run build
+npm start
+```
+
+This compiles TypeScript to JavaScript in the `dist/` directory and runs the compiled code.
+
+The server will start on http://localhost:8080
+
+## How to Use
+
+### Method 1: Using Browser DevTools (Recommended)
+
+1. Open the playground at http://localhost:8080
+2. Open DevTools (F12) and go to the Console tab
+3. Open **Network Conditions**:
+    - Click the 3-dot menu in Console
+    - More tools → Network conditions
+4. Under "User agent":
+    - Uncheck "Use browser default"
+    - Select "Custom..."
+    - Enter a bot user agent (see list below)
+5. **Refresh the page** (important!)
+6. Click "Send $pageview Event"
+7. Check the Console output to verify:
+    - Event name is `$bot_pageview` (not `$pageview`)
+    - Properties include `$browser_type: 'bot'`
+
+### Common Bot User Agents
+
+- `Googlebot/2.1`
+- `facebookexternalagent`
+- `Twitterbot/1.0`
+- `LinkedInBot/1.0`
+- `Chrome-Lighthouse`
+- `HeadlessChrome/91.0.4472.124`
+
+### Method 2: Using curl
+
+```bash
+# Simulate a bot pageview
+curl 'http://localhost:8080' -H 'User-Agent: Googlebot/2.1' -v
+```
+
+## What to Observe
+
+### When `__preview_send_bot_pageviews: true` (Default)
+
+- **Bot traffic**: Pageviews renamed to `$bot_pageview` with `$browser_type: 'bot'`
+- **Normal traffic**: Pageviews remain as `$pageview` without `$browser_type`
+- **Other events**: Sent normally regardless of user agent
+
+### When `__preview_send_bot_pageviews: false`
+
+- **Bot traffic**: All events dropped (default PostHog behavior)
+- **Normal traffic**: All events sent normally
+
+## Interactive Features
+
+The playground includes buttons to:
+
+1. **Send $pageview Event** - Manually trigger a pageview event
+2. **Send Custom Event** - Test non-pageview events from bots
+3. **Toggle \_\_preview_send_bot_pageviews** - Reinitialize PostHog with/without the flag
+
+## Console Output
+
+With debug mode enabled (default), you'll see detailed logging in the browser console:
+
+```javascript
+[PostHog.js] send "$bot_pageview" {
+  event: "$bot_pageview",
+  properties: {
+    $browser_type: "bot",
+    $current_url: "http://localhost:8080",
+    // ... other properties
+  }
+}
+```
+
+## Troubleshooting
+
+**Events not showing in console?**
+
+- PostHog debug mode is enabled automatically
+- Check that the PostHog instance initialized successfully
+
+**Bot detection not working?**
+
+- Verify you've changed the User Agent in DevTools Network Conditions
+- **Refresh the page** after changing the user agent
+- Check the console for the actual user agent being used
+
+**Server won't start?**
+
+- Make sure port 8080 is available
+- Check that you've run `pnpm install` first
+- The built PostHog library should exist at `../../dist/posthog.js`
+
+## Project Structure
+
+```
+bot-detection/
+├── src/
+│   ├── server.ts          # Express server (TypeScript)
+│   └── client/
+│       ├── index.tsx      # React app entry point
+│       ├── App.tsx        # Main App component
+│       ├── types.ts       # TypeScript interfaces
+│       └── components/
+│           ├── ControlBar.tsx    # Top control panel
+│           ├── BotSelector.tsx   # Bot dropdown selector
+│           ├── EventLog.tsx      # Event log container
+│           └── EventCard.tsx     # Individual event display
+├── static/
+│   ├── styles.css         # All CSS styles
+│   ├── bot-data.js        # Bot categories and user agents
+│   ├── bundle.js          # Compiled React app (generated)
+│   └── bundle.js.map      # Source map (generated)
+├── dist/                  # Compiled server code (generated)
+├── package.json           # Dependencies and scripts
+├── tsconfig.json          # Server TypeScript configuration
+├── tsconfig.client.json   # Client TypeScript configuration
+└── README.md
+```
+
+**Note**: Both `static/bundle.js` and `dist/` are build artifacts and should not be edited directly. Edit the TypeScript source files in `src/` instead.
+
+## Technology Stack
+
+- **Frontend**: React 18 + TypeScript
+- **Backend**: Express + TypeScript
+- **Build Tools**:
+    - esbuild for React bundling
+    - TypeScript compiler for server
+- **State Management**: React hooks (useState, useEffect)
+
+## Implementation Details
+
+This playground uses the bot detection feature added in the `lricoy/bot-pageview-collection` branch:
+
+- **Browser SDK**: Detects bots and renames pageviews to `$bot_pageview`
+- **Preview Flag**: `__preview_send_bot_pageviews` enables bot traffic collection
+- **Browser Type Property**: `$browser_type: 'bot'` is set on all `$bot_pageview` events for easy filtering
+- **React + TypeScript**: Component-based UI with full type safety
+- **Clean Architecture**: Separated concerns with reusable components

--- a/packages/browser/playground/bot-detection/package.json
+++ b/packages/browser/playground/bot-detection/package.json
@@ -1,0 +1,31 @@
+{
+    "name": "bot-detection-playground",
+    "version": "1.0.0",
+    "description": "A playground for testing bot detection and pageview collection with PostHog",
+    "main": "dist/server.js",
+    "scripts": {
+        "build": "npm run build:server && npm run build:client",
+        "build:server": "tsc",
+        "build:client": "esbuild src/client/index.tsx --bundle --outfile=static/bundle.js --sourcemap --jsx=automatic",
+        "dev": "npm run build:client && ts-node src/server.ts",
+        "start": "node dist/server.js",
+        "watch": "npm run watch:server & npm run watch:client",
+        "watch:server": "tsc --watch",
+        "watch:client": "esbuild src/client/index.tsx --bundle --outfile=static/bundle.js --sourcemap --watch --jsx=automatic"
+    },
+    "dependencies": {
+        "dotenv": "^16.5.0",
+        "express": "^4.18.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+    },
+    "devDependencies": {
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.10.0",
+        "@types/react": "^18.2.45",
+        "@types/react-dom": "^18.2.18",
+        "esbuild": "^0.19.10",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
+    }
+}

--- a/packages/browser/playground/bot-detection/src/client/App.tsx
+++ b/packages/browser/playground/bot-detection/src/client/App.tsx
@@ -1,0 +1,102 @@
+import { useState, useEffect } from 'react'
+import { CapturedEvent } from './types'
+import { ControlBar } from './components/ControlBar'
+import { EventLog } from './components/EventLog'
+
+interface AppProps {
+    token: string
+    apiHost: string
+    uiHost: string
+    initialUserAgent: string
+}
+
+export function App({ token, apiHost, uiHost, initialUserAgent }: AppProps) {
+    const [events, setEvents] = useState<CapturedEvent[]>([])
+    const [eventIdCounter, setEventIdCounter] = useState(0)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, setSelectedBotInfo] = useState<{ ua: string | null; name: string | null }>({
+        ua: null,
+        name: null,
+    })
+
+    useEffect(() => {
+        // Initialize PostHog
+        if (window.posthog) {
+            window.posthog.init(token, {
+                api_host: apiHost,
+                ui_host: uiHost,
+                __preview_send_bot_pageviews: true,
+                autocapture: false,
+                before_send: function (event: any) {
+                    const eventData: CapturedEvent = {
+                        id: eventIdCounter + 1,
+                        timestamp: new Date(),
+                        event: event.event,
+                        properties: event.properties || {},
+                        options: {},
+                    }
+
+                    setEventIdCounter((prev) => prev + 1)
+                    setEvents((prev) => {
+                        const newEvents = [...prev, eventData]
+                        if (newEvents.length > 100) {
+                            newEvents.shift()
+                        }
+                        return newEvents
+                    })
+
+                    return event
+                },
+                loaded: function (ph: any) {
+                    console.log('PostHog loaded successfully!')
+                    ph.debug()
+                },
+            })
+        }
+
+        console.log('Current User Agent:', navigator.userAgent)
+    }, [token, apiHost, uiHost, eventIdCounter])
+
+    const handleSendPageview = () => {
+        if (window.posthog) {
+            window.posthog.capture('$pageview', {
+                $current_url: window.location.href,
+            })
+        }
+    }
+
+    const handleSendCustomEvent = () => {
+        if (window.posthog) {
+            window.posthog.capture('custom_event', {
+                test: 'data',
+                timestamp: new Date().toISOString(),
+                random: Math.random().toString(36).substring(7),
+            })
+        }
+    }
+
+    const handleClearEvents = () => {
+        setEvents([])
+    }
+
+    const handleBotSelect = (botUA: string | null, botName: string | null) => {
+        setSelectedBotInfo({ ua: botUA, name: botName })
+        if (botUA) {
+            console.log('Selected Bot UA (for reference):', botUA)
+        } else {
+            console.log('No bot selected')
+        }
+    }
+
+    return (
+        <div className="container">
+            <ControlBar
+                userAgent={initialUserAgent}
+                onSendPageview={handleSendPageview}
+                onSendCustomEvent={handleSendCustomEvent}
+                onBotSelect={handleBotSelect}
+            />
+            <EventLog events={events} onClear={handleClearEvents} />
+        </div>
+    )
+}

--- a/packages/browser/playground/bot-detection/src/client/components/BotSelector.tsx
+++ b/packages/browser/playground/bot-detection/src/client/components/BotSelector.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { BotCategories } from '../types'
+
+interface BotSelectorProps {
+    onBotSelect: (botUA: string | null, botName: string | null) => void
+}
+
+export function BotSelector({ onBotSelect }: BotSelectorProps) {
+    const [selectedBotUA, setSelectedBotUA] = useState<string | null>(null)
+
+    const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = e.target.value
+
+        if (!value) {
+            setSelectedBotUA(null)
+            onBotSelect(null, null)
+            return
+        }
+
+        if (value === 'custom') {
+            const customUA = prompt('Enter custom User Agent:')
+            if (customUA) {
+                setSelectedBotUA(customUA)
+                onBotSelect(customUA, 'Custom Bot')
+            }
+        } else {
+            const selectedOption = e.target.options[e.target.selectedIndex]
+            setSelectedBotUA(value)
+            onBotSelect(value, selectedOption.text)
+        }
+    }
+
+    const botCategories: BotCategories = window.BOT_CATEGORIES || {}
+
+    return (
+        <>
+            <div className="card compact">
+                <h2>Bot Selector</h2>
+                <select onChange={handleChange} style={{ fontSize: '13px' }}>
+                    <option value="">-- Select a Bot --</option>
+                    {Object.entries(botCategories).map(([category, bots]) => (
+                        <optgroup key={category} label={category}>
+                            {bots.map((bot) => (
+                                <option key={bot.name} value={bot.example} data-pattern={bot.pattern}>
+                                    {bot.name}
+                                </option>
+                            ))}
+                        </optgroup>
+                    ))}
+                    <option value="custom">✏️ Custom User Agent...</option>
+                </select>
+                <div style={{ fontSize: '11px', color: '#718096', marginTop: '6px' }}>💡 For reference only</div>
+            </div>
+
+            {selectedBotUA && (
+                <div className="card compact">
+                    <h2>Selected Bot UA</h2>
+                    <div
+                        className="ua-display"
+                        style={{ fontSize: '11px', padding: '8px', borderLeftColor: '#f56565' }}
+                    >
+                        {selectedBotUA}
+                    </div>
+                    <div style={{ fontSize: '11px', color: '#718096', marginTop: '6px' }}>
+                        📋 Copy to use in DevTools
+                    </div>
+                </div>
+            )}
+        </>
+    )
+}

--- a/packages/browser/playground/bot-detection/src/client/components/ControlBar.tsx
+++ b/packages/browser/playground/bot-detection/src/client/components/ControlBar.tsx
@@ -1,0 +1,52 @@
+import { BotSelector } from './BotSelector'
+
+interface ControlBarProps {
+    userAgent: string
+    onSendPageview: () => void
+    onSendCustomEvent: () => void
+    onBotSelect: (botUA: string | null, botName: string | null) => void
+}
+
+export function ControlBar({ userAgent, onSendPageview, onSendCustomEvent, onBotSelect }: ControlBarProps) {
+    return (
+        <div className="control-bar">
+            <div className="card compact">
+                <h2>Browser UA</h2>
+                <div className="ua-display" style={{ fontSize: '11px', padding: '8px' }}>
+                    {userAgent}
+                </div>
+            </div>
+
+            <BotSelector onBotSelect={onBotSelect} />
+
+            <div className="card compact">
+                <h2>Actions</h2>
+                <div className="button-group" style={{ gap: '8px' }}>
+                    <button
+                        className="btn-primary"
+                        onClick={onSendPageview}
+                        style={{ padding: '8px 12px', fontSize: '13px' }}
+                    >
+                        📄 $pageview
+                    </button>
+                    <button
+                        className="btn-success"
+                        onClick={onSendCustomEvent}
+                        style={{ padding: '8px 12px', fontSize: '13px' }}
+                    >
+                        ✨ Custom
+                    </button>
+                </div>
+            </div>
+
+            <div className="card wide">
+                <h2>How to Test</h2>
+                <div style={{ fontSize: '12px' }}>
+                    <strong>1.</strong> Select bot → <strong>2.</strong> Open DevTools (F12) → <strong>3.</strong>{' '}
+                    Network conditions (Cmd+Shift+P) → <strong>4.</strong> Set Custom UA → <strong>5.</strong> Refresh →{' '}
+                    <strong>6.</strong> Send event
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/packages/browser/playground/bot-detection/src/client/components/EventCard.tsx
+++ b/packages/browser/playground/bot-detection/src/client/components/EventCard.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react'
+import { CapturedEvent } from '../types'
+
+interface EventCardProps {
+    event: CapturedEvent
+}
+
+export function EventCard({ event }: EventCardProps) {
+    const [isExpanded, setIsExpanded] = useState(false)
+    const [copyStatus, setCopyStatus] = useState<'idle' | 'copied'>('idle')
+
+    const eventClass =
+        event.event === '$pageview' ? 'pageview' : event.event === '$bot_pageview' ? 'bot-pageview' : 'custom'
+
+    const icon = eventClass === 'bot-pageview' ? '🤖' : eventClass === 'custom' ? '✨' : '📄'
+
+    const time =
+        event.timestamp.toLocaleTimeString('en-US', {
+            hour12: false,
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+        }) +
+        '.' +
+        event.timestamp.getMilliseconds().toString().padStart(3, '0')
+
+    const handleCopy = async () => {
+        try {
+            // eslint-disable-next-line compat/compat
+            await navigator.clipboard.writeText(JSON.stringify(event, null, 2))
+            setCopyStatus('copied')
+            setTimeout(() => setCopyStatus('idle'), 1000)
+        } catch (err) {
+            console.error('Failed to copy:', err)
+        }
+    }
+
+    const botProps = ['$bot_detection_method', '$bot_type', '$browser_type', '$raw_user_agent']
+
+    const sortedKeys = Object.keys(event.properties).sort()
+    const orderedProps: Record<string, any> = {}
+    sortedKeys.forEach((key) => {
+        orderedProps[key] = event.properties[key]
+    })
+
+    let eventJSON = '{\n'
+    eventJSON += `  "id": ${event.id},\n`
+    eventJSON += `  "timestamp": "${event.timestamp.toISOString()}",\n`
+    eventJSON += `  "event": "${event.event}",\n`
+    eventJSON += '  "properties": {\n'
+
+    const propKeys = Object.keys(orderedProps)
+    propKeys.forEach((key, idx) => {
+        const value = JSON.stringify(orderedProps[key])
+        const isBotProp = botProps.includes(key)
+        const comma = idx < propKeys.length - 1 ? ',' : ''
+
+        if (isBotProp) {
+            eventJSON += `    <strong style="color: #e53e3e;">"${key}"</strong>: ${value}${comma}\n`
+        } else {
+            eventJSON += `    "${key}": ${value}${comma}\n`
+        }
+    })
+
+    eventJSON += '  }'
+    if (Object.keys(event.options || {}).length > 0) {
+        eventJSON += ',\n  "options": ' + JSON.stringify(event.options, null, 2).replace(/\n/g, '\n  ')
+    }
+    eventJSON += '\n}'
+
+    return (
+        <div className={`event-card ${eventClass}`}>
+            <div className="event-header" onClick={() => setIsExpanded(!isExpanded)} style={{ cursor: 'pointer' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                    <span className="event-expand-icon">{isExpanded ? '▼' : '▶'}</span>
+                    <span className="event-icon">{icon}</span>
+                    <span className={`event-name ${eventClass}`}>{event.event}</span>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                    <span className="event-timestamp">{time}</span>
+                    <button
+                        className="btn-copy"
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            handleCopy()
+                        }}
+                        title="Copy JSON"
+                    >
+                        {copyStatus === 'copied' ? '✓' : '📋'}
+                    </button>
+                </div>
+            </div>
+            {isExpanded && (
+                <div className="event-details">
+                    <pre
+                        style={{
+                            margin: 0,
+                            fontFamily: 'monospace',
+                            fontSize: '11px',
+                            whiteSpace: 'pre-wrap',
+                            wordBreak: 'break-all',
+                            marginTop: '8px',
+                            paddingTop: '8px',
+                            borderTop: '1px solid #e2e8f0',
+                        }}
+                        dangerouslySetInnerHTML={{ __html: eventJSON }}
+                    />
+                </div>
+            )}
+        </div>
+    )
+}

--- a/packages/browser/playground/bot-detection/src/client/components/EventLog.tsx
+++ b/packages/browser/playground/bot-detection/src/client/components/EventLog.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react'
+import { CapturedEvent } from '../types'
+import { EventCard } from './EventCard'
+
+interface EventLogProps {
+    events: CapturedEvent[]
+    onClear: () => void
+}
+
+export function EventLog({ events, onClear }: EventLogProps) {
+    const [autoScroll, setAutoScroll] = useState(true)
+    const logContentRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (autoScroll && logContentRef.current) {
+            logContentRef.current.scrollTop = logContentRef.current.scrollHeight
+        }
+    }, [events, autoScroll])
+
+    return (
+        <div className="event-log-container">
+            <div className="event-log">
+                <div className="event-log-header">
+                    <div className="event-log-title">
+                        Event Log
+                        <span className="event-count">{events.length}</span>
+                    </div>
+                    <div className="event-log-controls">
+                        <button
+                            className={`btn-small ${autoScroll ? 'active' : ''}`}
+                            onClick={() => setAutoScroll(!autoScroll)}
+                        >
+                            {autoScroll ? '✓ ' : ''}Auto-scroll
+                        </button>
+                        <button className="btn-small" onClick={onClear}>
+                            🗑️ Clear
+                        </button>
+                    </div>
+                </div>
+                <div className="event-log-content" ref={logContentRef}>
+                    {events.length === 0 ? (
+                        <div className="event-log-empty">
+                            <div className="event-log-empty-icon">📭</div>
+                            <div>No events captured yet</div>
+                            <div style={{ fontSize: '12px', marginTop: '5px' }}>Click a button to send an event</div>
+                        </div>
+                    ) : (
+                        events.map((event) => <EventCard key={event.id} event={event} />)
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/packages/browser/playground/bot-detection/src/client/index.tsx
+++ b/packages/browser/playground/bot-detection/src/client/index.tsx
@@ -1,0 +1,16 @@
+import { createRoot } from 'react-dom/client'
+import { App } from './App'
+
+// Get config from data attributes on the root element
+const rootElement = document.getElementById('root')
+if (!rootElement) {
+    throw new Error('Root element not found')
+}
+
+const token = rootElement.dataset.token || 'test-key'
+const apiHost = rootElement.dataset.apiHost || 'https://us.i.posthog.com'
+const uiHost = rootElement.dataset.uiHost || apiHost
+const userAgent = rootElement.dataset.userAgent || navigator.userAgent
+
+const root = createRoot(rootElement)
+root.render(<App token={token} apiHost={apiHost} uiHost={uiHost} initialUserAgent={userAgent} />)

--- a/packages/browser/playground/bot-detection/src/client/types.ts
+++ b/packages/browser/playground/bot-detection/src/client/types.ts
@@ -1,0 +1,39 @@
+export interface CapturedEvent {
+    id: number
+    timestamp: Date
+    event: string
+    properties: Record<string, any>
+    options: Record<string, any>
+}
+
+export interface BotInfo {
+    name: string
+    pattern: string
+    example: string
+}
+
+export interface BotCategories {
+    [category: string]: BotInfo[]
+}
+
+export interface PostHogConfig {
+    api_host: string
+    ui_host: string
+    __preview_send_bot_pageviews: boolean
+    autocapture: boolean
+    before_send?: (event: any) => any
+    loaded?: (ph: any) => void
+}
+
+export interface PostHogInstance {
+    init: (token: string, config: PostHogConfig) => void
+    capture: (event: string, properties?: Record<string, any>) => void
+    debug: () => void
+}
+
+declare global {
+    interface Window {
+        posthog: PostHogInstance
+        BOT_CATEGORIES: BotCategories
+    }
+}

--- a/packages/browser/playground/bot-detection/src/server.ts
+++ b/packages/browser/playground/bot-detection/src/server.ts
@@ -1,0 +1,54 @@
+import 'dotenv/config'
+import express, { Request, Response } from 'express'
+import path from 'path'
+
+const app = express()
+const PORT = 8080
+
+const removeTrailingSlash = (str: string): string => str.replace(/\/$/, '')
+
+// Environment variables (with fallbacks for local development)
+const POSTHOG_TOKEN = process.env.POSTHOG_TOKEN || 'test-key'
+const POSTHOG_API_HOST = removeTrailingSlash(process.env.POSTHOG_API_HOST || 'https://us.i.posthog.com')
+const POSTHOG_UI_HOST = removeTrailingSlash(process.env.POSTHOG_UI_HOST || POSTHOG_API_HOST)
+
+// Serve static assets
+app.use('/static', express.static(path.join(__dirname, '../static')))
+
+// Serve the built PostHog library from the parent directory
+app.use('/posthog', express.static(path.join(__dirname, '../../../dist')))
+
+// Home page with React app
+app.get('/', (req: Request, res: Response) => {
+    const userAgent = req.headers['user-agent'] || 'No User Agent'
+
+    res.send(`
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Bot Detection Playground</title>
+      <link href="/static/styles.css" rel="stylesheet">
+      <script src="/posthog/array.js"></script>
+      <script src="/static/bot-data.js"></script>
+    </head>
+    <body>
+      <div
+        id="root"
+        data-token="${POSTHOG_TOKEN}"
+        data-api-host="${POSTHOG_API_HOST}"
+        data-ui-host="${POSTHOG_UI_HOST}"
+        data-user-agent="${userAgent.replace(/"/g, '&quot;')}"
+      ></div>
+      <script src="/static/bundle.js"></script>
+    </body>
+    </html>
+  `)
+})
+
+app.listen(PORT, () => {
+    console.log(`🚀 Bot Detection Playground running at http://localhost:${PORT}`)
+    console.log(`📊 PostHog: ${POSTHOG_API_HOST}`)
+    console.log(`🔑 Token: ${POSTHOG_TOKEN}`)
+})

--- a/packages/browser/playground/bot-detection/static/bot-data.js
+++ b/packages/browser/playground/bot-detection/static/bot-data.js
@@ -1,0 +1,175 @@
+// Categorized bot data from PostHog's blocked-uas.ts
+window.BOT_CATEGORIES = {
+    'Search Engines': [
+        {
+            name: 'Googlebot',
+            pattern: 'googlebot',
+            example: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+        },
+        {
+            name: 'Bingbot',
+            pattern: 'bingbot',
+            example: 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+        },
+        {
+            name: 'DuckDuckBot',
+            pattern: 'duckduckbot',
+            example: 'DuckDuckBot/1.0; (+http://duckduckgo.com/duckduckbot.html)',
+        },
+        {
+            name: 'Baiduspider',
+            pattern: 'baiduspider',
+            example: 'Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)',
+        },
+        {
+            name: 'Yandex',
+            pattern: 'yandexbot',
+            example: 'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
+        },
+        {
+            name: 'Yahoo Slurp',
+            pattern: 'yahoo! slurp',
+            example: 'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)',
+        },
+        {
+            name: 'Applebot',
+            pattern: 'applebot',
+            example:
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Applebot/0.1)',
+        },
+    ],
+    'Social Media': [
+        { name: 'Facebook', pattern: 'facebookexternal', example: 'facebookexternalagent' },
+        {
+            name: 'Meta External Agent',
+            pattern: 'meta-externalagent',
+            example:
+                'Mozilla/5.0 (compatible; Meta-ExternalAgent/1.1; +https://developers.facebook.com/docs/sharing/webmasters/crawler)',
+        },
+        { name: 'Twitter', pattern: 'twitterbot', example: 'Twitterbot/1.0' },
+        {
+            name: 'LinkedIn',
+            pattern: 'linkedinbot',
+            example: 'LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)',
+        },
+        { name: 'Pinterest', pattern: 'pinterest', example: 'Pinterest/0.2 (+http://www.pinterest.com/)' },
+        {
+            name: 'Slackbot',
+            pattern: 'slackbot',
+            example: 'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)',
+        },
+    ],
+    'SEO Tools': [
+        {
+            name: 'Ahrefs Bot',
+            pattern: 'ahrefsbot',
+            example: 'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)',
+        },
+        { name: 'Ahrefs Site Audit', pattern: 'ahrefssiteaudit', example: 'AhrefsSiteAudit/6.1' },
+        {
+            name: 'Semrush',
+            pattern: 'semrushbot',
+            example: 'Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)',
+        },
+        { name: 'Screaming Frog', pattern: 'screaming frog', example: 'Screaming Frog SEO Spider/16.0' },
+        { name: 'Sitebulb', pattern: 'sitebulb', example: 'Sitebulb/1.0.0 (https://sitebulb.com/)' },
+        {
+            name: 'MJ12bot',
+            pattern: 'mj12bot',
+            example: 'Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)',
+        },
+        {
+            name: 'Rogerbot',
+            pattern: 'rogerbot',
+            example: 'rogerbot/1.0 (http://www.moz.com/dp/rogerbot, rogerbot-crawler+shiny@moz.com)',
+        },
+        {
+            name: 'DataForSEO',
+            pattern: 'dataforseobot',
+            example: 'Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)',
+        },
+    ],
+    'AI Crawlers': [
+        {
+            name: 'GPTbot (OpenAI)',
+            pattern: 'gptbot',
+            example: 'Mozilla/5.0 (compatible; GPTbot/1.1; +https://openai.com/gptbot)',
+        },
+        {
+            name: 'ChatGPT-User',
+            pattern: 'chatgpt-user',
+            example:
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2.1 Safari/605.1.15 (ChatGPT-User/1.0)',
+        },
+        { name: 'Perplexity', pattern: 'perplexitybot', example: 'PerplexityBot/1.0 (+http://www.perplexity.ai/bot)' },
+        { name: 'Google Cloud Vertex', pattern: 'google-cloudvertexbot', example: 'Google-CloudVertexBot' },
+        { name: 'Claude Bot', pattern: 'claude-web', example: 'Claude-Web/1.0' },
+        {
+            name: 'ByteSpider (TikTok)',
+            pattern: 'bytespider',
+            example:
+                'Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)',
+        },
+    ],
+    'Development & Testing': [
+        {
+            name: 'Headless Chrome',
+            pattern: 'headlesschrome',
+            example:
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/91.0.4472.124 Safari/537.36',
+        },
+        {
+            name: 'Cypress',
+            pattern: 'cypress',
+            example:
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Cypress/12.0.0 Chrome/106.0.0.0 Safari/537.36',
+        },
+        {
+            name: 'Chrome Lighthouse',
+            pattern: 'chrome-lighthouse',
+            example:
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Chrome-Lighthouse',
+        },
+        { name: 'Vercel Bot', pattern: 'vercelbot', example: 'vercelbot' },
+        {
+            name: 'Prerender',
+            pattern: 'prerender',
+            example:
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Prerender (+https://github.com/prerender/prerender)',
+        },
+    ],
+    'Uptime Monitoring': [
+        {
+            name: 'UptimeRobot',
+            pattern: 'uptimerobot',
+            example: 'Mozilla/5.0+(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)',
+        },
+        { name: 'Sentry Uptime', pattern: 'sentryuptimebot', example: 'SentryUptimeBot/1.0 (+http://sentry.io/)' },
+        {
+            name: 'Better Uptime',
+            pattern: 'better uptime bot',
+            example:
+                'Better Uptime Bot Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36',
+        },
+    ],
+    'Other Crawlers': [
+        {
+            name: 'Archive.org',
+            pattern: 'archive.org_bot',
+            example: 'Mozilla/5.0 (compatible; archive.org_bot +http://archive.org/details/archive.org_bot)',
+        },
+        { name: 'HubSpot', pattern: 'hubspot', example: 'HubSpot Links Crawler 2.0' },
+        {
+            name: 'PetalBot (Huawei)',
+            pattern: 'petalbot',
+            example:
+                'Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; PetalBot;+https://webmaster.petalsearch.com/site/petalbot)',
+        },
+        {
+            name: 'Amazonbot',
+            pattern: 'amazonbot',
+            example:
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot)',
+        },
+    ],
+}

--- a/packages/browser/playground/bot-detection/static/styles.css
+++ b/packages/browser/playground/bot-detection/static/styles.css
@@ -1,0 +1,385 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    line-height: 1.6;
+    color: #333;
+    background: #f8f9fa;
+    margin: 0;
+    padding: 0;
+    height: 100vh;
+    overflow: hidden;
+}
+
+.container {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+}
+
+.control-bar {
+    display: flex;
+    gap: 12px;
+    padding: 12px;
+    background: white;
+    border-bottom: 2px solid #e2e8f0;
+    flex-wrap: wrap;
+    align-items: flex-start;
+}
+
+.event-log-container {
+    flex: 1;
+    min-height: 0;
+    padding: 12px;
+}
+
+.card {
+    background: white;
+    border-radius: 6px;
+    padding: 12px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+    flex: 0 0 auto;
+}
+
+.card.compact {
+    min-width: 200px;
+    max-width: 300px;
+}
+
+.card.wide {
+    flex: 1;
+    min-width: 250px;
+}
+
+.card h2 {
+    font-size: 14px;
+    margin-bottom: 10px;
+    color: #2d3748;
+    font-weight: 600;
+}
+
+.card h3 {
+    font-size: 13px;
+    margin-bottom: 8px;
+    color: #4a5568;
+    font-weight: 600;
+}
+
+.ua-display {
+    background: #f7fafc;
+    padding: 12px;
+    border-radius: 6px;
+    border-left: 3px solid #667eea;
+    font-family: 'Courier New', monospace;
+    font-size: 12px;
+    word-break: break-all;
+    line-height: 1.5;
+    color: #2d3748;
+}
+
+select {
+    width: 100%;
+    padding: 10px;
+    border: 2px solid #e2e8f0;
+    border-radius: 6px;
+    font-size: 14px;
+    background: white;
+    cursor: pointer;
+    transition: border-color 0.2s;
+}
+
+select:hover {
+    border-color: #cbd5e0;
+}
+
+select:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+.button-group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+button {
+    padding: 12px 20px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    border: none;
+    border-radius: 6px;
+    color: white;
+    transition: all 0.2s;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+button:active {
+    transform: translateY(0);
+}
+
+.btn-primary {
+    background: #3182ce;
+}
+.btn-primary:hover {
+    background: #2c5aa0;
+}
+
+.btn-success {
+    background: #38a169;
+}
+.btn-success:hover {
+    background: #2f855a;
+}
+
+.btn-purple {
+    background: #805ad5;
+}
+.btn-purple:hover {
+    background: #6b46c1;
+}
+
+.status {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 6px 12px;
+    border-radius: 20px;
+    font-weight: 600;
+    font-size: 13px;
+}
+
+.status.enabled {
+    background: #c6f6d5;
+    color: #22543d;
+}
+
+.status.disabled {
+    background: #fed7d7;
+    color: #742a2a;
+}
+
+.event-log {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.event-log-header {
+    padding: 15px 20px;
+    border-bottom: 2px solid #e2e8f0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: #f7fafc;
+    border-radius: 8px 8px 0 0;
+}
+
+.event-log-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: #2d3748;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.event-count {
+    background: #667eea;
+    color: white;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.event-log-controls {
+    display: flex;
+    gap: 10px;
+}
+
+.btn-small {
+    padding: 6px 12px;
+    font-size: 12px;
+    border-radius: 4px;
+    background: #e2e8f0;
+    color: #2d3748;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-small:hover {
+    background: #cbd5e0;
+}
+
+.btn-small.active {
+    background: #667eea;
+    color: white;
+}
+
+.event-log-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 15px;
+    background: #ffffff;
+}
+
+.event-log-empty {
+    text-align: center;
+    padding: 60px 20px;
+    color: #a0aec0;
+}
+
+.event-log-empty-icon {
+    font-size: 48px;
+    margin-bottom: 10px;
+}
+
+.event-card {
+    background: #f7fafc;
+    border-left: 4px solid #cbd5e0;
+    padding: 12px;
+    margin-bottom: 10px;
+    border-radius: 4px;
+    transition: all 0.2s;
+}
+
+.event-card:hover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    transform: translateX(2px);
+}
+
+.event-card.pageview {
+    border-left-color: #3182ce;
+    background: #ebf8ff;
+}
+
+.event-card.bot-pageview {
+    border-left-color: #ed8936;
+    background: #fffaf0;
+}
+
+.event-card.custom {
+    border-left-color: #38a169;
+    background: #f0fff4;
+}
+
+.event-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 4px 0;
+    transition: background-color 0.2s;
+}
+
+.event-header:hover {
+    background-color: rgba(0, 0, 0, 0.02);
+}
+
+.event-expand-icon {
+    font-size: 10px;
+    color: #718096;
+    transition: transform 0.2s;
+    display: inline-block;
+    width: 14px;
+}
+
+.event-icon {
+    font-size: 14px;
+}
+
+.btn-copy {
+    padding: 4px 8px;
+    font-size: 12px;
+    background: #e2e8f0;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-copy:hover {
+    background: #cbd5e0;
+    transform: scale(1.05);
+}
+
+.event-details {
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+}
+
+.event-name {
+    font-weight: 600;
+    font-size: 14px;
+    font-family: 'Courier New', monospace;
+}
+
+.event-name.pageview {
+    color: #2c5aa0;
+}
+.event-name.bot-pageview {
+    color: #c05621;
+}
+.event-name.custom {
+    color: #2f855a;
+}
+
+.event-timestamp {
+    font-size: 11px;
+    color: #718096;
+    font-family: 'Courier New', monospace;
+}
+
+.instructions {
+    font-size: 13px;
+    line-height: 1.7;
+}
+
+.instructions ol {
+    margin-left: 20px;
+}
+
+.instructions li {
+    margin: 8px 0;
+}
+
+.instructions code {
+    background: #edf2f7;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 12px;
+}
+
+.info-badge {
+    background: #bee3f8;
+    color: #2c5aa0;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-size: 12px;
+    margin-top: 10px;
+}
+
+@media (max-width: 1200px) {
+    .control-bar {
+        flex-direction: column;
+    }
+    .card.compact,
+    .card.wide {
+        max-width: none;
+        min-width: 0;
+    }
+}

--- a/packages/browser/playground/bot-detection/tsconfig.client.json
+++ b/packages/browser/playground/bot-detection/tsconfig.client.json
@@ -1,0 +1,23 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./static",
+        "rootDir": "./src/client",
+        "lib": ["ES2020", "DOM"],
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "jsx": "react-jsx",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "declaration": false,
+        "declarationMap": false,
+        "sourceMap": true,
+        "noEmit": true
+    },
+    "include": ["src/client/**/*"],
+    "exclude": ["node_modules", "dist", "static"]
+}

--- a/packages/browser/playground/bot-detection/tsconfig.json
+++ b/packages/browser/playground/bot-detection/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "commonjs",
+        "lib": ["ES2020"],
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "moduleResolution": "node",
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true
+    },
+    "include": ["src/server.ts"],
+    "exclude": ["node_modules", "dist", "static", "src/client"]
+}


### PR DESCRIPTION
## Summary

Interactive React playground for testing bot detection and pageview collection features.

Provides a visual interface to test the `__preview_send_bot_pageviews` flag with various bot user agents and see real-time event capture.

## Features

- Bot user agent selector with common bots (Googlebot, Facebook, LinkedIn, etc.)
- Live event log with JSON inspector
- Toggle `__preview_send_bot_pageviews` flag on/off
- Real-time event capture visualization
- Manual event testing buttons

## Tech Stack

- **Frontend**: React 18 + TypeScript
- **Backend**: Express + TypeScript  
- **Build**: esbuild (37ms builds)
- **Type Safety**: Full TypeScript coverage

## Project Structure

```
packages/browser/playground/bot-detection/
├── src/
│   ├── server.ts              # Express server
│   └── client/
│       ├── index.tsx          # React entry point
│       ├── App.tsx            # Main app component
│       ├── types.ts           # TypeScript interfaces
│       └── components/
│           ├── ControlBar.tsx
│           ├── BotSelector.tsx
│           ├── EventLog.tsx
│           └── EventCard.tsx
├── static/
│   ├── styles.css
│   ├── bot-data.js
│   └── bundle.js (generated)
├── package.json
├── tsconfig.json
└── README.md
```

## Test plan

- [x] Client builds successfully (37ms)
- [x] Server compiles without errors
- [ ] Manual testing: `npm run dev` and visit http://localhost:8080
- [ ] Test bot selection and event capture
- [ ] Verify `__preview_send_bot_pageviews` toggle works

## Related

- Library changes PR: #2520