### PR TITLE
ci: Fix turbo command not found

### DIFF
--- a/.github/workflows/label-version-bump.yml
+++ b/.github/workflows/label-version-bump.yml
@@ -25,7 +25,7 @@ jobs:
           build: false
 
       - name: Build @posthog-tooling/changelog
-        run: turbo --filter=@posthog-tooling/changelog build
+        run: pnpm turbo --filter=@posthog-tooling/changelog build
 
       - name: Update versions and changelogs
         id: versions


### PR DESCRIPTION
Releases are failing, see https://github.com/PostHog/posthog-js/actions/runs/19512554077/job/55855787513#step:4:9