### PR TITLE
feat(surveys): add hideCancelButton to sdk (not in backend yet)

### DIFF
--- a/.changeset/ready-cooks-fix.md
+++ b/.changeset/ready-cooks-fix.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+support hideCancelButton in survey appearance

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -1249,9 +1249,11 @@ export function Questions({
         return null
     }
 
+    const renderCancelButton = isPopup && survey.appearance?.hideCancelButton !== true
+
     return (
         <form className="survey-form" name="surveyForm">
-            {isPopup && (
+            {renderCancelButton && (
                 <Cancel
                     onClick={() => {
                         onPopupSurveyDismissed()

--- a/packages/browser/src/extensions/surveys/components/ConfirmationMessage.tsx
+++ b/packages/browser/src/extensions/surveys/components/ConfirmationMessage.tsx
@@ -42,9 +42,11 @@ export function ConfirmationMessage({
         }
     }, [onClose])
 
+    const renderCancelButton = isPopup && appearance.hideCancelButton !== true
+
     return (
         <div className="thank-you-message" role="status" tabIndex={0} aria-atomic="true">
-            {isPopup && <Cancel onClick={() => onClose()} />}
+            {renderCancelButton && <Cancel onClick={() => onClose()} />}
             <h3 className="thank-you-message-header">{header}</h3>
             {description &&
                 renderChildrenAsTextOrHtml({

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -88,6 +88,8 @@ export interface SurveyAppearance {
     boxPadding?: string
     inputTextColor?: string
     inputBackgroundColor?: string
+    // Hide the X (cancel) button - defaults to false (show the button)
+    hideCancelButton?: boolean
 }
 
 export enum SurveyType {


### PR DESCRIPTION
## Problem

adds support for new `hideCancelButton` to survey appearance. not yet available in the main posthog app, but used internally for product tours

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->