### PR TITLE
fix: alter how we add lazy loaded scripts to avoid hydration errors

### DIFF
--- a/.changeset/ready-knives-walk.md
+++ b/.changeset/ready-knives-walk.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: the way we added lazy loaded files could cause hydration errors (in a race against hydration). let's avoid that


### PR DESCRIPTION
change how we add lazy loaded scripts so that we don't cause hydration errors
(i worry this remains a race against hydration since we are still altering the DOM 🤞)

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

