### PR TITLE
feat: Add new `payload` entry to types

### DIFF
--- a/.changeset/rich-trains-stop.md
+++ b/.changeset/rich-trains-stop.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+Add new `payload` entry to the `EarlyAccessFeature` type

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -1771,13 +1771,14 @@ export type SnippetArrayItem = [method: string, ...args: any[]]
 export type JsonRecord = { [key: string]: JsonType }
 export type JsonType = string | number | boolean | null | undefined | JsonRecord | Array<JsonType>
 
+// Sync this with the backend's EarlyAccessFeatureSerializer!
 /** A feature that isn't publicly available yet.*/
 export interface EarlyAccessFeature {
-    // Sync this with the backend's EarlyAccessFeatureSerializer!
     name: string
     description: string
     stage: 'concept' | 'alpha' | 'beta'
     documentationUrl: string | null
+    payload: JsonType
     flagKey: string | null
 }
 


### PR DESCRIPTION
We're now sending the payload from the API, so let's fix the types by exposing it to our users!