### PR TITLE
feat(surveys): allow customization of input text color

### DIFF
--- a/.changeset/happy-hands-lick.md
+++ b/.changeset/happy-hands-lick.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+chore: allow customizing text input and background for surveys

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -137,13 +137,16 @@ export const addSurveyCSSVariablesToElement = (
     hostStyle.setProperty('--ph-widget-text-color', getContrastingTextColor(effectiveAppearance.widgetColor))
     hostStyle.setProperty('--ph-widget-z-index', effectiveAppearance.zIndex)
 
-    // Adjust input/choice background slightly if main background is white
-    if (effectiveAppearance.backgroundColor === 'white') {
-        hostStyle.setProperty('--ph-survey-input-background', '#f8f8f8')
+    // Use user-provided inputBackgroundColor, or fallback to internal default (with slight adjustment for white backgrounds)
+    let inputBgColor = appearance?.inputBackgroundColor || effectiveAppearance.inputBackground
+    if (!appearance?.inputBackgroundColor && effectiveAppearance.backgroundColor === 'white') {
+        inputBgColor = '#f8f8f8'
     }
-
-    hostStyle.setProperty('--ph-survey-input-background', effectiveAppearance.inputBackground)
-    hostStyle.setProperty('--ph-survey-input-text-color', getContrastingTextColor(effectiveAppearance.inputBackground))
+    hostStyle.setProperty('--ph-survey-input-background', inputBgColor)
+    hostStyle.setProperty(
+        '--ph-survey-input-text-color',
+        appearance?.inputTextColor || getContrastingTextColor(inputBgColor)
+    )
     hostStyle.setProperty('--ph-survey-scrollbar-thumb-color', effectiveAppearance.scrollbarThumbColor)
     hostStyle.setProperty('--ph-survey-scrollbar-track-color', effectiveAppearance.scrollbarTrackColor)
     hostStyle.setProperty('--ph-survey-outline-color', effectiveAppearance.outlineColor)

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -86,6 +86,8 @@ export interface SurveyAppearance {
     zIndex?: string
     disabledButtonOpacity?: string
     boxPadding?: string
+    inputTextColor?: string
+    inputBackgroundColor?: string
 }
 
 export enum SurveyType {


### PR DESCRIPTION
## Problem

we can't customize the styling for text input, which makes surveys hard to support on websites with dark mode

## Changes

allow customizing those values

relevant ticket: https://posthoghelp.zendesk.com/agent/tickets/43604 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/48182)

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
