### PR TITLE
docs: improve cookie + localStorage differentiation

### DIFF
--- a/packages/browser/src/storage.ts
+++ b/packages/browser/src/storage.ts
@@ -264,7 +264,7 @@ export const localStore: PersistentStore = {
  * By default, PostHog uses cookie + localStorage to store data:
  *
  * - Cookie: Cross-subdomain, limited to ~4kB
- *   - Stores ONLY critical properties: distinct_id, session_id, window_id, and a small subset of properties
+ *   - Stores ONLY critical properties: distinct_id, session_id, and a small subset of properties
  *   - Limited to the properties listed in COOKIE_PERSISTED_PROPERTIES below
  *
  * - localStorage: Subdomain-specific, larger capacity


### PR DESCRIPTION
## Problem

Just expanding the comment as how the `cookie + localStorage` data is saved. This comes from this thread that will involve other PRs: https://posthog.slack.com/archives/C03P7NL6RMW/p1761311281478969 

## Changes

Just the comment change.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size
