### PR TITLE
feat: allow adding lazy loaded scripts to head to avoid hydration errors

### DIFF
--- a/.changeset/breezy-steaks-pull.md
+++ b/.changeset/breezy-steaks-pull.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+feat: add external_scripts_inject_target config to control script injection location

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -95,5 +95,5 @@ module.exports = {
             },
         },
     ],
-    ignorePatterns: ['node_modules', 'dist', 'next-env.d.ts', '.next'],
+    ignorePatterns: ['node_modules', 'dist', 'next-env.d.ts', '.next', 'packages/browser/playground/hydration/vendor'],
 }

--- a/packages/browser/playground/hydration/index.html
+++ b/packages/browser/playground/hydration/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SSR Hydration Compatibility Test</title>
+    <script src="vendor/preact.umd.js"></script>
+    <script src="vendor/preact-hooks.umd.js"></script>
+    <script src="vendor/preact-compat.umd.js"></script>
+</head>
+<body>
+    <!-- This simulates server-rendered HTML that Preact will hydrate -->
+    <div id="root"><div class="app"><h1>SSR Hydration Test</h1><p>This content simulates server-rendered HTML</p><button id="test-btn">Click me</button></div></div>
+
+    <!-- This script simulates a framework bundle that was server-rendered -->
+    <!-- The bug was: PostHog's insertBefore would insert BEFORE this script -->
+    <script id="framework-bundle">
+        console.log('[Framework] Framework bundle loaded');
+    </script>
+
+    <script>
+        // Capture any hydration-related console errors/warnings
+        window.hydrationErrors = [];
+        const originalError = console.error;
+        const originalWarn = console.warn;
+
+        console.error = function(...args) {
+            const message = args.join(' ');
+            window.hydrationErrors.push(message);
+            originalError.apply(console, args);
+        };
+
+        console.warn = function(...args) {
+            const message = args.join(' ');
+            if (message.includes('hydrat') || message.includes('mismatch') || message.includes('did not match')) {
+                window.hydrationErrors.push(message);
+            }
+            originalWarn.apply(console, args);
+        };
+
+        // Store DOM state BEFORE PostHog loads
+        window.initialBodyChildCount = document.body.children.length;
+        window.initialFirstScriptId = document.querySelector('body > script')?.id;
+    </script>
+
+    <script src="/dist/array.js"></script>
+
+    <script>
+        // Define performHydration BEFORE posthog.init() since loaded callback may fire synchronously
+        window.performHydration = function() {
+            console.log('[Preact] Starting hydration...');
+
+            var h = preact.h;
+            var hydrate = preactCompat.hydrate;
+
+            // Component that matches the server-rendered HTML exactly
+            function App() {
+                return h('div', { class: 'app' },
+                    h('h1', null, 'SSR Hydration Test'),
+                    h('p', null, 'This content simulates server-rendered HTML'),
+                    h('button', { id: 'test-btn' }, 'Click me')
+                );
+            }
+
+            var container = document.getElementById('root');
+
+            try {
+                hydrate(h(App), container);
+                console.log('[Preact] Hydration completed successfully');
+            } catch (e) {
+                console.error('[Preact] Hydration error:', e.message);
+                window.hydrationErrors.push(e.message);
+            }
+
+            // Signal test complete
+            window.testComplete = true;
+        };
+
+        window.posthog.init('test-token', {
+            api_host: 'https://localhost:1234',
+            persistence: 'memory',
+            external_scripts_inject_target: 'head',
+            bootstrap: {
+                distinctID: 'test-user'
+            },
+            loaded: function(posthog) {
+                // Check if body DOM was mutated
+                const currentFirstScriptId = document.querySelector('body > script')?.id;
+                const currentBodyChildCount = document.body.children.length;
+
+                window.domMutated = window.initialFirstScriptId !== currentFirstScriptId;
+                window.newScriptsAdded = currentBodyChildCount > window.initialBodyChildCount ||
+                                         document.querySelectorAll('head > script').length > 0;
+
+                console.log('[PostHog] Loaded, DOM state:', {
+                    domMutated: window.domMutated,
+                    newScriptsAdded: window.newScriptsAdded
+                });
+
+                // Now perform hydration with Preact
+                window.performHydration();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/packages/browser/playground/hydration/vendor/preact-compat.umd.js
+++ b/packages/browser/playground/hydration/vendor/preact-compat.umd.js
@@ -1,0 +1,586 @@
+!(function (n, t) {
+    'object' == typeof exports && 'undefined' != typeof module
+        ? t(exports, require('preact'), require('preact/hooks'))
+        : 'function' == typeof define && define.amd
+          ? define(['exports', 'preact', 'preact/hooks'], t)
+          : t(((n || self).preactCompat = {}), n.preact, n.preactHooks)
+})(this, function (n, t, e) {
+    function r(n, t) {
+        for (var e in t) n[e] = t[e]
+        return n
+    }
+    function u(n, t) {
+        for (var e in n) if ('__source' !== e && !(e in t)) return !0
+        for (var r in t) if ('__source' !== r && n[r] !== t[r]) return !0
+        return !1
+    }
+    function o(n) {
+        this.props = n
+    }
+    function i(n, e) {
+        function r(n) {
+            var t = this.props.ref,
+                r = t == n.ref
+            return (!r && t && (t.call ? t(null) : (t.current = null)), e ? !e(this.props, n) || !r : u(this.props, n))
+        }
+        function o(e) {
+            return ((this.shouldComponentUpdate = r), t.createElement(n, e))
+        }
+        return (
+            (o.displayName = 'Memo(' + (n.displayName || n.name) + ')'),
+            (o.prototype.isReactComponent = !0),
+            (o.__f = !0),
+            o
+        )
+    }
+    ;(((o.prototype = new t.Component()).isPureReactComponent = !0),
+        (o.prototype.shouldComponentUpdate = function (n, t) {
+            return u(this.props, n) || u(this.state, t)
+        }))
+    var c = t.options.__b
+    t.options.__b = function (n) {
+        ;(n.type && n.type.__f && n.ref && ((n.props.ref = n.ref), (n.ref = null)), c && c(n))
+    }
+    var l = ('undefined' != typeof Symbol && Symbol.for && Symbol.for('react.forward_ref')) || 3911
+    function f(n) {
+        function t(t) {
+            var e = r({}, t)
+            return (delete e.ref, n(e, t.ref || null))
+        }
+        return (
+            (t.$$typeof = l),
+            (t.render = t),
+            (t.prototype.isReactComponent = t.__f = !0),
+            (t.displayName = 'ForwardRef(' + (n.displayName || n.name) + ')'),
+            t
+        )
+    }
+    var a = function (n, e) {
+            return null == n ? null : t.toChildArray(t.toChildArray(n).map(e))
+        },
+        s = {
+            map: a,
+            forEach: a,
+            count: function (n) {
+                return n ? t.toChildArray(n).length : 0
+            },
+            only: function (n) {
+                var e = t.toChildArray(n)
+                if (1 !== e.length) throw 'Children.only'
+                return e[0]
+            },
+            toArray: t.toChildArray,
+        },
+        h = t.options.__e
+    t.options.__e = function (n, t, e, r) {
+        if (n.then)
+            for (var u, o = t; (o = o.__); )
+                if ((u = o.__c) && u.__c) return (null == t.__e && ((t.__e = e.__e), (t.__k = e.__k)), u.__c(n, t))
+        h(n, t, e, r)
+    }
+    var d = t.options.unmount
+    function v(n, t, e) {
+        return (
+            n &&
+                (n.__c &&
+                    n.__c.__H &&
+                    (n.__c.__H.__.forEach(function (n) {
+                        'function' == typeof n.__c && n.__c()
+                    }),
+                    (n.__c.__H = null)),
+                null != (n = r({}, n)).__c && (n.__c.__P === e && (n.__c.__P = t), (n.__c = null)),
+                (n.__k =
+                    n.__k &&
+                    n.__k.map(function (n) {
+                        return v(n, t, e)
+                    }))),
+            n
+        )
+    }
+    function p(n, t, e) {
+        return (
+            n &&
+                e &&
+                ((n.__v = null),
+                (n.__k =
+                    n.__k &&
+                    n.__k.map(function (n) {
+                        return p(n, t, e)
+                    })),
+                n.__c && n.__c.__P === t && (n.__e && e.appendChild(n.__e), (n.__c.__e = !0), (n.__c.__P = e))),
+            n
+        )
+    }
+    function m() {
+        ;((this.__u = 0), (this.t = null), (this.__b = null))
+    }
+    function b(n) {
+        var t = n.__.__c
+        return t && t.__a && t.__a(n)
+    }
+    function y(n) {
+        var e, r, u
+        function o(o) {
+            if (
+                (e ||
+                    (e = n()).then(
+                        function (n) {
+                            r = n.default || n
+                        },
+                        function (n) {
+                            u = n
+                        }
+                    ),
+                u)
+            )
+                throw u
+            if (!r) throw e
+            return t.createElement(r, o)
+        }
+        return ((o.displayName = 'Lazy'), (o.__f = !0), o)
+    }
+    function _() {
+        ;((this.u = null), (this.o = null))
+    }
+    ;((t.options.unmount = function (n) {
+        var t = n.__c
+        ;(t && t.__R && t.__R(), t && 32 & n.__u && (n.type = null), d && d(n))
+    }),
+        ((m.prototype = new t.Component()).__c = function (n, t) {
+            var e = t.__c,
+                r = this
+            ;(null == r.t && (r.t = []), r.t.push(e))
+            var u = b(r.__v),
+                o = !1,
+                i = function () {
+                    o || ((o = !0), (e.__R = null), u ? u(c) : c())
+                }
+            e.__R = i
+            var c = function () {
+                if (!--r.__u) {
+                    if (r.state.__a) {
+                        var n = r.state.__a
+                        r.__v.__k[0] = p(n, n.__c.__P, n.__c.__O)
+                    }
+                    var t
+                    for (r.setState({ __a: (r.__b = null) }); (t = r.t.pop()); ) t.forceUpdate()
+                }
+            }
+            ;(r.__u++ || 32 & t.__u || r.setState({ __a: (r.__b = r.__v.__k[0]) }), n.then(i, i))
+        }),
+        (m.prototype.componentWillUnmount = function () {
+            this.t = []
+        }),
+        (m.prototype.render = function (n, e) {
+            if (this.__b) {
+                if (this.__v.__k) {
+                    var r = document.createElement('div'),
+                        u = this.__v.__k[0].__c
+                    this.__v.__k[0] = v(this.__b, r, (u.__O = u.__P))
+                }
+                this.__b = null
+            }
+            var o = e.__a && t.createElement(t.Fragment, null, n.fallback)
+            return (o && (o.__u &= -33), [t.createElement(t.Fragment, null, e.__a ? null : n.children), o])
+        }))
+    var g = function (n, t, e) {
+        if ((++e[1] === e[0] && n.o.delete(t), n.props.revealOrder && ('t' !== n.props.revealOrder[0] || !n.o.size)))
+            for (e = n.u; e; ) {
+                for (; e.length > 3; ) e.pop()()
+                if (e[1] < e[0]) break
+                n.u = e = e[2]
+            }
+    }
+    function S(n) {
+        return (
+            (this.getChildContext = function () {
+                return n.context
+            }),
+            n.children
+        )
+    }
+    function C(n) {
+        var e = this,
+            r = n.i
+        ;((e.componentWillUnmount = function () {
+            ;(t.render(null, e.l), (e.l = null), (e.i = null))
+        }),
+            e.i && e.i !== r && e.componentWillUnmount(),
+            e.l ||
+                ((e.i = r),
+                (e.l = {
+                    nodeType: 1,
+                    parentNode: r,
+                    childNodes: [],
+                    appendChild: function (n) {
+                        ;(this.childNodes.push(n), e.i.appendChild(n))
+                    },
+                    insertBefore: function (n, t) {
+                        ;(this.childNodes.push(n), e.i.appendChild(n))
+                    },
+                    removeChild: function (n) {
+                        ;(this.childNodes.splice(this.childNodes.indexOf(n) >>> 1, 1), e.i.removeChild(n))
+                    },
+                })),
+            t.render(t.createElement(S, { context: e.context }, n.__v), e.l))
+    }
+    function E(n, e) {
+        var r = t.createElement(C, { __v: n, i: e })
+        return ((r.containerInfo = e), r)
+    }
+    ;(((_.prototype = new t.Component()).__a = function (n) {
+        var t = this,
+            e = b(t.__v),
+            r = t.o.get(n)
+        return (
+            r[0]++,
+            function (u) {
+                var o = function () {
+                    t.props.revealOrder ? (r.push(u), g(t, n, r)) : u()
+                }
+                e ? e(o) : o()
+            }
+        )
+    }),
+        (_.prototype.render = function (n) {
+            ;((this.u = null), (this.o = new Map()))
+            var e = t.toChildArray(n.children)
+            n.revealOrder && 'b' === n.revealOrder[0] && e.reverse()
+            for (var r = e.length; r--; ) this.o.set(e[r], (this.u = [1, 0, this.u]))
+            return n.children
+        }),
+        (_.prototype.componentDidUpdate = _.prototype.componentDidMount =
+            function () {
+                var n = this
+                this.o.forEach(function (t, e) {
+                    g(n, e, t)
+                })
+            }))
+    var O = ('undefined' != typeof Symbol && Symbol.for && Symbol.for('react.element')) || 60103,
+        w =
+            /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|image(!S)|letter|lighting|marker(?!H|W|U)|overline|paint|pointer|shape|stop|strikethrough|stroke|text(?!L)|transform|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/,
+        x = /^on(Ani|Tra|Tou|BeforeInp|Compo)/,
+        R = /[A-Z0-9]/g,
+        j = 'undefined' != typeof document,
+        N = function (n) {
+            return ('undefined' != typeof Symbol && 'symbol' == typeof Symbol() ? /fil|che|rad/ : /fil|che|ra/).test(n)
+        }
+    function T(n, e, r) {
+        return (null == e.__k && (e.textContent = ''), t.render(n, e), 'function' == typeof r && r(), n ? n.__c : null)
+    }
+    function k(n, e, r) {
+        return (t.hydrate(n, e), 'function' == typeof r && r(), n ? n.__c : null)
+    }
+    ;((t.Component.prototype.isReactComponent = {}),
+        ['componentWillMount', 'componentWillReceiveProps', 'componentWillUpdate'].forEach(function (n) {
+            Object.defineProperty(t.Component.prototype, n, {
+                configurable: !0,
+                get: function () {
+                    return this['UNSAFE_' + n]
+                },
+                set: function (t) {
+                    Object.defineProperty(this, n, { configurable: !0, writable: !0, value: t })
+                },
+            })
+        }))
+    var A = t.options.event
+    function F() {}
+    function I() {
+        return this.cancelBubble
+    }
+    function L() {
+        return this.defaultPrevented
+    }
+    t.options.event = function (n) {
+        return (
+            A && (n = A(n)),
+            (n.persist = F),
+            (n.isPropagationStopped = I),
+            (n.isDefaultPrevented = L),
+            (n.nativeEvent = n)
+        )
+    }
+    var U,
+        D = {
+            enumerable: !1,
+            configurable: !0,
+            get: function () {
+                return this.class
+            },
+        },
+        M = t.options.vnode
+    t.options.vnode = function (n) {
+        ;('string' == typeof n.type &&
+            (function (n) {
+                var e = n.props,
+                    r = n.type,
+                    u = {}
+                for (var o in e) {
+                    var i = e[o]
+                    if (
+                        !(
+                            ('value' === o && 'defaultValue' in e && null == i) ||
+                            (j && 'children' === o && 'noscript' === r) ||
+                            'class' === o ||
+                            'className' === o
+                        )
+                    ) {
+                        var c = o.toLowerCase()
+                        ;('defaultValue' === o && 'value' in e && null == e.value
+                            ? (o = 'value')
+                            : 'download' === o && !0 === i
+                              ? (i = '')
+                              : 'ondoubleclick' === c
+                                ? (o = 'ondblclick')
+                                : 'onchange' !== c || ('input' !== r && 'textarea' !== r) || N(e.type)
+                                  ? 'onfocus' === c
+                                      ? (o = 'onfocusin')
+                                      : 'onblur' === c
+                                        ? (o = 'onfocusout')
+                                        : x.test(o)
+                                          ? (o = c)
+                                          : -1 === r.indexOf('-') && w.test(o)
+                                            ? (o = o.replace(R, '-$&').toLowerCase())
+                                            : null === i && (i = void 0)
+                                  : (c = o = 'oninput'),
+                            'oninput' === c && u[(o = c)] && (o = 'oninputCapture'),
+                            (u[o] = i))
+                    }
+                }
+                ;('select' == r &&
+                    u.multiple &&
+                    Array.isArray(u.value) &&
+                    (u.value = t.toChildArray(e.children).forEach(function (n) {
+                        n.props.selected = -1 != u.value.indexOf(n.props.value)
+                    })),
+                    'select' == r &&
+                        null != u.defaultValue &&
+                        (u.value = t.toChildArray(e.children).forEach(function (n) {
+                            n.props.selected = u.multiple
+                                ? -1 != u.defaultValue.indexOf(n.props.value)
+                                : u.defaultValue == n.props.value
+                        })),
+                    e.class && !e.className
+                        ? ((u.class = e.class), Object.defineProperty(u, 'className', D))
+                        : ((e.className && !e.class) || (e.class && e.className)) &&
+                          (u.class = u.className = e.className),
+                    (n.props = u))
+            })(n),
+            (n.$$typeof = O),
+            M && M(n))
+    }
+    var V = t.options.__r
+    t.options.__r = function (n) {
+        ;(V && V(n), (U = n.__c))
+    }
+    var W = t.options.diffed
+    t.options.diffed = function (n) {
+        W && W(n)
+        var t = n.props,
+            e = n.__e
+        ;(null != e &&
+            'textarea' === n.type &&
+            'value' in t &&
+            t.value !== e.value &&
+            (e.value = null == t.value ? '' : t.value),
+            (U = null))
+    }
+    var P = {
+            ReactCurrentDispatcher: {
+                current: {
+                    readContext: function (n) {
+                        return U.__n[n.__c].props.value
+                    },
+                },
+            },
+        },
+        z = '17.0.2'
+    function B(n) {
+        return t.createElement.bind(null, n)
+    }
+    function q(n) {
+        return !!n && n.$$typeof === O
+    }
+    function H(n) {
+        return q(n) && n.type === t.Fragment
+    }
+    function Z(n) {
+        return q(n) ? t.cloneElement.apply(null, arguments) : n
+    }
+    function Y(n) {
+        return !!n.__k && (t.render(null, n), !0)
+    }
+    function $(n) {
+        return (n && (n.base || (1 === n.nodeType && n))) || null
+    }
+    var G = function (n, t) {
+            return n(t)
+        },
+        J = function (n, t) {
+            return n(t)
+        },
+        K = t.Fragment
+    function Q(n) {
+        n()
+    }
+    function X(n) {
+        return n
+    }
+    function nn() {
+        return [!1, Q]
+    }
+    var tn = e.useLayoutEffect,
+        en = q
+    function rn(n, t) {
+        var r = t(),
+            u = e.useState({ h: { __: r, v: t } }),
+            o = u[0].h,
+            i = u[1]
+        return (
+            e.useLayoutEffect(
+                function () {
+                    ;((o.__ = r), (o.v = t), un(o) && i({ h: o }))
+                },
+                [n, r, t]
+            ),
+            e.useEffect(
+                function () {
+                    return (
+                        un(o) && i({ h: o }),
+                        n(function () {
+                            un(o) && i({ h: o })
+                        })
+                    )
+                },
+                [n]
+            ),
+            r
+        )
+    }
+    function un(n) {
+        var t,
+            e,
+            r = n.v,
+            u = n.__
+        try {
+            var o = r()
+            return !(((t = u) === (e = o) && (0 !== t || 1 / t == 1 / e)) || (t != t && e != e))
+        } catch (n) {
+            return !0
+        }
+    }
+    var on = {
+        useState: e.useState,
+        useId: e.useId,
+        useReducer: e.useReducer,
+        useEffect: e.useEffect,
+        useLayoutEffect: e.useLayoutEffect,
+        useInsertionEffect: tn,
+        useTransition: nn,
+        useDeferredValue: X,
+        useSyncExternalStore: rn,
+        startTransition: Q,
+        useRef: e.useRef,
+        useImperativeHandle: e.useImperativeHandle,
+        useMemo: e.useMemo,
+        useCallback: e.useCallback,
+        useContext: e.useContext,
+        useDebugValue: e.useDebugValue,
+        version: z,
+        Children: s,
+        render: T,
+        hydrate: k,
+        unmountComponentAtNode: Y,
+        createPortal: E,
+        createElement: t.createElement,
+        createContext: t.createContext,
+        createFactory: B,
+        cloneElement: Z,
+        createRef: t.createRef,
+        Fragment: t.Fragment,
+        isValidElement: q,
+        isElement: en,
+        isFragment: H,
+        findDOMNode: $,
+        Component: t.Component,
+        PureComponent: o,
+        memo: i,
+        forwardRef: f,
+        flushSync: J,
+        unstable_batchedUpdates: G,
+        StrictMode: K,
+        Suspense: m,
+        SuspenseList: _,
+        lazy: y,
+        __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: P,
+    }
+    ;(Object.defineProperty(n, 'Component', {
+        enumerable: !0,
+        get: function () {
+            return t.Component
+        },
+    }),
+        Object.defineProperty(n, 'Fragment', {
+            enumerable: !0,
+            get: function () {
+                return t.Fragment
+            },
+        }),
+        Object.defineProperty(n, 'createContext', {
+            enumerable: !0,
+            get: function () {
+                return t.createContext
+            },
+        }),
+        Object.defineProperty(n, 'createElement', {
+            enumerable: !0,
+            get: function () {
+                return t.createElement
+            },
+        }),
+        Object.defineProperty(n, 'createRef', {
+            enumerable: !0,
+            get: function () {
+                return t.createRef
+            },
+        }),
+        (n.Children = s),
+        (n.PureComponent = o),
+        (n.StrictMode = K),
+        (n.Suspense = m),
+        (n.SuspenseList = _),
+        (n.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = P),
+        (n.cloneElement = Z),
+        (n.createFactory = B),
+        (n.createPortal = E),
+        (n.default = on),
+        (n.findDOMNode = $),
+        (n.flushSync = J),
+        (n.forwardRef = f),
+        (n.hydrate = k),
+        (n.isElement = en),
+        (n.isFragment = H),
+        (n.isValidElement = q),
+        (n.lazy = y),
+        (n.memo = i),
+        (n.render = T),
+        (n.startTransition = Q),
+        (n.unmountComponentAtNode = Y),
+        (n.unstable_batchedUpdates = G),
+        (n.useDeferredValue = X),
+        (n.useInsertionEffect = tn),
+        (n.useSyncExternalStore = rn),
+        (n.useTransition = nn),
+        (n.version = z),
+        Object.keys(e).forEach(function (t) {
+            'default' === t ||
+                n.hasOwnProperty(t) ||
+                Object.defineProperty(n, t, {
+                    enumerable: !0,
+                    get: function () {
+                        return e[t]
+                    },
+                })
+        }))
+})
+//# sourceMappingURL=compat.umd.js.map

--- a/packages/browser/playground/hydration/vendor/preact-hooks.umd.js
+++ b/packages/browser/playground/hydration/vendor/preact-hooks.umd.js
@@ -1,0 +1,267 @@
+!(function (n, t) {
+    'object' == typeof exports && 'undefined' != typeof module
+        ? t(exports, require('preact'))
+        : 'function' == typeof define && define.amd
+          ? define(['exports', 'preact'], t)
+          : t(((n || self).preactHooks = {}), n.preact)
+})(this, function (n, t) {
+    var u,
+        r,
+        i,
+        o,
+        f = 0,
+        e = [],
+        c = [],
+        a = t.options.__b,
+        v = t.options.__r,
+        l = t.options.diffed,
+        d = t.options.__c,
+        s = t.options.unmount
+    function p(n, u) {
+        ;(t.options.__h && t.options.__h(r, n, f || u), (f = 0))
+        var i = r.__H || (r.__H = { __: [], __h: [] })
+        return (n >= i.__.length && i.__.push({ __V: c }), i.__[n])
+    }
+    function h(n) {
+        return ((f = 1), y(g, n))
+    }
+    function y(n, t, i) {
+        var o = p(u++, 2)
+        if (
+            ((o.t = n),
+            !o.__c &&
+                ((o.__ = [
+                    i ? i(t) : g(void 0, t),
+                    function (n) {
+                        var t = o.__N ? o.__N[0] : o.__[0],
+                            u = o.t(t, n)
+                        t !== u && ((o.__N = [u, o.__[1]]), o.__c.setState({}))
+                    },
+                ]),
+                (o.__c = r),
+                !r.u))
+        ) {
+            var f = function (n, t, u) {
+                if (!o.__c.__H) return !0
+                var r = o.__c.__H.__.filter(function (n) {
+                    return n.__c
+                })
+                if (
+                    r.every(function (n) {
+                        return !n.__N
+                    })
+                )
+                    return !e || e.call(this, n, t, u)
+                var i = !1
+                return (
+                    r.forEach(function (n) {
+                        if (n.__N) {
+                            var t = n.__[0]
+                            ;((n.__ = n.__N), (n.__N = void 0), t !== n.__[0] && (i = !0))
+                        }
+                    }),
+                    !(!i && o.__c.props === n) && (!e || e.call(this, n, t, u))
+                )
+            }
+            r.u = !0
+            var e = r.shouldComponentUpdate,
+                c = r.componentWillUpdate
+            ;((r.componentWillUpdate = function (n, t, u) {
+                if (this.__e) {
+                    var r = e
+                    ;((e = void 0), f(n, t, u), (e = r))
+                }
+                c && c.call(this, n, t, u)
+            }),
+                (r.shouldComponentUpdate = f))
+        }
+        return o.__N || o.__
+    }
+    function m(n, i) {
+        var o = p(u++, 4)
+        !t.options.__s && F(o.__H, i) && ((o.__ = n), (o.i = i), r.__h.push(o))
+    }
+    function _(n, t) {
+        var r = p(u++, 7)
+        return F(r.__H, t) ? ((r.__V = n()), (r.i = t), (r.__h = n), r.__V) : r.__
+    }
+    function T() {
+        for (var n; (n = e.shift()); )
+            if (n.__P && n.__H)
+                try {
+                    ;(n.__H.__h.forEach(x), n.__H.__h.forEach(A), (n.__H.__h = []))
+                } catch (u) {
+                    ;((n.__H.__h = []), t.options.__e(u, n.__v))
+                }
+    }
+    ;((t.options.__b = function (n) {
+        ;((r = null), a && a(n))
+    }),
+        (t.options.__r = function (n) {
+            ;(v && v(n), (u = 0))
+            var t = (r = n.__c).__H
+            ;(t &&
+                (i === r
+                    ? ((t.__h = []),
+                      (r.__h = []),
+                      t.__.forEach(function (n) {
+                          ;(n.__N && (n.__ = n.__N), (n.__V = c), (n.__N = n.i = void 0))
+                      }))
+                    : (t.__h.forEach(x), t.__h.forEach(A), (t.__h = []), (u = 0))),
+                (i = r))
+        }),
+        (t.options.diffed = function (n) {
+            l && l(n)
+            var u = n.__c
+            ;(u &&
+                u.__H &&
+                (u.__H.__h.length &&
+                    ((1 !== e.push(u) && o === t.options.requestAnimationFrame) ||
+                        ((o = t.options.requestAnimationFrame) || q)(T)),
+                u.__H.__.forEach(function (n) {
+                    ;(n.i && (n.__H = n.i), n.__V !== c && (n.__ = n.__V), (n.i = void 0), (n.__V = c))
+                })),
+                (i = r = null))
+        }),
+        (t.options.__c = function (n, u) {
+            ;(u.some(function (n) {
+                try {
+                    ;(n.__h.forEach(x),
+                        (n.__h = n.__h.filter(function (n) {
+                            return !n.__ || A(n)
+                        })))
+                } catch (r) {
+                    ;(u.some(function (n) {
+                        n.__h && (n.__h = [])
+                    }),
+                        (u = []),
+                        t.options.__e(r, n.__v))
+                }
+            }),
+                d && d(n, u))
+        }),
+        (t.options.unmount = function (n) {
+            s && s(n)
+            var u,
+                r = n.__c
+            r &&
+                r.__H &&
+                (r.__H.__.forEach(function (n) {
+                    try {
+                        x(n)
+                    } catch (n) {
+                        u = n
+                    }
+                }),
+                (r.__H = void 0),
+                u && t.options.__e(u, r.__v))
+        }))
+    var b = 'function' == typeof requestAnimationFrame
+    function q(n) {
+        var t,
+            u = function () {
+                ;(clearTimeout(r), b && cancelAnimationFrame(t), setTimeout(n))
+            },
+            r = setTimeout(u, 100)
+        b && (t = requestAnimationFrame(u))
+    }
+    function x(n) {
+        var t = r,
+            u = n.__c
+        ;('function' == typeof u && ((n.__c = void 0), u()), (r = t))
+    }
+    function A(n) {
+        var t = r
+        ;((n.__c = n.__()), (r = t))
+    }
+    function F(n, t) {
+        return (
+            !n ||
+            n.length !== t.length ||
+            t.some(function (t, u) {
+                return t !== n[u]
+            })
+        )
+    }
+    function g(n, t) {
+        return 'function' == typeof t ? t(n) : t
+    }
+    ;((n.useCallback = function (n, t) {
+        return (
+            (f = 8),
+            _(function () {
+                return n
+            }, t)
+        )
+    }),
+        (n.useContext = function (n) {
+            var t = r.context[n.__c],
+                i = p(u++, 9)
+            return ((i.c = n), t ? (null == i.__ && ((i.__ = !0), t.sub(r)), t.props.value) : n.__)
+        }),
+        (n.useDebugValue = function (n, u) {
+            t.options.useDebugValue && t.options.useDebugValue(u ? u(n) : n)
+        }),
+        (n.useEffect = function (n, i) {
+            var o = p(u++, 3)
+            !t.options.__s && F(o.__H, i) && ((o.__ = n), (o.i = i), r.__H.__h.push(o))
+        }),
+        (n.useErrorBoundary = function (n) {
+            var t = p(u++, 10),
+                i = h()
+            return (
+                (t.__ = n),
+                r.componentDidCatch ||
+                    (r.componentDidCatch = function (n, u) {
+                        ;(t.__ && t.__(n, u), i[1](n))
+                    }),
+                [
+                    i[0],
+                    function () {
+                        i[1](void 0)
+                    },
+                ]
+            )
+        }),
+        (n.useId = function () {
+            var n = p(u++, 11)
+            if (!n.__) {
+                for (var t = r.__v; null !== t && !t.__m && null !== t.__; ) t = t.__
+                var i = t.__m || (t.__m = [0, 0])
+                n.__ = 'P' + i[0] + '-' + i[1]++
+            }
+            return n.__
+        }),
+        (n.useImperativeHandle = function (n, t, u) {
+            ;((f = 6),
+                m(
+                    function () {
+                        return 'function' == typeof n
+                            ? (n(t()),
+                              function () {
+                                  return n(null)
+                              })
+                            : n
+                              ? ((n.current = t()),
+                                function () {
+                                    return (n.current = null)
+                                })
+                              : void 0
+                    },
+                    null == u ? u : u.concat(n)
+                ))
+        }),
+        (n.useLayoutEffect = m),
+        (n.useMemo = _),
+        (n.useReducer = y),
+        (n.useRef = function (n) {
+            return (
+                (f = 5),
+                _(function () {
+                    return { current: n }
+                }, [])
+            )
+        }),
+        (n.useState = h))
+})
+//# sourceMappingURL=hooks.umd.js.map

--- a/packages/browser/playground/hydration/vendor/preact.umd.js
+++ b/packages/browser/playground/hydration/vendor/preact.umd.js
@@ -1,0 +1,658 @@
+!(function (n, l) {
+    'object' == typeof exports && 'undefined' != typeof module
+        ? l(exports)
+        : 'function' == typeof define && define.amd
+          ? define(['exports'], l)
+          : l(((n || self).preact = {}))
+})(this, function (n) {
+    var l,
+        u,
+        t,
+        i,
+        o,
+        r,
+        f,
+        e,
+        c,
+        s = 65536,
+        a = 1 << 17,
+        h = {},
+        p = [],
+        v = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i,
+        y = Array.isArray
+    function d(n, l) {
+        for (var u in l) n[u] = l[u]
+        return n
+    }
+    function _(n) {
+        var l = n.parentNode
+        l && l.removeChild(n)
+    }
+    function b(n, u, t) {
+        var i,
+            o,
+            r,
+            f = {}
+        for (r in u) 'key' == r ? (i = u[r]) : 'ref' == r ? (o = u[r]) : (f[r] = u[r])
+        if (
+            (arguments.length > 2 && (f.children = arguments.length > 3 ? l.call(arguments, 2) : t),
+            'function' == typeof n && null != n.defaultProps)
+        )
+            for (r in n.defaultProps) void 0 === f[r] && (f[r] = n.defaultProps[r])
+        return g(n, f, i, o, null)
+    }
+    function g(n, l, i, o, r) {
+        var f = {
+            type: n,
+            props: l,
+            key: i,
+            ref: o,
+            __k: null,
+            __: null,
+            __b: 0,
+            __e: null,
+            __d: void 0,
+            __c: null,
+            constructor: void 0,
+            __v: null == r ? ++t : r,
+            __i: -1,
+            __u: 0,
+        }
+        return (null == r && null != u.vnode && u.vnode(f), f)
+    }
+    function m(n) {
+        return n.children
+    }
+    function k(n, l) {
+        ;((this.props = n), (this.context = l))
+    }
+    function w(n, l) {
+        if (null == l) return n.__ ? w(n.__, n.__i + 1) : null
+        for (var u; l < n.__k.length; l++) if (null != (u = n.__k[l]) && null != u.__e) return u.__e
+        return 'function' == typeof n.type ? w(n) : null
+    }
+    function x(n) {
+        var l, u
+        if (null != (n = n.__) && null != n.__c) {
+            for (n.__e = n.__c.base = null, l = 0; l < n.__k.length; l++)
+                if (null != (u = n.__k[l]) && null != u.__e) {
+                    n.__e = n.__c.base = u.__e
+                    break
+                }
+            return x(n)
+        }
+    }
+    function P(n) {
+        ;((!n.__d && (n.__d = !0) && o.push(n) && !S.__r++) || r !== u.debounceRendering) &&
+            ((r = u.debounceRendering) || f)(S)
+    }
+    function S() {
+        var n, l, t, i, r, f, c, s, a
+        for (o.sort(e); (n = o.shift()); )
+            n.__d &&
+                ((l = o.length),
+                (i = void 0),
+                (f = (r = (t = n).__v).__e),
+                (s = []),
+                (a = []),
+                (c = t.__P) &&
+                    (((i = d({}, r)).__v = r.__v + 1),
+                    u.vnode && u.vnode(i),
+                    L(
+                        c,
+                        i,
+                        r,
+                        t.__n,
+                        void 0 !== c.ownerSVGElement,
+                        32 & r.__u ? [f] : null,
+                        s,
+                        null == f ? w(r) : f,
+                        !!(32 & r.__u),
+                        a
+                    ),
+                    (i.__.__k[i.__i] = i),
+                    M(s, i, a),
+                    i.__e != f && x(i)),
+                o.length > l && o.sort(e))
+        S.__r = 0
+    }
+    function T(n, l, u, t, i, o, r, f, e, c, a) {
+        var v,
+            y,
+            d,
+            _,
+            b,
+            g = (t && t.__k) || p,
+            m = l.length
+        for (u.__d = e, $(u, l, g), e = u.__d, v = 0; v < m; v++)
+            null != (d = u.__k[v]) &&
+                'boolean' != typeof d &&
+                'function' != typeof d &&
+                ((y = -1 === d.__i ? h : g[d.__i] || h),
+                (d.__i = v),
+                L(n, d, y, i, o, r, f, e, c, a),
+                (_ = d.__e),
+                d.ref && y.ref != d.ref && (y.ref && N(y.ref, null, d), a.push(d.ref, d.__c || _, d)),
+                null == b && null != _ && (b = _),
+                d.__u & s || y.__k === d.__k
+                    ? (e = C(d, e, n))
+                    : 'function' == typeof d.type && void 0 !== d.__d
+                      ? (e = d.__d)
+                      : _ && (e = _.nextSibling),
+                (d.__d = void 0),
+                (d.__u &= -196609))
+        ;((u.__d = e), (u.__e = b))
+    }
+    function $(n, l, u) {
+        var t,
+            i,
+            o,
+            r,
+            f,
+            e = l.length,
+            c = u.length,
+            h = c,
+            p = 0
+        for (n.__k = [], t = 0; t < e; t++)
+            null !=
+            (i = n.__k[t] =
+                null == (i = l[t]) || 'boolean' == typeof i || 'function' == typeof i
+                    ? null
+                    : 'string' == typeof i || 'number' == typeof i || 'bigint' == typeof i || i.constructor == String
+                      ? g(null, i, null, null, i)
+                      : y(i)
+                        ? g(m, { children: i }, null, null, null)
+                        : void 0 === i.constructor && i.__b > 0
+                          ? g(i.type, i.props, i.key, i.ref ? i.ref : null, i.__v)
+                          : i)
+                ? ((i.__ = n),
+                  (i.__b = n.__b + 1),
+                  (f = H(i, u, (r = t + p), h)),
+                  (i.__i = f),
+                  (o = null),
+                  -1 !== f && (h--, (o = u[f]) && (o.__u |= a)),
+                  null == o || null === o.__v
+                      ? (-1 == f && p--, 'function' != typeof i.type && (i.__u |= s))
+                      : f !== r &&
+                        (f === r + 1
+                            ? p++
+                            : f > r
+                              ? h > e - r
+                                  ? (p += f - r)
+                                  : p--
+                              : (p = f < r && f == r - 1 ? f - r : 0),
+                        f !== t + p && (i.__u |= s)))
+                : (o = u[t]) &&
+                  null == o.key &&
+                  o.__e &&
+                  (o.__e == n.__d && (n.__d = w(o)), O(o, o, !1), (u[t] = null), h--)
+        if (h)
+            for (t = 0; t < c; t++)
+                null != (o = u[t]) && 0 == (o.__u & a) && (o.__e == n.__d && (n.__d = w(o)), O(o, o))
+    }
+    function C(n, l, u) {
+        var t, i
+        if ('function' == typeof n.type) {
+            for (t = n.__k, i = 0; t && i < t.length; i++) t[i] && ((t[i].__ = n), (l = C(t[i], l, u)))
+            return l
+        }
+        return (n.__e != l && (u.insertBefore(n.__e, l || null), (l = n.__e)), l && l.nextSibling)
+    }
+    function H(n, l, u, t) {
+        var i = n.key,
+            o = n.type,
+            r = u - 1,
+            f = u + 1,
+            e = l[u]
+        if (null === e || (e && i == e.key && o === e.type)) return u
+        if (t > (null != e && 0 == (e.__u & a) ? 1 : 0))
+            for (; r >= 0 || f < l.length; ) {
+                if (r >= 0) {
+                    if ((e = l[r]) && 0 == (e.__u & a) && i == e.key && o === e.type) return r
+                    r--
+                }
+                if (f < l.length) {
+                    if ((e = l[f]) && 0 == (e.__u & a) && i == e.key && o === e.type) return f
+                    f++
+                }
+            }
+        return -1
+    }
+    function I(n, l, u) {
+        '-' === l[0]
+            ? n.setProperty(l, null == u ? '' : u)
+            : (n[l] = null == u ? '' : 'number' != typeof u || v.test(l) ? u : u + 'px')
+    }
+    function j(n, l, u, t, i) {
+        var o
+        n: if ('style' === l)
+            if ('string' == typeof u) n.style.cssText = u
+            else {
+                if (('string' == typeof t && (n.style.cssText = t = ''), t))
+                    for (l in t) (u && l in u) || I(n.style, l, '')
+                if (u) for (l in u) (t && u[l] === t[l]) || I(n.style, l, u[l])
+            }
+        else if ('o' === l[0] && 'n' === l[1])
+            ((o = l !== (l = l.replace(/(PointerCapture)$|Capture$/, '$1'))),
+                (l = l.toLowerCase() in n ? l.toLowerCase().slice(2) : l.slice(2)),
+                n.l || (n.l = {}),
+                (n.l[l + o] = u),
+                u
+                    ? t
+                        ? (u.u = t.u)
+                        : ((u.u = Date.now()), n.addEventListener(l, o ? D : A, o))
+                    : n.removeEventListener(l, o ? D : A, o))
+        else {
+            if (i) l = l.replace(/xlink(H|:h)/, 'h').replace(/sName$/, 's')
+            else if (
+                'width' !== l &&
+                'height' !== l &&
+                'href' !== l &&
+                'list' !== l &&
+                'form' !== l &&
+                'tabIndex' !== l &&
+                'download' !== l &&
+                'rowSpan' !== l &&
+                'colSpan' !== l &&
+                'role' !== l &&
+                l in n
+            )
+                try {
+                    n[l] = null == u ? '' : u
+                    break n
+                } catch (n) {}
+            'function' == typeof u ||
+                (null == u || (!1 === u && '-' !== l[4]) ? n.removeAttribute(l) : n.setAttribute(l, u))
+        }
+    }
+    function A(n) {
+        var l = this.l[n.type + !1]
+        if (n.t) {
+            if (n.t <= l.u) return
+        } else n.t = Date.now()
+        return l(u.event ? u.event(n) : n)
+    }
+    function D(n) {
+        return this.l[n.type + !0](u.event ? u.event(n) : n)
+    }
+    function L(n, l, t, i, o, r, f, e, c, s) {
+        var a,
+            h,
+            p,
+            v,
+            _,
+            b,
+            g,
+            w,
+            x,
+            P,
+            S,
+            $,
+            C,
+            H,
+            I,
+            j = l.type
+        if (void 0 !== l.constructor) return null
+        ;(128 & t.__u && ((c = !!(32 & t.__u)), (r = [(e = l.__e = t.__e)])), (a = u.__b) && a(l))
+        n: if ('function' == typeof j)
+            try {
+                if (
+                    ((w = l.props),
+                    (x = (a = j.contextType) && i[a.__c]),
+                    (P = a ? (x ? x.props.value : a.__) : i),
+                    t.__c
+                        ? (g = (h = l.__c = t.__c).__ = h.__E)
+                        : ('prototype' in j && j.prototype.render
+                              ? (l.__c = h = new j(w, P))
+                              : ((l.__c = h = new k(w, P)), (h.constructor = j), (h.render = q)),
+                          x && x.sub(h),
+                          (h.props = w),
+                          h.state || (h.state = {}),
+                          (h.context = P),
+                          (h.__n = i),
+                          (p = h.__d = !0),
+                          (h.__h = []),
+                          (h._sb = [])),
+                    null == h.__s && (h.__s = h.state),
+                    null != j.getDerivedStateFromProps &&
+                        (h.__s == h.state && (h.__s = d({}, h.__s)), d(h.__s, j.getDerivedStateFromProps(w, h.__s))),
+                    (v = h.props),
+                    (_ = h.state),
+                    (h.__v = l),
+                    p)
+                )
+                    (null == j.getDerivedStateFromProps && null != h.componentWillMount && h.componentWillMount(),
+                        null != h.componentDidMount && h.__h.push(h.componentDidMount))
+                else {
+                    if (
+                        (null == j.getDerivedStateFromProps &&
+                            w !== v &&
+                            null != h.componentWillReceiveProps &&
+                            h.componentWillReceiveProps(w, P),
+                        !h.__e &&
+                            ((null != h.shouldComponentUpdate && !1 === h.shouldComponentUpdate(w, h.__s, P)) ||
+                                l.__v === t.__v))
+                    ) {
+                        for (
+                            l.__v !== t.__v && ((h.props = w), (h.state = h.__s), (h.__d = !1)),
+                                l.__e = t.__e,
+                                l.__k = t.__k,
+                                l.__k.forEach(function (n) {
+                                    n && (n.__ = l)
+                                }),
+                                S = 0;
+                            S < h._sb.length;
+                            S++
+                        )
+                            h.__h.push(h._sb[S])
+                        ;((h._sb = []), h.__h.length && f.push(h))
+                        break n
+                    }
+                    ;(null != h.componentWillUpdate && h.componentWillUpdate(w, h.__s, P),
+                        null != h.componentDidUpdate &&
+                            h.__h.push(function () {
+                                h.componentDidUpdate(v, _, b)
+                            }))
+                }
+                if (
+                    ((h.context = P),
+                    (h.props = w),
+                    (h.__P = n),
+                    (h.__e = !1),
+                    ($ = u.__r),
+                    (C = 0),
+                    'prototype' in j && j.prototype.render)
+                ) {
+                    for (
+                        h.state = h.__s, h.__d = !1, $ && $(l), a = h.render(h.props, h.state, h.context), H = 0;
+                        H < h._sb.length;
+                        H++
+                    )
+                        h.__h.push(h._sb[H])
+                    h._sb = []
+                } else
+                    do {
+                        ;((h.__d = !1), $ && $(l), (a = h.render(h.props, h.state, h.context)), (h.state = h.__s))
+                    } while (h.__d && ++C < 25)
+                ;((h.state = h.__s),
+                    null != h.getChildContext && (i = d(d({}, i), h.getChildContext())),
+                    p || null == h.getSnapshotBeforeUpdate || (b = h.getSnapshotBeforeUpdate(v, _)),
+                    T(
+                        n,
+                        y((I = null != a && a.type === m && null == a.key ? a.props.children : a)) ? I : [I],
+                        l,
+                        t,
+                        i,
+                        o,
+                        r,
+                        f,
+                        e,
+                        c,
+                        s
+                    ),
+                    (h.base = l.__e),
+                    (l.__u &= -161),
+                    h.__h.length && f.push(h),
+                    g && (h.__E = h.__ = null))
+            } catch (n) {
+                ;((l.__v = null),
+                    c || null != r
+                        ? ((l.__e = e), (l.__u |= c ? 160 : 32), (r[r.indexOf(e)] = null))
+                        : ((l.__e = t.__e), (l.__k = t.__k)),
+                    u.__e(n, l, t))
+            }
+        else
+            null == r && l.__v === t.__v
+                ? ((l.__k = t.__k), (l.__e = t.__e))
+                : (l.__e = z(t.__e, l, t, i, o, r, f, c, s))
+        ;(a = u.diffed) && a(l)
+    }
+    function M(n, l, t) {
+        l.__d = void 0
+        for (var i = 0; i < t.length; i++) N(t[i], t[++i], t[++i])
+        ;(u.__c && u.__c(l, n),
+            n.some(function (l) {
+                try {
+                    ;((n = l.__h),
+                        (l.__h = []),
+                        n.some(function (n) {
+                            n.call(l)
+                        }))
+                } catch (n) {
+                    u.__e(n, l.__v)
+                }
+            }))
+    }
+    function z(n, u, t, i, o, r, f, e, c) {
+        var s,
+            a,
+            p,
+            v,
+            d,
+            b,
+            g,
+            m = t.props,
+            k = u.props,
+            x = u.type
+        if (('svg' === x && (o = !0), null != r))
+            for (s = 0; s < r.length; s++)
+                if ((d = r[s]) && 'setAttribute' in d == !!x && (x ? d.localName === x : 3 === d.nodeType)) {
+                    ;((n = d), (r[s] = null))
+                    break
+                }
+        if (null == n) {
+            if (null === x) return document.createTextNode(k)
+            ;((n = o
+                ? document.createElementNS('http://www.w3.org/2000/svg', x)
+                : document.createElement(x, k.is && k)),
+                (r = null),
+                (e = !1))
+        }
+        if (null === x) m === k || (e && n.data === k) || (n.data = k)
+        else {
+            if (((r = r && l.call(n.childNodes)), (m = t.props || h), !e && null != r))
+                for (m = {}, s = 0; s < n.attributes.length; s++) m[(d = n.attributes[s]).name] = d.value
+            for (s in m)
+                ((d = m[s]),
+                    'children' == s ||
+                        ('dangerouslySetInnerHTML' == s ? (p = d) : 'key' === s || s in k || j(n, s, null, d, o)))
+            for (s in k)
+                ((d = k[s]),
+                    'children' == s
+                        ? (v = d)
+                        : 'dangerouslySetInnerHTML' == s
+                          ? (a = d)
+                          : 'value' == s
+                            ? (b = d)
+                            : 'checked' == s
+                              ? (g = d)
+                              : 'key' === s || (e && 'function' != typeof d) || m[s] === d || j(n, s, d, m[s], o))
+            if (a)
+                (e || (p && (a.__html === p.__html || a.__html === n.innerHTML)) || (n.innerHTML = a.__html),
+                    (u.__k = []))
+            else if (
+                (p && (n.innerHTML = ''),
+                T(n, y(v) ? v : [v], u, t, i, o && 'foreignObject' !== x, r, f, r ? r[0] : t.__k && w(t, 0), e, c),
+                null != r)
+            )
+                for (s = r.length; s--; ) null != r[s] && _(r[s])
+            e ||
+                ((s = 'value'),
+                void 0 !== b &&
+                    (b !== n[s] || ('progress' === x && !b) || ('option' === x && b !== m[s])) &&
+                    j(n, s, b, m[s], !1),
+                (s = 'checked'),
+                void 0 !== g && g !== n[s] && j(n, s, g, m[s], !1))
+        }
+        return n
+    }
+    function N(n, l, t) {
+        try {
+            'function' == typeof n ? n(l) : (n.current = l)
+        } catch (n) {
+            u.__e(n, t)
+        }
+    }
+    function O(n, l, t) {
+        var i, o
+        if (
+            (u.unmount && u.unmount(n),
+            (i = n.ref) && ((i.current && i.current !== n.__e) || N(i, null, l)),
+            null != (i = n.__c))
+        ) {
+            if (i.componentWillUnmount)
+                try {
+                    i.componentWillUnmount()
+                } catch (n) {
+                    u.__e(n, l)
+                }
+            ;((i.base = i.__P = null), (n.__c = void 0))
+        }
+        if ((i = n.__k)) for (o = 0; o < i.length; o++) i[o] && O(i[o], l, t || 'function' != typeof n.type)
+        ;(t || null == n.__e || _(n.__e), (n.__ = n.__e = n.__d = void 0))
+    }
+    function q(n, l, u) {
+        return this.constructor(n, u)
+    }
+    function B(n, t, i) {
+        var o, r, f, e
+        ;(u.__ && u.__(n, t),
+            (r = (o = 'function' == typeof i) ? null : (i && i.__k) || t.__k),
+            (f = []),
+            (e = []),
+            L(
+                t,
+                (n = ((!o && i) || t).__k = b(m, null, [n])),
+                r || h,
+                h,
+                void 0 !== t.ownerSVGElement,
+                !o && i ? [i] : r ? null : t.firstChild ? l.call(t.childNodes) : null,
+                f,
+                !o && i ? i : r ? r.__e : t.firstChild,
+                o,
+                e
+            ),
+            M(f, n, e))
+    }
+    ;((l = p.slice),
+        (u = {
+            __e: function (n, l, u, t) {
+                for (var i, o, r; (l = l.__); )
+                    if ((i = l.__c) && !i.__)
+                        try {
+                            if (
+                                ((o = i.constructor) &&
+                                    null != o.getDerivedStateFromError &&
+                                    (i.setState(o.getDerivedStateFromError(n)), (r = i.__d)),
+                                null != i.componentDidCatch && (i.componentDidCatch(n, t || {}), (r = i.__d)),
+                                r)
+                            )
+                                return (i.__E = i)
+                        } catch (l) {
+                            n = l
+                        }
+                throw n
+            },
+        }),
+        (t = 0),
+        (i = function (n) {
+            return null != n && null == n.constructor
+        }),
+        (k.prototype.setState = function (n, l) {
+            var u
+            ;((u = null != this.__s && this.__s !== this.state ? this.__s : (this.__s = d({}, this.state))),
+                'function' == typeof n && (n = n(d({}, u), this.props)),
+                n && d(u, n),
+                null != n && this.__v && (l && this._sb.push(l), P(this)))
+        }),
+        (k.prototype.forceUpdate = function (n) {
+            this.__v && ((this.__e = !0), n && this.__h.push(n), P(this))
+        }),
+        (k.prototype.render = m),
+        (o = []),
+        (f = 'function' == typeof Promise ? Promise.prototype.then.bind(Promise.resolve()) : setTimeout),
+        (e = function (n, l) {
+            return n.__v.__b - l.__v.__b
+        }),
+        (S.__r = 0),
+        (c = 0),
+        (n.Component = k),
+        (n.Fragment = m),
+        (n.cloneElement = function (n, u, t) {
+            var i,
+                o,
+                r,
+                f,
+                e = d({}, n.props)
+            for (r in (n.type && n.type.defaultProps && (f = n.type.defaultProps), u))
+                'key' == r
+                    ? (i = u[r])
+                    : 'ref' == r
+                      ? (o = u[r])
+                      : (e[r] = void 0 === u[r] && void 0 !== f ? f[r] : u[r])
+            return (
+                arguments.length > 2 && (e.children = arguments.length > 3 ? l.call(arguments, 2) : t),
+                g(n.type, e, i || n.key, o || n.ref, null)
+            )
+        }),
+        (n.createContext = function (n, l) {
+            var u = {
+                __c: (l = '__cC' + c++),
+                __: n,
+                Consumer: function (n, l) {
+                    return n.children(l)
+                },
+                Provider: function (n) {
+                    var u, t
+                    return (
+                        this.getChildContext ||
+                            ((u = []),
+                            ((t = {})[l] = this),
+                            (this.getChildContext = function () {
+                                return t
+                            }),
+                            (this.shouldComponentUpdate = function (n) {
+                                this.props.value !== n.value &&
+                                    u.some(function (n) {
+                                        ;((n.__e = !0), P(n))
+                                    })
+                            }),
+                            (this.sub = function (n) {
+                                u.push(n)
+                                var l = n.componentWillUnmount
+                                n.componentWillUnmount = function () {
+                                    ;(u.splice(u.indexOf(n), 1), l && l.call(n))
+                                }
+                            })),
+                        n.children
+                    )
+                },
+            }
+            return (u.Provider.__ = u.Consumer.contextType = u)
+        }),
+        (n.createElement = b),
+        (n.createRef = function () {
+            return { current: null }
+        }),
+        (n.h = b),
+        (n.hydrate = function n(l, u) {
+            B(l, u, n)
+        }),
+        (n.isValidElement = i),
+        (n.options = u),
+        (n.render = B),
+        (n.toChildArray = function n(l, u) {
+            return (
+                (u = u || []),
+                null == l ||
+                    'boolean' == typeof l ||
+                    (y(l)
+                        ? l.some(function (l) {
+                              n(l, u)
+                          })
+                        : u.push(l)),
+                u
+            )
+        }))
+})
+//# sourceMappingURL=preact.umd.js.map

--- a/packages/browser/playwright/mocked/hydration-error.spec.ts
+++ b/packages/browser/playwright/mocked/hydration-error.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from './utils/posthog-playwright-test-base'
+import { gotoPage } from './utils/setup'
+
+test.describe('SSR hydration compatibility', () => {
+    test('does not cause hydration errors when scripts are loaded', async ({ page, context }) => {
+        await context.route('**/flags/*', (route) => {
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    featureFlags: {},
+                    featureFlagPayloads: {},
+                    sessionRecording: {
+                        endpoint: '/ses/',
+                    },
+                }),
+            })
+        })
+
+        await context.route('**/static/recorder.js*', (route) => {
+            route.fulfill({
+                status: 200,
+                contentType: 'application/javascript',
+                body: 'console.log("recorder loaded"); window.__PosthogExtensions__ = window.__PosthogExtensions__ || {}; window.__PosthogExtensions__.rrweb = {};',
+            })
+        })
+
+        await gotoPage(page, '/playground/hydration/index.html')
+        await page.waitForFunction(() => (window as any).testComplete === true, { timeout: 10000 })
+
+        const domMutated = await page.evaluate(() => (window as any).domMutated)
+        const newScriptsAdded = await page.evaluate(() => (window as any).newScriptsAdded)
+        const hydrationErrors: string[] = await page.evaluate(() => (window as any).hydrationErrors)
+
+        expect(newScriptsAdded).toBe(true)
+        expect(domMutated).toBe(false)
+        expect(hydrationErrors).toEqual([])
+    })
+
+    test('appends scripts to head, leaving body untouched for SSR hydration', async ({ page, context }) => {
+        await context.route('**/flags/*', (route) => {
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    featureFlags: {},
+                    featureFlagPayloads: {},
+                    sessionRecording: {
+                        endpoint: '/ses/',
+                    },
+                }),
+            })
+        })
+
+        await context.route('**/static/recorder.js*', (route) => {
+            route.fulfill({
+                status: 200,
+                contentType: 'application/javascript',
+                body: `
+                    console.log("recorder loaded");
+                    window.__PosthogExtensions__ = window.__PosthogExtensions__ || {};
+                    window.__PosthogExtensions__.rrweb = {};
+                    window.__PosthogExtensions__.rrwebPlugins = { getRecordConsolePlugin: function() { return {}; } };
+                `,
+            })
+        })
+
+        await gotoPage(page, '/playground/hydration/index.html')
+        await page.waitForFunction(() => (window as any).testComplete === true, { timeout: 10000 })
+
+        const bodyScripts = await page.evaluate(() => {
+            const scripts = Array.from(document.querySelectorAll('body > script')) as HTMLScriptElement[]
+            return scripts.map((s) => ({
+                id: s.id || null,
+                src: s.src || null,
+                isPosthogScript: s.src?.includes('posthog') || s.src?.includes('recorder') || false,
+            }))
+        })
+
+        const headScripts = await page.evaluate(() => {
+            const scripts = Array.from(document.querySelectorAll('head > script')) as HTMLScriptElement[]
+            return scripts.map((s) => ({
+                src: s.src || null,
+                isPosthogScript: s.src?.includes('posthog') || s.src?.includes('recorder') || false,
+            }))
+        })
+
+        const posthogScriptsInBody = bodyScripts.filter((s) => s.isPosthogScript)
+        const posthogScriptsInHead = headScripts.filter((s) => s.isPosthogScript)
+
+        expect(posthogScriptsInBody).toEqual([])
+        expect(posthogScriptsInHead.length).toBeGreaterThan(0)
+    })
+})

--- a/packages/browser/src/__tests__/utils/external-scripts-loader.test.ts
+++ b/packages/browser/src/__tests__/utils/external-scripts-loader.test.ts
@@ -5,9 +5,10 @@ import '../../entrypoints/external-scripts-loader'
 
 describe('external-scripts-loader', () => {
     describe('loadScript', () => {
-        const mockPostHog: PostHog = {
+        const mockPostHog = {
             config: {
                 api_host: 'https://us.posthog.com',
+                external_scripts_inject_target: 'body',
             },
             version: '1.0.0',
         } as PostHog
@@ -19,87 +20,97 @@ describe('external-scripts-loader', () => {
             document!.getElementsByTagName('html')![0].innerHTML = ''
         })
 
-        it('should insert the given script before the one already on the page', () => {
-            document!.body.appendChild(document!.createElement('script'))
-            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
-            const scripts = document!.getElementsByTagName('script')
-            const new_script = scripts[0]
+        it('appends scripts to body by default', () => {
+            const existingBodyScript = document!.createElement('script')
+            existingBodyScript.id = 'framework-bundle'
+            document!.body.appendChild(existingBodyScript)
 
-            expect(scripts.length).toBe(2)
-            expect(new_script.type).toBe('text/javascript')
-            expect(new_script.src).toMatchInlineSnapshot(`"https://us-assets.i.posthog.com/static/recorder.js?v=1.0.0"`)
-            const event = new Event('test')
-            new_script.onload!(event)
-            expect(callback).toHaveBeenCalledWith(undefined, event)
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
+
+            const bodyScripts = document!.querySelectorAll('body > script')
+            expect(bodyScripts.length).toBe(2)
+            expect(bodyScripts[0].src).toContain('recorder.js')
+            expect(bodyScripts[1].id).toBe('framework-bundle')
+
+            expect(document!.querySelectorAll('head > script').length).toBe(0)
         })
 
-        it('should not add duplicate scripts when called multiple times with the same URL', () => {
-            // First call to load the script
+        it('appends scripts to head when configured', () => {
+            mockPostHog.config.external_scripts_inject_target = 'head'
+
+            const existingBodyScript = document!.createElement('script')
+            existingBodyScript.id = 'framework-bundle'
+            document!.body.appendChild(existingBodyScript)
+
             assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
 
-            // Second call with the same script
+            const bodyScripts = document!.querySelectorAll('body > script')
+            expect(bodyScripts.length).toBe(1)
+            expect(bodyScripts[0].id).toBe('framework-bundle')
+
+            const headScripts = document!.querySelectorAll('head > script')
+            expect(headScripts.length).toBe(1)
+            expect(headScripts[0].src).toContain('recorder.js')
+
+            mockPostHog.config.external_scripts_inject_target = 'body'
+        })
+
+        it('does not add duplicate scripts', () => {
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
             assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
 
             const scripts = document!.getElementsByTagName('script')
             expect(scripts.length).toBe(1)
             expect(scripts[0].src).toMatchInlineSnapshot(`"https://us-assets.i.posthog.com/static/recorder.js?v=1.0.0"`)
 
-            // Verify both callbacks are called when script loads
-            const event = new Event('test')
-
             scripts[0].dispatchEvent(new Event('load'))
-
-            // we replace the handler
             expect(callback).toHaveBeenCalledTimes(2)
-            expect(callback).toHaveBeenCalledWith(undefined, event)
         })
 
-        it("should add the script to the page when there aren't any preexisting scripts on the page", () => {
+        it('adds script when no preexisting scripts exist', () => {
             assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
             const scripts = document!.getElementsByTagName('script')
 
-            expect(scripts?.length).toBe(1)
-            expect(scripts![0].type).toBe('text/javascript')
-            expect(scripts![0].src).toMatchInlineSnapshot(
-                `"https://us-assets.i.posthog.com/static/recorder.js?v=1.0.0"`
-            )
+            expect(scripts.length).toBe(1)
+            expect(scripts[0].type).toBe('text/javascript')
+            expect(scripts[0].src).toMatchInlineSnapshot(`"https://us-assets.i.posthog.com/static/recorder.js?v=1.0.0"`)
         })
 
-        it('should respond with an error if one happens', () => {
+        it('calls callback with error on failure', () => {
             assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'recorder', callback)
-            const scripts = document!.getElementsByTagName('script')
-            const new_script = scripts[0]
-
-            new_script.onerror!('uh-oh')
+            document!.getElementsByTagName('script')[0].onerror!('uh-oh')
             expect(callback).toHaveBeenCalledWith('uh-oh')
         })
 
-        it('should add a timestamp to the toolbar loader', () => {
+        it('adds timestamp to toolbar loader', () => {
             jest.useFakeTimers()
             jest.setSystemTime(1726067100000)
             assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'toolbar', callback)
-            const scripts = document!.getElementsByTagName('script')
-            const new_script = scripts[0]
-            expect(new_script.src).toBe('https://us-assets.i.posthog.com/static/toolbar.js?v=1.0.0&t=1726067100000')
+            expect(document!.getElementsByTagName('script')[0].src).toBe(
+                'https://us-assets.i.posthog.com/static/toolbar.js?v=1.0.0&t=1726067100000'
+            )
         })
 
-        it('allows adding a nonce via the prepare_external_dependency_script config', () => {
+        it('allows adding nonce via prepare_external_dependency_script', () => {
             mockPostHog.config.prepare_external_dependency_script = (script) => {
                 script.nonce = '123'
                 return script
             }
+
             assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'toolbar', callback)
-            const scripts = document!.getElementsByTagName('script')
-            const new_script = scripts[0]
-            expect(new_script.nonce).toBe('123')
+            expect(document!.getElementsByTagName('script')[0].nonce).toBe('123')
+
+            delete mockPostHog.config.prepare_external_dependency_script
         })
 
         it('does not load script if prepare_external_dependency_script returns null', () => {
             mockPostHog.config.prepare_external_dependency_script = () => null
+
             assignableWindow.__PosthogExtensions__.loadExternalDependency(mockPostHog, 'toolbar', callback)
-            const scripts = document!.getElementsByTagName('script')
-            expect(scripts.length).toBe(0)
+            expect(document!.getElementsByTagName('script').length).toBe(0)
             expect(callback).toHaveBeenCalledWith('prepare_external_dependency_script returned null')
+
+            delete mockPostHog.config.prepare_external_dependency_script
         })
     })
 })

--- a/packages/browser/src/entrypoints/external-scripts-loader.ts
+++ b/packages/browser/src/entrypoints/external-scripts-loader.ts
@@ -62,12 +62,15 @@ const loadScript = (posthog: PostHog, url: string, callback: (error?: string | E
             return callback('prepare_external_dependency_script returned null')
         }
 
-        const scripts = document.querySelectorAll('body > script')
-        if (scripts.length > 0) {
-            scripts[0].parentNode?.insertBefore(scriptTag, scripts[0])
+        if (posthog.config.external_scripts_inject_target === 'head') {
+            document.head.appendChild(scriptTag)
         } else {
-            // In exceptional situations this call might load before the DOM is fully ready.
-            document.body.appendChild(scriptTag)
+            const scripts = document.querySelectorAll('body > script')
+            if (scripts.length > 0) {
+                scripts[0].parentNode?.insertBefore(scriptTag, scripts[0])
+            } else {
+                document.body.appendChild(scriptTag)
+            }
         }
     }
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -153,10 +153,11 @@ let ENQUEUE_REQUESTS = !SUPPORTS_REQUEST && userAgent?.indexOf('MSIE') === -1 &&
 
 const defaultsThatVaryByConfig = (
     defaults?: ConfigDefaults
-): Pick<PostHogConfig, 'rageclick' | 'capture_pageview' | 'session_recording'> => ({
+): Pick<PostHogConfig, 'rageclick' | 'capture_pageview' | 'session_recording' | 'external_scripts_inject_target'> => ({
     rageclick: defaults && defaults >= '2025-11-30' ? { content_ignorelist: true } : true,
     capture_pageview: defaults && defaults >= '2025-05-24' ? 'history_change' : true,
     session_recording: defaults && defaults >= '2025-11-30' ? { strictMinimumDuration: true } : {},
+    external_scripts_inject_target: defaults && defaults >= '2026-01-30' ? 'head' : 'body',
 })
 
 // NOTE: Remember to update `types.ts` when changing a default value

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -216,6 +216,11 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "undefined",
     "(stylesheet: HTMLStyleElement) => HTMLStyleElement | null"
   ],
+  "external_scripts_inject_target": [
+    "undefined",
+    "\\"body\\"",
+    "\\"head\\""
+  ],
   "enable_recording_console_log": [
     "undefined",
     "false",
@@ -282,6 +287,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
   ],
   "properties_string_max_length": "number",
   "defaults": [
+    "\\"2026-01-30\\"",
     "\\"2025-11-30\\"",
     "\\"2025-05-24\\"",
     "\\"unset\\""

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -271,7 +271,7 @@ export interface HeatmapConfig {
     flush_interval_milliseconds: number
 }
 
-export type ConfigDefaults = '2025-11-30' | '2025-05-24' | 'unset'
+export type ConfigDefaults = '2026-01-30' | '2025-11-30' | '2025-05-24' | 'unset'
 
 export type ExternalIntegrationKind = 'intercom' | 'crispChat'
 
@@ -844,6 +844,15 @@ export interface PostHogConfig {
     prepare_external_dependency_stylesheet?: (stylesheet: HTMLStyleElement) => HTMLStyleElement | null
 
     /**
+     * Where to inject external dependency scripts (recorder, surveys, etc.) in the DOM.
+     * - 'body': Injects scripts into document.body (legacy behavior)
+     * - 'head': Injects scripts into document.head (avoids SSR hydration errors)
+     *
+     * @default 'body' (or 'head' when defaults >= '2026-01-30')
+     */
+    external_scripts_inject_target?: 'body' | 'head'
+
+    /**
      * Determines whether PostHog should enable recording console logs.
      * When undefined, it falls back to the remote config setting.
      *
@@ -971,6 +980,7 @@ export interface PostHogConfig {
      * - `'unset'`: Use legacy default behaviors
      * - `'2025-05-24'`: Use updated default behaviors (e.g. capture_pageview defaults to 'history_change')
      * - `'2025-11-30'`: Defaults from '2025-05-24' plus additional changes (e.g. strict minimum duration for replay and rageclick content ignore list defaults to active)
+     * - `'2026-01-30'`: Defaults from '2025-11-30' plus external_scripts_inject_target defaults to 'head' (avoids SSR hydration errors)
      *
      * @default 'unset'
      */


### PR DESCRIPTION
avoid hydration errors https://github.com/PostHog/posthog-js/issues/2781

when someone is using SSR and we're lazy loading scripts we have a race between react hydrating and us altering the DOM

if we manage to alter the DOM before hydration complests then we'll cause a hydration error  
  
i don't believe we care where the script is added (since we're adding it async from code the location isn't going to affect whether it blocks) so we can add the script to the head and not have any risk of causing a hydration error

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin