### PR TITLE
fix(surveys): do not dismiss keyboard on submit button tap

### DIFF
--- a/.changeset/sharp-birds-fix.md
+++ b/.changeset/sharp-birds-fix.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+surveys fix: do not dismiss keyboard on submit button tap

--- a/packages/react-native/src/surveys/components/Surveys.tsx
+++ b/packages/react-native/src/surveys/components/Surveys.tsx
@@ -150,7 +150,10 @@ export function Questions({
   const question = surveyQuestions[currentQuestionIndex]
 
   return (
-    <ScrollView style={[styleOverrides, { flexGrow: 0 }]}>
+    <ScrollView
+      style={[styleOverrides, { flexGrow: 0 }]}
+      keyboardShouldPersistTaps="handled" // do not dismiss keyboard on submit button tap
+    >
       {getQuestionComponent({
         question,
         appearance,


### PR DESCRIPTION
## Problem

surveys - tapping submit button when keyboard is open dismisses the keyboard, and does not trigger the tap on the submit button

ticket: https://posthoghelp.zendesk.com/agent/tickets/44614 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/48378)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

prevents keyboard from dismissing if another element handled the click

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->