### PR TITLE
chore: refactor all tests to use the same helpers for instant'ing posthog

### DIFF
--- a/packages/browser/functional_tests/feature-flags.test.ts
+++ b/packages/browser/functional_tests/feature-flags.test.ts
@@ -19,7 +19,7 @@ describe('FunctionalTests / Feature Flags', () => {
     })
 
     test('person properties set in identify() with new distinct_id are sent to /flags', async () => {
-        const posthog = await createPosthogInstance(token, { advanced_disable_flags: false })
+        const posthog = await createPosthogInstance(token, { advanced_disable_flags: false, before_send: (cr) => cr })
 
         const anonymousId = posthog.get_distinct_id()
 
@@ -94,7 +94,7 @@ describe('FunctionalTests / Feature Flags', () => {
     })
 
     test('person properties set in identify() with the same distinct_id are sent to flags', async () => {
-        const posthog = await createPosthogInstance(token, { advanced_disable_flags: false })
+        const posthog = await createPosthogInstance(token, { advanced_disable_flags: false, before_send: (cr) => cr })
 
         const anonymousId = posthog.get_distinct_id()
 
@@ -213,7 +213,7 @@ describe('FunctionalTests / Feature Flags', () => {
     })
 
     test('identify() triggers new request in queue after first request', async () => {
-        const posthog = await createPosthogInstance(token, { advanced_disable_flags: false })
+        const posthog = await createPosthogInstance(token, { advanced_disable_flags: false, before_send: (cr) => cr })
 
         const anonymousId = posthog.get_distinct_id()
 
@@ -292,6 +292,7 @@ describe('FunctionalTests / Feature Flags', () => {
         await createPosthogInstance(token, {
             advanced_disable_flags: false,
             bootstrap: { distinctID: 'anon-id' },
+            before_send: (cr) => cr,
             loaded: (ph) => {
                 ph.identify('test-id', { email: 'test3@email.com' })
                 ph.group('playlist', 'id:77', { length: 8 })
@@ -361,6 +362,7 @@ describe('feature flags v2', () => {
             __preview_flags_v2: true,
             __preview_remote_config: true,
             advanced_disable_flags: false,
+            before_send: (cr) => cr,
         })
 
         await waitFor(() => {
@@ -378,6 +380,7 @@ describe('feature flags v2', () => {
             __preview_flags_v2: false,
             __preview_remote_config: true,
             advanced_disable_flags: false,
+            before_send: (cr) => cr,
         })
 
         await waitFor(() => {
@@ -396,6 +399,7 @@ describe('feature flags v2', () => {
             __preview_flags_v2: true,
             __preview_remote_config: false,
             advanced_disable_flags: false,
+            before_send: (cr) => cr,
         })
 
         await waitFor(() => {

--- a/packages/browser/functional_tests/identify.test.ts
+++ b/packages/browser/functional_tests/identify.test.ts
@@ -15,7 +15,7 @@ describe('FunctionalTests / Identify', () => {
 
     beforeEach(async () => {
         token = uuidv7()
-        posthog = await createPosthogInstance(token, { disable_surveys: true })
+        posthog = await createPosthogInstance(token, { disable_surveys: true, before_send: (cr) => cr })
         anonymousId = posthog.get_distinct_id()
     })
 

--- a/packages/browser/src/__tests__/extensions/replay/flushed-size-tracker.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/flushed-size-tracker.test.ts
@@ -2,7 +2,7 @@ import { FlushedSizeTracker } from '../../../extensions/replay/external/flushed-
 import { PostHog } from '../../../posthog-core'
 import { jest } from '@jest/globals'
 import { PostHogPersistence } from '../../../posthog-persistence'
-import { PostHogConfig } from '../../../types'
+import { createMockPostHog, createMockConfig } from '../../helpers/posthog-instance'
 
 describe('FlushedSizeTracker', () => {
     let mockPostHog: PostHog
@@ -11,9 +11,9 @@ describe('FlushedSizeTracker', () => {
 
     beforeEach(() => {
         persistence = new PostHogPersistence(
-            {
+            createMockConfig({
                 persistence: 'memory',
-            } as unknown as PostHogConfig,
+            }),
             false
         )
 
@@ -21,10 +21,10 @@ describe('FlushedSizeTracker', () => {
         persistence.get_property = persistence.get_property.bind(persistence)
         persistence.set_property = persistence.set_property.bind(persistence)
 
-        mockPostHog = {
+        mockPostHog = createMockPostHog({
             get_property: persistence.get_property,
             persistence,
-        } as unknown as PostHog
+        })
 
         tracker = new FlushedSizeTracker(mockPostHog)
     })
@@ -40,10 +40,10 @@ describe('FlushedSizeTracker', () => {
         })
 
         it('throws error when persistence is missing', () => {
-            const invalidPostHog = {
+            const invalidPostHog = createMockPostHog({
                 get_property: () => {},
                 persistence: undefined,
-            } as unknown as PostHog
+            })
 
             expect(() => new FlushedSizeTracker(invalidPostHog)).toThrow(
                 'it is not valid to not have persistence and be this far into setting up the application'
@@ -51,10 +51,10 @@ describe('FlushedSizeTracker', () => {
         })
 
         it('throws error when persistence is null', () => {
-            const invalidPostHog = {
+            const invalidPostHog = createMockPostHog({
                 get_property: () => {},
                 persistence: null,
-            } as unknown as PostHog
+            })
 
             expect(() => new FlushedSizeTracker(invalidPostHog)).toThrow(
                 'it is not valid to not have persistence and be this far into setting up the application'

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -10,6 +10,7 @@ import {
     SESSION_RECORDING_REMOTE_CONFIG,
 } from '../../../constants'
 import { SessionIdManager } from '../../../sessionid'
+import { createMockPostHog, createMockConfig } from '../../helpers/posthog-instance'
 import {
     FULL_SNAPSHOT_EVENT_TYPE,
     INCREMENTAL_SNAPSHOT_EVENT_TYPE,
@@ -213,7 +214,7 @@ describe('Lazy SessionRecording', () => {
         removePageviewCaptureHookMock = jest.fn()
         sessionId = 'sessionId' + uuidv7()
 
-        config = {
+        config = createMockConfig({
             api_host: 'https://test.com',
             disable_session_recording: false,
             enable_recording_console_log: false,
@@ -224,7 +225,7 @@ describe('Lazy SessionRecording', () => {
                 compress_events: false,
             },
             persistence: 'memory',
-        } as unknown as PostHogConfig
+        })
 
         assignableWindow.__PosthogExtensions__ = {
             rrweb: undefined,
@@ -241,7 +242,7 @@ describe('Lazy SessionRecording', () => {
         postHogPersistence.clear()
 
         sessionManager = new SessionIdManager(
-            { config, persistence: postHogPersistence, register: jest.fn() } as unknown as PostHog,
+            createMockPostHog({ config, persistence: postHogPersistence, register: jest.fn() }),
             sessionIdGeneratorMock,
             windowIdGeneratorMock
         )
@@ -1732,11 +1733,13 @@ describe('Lazy SessionRecording', () => {
                 let unsubscribeCallback: () => void
 
                 beforeEach(() => {
-                    sessionManager = new SessionIdManager({
-                        config,
-                        persistence: new PostHogPersistence(config),
-                        register: jest.fn(),
-                    } as unknown as PostHog)
+                    sessionManager = new SessionIdManager(
+                        createMockPostHog({
+                            config,
+                            persistence: new PostHogPersistence(config),
+                            register: jest.fn(),
+                        })
+                    )
                     posthog.sessionManager = sessionManager
 
                     mockCallback = jest.fn()
@@ -1828,11 +1831,13 @@ describe('Lazy SessionRecording', () => {
 
             describe('with a real session id manager', () => {
                 beforeEach(() => {
-                    sessionManager = new SessionIdManager({
-                        config,
-                        persistence: new PostHogPersistence(config),
-                        register: jest.fn(),
-                    } as unknown as PostHog)
+                    sessionManager = new SessionIdManager(
+                        createMockPostHog({
+                            config,
+                            persistence: new PostHogPersistence(config),
+                            register: jest.fn(),
+                        })
+                    )
                     posthog.sessionManager = sessionManager
 
                     sessionRecording.onRemoteConfig(

--- a/packages/browser/src/__tests__/extensions/replay/sessionRecording-onRemoteConfig.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/sessionRecording-onRemoteConfig.test.ts
@@ -23,6 +23,7 @@ import {
     OrTriggerMatching,
 } from '../../../extensions/replay/external/triggerMatching'
 import { LazyLoadedSessionRecording } from '../../../extensions/replay/external/lazy-loaded-session-recorder'
+import { createMockPostHog, createMockConfig } from '../../helpers/posthog-instance'
 
 // Type and source defined here designate a non-user-generated recording event
 
@@ -94,7 +95,7 @@ describe('SessionRecording', () => {
         removePageviewCaptureHookMock = jest.fn()
         sessionId = 'sessionId' + uuidv7()
 
-        config = {
+        config = createMockConfig({
             api_host: 'https://test.com',
             disable_session_recording: false,
             enable_recording_console_log: false,
@@ -104,7 +105,7 @@ describe('SessionRecording', () => {
                 compress_events: false,
             },
             persistence: 'memory',
-        } as unknown as PostHogConfig
+        })
 
         assignableWindow.__PosthogExtensions__ = {
             rrweb: undefined,
@@ -121,7 +122,7 @@ describe('SessionRecording', () => {
         postHogPersistence.clear()
 
         sessionManager = new SessionIdManager(
-            { config, persistence: postHogPersistence, register: jest.fn() } as unknown as PostHog,
+            createMockPostHog({ config, persistence: postHogPersistence, register: jest.fn() }),
             sessionIdGeneratorMock,
             windowIdGeneratorMock
         )

--- a/packages/browser/src/__tests__/extensions/replay/sessionRecordingStatus.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/sessionRecordingStatus.test.ts
@@ -15,7 +15,7 @@ import {
     TRIGGER_PENDING,
     URLTriggerMatching,
 } from '../../../extensions/replay/external/triggerMatching'
-import { PostHog } from '../../../posthog-core'
+import { createMockPostHog } from '../../helpers/posthog-instance'
 
 type TestConfig = {
     name: string
@@ -24,7 +24,7 @@ type TestConfig = {
     allMatchExpected: SessionRecordingStatus
 }
 
-const fakePostHog = { register_for_session: () => {} } as unknown as PostHog
+const fakePostHog = createMockPostHog({ register_for_session: () => {} })
 
 const defaultTriggersStatus: RecordingTriggersStatus = {
     receivedFlags: true,

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -18,6 +18,7 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import { PostHog } from '../../posthog-core'
 import { FlagsResponse } from '../../types'
 import { SURVEY_IN_PROGRESS_PREFIX } from '../../utils/survey-utils'
+import { createMockPostHog } from '../helpers/posthog-instance'
 
 declare const global: any
 
@@ -68,7 +69,7 @@ describe('survey display logic', () => {
         },
     ]
 
-    const mockPostHog = {
+    const mockPostHog = createMockPostHog({
         surveys: {
             getSurveys: jest.fn().mockImplementation((callback) => callback(mockSurveys)),
         },
@@ -77,7 +78,7 @@ describe('survey display logic', () => {
         config: {
             disable_surveys_automatic_display: false,
         },
-    } as unknown as PostHog
+    })
 
     test('callSurveysAndEvaluateDisplayLogic runs on interval irrespective of url change', () => {
         jest.useFakeTimers()
@@ -122,11 +123,11 @@ describe('usePopupVisibility', () => {
         current_iteration_start_date: null,
         feature_flag_keys: null,
     }
-    const mockPostHog = {
+    const mockPostHog = createMockPostHog({
         getActiveMatchingSurveys: jest.fn().mockImplementation((callback) => callback([mockSurvey])),
         get_session_replay_url: jest.fn(),
         capture: jest.fn().mockImplementation((eventName) => eventName),
-    } as unknown as PostHog
+    })
 
     const removeSurvey = jest.fn()
 
@@ -300,7 +301,7 @@ describe('SurveyManager', () => {
             },
         ]
 
-        mockPostHog = {
+        mockPostHog = createMockPostHog({
             getActiveMatchingSurveys: jest.fn(),
             get_session_replay_url: jest.fn(),
             capture: jest.fn(),
@@ -316,7 +317,7 @@ describe('SurveyManager', () => {
             surveys: {
                 getSurveys: jest.fn().mockImplementation((callback) => callback(mockSurveys)),
             },
-        } as unknown as PostHog
+        })
 
         surveyManager = new SurveyManager(mockPostHog)
     })
@@ -600,14 +601,14 @@ describe('SurveyManager', () => {
         beforeEach(() => {
             jest.useFakeTimers()
             // Set up mocks
-            mockPostHog = {
+            mockPostHog = createMockPostHog({
                 getActiveMatchingSurveys: jest.fn(),
                 get_session_replay_url: jest.fn(),
                 capture: jest.fn(),
                 featureFlags: {
                     isFeatureEnabled: jest.fn().mockReturnValue(true),
                 },
-            } as unknown as PostHog
+            })
 
             surveyManager = new SurveyManager(mockPostHog)
 
@@ -809,10 +810,10 @@ describe('usePopupVisibility URL changes should hide surveys accordingly', () =>
 
     beforeEach(() => {
         // Mock PostHog instance
-        posthog = {
+        posthog = createMockPostHog({
             capture: jest.fn(),
             get_session_replay_url: jest.fn(),
-        } as unknown as PostHog
+        })
 
         mockRemoveSurveyFromFocus = jest.fn()
 

--- a/packages/browser/src/__tests__/extensions/surveys/action-matcher.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys/action-matcher.test.ts
@@ -5,23 +5,24 @@ import { PostHogPersistence } from '../../../posthog-persistence'
 import { PostHog } from '../../../posthog-core'
 import { CaptureResult, PostHogConfig } from '../../../types'
 import { ActionMatcher } from '../../../extensions/surveys/action-matcher'
+import { createMockPostHog, createMockConfig } from '../../helpers/posthog-instance'
 
 describe('action-matcher', () => {
     let config: PostHogConfig
     let instance: PostHog
 
     beforeEach(() => {
-        config = {
+        config = createMockConfig({
             token: 'testtoken',
             api_host: 'https://app.posthog.com',
             persistence: 'memory',
-        } as unknown as PostHogConfig
+        })
 
-        instance = {
+        instance = createMockPostHog({
             config: config,
             persistence: new PostHogPersistence(config),
             _addCaptureHook: jest.fn(),
-        } as unknown as PostHog
+        })
     })
 
     afterEach(() => {

--- a/packages/browser/src/__tests__/extensions/surveys/feedback-widget.test.tsx
+++ b/packages/browser/src/__tests__/extensions/surveys/feedback-widget.test.tsx
@@ -2,18 +2,19 @@
 import '@testing-library/jest-dom'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
 import { FeedbackWidget } from '../../../extensions/surveys'
-import { PostHog } from '../../../posthog-core' // Import PostHog type for mocking
 import { Survey, SurveyQuestionType, SurveyType, SurveyWidgetType } from '../../../posthog-surveys-types'
+import { createMockPostHog } from '../../helpers/posthog-instance'
+import { PostHogFeatureFlags } from '../../../posthog-featureflags'
 
 // Mock PostHog instance
-const mockPosthog = {
+const mockPosthog = createMockPostHog({
     capture: jest.fn(),
     getActiveMatchingSurveys: jest.fn(),
     featureFlags: {
         isFeatureEnabled: jest.fn().mockReturnValue(true),
-    },
+    } as Partial<PostHogFeatureFlags> as unknown as PostHogFeatureFlags,
     get_session_replay_url: jest.fn().mockReturnValue('http://example.com/replay'),
-} as unknown as PostHog
+})
 
 // Base mock survey for widget type
 const baseWidgetSurvey: Survey = {

--- a/packages/browser/src/__tests__/extensions/toolbar.test.ts
+++ b/packages/browser/src/__tests__/extensions/toolbar.test.ts
@@ -1,10 +1,11 @@
 import { Toolbar } from '../../extensions/toolbar'
 import { isString, isUndefined } from '@posthog/core'
 import { PostHog } from '../../posthog-core'
-import { PostHogConfig, ToolbarParams } from '../../types'
+import { ToolbarParams } from '../../types'
 import { assignableWindow, window } from '../../utils/globals'
 import { RequestRouter } from '../../utils/request-router'
 import { TOOLBAR_ID } from '../../constants'
+import { createMockPostHog, createMockConfig } from '../helpers/posthog-instance'
 
 const makeToolbarParams = (overrides: Partial<ToolbarParams>): ToolbarParams => ({
     token: 'test_token',
@@ -17,15 +18,14 @@ describe('Toolbar', () => {
     const toolbarParams = makeToolbarParams({})
 
     beforeEach(() => {
-        instance = {
-            config: {
+        instance = createMockPostHog({
+            config: createMockConfig({
                 api_host: 'http://api.example.com',
                 token: 'test_token',
-            } as unknown as PostHogConfig,
-            requestRouter: new RequestRouter(instance),
-
+            }),
             set_config: jest.fn(),
-        } as unknown as PostHog
+        })
+        instance.requestRouter = new RequestRouter(instance)
 
         assignableWindow.__PosthogExtensions__ = {
             loadExternalDependency: jest.fn((_ph, _path: any, callback: any) => callback()),

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -4,6 +4,7 @@ import { filterActiveFeatureFlags, parseFlagsResponse, PostHogFeatureFlags } fro
 import { PostHogPersistence } from '../posthog-persistence'
 import { RequestRouter } from '../utils/request-router'
 import { PostHogConfig } from '../types'
+import { createMockPostHog } from './helpers/posthog-instance'
 
 jest.useFakeTimers()
 jest.spyOn(global, 'setTimeout')
@@ -2173,7 +2174,7 @@ describe('getRemoteConfigPayload', () => {
     let featureFlags: PostHogFeatureFlags
 
     beforeEach(() => {
-        instance = {
+        instance = createMockPostHog({
             config: {
                 token: 'test-token',
                 api_host: 'https://test.com',
@@ -2183,7 +2184,7 @@ describe('getRemoteConfigPayload', () => {
             requestRouter: {
                 endpointFor: jest.fn().mockImplementation((endpoint, path) => `${endpoint}${path}`),
             },
-        } as unknown as PostHog
+        })
 
         featureFlags = new PostHogFeatureFlags(instance)
     })
@@ -2253,7 +2254,7 @@ describe('getRemoteConfigPayload', () => {
                 api_host: 'https://app.posthog.com',
                 flags_api_host: 'https://example.com/feature-flags',
             }
-            const customInstance = {
+            const customInstance = createMockPostHog({
                 config: {
                     token: 'test-token',
                     ...apiConfig,
@@ -2261,7 +2262,7 @@ describe('getRemoteConfigPayload', () => {
                 get_distinct_id: () => 'test-distinct-id',
                 _send_request: jest.fn(),
                 requestRouter: new RequestRouter({ config: apiConfig } as any),
-            } as unknown as PostHog
+            })
 
             const customFeatureFlags = new PostHogFeatureFlags(customInstance)
             const callback = jest.fn()
@@ -2276,7 +2277,7 @@ describe('getRemoteConfigPayload', () => {
         })
 
         it('should fall back to api_host when flags_api_host is not configured', () => {
-            const customInstance = {
+            const customInstance = createMockPostHog({
                 config: {
                     token: 'test-token',
                     api_host: 'https://app.posthog.com',
@@ -2288,7 +2289,7 @@ describe('getRemoteConfigPayload', () => {
                         api_host: 'https://app.posthog.com',
                     },
                 } as any),
-            } as unknown as PostHog
+            })
 
             const customFeatureFlags = new PostHogFeatureFlags(customInstance)
             const callback = jest.fn()

--- a/packages/browser/src/__tests__/identify.test.ts
+++ b/packages/browser/src/__tests__/identify.test.ts
@@ -11,7 +11,7 @@ describe('identify', () => {
     it('should persist the distinct_id', async () => {
         // arrange
         const token = uuidv7()
-        const posthog = await createPosthogInstance(token)
+        const posthog = await createPosthogInstance(token, { before_send: (cr) => cr })
         const distinctId = '123'
 
         // act
@@ -26,7 +26,7 @@ describe('identify', () => {
     it('should convert a numeric distinct_id to a string', async () => {
         // arrange
         const token = uuidv7()
-        const posthog = await createPosthogInstance(token)
+        const posthog = await createPosthogInstance(token, { before_send: (cr) => cr })
         const distinctIdNum = 123
         const distinctIdString = '123'
 
@@ -36,7 +36,9 @@ describe('identify', () => {
         // assert
         expect(posthog.persistence!.properties()['$user_id']).toEqual(distinctIdString)
         expect(mockLogger.error).toBeCalledTimes(0)
-        expect(mockLogger.warn).toBeCalledTimes(1)
+        expect(mockLogger.warn).toBeCalledWith(
+            'The first argument to posthog.identify was a number, but it should be a string. It has been converted to a string.'
+        )
     })
 
     it('should send $is_identified = true with the identify event and following events', async () => {

--- a/packages/browser/src/__tests__/posthog-surveys.test.ts
+++ b/packages/browser/src/__tests__/posthog-surveys.test.ts
@@ -16,6 +16,7 @@ import { Survey, SurveySchedule, SurveyType } from '../posthog-surveys-types'
 import { FlagsResponse } from '../types'
 import { assignableWindow } from '../utils/globals'
 import { SURVEY_IN_PROGRESS_PREFIX, SURVEY_SEEN_PREFIX } from '../utils/survey-utils'
+import { createMockPostHog } from './helpers/posthog-instance'
 
 describe('posthog-surveys', () => {
     describe('PostHogSurveys Class', () => {
@@ -85,7 +86,7 @@ describe('posthog-surveys', () => {
             localStorage.clear()
 
             // Mock PostHog instance
-            mockPostHog = {
+            mockPostHog = createMockPostHog({
                 config: {
                     disable_surveys: false,
                     token: 'test-token',
@@ -124,7 +125,7 @@ describe('posthog-surveys', () => {
                         .fn()
                         .mockImplementation((featureFlag) => flagsResponse.featureFlags[featureFlag]),
                 },
-            } as unknown as PostHog & {
+            }) as PostHog & {
                 get_property: jest.Mock
                 _send_request: jest.Mock
             }

--- a/packages/browser/src/__tests__/remote-config.test.ts
+++ b/packages/browser/src/__tests__/remote-config.test.ts
@@ -4,6 +4,7 @@ import { PostHog } from '../posthog-core'
 import { PostHogConfig, RemoteConfig } from '../types'
 import '../entrypoints/external-scripts-loader'
 import { assignableWindow } from '../utils/globals'
+import { createMockPostHog } from './helpers/posthog-instance'
 
 describe('RemoteConfigLoader', () => {
     let posthog: PostHog
@@ -19,7 +20,7 @@ describe('RemoteConfigLoader', () => {
         document.head.innerHTML = ''
         jest.spyOn(window.console, 'error').mockImplementation()
 
-        posthog = {
+        posthog = createMockPostHog({
             config: { ...defaultConfig },
             _onRemoteConfig: jest.fn(),
             _send_request: jest.fn().mockImplementation(({ callback }) => callback?.({ config: {} })),
@@ -28,8 +29,8 @@ describe('RemoteConfigLoader', () => {
             featureFlags: {
                 ensureFlagsLoaded: jest.fn(),
             },
-            requestRouter: new RequestRouter({ config: defaultConfig } as unknown as PostHog),
-        } as unknown as PostHog
+            requestRouter: new RequestRouter(createMockPostHog({ config: defaultConfig })),
+        })
     })
 
     describe('remote config', () => {

--- a/packages/browser/src/__tests__/session-props.test.ts
+++ b/packages/browser/src/__tests__/session-props.test.ts
@@ -1,7 +1,6 @@
 import { SessionPropsManager } from '../session-props'
 import { SessionIdManager } from '../sessionid'
-import { PostHogPersistence } from '../posthog-persistence'
-import { PostHog } from '../posthog-core'
+import { createMockPostHog, createMockPersistence } from './helpers/posthog-instance'
 
 describe('Session Props Manager', () => {
     const createSessionPropsManager = () => {
@@ -11,15 +10,15 @@ describe('Session Props Manager', () => {
         const sessionIdManager = {
             onSessionId,
         } as unknown as SessionIdManager
-        const persistence = {
+        const persistence = createMockPersistence({
             register: persistenceRegister,
             props: {},
-        } as unknown as PostHogPersistence
-        const posthog = {
+        })
+        const posthog = createMockPostHog({
             sessionManager: sessionIdManager,
             persistence,
             config: {},
-        } as unknown as PostHog
+        })
 
         const sessionPropsManager = new SessionPropsManager(posthog, sessionIdManager, persistence, generateProps)
 

--- a/packages/browser/src/__tests__/site-apps.test.ts
+++ b/packages/browser/src/__tests__/site-apps.test.ts
@@ -8,6 +8,7 @@ import { PostHogConfig, Properties, CaptureResult, RemoteConfig } from '../types
 import { assignableWindow } from '../utils/globals'
 import '../entrypoints/external-scripts-loader'
 import { isFunction } from '@posthog/core'
+import { createMockPostHog } from './helpers/posthog-instance'
 
 describe('SiteApps', () => {
     let posthog: PostHog
@@ -47,7 +48,7 @@ describe('SiteApps', () => {
 
         removeCaptureHook = jest.fn()
 
-        posthog = {
+        posthog = createMockPostHog({
             config: { ...defaultConfig, opt_in_site_apps: true },
             persistence: new PostHogPersistence(defaultConfig as PostHogConfig),
             register: (props: Properties) => posthog.persistence!.register(props),
@@ -66,11 +67,11 @@ describe('SiteApps', () => {
                 setReloadingPaused: jest.fn(),
                 _startReloadTimer: jest.fn(),
             },
-            requestRouter: new RequestRouter({ config: defaultConfig } as unknown as PostHog),
+            requestRouter: new RequestRouter(createMockPostHog({ config: defaultConfig })),
             _hasBootstrappedFeatureFlags: jest.fn(),
             getGroups: () => ({ organization: '5' }),
             on: jest.fn(),
-        } as unknown as PostHog
+        })
 
         siteAppsInstance = new SiteApps(posthog)
     })

--- a/packages/browser/src/__tests__/surveys.test.ts
+++ b/packages/browser/src/__tests__/surveys.test.ts
@@ -26,6 +26,7 @@ import { assignableWindow, window } from '../utils/globals'
 import { RequestRouter } from '../utils/request-router'
 import { SurveyEventReceiver } from '../utils/survey-event-receiver'
 import { SURVEY_LOGGER as logger } from '../utils/survey-utils'
+import { createMockPostHog, createMockConfig } from './helpers/posthog-instance'
 
 describe('surveys', () => {
     let config: PostHogConfig
@@ -182,14 +183,14 @@ describe('surveys', () => {
             callback()
         })
 
-        config = {
+        config = createMockConfig({
             token: 'testtoken',
             api_host: 'https://app.posthog.com',
             persistence: 'memory',
             surveys_request_timeout_ms: SURVEYS_REQUEST_TIMEOUT_MS,
-        } as unknown as PostHogConfig
+        })
 
-        instance = {
+        instance = createMockPostHog({
             config: config,
             persistence: new PostHogPersistence(config),
             requestRouter: new RequestRouter({ config } as any),
@@ -209,7 +210,7 @@ describe('surveys', () => {
                     .fn()
                     .mockImplementation((featureFlag) => flagsResponse.featureFlags[featureFlag]),
             },
-        } as unknown as PostHog
+        })
 
         assignableWindow.__PosthogExtensions__ = {
             loadExternalDependency: loadScriptMock,

--- a/packages/browser/src/__tests__/utils/survey-event-receiver.test.ts
+++ b/packages/browser/src/__tests__/utils/survey-event-receiver.test.ts
@@ -11,6 +11,7 @@ import { PostHogPersistence } from '../../posthog-persistence'
 import { PostHog } from '../../posthog-core'
 import { CaptureResult, PostHogConfig, PropertyMatchType } from '../../types'
 import { SurveyEventReceiver } from '../../utils/survey-event-receiver'
+import { createMockPostHog, createMockConfig } from '../helpers/posthog-instance'
 
 describe('survey-event-receiver', () => {
     describe('event based surveys', () => {
@@ -77,18 +78,18 @@ describe('survey-event-receiver', () => {
 
         beforeEach(() => {
             mockAddCaptureHook = jest.fn()
-            config = {
+            config = createMockConfig({
                 token: 'testtoken',
                 api_host: 'https://app.posthog.com',
                 persistence: 'memory',
-            } as unknown as PostHogConfig
+            })
 
-            instance = {
+            instance = createMockPostHog({
                 config: config,
                 persistence: new PostHogPersistence(config),
                 _addCaptureHook: mockAddCaptureHook,
                 getSurveys: jest.fn((callback) => callback(surveysWithEvents)),
-            } as unknown as PostHog
+            })
         })
 
         afterEach(() => {
@@ -210,18 +211,18 @@ describe('survey-event-receiver', () => {
 
         beforeEach(() => {
             mockAddCaptureHook = jest.fn()
-            config = {
+            config = createMockConfig({
                 token: 'testtoken',
                 api_host: 'https://app.posthog.com',
                 persistence: 'memory',
-            } as unknown as PostHogConfig
+            })
 
-            instance = {
+            instance = createMockPostHog({
                 config: config,
                 persistence: new PostHogPersistence(config),
                 _addCaptureHook: mockAddCaptureHook,
                 getSurveys: jest.fn((callback) => callback([])),
-            } as unknown as PostHog
+            })
         })
 
         afterEach(() => {
@@ -369,18 +370,18 @@ describe('survey-event-receiver', () => {
         let instance: PostHog
 
         beforeEach(() => {
-            config = {
+            config = createMockConfig({
                 token: 'testtoken',
                 api_host: 'https://app.posthog.com',
                 persistence: 'memory',
-            } as unknown as PostHogConfig
+            })
 
-            instance = {
+            instance = createMockPostHog({
                 config: config,
                 persistence: new PostHogPersistence(config),
                 _addCaptureHook: jest.fn(),
                 getSurveys: jest.fn((callback) => callback([])),
-            } as unknown as PostHog
+            })
         })
 
         afterEach(() => {

--- a/packages/browser/src/__tests__/web-experiments.test.ts
+++ b/packages/browser/src/__tests__/web-experiments.test.ts
@@ -1,10 +1,10 @@
 import { WebExperiments } from '../web-experiments'
 import { PostHog } from '../posthog-core'
-import { PostHogConfig } from '../types'
 import { PostHogPersistence } from '../posthog-persistence'
 import { WebExperiment } from '../web-experiments-types'
 import { RequestRouter } from '../utils/request-router'
 import { ConsentManager } from '../consent'
+import { createMockPostHog, createMockConfig, createMockPersistence } from './helpers/posthog-instance'
 
 describe('Web Experimentation', () => {
     let webExperiment: WebExperiments
@@ -109,15 +109,15 @@ describe('Web Experimentation', () => {
 
     beforeEach(() => {
         let cachedFlags = {}
-        persistence = { props: {}, register: jest.fn() } as unknown as PostHogPersistence
+        persistence = createMockPersistence({ props: {}, register: jest.fn() })
         posthog = makePostHog({
-            config: {
+            config: createMockConfig({
                 disable_web_experiments: false,
                 api_host: 'https://test.com',
                 token: 'testtoken',
                 autocapture: true,
                 region: 'us-east-1',
-            } as unknown as PostHogConfig,
+            }),
             persistence: persistence,
             get_property: jest.fn(),
             capture: jest.fn(),
@@ -247,13 +247,13 @@ describe('Web Experimentation', () => {
                 experiments: [signupButtonWebExperimentWithFeatureFlag],
             }
             const disabledPostHog = makePostHog({
-                config: {
+                config: createMockConfig({
                     api_host: 'https://test.com',
                     token: 'testtoken',
                     autocapture: true,
                     region: 'us-east-1',
-                    // no disable_web_experiments set to false here, so it’s implicitly enabled
-                } as unknown as PostHogConfig,
+                    // no disable_web_experiments set to false here, so it's implicitly enabled
+                }),
                 persistence: persistence,
                 get_property: jest.fn(),
                 _send_request: jest
@@ -328,11 +328,11 @@ describe('Web Experimentation', () => {
     })
 
     function makePostHog(ph: Partial<PostHog>): PostHog {
-        return {
+        return createMockPostHog({
             get_distinct_id() {
                 return 'distinctid'
             },
             ...ph,
-        } as unknown as PostHog
+        })
     }
 })


### PR DESCRIPTION
in another PR I was having to make changes to tonnes of files just to change setting up PostHog

but we shouldn't have lots of different ways of setting up posthog in tests

let's collapse to two

* a shared instance
* a new instance each time (but a mock)

and then it's easy to improve this over time
(since it'd be nice to remove all the untyped fake posthog's in our tests)