### PR TITLE
fix(err): fix args with spaces

### DIFF
--- a/.changeset/sweet-pants-kneel.md
+++ b/.changeset/sweet-pants-kneel.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+escape cli args and path in shell mode

--- a/examples/example-nextjs/pnpm-lock.yaml
+++ b/examples/example-nextjs/pnpm-lock.yaml
@@ -330,24 +330,24 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@posthog/cli@0.4.7':
-    resolution: {integrity: sha512-FTIQMW7J+OaN0B/cRGvXUL2bJaSwr19ef2Vu8UzkQb5/9U/FtbYIcGqpdlv82Bi4Aet9S/k+RmVO2wlCq34dZw==}
+  '@posthog/cli@0.5.7':
+    resolution: {integrity: sha512-PIDUJmXVRm4Jl5scujGHkjxpJhxnPXlZLMDpFqDwI5YoPTq+strWSN2wbfKe6JcgkqBaKamW1aDqCx4UTBkTJA==}
     engines: {node: '>=14', npm: '>=6'}
     hasBin: true
 
   '@posthog/core@file:../../target/posthog-core.tgz':
-    resolution: {integrity: sha512-J4fhWuE42kLfwnsCG8Qsfd4+wWAGNsqqewOQsanSghr29Gk6ypue4sCK2SjT7kjEmgTazsCAYUOi/H91hpTIiw==, tarball: file:../../target/posthog-core.tgz}
-    version: 1.2.2
+    resolution: {integrity: sha512-lN8Y0eIw+RY6f1s73SE/s7SBsyhOpzLSejZEiZ2MRaSvqhLNMd52Vzzmdh90Fay4Mp42RbQKQfLBTsQgUQqJsw==, tarball: file:../../target/posthog-core.tgz}
+    version: 1.3.0
 
   '@posthog/nextjs-config@file:../../target/posthog-nextjs-config.tgz':
-    resolution: {integrity: sha512-gakKpcGmE4IZHto4W2RhyFhmiS9zzSugXGO+hpTLqy+rgzX8FMnB9V0t0IiSrlxDoXa2jQrS1Hh3XAQGHtZYsg==, tarball: file:../../target/posthog-nextjs-config.tgz}
-    version: 1.3.1
+    resolution: {integrity: sha512-L+Sj27xqXxJaMAfMSP1KjghttnPgpWiXygmO9XO1lm1re/FD2ul6kcEXmImvEmEmzeX83Hpp9IkPhynNoiouxg==, tarball: file:../../target/posthog-nextjs-config.tgz}
+    version: 1.3.4
     engines: {node: '>=20'}
     peerDependencies:
       next: '>12.1.0'
 
   '@posthog/react@file:../../target/posthog-react.tgz':
-    resolution: {integrity: sha512-bpLuHLQ4gIwgK4ikbPhEQrPurXioGiTDwe/qFJFYWaBtllb53/2+eWyFTZbfbqj68Gylid+/d8F6WFIpwDn3QA==, tarball: file:../../target/posthog-react.tgz}
+    resolution: {integrity: sha512-mKtFwyxmmZJsU6bhkJYDa9EV2WTcXMbyUQIAjgV2zhYNQv6fuqpkwWWAu/yYHJlllk+FETxIpT4Vf/eNprLzDg==, tarball: file:../../target/posthog-react.tgz}
     version: 1.2.3
     peerDependencies:
       '@types/react': '>=16.8.0'
@@ -632,8 +632,8 @@ packages:
   axios-proxy-builder@0.1.2:
     resolution: {integrity: sha512-6uBVsBZzkB3tCC8iyx59mCjQckhB8+GQrI9Cop8eC7ybIsvs/KtnNgEBfRMSEa7GqK2VBGUzgjNYMdPIfotyPA==}
 
