### PR TITLE
feat(surveys): support actions with event properties

### DIFF
--- a/.changeset/shaky-rats-sip.md
+++ b/.changeset/shaky-rats-sip.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+add support for surveys triggered by actions with event property filters

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -11,14 +11,16 @@ export enum SurveyEventType {
     Cancellation = 'cancelEvents',
 }
 
+export type PropertyFilters = {
+    [propertyName: string]: {
+        values: string[]
+        operator: PropertyMatchType
+    }
+}
+
 export interface SurveyEventWithFilters {
     name: string
-    propertyFilters?: {
-        [propertyName: string]: {
-            values: string[]
-            operator: PropertyMatchType
-        }
-    }
+    propertyFilters?: PropertyFilters
 }
 
 export enum SurveyWidgetType {
@@ -267,6 +269,13 @@ export interface ActionStepType {
     url?: string | null
     /** @default StringMatching.Contains */
     url_matching?: ActionStepStringMatching | null
+    /** Property filters for action step matching */
+    properties?: {
+        key: string
+        value?: string | number | boolean | (string | number | boolean)[] | null
+        operator?: PropertyMatchType
+        type?: string
+    }[]
 }
 
 export enum SurveyEventName {

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -50,6 +50,7 @@
         "_checkStep",
         "_checkStepElement",
         "_checkStepEvent",
+        "_checkStepProperties",
         "_checkStepUrl",
         "_checkSurveyEligibility",
         "_clearAutoSubmitTimeout",


### PR DESCRIPTION
## Problem

we don't support triggering surveys based on actions with event filters

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- added support for triggering surveys based on actions with event filters :smiley:
    - uses the same logic as events and cancel events, just with a bit of transformation since the shape is different

<!-- What is changed and what information would be useful to a reviewer? -->

**_this is largely untested, but it's behind a feature flag, it'll be easier to test once deployed!_**

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->