### PR TITLE
fix(surveys): only auto-submit on pageload for questoins with auto-submit enabled (hosted surveys)

### DIFF
--- a/.changeset/long-rivers-kneel.md
+++ b/.changeset/long-rivers-kneel.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+fix: hosted survey auto-submit behavior only submits skipped questions

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -789,6 +789,255 @@ describe('SurveyManager', () => {
             expect(result).toBe(true)
         })
     })
+
+    describe('URL prefill auto-submit behavior', () => {
+        let mockPostHog: PostHog
+        let surveyManager: SurveyManager
+        let originalLocation: Location
+
+        beforeEach(() => {
+            localStorage.clear()
+            jest.clearAllMocks()
+
+            originalLocation = window.location
+            delete (window as any).location
+            window.location = { ...originalLocation, search: '' } as Location
+
+            mockPostHog = createMockPostHog({
+                getActiveMatchingSurveys: jest.fn(),
+                get_session_replay_url: jest.fn(),
+                capture: jest.fn(),
+                featureFlags: {
+                    isFeatureEnabled: jest.fn().mockReturnValue(true),
+                },
+            })
+
+            surveyManager = new SurveyManager(mockPostHog)
+        })
+
+        afterEach(() => {
+            window.location = originalLocation
+        })
+
+        it('should auto-submit prefilled responses when skipSubmitButton is true and enable_partial_responses is true', () => {
+            const survey: Survey = {
+                id: 'prefill-survey',
+                name: 'Prefill Survey',
+                type: SurveyType.Popover,
+                enable_partial_responses: true,
+                questions: [
+                    {
+                        id: 'q1',
+                        type: SurveyQuestionType.Rating,
+                        question: 'Rate us',
+                        scale: 10,
+                        skipSubmitButton: true,
+                    },
+                    {
+                        id: 'q2',
+                        type: SurveyQuestionType.Open,
+                        question: 'Any feedback?',
+                    },
+                ],
+                appearance: {},
+                conditions: null,
+                start_date: '2021-01-01T00:00:00.000Z',
+                end_date: null,
+                current_iteration: null,
+                current_iteration_start_date: null,
+                feature_flag_keys: [],
+                linked_flag_key: null,
+                targeting_flag_key: null,
+                internal_targeting_flag_key: null,
+            }
+
+            window.location.search = '?q0=8'
+            ;(surveyManager as any)._handleUrlPrefill(survey)
+
+            expect(mockPostHog.capture).toHaveBeenCalledWith(
+                'survey sent',
+                expect.objectContaining({
+                    $survey_id: 'prefill-survey',
+                    $survey_response_q1: 8,
+                    $survey_completed: false,
+                })
+            )
+        })
+
+        it('should NOT auto-submit when skipSubmitButton is false, even with enable_partial_responses true', () => {
+            const survey: Survey = {
+                id: 'prefill-survey-no-skip',
+                name: 'Prefill Survey No Skip',
+                type: SurveyType.Popover,
+                enable_partial_responses: true,
+                questions: [
+                    {
+                        id: 'q1',
+                        type: SurveyQuestionType.Rating,
+                        question: 'Rate us',
+                        scale: 10,
+                        skipSubmitButton: false,
+                    },
+                    {
+                        id: 'q2',
+                        type: SurveyQuestionType.Open,
+                        question: 'Any feedback?',
+                    },
+                ],
+                appearance: {},
+                conditions: null,
+                start_date: '2021-01-01T00:00:00.000Z',
+                end_date: null,
+                current_iteration: null,
+                current_iteration_start_date: null,
+                feature_flag_keys: [],
+                linked_flag_key: null,
+                targeting_flag_key: null,
+                internal_targeting_flag_key: null,
+            }
+
+            window.location.search = '?q0=8'
+            ;(surveyManager as any)._handleUrlPrefill(survey)
+
+            expect(mockPostHog.capture).not.toHaveBeenCalled()
+        })
+
+        it('should NOT auto-submit when enable_partial_responses is false, even with skipSubmitButton true', () => {
+            const survey: Survey = {
+                id: 'prefill-survey-no-partial',
+                name: 'Prefill Survey No Partial',
+                type: SurveyType.Popover,
+                enable_partial_responses: false,
+                questions: [
+                    {
+                        id: 'q1',
+                        type: SurveyQuestionType.Rating,
+                        question: 'Rate us',
+                        scale: 10,
+                        skipSubmitButton: true,
+                    },
+                    {
+                        id: 'q2',
+                        type: SurveyQuestionType.Open,
+                        question: 'Any feedback?',
+                    },
+                ],
+                appearance: {},
+                conditions: null,
+                start_date: '2021-01-01T00:00:00.000Z',
+                end_date: null,
+                current_iteration: null,
+                current_iteration_start_date: null,
+                feature_flag_keys: [],
+                linked_flag_key: null,
+                targeting_flag_key: null,
+                internal_targeting_flag_key: null,
+            }
+
+            window.location.search = '?q0=8'
+            ;(surveyManager as any)._handleUrlPrefill(survey)
+
+            expect(mockPostHog.capture).not.toHaveBeenCalled()
+        })
+
+        it('should auto-submit when all questions are prefilled with skipSubmitButton true (survey completed)', () => {
+            const survey: Survey = {
+                id: 'prefill-survey-complete',
+                name: 'Prefill Survey Complete',
+                type: SurveyType.Popover,
+                enable_partial_responses: false,
+                questions: [
+                    {
+                        id: 'q1',
+                        type: SurveyQuestionType.Rating,
+                        question: 'Rate us',
+                        scale: 10,
+                        skipSubmitButton: true,
+                    },
+                ],
+                appearance: {},
+                conditions: null,
+                start_date: '2021-01-01T00:00:00.000Z',
+                end_date: null,
+                current_iteration: null,
+                current_iteration_start_date: null,
+                feature_flag_keys: [],
+                linked_flag_key: null,
+                targeting_flag_key: null,
+                internal_targeting_flag_key: null,
+            }
+
+            window.location.search = '?q0=8'
+            ;(surveyManager as any)._handleUrlPrefill(survey)
+
+            expect(mockPostHog.capture).toHaveBeenCalledWith(
+                'survey sent',
+                expect.objectContaining({
+                    $survey_id: 'prefill-survey-complete',
+                    $survey_response_q1: 8,
+                    $survey_completed: true,
+                })
+            )
+        })
+
+        it('should only include skipped responses in auto-submit, not all prefilled responses', () => {
+            const survey: Survey = {
+                id: 'prefill-survey-partial',
+                name: 'Prefill Survey Partial',
+                type: SurveyType.Popover,
+                enable_partial_responses: true,
+                questions: [
+                    {
+                        id: 'q1',
+                        type: SurveyQuestionType.Rating,
+                        question: 'Rate us',
+                        scale: 10,
+                        skipSubmitButton: true,
+                    },
+                    {
+                        id: 'q2',
+                        type: SurveyQuestionType.Rating,
+                        question: 'Rate again',
+                        scale: 10,
+                        skipSubmitButton: false,
+                    },
+                    {
+                        id: 'q3',
+                        type: SurveyQuestionType.Open,
+                        question: 'Any feedback?',
+                    },
+                ],
+                appearance: {},
+                conditions: null,
+                start_date: '2021-01-01T00:00:00.000Z',
+                end_date: null,
+                current_iteration: null,
+                current_iteration_start_date: null,
+                feature_flag_keys: [],
+                linked_flag_key: null,
+                targeting_flag_key: null,
+                internal_targeting_flag_key: null,
+            }
+
+            window.location.search = '?q0=8&q1=5'
+            ;(surveyManager as any)._handleUrlPrefill(survey)
+
+            expect(mockPostHog.capture).toHaveBeenCalledWith(
+                'survey sent',
+                expect.objectContaining({
+                    $survey_id: 'prefill-survey-partial',
+                    $survey_response_q1: 8,
+                    $survey_completed: false,
+                })
+            )
+            expect(mockPostHog.capture).toHaveBeenCalledWith(
+                'survey sent',
+                expect.not.objectContaining({
+                    $survey_response_q2: 5,
+                })
+            )
+        })
+    })
 })
 
 describe('usePopupVisibility URL changes should hide surveys accordingly', () => {

--- a/packages/browser/src/utils/survey-url-prefill.ts
+++ b/packages/browser/src/utils/survey-url-prefill.ts
@@ -143,10 +143,15 @@ export function convertPrefillToResponses(survey: Survey, prefillParams: Prefill
  *
  * @param questions - The survey questions array
  * @param prefilledIndices - Array of question indices that have been prefilled
- * @returns The question index to start at
+ * @returns Object with startQuestionIndex and map of questions which have been skipped
  */
-export function calculatePrefillStartIndex(questions: SurveyQuestion[], prefilledIndices: number[]): number {
+export function calculatePrefillStartIndex(
+    questions: SurveyQuestion[],
+    prefilledIndices: number[],
+    responses: Record<string, any>
+): { startQuestionIndex: number; skippedResponses: Record<string, any> } {
     let startQuestionIndex = 0
+    const skippedResponses: Record<string, any> = {}
 
     for (let i = 0; i < questions.length; i++) {
         // stop at the first question that is not prefilled
@@ -158,11 +163,16 @@ export function calculatePrefillStartIndex(questions: SurveyQuestion[], prefille
         // only advance if the prefilled question has skipSubmitButton
         if (question && 'skipSubmitButton' in question && question.skipSubmitButton) {
             startQuestionIndex = i + 1
+            if (!question.id) continue
+            const responseKey = getSurveyResponseKey(question.id)
+            if (!isUndefined(responses[responseKey])) {
+                skippedResponses[responseKey] = responses[responseKey]
+            }
         } else {
             // show question if skipSubmitButton is false, even if prefilled
             break
         }
     }
 
-    return startQuestionIndex
+    return { startQuestionIndex, skippedResponses }
 }


### PR DESCRIPTION
## Problem

right now, for hosted surveys, we auto-submit survey responses for prefilled q's on pageload if:

1. partial responses are enabled
2. OR survey is complete

this is _almost_ correct, but does not match the rest of the logic we have...

hosted surveys will skip questions that are 1) prefilled and 2) have auto-submit enabled for that question.

the auto-submit on pageload logic does _not_ consider whether the question has auto-submit enabled, so survey responses are being sent when they shouldn't. this is particularly problematic for email clients pre-fetching links (PR to add optional captcha soon)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

updates logic to only auto-submit questoins that were already skipped in the UI

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->