### PR TITLE
fix: Only match prefixes in sensitive name regex

### DIFF
--- a/packages/browser/src/__tests__/autocapture-utils.test.ts
+++ b/packages/browser/src/__tests__/autocapture-utils.test.ts
@@ -398,34 +398,36 @@ describe(`Autocapture utility functions`, () => {
             expect(shouldCaptureElement(input)).toBe(false)
         })
 
-        it(`should not include fields with sensitive names`, () => {
-            const sensitiveNames = [
-                `cc_name`,
-                `card-num`,
-                `ccnum`,
-                `credit-card_number`,
-                `credit_card[number]`,
-                `csc num`,
-                `CVC`,
-                `Expiration`,
-                `password`,
-                `pwd`,
-                `routing`,
-                `routing-number`,
-                `security code`,
-                `seccode`,
-                `security number`,
-                `social sec`,
-                `SsN`,
-            ]
-            sensitiveNames.forEach((name) => {
-                input.name = ''
-                expect(shouldCaptureElement(input)).toBe(true)
-
-                input.name = name
-                expect(shouldCaptureElement(input)).toBe(false)
-            })
+        it.each([
+            'cc_name',
+            'card-num',
+            'ccnum',
+            'credit-card_number',
+            'credit_card[number]',
+            'csc num',
+            'CVC',
+            'Expiration',
+            'password',
+            'pwd',
+            'routing',
+            'routing-number',
+            'security code',
+            'seccode',
+            'security number',
+            'social sec',
+            'SsN',
+        ])(`should not include fields with sensitive name: %s`, (name) => {
+            input.name = name
+            expect(shouldCaptureElement(input)).toBe(false)
         })
+
+        it.each(['document-expiry', 'success_message', 'account-settings', 'compass-icon'])(
+            `should include fields with sensitive substrings that are not prefixes: %s`,
+            (name) => {
+                input.name = name
+                expect(shouldCaptureElement(input)).toBe(true)
+            }
+        )
 
         // See https://github.com/posthog/posthog-js/issues/165
         // Under specific circumstances a bug caused .replace to be called on a DOM element

--- a/packages/browser/src/autocapture-utils.ts
+++ b/packages/browser/src/autocapture-utils.ts
@@ -375,7 +375,7 @@ export function shouldCaptureElement(el: Element): boolean {
     if (isString(name)) {
         // it's possible for el.name or el.id to be a DOM element if el is a form with a child input[name="name"]
         const sensitiveNameRegex =
-            /^cc|cardnum|ccnum|creditcard|csc|cvc|cvv|exp|pass|pwd|routing|seccode|securitycode|securitynum|socialsec|socsec|ssn/i
+            /^(cc|cardnum|ccnum|creditcard|csc|cvc|cvv|exp|pass|pwd|routing|seccode|securitycode|securitynum|socialsec|socsec|ssn)/i
         if (sensitiveNameRegex.test(name.replace(/[^a-zA-Z0-9]/g, ''))) {
             return false
         }


### PR DESCRIPTION
It looks like this has been in the SDK forever, but the regex pattern we use was matching any substring for most of our sensitive looking fields (everything except `cc`). I think the intent would've been to only look at prefixes, as we were doing for `cc`.

Currently if, for example, `exp` appeared anywhere inside the `name`/`id` attribute of an element then we wouldn't capture it.

https://posthoghelp.zendesk.com/agent/tickets/42648 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56562)

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