-  axios@1.10.0:
-    resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
+  axios@1.13.1:
+    resolution: {integrity: sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1456,20 +1456,12 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
 
   posthog-js@file:../../target/posthog-js.tgz:
-    resolution: {integrity: sha512-k5Bkl+Mhkt+0YYYRWcoA9FDMQjRIrGXR9ZmsivZl08QZplPsndNAvU2mSErtDtuoYFyLsO0BGSFKhv8qcyDfxQ==, tarball: file:../../target/posthog-js.tgz}
-    version: 1.273.1
-    peerDependencies:
-      '@rrweb/types': 2.0.0-alpha.17
-      rrweb-snapshot: 2.0.0-alpha.17
-    peerDependenciesMeta:
-      '@rrweb/types':
-        optional: true
-      rrweb-snapshot:
-        optional: true
+    resolution: {integrity: sha512-+OwA0RV5vCX8fBck+SYSZBEAfaIt3Z5Z2/Y9uk86aOfJkTZZedPRo+bgQ9fActa9FJingq6Aoh4e0ORbIYrkKQ==, tarball: file:../../target/posthog-js.tgz}
+    version: 1.279.1
 
   posthog-node@file:../../target/posthog-node.tgz:
-    resolution: {integrity: sha512-bc03eICCQPUiKyBG9F+wKMN5FvhSDvUvd0LGO3TyczE5rn3mlH/7Nm3Z+xgFWf/qIFYuiPU08EgoxrN35zrl1w==, tarball: file:../../target/posthog-node.tgz}
-    version: 5.9.3
+    resolution: {integrity: sha512-Pix26KSNWwIVCRzkpssCNuSnCCN+k8yukBrchIIxJSSYPq2BbCTMUR9x0Iz4mP5Rc9sDVP8g53o8B1hX+owg3Q==, tarball: file:../../target/posthog-node.tgz}
+    version: 5.10.2
     engines: {node: '>=20'}
 
   preact@10.26.9:
@@ -2022,9 +2014,9 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@posthog/cli@0.4.7':
+  '@posthog/cli@0.5.7':
     dependencies:
-      axios: 1.10.0
+      axios: 1.13.1
       axios-proxy-builder: 0.1.2
       console.table: 0.10.0
       detect-libc: 2.0.4
@@ -2036,7 +2028,7 @@ snapshots:
 
   '@posthog/nextjs-config@file:../../target/posthog-nextjs-config.tgz(next@15.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
-      '@posthog/cli': 0.4.7
+      '@posthog/cli': 0.5.7
       '@posthog/core': file:../../target/posthog-core.tgz
       next: 15.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       semver: 7.7.2
@@ -2343,7 +2335,7 @@ snapshots:
     dependencies:
       tunnel: 0.0.6
 
-  axios@1.10.0:
+  axios@1.13.1:
     dependencies:
       follow-redirects: 1.15.9
       form-data: 4.0.4

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,6 +59,10 @@
   "devDependencies": {
     "@posthog-tooling/tsconfig-base": "workspace:*",
     "@rslib/core": "catalog:",
+    "@types/cross-spawn": "^6.0.6",
     "jest": "catalog:"
+  },
+  "dependencies": {
+    "cross-spawn": "^7.0.6"
   }
 }

--- a/packages/core/src/process/spawn-local.ts
+++ b/packages/core/src/process/spawn-local.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import { resolveBinaryPath } from './utils'
+import os from 'node:os'
 
 export async function spawnLocal(
   binaryName: string,
@@ -24,7 +25,7 @@ export async function spawnLocal(
     )
   }
 
