### PR TITLE
feat(product tours): allow customization

### DIFF
--- a/.changeset/eighty-glasses-prove.md
+++ b/.changeset/eighty-glasses-prove.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+product tours: support custom appearance, clean up animations

--- a/packages/browser/src/entrypoints/product-tours-preview.es.ts
+++ b/packages/browser/src/entrypoints/product-tours-preview.es.ts
@@ -1,0 +1,1 @@
+export { renderProductTourPreview } from '../extensions/product-tours/preview'

--- a/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
@@ -1,0 +1,77 @@
+import { h } from 'preact'
+import { ProductTourStep, ProductTourAppearance } from '../../../posthog-product-tours-types'
+import { renderTipTapContent } from '../product-tours-utils'
+import { IconPosthogLogo, cancelSVG } from '../../surveys/icons'
+
+export interface ProductTourTooltipInnerProps {
+    step: ProductTourStep
+    appearance?: ProductTourAppearance
+    stepIndex: number
+    totalSteps: number
+    onNext?: () => void
+    onPrevious?: () => void
+    onDismiss?: () => void
+}
+
+export function ProductTourTooltipInner({
+    step,
+    appearance,
+    stepIndex,
+    totalSteps,
+    onNext,
+    onPrevious,
+    onDismiss,
+}: ProductTourTooltipInnerProps): h.JSX.Element {
+    const whiteLabel = appearance?.whiteLabel ?? false
+    const isLastStep = stepIndex >= totalSteps - 1
+    const isFirstStep = stepIndex === 0
+    const showNextButton = step.progressionTrigger === 'button' || step.type === 'modal'
+
+    const isInteractive = !!(onNext || onPrevious || onDismiss)
+    const cursorStyle = isInteractive ? undefined : { cursor: 'default' }
+
+    return (
+        <>
+            <button class="ph-tour-dismiss" onClick={onDismiss} aria-label="Close tour" style={cursorStyle}>
+                {cancelSVG}
+            </button>
+
+            <div class="ph-tour-content" dangerouslySetInnerHTML={{ __html: renderTipTapContent(step.content) }} />
+
+            <div class="ph-tour-footer">
+                <span class="ph-tour-progress">
+                    {stepIndex + 1} of {totalSteps}
+                </span>
+
+                <div class="ph-tour-buttons">
+                    {!isFirstStep && (
+                        <button
+                            class="ph-tour-button ph-tour-button--secondary"
+                            onClick={onPrevious}
+                            style={cursorStyle}
+                        >
+                            Back
+                        </button>
+                    )}
+                    {showNextButton && (
+                        <button class="ph-tour-button ph-tour-button--primary" onClick={onNext} style={cursorStyle}>
+                            {isLastStep ? 'Done' : 'Next'}
+                        </button>
+                    )}
+                </div>
+            </div>
+
+            {!whiteLabel && (
+                <a
+                    href={isInteractive ? 'https://posthog.com/product-tours' : undefined}
+                    target={isInteractive ? '_blank' : undefined}
+                    rel={isInteractive ? 'noopener noreferrer' : undefined}
+                    class="ph-tour-branding"
+                    style={isInteractive ? undefined : { cursor: 'default', pointerEvents: 'none' }}
+                >
+                    Tour by {IconPosthogLogo}
+                </a>
+            )}
+        </>
+    )
+}

