### PR TITLE
fix: cut a new version for fixing compromised packages

### DIFF
--- a/.changeset/light-guests-arrive.md
+++ b/.changeset/light-guests-arrive.md
@@ -1,0 +1,17 @@
+---
+'@posthog/ai': patch
+'posthog-js': patch
+'@posthog/core': patch
+'@posthog/nextjs-config': patch
+'posthog-node': patch
+'@posthog/nuxt': patch
+'@posthog/react': patch
+'posthog-react-native': patch
+'@posthog/rollup-plugin': patch
+'posthog-js-lite': patch
+'@posthog/webpack-plugin': patch
+'@posthog-tooling/rollup-utils': patch
+'@posthog-tooling/tsconfig-base': patch
+---
+
+last version was compromised


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [X] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [X] Ran `pnpm changeset` to generate a changeset file
- [X] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
