### PR TITLE
fix: can we minify all the usages of object.keys

### DIFF
--- a/packages/browser/.eslintrc.cjs
+++ b/packages/browser/.eslintrc.cjs
@@ -21,6 +21,7 @@ module.exports = {
                 'no-console': 'off',
                 'no-restricted-globals': 'off',
                 'compat/compat': 'off',
+                'posthog-js/no-direct-object-keys': 'off',
             },
         },
         {
@@ -46,6 +47,7 @@ module.exports = {
                 'posthog-js/no-direct-array-check': 'off',
                 'posthog-js/no-direct-undefined-check': 'off',
                 'posthog-js/no-direct-null-check': 'off',
+                'posthog-js/no-direct-object-keys': 'off',
                 '@typescript-eslint/naming-convention': 'off',
                 'compat/compat': 'off',
                 '@typescript-eslint/no-unsafe-function-type': 'off',

--- a/packages/browser/src/customizations/posthogReduxLogger.ts
+++ b/packages/browser/src/customizations/posthogReduxLogger.ts
@@ -1,4 +1,4 @@
-import { BucketedRateLimiter, isEmptyObject, isNullish, isObject, isUndefined, Logger } from '@posthog/core'
+import { BucketedRateLimiter, isEmptyObject, isNullish, isObject, isUndefined, objectKeys, Logger } from '@posthog/core'
 import { createLogger } from '../utils/logger'
 import type { PostHog } from '../posthog-core'
 
@@ -150,7 +150,7 @@ export function getChangedState<S>(prevState: S, nextState: S, maxDepth: number 
     if (!nextState || !prevState) return {}
 
     const changed: any = {}
-    const allKeys = new Set([...Object.keys(prevState), ...Object.keys(nextState)])
+    const allKeys = new Set([...objectKeys(prevState), ...objectKeys(nextState)])
 
     for (const key of allKeys) {
         const prevValue = (prevState as any)[key]

--- a/packages/browser/src/extensions/replay/external/config.ts
+++ b/packages/browser/src/extensions/replay/external/config.ts
@@ -1,5 +1,5 @@
 import { CapturedNetworkRequest, NetworkRecordOptions, PostHogConfig } from '../../../types'
-import { isFunction, isNullish, isString, isUndefined } from '@posthog/core'
+import { isFunction, isNullish, isString, isUndefined, objectKeys } from '@posthog/core'
 import { convertToURL } from '../../../utils/request-utils'
 import { logger } from '../../../utils/logger'
 import { shouldCaptureValue } from '../../../autocapture-utils'
@@ -92,7 +92,7 @@ const PAYLOAD_CONTENT_DENY_LIST = [
 const removeAuthorizationHeader = (data: CapturedNetworkRequest): CapturedNetworkRequest => {
     const headers = data.requestHeaders
     if (!isNullish(headers)) {
-        each(Object.keys(headers ?? {}), (header) => {
+        each(objectKeys(headers ?? {}), (header) => {
             if (HEADER_DENY_LIST.includes(header.toLowerCase())) {
                 headers[header] = REDACTED
             }

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -11,7 +11,17 @@
 
 import type { IWindow, listenerHandler, RecordPlugin } from '../types/rrweb-types'
 import { CapturedNetworkRequest, Headers, InitiatorType, NetworkRecordOptions } from '../../../types'
-import { isArray, isBoolean, isFormData, isNull, isNullish, isString, isUndefined, isObject } from '@posthog/core'
+import {
+    isArray,
+    isBoolean,
+    isFormData,
+    isNull,
+    isNullish,
+    isString,
+    isUndefined,
+    isObject,
+    objectKeys,
+} from '@posthog/core'
 import { isDocument } from '../../../utils/type-utils'
 import { createLogger } from '../../../utils/logger'
 import { formDataToQuery } from '../../../utils/request-utils'
@@ -120,7 +130,7 @@ export function shouldRecordBody({
     recordBody: NetworkRecordOptions['recordBody']
 }) {
     function matchesContentType(contentTypes: string[]) {
-        const contentTypeHeader = Object.keys(headers).find((key) => key.toLowerCase() === 'content-type')
+        const contentTypeHeader = objectKeys(headers).find((key) => key.toLowerCase() === 'content-type')
         const contentType = contentTypeHeader && headers[contentTypeHeader]
         return contentTypes.some((ct) => contentType?.includes(ct))
     }

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -25,7 +25,7 @@ import {
     isSurveyRunning,
     SURVEY_LOGGER as logger,
 } from '../utils/survey-utils'
-import { isNull, isUndefined } from '@posthog/core'
+import { isNull, isUndefined, isEmptyObject, objectKeys } from '@posthog/core'
 import { uuidv7 } from '../uuidv7'
 import { ConfirmationMessage } from './surveys/components/ConfirmationMessage'
 import { Cancel } from './surveys/components/QuestionHeader'
@@ -437,7 +437,7 @@ export class SurveyManager {
         try {
             const { params } = extractPrefillParamsFromUrl(window.location.search)
 
-            if (Object.keys(params).length === 0) {
+            if (isEmptyObject(params)) {
                 return
             }
 
@@ -445,7 +445,7 @@ export class SurveyManager {
 
             const responses = convertPrefillToResponses(survey, params)
 
-            if (Object.keys(responses).length === 0) {
+            if (isEmptyObject(responses)) {
                 logger.warn('[Survey Prefill] No valid responses after conversion')
                 return
             }
@@ -453,7 +453,7 @@ export class SurveyManager {
             const submissionId = uuidv7()
 
             // calculate which question to start at based on prefilled questions
-            const prefilledIndices = Object.keys(params).map((k) => parseInt(k, 10))
+            const prefilledIndices = objectKeys(params).map((k) => parseInt(k, 10))
             const startQuestionIndex = calculatePrefillStartIndex(survey.questions, prefilledIndices)
             const isSurveyCompleted = startQuestionIndex >= survey.questions.length
 

--- a/packages/browser/src/extensions/toolbar.ts
+++ b/packages/browser/src/extensions/toolbar.ts
@@ -5,7 +5,7 @@ import { _getHashParam } from '../utils/request-utils'
 import { createLogger } from '../utils/logger'
 import { window, document, assignableWindow } from '../utils/globals'
 import { TOOLBAR_ID } from '../constants'
-import { isFunction, isNullish } from '@posthog/core'
+import { isFunction, isNullish, isEmptyObject } from '@posthog/core'
 
 // TRICKY: Many web frameworks will modify the route on load, potentially before posthog is initialized.
 // To get ahead of this we grab it as soon as the posthog-js is parsed
@@ -93,7 +93,7 @@ export class Toolbar {
                 toolbarParams = state
                 toolbarParams.source = 'url'
 
-                if (toolbarParams && Object.keys(toolbarParams).length > 0) {
+                if (toolbarParams && !isEmptyObject(toolbarParams)) {
                     if (state['desiredHash']) {
                         // hash that was in the url before the redirect
                         location.hash = state['desiredHash']

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -12,7 +12,7 @@ import {
     PERSISTENCE_RESERVED_PROPERTIES,
 } from './constants'
 
-import { isUndefined } from '@posthog/core'
+import { isUndefined, objectKeys } from '@posthog/core'
 import {
     getCampaignParams,
     getInitialPersonPropsFromInfo,
@@ -126,9 +126,9 @@ export class PostHogPersistence {
         // Filter out reserved properties
         each(this.props, function (v, k) {
             if (k === ENABLED_FEATURE_FLAGS && isObject(v)) {
-                const keys = Object.keys(v)
-                for (let i = 0; i < keys.length; i++) {
-                    p[`$feature/${keys[i]}`] = v[keys[i]]
+                const flagKeys = objectKeys(v)
+                for (let i = 0; i < flagKeys.length; i++) {
+                    p[`$feature/${flagKeys[i]}`] = v[flagKeys[i]]
                 }
             } else if (!include(PERSISTENCE_RESERVED_PROPERTIES, k)) {
                 p[k] = v

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -22,6 +22,10 @@ import {
 } from './utils/survey-utils'
 import { isNullish, isUndefined, isArray } from '@posthog/core'
 
+// Shared error messages - extracted for bundle size optimization
+const WARN_INIT_NOT_CALLED = 'init was not called'
+const WARN_SURVEY_NOT_FOUND = 'Survey not found'
+
 export class PostHogSurveys {
     // this is set to undefined until the remote config is loaded
     // then it's set to true if there are surveys to load
@@ -271,7 +275,7 @@ export class PostHogSurveys {
 
     getActiveMatchingSurveys(callback: SurveyCallback, forceReload = false) {
         if (isNullish(this._surveyManager)) {
-            logger.warn('init was not called')
+            logger.warn(WARN_INIT_NOT_CALLED)
             return
         }
         return this._surveyManager.getActiveMatchingSurveys(callback, forceReload)
@@ -291,14 +295,14 @@ export class PostHogSurveys {
         }
         const survey = typeof surveyId === 'string' ? this._getSurveyById(surveyId) : surveyId
         if (!survey) {
-            return { eligible: false, reason: 'Survey not found' }
+            return { eligible: false, reason: WARN_SURVEY_NOT_FOUND }
         }
         return this._surveyManager.checkSurveyEligibility(survey)
     }
 
     canRenderSurvey(surveyId: string | Survey): SurveyRenderReason {
         if (isNullish(this._surveyManager)) {
-            logger.warn('init was not called')
+            logger.warn(WARN_INIT_NOT_CALLED)
             return { visible: false, disabledReason: 'SDK is not enabled or survey functionality is not yet loaded' }
         }
         const eligibility = this._checkSurveyEligibility(surveyId)
@@ -310,7 +314,7 @@ export class PostHogSurveys {
         // Ensure surveys are loaded before checking
         // Using Promise to wrap the callback-based getSurveys method
         if (isNullish(this._surveyManager)) {
-            logger.warn('init was not called')
+            logger.warn(WARN_INIT_NOT_CALLED)
             return Promise.resolve({
                 visible: false,
                 disabledReason: 'SDK is not enabled or survey functionality is not yet loaded',
@@ -322,7 +326,7 @@ export class PostHogSurveys {
             this.getSurveys((surveys) => {
                 const survey = surveys.find((x) => x.id === surveyId) ?? null
                 if (!survey) {
-                    resolve({ visible: false, disabledReason: 'Survey not found' })
+                    resolve({ visible: false, disabledReason: WARN_SURVEY_NOT_FOUND })
                 } else {
                     const eligibility = this._checkSurveyEligibility(survey)
                     resolve({ visible: eligibility.eligible, disabledReason: eligibility.reason })
@@ -333,12 +337,12 @@ export class PostHogSurveys {
 
     renderSurvey(surveyId: string | Survey, selector: string) {
         if (isNullish(this._surveyManager)) {
-            logger.warn('init was not called')
+            logger.warn(WARN_INIT_NOT_CALLED)
             return
         }
         const survey = typeof surveyId === 'string' ? this._getSurveyById(surveyId) : surveyId
         if (!survey?.id) {
-            logger.warn('Survey not found')
+            logger.warn(WARN_SURVEY_NOT_FOUND)
             return
         }
         if (!IN_APP_SURVEY_TYPES.includes(survey.type)) {
@@ -368,12 +372,12 @@ export class PostHogSurveys {
 
     displaySurvey(surveyId: string, options: DisplaySurveyOptions) {
         if (isNullish(this._surveyManager)) {
-            logger.warn('init was not called')
+            logger.warn(WARN_INIT_NOT_CALLED)
             return
         }
         const survey = this._getSurveyById(surveyId)
         if (!survey) {
-            logger.warn('Survey not found')
+            logger.warn(WARN_SURVEY_NOT_FOUND)
             return
         }
         let surveyToDisplay = survey
@@ -402,7 +406,7 @@ export class PostHogSurveys {
 
     cancelPendingSurvey(surveyId: string): void {
         if (isNullish(this._surveyManager)) {
-            logger.warn('init was not called')
+            logger.warn(WARN_INIT_NOT_CALLED)
             return
         }
         this._surveyManager.cancelSurvey(surveyId)

--- a/packages/browser/src/site-apps.ts
+++ b/packages/browser/src/site-apps.ts
@@ -2,6 +2,7 @@ import { PostHog } from './posthog-core'
 import { CaptureResult, Properties, RemoteConfig, SiteApp, SiteAppGlobals, SiteAppLoader } from './types'
 import { assignableWindow } from './utils/globals'
 import { createLogger } from './utils/logger'
+import { isEmptyObject } from '@posthog/core'
 
 const logger = createLogger('[SiteApps]')
 
@@ -153,7 +154,7 @@ export class SiteApps {
     }
 
     private _onCapturedEvent(event: CaptureResult) {
-        if (Object.keys(this.apps).length === 0) {
+        if (isEmptyObject(this.apps)) {
             return
         }
 

--- a/packages/browser/src/storage.ts
+++ b/packages/browser/src/storage.ts
@@ -8,10 +8,13 @@ import {
     SESSION_RECORDING_IS_SAMPLED,
 } from './constants'
 
-import { isNull, isUndefined } from '@posthog/core'
+import { isNull, isUndefined, objectKeys } from '@posthog/core'
 import { logger } from './utils/logger'
 import { window, document } from './utils/globals'
 import { uuidv7 } from './uuidv7'
+
+// Helper for storage error messages - saves bytes when minified
+const storageError = (type: string, msg: unknown) => logger.error(`${type} error: ` + msg)
 
 // we store the discovered subdomain in memory because it might be read multiple times
 let firstNonPublicSubDomain = ''
@@ -94,7 +97,7 @@ export const cookieStore: PersistentStore = {
     _is_supported: () => !!document,
 
     _error: function (msg) {
-        logger.error('cookieStore error: ' + msg)
+        storageError('cookieStore', msg)
     },
 
     _get: function (name) {
@@ -217,7 +220,7 @@ export const localStore: PersistentStore = {
     },
 
     _error: function (msg) {
-        logger.error('localStorage error: ' + msg)
+        storageError('localStorage', msg)
     },
 
     _get: function (name) {
@@ -294,7 +297,7 @@ export const localPlusCookieStore: PersistentStore = {
                 }
             })
 
-            if (Object.keys(cookiePersistedProperties).length) {
+            if (objectKeys(cookiePersistedProperties).length) {
                 cookieStore._set(name, cookiePersistedProperties, days, cross_subdomain, is_secure, debug)
             }
         } catch (err) {
@@ -321,7 +324,7 @@ export const memoryStore: PersistentStore = {
     },
 
     _error: function (msg) {
-        logger.error('memoryStorage error: ' + msg)
+        storageError('memoryStorage', msg)
     },
 
     _get: function (name) {
@@ -371,7 +374,7 @@ export const sessionStore: PersistentStore = {
     },
 
     _error: function (msg) {
-        logger.error('sessionStorage error: ', msg)
+        storageError('sessionStorage', msg)
     },
 
     _get: function (name) {

--- a/packages/browser/src/utils/index.ts
+++ b/packages/browser/src/utils/index.ts
@@ -1,7 +1,17 @@
 import { Breaker, Properties } from '../types'
 import { nativeForEach, nativeIndexOf } from './globals'
 import { logger } from './logger'
-import { isFormData, isNull, isNullish, isNumber, isString, isUndefined, hasOwnProperty, isArray } from '@posthog/core'
+import {
+    isFormData,
+    isNull,
+    isNullish,
+    isNumber,
+    isString,
+    isUndefined,
+    hasOwnProperty,
+    isArray,
+    objectKeys,
+} from '@posthog/core'
 
 const breaker: Breaker = {}
 
@@ -97,7 +107,7 @@ export const include = function (
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
  */
 export function entries<T = any>(obj: Record<string, T>): [string, T][] {
-    const ownProps = Object.keys(obj)
+    const ownProps = objectKeys(obj)
     let i = ownProps.length
     const resArray = new Array(i) // preallocate the Array
 

--- a/packages/core/.eslintrc.cjs
+++ b/packages/core/.eslintrc.cjs
@@ -1,3 +1,7 @@
 module.exports = {
   ignorePatterns: ['src/vendor/**/*', 'dist/**/*', 'node_modules/**/*', 'coverage/**/*'],
+  rules: {
+    // This is where objectKeys is defined, so we need to use Object.keys here
+    'posthog-js/no-direct-object-keys': 'off',
+  },
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -10,6 +10,10 @@ export * from './logger'
 
 export const STRING_FORMAT = 'utf8'
 
+// Alias for Object.keys - saves bytes when minified since
+// `Object.keys` cannot be shortened but `objectKeys` can become a single char
+export const objectKeys: (obj: object) => string[] = Object.keys
+
 export function assert(truthyValue: any, message: string): void {
   if (!truthyValue || typeof truthyValue !== 'string' || isEmpty(truthyValue)) {
     throw new Error(message)

--- a/tooling/eslint-plugin-posthog-js/no-direct-object-keys.js
+++ b/tooling/eslint-plugin-posthog-js/no-direct-object-keys.js
@@ -1,0 +1,21 @@
+module.exports = {
+    create(context) {
+        return {
+            MemberExpression: function (node) {
+                // Check if the object is 'Object' and the property is 'keys'
+                if (
+                    node.object.type === 'Identifier' &&
+                    node.object.name === 'Object' &&
+                    node.property.type === 'Identifier' &&
+                    node.property.name === 'keys'
+                ) {
+                    context.report({
+                        node,
+                        message:
+                            'Use objectKeys() from @posthog/core instead of Object.keys() for bundle size optimization.',
+                    })
+                }
+            },
+        }
+    },
+}


### PR DESCRIPTION
## Problem

repeated code is killer for bundle
particularly if the bundler can't minify it

## Changes

i think Object.keys is used a lot and can't be minified
let's check

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
