### PR TITLE
feat(surveys): support event property filters in react-native

### DIFF
--- a/.changeset/full-ducks-wait.md
+++ b/.changeset/full-ducks-wait.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': minor
+---
+
+support event property filters on surveys

--- a/packages/react-native/src/surveys/surveys-utils.ts
+++ b/packages/react-native/src/surveys/surveys-utils.ts
@@ -9,13 +9,93 @@ import {
   SurveyAppearance,
   SurveyPosition,
   SurveyQuestionDescriptionContentType,
+  SurveyMatchType,
 } from '@posthog/core'
 
-/**
- * Utility function to check if some value is an integer
- * @param value The value to check
- * @returns Truthy if the value is an integer
- */
+// Extended operator type to include numeric operators not in core SurveyMatchType
+export type PropertyOperator = SurveyMatchType | 'gt' | 'lt'
+
+export type PropertyFilters = {
+  [propertyName: string]: {
+    values: string[]
+    operator: PropertyOperator
+  }
+}
+
+export interface SurveyEventWithFilters {
+  name: string
+  propertyFilters?: PropertyFilters
+}
+
+const isValidRegex = (str: string): boolean => {
+  try {
+    new RegExp(str)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const isMatchingRegex = (value: string, pattern: string): boolean => {
+  if (!isValidRegex(pattern)) {
+    return false
+  }
+  try {
+    return new RegExp(pattern).test(value)
+  } catch {
+    return false
+  }
+}
+
+export const surveyValidationMap: Record<PropertyOperator, (targets: string[], values: string[]) => boolean> = {
+  [SurveyMatchType.Icontains]: (targets, values) =>
+    values.some((value) => targets.some((target) => value.toLowerCase().includes(target.toLowerCase()))),
+  [SurveyMatchType.NotIcontains]: (targets, values) =>
+    values.every((value) => targets.every((target) => !value.toLowerCase().includes(target.toLowerCase()))),
+  [SurveyMatchType.Regex]: (targets, values) =>
+    values.some((value) => targets.some((target) => isMatchingRegex(value, target))),
+  [SurveyMatchType.NotRegex]: (targets, values) =>
+    values.every((value) => targets.every((target) => !isMatchingRegex(value, target))),
+  [SurveyMatchType.Exact]: (targets, values) => values.some((value) => targets.some((target) => value === target)),
+  [SurveyMatchType.IsNot]: (targets, values) => values.every((value) => targets.every((target) => value !== target)),
+  gt: (targets, values) =>
+    values.some((value) => {
+      const numValue = parseFloat(value)
+      return !isNaN(numValue) && targets.some((t) => numValue > parseFloat(t))
+    }),
+  lt: (targets, values) =>
+    values.some((value) => {
+      const numValue = parseFloat(value)
+      return !isNaN(numValue) && targets.some((t) => numValue < parseFloat(t))
+    }),
+}
+
+export function matchPropertyFilters(
+  propertyFilters: PropertyFilters | undefined,
+  eventProperties: Record<string, unknown> | undefined
+): boolean {
+  if (!propertyFilters) {
+    return true
+  }
+
+  return Object.entries(propertyFilters).every(([propertyName, filter]) => {
+    const eventPropertyValue = eventProperties?.[propertyName]
+
+    if (eventPropertyValue === undefined || eventPropertyValue === null) {
+      return false
+    }
+
+    const values = [String(eventPropertyValue)]
+
+    const comparisonFunction = surveyValidationMap[filter.operator]
+    if (!comparisonFunction) {
+      return false
+    }
+
+    return comparisonFunction(filter.values, values)
+  })
+}
+
 function isInteger(value: unknown): boolean {
   return typeof value === 'number' && Number.isInteger(value)
 }

--- a/packages/react-native/test/matchPropertyFilters.spec.ts
+++ b/packages/react-native/test/matchPropertyFilters.spec.ts
@@ -1,0 +1,234 @@
+import { matchPropertyFilters, PropertyFilters } from '../src/surveys/surveys-utils'
+import { SurveyMatchType } from '@posthog/core'
+
+describe('matchPropertyFilters', () => {
+  describe('when no property filters are defined', () => {
+    it('returns true with undefined filters', () => {
+      expect(matchPropertyFilters(undefined, { some_prop: 'value' })).toBe(true)
+    })
+
+    it('returns true with empty filters object', () => {
+      expect(matchPropertyFilters({}, { some_prop: 'value' })).toBe(true)
+    })
+
+    it('returns true with undefined event properties', () => {
+      expect(matchPropertyFilters(undefined, undefined)).toBe(true)
+    })
+  })
+
+  describe('exact operator', () => {
+    const filters: PropertyFilters = {
+      product_type: { values: ['premium'], operator: SurveyMatchType.Exact },
+    }
+
+    it('matches when property value equals target', () => {
+      expect(matchPropertyFilters(filters, { product_type: 'premium' })).toBe(true)
+    })
+
+    it('does not match when property value differs', () => {
+      expect(matchPropertyFilters(filters, { product_type: 'basic' })).toBe(false)
+    })
+
+    it('does not match when property is missing', () => {
+      expect(matchPropertyFilters(filters, { other_prop: 'value' })).toBe(false)
+    })
+
+    it('does not match when property is null', () => {
+      expect(matchPropertyFilters(filters, { product_type: null })).toBe(false)
+    })
+
+    it('does not match when property is undefined', () => {
+      expect(matchPropertyFilters(filters, { product_type: undefined })).toBe(false)
+    })
+
+    it('matches any value in the values array', () => {
+      const multiValueFilters: PropertyFilters = {
+        status: { values: ['active', 'pending'], operator: SurveyMatchType.Exact },
+      }
+      expect(matchPropertyFilters(multiValueFilters, { status: 'active' })).toBe(true)
+      expect(matchPropertyFilters(multiValueFilters, { status: 'pending' })).toBe(true)
+      expect(matchPropertyFilters(multiValueFilters, { status: 'inactive' })).toBe(false)
+    })
+  })
+
+  describe('is_not operator', () => {
+    const filters: PropertyFilters = {
+      product_type: { values: ['basic'], operator: SurveyMatchType.IsNot },
+    }
+
+    it('matches when property value is not the target', () => {
+      expect(matchPropertyFilters(filters, { product_type: 'premium' })).toBe(true)
+    })
+
+    it('does not match when property value equals target', () => {
+      expect(matchPropertyFilters(filters, { product_type: 'basic' })).toBe(false)
+    })
+
+    it('does not match when property is missing', () => {
+      expect(matchPropertyFilters(filters, { other_prop: 'value' })).toBe(false)
+    })
+
+    it('must not equal any value in the values array', () => {
+      const multiValueFilters: PropertyFilters = {
+        status: { values: ['deleted', 'archived'], operator: SurveyMatchType.IsNot },
+      }
+      expect(matchPropertyFilters(multiValueFilters, { status: 'active' })).toBe(true)
+      expect(matchPropertyFilters(multiValueFilters, { status: 'deleted' })).toBe(false)
+      expect(matchPropertyFilters(multiValueFilters, { status: 'archived' })).toBe(false)
+    })
+  })
+
+  describe('icontains operator', () => {
+    const filters: PropertyFilters = {
+      query: { values: ['product'], operator: SurveyMatchType.Icontains },
+    }
+
+    it('matches when property contains target (case insensitive)', () => {
+      expect(matchPropertyFilters(filters, { query: 'new product features' })).toBe(true)
+      expect(matchPropertyFilters(filters, { query: 'NEW PRODUCT FEATURES' })).toBe(true)
+      expect(matchPropertyFilters(filters, { query: 'Product' })).toBe(true)
+    })
+
+    it('does not match when property does not contain target', () => {
+      expect(matchPropertyFilters(filters, { query: 'something else' })).toBe(false)
+    })
+  })
+
+  describe('not_icontains operator', () => {
+    const filters: PropertyFilters = {
+      query: { values: ['spam'], operator: SurveyMatchType.NotIcontains },
+    }
+
+    it('matches when property does not contain target', () => {
+      expect(matchPropertyFilters(filters, { query: 'legitimate content' })).toBe(true)
+    })
+
+    it('does not match when property contains target (case insensitive)', () => {
+      expect(matchPropertyFilters(filters, { query: 'this is SPAM' })).toBe(false)
+      expect(matchPropertyFilters(filters, { query: 'spam message' })).toBe(false)
+    })
+  })
+
+  describe('regex operator', () => {
+    const filters: PropertyFilters = {
+      url: { values: ['^/app/.*'], operator: SurveyMatchType.Regex },
+    }
+
+    it('matches when property matches regex pattern', () => {
+      expect(matchPropertyFilters(filters, { url: '/app/dashboard' })).toBe(true)
+      expect(matchPropertyFilters(filters, { url: '/app/settings/profile' })).toBe(true)
+    })
+
+    it('does not match when property does not match regex', () => {
+      expect(matchPropertyFilters(filters, { url: '/home' })).toBe(false)
+      expect(matchPropertyFilters(filters, { url: '/other/app/path' })).toBe(false)
+    })
+
+    it('handles invalid regex gracefully', () => {
+      const invalidRegexFilters: PropertyFilters = {
+        value: { values: ['[invalid(regex'], operator: SurveyMatchType.Regex },
+      }
+      expect(matchPropertyFilters(invalidRegexFilters, { value: 'test' })).toBe(false)
+    })
+  })
+
+  describe('not_regex operator', () => {
+    const filters: PropertyFilters = {
+      email: { values: ['.*@test\\.com$'], operator: SurveyMatchType.NotRegex },
+    }
+
+    it('matches when property does not match regex pattern', () => {
+      expect(matchPropertyFilters(filters, { email: 'user@example.com' })).toBe(true)
+    })
+
+    it('does not match when property matches regex', () => {
+      expect(matchPropertyFilters(filters, { email: 'user@test.com' })).toBe(false)
+    })
+  })
+
+  describe('multiple property filters', () => {
+    const filters: PropertyFilters = {
+      product_type: { values: ['premium'], operator: SurveyMatchType.Exact },
+      amount: { values: ['100'], operator: SurveyMatchType.IsNot },
+    }
+
+    it('matches when all filters pass', () => {
+      expect(matchPropertyFilters(filters, { product_type: 'premium', amount: '200' })).toBe(true)
+    })
+
+    it('does not match when first filter fails', () => {
+      expect(matchPropertyFilters(filters, { product_type: 'basic', amount: '200' })).toBe(false)
+    })
+
+    it('does not match when second filter fails', () => {
+      expect(matchPropertyFilters(filters, { product_type: 'premium', amount: '100' })).toBe(false)
+    })
+
+    it('does not match when any property is missing', () => {
+      expect(matchPropertyFilters(filters, { product_type: 'premium' })).toBe(false)
+      expect(matchPropertyFilters(filters, { amount: '200' })).toBe(false)
+    })
+  })
+
+  describe('type coercion', () => {
+    it('converts number property values to strings', () => {
+      const filters: PropertyFilters = {
+        count: { values: ['5'], operator: SurveyMatchType.Exact },
+      }
+      expect(matchPropertyFilters(filters, { count: 5 })).toBe(true)
+    })
+
+    it('converts boolean property values to strings', () => {
+      const filters: PropertyFilters = {
+        enabled: { values: ['true'], operator: SurveyMatchType.Exact },
+      }
+      expect(matchPropertyFilters(filters, { enabled: true })).toBe(true)
+    })
+  })
+
+  describe('gt operator (numeric)', () => {
+    const filters: PropertyFilters = {
+      amount: { values: ['5'], operator: 'gt' },
+    }
+
+    it('matches when numeric value is greater than target', () => {
+      expect(matchPropertyFilters(filters, { amount: 10 })).toBe(true)
+      expect(matchPropertyFilters(filters, { amount: 6 })).toBe(true)
+      expect(matchPropertyFilters(filters, { amount: '10' })).toBe(true)
+    })
+
+    it('does not match when numeric value equals target', () => {
+      expect(matchPropertyFilters(filters, { amount: 5 })).toBe(false)
+    })
+
+    it('does not match when numeric value is less than target', () => {
+      expect(matchPropertyFilters(filters, { amount: 3 })).toBe(false)
+      expect(matchPropertyFilters(filters, { amount: 0 })).toBe(false)
+    })
+
+    it('does not match for non-numeric values', () => {
+      expect(matchPropertyFilters(filters, { amount: 'not a number' })).toBe(false)
+    })
+  })
+
+  describe('lt operator (numeric)', () => {
+    const filters: PropertyFilters = {
+      amount: { values: ['10'], operator: 'lt' },
+    }
+
+    it('matches when numeric value is less than target', () => {
+      expect(matchPropertyFilters(filters, { amount: 5 })).toBe(true)
+      expect(matchPropertyFilters(filters, { amount: 0 })).toBe(true)
+      expect(matchPropertyFilters(filters, { amount: '3' })).toBe(true)
+    })
+
+    it('does not match when numeric value equals target', () => {
+      expect(matchPropertyFilters(filters, { amount: 10 })).toBe(false)
+    })
+
+    it('does not match when numeric value is greater than target', () => {
+      expect(matchPropertyFilters(filters, { amount: 15 })).toBe(false)
+      expect(matchPropertyFilters(filters, { amount: 100 })).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Problem

react-native sdk does not support survey event triggers with filtering on event properties. this was recently added to the js sdk.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

adds event property filter support for surveys triggered by events

| before - survey set to render if my_prop > 5 | after - survey display if paid_bill > 5 |
| --- | --- |
| [survey-demo-no-filters.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/4c4d4a0d-6cfc-4a63-b0ba-4a751c3d3e6d.mp4" />](https://app.graphite.com/user-attachments/video/4c4d4a0d-6cfc-4a63-b0ba-4a751c3d3e6d.mp4)<br> | [survey-rn-demo-with-filters.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/9e978b31-0090-423a-9c08-83cb8bcf0458.mp4" />](https://app.graphite.com/user-attachments/video/9e978b31-0090-423a-9c08-83cb8bcf0458.mp4)<br> |

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->