### PR TITLE
fix(replay): add targetSessionId to avoid session rotation bugs

### DIFF
--- a/.changeset/early-rats-follow.md
+++ b/.changeset/early-rats-follow.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Add targetSessionID to lifecycle start events


### PR DESCRIPTION
## Problem

we're still seeing some instances of session IDs not rotating properly, there seems to be some subtle timing issue that happens some of the time. 

## Changes

This aims to be more explicit about what sessionID should be used, rather than rely on this.session_id, which is updated at various points in this flow and i suspect can be momentarily out of date?

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