--- a/packages/browser/src/extensions/product-tours/preview.tsx
+++ b/packages/browser/src/extensions/product-tours/preview.tsx
@@ -1,0 +1,68 @@
+import { render, JSX } from 'preact'
+
+import { ProductTourStep, ProductTourAppearance } from '../../posthog-product-tours-types'
+import { document as _document } from '../../utils/globals'
+import { ProductTourSurveyStepInner } from './components/ProductTourSurveyStepInner'
+import { ProductTourTooltipInner } from './components/ProductTourTooltipInner'
+import { getProductTourStylesheet, addProductTourCSSVariablesToElement } from './product-tours-utils'
+
+const document = _document as Document
+
+export interface RenderProductTourPreviewOptions {
+    step: ProductTourStep
+    appearance?: ProductTourAppearance
+    parentElement: HTMLElement
+    stepIndex?: number
+    totalSteps?: number
+    style?: JSX.CSSProperties
+}
+
+export function renderProductTourPreview({
+    step,
+    appearance,
+    parentElement,
+    stepIndex = 0,
+    totalSteps = 1,
+    style,
+}: RenderProductTourPreviewOptions): void {
+    parentElement.innerHTML = ''
+
+    const shadowHost = document.createElement('div')
+    addProductTourCSSVariablesToElement(shadowHost, appearance)
+    parentElement.appendChild(shadowHost)
+    const shadow = shadowHost.attachShadow({ mode: 'open' })
+
+    const stylesheet = getProductTourStylesheet()
+    if (stylesheet) {
+        shadow.appendChild(stylesheet)
+    }
+
+    const renderTarget = document.createElement('div')
+    shadow.appendChild(renderTarget)
+
+    const isSurveyStep = step.type === 'survey'
+    const tooltipClass = isSurveyStep ? 'ph-tour-tooltip ph-tour-survey-step' : 'ph-tour-tooltip'
+
+    render(
+        <div class="ph-tour-container">
+            <div class={tooltipClass} style={{ position: 'relative', animation: 'none', ...style }}>
+                {isSurveyStep ? (
+                    <ProductTourSurveyStepInner
+                        step={step}
+                        appearance={appearance}
+                        stepIndex={stepIndex}
+                        totalSteps={totalSteps}
+                    />
+                ) : (
+                    <ProductTourTooltipInner
+                        step={step}
+                        appearance={appearance}
+                        stepIndex={stepIndex}
+                        totalSteps={totalSteps}
+                    />
+                )}
+            </div>
+        </div>,
+        renderTarget
+    )
+}

--- a/packages/browser/src/extensions/product-tours/product-tour.css
+++ b/packages/browser/src/extensions/product-tours/product-tour.css
@@ -12,6 +12,7 @@
     --ph-tour-border-color: #e5e7eb;
 
     --ph-tour-border-radius: 8px;
+    --ph-tour-button-border-radius: 6px;
     --ph-tour-box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     --ph-tour-max-width: 320px;
     --ph-tour-padding: 16px;
@@ -184,7 +185,7 @@
     padding: 8px 16px;
     font-size: 14px;
     font-weight: 500;
-    border-radius: 6px;
+    border-radius: var(--ph-tour-button-border-radius);
     border: none;
     cursor: pointer;
     transition:
@@ -233,7 +234,7 @@
 }
 
 .ph-tour-dismiss:hover {
-    background: var(--ph-tour-border-color);
+    background: rgba(0, 0, 0, 0.08);
     color: var(--ph-tour-text-color);
 }
 
@@ -246,12 +247,12 @@
     padding-top: 12px;
     border-top: 1px solid var(--ph-tour-border-color);
     font-size: 11px;
-    color: var(--ph-tour-text-secondary-color);
+    color: var(--ph-tour-branding-text-color, var(--ph-tour-text-secondary-color));
     text-decoration: none;
 }
 
 .ph-tour-branding:hover {
-    color: var(--ph-tour-text-color);
+    color: var(--ph-tour-branding-text-color, var(--ph-tour-text-color));
 }
 
 .ph-tour-branding svg {
@@ -401,30 +402,3 @@
     color: var(--ph-tour-button-text-color);
 }
 
