### PR TITLE
fix: autocapture rageclick detection used date.now and instead should use the event timestamp

### DIFF
--- a/.changeset/seven-crews-design.md
+++ b/.changeset/seven-crews-design.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: rageclick detection should use event timestamp not current time

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -356,7 +356,7 @@ export class Autocapture {
         if (eventName === '$autocapture' && e.type === 'click' && e instanceof MouseEvent) {
             if (
                 !!this.instance.config.rageclick &&
-                this.rageclicks?.isRageClick(e.clientX, e.clientY, new Date().getTime())
+                this.rageclicks?.isRageClick(e.clientX, e.clientY, e.timeStamp || new Date().getTime())
             ) {
                 if (shouldCaptureRageclick(target, this.instance.config.rageclick)) {
                     this._captureEvent(e, '$rageclick')


### PR DESCRIPTION
## Problem

rageclick test was flapping
because detection was using date.now for event check

## Changes

instead use event.timeStamp when present and fall back to date.now

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
