### PR TITLE
fix(ci): use read instead of head pipe to avoid SIGPIPE

### DIFF
--- a/.github/actions/notify-slack-release-approval/action.yaml
+++ b/.github/actions/notify-slack-release-approval/action.yaml
@@ -28,9 +28,9 @@ runs:
               git fetch --tags --force
 
               # Get the most recent tag (sorted by date, not version)
-              # Note: Store all tags first to avoid SIGPIPE (exit 141) when piping to head
+              # Note: Use read instead of piping to head to avoid SIGPIPE (exit 141)
               ALL_TAGS=$(git tag --sort=-creatordate)
-              LATEST_TAG=$(echo "$ALL_TAGS" | head -n 1)
+              read -r LATEST_TAG <<< "$ALL_TAGS"
 
               if [ -z "$LATEST_TAG" ]; then
                 echo "No tags found, using initial commit"


### PR DESCRIPTION
## Summary

Follow-up to #2805 - the `echo | head` approach still triggered SIGPIPE in CI.

## The fix

```bash
# Before: still has a pipe that can cause SIGPIPE
ALL_TAGS=$(git tag --sort=-creatordate)
LATEST_TAG=$(echo "$ALL_TAGS" | head -n 1)

# After: no pipes at all - read is a bash builtin
ALL_TAGS=$(git tag --sort=-creatordate)
read -r LATEST_TAG <<< "$ALL_TAGS"
```

`read -r VAR <<< "$DATA"` reads the first line from a here-string without any pipes.

## Test plan

- [ ] Trigger release workflow and verify no SIGPIPE errors