### PR TITLE
fix: Fix CD by using PAT token

### DIFF
--- a/.github/workflows/label-version-bump.yml
+++ b/.github/workflows/label-version-bump.yml
@@ -8,6 +8,8 @@ jobs:
     label-version-bump:
         name: Bump versions based on PR label
         runs-on: ubuntu-22.04
+        permissions:
+            contents: write
         if: |
             github.event.pull_request.merged
             && contains(github.event.pull_request.labels.*.name, 'release')


### PR DESCRIPTION
The commit is being created with the wrong username which is causing us to block the push (that user cannot push directly to master without codeql checks)

Let's instead use the global PAT