### PR TITLE
fix(surveys): support gt/lt operator in event filters

### DIFF
--- a/.changeset/plenty-things-listen.md
+++ b/.changeset/plenty-things-listen.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+support lt/gt operator in survey event property filters

--- a/packages/browser/src/__tests__/utils/survey-event-receiver.test.ts
+++ b/packages/browser/src/__tests__/utils/survey-event-receiver.test.ts
@@ -363,6 +363,36 @@ describe('survey-event-receiver', () => {
             registeredHook('purchase', createEventPayload('purchase', { any_prop: 'any_value' }))
             expect(surveyEventReceiver.getSurveys()).toContain('no-filters-test')
         })
+
+        it('activates survey with gt (greater than) numeric property match', () => {
+            const survey = createSurveyWithPropertyFilters('gt-test', 'purchase', {
+                amount: { values: ['100'], operator: 'gt' },
+            })
+
+            const surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register([survey])
+            const registeredHook = mockAddCaptureHook.mock.calls[0][0]
+
+            ;(instance.getSurveys as jest.Mock).mockImplementation((callback) => callback([survey]))
+
+            registeredHook('purchase', createEventPayload('purchase', { amount: 150 }))
+            expect(surveyEventReceiver.getSurveys()).toContain('gt-test')
+        })
+
+        it('activates survey with lt (less than) numeric property match', () => {
+            const survey = createSurveyWithPropertyFilters('lt-test', 'purchase', {
+                amount: { values: ['100'], operator: 'lt' },
+            })
+
+            const surveyEventReceiver = new SurveyEventReceiver(instance)
+            surveyEventReceiver.register([survey])
+            const registeredHook = mockAddCaptureHook.mock.calls[0][0]
+
+            ;(instance.getSurveys as jest.Mock).mockImplementation((callback) => callback([survey]))
+
+            registeredHook('purchase', createEventPayload('purchase', { amount: 50 }))
+            expect(surveyEventReceiver.getSurveys()).toContain('lt-test')
+        })
     })
 
     describe('action based surveys', () => {

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -11,10 +11,13 @@ export enum SurveyEventType {
     Cancellation = 'cancelEvents',
 }
 
+// Extended operator type to include numeric operators not in PropertyMatchType
+export type PropertyOperator = PropertyMatchType | 'gt' | 'lt'
+
 export type PropertyFilters = {
     [propertyName: string]: {
         values: string[]
-        operator: PropertyMatchType
+        operator: PropertyOperator
     }
 }
 


### PR DESCRIPTION
## Problem

web sdk supports triggering surveys from events with property filters, but it's missing support for lt/gt

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

adds support for lt/gt

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->