### PR TITLE
chore: block merge if release label but no changeset, and adds date to the changelog

### DIFF
--- a/.changeset/changelog-with-date.js
+++ b/.changeset/changelog-with-date.js
@@ -1,0 +1,24 @@
+const githubChangelog = require('@changesets/changelog-github')
+
+const getReleaseLine = async (changeset, type, options) => {
+    return githubChangelog.getReleaseLine(changeset, type, options)
+}
+
+const getDependencyReleaseLine = async (changesets, dependenciesUpdated, options) => {
+    return githubChangelog.getDependencyReleaseLine(changesets, dependenciesUpdated, options)
+}
+
+async function getChangelogEntry(release, options) {
+    const date = new Date().toISOString().split('T')[0]
+    const githubEntry = await githubChangelog.getChangelogEntry(release, options)
+
+    return githubEntry.replace(`## ${release.newVersion}`, `## ${release.newVersion} - ${date}`)
+}
+
+const defaultChangelogFunctions = {
+    getReleaseLine,
+    getDependencyReleaseLine,
+    getChangelogEntry,
+}
+
+module.exports = defaultChangelogFunctions

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-    "changelog": ["@changesets/changelog-github", { "repo": "PostHog/posthog-js" }],
+    "changelog": ["./.changeset/changelog-with-date.js", { "repo": "PostHog/posthog-js" }],
     "commit": false,
     "fixed": [],
     "linked": [],

--- a/.github/workflows/check-posthog-major-version.yml
+++ b/.github/workflows/check-posthog-major-version.yml
@@ -23,10 +23,19 @@ jobs:
         run: |
           # Get only added changeset files in this PR
           changesets=$(git diff --name-only --diff-filter=A origin/${{ github.base_ref }}...HEAD | grep '^\.changeset/.*\.md$' | grep -v 'README.md' || true)
-          
+
           if [ -z "$changesets" ]; then
             echo "No new changesets found in this PR"
             echo "no_changesets=true" >> $GITHUB_OUTPUT
+
+            # Check if PR has release label
+            has_release_label=$(echo '${{ toJSON(github.event.pull_request.labels) }}' | jq -r '.[] | select(.name == "release") | .name')
+
+            if [ -n "$has_release_label" ]; then
+              echo "❌ Error: PR has 'release' label but no changeset found"
+              exit 1
+            fi
+
             exit 0
           fi
           
@@ -164,22 +173,37 @@ jobs:
             }
       
       - name: Comment about missing changeset
-        if: success() && steps.check-major.outputs.no_changesets == 'true'
+        if: always() && steps.check-major.outputs.no_changesets == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const comment = `## 📝 No Changeset Found
-            
-            This PR doesn't include a changeset. A changeset (and the release label) is required to release a new version.
-            
+            const hasReleaseLabel = context.payload.pull_request.labels.some(label => label.name === 'release');
+
+            const comment = hasReleaseLabel
+              ? `## ❌ No Changeset Found (Build Failed)
+
+            This PR has the \`release\` label but doesn't include a changeset. A changeset is **required** when the release label is present.
+
             ### How to add a changeset
-            
+
             Run this command and follow the prompts:
             \`\`\`bash
             pnpm changeset
             \`\`\`
-            
+
+            **Remember:** Never use \`major\` version bumps for \`posthog-js\` as it's autoloaded by clients.`
+              : `## 📝 No Changeset Found
+
+            This PR doesn't include a changeset. A changeset (and the release label) is required to release a new version.
+
+            ### How to add a changeset
+
+            Run this command and follow the prompts:
+            \`\`\`bash
+            pnpm changeset
+            \`\`\`
+
             **Remember:** Never use \`major\` version bumps for \`posthog-js\` as it's autoloaded by clients.`;
             
             // Check if we already commented about missing changeset


### PR DESCRIPTION
i missed a changeset while trying to release three prs together so ended up with a changelog i had to edit

let's fail the job that checks changesets if there's a release label but no changeset and then we can make that job required and avoid this in future

Claude also wrote the code to add date to the changelog

We release posthog-js so frequently the date is useful so we can see how far back someone is