### PR TITLE
feat(nuxt): Added name to nuxt client plugin

### DIFF
--- a/.changeset/red-dots-travel.md
+++ b/.changeset/red-dots-travel.md
@@ -1,0 +1,5 @@
+---
+'@posthog/nuxt': minor
+---
+
+added name to nuxt client plugin

--- a/packages/nuxt/src/runtime/vue-plugin.ts
+++ b/packages/nuxt/src/runtime/vue-plugin.ts
@@ -3,36 +3,39 @@ import { defineNuxtPlugin, useRuntimeConfig } from '#app'
 import posthog from 'posthog-js'
 import type { PostHogClientConfig, PostHogCommon } from '../module'
 
-export default defineNuxtPlugin((nuxtApp) => {
-  const runtimeConfig = useRuntimeConfig()
-  const posthogCommon = runtimeConfig.public.posthog as PostHogCommon
-  const posthogClientConfig = runtimeConfig.public.posthogClientConfig as PostHogClientConfig
+export default defineNuxtPlugin({
+  name: 'posthog-client',
+  setup(nuxtApp) {
+    const runtimeConfig = useRuntimeConfig()
+    const posthogCommon = runtimeConfig.public.posthog as PostHogCommon
+    const posthogClientConfig = runtimeConfig.public.posthogClientConfig as PostHogClientConfig
 
-  // prevent nitro from trying to load this
-  if (!window || posthog.__loaded) {
-    return
-  }
+    // prevent nitro from trying to load this
+    if (!window || posthog.__loaded) {
+      return
+    }
 
-  posthog.init(posthogCommon.publicKey, {
-    api_host: posthogCommon.host,
-    ...posthogClientConfig,
-  })
-
-  if (posthogCommon.debug) {
-    posthog.debug(true)
-  }
-
-  if (autocaptureEnabled(posthogClientConfig)) {
-    nuxtApp.hook('vue:error', (error, info) => {
-      posthog.captureException(error, { info })
+    posthog.init(posthogCommon.publicKey, {
+      api_host: posthogCommon.host,
+      ...posthogClientConfig,
     })
-  }
 
-  return {
-    provide: {
-      posthog: () => posthog,
-    },
-  }
+    if (posthogCommon.debug) {
+      posthog.debug(true)
+    }
+
+    if (autocaptureEnabled(posthogClientConfig)) {
+      nuxtApp.hook('vue:error', (error, info) => {
+        posthog.captureException(error, { info })
+      })
+    }
+
+    return {
+      provide: {
+        posthog: () => posthog,
+      },
+    }
+  },
 })
 
 function autocaptureEnabled(config: PostHogClientConfig): boolean {


### PR DESCRIPTION
## Problem

Currently, the Nuxt Client Plugin lacks a name, which means that other plugins can't depend on it, so execution order isn't guaranteed, etc.

## Changes

Added name to Nuxt Client Plugin `posthog-client`, which will allow other plugins to depend on it. Fixes #2558 

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [x] @posthog/nuxt

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
