### PR TITLE
feat: add `$device_id` to cookies

### DIFF
--- a/.changeset/whole-birds-own.md
+++ b/.changeset/whole-birds-own.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Persist $device_id to cookies so it survives localStorage clears

--- a/packages/browser/src/__tests__/posthog-persistence.test.ts
+++ b/packages/browser/src/__tests__/posthog-persistence.test.ts
@@ -1,6 +1,6 @@
 /// <reference lib="dom" />
 import { PostHogPersistence } from '../posthog-persistence'
-import { INITIAL_PERSON_INFO, SESSION_ID, USER_STATE } from '../constants'
+import { DEVICE_ID, INITIAL_PERSON_INFO, SESSION_ID, USER_STATE } from '../constants'
 import { PostHogConfig } from '../types'
 import { PostHog } from '../posthog-core'
 import { window } from '../utils/globals'
@@ -153,9 +153,10 @@ describe('persistence', () => {
             expect(document.cookie).toEqual('')
 
             const lib = new PostHogPersistence(makePostHogConfig('test', 'localStorage+cookie'))
-            lib.register({ distinct_id: 'test', test_prop: 'test_val' })
+            lib.register({ distinct_id: 'test', test_prop: 'test_val', [DEVICE_ID]: 'device-123' })
             expect(document.cookie).toContain(
                 `ph__posthog=${encode({
+                    $device_id: 'device-123',
                     distinct_id: 'test',
                 })}`
             )
@@ -164,6 +165,7 @@ describe('persistence', () => {
             lib.register({ otherProp: 'prop' })
             expect(document.cookie).toContain(
                 `ph__posthog=${encode({
+                    $device_id: 'device-123',
                     distinct_id: 'test',
                 })}`
             )
@@ -171,6 +173,7 @@ describe('persistence', () => {
             lib.register({ [SESSION_ID]: [1000, 'sid', 2000] })
             expect(document.cookie).toContain(
                 `ph__posthog=${encode({
+                    $device_id: 'device-123',
                     distinct_id: 'test',
                     $sesid: [1000, 'sid', 2000],
                 })}`
@@ -179,6 +182,7 @@ describe('persistence', () => {
             lib.register({ [INITIAL_PERSON_INFO]: { u: 'https://www.example.com', r: 'https://www.referrer.com' } })
             expect(document.cookie).toContain(
                 `ph__posthog=${encode({
+                    $device_id: 'device-123',
                     distinct_id: 'test',
                     $sesid: [1000, 'sid', 2000],
                     $initial_person_info: { u: 'https://www.example.com', r: 'https://www.referrer.com' },
@@ -190,8 +194,10 @@ describe('persistence', () => {
 
             const newLib = new PostHogPersistence(makePostHogConfig('test', 'localStorage+cookie'))
 
+            // $device_id should be recovered from cookies after localStorage is cleared
             expect(newLib.props).toEqual({
                 distinct_id: 'test',
+                $device_id: 'device-123',
                 $sesid: [1000, 'sid', 2000],
                 $initial_person_info: { u: 'https://www.example.com', r: 'https://www.referrer.com' },
             })

--- a/packages/browser/src/constants.ts
+++ b/packages/browser/src/constants.ts
@@ -7,6 +7,7 @@
 // This key is deprecated, but we want to check for it to see whether aliasing is allowed.
 export const PEOPLE_DISTINCT_ID_KEY = '$people_distinct_id'
 export const DISTINCT_ID = 'distinct_id'
+export const DEVICE_ID = '$device_id'
 export const ALIAS_ID_KEY = '__alias'
 export const CAMPAIGN_IDS_KEY = '__cmpns'
 export const EVENT_TIMERS_KEY = '__timers'

--- a/packages/browser/src/storage.ts
+++ b/packages/browser/src/storage.ts
@@ -1,6 +1,7 @@
 import { extend } from './utils'
 import { PersistentStore, Properties } from './types'
 import {
+    DEVICE_ID,
     DISTINCT_ID,
     ENABLE_PERSON_PROCESSING,
     INITIAL_PERSON_INFO,
@@ -259,6 +260,7 @@ export const localStore: PersistentStore = {
 // This solves issues with cookies having too much data in them causing headers too large
 // Also makes sure we don't have to send a ton of data to the server
 const COOKIE_PERSISTED_PROPERTIES = [
+    DEVICE_ID,
     DISTINCT_ID,
     SESSION_ID,
     SESSION_RECORDING_IS_SAMPLED,


### PR DESCRIPTION
## Changes
Persist device ID to cookies in addition to localStorage. This fixes an issue where device ID becomes null for identified users when localStorage is cleared.

Context: https://posthoghelp.zendesk.com/agent/tickets/45826 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50767)