### PR TITLE
fix: don't rely on order of method calls to gate calling url trigger activate too many times

### DIFF
--- a/.changeset/whole-rockets-wash.md
+++ b/.changeset/whole-rockets-wash.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: don't rely on order of method calls to gate calling url

--- a/packages/browser/src/__tests__/extensions/replay/checkUrlTriggerConditions.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/checkUrlTriggerConditions.test.ts
@@ -1,0 +1,327 @@
+import * as fc from 'fast-check'
+import {
+    URLTriggerMatching,
+    TRIGGER_ACTIVATED,
+    TRIGGER_PENDING,
+} from '../../../extensions/replay/external/triggerMatching'
+import { createMockPostHog } from '../../helpers/posthog-instance'
+import { SessionRecordingUrlTrigger } from '../../../types'
+import { SESSION_RECORDING_URL_TRIGGER_ACTIVATED_SESSION } from '../../../constants'
+
+describe('checkUrlTriggerConditions - activation loop detection', () => {
+    let urlTriggerMatching: URLTriggerMatching
+    let mockPostHog: any
+    let onPauseCalls: number
+    let onResumeCalls: number
+    let onActivateCalls: number
+    let persistedSession: string | null
+
+    const setWindowLocation = (url: string) => {
+        Object.defineProperty(window, 'location', {
+            value: { href: url },
+            writable: true,
+            configurable: true,
+        })
+    }
+
+    const configureTriggers = (
+        triggers: SessionRecordingUrlTrigger[],
+        blocklist: SessionRecordingUrlTrigger[] = []
+    ) => {
+        urlTriggerMatching.onConfig({
+            urlTriggers: triggers,
+            urlBlocklist: blocklist,
+        } as any)
+    }
+
+    const createActivateCallback = (sessionId: string) => () => {
+        onActivateCalls++
+        if (onActivateCalls === 1) {
+            persistedSession = sessionId
+        }
+    }
+
+    const checkTriggers = (sessionId: string, onActivate = createActivateCallback(sessionId)) => {
+        urlTriggerMatching.checkUrlTriggerConditions(
+            () => onPauseCalls++,
+            () => onResumeCalls++,
+            onActivate,
+            sessionId
+        )
+    }
+
+    const assertPendingToActivated = (sessionId: string) => {
+        expect(urlTriggerMatching.triggerStatus(sessionId)).toBe(TRIGGER_PENDING)
+        checkTriggers(sessionId)
+        expect(urlTriggerMatching.triggerStatus(sessionId)).toBe(TRIGGER_ACTIVATED)
+    }
+
+    const assertStaysActivated = (sessionId: string) => {
+        const beforeStatus = urlTriggerMatching.triggerStatus(sessionId)
+        checkTriggers(sessionId)
+        const afterStatus = urlTriggerMatching.triggerStatus(sessionId)
+        expect(beforeStatus).toBe(TRIGGER_ACTIVATED)
+        expect(afterStatus).toBe(TRIGGER_ACTIVATED)
+    }
+
+    beforeEach(() => {
+        onPauseCalls = 0
+        onResumeCalls = 0
+        onActivateCalls = 0
+        persistedSession = null
+
+        mockPostHog = createMockPostHog({
+            register_for_session: jest.fn(),
+            get_property: jest.fn((key: string) => {
+                if (key === SESSION_RECORDING_URL_TRIGGER_ACTIVATED_SESSION) {
+                    return persistedSession
+                }
+                return undefined
+            }),
+        })
+
+        urlTriggerMatching = new URLTriggerMatching(mockPostHog)
+    })
+
+    describe('property-based tests for activation loop', () => {
+        it('onActivate called once regardless of number of checks', () => {
+            fc.assert(
+                fc.property(
+                    fc.record({
+                        urlPath: fc.stringOf(
+                            fc.char().filter((c) => /[a-z]/.test(c)),
+                            {
+                                minLength: 1,
+                                maxLength: 10,
+                            }
+                        ),
+                        numberOfCalls: fc.integer({ min: 2, max: 100 }),
+                    }),
+                    ({ urlPath, numberOfCalls }) => {
+                        onPauseCalls = 0
+                        onResumeCalls = 0
+                        onActivateCalls = 0
+                        persistedSession = null
+
+                        const url = `https://example.com/${urlPath}`
+                        configureTriggers([{ url, matching: 'regex' }])
+                        setWindowLocation(url)
+
+                        const sessionId = 'test-session'
+
+                        for (let i = 0; i < numberOfCalls; i++) {
+                            const beforeStatus = urlTriggerMatching.triggerStatus(sessionId)
+                            checkTriggers(sessionId)
+                            const afterStatus = urlTriggerMatching.triggerStatus(sessionId)
+
+                            const isFirstCall = i === 0
+                            const expectedBeforeStatus = isFirstCall ? TRIGGER_PENDING : TRIGGER_ACTIVATED
+                            const expectedAfterStatus = TRIGGER_ACTIVATED
+
+                            if (beforeStatus !== expectedBeforeStatus) return false
+                            if (afterStatus !== expectedAfterStatus) return false
+                        }
+
+                        return onActivateCalls === 1
+                    }
+                ),
+                { numRuns: 100, verbose: true }
+            )
+        })
+
+        it('onActivate called at most once with URL triggers and blocklists', () => {
+            fc.assert(
+                fc.property(
+                    fc.record({
+                        triggerUrls: fc.array(
+                            fc.record({
+                                url: fc
+                                    .stringOf(
+                                        fc.char().filter((c) => /[a-z]/.test(c)),
+                                        {
+                                            minLength: 3,
+                                            maxLength: 8,
+                                        }
+                                    )
+                                    .map((s) => `https://${s}.com/.*`),
+                                matching: fc.constant('regex' as const),
+                            }),
+                            { minLength: 1, maxLength: 5 }
+                        ),
+                        blocklistUrls: fc.array(
+                            fc.record({
+                                url: fc
+                                    .stringOf(
+                                        fc.char().filter((c) => /[a-z]/.test(c)),
+                                        {
+                                            minLength: 3,
+                                            maxLength: 8,
+                                        }
+                                    )
+                                    .map((s) => `https://blocked${s}.com/.*`),
+                                matching: fc.constant('regex' as const),
+                            }),
+                            { maxLength: 3 }
+                        ),
+                        currentUrl: fc
+                            .tuple(
+                                fc.stringOf(
+                                    fc.char().filter((c) => /[a-z]/.test(c)),
+                                    {
+                                        minLength: 3,
+                                        maxLength: 8,
+                                    }
+                                ),
+                                fc.stringOf(
+                                    fc.char().filter((c) => /[a-z]/.test(c)),
+                                    { maxLength: 8 }
+                                )
+                            )
+                            .map(([domain, path]) => `https://${domain}.com/${path}`),
+                        callCount: fc.integer({ min: 2, max: 50 }),
+                    }),
+                    ({ triggerUrls, blocklistUrls, currentUrl, callCount }) => {
+                        onPauseCalls = 0
+                        onResumeCalls = 0
+                        onActivateCalls = 0
+                        persistedSession = null
+                        urlTriggerMatching.urlBlocked = false
+
+                        configureTriggers(triggerUrls, blocklistUrls)
+                        setWindowLocation(currentUrl)
+
+                        const sessionId = 'session-' + currentUrl
+
+                        const urlMatchesTrigger = triggerUrls.some((t) => new RegExp(t.url).test(currentUrl))
+                        const urlMatchesBlocklist = blocklistUrls.some((b) => new RegExp(b.url).test(currentUrl))
+
+                        for (let i = 0; i < callCount; i++) {
+                            urlTriggerMatching.checkUrlTriggerConditions(
+                                () => {
+                                    onPauseCalls++
+                                    urlTriggerMatching.urlBlocked = true
+                                },
+                                () => {
+                                    onResumeCalls++
+                                    urlTriggerMatching.urlBlocked = false
+                                },
+                                createActivateCallback(sessionId),
+                                sessionId
+                            )
+                        }
+
+                        if (urlMatchesTrigger && !urlMatchesBlocklist) {
+                            return onActivateCalls === 1
+                        } else if (urlMatchesBlocklist) {
+                            return onPauseCalls >= 1
+                        }
+                        return true
+                    }
+                ),
+                { numRuns: 100 }
+            )
+        })
+
+        it('URL transitions between blocked and unblocked states', () => {
+            fc.assert(
+                fc.property(
+                    fc.record({
+                        blockedUrl: fc.constant('https://blocked.com/page'),
+                        unblockedUrl: fc.constant('https://example.com/page'),
+                        transitions: fc.array(fc.boolean(), { minLength: 1, maxLength: 20 }),
+                    }),
+                    ({ blockedUrl, unblockedUrl, transitions }) => {
+                        onPauseCalls = 0
+                        onResumeCalls = 0
+                        onActivateCalls = 0
+                        urlTriggerMatching.urlBlocked = false
+
+                        configureTriggers([{ url: '.*', matching: 'regex' }], [{ url: blockedUrl, matching: 'regex' }])
+
+                        const sessionId = 'test-session-transitions'
+
+                        for (const shouldBlock of transitions) {
+                            const url = shouldBlock ? blockedUrl : unblockedUrl
+                            setWindowLocation(url)
+
+                            urlTriggerMatching.checkUrlTriggerConditions(
+                                () => {
+                                    onPauseCalls++
+                                    urlTriggerMatching.urlBlocked = true
+                                },
+                                () => {
+                                    onResumeCalls++
+                                    urlTriggerMatching.urlBlocked = false
+                                },
+                                () => {
+                                    onActivateCalls++
+                                },
+                                sessionId
+                            )
+                        }
+
+                        return onPauseCalls > 0 || onResumeCalls > 0 || onActivateCalls > 0
+                    }
+                ),
+                { numRuns: 100 }
+            )
+        })
+    })
+
+    describe('state transitions', () => {
+        it.each([
+            [3, 'few'],
+            [10, 'multiple'],
+            [1000, 'many'],
+        ])('transitions PENDING to ACTIVATED after first of %i checks', (callCount) => {
+            const url = 'https://example.com/test'
+            configureTriggers([{ url, matching: 'regex' }])
+            setWindowLocation(url)
+
+            const sessionId = 'test-session'
+
+            assertPendingToActivated(sessionId)
+
+            for (let i = 1; i < callCount; i++) {
+                assertStaysActivated(sessionId)
+            }
+
+            expect(urlTriggerMatching.triggerStatus(sessionId)).toBe(TRIGGER_ACTIVATED)
+            expect(onActivateCalls).toBe(1)
+        })
+
+        it('does not call onPause or onResume when URL remains blocked', () => {
+            const blockedUrl = 'https://blocked.com/page'
+
+            configureTriggers([], [{ url: blockedUrl, matching: 'regex' }])
+            setWindowLocation(blockedUrl)
+
+            urlTriggerMatching.urlBlocked = false
+
+            const sessionId = 'test-session-blocked'
+
+            urlTriggerMatching.checkUrlTriggerConditions(
+                () => {
+                    onPauseCalls++
+                    urlTriggerMatching.urlBlocked = true
+                },
+                () => onResumeCalls++,
+                () => onActivateCalls++,
+                sessionId
+            )
+
+            expect(onPauseCalls).toBe(1)
+            expect(onResumeCalls).toBe(0)
+
+            urlTriggerMatching.checkUrlTriggerConditions(
+                () => onPauseCalls++,
+                () => onResumeCalls++,
+                () => onActivateCalls++,
+                sessionId
+            )
+
+            expect(onPauseCalls).toBe(1)
+            expect(onResumeCalls).toBe(0)
+        })
+    })
+})

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -904,7 +904,8 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         this._urlTriggerMatching.checkUrlTriggerConditions(
             () => this._pauseRecording(),
             () => this._resumeRecording(),
-            (triggerType) => this._activateTrigger(triggerType)
+            (triggerType) => this._activateTrigger(triggerType),
+            this.sessionId
         )
         // always have to check if the URL is blocked really early,
         // or you risk getting stuck in a loop

