### PR TITLE
fix: session replay on react native web

### DIFF
--- a/.changeset/legal-numbers-sin.md
+++ b/.changeset/legal-numbers-sin.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: session replay on react native web

--- a/examples/example-expo-53/app/posthog.tsx
+++ b/examples/example-expo-53/app/posthog.tsx
@@ -1,5 +1,17 @@
 import PostHog from 'posthog-react-native'
 
+// If you want to use Session relay on React Native web, use the posthog-js SDK instead.
+// Example:
+//
+// import posthog from 'posthog-js'
+//
+// posthog.init(process.env.EXPO_PUBLIC_POSTHOG_PROJECT_KEY!, {
+//     host: process.env.EXPO_PUBLIC_POSTHOG_API_HOST,
+//     debug: true,
+// })
+//
+// export { posthog }
+
 export const posthog = new PostHog(process.env.EXPO_PUBLIC_POSTHOG_PROJECT_KEY!, {
     host: process.env.EXPO_PUBLIC_POSTHOG_API_HOST,
     flushAt: 1,
@@ -12,7 +24,7 @@ export const posthog = new PostHog(process.env.EXPO_PUBLIC_POSTHOG_PROJECT_KEY!,
             console: ['error', 'warn'],
         },
     },
-
+    // persistence: 'memory',
     // if using WebView, you have to disable masking for text inputs and images
     // sessionReplayConfig: {
     //   maskAllTextInputs: false,

--- a/packages/browser/src/utils/globals.ts
+++ b/packages/browser/src/utils/globals.ts
@@ -222,6 +222,14 @@ interface PostHogExtensions {
 
 const global: typeof globalThis | undefined = typeof globalThis !== 'undefined' ? globalThis : win
 
+// React Native polyfills for posthog-js compatibility
+if (typeof self === 'undefined') {
+    ;(global as any).self = global
+}
+if (typeof File === 'undefined') {
+    ;(global as any).File = function () {}
+}
+
 export const ArrayProto = Array.prototype
 export const nativeForEach = ArrayProto.forEach
 export const nativeIndexOf = ArrayProto.indexOf


### PR DESCRIPTION
## Problem

workaround for https://github.com/PostHog/posthog-js/issues/2157

otherwise users would have to polyfill manually.

ideally users init the SDK conditionally, if mobile: uses the RN SDK, if web: uses the JS SDK

example: https://us.posthog.com/shared/6K26C6g8ljMoa0ZDOR9nJkXHchLHJg?t=4

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [X] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [X] Ran `pnpm changeset` to generate a changeset file
- [X] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
