### PR TITLE
fix(surveys): properly clean up popover surveys on close

### DIFF
--- a/.changeset/lazy-chairs-show.md
+++ b/.changeset/lazy-chairs-show.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+fix(surveys): clean up popover surveys from dom on close

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -899,6 +899,7 @@ export function usePopupVisibility(
     millisecondDelay: number,
     isPreviewMode: boolean,
     removeSurveyFromFocus: (survey: SurveyWithTypeAndAppearance) => void,
+    isPopup: boolean,
     surveyContainerRef?: React.RefObject<HTMLDivElement>
 ) {
     const [isPopupVisible, setIsPopupVisible] = useState(
@@ -908,7 +909,7 @@ export function usePopupVisibility(
 
     const hidePopupWithViewTransition = () => {
         const removeDOMAndHidePopup = () => {
-            if (survey.type === SurveyType.Popover) {
+            if (isPopup) {
                 removeSurveyFromFocus(survey)
             }
             setIsPopupVisible(false)
@@ -1102,6 +1103,7 @@ export function SurveyPopup({
         surveyPopupDelayMilliseconds,
         isPreviewMode,
         removeSurveyFromFocus,
+        isPopup,
         surveyContainerRef
     )
 


### PR DESCRIPTION
## Problem

when opening surveys via API `displaySurvey`​, they are not properly cleaned up on close, and then cannot be re-opened

closes https://github.com/PostHog/posthog-js/issues/2586

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

instead of checking only survey type, check display type -- so all surveys displayed as popovers (regardless of survey type) are cleaned up as needed

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->