### PR TITLE
fix(replay): update to use non-deprecated masking function, fallback to deprecated

### DIFF
--- a/.changeset/short-doodles-yawn.md
+++ b/.changeset/short-doodles-yawn.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Update which network masking function usage

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -3223,4 +3223,173 @@ describe('Lazy SessionRecording', () => {
             })
         })
     })
+
+    describe('URL masking with maskCapturedNetworkRequestFn', () => {
+        it('uses maskCapturedNetworkRequestFn to mask page URLs when configured', () => {
+            const maskFn = jest.fn((data) => {
+                // CapturedNetworkRequest uses 'name' for the URL
+                if (data.name) {
+                    return { ...data, name: data.name.replace(/token=[^&]+/, 'token=[REDACTED]') }
+                }
+                return data
+            })
+
+            posthog.config.session_recording.maskCapturedNetworkRequestFn = maskFn
+
+            addRRwebToWindow()
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: { endpoint: '/s/' },
+                })
+            )
+            sessionRecording['_onScriptLoaded']()
+
+            // Emit a meta event with a URL containing a sensitive token
+            _emit(
+                createMetaSnapshot({
+                    data: { href: 'https://example.com/?token=secret123&other=value' },
+                })
+            )
+
+            // Verify the masking function was called with 'name' property
+            expect(maskFn).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    name: 'https://example.com/?token=secret123&other=value',
+                })
+            )
+
+            // Verify the URL was masked in the captured snapshot
+            expect(posthog.capture).toHaveBeenCalledWith(
+                '$snapshot',
+                expect.objectContaining({
+                    $snapshot_data: expect.objectContaining({
+                        data: expect.objectContaining({
+                            href: 'https://example.com/?token=[REDACTED]&other=value',
+                        }),
+                    }),
+                })
+            )
+        })
+
+        it('falls back to deprecated maskNetworkRequestFn when maskCapturedNetworkRequestFn is not set', () => {
+            const deprecatedMaskFn = jest.fn((data) => {
+                if (data.url) {
+                    return { ...data, url: data.url.replace(/token=[^&]+/, 'token=[REDACTED]') }
+                }
+                return data
+            })
+
+            posthog.config.session_recording.maskNetworkRequestFn = deprecatedMaskFn
+
+            addRRwebToWindow()
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: { endpoint: '/s/' },
+                })
+            )
+            sessionRecording['_onScriptLoaded']()
+
+            // Emit a meta event with a URL containing a sensitive token
+            _emit(
+                createMetaSnapshot({
+                    data: { href: 'https://example.com/?token=secret123' },
+                })
+            )
+
+            // Verify the deprecated masking function was called
+            expect(deprecatedMaskFn).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    url: 'https://example.com/?token=secret123',
+                })
+            )
+
+            // Verify the URL was masked
+            expect(posthog.capture).toHaveBeenCalledWith(
+                '$snapshot',
+                expect.objectContaining({
+                    $snapshot_data: expect.objectContaining({
+                        data: expect.objectContaining({
+                            href: 'https://example.com/?token=[REDACTED]',
+                        }),
+                    }),
+                })
+            )
+        })
+
+        it('prefers maskCapturedNetworkRequestFn over deprecated maskNetworkRequestFn', () => {
+            const newMaskFn = jest.fn((data) => ({ ...data, name: 'masked-by-new' }))
+            const deprecatedMaskFn = jest.fn((data) => ({ ...data, url: 'masked-by-deprecated' }))
+
+            posthog.config.session_recording.maskCapturedNetworkRequestFn = newMaskFn
+            posthog.config.session_recording.maskNetworkRequestFn = deprecatedMaskFn
+
+            addRRwebToWindow()
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: { endpoint: '/s/' },
+                })
+            )
+            sessionRecording['_onScriptLoaded']()
+
+            _emit(
+                createMetaSnapshot({
+                    data: { href: 'https://example.com/?token=secret' },
+                })
+            )
+
+            // Should only call the new function, not the deprecated one
+            expect(newMaskFn).toHaveBeenCalled()
+            expect(deprecatedMaskFn).not.toHaveBeenCalled()
+
+            // Should use the result from the new function
+            expect(posthog.capture).toHaveBeenCalledWith(
+                '$snapshot',
+                expect.objectContaining({
+                    $snapshot_data: expect.objectContaining({
+                        data: expect.objectContaining({
+                            href: 'masked-by-new',
+                        }),
+                    }),
+                })
+            )
+        })
+
+        it('supports backward compatibility when maskCapturedNetworkRequestFn returns url instead of name', () => {
+            // Some users might check 'url' property instead of 'name'
+            const maskFn = jest.fn((data) => {
+                if (data.url) {
+                    return { ...data, url: data.url.replace(/token=[^&]+/, 'token=[REDACTED]') }
+                }
+                return data
+            })
+
+            posthog.config.session_recording.maskCapturedNetworkRequestFn = maskFn
+
+            addRRwebToWindow()
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: { endpoint: '/s/' },
+                })
+            )
+            sessionRecording['_onScriptLoaded']()
+
+            _emit(
+                createMetaSnapshot({
+                    data: { href: 'https://example.com/?token=secret123' },
+                })
+            )
+
+            // Should still work by checking the 'url' property as fallback
+            expect(posthog.capture).toHaveBeenCalledWith(
+                '$snapshot',
+                expect.objectContaining({
+                    $snapshot_data: expect.objectContaining({
+                        data: expect.objectContaining({
+                            href: 'https://example.com/?token=[REDACTED]',
+                        }),
+                    }),
+                })
+            )
+        })
+    })
 })

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -502,14 +502,17 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     private _maskUrl(url: string): string | undefined {
         const userSessionRecordingOptions = this._instance.config.session_recording
 
-        if (userSessionRecordingOptions.maskNetworkRequestFn) {
+        // userSessionRecordingOptions.maskNetworkRequestFn is deprecated, fallback to it
+        const maskFn =
+            userSessionRecordingOptions.maskCapturedNetworkRequestFn ||
+            userSessionRecordingOptions.maskNetworkRequestFn
+
+        if (maskFn) {
             let networkRequest: NetworkRequest | null | undefined = {
                 url,
             }
 
-            // TODO we should deprecate this and use the same function for this masking and the rrweb/network plugin
-            // TODO or deprecate this and provide a new clearer name so this would be `maskURLPerformanceFn` or similar
-            networkRequest = userSessionRecordingOptions.maskNetworkRequestFn(networkRequest)
+            networkRequest = maskFn(networkRequest as any)
 
             return networkRequest?.url
         }

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -503,18 +503,19 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         const userSessionRecordingOptions = this._instance.config.session_recording
 
         // userSessionRecordingOptions.maskNetworkRequestFn is deprecated, fallback to it
-        const maskFn =
-            userSessionRecordingOptions.maskCapturedNetworkRequestFn ||
-            userSessionRecordingOptions.maskNetworkRequestFn
+        if (userSessionRecordingOptions.maskCapturedNetworkRequestFn) {
+            const result = userSessionRecordingOptions.maskCapturedNetworkRequestFn({
+                name: url,
+            } as any)
+            // CapturedNetworkRequest uses 'name' for URL, but also check 'url' for compatibility
+            return result?.name ?? (result as any)?.url
+        }
 
-        if (maskFn) {
-            let networkRequest: NetworkRequest | null | undefined = {
+        if (userSessionRecordingOptions.maskNetworkRequestFn) {
+            const result = userSessionRecordingOptions.maskNetworkRequestFn({
                 url,
-            }
-
-            networkRequest = maskFn(networkRequest as any)
-
-            return networkRequest?.url
+            })
+            return result?.url
         }
 
         return url

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -62,7 +62,6 @@ import { PostHog } from '../../../posthog-core'
 import {
     CaptureResult,
     NetworkRecordOptions,
-    NetworkRequest,
     Properties,
     SessionIdChangedCallback,
     SessionRecordingOptions,


### PR DESCRIPTION
## Problem

ticket: https://posthoghelp.zendesk.com/agent/tickets/44023 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/48976)
gh issue: https://github.com/PostHog/posthog-js/issues/2332

## Changes

use new masking function, fallback to depreacted one for backwards compatibility

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
