### PR TITLE
fix: add support for passing global CLI flags to source map uploads

### DIFF
--- a/.changeset/little-bikes-deny.md
+++ b/.changeset/little-bikes-deny.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+add support for passing global CLI flags to source map uploads

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -84,9 +84,11 @@ else
 fi
 set -x -e # re-enable
 
+PH_CLI_OPTS="${POSTHOG_CLI_OPTIONS:-}"
+
 # Execute posthog cli clone
 set +x +e
-CLI_CLONE_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH exp hermes clone --minified-map-path $SOURCEMAP_PACKAGER_FILE --composed-map-path $SOURCEMAP_FILE" 2>&1)
+CLI_CLONE_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH $PH_CLI_OPTS exp hermes clone --minified-map-path $SOURCEMAP_PACKAGER_FILE --composed-map-path $SOURCEMAP_FILE" 2>&1)
 CLONE_EXIT_CODE=$?
 if [ $CLONE_EXIT_CODE -eq 0 ]; then
   echo "$CLI_CLONE_OUTPUT" | awk '{print "output: posthog-cli - " $0}'
@@ -98,7 +100,7 @@ set -x -e
 
 # Execute posthog cli upload
 set +x +e
-CLI_UPLOAD_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH exp hermes upload --directory $DERIVED_FILE_DIR" 2>&1)
+CLI_UPLOAD_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH $PH_CLI_OPTS exp hermes upload --directory $DERIVED_FILE_DIR" 2>&1)
 UPLOAD_EXIT_CODE=$?
 if [ $UPLOAD_EXIT_CODE -eq 0 ]; then
   echo "$CLI_UPLOAD_OUTPUT" | awk '{print "output: posthog-cli - " $0}'

--- a/packages/react-native/tooling/posthog.gradle
+++ b/packages/react-native/tooling/posthog.gradle
@@ -75,6 +75,9 @@ plugins.withId('com.android.application') {
                         description = "upload sourcemaps to PostHog"
                         group = 'posthog.com'
 
+                        def cliOptsEnv = System.getenv("POSTHOG_CLI_OPTIONS")
+                        def globalCliArgs = cliOptsEnv ? cliOptsEnv.split(" ").findAll { it?.trim() } : []
+
                         def extraArgs = []
 
                         def injected = project.objects.newInstance(InjectedExecOps)
@@ -84,6 +87,7 @@ plugins.withId('com.android.application') {
 
                                 def cliPackage = "posthog-cli"
                                 def args = [cliPackage]
+                                args.addAll(globalCliArgs)
 
                                 args.addAll(["exp", "hermes", "clone",
                                     "--minified-map-path", packagerSourcemapOutput, // The path to a sourcemap
@@ -105,6 +109,7 @@ plugins.withId('com.android.application') {
 
                                 def cliPackage = "posthog-cli"
                                 def args = [cliPackage]
+                                args.addAll(globalCliArgs)
 
                                 def sourcemapDir = sourcemapOutput.getParent()
                                 args.addAll(["exp", "hermes", "upload",


### PR DESCRIPTION
## Problem

Current source map handling does not support the EU host.

## Changes

Adds a new `POSTHOG_CLI_OPTIONS` env var to pass these through, e.g. `export POSTHOG_CLI_OPTIONS="--host https://eu.posthog.com"`

Closes #2596

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
