### PR TITLE
chore: Create new release of all packages after bumping react and next dev/test/plaground dependencies

### DIFF
--- a/.changeset/clever-rooms-hunt.md
+++ b/.changeset/clever-rooms-hunt.md
@@ -14,4 +14,12 @@
 '@posthog-tooling/tsconfig-base': patch
 ---
 
-Bump all packages, after bumping next/react
+Related to https://www.wiz.io/blog/critical-vulnerability-in-react-cve-2025-55182
+
+We didn't include any of the vulnerable deps in any of our packages, however we did have them as dev / test / example project dependencies.
+
+There was no way that any of these vulnerable packages were included in any of our published packages.
+
+We've now patched out those dependencies.
+
+Out of an abundance of caution, let's create a new release of all of our packages.


### PR DESCRIPTION
## Problem

Related to https://www.wiz.io/blog/critical-vulnerability-in-react-cve-2025-55182

We didn't include any of the vulnerable deps in any of our packages, however we did have them as dev / test / example project dependencies.

There was no way that any of these vulnerable packages were included in any of our published packages.

We've now patched out those dependencies.

Out of an abundance of caution, let's create a new release of all of our packages.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [x] posthog-js (web)
- [x] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native
- [x] @posthog/react
- [x] @posthog/ai
- [x] @posthog/nextjs-config
- [x] @posthog/nuxt
- [x] @posthog/rollup-plugin
- [x] @posthog/webpack-plugin

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