--- a/packages/browser/src/extensions/replay/external/triggerMatching.ts
+++ b/packages/browser/src/extensions/replay/external/triggerMatching.ts
@@ -181,7 +181,8 @@ export class URLTriggerMatching implements TriggerStatusMatching {
     checkUrlTriggerConditions(
         onPause: () => void,
         onResume: () => void,
-        onActivate: (triggerType: TriggerType) => void
+        onActivate: (triggerType: TriggerType) => void,
+        sessionId: string
     ) {
         if (typeof window === 'undefined' || !window.location.href) {
             return
@@ -193,15 +194,19 @@ export class URLTriggerMatching implements TriggerStatusMatching {
         const isNowBlocked = sessionRecordingUrlTriggerMatches(url, this._urlBlocklist)
 
         if (wasBlocked && isNowBlocked) {
-            // if the url is blocked and was already blocked, do nothing
             return
-        } else if (isNowBlocked && !wasBlocked) {
+        }
+
+        if (isNowBlocked && !wasBlocked) {
             onPause()
         } else if (!isNowBlocked && wasBlocked) {
             onResume()
         }
 
-        if (sessionRecordingUrlTriggerMatches(url, this._urlTriggers)) {
+        const isActivated = this._urlTriggerStatus(sessionId) === TRIGGER_ACTIVATED
+        const urlMatches = sessionRecordingUrlTriggerMatches(url, this._urlTriggers)
+
+        if (!isActivated && urlMatches) {
             onActivate('url')
         }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,13 +442,13 @@ importers:
         version: 7.7.0
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+        version: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
       next:
         specifier: ^15.4.1
         version: 15.4.6(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       ts-jest:
         specifier: 'catalog:'
-        version: 29.4.0(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)))(typescript@5.8.2)
+        version: 29.4.0(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2)))(typescript@5.8.2)
 
   packages/node:
     dependencies:
@@ -467,7 +467,7 @@ importers:
         version: 20.19.9
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2))
+        version: 29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
 
   packages/nuxt:
     dependencies:
@@ -2026,7 +2026,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.1.7':
     resolution: {integrity: sha512-F81fPthpT7QtVu1P7QeZMezGn0tCcalCh3ANIzWBaQZNG4vly7mo2dp3PMGzNdmXq6yt93bJ4HbfS+0/NpKl7g==}
@@ -15294,80 +15294,6 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0(node-notifier@8.0.2)
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.17.0
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.9
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    optionalDependencies:
-      node-notifier: 8.0.2
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0(node-notifier@8.0.2)
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.17.0
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.9
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    optionalDependencies:
-      node-notifier: 8.0.2
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))':
     dependencies:
       '@jest/console': 29.7.0
@@ -19696,13 +19622,13 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.7.0
 
-  create-jest@29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2)):
+  create-jest@29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.9
-      jest-config: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -19711,13 +19637,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+  create-jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.9
-      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -22738,16 +22664,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2)):
+  jest-cli@29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2))
+      create-jest: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
       exit: 0.1.2
       import-local: 3.0.2
-      jest-config: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -22759,16 +22685,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+  jest-cli@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      create-jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
       exit: 0.1.2
       import-local: 3.0.2
-      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -22822,7 +22748,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2)):
+  jest-config@29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.27.1
       '@jest/test-sequencer': 29.7.0
@@ -22848,12 +22774,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.9
-      ts-node: 10.9.2(@types/node@20.19.9)(typescript@5.8.2)
+      ts-node: 10.9.2(@types/node@22.17.0)(typescript@5.8.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+  jest-config@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.27.1
       '@jest/test-sequencer': 29.7.0
@@ -22879,69 +22805,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.16.5
-      ts-node: 10.9.2(@types/node@22.16.5)(typescript@5.8.2)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2)):
-    dependencies:
-      '@babel/core': 7.27.1
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.27.1)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.9
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.17.0
-      ts-node: 10.9.2(@types/node@20.19.9)(typescript@5.8.2)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@22.17.0)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
-    dependencies:
-      '@babel/core': 7.27.1
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.27.1)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.2.2
-      glob: 7.2.3
-      graceful-fs: 4.2.9
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.17.0
-      ts-node: 10.9.2(@types/node@22.16.5)(typescript@5.8.2)
+      ts-node: 10.9.2(@types/node@22.17.0)(typescript@5.8.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -23454,12 +23318,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2)):
+  jest@29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
       '@jest/types': 29.6.3
       import-local: 3.0.2
-      jest-cli: 29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2))
+      jest-cli: 29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -23468,12 +23332,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+  jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
       '@jest/types': 29.6.3
       import-local: 3.0.2
-      jest-cli: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      jest-cli: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -28210,12 +28074,12 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.27.1)
       jest-util: 29.7.0
 
-  ts-jest@29.4.0(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)))(typescript@5.8.2):
+  ts-jest@29.4.0(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2)))(typescript@5.8.2):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      jest: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -28229,44 +28093,6 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.28.4)
       jest-util: 29.7.0
-
-  ts-node@10.9.2(@types/node@20.19.9)(typescript@5.8.2):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.9
-      acorn: 8.11.3
-      acorn-walk: 8.3.3
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.8.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
-  ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.16.5
-      acorn: 8.11.3
-      acorn-walk: 8.3.3
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.8.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-node@10.9.2(@types/node@22.17.0)(typescript@5.8.2):
     dependencies:


### PR DESCRIPTION
a customer reports that they are getting stuck in an infinite loop during url trigger activation

the order of method calls when we activate a trigger should protect us from calling it more than once (but obviously not _always_)

let's move the check in for existing activation inside the method
instead of relying on the correct order of method calls

