### PR TITLE
feat: add survey feedback button position options

### DIFF
--- a/.changeset/dirty-frogs-thank.md
+++ b/.changeset/dirty-frogs-thank.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+feat: add survey feedback button custom positions

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -11,6 +11,7 @@ import {
     SurveyQuestionBranchingType,
     SurveyQuestionType,
     SurveySchedule,
+    SurveyTabPosition,
     SurveyType,
     SurveyWidgetType,
     SurveyWithTypeAndAppearance,
@@ -1057,6 +1058,23 @@ function getPopoverPosition(
     }
 }
 
+function getTabPositionStyles(
+    position: SurveyTabPosition = SurveyTabPosition.Right
+): React.CSSProperties {
+    switch (position) {
+        case SurveyTabPosition.Top:
+            return { top: '0', left: '50%', transform: 'translateX(-50%)' }
+        case SurveyTabPosition.Left:
+            return { top: '50%', left: '0', transform: 'rotate(90deg) translateY(-100%)', transformOrigin: 'left top' }
+        case SurveyTabPosition.Bottom: // bottom center
+            return { bottom: '0', left: '50%', transform: 'translateX(-50%)' }
+        default:
+        case SurveyTabPosition.Right:
+            // not perfectly centered vertically, to avoid a "breaking" change
+            return { top: '50%', right: '0', transform: 'rotate(-90deg) translateY(-100%)', transformOrigin: 'right top' }
+    }
+}
+
 export function SurveyPopup({
     survey,
     forceDisableHtml,
@@ -1335,7 +1353,14 @@ export function FeedbackWidget({
     return (
         <Preact.Fragment>
             {survey.appearance?.widgetType === 'tab' && (
-                <button className="ph-survey-widget-tab" onClick={toggleSurvey} disabled={readOnly}>
+                <button
+                    className={`ph-survey-widget-tab ${survey.appearance?.tabPosition === SurveyTabPosition.Top ? 'widget-tab-top' : ''}`}
+                    onClick={toggleSurvey}
+                    disabled={readOnly}
+                    style={
+                        getTabPositionStyles(survey.appearance?.tabPosition)
+                    }
+                >
                     {survey.appearance?.widgetLabel || ''}
                 </button>
             )}

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -1058,9 +1058,7 @@ function getPopoverPosition(
     }
 }
 
-function getTabPositionStyles(
-    position: SurveyTabPosition = SurveyTabPosition.Right
-): React.CSSProperties {
+function getTabPositionStyles(position: SurveyTabPosition = SurveyTabPosition.Right): React.CSSProperties {
     switch (position) {
         case SurveyTabPosition.Top:
             return { top: '0', left: '50%', transform: 'translateX(-50%)' }
@@ -1071,7 +1069,12 @@ function getTabPositionStyles(
         default:
         case SurveyTabPosition.Right:
             // not perfectly centered vertically, to avoid a "breaking" change
-            return { top: '50%', right: '0', transform: 'rotate(-90deg) translateY(-100%)', transformOrigin: 'right top' }
+            return {
+                top: '50%',
+                right: '0',
+                transform: 'rotate(-90deg) translateY(-100%)',
+                transformOrigin: 'right top',
+            }
     }
 }
 
@@ -1357,9 +1360,7 @@ export function FeedbackWidget({
                     className={`ph-survey-widget-tab ${survey.appearance?.tabPosition === SurveyTabPosition.Top ? 'widget-tab-top' : ''}`}
                     onClick={toggleSurvey}
                     disabled={readOnly}
-                    style={
-                        getTabPositionStyles(survey.appearance?.tabPosition)
-                    }
+                    style={getTabPositionStyles(survey.appearance?.tabPosition)}
                 >
                     {survey.appearance?.widgetLabel || ''}
                 </button>

--- a/packages/browser/src/extensions/surveys/survey.css
+++ b/packages/browser/src/extensions/surveys/survey.css
@@ -152,23 +152,27 @@
 
 .ph-survey-widget-tab {
     position: fixed;
-    top: 50%;
-    right: 0;
     background: var(--ph-widget-color);
     color: var(--ph-widget-text-color);
-    transform: rotate(-90deg) translateY(-100%);
-    transform-origin: right top;
     padding: 10px 12px;
     border-radius: 3px 3px 0 0;
     text-align: center;
     cursor: pointer;
     z-index: var(--ph-survey-z-index);
-    transition: padding-bottom 0.2s ease-out;
+    transition: padding 0.2s ease-out;
     border: none;
 }
 
-.ph-survey-widget-tab:hover {
+.ph-survey-widget-tab:hover:not(.widget-tab-top) {
     padding-bottom: 16px;
+}
+
+.ph-survey-widget-tab.widget-tab-top {
+    border-radius: 0 0 3px 3px;
+}
+
+.ph-survey-widget-tab.widget-tab-top:hover {
+    padding-top: 16px;
 }
 
 /* --- Animations --- */

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -25,6 +25,13 @@ export enum SurveyPosition {
     NextToTrigger = 'next_to_trigger',
 }
 
+export enum SurveyTabPosition {
+    Top = 'top',
+    Left = 'left',
+    Right = 'right',
+    Bottom = 'bottom',
+}
+
 export interface SurveyAppearance {
     // keep in sync with frontend/src/types.ts -> SurveyAppearance
     backgroundColor?: string
@@ -47,6 +54,7 @@ export interface SurveyAppearance {
     thankYouMessageCloseButtonText?: string
     borderColor?: string
     position?: SurveyPosition
+    tabPosition?: SurveyTabPosition
     placeholder?: string
     shuffleQuestions?: boolean
     surveyPopupDelaySeconds?: number


### PR DESCRIPTION
## Problem
![473110514-92cc9b22-d363-4e6f-af92-c90b484a2955](https://github.com/user-attachments/assets/7546cc42-a043-4216-bad9-9151d372e71c)

Surveys with "feedback button" presentation mode display a tab/button on the right side of the page. This position cannot be changed.

Issue w/ customer +1s: https://github.com/PostHog/posthog/issues/35976

Frontend changing coming here - https://github.com/PostHog/posthog/pull/41410 - working on a better UX for why it's disabled before payment. This is safe to merge beforehand, as it defaults to "right" which is the only option available currently

## Changes

| | |
|:-------------------------:|:-------------------------:|
|<img width="1818" height="1441" alt="Screenshot 2025-11-12 at 7 39 13 PM" src="https://github.com/user-attachments/assets/c0cc1275-c83c-4294-96dc-5048499d9f6b" />|<img width="1818" height="1441" alt="Screenshot 2025-11-12 at 7 39 25 PM" src="https://github.com/user-attachments/assets/5347edfc-3c3a-41ee-8f66-66d4457f79e0" />|
|<img width="1818" height="1441" alt="Screenshot 2025-11-12 at 7 39 32 PM" src="https://github.com/user-attachments/assets/d3fced8d-944e-4bac-b366-e93968e4f0a8" />|<img width="1818" height="1441" alt="Screenshot 2025-11-12 at 7 39 41 PM" src="https://github.com/user-attachments/assets/90164e5a-0336-4e56-8f76-523b41e09044" />|

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
