### PR TITLE
feat: allow customizing text color on surveys

### DIFF
--- a/.changeset/shaggy-numbers-dream.md
+++ b/.changeset/shaggy-numbers-dream.md
@@ -1,0 +1,7 @@
+---
+'posthog-react-native': minor
+'posthog-js': minor
+'@posthog/core': minor
+---
+
+feat: allow customizing text colors on web and react native

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -120,34 +120,34 @@ export const addSurveyCSSVariablesToElement = (
         appearance?.submitButtonTextColor || getContrastingTextColor(effectiveAppearance.submitButtonColor)
     )
     hostStyle.setProperty('--ph-survey-rating-bg-color', effectiveAppearance.ratingButtonColor)
-    hostStyle.setProperty(
-        '--ph-survey-rating-text-color',
-        getContrastingTextColor(effectiveAppearance.ratingButtonColor)
-    )
     hostStyle.setProperty('--ph-survey-rating-active-bg-color', effectiveAppearance.ratingButtonActiveColor)
+    // Active rating text is always auto-calculated for contrast with active background
     hostStyle.setProperty(
         '--ph-survey-rating-active-text-color',
         getContrastingTextColor(effectiveAppearance.ratingButtonActiveColor)
     )
+    // Primary text color: use override if provided, otherwise auto-calculate from background
     hostStyle.setProperty(
         '--ph-survey-text-primary-color',
-        getContrastingTextColor(effectiveAppearance.backgroundColor)
+        appearance?.textColor || getContrastingTextColor(effectiveAppearance.backgroundColor)
     )
     hostStyle.setProperty('--ph-survey-text-subtle-color', effectiveAppearance.textSubtleColor)
     hostStyle.setProperty('--ph-widget-color', effectiveAppearance.widgetColor)
     hostStyle.setProperty('--ph-widget-text-color', getContrastingTextColor(effectiveAppearance.widgetColor))
     hostStyle.setProperty('--ph-widget-z-index', effectiveAppearance.zIndex)
 
