### PR TITLE
chore: properly not es5 in browserslist

### DIFF
--- a/packages/browser/babel.config.cjs
+++ b/packages/browser/babel.config.cjs
@@ -1,5 +1,8 @@
 module.exports = {
-    presets: ['@babel/env', ['@babel/typescript', { jsxPragma: 'h' }]],
+    presets: [
+        ['@babel/env', { targets: { node: 'current' } }],
+        ['@babel/typescript', { jsxPragma: 'h' }],
+    ],
     plugins: [
         '@babel/plugin-transform-nullish-coalescing-operator',
         [

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -124,6 +124,6 @@
         "yargs": "^17.7.2"
     },
     "browserslist": [
-        "> 0.5%, last 2 versions, Firefox ESR, not dead, IE 11"
+        "> 0.5%, last 2 versions, Firefox ESR, not dead"
     ]
 }

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -12,17 +12,19 @@ import { SessionIdManager } from '../sessionid'
 import { RequestQueue } from '../request-queue'
 import { SessionRecording } from '../extensions/replay/session-recording'
 import { SessionPropsManager } from '../session-props'
-
-let mockGetProperties: jest.Mock
+import { getEventProperties } from '../utils/event-utils'
 
 jest.mock('../utils/event-utils', () => {
     const originalEventUtils = jest.requireActual('../utils/event-utils')
-    mockGetProperties = jest.fn().mockImplementation((...args) => originalEventUtils.getEventProperties(...args))
     return {
         ...originalEventUtils,
-        getEventProperties: mockGetProperties,
+        getEventProperties: jest
+            .fn()
+            .mockImplementation((...args: unknown[]) => originalEventUtils.getEventProperties(...args)),
     }
 })
+
+const mockGetPropertiesFn = jest.mocked(getEventProperties)
 
 describe('posthog core', () => {
     const baseUTCDateTime = new Date(Date.UTC(2020, 0, 1, 0, 0, 0))
@@ -441,7 +443,7 @@ describe('posthog core', () => {
         }
 
         beforeEach(() => {
-            mockGetProperties.mockReturnValue({ $lib: 'web' })
+            mockGetPropertiesFn.mockReturnValue({ $lib: 'web' })
 
             posthog = posthogWith(
                 {


### PR DESCRIPTION
we don't support es5 in the main bundles
but the last time i removed ie11 from the package.json
it broke CI

let's see....