### PR TITLE
fix: use ph persistence instead of localStorage on surveys

### DIFF
--- a/.changeset/giant-lamps-cover.md
+++ b/.changeset/giant-lamps-cover.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+use ph persistence instead of localStorage on surveys

--- a/packages/browser/playwright/mocked/surveys/core-display-logic.spec.ts
+++ b/packages/browser/playwright/mocked/surveys/core-display-logic.spec.ts
@@ -75,7 +75,8 @@ test.describe('surveys - core display logic', () => {
 
         expect(
             await page.evaluate(() => {
-                return window.localStorage.getItem('seenSurvey_123')
+                // @ts-expect-error - posthog is added to window in test setup
+                return window.posthog.persistence.get_property('seenSurvey_123')
             })
         ).toBeTruthy()
 
@@ -114,7 +115,8 @@ test.describe('surveys - core display logic', () => {
 
         expect(
             await page.evaluate(() => {
-                return window.localStorage.getItem('seenSurvey_123')
+                // @ts-expect-error - posthog is added to window in test setup
+                return window.posthog.persistence.get_property('seenSurvey_123')
             })
         ).toBeTruthy()
 
@@ -129,7 +131,8 @@ test.describe('surveys - core display logic', () => {
 
         expect(
             await page.evaluate(() => {
-                return window.localStorage.getItem('seenSurvey_123')
+                // @ts-expect-error - posthog is added to window in test setup
+                return window.posthog.persistence.get_property('seenSurvey_123')
             })
         ).toBeTruthy()
     })
@@ -162,7 +165,8 @@ test.describe('surveys - core display logic', () => {
         await expect(page.locator('.PostHogSurvey-123').locator('.survey-form')).toBeVisible()
 
         const lastSeenDate = await page.evaluate(() => {
-            return window.localStorage.getItem('lastSeenSurveyDate')
+            // @ts-expect-error - posthog is added to window in test setup
+            return window.posthog.persistence.get_property('lastSeenSurveyDate')
         })
 
         expect(lastSeenDate!.split('T')[0]).toEqual(new Date().toISOString().split('T')[0])

--- a/packages/browser/src/__tests__/extensions/surveys-persistence.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys-persistence.test.ts
@@ -1,0 +1,179 @@
+import { PostHogPersistence } from '../../posthog-persistence'
+import { PostHogConfig } from '../../types'
+import { setSurveySeenOnLocalStorage } from '../../utils/survey-utils'
+import {
+    getSurveySeen,
+    setInProgressSurveyState,
+    getInProgressSurveyState,
+    clearInProgressSurveyState,
+} from '../../extensions/surveys/surveys-extension-utils'
+import { Survey, SurveyType, SurveySchedule } from '../../posthog-surveys-types'
+
+describe('Surveys Persistence Migration', () => {
+    let instance: any
+
+    const config = {
+        token: 'test-token',
+        persistence: 'localStorage+cookie',
+        api_host: 'https://app.posthog.com',
+    } as PostHogConfig
+
+    const baseSurvey: Survey = {
+        id: 'test-survey',
+        name: 'Test Survey',
+        description: 'Test Description',
+        type: SurveyType.Popover,
+        questions: [],
+        appearance: null,
+        conditions: null,
+        start_date: null,
+        end_date: null,
+        current_iteration: null,
+        current_iteration_start_date: null,
+        feature_flag_keys: null,
+        linked_flag_key: null,
+        targeting_flag_key: null,
+        internal_targeting_flag_key: null,
+    }
+
+    beforeEach(() => {
+        localStorage.clear()
+        instance = {
+            config: { ...config },
+            persistence: new PostHogPersistence(config),
+        }
+    })
+
+    describe('Core persistence functionality', () => {
+        it('should write and read via persistence API', () => {
+            setSurveySeenOnLocalStorage(baseSurvey, instance)
+
+            expect(instance.persistence.get_property('seenSurvey_test-survey')).toBe(true)
+            expect(getSurveySeen(baseSurvey, instance)).toBe(true)
+        })
+
+        it('should handle complex JSON state', () => {
+            const state = {
+                surveySubmissionId: 'test-123',
+                lastQuestionIndex: 2,
+                responses: { $survey_response_q1: 'answer1' },
+            }
+
+            setInProgressSurveyState(baseSurvey, state, instance)
+            const retrieved = getInProgressSurveyState(baseSurvey, instance)
+
+            expect(retrieved).toEqual(state)
+        })
+
+        it('should clear state completely', () => {
+            const state = { surveySubmissionId: 'test-123', lastQuestionIndex: 1, responses: {} }
+            setInProgressSurveyState(baseSurvey, state, instance)
+
+            clearInProgressSurveyState(baseSurvey, instance)
+
+            expect(getInProgressSurveyState(baseSurvey, instance)).toBeNull()
+        })
+    })
+
+    describe('Backwards compatibility', () => {
+        it('should fallback to localStorage when no posthog instance', () => {
+            setSurveySeenOnLocalStorage(baseSurvey)
+
+            expect(localStorage.getItem('seenSurvey_test-survey')).toBe('true')
+            expect(getSurveySeen(baseSurvey)).toBe(true)
+        })
+
+        it('should fallback to localStorage when persistence disabled', () => {
+            const disabledInstance: any = {
+                config: { ...config, disable_persistence: true },
+                persistence: new PostHogPersistence({ ...config, disable_persistence: true }),
+            }
+
+            setSurveySeenOnLocalStorage(baseSurvey, disabledInstance)
+
+            expect(localStorage.getItem('seenSurvey_test-survey')).toBe('true')
+            expect(disabledInstance.persistence.isDisabled()).toBe(true)
+        })
+
+        it('should not require persistence.isDisabled to exist', () => {
+            const legacyInstance: any = {
+                config: { ...config },
+                persistence: new PostHogPersistence(config),
+            }
+            delete legacyInstance.persistence.isDisabled
+
+            expect(() => setSurveySeenOnLocalStorage(baseSurvey, legacyInstance)).not.toThrow()
+            expect(legacyInstance.persistence.get_property('seenSurvey_test-survey')).toBe(true)
+        })
+    })
+
+    describe('Migration from localStorage to persistence', () => {
+        it('should read old localStorage data when not yet in persistence', () => {
+            // CRITICAL: User has old data, new code deployed
+            localStorage.setItem('seenSurvey_test-survey', 'true')
+
+            const result = getSurveySeen(baseSurvey, instance)
+
+            expect(result).toBe(true) // Reads from localStorage
+            expect(instance.persistence.get_property('seenSurvey_test-survey')).toBeUndefined() // Not migrated yet
+        })
+
+        it('should prefer persistence over localStorage when both exist', () => {
+            // Edge case: Both sources have data
+            localStorage.setItem('seenSurvey_test-survey', 'false') // Stale
+            instance.persistence.set_property('seenSurvey_test-survey', true) // Current
+
+            const result = getSurveySeen(baseSurvey, instance)
+
+            expect(result).toBe(true) // Uses persistence
+        })
+
+        it('should read complex JSON state from localStorage without migrating yet', () => {
+            // Lazy migration: reads work, but data doesn't migrate until written
+            const state = {
+                surveySubmissionId: 'test-123',
+                lastQuestionIndex: 2,
+                responses: { $survey_response_q1: 'answer1' },
+            }
+            localStorage.setItem('inProgressSurvey_test-survey', JSON.stringify(state))
+
+            const retrieved = getInProgressSurveyState(baseSurvey, instance)
+
+            expect(retrieved).toEqual(state) // Read succeeds
+            expect(instance.persistence.get_property('inProgressSurvey_test-survey')).toBeUndefined() // Not migrated yet
+        })
+    })
+
+    describe('Regression protection', () => {
+        it('should handle survey iterations with correct keys', () => {
+            const surveyWithIteration = { ...baseSurvey, current_iteration: 2 }
+
+            setSurveySeenOnLocalStorage(surveyWithIteration, instance)
+
+            expect(instance.persistence.get_property('seenSurvey_test-survey_2')).toBe(true)
+            expect(instance.persistence.get_property('seenSurvey_test-survey')).toBeUndefined()
+        })
+
+        it('should respect repeatable survey behavior', () => {
+            const repeatableSurvey = { ...baseSurvey, schedule: SurveySchedule.Always }
+            instance.persistence.set_property('seenSurvey_test-survey', true)
+
+            const result = getSurveySeen(repeatableSurvey, instance)
+
+            expect(result).toBe(false) // Allows repeat activation
+        })
+    })
+
+    describe('Storage isolation', () => {
+        it('should use namespaced keys to avoid conflicts', () => {
+            // Documents that persistence and direct localStorage are isolated
+            instance.persistence.set_property('seenSurvey_test-survey', true)
+
+            // Direct localStorage doesn't see it (different key structure)
+            expect(localStorage.getItem('seenSurvey_test-survey')).toBeNull()
+
+            // Persistence uses namespaced key
+            expect(localStorage.getItem('ph_test-token_posthog')).toBeTruthy()
+        })
+    })
+})

--- a/packages/browser/src/__tests__/posthog-core.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.test.ts
@@ -2,7 +2,7 @@ import { defaultPostHog } from './helpers/posthog-instance'
 import type { PostHogConfig } from '../types'
 import { uuidv7 } from '../uuidv7'
 import { SurveyEventName, SurveyEventProperties } from '../posthog-surveys-types'
-import { SURVEY_SEEN_PREFIX } from '../utils/survey-utils'
+import { getFromPersistenceWithLocalStorageFallback, SURVEY_SEEN_PREFIX } from '../utils/survey-utils'
 import { beforeEach } from '@jest/globals'
 
 describe('posthog core', () => {
@@ -296,7 +296,7 @@ describe('posthog core', () => {
                 })
 
                 // assert
-                expect(localStorage.getItem(surveySeenKey)).toBe('true')
+                expect(getFromPersistenceWithLocalStorageFallback(surveySeenKey, posthog)).toBe(true)
                 // test if property contains at least $set but dont care about the other properties
                 expect(beforeSendMock.mock.calls[0][0]).toMatchObject({
                     properties: {
@@ -324,7 +324,7 @@ describe('posthog core', () => {
                 })
 
                 // assert
-                expect(localStorage.getItem(surveySeenKey)).toBe('true')
+                expect(getFromPersistenceWithLocalStorageFallback(surveySeenKey, posthog)).toBe(true)
                 // test if property contains at least $set but dont care about the other properties
                 expect(beforeSendMock.mock.calls[0][0]).toMatchObject({
                     properties: {

--- a/packages/browser/src/__tests__/posthog-surveys.test.ts
+++ b/packages/browser/src/__tests__/posthog-surveys.test.ts
@@ -27,6 +27,7 @@ describe('posthog-surveys', () => {
         let surveys: PostHogSurveys
         let mockGenerateSurveys: jest.Mock
         let mockLoadExternalDependency: jest.Mock
+        let persistedBucket = {}
 
         const survey: Survey = {
             id: 'completed-survey',
@@ -82,8 +83,8 @@ describe('posthog-surveys', () => {
             // Reset mocks
             jest.clearAllMocks()
 
-            // Clear localStorage
-            localStorage.clear()
+            // Reset in-memory persistence bucket
+            persistedBucket = {}
 
             // Mock PostHog instance
             mockPostHog = createMockPostHog({
@@ -91,10 +92,16 @@ describe('posthog-surveys', () => {
                     disable_surveys: false,
                     token: 'test-token',
                     surveys_request_timeout_ms: SURVEYS_REQUEST_TIMEOUT_MS,
+                    persistence: 'localStorage+cookie',
                 },
                 persistence: {
                     register: jest.fn(),
                     props: {},
+                    get_property: jest.fn((key) => persistedBucket[key]),
+                    set_property: jest.fn((key, value) => {
+                        persistedBucket[key] = value
+                    }),
+                    isDisabled: jest.fn().mockReturnValue(false),
                 },
                 requestRouter: {
                     endpointFor: jest.fn().mockReturnValue('https://test.com/api/surveys'),
@@ -147,7 +154,6 @@ describe('posthog-surveys', () => {
         afterEach(() => {
             // Clean up
             delete assignableWindow.__PosthogExtensions__
-            localStorage.clear()
         })
 
         describe('canRenderSurvey', () => {
@@ -264,12 +270,9 @@ describe('posthog-surveys', () => {
                 flagsResponse.featureFlags[survey.targeting_flag_key] = true
                 flagsResponse.featureFlags[survey.linked_flag_key] = true
                 flagsResponse.featureFlags[survey.internal_targeting_flag_key] = false
-                localStorage.setItem(
-                    `${SURVEY_IN_PROGRESS_PREFIX}${survey.id}`,
-                    JSON.stringify({
-                        surveySubmissionId: '123',
-                    })
-                )
+                persistedBucket[`${SURVEY_IN_PROGRESS_PREFIX}${survey.id}`] = JSON.stringify({
+                    surveySubmissionId: '123',
+                })
                 const result = surveys['_checkSurveyEligibility'](survey.id)
                 expect(result.eligible).toBeTruthy()
             })
@@ -301,7 +304,7 @@ describe('posthog-surveys', () => {
                     // Set last seen survey date to 3 days ago (less than 7 day wait period)
                     const threeDaysAgo = new Date()
                     threeDaysAgo.setDate(threeDaysAgo.getDate() - 3)
-                    localStorage.setItem('lastSeenSurveyDate', threeDaysAgo.toISOString())
+                    persistedBucket['lastSeenSurveyDate'] = threeDaysAgo.toISOString()
 
                     const result = surveys['_checkSurveyEligibility'](surveyWithWaitPeriod.id)
                     expect(result.eligible).toBeFalsy()
@@ -310,7 +313,7 @@ describe('posthog-surveys', () => {
 
                 it('integrates survey seen check with other eligibility criteria', () => {
                     // Mark survey as seen
-                    localStorage.setItem(`${SURVEY_SEEN_PREFIX}${survey.id}`, 'true')
+                    persistedBucket[`${SURVEY_SEEN_PREFIX}${survey.id}`] = 'true'
 
                     const result = surveys['_checkSurveyEligibility'](survey.id)
                     expect(result.eligible).toBeFalsy()
@@ -319,7 +322,7 @@ describe('posthog-surveys', () => {
 
                 it('allows repeatable surveys even when seen', () => {
                     // Use repeatable survey (has SurveySchedule.Always)
-                    localStorage.setItem(`${SURVEY_SEEN_PREFIX}${repeatableSurvey.id}`, 'true')
+                    persistedBucket[`${SURVEY_SEEN_PREFIX}${repeatableSurvey.id}`] = 'true'
 
                     const result = surveys['_checkSurveyEligibility'](repeatableSurvey.id)
                     expect(result.eligible).toBeTruthy()
@@ -349,10 +352,10 @@ describe('posthog-surveys', () => {
                     // Set last seen survey date to 2 days ago (less than 5 day wait period)
                     const twoDaysAgo = new Date()
                     twoDaysAgo.setDate(twoDaysAgo.getDate() - 2)
-                    localStorage.setItem('lastSeenSurveyDate', twoDaysAgo.toISOString())
+                    persistedBucket['lastSeenSurveyDate'] = twoDaysAgo.toISOString()
 
                     // Also mark survey as seen (but this should not be checked since wait period fails first)
-                    localStorage.setItem(`${SURVEY_SEEN_PREFIX}${surveyWithBothConditions.id}`, 'true')
+                    persistedBucket[`${SURVEY_SEEN_PREFIX}${surveyWithBothConditions.id}`] = 'true'
 
                     const result = surveys['_checkSurveyEligibility'](surveyWithBothConditions.id)
                     expect(result.eligible).toBeFalsy()
@@ -363,10 +366,10 @@ describe('posthog-surveys', () => {
                     // Set last seen survey date to 10 days ago (more than 5 day wait period)
                     const tenDaysAgo = new Date()
                     tenDaysAgo.setDate(tenDaysAgo.getDate() - 10)
-                    localStorage.setItem('lastSeenSurveyDate', tenDaysAgo.toISOString())
+                    persistedBucket['lastSeenSurveyDate'] = tenDaysAgo.toISOString()
 
                     // Mark survey as seen and cannot repeat
-                    localStorage.setItem(`${SURVEY_SEEN_PREFIX}${surveyWithBothConditions.id}`, 'true')
+                    persistedBucket[`${SURVEY_SEEN_PREFIX}${surveyWithBothConditions.id}`] = 'true'
 
                     const result = surveys['_checkSurveyEligibility'](surveyWithBothConditions.id)
                     expect(result.eligible).toBeFalsy()
@@ -389,10 +392,10 @@ describe('posthog-surveys', () => {
                     // Set last seen survey date to 10 days ago (more than 5 day wait period)
                     const tenDaysAgo = new Date()
                     tenDaysAgo.setDate(tenDaysAgo.getDate() - 10)
-                    localStorage.setItem('lastSeenSurveyDate', tenDaysAgo.toISOString())
+                    persistedBucket['lastSeenSurveyDate'] = tenDaysAgo.toISOString()
 
                     // Mark survey as seen but can repeat (due to SurveySchedule.Always)
-                    localStorage.setItem(`${SURVEY_SEEN_PREFIX}${repeatableSurveyWithWaitPeriod.id}`, 'true')
+                    persistedBucket[`${SURVEY_SEEN_PREFIX}${repeatableSurveyWithWaitPeriod.id}`] = 'true'
 
                     const result = surveys['_checkSurveyEligibility'](repeatableSurveyWithWaitPeriod.id)
                     expect(result.eligible).toBeTruthy()

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -14,9 +14,13 @@ import {
 } from '../../posthog-surveys-types'
 import { document as _document, window as _window, userAgent } from '../../utils/globals'
 import {
+    clearFromPersistenceWithLocalStorageFallback,
+    getFromPersistenceWithLocalStorageFallback,
     getSurveyInteractionProperty,
     getSurveySeenKey,
+    LAST_SEEN_SURVEY_DATE_KEY,
     SURVEY_LOGGER as logger,
+    setOnPersistenceWithLocalStorageFallback,
     setSurveySeenOnLocalStorage,
     SURVEY_IN_PROGRESS_PREFIX,
 } from '../../utils/survey-utils'
@@ -403,7 +407,7 @@ export const sendSurveyEvent = ({
         logger.error('[survey sent] event not captured, PostHog instance not found.')
         return
     }
-    setSurveySeenOnLocalStorage(survey)
+    setSurveySeenOnLocalStorage(survey, posthog)
     posthog.capture(SurveyEventName.SENT, {
         [SurveyEventProperties.SURVEY_NAME]: survey.name,
         [SurveyEventProperties.SURVEY_ID]: survey.id,
@@ -425,7 +429,7 @@ export const sendSurveyEvent = ({
     if (isSurveyCompleted) {
         // Only dispatch PHSurveySent if the survey is completed, as that removes the survey from focus
         window.dispatchEvent(new CustomEvent('PHSurveySent', { detail: { surveyId: survey.id } }))
-        clearInProgressSurveyState(survey)
+        clearInProgressSurveyState(survey, posthog)
     }
 }
 
@@ -438,7 +442,7 @@ export const dismissedSurveyEvent = (survey: Survey, posthog?: PostHog, readOnly
         return
     }
 
-    const inProgressSurvey = getInProgressSurveyState(survey)
+    const inProgressSurvey = getInProgressSurveyState(survey, posthog)
     posthog.capture(SurveyEventName.DISMISSED, {
         [SurveyEventProperties.SURVEY_NAME]: survey.name,
         [SurveyEventProperties.SURVEY_ID]: survey.id,
@@ -460,8 +464,8 @@ export const dismissedSurveyEvent = (survey: Survey, posthog?: PostHog, readOnly
         },
     })
     // Clear in-progress state on dismissal
-    clearInProgressSurveyState(survey)
-    setSurveySeenOnLocalStorage(survey)
+    clearInProgressSurveyState(survey, posthog)
+    setSurveySeenOnLocalStorage(survey, posthog)
     window.dispatchEvent(new CustomEvent('PHSurveyClosed', { detail: { surveyId: survey.id } }))
 }
 
@@ -517,35 +521,35 @@ export const hasEvents = (survey: Pick<Survey, 'conditions'>): boolean => {
 }
 
 export const canActivateRepeatedly = (
-    survey: Pick<Survey, 'schedule' | 'conditions' | 'id' | 'current_iteration'>
+    survey: Pick<Survey, 'schedule' | 'conditions' | 'id' | 'current_iteration'>,
+    posthog?: PostHog
 ): boolean => {
     return (
         !!(survey.conditions?.events?.repeatedActivation && hasEvents(survey)) ||
         survey.schedule === SurveySchedule.Always ||
-        isSurveyInProgress(survey)
+        isSurveyInProgress(survey, posthog)
     )
 }
 
 /**
- * getSurveySeen checks local storage for the surveySeen Key a
+ * getSurveySeen checks persistence for the surveySeenKey
  * and overrides this value if the survey can be repeatedly activated by its events.
  * @param survey
+ * @param posthog
  */
-export const getSurveySeen = (survey: Survey): boolean => {
-    const surveySeen = localStorage.getItem(getSurveySeenKey(survey))
+export const getSurveySeen = (survey: Survey, posthog?: PostHog): boolean => {
+    const surveySeen = getFromPersistenceWithLocalStorageFallback(getSurveySeenKey(survey), posthog)
     if (surveySeen) {
         // if a survey has already been seen,
         // we will override it with the event repeated activation value.
-        return !canActivateRepeatedly(survey)
+        return !canActivateRepeatedly(survey, posthog)
     }
 
     return false
 }
 
-const LAST_SEEN_SURVEY_DATE_KEY = 'lastSeenSurveyDate'
-
-export const hasWaitPeriodPassed = (waitPeriodInDays: number | undefined): boolean => {
-    const lastSeenSurveyDate = localStorage.getItem(LAST_SEEN_SURVEY_DATE_KEY)
+export const hasWaitPeriodPassed = (waitPeriodInDays: number | undefined, posthog?: PostHog): boolean => {
+    const lastSeenSurveyDate = getFromPersistenceWithLocalStorageFallback(LAST_SEEN_SURVEY_DATE_KEY, posthog)
     if (!waitPeriodInDays || !lastSeenSurveyDate) {
         return true
     }
@@ -646,29 +650,31 @@ interface InProgressSurveyState {
 }
 
 const getInProgressSurveyStateKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
-    let key = `${SURVEY_IN_PROGRESS_PREFIX}${survey.id}`
     if (survey.current_iteration && survey.current_iteration > 0) {
-        key = `${SURVEY_IN_PROGRESS_PREFIX}${survey.id}_${survey.current_iteration}`
+        return `${SURVEY_IN_PROGRESS_PREFIX}${survey.id}_${survey.current_iteration}`
     }
-    return key
+
+    return `${SURVEY_IN_PROGRESS_PREFIX}${survey.id}`
 }
 
 export const setInProgressSurveyState = (
     survey: Pick<Survey, 'id' | 'current_iteration'>,
-    state: InProgressSurveyState
+    state: InProgressSurveyState,
+    posthog?: PostHog
 ): void => {
     try {
-        localStorage.setItem(getInProgressSurveyStateKey(survey), JSON.stringify(state))
+        setOnPersistenceWithLocalStorageFallback(getInProgressSurveyStateKey(survey), JSON.stringify(state), posthog)
     } catch (e) {
-        logger.error('Error setting in-progress survey state in localStorage', e)
+        logger.error('Error setting in-progress survey state', e)
     }
 }
 
 export const getInProgressSurveyState = (
-    survey: Pick<Survey, 'id' | 'current_iteration'>
+    survey: Pick<Survey, 'id' | 'current_iteration'>,
+    posthog?: PostHog
 ): InProgressSurveyState | null => {
     try {
-        const stateString = localStorage.getItem(getInProgressSurveyStateKey(survey))
+        const stateString = getFromPersistenceWithLocalStorageFallback(getInProgressSurveyStateKey(survey), posthog)
         if (stateString) {
             return JSON.parse(stateString) as InProgressSurveyState
         }
@@ -678,14 +684,17 @@ export const getInProgressSurveyState = (
     return null
 }
 
-export const isSurveyInProgress = (survey: Pick<Survey, 'id' | 'current_iteration'>): boolean => {
-    const state = getInProgressSurveyState(survey)
+export const isSurveyInProgress = (survey: Pick<Survey, 'id' | 'current_iteration'>, posthog?: PostHog): boolean => {
+    const state = getInProgressSurveyState(survey, posthog)
     return !isNullish(state?.surveySubmissionId)
 }
 
-export const clearInProgressSurveyState = (survey: Pick<Survey, 'id' | 'current_iteration'>): void => {
+export const clearInProgressSurveyState = (
+    survey: Pick<Survey, 'id' | 'current_iteration'>,
+    posthog?: PostHog
+): void => {
     try {
-        localStorage.removeItem(getInProgressSurveyStateKey(survey))
+        clearFromPersistenceWithLocalStorageFallback(getInProgressSurveyStateKey(survey), posthog)
     } catch (e) {
         logger.error('Error clearing in-progress survey state from localStorage', e)
     }

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1149,7 +1149,7 @@ export class PostHog {
         if (event_name === SurveyEventName.DISMISSED || event_name === SurveyEventName.SENT) {
             const surveyId = properties?.[SurveyEventProperties.SURVEY_ID]
             const surveyIteration = properties?.[SurveyEventProperties.SURVEY_ITERATION]
-            setSurveySeenOnLocalStorage({ id: surveyId, current_iteration: surveyIteration })
+            setSurveySeenOnLocalStorage({ id: surveyId, current_iteration: surveyIteration }, this)
             data.$set = {
                 ...data.$set,
                 [getSurveyInteractionProperty(

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -385,7 +385,8 @@ export interface PostHogConfig {
 
     /**
      * Determines how PostHog stores information about the user. See [persistence](https://posthog.com/docs/libraries/js#persistence) for details.
-     *
+     * Surveys functionality requires localStorage to work properly, so if you are using it, please set this to 'localStorage+cookie' (default value) or 'localStorage'.
+     * If surveys are used with persistence disabled, localStorage will be used directly.
      * @default 'localStorage+cookie'
      */
     persistence: 'localStorage' | 'cookie' | 'memory' | 'localStorage+cookie' | 'sessionStorage'

--- a/packages/browser/src/utils/survey-utils.ts
+++ b/packages/browser/src/utils/survey-utils.ts
@@ -1,5 +1,8 @@
 import { DisplaySurveyOptions, DisplaySurveyType, Survey, SurveyType } from '../posthog-surveys-types'
 import { createLogger } from '../utils/logger'
+import { PostHog } from '../posthog-core'
+import { PostHogPersistence } from '../posthog-persistence'
+import { isFunction, isNullish } from '@posthog/core'
 
 export const SURVEY_LOGGER = createLogger('[Surveys]')
 
@@ -17,6 +20,7 @@ export function doesSurveyActivateByAction(survey: Pick<Survey, 'conditions'>): 
 
 export const SURVEY_SEEN_PREFIX = 'seenSurvey_'
 export const SURVEY_IN_PROGRESS_PREFIX = 'inProgressSurvey_'
+export const LAST_SEEN_SURVEY_DATE_KEY = 'lastSeenSurveyDate'
 
 export const getSurveyInteractionProperty = (
     survey: Pick<Survey, 'id' | 'current_iteration'>,
@@ -39,14 +43,106 @@ export const getSurveySeenKey = (survey: Pick<Survey, 'id' | 'current_iteration'
     return surveySeenKey
 }
 
-export const setSurveySeenOnLocalStorage = (survey: Pick<Survey, 'id' | 'current_iteration'>) => {
-    const isSurveySeen = localStorage.getItem(getSurveySeenKey(survey))
-    // if survey is already seen, no need to set it again
+export function isPersistenceEnabledWithLocalStorage(
+    posthog?: PostHog
+): posthog is PostHog & { persistence: PostHogPersistence } {
+    if (!posthog?.persistence) {
+        return false
+    }
+
+    const persistenceSetting = posthog.config?.persistence?.toLowerCase() || ''
+    if (!persistenceSetting.includes('localstorage')) {
+        return false
+    }
+
+    const persistenceIsDisabled = isFunction(posthog.persistence.isDisabled)
+        ? posthog.persistence.isDisabled()
+        : !!posthog.persistence._disabled
+
+    return !persistenceIsDisabled
+}
+
+/**
+ * We used to retrieve from localStorage directly. Now, we instead rely on the persistence API, since this is the preferred way to store data.
+ * But, since we might have customers that might be using surveys with persistence disabled, we need to fallback to localStorage
+ * to maintain backwards compatibility.
+ */
+export const getFromPersistenceWithLocalStorageFallback = (key: string, posthog?: PostHog) => {
+    let value = undefined
+
+    // Try persistence if available
+    if (isPersistenceEnabledWithLocalStorage(posthog)) {
+        try {
+            value = posthog.persistence.get_property(key)
+        } catch (e) {
+            SURVEY_LOGGER.error('Error getting property from persistence', e)
+        }
+    }
+
+    // Fall back to localStorage if not found or error
+    if (isNullish(value)) {
+        try {
+            return localStorage.getItem(key)
+        } catch (e) {
+            SURVEY_LOGGER.error('Error getting property from localStorage', e)
+            return null
+        }
+    }
+
+    return value
+}
+
+/**
+ * We used to set on localStorage directly. Now, we instead rely on the persistence API, since this is the preferred way to store data.
+ * But, since we might have customers that might be using surveys with persistence disabled, we need to fallback to localStorage
+ * to maintain backwards compatibility.
+ */
+export const setOnPersistenceWithLocalStorageFallback = (key: string, value: any, posthog?: PostHog) => {
+    if (!isPersistenceEnabledWithLocalStorage(posthog)) {
+        try {
+            localStorage.setItem(key, value)
+        } catch (e) {
+            SURVEY_LOGGER.error('Error setting property on localStorage', e)
+        }
+
+        return
+    }
+
+    try {
+        posthog.persistence.set_property(key, value)
+    } catch (e) {
+        SURVEY_LOGGER.error('Error setting property on persistence', e)
+    }
+}
+
+/**
+ * When removing a property from persistence, remove from localStorage for backwards compatibility.
+ */
+export const clearFromPersistenceWithLocalStorageFallback = (key: string, posthog?: PostHog) => {
+    if (!isPersistenceEnabledWithLocalStorage(posthog)) {
+        try {
+            localStorage.removeItem(key)
+        } catch (e) {
+            SURVEY_LOGGER.error('Error clearing property from localStorage', e)
+        }
+
+        return
+    }
+
+    try {
+        posthog.persistence.unregister(key)
+    } catch (e) {
+        SURVEY_LOGGER.error('Error clearing property from persistence', e)
+    }
+}
+
+export const setSurveySeenOnLocalStorage = (survey: Pick<Survey, 'id' | 'current_iteration'>, posthog?: PostHog) => {
+    const isSurveySeen = getFromPersistenceWithLocalStorageFallback(getSurveySeenKey(survey), posthog)
     if (isSurveySeen) {
         return
     }
 
-    localStorage.setItem(getSurveySeenKey(survey), 'true')
+    setOnPersistenceWithLocalStorageFallback(getSurveySeenKey(survey), true, posthog)
 }
 
 // These surveys are relevant for the getActiveMatchingSurveys method. They are used to


### PR DESCRIPTION
## Problem

A fix went in for [local storage usage](https://github.com/PostHog/posthog-js/issues/1898) in surveys but it was [reverted](https://github.com/PostHog/posthog-js/commit/7e568fe09e6d642a01397327b54b8aea0e836fde) due to a bug.

My understanding is that [the bug](https://github.com/PostHog/posthog/pull/39126) was related to `persistence.isDisabled is not a function`. This PR reapplies the fix with a few extra checks around the isDisabled function and falls back to `_disabled` if necessary.

## Changes

- Reapplied the persistence migration for surveys (using the shared persistence layer instead of touching localStorage directly).
- Guarded the persistence check with isFunction and a _disabled fallback so we never call a missing isDisabled.
- Added a regression test (surveys-persistence.test.ts) that simulates a “legacy” instance without isDisabled to make sure we don’t regress again.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [X] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt

## Checklist

- [x] Tests for new code (runs for packages/browser/src/__tests__/extensions/surveys-persistence.test.ts; rest of the suite currently fails earlier because other packages are missing dev deps, so reviewers may want to re-run once the workspace installs)
- [x] Accounted for cross-platform impact (surveys only touch the browser SDK)
- [x] Backwards compatibility (still falls back to localStorage when persistence is disabled or unavailable)
- [x] Bundle size considerations (only adds a tiny helper import; no new runtime dependencies)

### If releasing new changes

- [x] Ran pnpm changeset (see .changeset/giant-lamps-cover.md or whatever file you created)
- [] Added the release label once you’re ready to publish

<!-- For more details check RELEASING.md -->