-@keyframes ph-tour-fade-in {
-    from {
-        opacity: 0;
-        transform: translateY(4px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes ph-tour-modal-fade-in {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
-
-.ph-tour-tooltip {
-    animation: ph-tour-fade-in 0.2s ease-out;
-}
-
-.ph-tour-tooltip--modal {
-    animation: ph-tour-modal-fade-in 0.2s ease-out;
-}

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -298,18 +298,34 @@ function nameToHex(name: string) {
     }[name.toLowerCase()]
 }
 
-function hex2rgb(c: string) {
-    if (c[0] === '#') {
-        const hexColor = c.replace(/^#/, '')
+export function hex2rgb(c: string): string {
+    if (c.startsWith('#')) {
+        let hexColor = c.replace(/^#/, '')
+        // Handle 3-character shorthand (e.g., #111 -> #111111, #abc -> #aabbcc)
+        if (/^[0-9A-Fa-f]{3}$/.test(hexColor)) {
+            hexColor = hexColor[0] + hexColor[0] + hexColor[1] + hexColor[1] + hexColor[2] + hexColor[2]
+        }
+        if (!/^[0-9A-Fa-f]{6}$/.test(hexColor)) {
+            return 'rgb(255, 255, 255)'
+        }
         const r = parseInt(hexColor.slice(0, 2), 16)
         const g = parseInt(hexColor.slice(2, 4), 16)
         const b = parseInt(hexColor.slice(4, 6), 16)
-        return 'rgb(' + r + ',' + g + ',' + b + ')'
+        return `rgb(${r},${g},${b})`
     }
     return 'rgb(255, 255, 255)'
 }
 
-function getContrastingTextColor(color: string = defaultSurveyAppearance.backgroundColor) {
+export function hexToRgba(hex: string, opacity: number): string {
+    const rgb = hex2rgb(hex)
+    const match = rgb.match(/^rgb\((\d+),(\d+),(\d+)\)$/)
+    if (!match) {
+        return hex
+    }
+    return `rgba(${match[1]}, ${match[2]}, ${match[3]}, ${opacity})`
+}
+
+export function getContrastingTextColor(color: string = defaultSurveyAppearance.backgroundColor) {
     let rgb
     if (color[0] === '#') {
         rgb = hex2rgb(color)

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -9,6 +9,8 @@ export interface JSONContent {
     text?: string
 }
 
+export type ProductTourStepType = 'element' | 'modal' | 'survey'
+
 export type ProductTourSurveyQuestionType = 'open' | 'rating'
 
 export interface ProductTourSurveyQuestion {
@@ -26,6 +28,7 @@ export interface ProductTourSurveyQuestion {
 
 export interface ProductTourStep {
     id: string
+    type: ProductTourStepType
     selector?: string
     progressionTrigger: 'button' | 'click'
     content: JSONContent | null
@@ -57,9 +60,12 @@ export interface ProductTourAppearance {
     backgroundColor?: string
     textColor?: string
     buttonColor?: string
-    buttonTextColor?: string
     borderRadius?: number
+    buttonBorderRadius?: number
     borderColor?: string
+    fontFamily?: string
+    boxShadow?: string
+    showOverlay?: boolean
     whiteLabel?: boolean
 }
 
@@ -95,9 +101,12 @@ export const DEFAULT_PRODUCT_TOUR_APPEARANCE: Required<ProductTourAppearance> = 
     backgroundColor: '#ffffff',
     textColor: '#1d1f27',
     buttonColor: '#1d1f27',
-    buttonTextColor: '#ffffff',
     borderRadius: 8,
+    buttonBorderRadius: 6,
     borderColor: '#e5e7eb',
+    fontFamily: 'system-ui',
+    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+    showOverlay: true,
     whiteLabel: false,
 }
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

- product tours can't be customized
- animations were a bit janky

## Changes

add customization, clean up components so they're less janky and animations are smooth, expose some methods to preview cards for main app

[pt-customization.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/499bd6f4-41f0-4e97-8af1-c4dc643f4d6c.mp4" />](https://app.graphite.com/user-attachments/video/499bd6f4-41f0-4e97-8af1-c4dc643f4d6c.mp4)

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->