### PR TITLE
fix: undefined client errors hasLoadedFlags

### DIFF
--- a/packages/react/src/hooks/useFeatureFlagEnabled.ts
+++ b/packages/react/src/hooks/useFeatureFlagEnabled.ts
@@ -16,7 +16,7 @@ export function useFeatureFlagEnabled(flag: string): boolean | undefined {
     const bootstrapped = bootstrap?.featureFlags?.[flag]
 
     // if the client is not loaded yet, check if we have a bootstrapped value and then true/false it
-    if (!client.featureFlags.hasLoadedFlags && bootstrap?.featureFlags) {
+    if (!client?.featureFlags?.hasLoadedFlags && bootstrap?.featureFlags) {
         return isUndefined(bootstrapped) ? undefined : !!bootstrapped
     }
 


### PR DESCRIPTION


## Problem

The check `!client.featureFlags.hasLoadedFlags` was causing "cannot read properties of undefined (reading `hasLoadedFlags`) so changed it to `!client?.featureFlags?.hasLoadedFlags`

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
