### PR TITLE
fix: we want to capture session ending when idle

### DIFF
--- a/.changeset/fruity-states-sip.md
+++ b/.changeset/fruity-states-sip.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: allow session ending payload when recording is idle


### PR DESCRIPTION
when capturing a session ending custom payload in replay
we might be idle

if we're idle, we'll drop the event since we only only the session idle event when idle

so, we need to treat session_start and session_ending like session_idle  
we allow them through when idle  
and we correct the timestamp of the event so that we don't extend the session