### PR TITLE
chore: Run minimum version ts check against TS 6

### DIFF
--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -13,7 +13,15 @@ jobs:
     strategy:
       matrix:
         node-version: [20, 22, 24]
-        typescript-version: ["4.7.2", "5.5.4", "latest"]
+        typescript-version:
+          - version: "4.7.4"
+            extra-flags: "--moduleResolution node"
+          - version: "5.9.2"
+            extra-flags: "--moduleResolution node"
+          - version: "latest"
+            extra-flags: "--moduleResolution node"
+          - version: "6.0.0-dev.20251204"
+            extra-flags: "--ignoreConfig"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -25,12 +33,14 @@ jobs:
 
       # once its built we can see if we can use it on the forced version
       - name: Override TypeScript version
-        run: pnpm add typescript@${{ matrix.typescript-version }} --save-dev
-        working-directory: packages/browser
+        env:
+          TS_VERSION: ${{ matrix.typescript-version.version }}
+        run: yq -i '.catalog.typescript = strenv(TS_VERSION)' pnpm-workspace.yaml && pnpm install --no-frozen-lockfile
 
       - name: Test TypeScript Import
         run: |
-          rm test.ts || true
-          echo "import { posthog } from './dist/module'; console.log(posthog);" > test.ts
-          pnpm exec tsc test.ts --strict --target es2017 --module commonjs --moduleResolution node --noEmit --skipLibCheck
+          rm ci-ts-file.js || true
+          pnpm exec tsc --version
+          pnpm exec tsc ci-ts-file.ts --strict --target es2017 --module commonjs --skipLibCheck ${{ matrix.typescript-version.extra-flags }}
+          node ci-ts-file.js
         working-directory: packages/browser

--- a/packages/browser/.gitignore
+++ b/packages/browser/.gitignore
@@ -37,3 +37,5 @@ cypress/downloads/downloads.html
 
 react/sync.js
 react/dist
+
+ci-ts-file.js

--- a/packages/browser/ci-ts-file.ts
+++ b/packages/browser/ci-ts-file.ts
@@ -1,0 +1,6 @@
+/* eslint-disable */
+import { posthog } from './dist/module'
+import * as ts from 'typescript'
+
+console.log(posthog)
+console.log(ts.version)


### PR DESCRIPTION


TS 6 is not too far away; let's make sure that posthog-js works with it :)


## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
