### PR TITLE
chore(product tours): update url matching to re-use surveys util

### DIFF
--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -1,3 +1,5 @@
+import { PropertyMatchType } from './types'
+
 export interface JSONContent {
     type?: string
     attrs?: Record<string, any>
@@ -33,7 +35,7 @@ export interface ProductTourStep {
 
 export interface ProductTourConditions {
     url?: string
-    urlMatchType?: 'exact' | 'contains' | 'regex'
+    urlMatchType?: PropertyMatchType
     selector?: string
 }
 


### PR DESCRIPTION
## Problem

product tours had custom url logic for no reason

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

updates to use the same URL matching logic as surveys

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->