### PR TITLE
chore: update changelog with security note and dependency update

### DIFF
--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -24,7 +24,7 @@
 ### Patch Changes
 
 - [#2618](https://github.com/PostHog/posthog-js/pull/2618) [`3eed1a4`](https://github.com/PostHog/posthog-js/commit/3eed1a42a50bff310fde3a91308a0f091b39e3fe) Thanks [@marandaneto](https://github.com/marandaneto)! - last version was compromised
-  (2025-11-24)
+  (2025-11-24) see the [post-mortem](https://posthog.com/blog/nov-24-shai-hulud-attack-post-mortem). All versions listed in this changelog are safe to install 
 - Updated dependencies [[`3eed1a4`](https://github.com/PostHog/posthog-js/commit/3eed1a42a50bff310fde3a91308a0f091b39e3fe)]:
     - @posthog/core@1.5.6
 


### PR DESCRIPTION
I forgot about the customer feedback here that they didn't see the note in the changelog