-    // Use user-provided inputBackgroundColor, or fallback to internal default (with slight adjustment for white backgrounds)
-    let inputBgColor = appearance?.inputBackgroundColor || effectiveAppearance.inputBackground
-    if (!appearance?.inputBackgroundColor && effectiveAppearance.backgroundColor === 'white') {
+    // Use user-provided inputBackground (or deprecated inputBackgroundColor for backwards compat)
+    // Fallback to internal default, with slight adjustment for white backgrounds
+    const userInputBg = appearance?.inputBackground || appearance?.inputBackgroundColor
+    let inputBgColor = userInputBg || effectiveAppearance.inputBackground
+    if (!userInputBg && effectiveAppearance.backgroundColor === 'white') {
         inputBgColor = '#f8f8f8'
     }
     hostStyle.setProperty('--ph-survey-input-background', inputBgColor)
-    hostStyle.setProperty(
-        '--ph-survey-input-text-color',
-        appearance?.inputTextColor || getContrastingTextColor(inputBgColor)
-    )
+    // Input text color applies to both text inputs and inactive rating buttons
+    const inputTextColor = appearance?.inputTextColor || getContrastingTextColor(inputBgColor)
+    hostStyle.setProperty('--ph-survey-input-text-color', inputTextColor)
+    hostStyle.setProperty('--ph-survey-rating-text-color', inputTextColor)
     hostStyle.setProperty('--ph-survey-scrollbar-thumb-color', effectiveAppearance.scrollbarThumbColor)
     hostStyle.setProperty('--ph-survey-scrollbar-track-color', effectiveAppearance.scrollbarTrackColor)
     hostStyle.setProperty('--ph-survey-outline-color', effectiveAppearance.outlineColor)

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { PropertyMatchType } from './types'
+import type { SurveyAppearance as CoreSurveyAppearance } from '@posthog/core'
 
 export enum SurveyEventType {
     Activation = 'events',
@@ -52,47 +53,26 @@ export enum SurveyTabPosition {
     Bottom = 'bottom',
 }
 
-export interface SurveyAppearance {
-    // keep in sync with frontend/src/types.ts -> SurveyAppearance
-    backgroundColor?: string
-    submitButtonColor?: string
-    // text color is deprecated, use auto contrast text color instead
-    textColor?: string
-    // deprecate submit button text eventually
-    submitButtonText?: string
-    submitButtonTextColor?: string
+// Extends core SurveyAppearance with browser-specific fields
+// Omit 'position' from core because browser's SurveyPosition has additional values (e.g., NextToTrigger)
+export interface SurveyAppearance extends Omit<CoreSurveyAppearance, 'position'> {
+    // Browser-specific fields not in core
+    /** @deprecated - not currently used */
     descriptionTextColor?: string
-    ratingButtonColor?: string
-    ratingButtonActiveColor?: string
     ratingButtonHoverColor?: string
     whiteLabel?: boolean
-    autoDisappear?: boolean
-    displayThankYouMessage?: boolean
-    thankYouMessageHeader?: string
-    thankYouMessageDescription?: string
-    thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType
-    thankYouMessageCloseButtonText?: string
-    borderColor?: string
-    position?: SurveyPosition
     tabPosition?: SurveyTabPosition
-    placeholder?: string
-    shuffleQuestions?: boolean
-    surveyPopupDelaySeconds?: number
-    // widget options
-    widgetType?: SurveyWidgetType
-    widgetSelector?: string
-    widgetLabel?: string
-    widgetColor?: string
     fontFamily?: string
-    // questionable: Not in frontend/src/types.ts -> SurveyAppearance, but used in site app
     maxWidth?: string
     zIndex?: string
     disabledButtonOpacity?: string
     boxPadding?: string
-    inputTextColor?: string
+    /** @deprecated Use inputBackground instead (inherited from core) */
     inputBackgroundColor?: string
     // Hide the X (cancel) button - defaults to false (show the button)
     hideCancelButton?: boolean
+    // Browser's SurveyPosition has more options than core (e.g., NextToTrigger)
+    position?: SurveyPosition
 }
 
 export enum SurveyType {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -294,13 +294,18 @@ export type EvaluationReason = {
 export type SurveyAppearance = {
   // keep in sync with frontend/src/types.ts -> SurveyAppearance
   backgroundColor?: string
+  // Optional override for main survey text color. If not set, auto-calculated from backgroundColor.
+  textColor?: string
   submitButtonColor?: string
   // deprecate submit button text eventually
   submitButtonText?: string
+  // Optional override for submit button text color. If not set, auto-calculated from submitButtonColor.
   submitButtonTextColor?: string
   ratingButtonColor?: string
   ratingButtonActiveColor?: string
   inputBackground?: string
+  // Optional override for input and rating button text color. If not set, auto-calculated from inputBackground.
+  inputTextColor?: string
   autoDisappear?: boolean
   displayThankYouMessage?: boolean
   thankYouMessageHeader?: string

--- a/packages/react-native/src/surveys/components/QuestionHeader.tsx
+++ b/packages/react-native/src/surveys/components/QuestionHeader.tsx
@@ -20,7 +20,8 @@ export function QuestionHeader({
   descriptionContentType?: SurveyQuestionDescriptionContentType
   appearance: SurveyAppearanceTheme
 }): JSX.Element {
-  const textColor = getContrastingTextColor(appearance.backgroundColor)
+  // Use textColor override if provided, otherwise auto-calculate from background
+  const textColor = appearance.textColor ?? getContrastingTextColor(appearance.backgroundColor)
 
   return (
     <View style={styles.container}>

--- a/packages/react-native/src/surveys/components/QuestionTypes.tsx
+++ b/packages/react-native/src/surveys/components/QuestionTypes.tsx
@@ -61,7 +61,9 @@ export function OpenTextQuestion({
           numberOfLines={4}
           placeholder={appearance.placeholder}
           placeholderTextColor={
-            (appearance.inputTextColor ?? getContrastingTextColor(appearance.inputBackground)) === 'black'
+            getContrastingTextColor(
+              appearance.inputTextColor ?? getContrastingTextColor(appearance.inputBackground)
+            ) === 'white'
               ? 'rgba(0, 0, 0, 0.5)'
               : 'rgba(255, 255, 255, 0.5)'
           }

--- a/packages/react-native/src/surveys/components/QuestionTypes.tsx
+++ b/packages/react-native/src/surveys/components/QuestionTypes.tsx
@@ -54,14 +54,14 @@ export function OpenTextQuestion({
             styles.textInput,
             {
               backgroundColor: appearance.inputBackground,
-              color: getContrastingTextColor(appearance.inputBackground),
+              color: appearance.inputTextColor ?? getContrastingTextColor(appearance.inputBackground),
             },
           ]}
           multiline
           numberOfLines={4}
           placeholder={appearance.placeholder}
           placeholderTextColor={
-            getContrastingTextColor(appearance.inputBackground) === 'black'
+            (appearance.inputTextColor ?? getContrastingTextColor(appearance.inputBackground)) === 'black'
               ? 'rgba(0, 0, 0, 0.5)'
               : 'rgba(255, 255, 255, 0.5)'
           }
@@ -160,12 +160,18 @@ export function RatingQuestion({
         </View>
         <View style={styles.ratingText}>
           <Text
-            style={{ color: getContrastingTextColor(appearance.backgroundColor), opacity: defaultRatingLabelOpacity }}
+            style={{
+              color: appearance.textColor ?? getContrastingTextColor(appearance.backgroundColor),
+              opacity: defaultRatingLabelOpacity,
+            }}
           >
             {question.lowerBoundLabel}
           </Text>
           <Text
-            style={{ color: getContrastingTextColor(appearance.backgroundColor), opacity: defaultRatingLabelOpacity }}
+            style={{
+              color: appearance.textColor ?? getContrastingTextColor(appearance.backgroundColor),
+              opacity: defaultRatingLabelOpacity,
+            }}
           >
             {question.upperBoundLabel}
           </Text>
@@ -195,7 +201,10 @@ export function RatingButton({
   setActiveNumber: (num: number) => void
 }): JSX.Element {
   const backgroundColor = active ? appearance.ratingButtonActiveColor : appearance.ratingButtonColor
-  const textColor = getContrastingTextColor(backgroundColor)
+  // Active state always auto-calculates for contrast; inactive uses inputTextColor override if provided
+  const textColor = active
+    ? getContrastingTextColor(backgroundColor)
+    : (appearance.inputTextColor ?? getContrastingTextColor(backgroundColor))
 
   return (
     <TouchableOpacity
@@ -238,7 +247,7 @@ export function MultipleChoiceQuestion({
           const isOpenChoice = choice === openChoice
           const isSelected = selectedChoices.includes(choice)
 
-          const inputTextColor = getContrastingTextColor(appearance.inputBackground)
+          const choiceTextColor = appearance.inputTextColor ?? getContrastingTextColor(appearance.inputBackground)
 
           return (
             <Pressable
@@ -259,7 +268,7 @@ export function MultipleChoiceQuestion({
               }}
             >
               <View style={styles.choiceText}>
-                <Text style={{ flexGrow: 1, color: inputTextColor }}>
+                <Text style={{ flexGrow: 1, color: choiceTextColor }}>
                   {choice}
                   {isOpenChoice ? ':' : ''}
                 </Text>

--- a/packages/react-native/src/surveys/surveys-utils.ts
+++ b/packages/react-native/src/surveys/surveys-utils.ts
@@ -120,10 +120,14 @@ export const defaultBackgroundColor = '#eeeded' as const
 export const defaultDescriptionOpacity = 0.8
 export const defaultRatingLabelOpacity = 0.7
 
+// textColor and inputTextColor are optional overrides (auto-calculated if not provided)
 export type SurveyAppearanceTheme = Omit<
   Required<SurveyAppearance>,
-  'widgetSelector' | 'widgetType' | 'widgetColor' | 'widgetLabel' | 'shuffleQuestions'
->
+  'widgetSelector' | 'widgetType' | 'widgetColor' | 'widgetLabel' | 'shuffleQuestions' | 'textColor' | 'inputTextColor'
+> & {
+  textColor?: string
+  inputTextColor?: string
+}
 export const defaultSurveyAppearance: SurveyAppearanceTheme = {
   backgroundColor: defaultBackgroundColor,
   submitButtonColor: 'black',


### PR DESCRIPTION
## Problem

Survey appearance customization needs improvement to ensure consistent text contrast across different elements, particularly for rating buttons and text inputs.

## Changes

- Added support for consistent text color handling in surveys:
  - Rating button text now uses the same color as input text
  - Primary text color can be explicitly set or auto-calculated based on background
  - Active rating text color is always auto-calculated for proper contrast

Implemented the changes for both React Native and Web (posthog-js) and now began sharing more fields between them too.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)
- [x] posthog-react-native

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages