### PR TITLE
fix(ci): Grant required perms to bundled size action

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -8,6 +8,7 @@ jobs:
 
     permissions:
       contents: read
+      issues: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
Attempt to fix https://github.com/PostHog/posthog-js/actions/runs/20386257542/job/58587668487