### PR TITLE
feat: dead clicks should be ignored if alt/ctrl/etc are held down

### DIFF
--- a/.changeset/dark-insects-roll.md
+++ b/.changeset/dark-insects-roll.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+A click while holding a modifier key (CTRL, ALT, CMD, Windows) shouldn't ever count as a dead click - so that we don't pick up e.g. open in a new tab as a dead click

--- a/packages/browser/playwright/mocked/dead-clicks.spec.ts
+++ b/packages/browser/playwright/mocked/dead-clicks.spec.ts
@@ -30,6 +30,96 @@ test.describe('Dead clicks', () => {
         expect(deadClick.properties.$dead_click_absolute_timeout).toBe(true)
     })
 
+    test('does not capture dead click when ctrl key is held', async ({ page, context }) => {
+        await start(startOptions, page, context)
+
+        await page.resetCapturedEvents()
+
+        await page.locator('[data-cy-not-an-order-button]').click({ modifiers: ['Control'] })
+
+        // wait long enough for a dead click to be detected if it was going to be
+        await page.waitForTimeout(3500)
+
+        const deadClicks = (await page.capturedEvents()).filter((event) => event.event === '$dead_click')
+        expect(deadClicks.length).toBe(0)
+    })
+
+    test('does not capture dead click when meta/cmd key is held', async ({ page, context }) => {
+        await start(startOptions, page, context)
+
+        await page.resetCapturedEvents()
+
+        await page.locator('[data-cy-not-an-order-button]').click({ modifiers: ['Meta'] })
+
+        await page.waitForTimeout(3500)
+
+        const deadClicks = (await page.capturedEvents()).filter((event) => event.event === '$dead_click')
+        expect(deadClicks.length).toBe(0)
+    })
+
+    test('does not capture dead click when shift key is held', async ({ page, context }) => {
+        await start(startOptions, page, context)
+
+        await page.resetCapturedEvents()
+
+        await page.locator('[data-cy-not-an-order-button]').click({ modifiers: ['Shift'] })
+
+        await page.waitForTimeout(3500)
+
+        const deadClicks = (await page.capturedEvents()).filter((event) => event.event === '$dead_click')
+        expect(deadClicks.length).toBe(0)
+    })
+
+    test('does not capture dead click when alt key is held', async ({ page, context }) => {
+        await start(startOptions, page, context)
+
+        await page.resetCapturedEvents()
+
+        await page.locator('[data-cy-not-an-order-button]').click({ modifiers: ['Alt'] })
+
+        await page.waitForTimeout(3500)
+
+        const deadClicks = (await page.capturedEvents()).filter((event) => event.event === '$dead_click')
+        expect(deadClicks.length).toBe(0)
+    })
+
+    test('captures dead click with modifier key when capture_clicks_with_modifier_keys is true', async ({
+        page,
+        context,
+    }) => {
+        await start(
+            {
+                options: {
+                    capture_dead_clicks: {
+                        capture_clicks_with_modifier_keys: true,
+                    },
+                },
+                url: '/playground/cypress/index.html',
+            },
+            page,
+            context
+        )
+
+        // Wait for dead clicks extension to be fully loaded
+        await page.waitForFunction(
+            () => {
+                const win = window as any
+                return !!win.posthog?.deadClicksAutocapture?.lazyLoadedDeadClicksAutocapture
+            },
+            { timeout: 10000 }
+        )
+
+        await page.resetCapturedEvents()
+
+        // Use Shift modifier since Ctrl+Click triggers contextmenu instead of click in some browsers
+        await page.locator('[data-cy-not-an-order-button]').click({ modifiers: ['Shift'] })
+
+        await pollUntilEventCaptured(page, '$dead_click')
+
+        const deadClicks = (await page.capturedEvents()).filter((event) => event.event === '$dead_click')
+        expect(deadClicks.length).toBe(1)
+    })
+
     test('does not capture dead click for selected text', async ({ page, context }) => {
         await start(startOptions, page, context)
 

--- a/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -544,7 +544,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "false",
     "true",
     [
-      "{ scroll_threshold_ms?: number | undefined; selection_change_threshold_ms?: number | undefined; mutation_threshold_ms?: number | undefined; __onCapture?: ((click: DeadClickCandidate, properties: Properties) => void) | undefined; }",
+      "{ scroll_threshold_ms?: number | undefined; selection_change_threshold_ms?: number | undefined; mutation_threshold_ms?: number | undefined; capture_clicks_with_modifier_keys?: boolean | undefined; __onCapture?: ((click: DeadClickCandidate, properties: Properties) => void) | undefined; }",
       "Pick<AutocaptureConfig, \\"element_attribute_ignorelist\\">"
     ]
   ],

--- a/packages/browser/src/entrypoints/dead-clicks-autocapture.ts
+++ b/packages/browser/src/entrypoints/dead-clicks-autocapture.ts
@@ -20,6 +20,10 @@ function asClick(event: MouseEvent): DeadClickCandidate | null {
     return null
 }
 
+function hasModifierKey(event: MouseEvent): boolean {
+    return event.ctrlKey || event.metaKey || event.altKey || event.shiftKey
+}
+
 function checkTimeout(value: number | undefined, thresholdMs: number) {
     return isNumber(value) && value >= thresholdMs
 }
@@ -38,6 +42,7 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
         scroll_threshold_ms: 100,
         selection_change_threshold_ms: 100,
         mutation_threshold_ms: 2500,
+        capture_clicks_with_modifier_keys: false,
         __onCapture: defaultOnCapture,
     })
 
@@ -50,6 +55,8 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
             selection_change_threshold_ms:
                 providedConfig?.selection_change_threshold_ms ?? defaultConfig.selection_change_threshold_ms,
             mutation_threshold_ms: providedConfig?.mutation_threshold_ms ?? defaultConfig.mutation_threshold_ms,
+            capture_clicks_with_modifier_keys:
+                providedConfig?.capture_clicks_with_modifier_keys ?? defaultConfig.capture_clicks_with_modifier_keys,
             __onCapture: defaultConfig.__onCapture,
         }
     }
@@ -151,6 +158,10 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
 
     private _ignoreClick(click: DeadClickCandidate | null): boolean {
         if (!click) {
+            return true
+        }
+
+        if (!this._config.capture_clicks_with_modifier_keys && hasModifierKey(click.originalEvent)) {
             return true
         }
 

--- a/packages/browser/src/extensions/dead-clicks-autocapture.ts
+++ b/packages/browser/src/extensions/dead-clicks-autocapture.ts
@@ -13,7 +13,13 @@ export const isDeadClicksEnabledForHeatmaps = () => {
 export const isDeadClicksEnabledForAutocapture = (instance: DeadClicksAutocapture) => {
     const isRemoteEnabled = !!instance.instance.persistence?.get_property(DEAD_CLICKS_ENABLED_SERVER_SIDE)
     const clientConfig = instance.instance.config.capture_dead_clicks
-    return isBoolean(clientConfig) ? clientConfig : isRemoteEnabled
+    if (isBoolean(clientConfig)) {
+        return clientConfig
+    }
+    if (isObject(clientConfig)) {
+        return true
+    }
+    return isRemoteEnabled
 }
 
 export class DeadClicksAutocapture {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -277,6 +277,16 @@ export type DeadClicksAutoCaptureConfig = {
     mutation_threshold_ms?: number
 
     /**
+     * By default, clicks with modifier keys (ctrl, shift, alt, meta/cmd) held down are not considered dead clicks,
+     * since these typically indicate intentional actions like "open in new tab".
+     *
+     * Set this to true to capture dead clicks even when modifier keys are held.
+     *
+     * @default false
+     */
+    capture_clicks_with_modifier_keys?: boolean
+
+    /**
      * Allows setting behavior for when a dead click is captured.
      * For e.g. to support capture to heatmaps
      *


### PR DESCRIPTION
dead clicks would be captured if someone ctrl + clicked to open in a new tab or window

yuck