### PR TITLE
feat(node): support $anon_distinct_id for identify methods

### DIFF
--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -439,7 +439,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     const eventProperties = {
       $set: setProps,
       $set_once: setOnceProps,
-      $anon_distinct_id: $anon_distinct_id || undefined,
+      $anon_distinct_id: $anon_distinct_id ?? undefined,
     }
     super.identifyStateless(distinctId, eventProperties, { disableGeoip })
   }


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C03P7NL6RMW/p1765511633103549

## Changes

Identify can be called like this now:
```
client.identify({
  distinctId: 'foo',
  properties: {
    $anon_distinct_id: 'bar',
  },
})
```

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