-  const child = spawn(binaryLocation, [...args], {
+  const child = spawn(`${escapeOS(binaryLocation)}`, [...args.map(escapeOS)], {
     shell: true,
     stdio: options?.stdio ?? 'inherit',
     env: options.env,
@@ -44,4 +45,13 @@ export async function spawnLocal(
       reject(error)
     })
   })
+}
+
+function escapeOS(arg: string): string {
+  if (os.platform() === 'win32') {
+    if (!/\s|["]/.test(arg)) return arg
+    return `"${arg.replace(/(["\\])/g, '\\$1')}"`
+  } else {
+    return `'${arg.replace(/'/g, `'\\''`)}'`
+  }
 }

--- a/packages/nextjs-config/package.json
+++ b/packages/nextjs-config/package.json
@@ -42,7 +42,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@posthog/cli": "^0.5.2",
+    "@posthog/cli": "^0.5.7",
     "semver": "^7.7.2",
     "@posthog/core": "workspace:*"
   },

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@posthog/cli": "^0.5.2",
+    "@posthog/cli": "^0.5.7",
     "@nuxt/kit": ">=3.7.0",
     "posthog-node": "workspace:*",
     "@posthog/core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,8 +406,8 @@ importers:
   packages/nextjs-config:
     dependencies:
       '@posthog/cli':
-        specifier: ^0.5.2
-        version: 0.5.2
+        specifier: ^0.5.7
+        version: 0.5.7
       '@posthog/core':
         specifier: workspace:*
         version: link:../core
@@ -465,8 +465,8 @@ importers:
         specifier: '>=3.7.0'
         version: 4.1.3(magicast@0.3.5)
       '@posthog/cli':
-        specifier: ^0.5.2
-        version: 0.5.2
+        specifier: ^0.5.7
+        version: 0.5.7
       '@posthog/core':
         specifier: workspace:*
         version: link:../core
@@ -3228,8 +3228,8 @@ packages:
   '@poppinss/exception@1.2.2':
     resolution: {integrity: sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==}
 
-  '@posthog/cli@0.5.2':
-    resolution: {integrity: sha512-+jV6qbDHq1r7iTmk7JVMX4rlmCVhptlP0ngyI3WsBkY9I9mGRelHXbyJb6AFbJouKHERBLkGMZmMNT7pzuPZng==}
+  '@posthog/cli@0.5.7':
+    resolution: {integrity: sha512-PIDUJmXVRm4Jl5scujGHkjxpJhxnPXlZLMDpFqDwI5YoPTq+strWSN2wbfKe6JcgkqBaKamW1aDqCx4UTBkTJA==}
     engines: {node: '>=14', npm: '>=6'}
     hasBin: true
 
@@ -16743,7 +16743,7 @@ snapshots:
 
   '@poppinss/exception@1.2.2': {}
 
-  '@posthog/cli@0.5.2':
+  '@posthog/cli@0.5.7':
     dependencies:
       axios: 1.12.2
       axios-proxy-builder: 0.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,10 @@ importers:
         version: 17.7.2
 
   packages/core:
+    dependencies:
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
     devDependencies:
       '@posthog-tooling/tsconfig-base':
         specifier: workspace:*
@@ -399,6 +403,9 @@ importers:
       '@rslib/core':
         specifier: 'catalog:'
         version: 0.10.6(@microsoft/api-extractor@7.52.8(@types/node@22.17.0))(typescript@5.8.2)
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       jest:
         specifier: 'catalog:'
         version: 29.7.0(@types/node@22.17.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
@@ -2016,7 +2023,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.1.7':
     resolution: {integrity: sha512-F81fPthpT7QtVu1P7QeZMezGn0tCcalCh3ANIzWBaQZNG4vly7mo2dp3PMGzNdmXq6yt93bJ4HbfS+0/NpKl7g==}
@@ -3985,6 +3992,9 @@ packages:
   '@types/cookie@0.4.1':
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
 
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
+
   '@types/css-font-loading-module@0.0.7':
     resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
 
@@ -5641,10 +5651,6 @@ packages:
   cross-spawn@6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
     engines: {node: '>=4.8'}
-
-  cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
-    engines: {node: '>= 8'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -15125,7 +15131,7 @@ snapshots:
 
   '@expo/spawn-async@1.7.2':
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
 
   '@expo/sudo-prompt@9.3.2': {}
 
@@ -17773,6 +17779,10 @@ snapshots:
 
   '@types/cookie@0.4.1': {}
 
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 22.17.0
+
   '@types/css-font-loading-module@0.0.7': {}
 
   '@types/debug@4.1.7':
@@ -19765,7 +19775,7 @@ snapshots:
 
   cross-env@7.0.3:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
 
   cross-fetch@3.2.0:
     dependencies:
@@ -19780,12 +19790,6 @@ snapshots:
       semver: 5.7.1
       shebang-command: 1.2.0
       which: 1.3.1
-
-  cross-spawn@7.0.3:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -20814,7 +20818,7 @@ snapshots:
       '@ungap/structured-clone': 1.2.0
       ajv: 6.12.6
       chalk: 4.1.2
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
@@ -20971,7 +20975,7 @@ snapshots:
 
   execa@3.4.0:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 5.2.0
       human-signals: 1.1.1
       is-stream: 2.0.0
@@ -20984,7 +20988,7 @@ snapshots:
 
   execa@4.1.0:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 5.2.0
       human-signals: 1.1.1
       is-stream: 2.0.0
@@ -20996,7 +21000,7 @@ snapshots:
 
   execa@5.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.0


### PR DESCRIPTION
## Problem

- https://posthoghelp.zendesk.com/agent/tickets/41451 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/44092)
- When CLI arguments or path have spaces, program exit

## Changes

- escape path and argument as we are using shell mode

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [x] @posthog/nextjs-config

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
