### PR TITLE
chore: upgrade the hedgebox demo account when upgrading in posthog repo

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -56,6 +56,25 @@ jobs:
           RETRY_TIMES: 20
           RETRY_WAIT_SECONDS: 5
 
+      - name: Install new package version in hedgebox-dummy
+        shell: bash
+        run: |
+          if [ -d "hedgebox-dummy" ]; then
+              cd hedgebox-dummy
+              for i in $(seq 1 $RETRY_TIMES); do
+                  if pnpm upgrade ${{ github.event.inputs.package_name }}@${{ github.event.inputs.package_version }}; then
+                      break
+                  else
+                      [ $i -ne $RETRY_TIMES ] && sleep $RETRY_WAIT_SECONDS || false
+                  fi
+              done
+          else
+              echo "hedgebox-dummy folder not found, skipping"
+          fi
+        env:
+          RETRY_TIMES: 20
+          RETRY_WAIT_SECONDS: 5
+
       - name: Generate branch name
         id: generate-branch-name
         shell: bash


### PR DESCRIPTION
we aren't upgrading the hedgebox-dummy project when we upgrade posthog-js in the main repo
so it gets out of date

let's update it