### PR TITLE
feat(product tours): click element to advance to next step

### DIFF
--- a/.changeset/late-pianos-share.md
+++ b/.changeset/late-pianos-share.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+product tours: enable click-element-to-progress steps

--- a/packages/browser/src/extensions/product-tours/components/ProductTourTooltip.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourTooltip.tsx
@@ -240,6 +240,14 @@ export function ProductTourTooltip({
         e.stopPropagation()
     }
 
+    const handleSpotlightClick = (e: MouseEvent) => {
+        e.stopPropagation()
+        if (targetElement) {
+            targetElement.click()
+        }
+        onNext()
+    }
+
     const isLastStep = displayedStepIndex >= totalSteps - 1
     const isFirstStep = displayedStepIndex === 0
 
@@ -295,6 +303,7 @@ export function ProductTourTooltip({
                                     Back
                                 </button>
                             )}
+                            {/* modal steps cannot have action triggers, so we always show the next/done button */}
                             <button class="ph-tour-button ph-tour-button--primary" onClick={onNext}>
                                 {isLastStep ? 'Done' : 'Next'}
                             </button>
@@ -322,16 +331,21 @@ export function ProductTourTooltip({
 
             <div
                 class="ph-tour-spotlight"
-                style={
-                    isVisible && spotlightStyle
+                style={{
+                    ...(isVisible && spotlightStyle
                         ? spotlightStyle
                         : {
                               top: '50%',
                               left: '50%',
                               width: '0px',
                               height: '0px',
-                          }
-                }
+                          }),
+                    ...(displayedStep.progressionTrigger === 'click' && {
+                        pointerEvents: 'auto',
+                        cursor: 'pointer',
+                    }),
+                }}
+                onClick={displayedStep.progressionTrigger === 'click' ? handleSpotlightClick : undefined}
             />
 
             <div
@@ -367,9 +381,11 @@ export function ProductTourTooltip({
                                 Back
                             </button>
                         )}
-                        <button class="ph-tour-button ph-tour-button--primary" onClick={onNext}>
-                            {isLastStep ? 'Done' : 'Next'}
-                        </button>
+                        {displayedStep.progressionTrigger === 'button' && (
+                            <button class="ph-tour-button ph-tour-button--primary" onClick={onNext}>
+                                {isLastStep ? 'Done' : 'Next'}
+                            </button>
+                        )}
                     </div>
                 </div>
 

--- a/packages/browser/src/extensions/product-tours/product-tours-utils.ts
+++ b/packages/browser/src/extensions/product-tours/product-tours-utils.ts
@@ -209,6 +209,10 @@ export function renderTipTapContent(content: any): string {
     }
 }
 
+export function normalizeUrl(url: string): string {
+    return url.endsWith('/') ? url.slice(0, -1) : url
+}
+
 function escapeHtml(text: string): string {
     const div = document.createElement('div')
     div.textContent = text

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -26,6 +26,7 @@ export interface ProductTourSurveyQuestion {
 export interface ProductTourStep {
     id: string
     selector?: string
+    progressionTrigger: 'button' | 'click'
     content: JSONContent | null
     /** Inline survey question config - if present, this is a survey step */
     survey?: ProductTourSurveyQuestion
@@ -88,4 +89,9 @@ export const DEFAULT_PRODUCT_TOUR_APPEARANCE: Required<ProductTourAppearance> = 
     borderRadius: 8,
     borderColor: '#e5e7eb',
     whiteLabel: false,
+}
+
+export interface ShowTourOptions {
+    reason?: ProductTourRenderReason
+    enableStrictValidation?: boolean
 }

--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -12,6 +12,7 @@ export default function Home() {
     const flags = useActiveFeatureFlags()
 
     const [time, setTime] = useState('')
+    const [modalOpen, setModalOpen] = useState(false)
     const consentGiven = cookieConsentGiven()
 
     useEffect(() => {
@@ -112,7 +113,42 @@ export default function Home() {
                 <button onClick={() => posthog?.reset()} id="set-user-properties">
                     Reset
                 </button>
+                <button onClick={() => setModalOpen(true)}>Open Modal</button>
             </div>
+
+            {modalOpen && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        backgroundColor: 'rgba(0,0,0,0.5)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        zIndex: 1000,
+                    }}
+                    onClick={() => setModalOpen(false)}
+                >
+                    <div
+                        style={{
+                            backgroundColor: 'white',
+                            padding: '24px',
+                            borderRadius: '8px',
+                        }}
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <h3>Modal</h3>
+                        <button data-attr="surprise-modal-button">Button inside modal</button>
+                        <br />
+                        <button onClick={() => setModalOpen(false)} style={{ marginTop: '12px' }}>
+                            Close
+                        </button>
+                    </div>
+                </div>
+            )}
 
             {isClient && (
                 <>


### PR DESCRIPTION
## Problem

product tours only support progression through a "next" button, which means you cannot build a tour that requires any user interaction (e.g. opening a drawer or modal, etc)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

adds support for a new `click`\-type trigger that will progress the tour when the target element is clicked. after click, the tour waits up to 2s for the next step's element to be visible.

also:

- removes the strict validation that "all elements must be in the dom at tour start"
- adds URL "normalization" to strip trailing slashes when the operator is `exact` (PR to add this note in main repo coming soon)

[product-tour-click-action.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/47ac12a5-4f73-4e73-af8b-035c909da6ff.mp4" />](https://app.graphite.com/user-attachments/video/47ac12a5-4f73-4e73-af8b-035c909da6ff.mp4)



<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->