### PR TITLE
fix(surveys): android keyboard glitching

### DIFF
--- a/.changeset/yellow-teeth-mix.md
+++ b/.changeset/yellow-teeth-mix.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+add control for keyboard avoiding behavior on android

--- a/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
+++ b/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
@@ -66,6 +66,14 @@ export type PostHogSurveyProviderProps = {
    */
   overrideAppearanceWithDefault?: boolean
 
+  /**
+   * The keyboard avoiding behavior for the survey modal (KeyboardAvoidingView), applied only to Android devices.
+   * - 'padding': Adds padding to avoid keyboard (recommended)
+   * - 'height': Resizes the view height (default, for legacy - may cause flickering on some Android devices)
+   * @default 'height'
+   */
+  androidKeyboardBehavior?: 'padding' | 'height'
+
   client?: PostHog
 
   children: React.ReactNode
@@ -165,7 +173,13 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
     <ActiveSurveyContext.Provider value={activeContext}>
       <FeedbackSurveyContext.Provider value={{ surveys, activeSurvey, setActiveSurvey }}>
         {props.children}
-        {shouldShowModal && <SurveyModal appearance={surveyAppearance} {...activeContext} />}
+        {shouldShowModal && (
+          <SurveyModal
+            appearance={surveyAppearance}
+            androidKeyboardBehavior={props.androidKeyboardBehavior}
+            {...activeContext}
+          />
+        )}
       </FeedbackSurveyContext.Provider>
     </ActiveSurveyContext.Provider>
   )

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -14,10 +14,11 @@ export type SurveyModalProps = {
   appearance: SurveyAppearanceTheme
   onShow: () => void
   onClose: (submitted: boolean) => void
+  androidKeyboardBehavior?: 'padding' | 'height'
 }
 
 export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
-  const { survey, appearance, onShow } = props
+  const { survey, appearance, onShow, androidKeyboardBehavior = 'height' } = props
   const [isSurveySent, setIsSurveySent] = useState(false)
   const onClose = useCallback(() => props.onClose(isSurveySent), [isSurveySent, props])
   const insets = useOptionalSafeAreaInsets()
@@ -39,7 +40,7 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
   return (
     <Modal animationType="fade" transparent onRequestClose={onClose} statusBarTranslucent={true}>
       <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior={Platform.OS === 'ios' ? 'padding' : androidKeyboardBehavior}
         style={{ flex: 1, justifyContent: 'flex-end' }}
         keyboardVerticalOffset={Platform.OS === 'ios' ? 10 : 0}
       >


### PR DESCRIPTION
## Problem
the keyboard causes major glitching in some cases on android. customer video here: https://posthoghelp.zendesk.com/agent/tickets/44614 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/48378)

reproduction here, on android 16 with physical keyboard + stylus input modes enabled:

[Screen Recording 2025-12-22 at 12.53.23 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/5fe5cfd4-f747-42a0-abe8-2ce942217ead.mov" />](https://app.graphite.com/user-attachments/video/5fe5cfd4-f747-42a0-abe8-2ce942217ead.mov)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->
adds a new sdk param `androidKeyboardBehavior` to control the behavior for `KeyboardAvoidingView` on android

setting it to `padding` resolved the issue in my testing, but i do not want to risk a regression here
## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
