### PR TITLE
feat(surveys): emit survey abandoned event

### DIFF
--- a/.changeset/pretty-dragons-care.md
+++ b/.changeset/pretty-dragons-care.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+emit new "survey abandoned" event on pageleave

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -882,6 +882,8 @@ export class PostHog {
     }
 
     _handle_unload(): void {
+        this.surveys.handlePageUnload()
+
         if (!this.config.request_batching) {
             if (this._shouldCapturePageleave()) {
                 this.capture('$pageleave', null, { transport: 'sendBeacon' })

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -291,6 +291,7 @@ export enum SurveyEventName {
     SHOWN = 'survey shown',
     DISMISSED = 'survey dismissed',
     SENT = 'survey sent',
+    ABANDONED = 'survey abandoned',
 }
 
 export enum SurveyEventProperties {

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -407,4 +407,8 @@ export class PostHogSurveys {
         }
         this._surveyManager.cancelSurvey(surveyId)
     }
+
+    handlePageUnload(): void {
+        this._surveyManager?.handlePageUnload()
+    }
 }

--- a/packages/browser/src/utils/survey-utils.ts
+++ b/packages/browser/src/utils/survey-utils.ts
@@ -17,6 +17,7 @@ export function doesSurveyActivateByAction(survey: Pick<Survey, 'conditions'>): 
 
 export const SURVEY_SEEN_PREFIX = 'seenSurvey_'
 export const SURVEY_IN_PROGRESS_PREFIX = 'inProgressSurvey_'
+export const SURVEY_ABANDONED_PREFIX = 'abandonedSurvey_'
 
 export const getSurveyInteractionProperty = (
     survey: Pick<Survey, 'id' | 'current_iteration'>,
@@ -30,13 +31,20 @@ export const getSurveyInteractionProperty = (
     return surveyProperty
 }
 
-export const getSurveySeenKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
-    let surveySeenKey = `${SURVEY_SEEN_PREFIX}${survey.id}`
+const getSurveyStorageKey = (prefix: string, survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
+    let key = `${prefix}${survey.id}`
     if (survey.current_iteration && survey.current_iteration > 0) {
-        surveySeenKey = `${SURVEY_SEEN_PREFIX}${survey.id}_${survey.current_iteration}`
+        key = `${prefix}${survey.id}_${survey.current_iteration}`
     }
+    return key
+}
 
-    return surveySeenKey
+export const getSurveySeenKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
+    return getSurveyStorageKey(SURVEY_SEEN_PREFIX, survey)
+}
+
+export const getSurveyAbandonedKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {
+    return getSurveyStorageKey(SURVEY_ABANDONED_PREFIX, survey)
 }
 
 export const setSurveySeenOnLocalStorage = (survey: Pick<Survey, 'id' | 'current_iteration'>) => {


### PR DESCRIPTION
## Problem

for surveys with partial responses enabled, there's no good way to know "the user is definitely done with this survey". examples:

1. :white_check_mark: user completes the whole thing
    1. listen for `survey sent` where complete=true
2. :white_check_mark: user dismisses after completing some of it
    1. listen for `survey dismissed` where partially complete = true
3. :x: user completes some, then closes the browser
    1. no event here! you'd have to build custom logic with timeouts or tie into pageleaves or something

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

emits a new `survey abandoned` event that can fill the gap

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->