### PR TITLE
fix: because replay has partial compression during processing we now have double compression on replay during processing

### DIFF
--- a/.changeset/cold-pans-wash.md
+++ b/.changeset/cold-pans-wash.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+allow config to not gzip compress snapshot events when sending (they are already partially compressed when being generated)

--- a/packages/browser/playwright/mocked/session-recording/lazy-session-recording.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/lazy-session-recording.spec.ts
@@ -326,4 +326,18 @@ test.describe('Session recording - array.js', () => {
         expect(targetEvent!['properties']['$sdk_debug_current_session_duration']).toBeDefined()
         expect(targetEvent!['properties']['$sdk_debug_session_start']).toBeDefined()
     })
+
+    test('sends session recording snapshots with compression=none', async ({ page }) => {
+        await page.resetCapturedEvents()
+
+        const recordingRequestPromise = page.waitForRequest((request) => {
+            return request.url().includes('/ses/') && request.method() === 'POST'
+        })
+
+        await page.locator('[data-cy-input]').type('hello posthog!')
+        const recordingRequest = await recordingRequestPromise
+
+        expect(recordingRequest.url()).toContain('compression=none')
+        expect(recordingRequest.headers()['content-type']).toEqual('application/json')
+    })
 })

--- a/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
+++ b/packages/browser/src/__tests__/__snapshots__/config-snapshot.test.ts.snap
@@ -391,6 +391,13 @@ exports[`config snapshot for PostHogConfig 1`] = `
       "undefined",
       "false",
       "true"
+    ],
+    "compress_snapshot_requests": [
+      "undefined",
+      "Compression.GZipJS",
+      "Compression.Base64",
+      "Compression.None",
+      "\\"best-available\\""
     ]
   },
   "error_tracking": {

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -350,6 +350,34 @@ describe('posthog core', () => {
 
             expect(captureResult.properties.$current_url).toEqual('http://localhost/')
         })
+
+        it.each([
+            ['none', 'none'],
+            ['gzip-js', 'gzip-js'],
+            ['base64', 'base64'],
+        ])('passes compression option %s through to _send_request', (compressionOption, expectedCompression) => {
+            const posthog = posthogWith({ ...defaultConfig, request_batching: false }, defaultOverrides)
+
+            posthog.capture('event-name', { foo: 'bar' }, { compression: compressionOption as any })
+
+            expect(posthog._send_request).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    compression: expectedCompression,
+                })
+            )
+        })
+
+        it('defaults to best-available compression when no compression option specified', () => {
+            const posthog = posthogWith({ ...defaultConfig, request_batching: false }, defaultOverrides)
+
+            posthog.capture('event-name', { foo: 'bar' })
+
+            expect(posthog._send_request).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    compression: 'best-available',
+                })
+            )
+        })
     })
 
     describe('_afterFlagsResponse', () => {

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -437,6 +437,19 @@ describe('request', () => {
                     'application/x-www-form-urlencoded'
                 )
             })
+
+            it('should send plain JSON when Compression.None is set', () => {
+                request(
+                    createRequest({
+                        url: 'https://any.posthog-instance.com/',
+                        method: 'POST',
+                        compression: Compression.None,
+                        data: { foo: 'bar' },
+                    })
+                )
+                expect(mockedXHR.send.mock.calls[0][0]).toMatchInlineSnapshot(`"{"foo":"bar"}"`)
+                expect(mockedXHR.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/json')
+            })
         })
 
         describe('sendBeacon', () => {
@@ -519,6 +532,31 @@ describe('request', () => {
                 "�      �VJ��W�RJJ,R� ��+�
                    "
             `)
+            })
+
+            it('should send plain JSON with compression=none in URL when Compression.None is set', async () => {
+                request(
+                    createRequest({
+                        url: 'https://any.posthog-instance.com/',
+                        method: 'POST',
+                        compression: Compression.None,
+                        data: { foo: 'bar' },
+                    })
+                )
+
+                expect(mockedNavigator?.sendBeacon).toHaveBeenCalledWith(
+                    'https://any.posthog-instance.com/?_=1700000000000&ver=1.23.45&compression=none&beacon=1',
+                    expect.any(Blob)
+                )
+                const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
+
+                const reader = new FileReader()
+                const result = await new Promise((resolve) => {
+                    reader.onload = () => resolve(reader.result)
+                    reader.readAsText(blob)
+                })
+
+                expect(result).toMatchInlineSnapshot(`"{"foo":"bar"}"`)
             })
         })
     })

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -31,7 +31,7 @@ import {
 } from './triggerMatching'
 import { estimateSize, INCREMENTAL_SNAPSHOT_EVENT_TYPE, truncateLargeConsoleLogs } from './sessionrecording-utils'
 import { gzipSync, strFromU8, strToU8 } from 'fflate'
-import { assignableWindow, LazyLoadedSessionRecordingInterface, window, document } from '../../../utils/globals'
+import { assignableWindow, document, LazyLoadedSessionRecordingInterface, window } from '../../../utils/globals'
 import { addEventListener } from '../../../utils'
 import { MutationThrottler } from './mutation-throttler'
 import { createLogger } from '../../../utils/logger'
@@ -50,9 +50,9 @@ import {
 import {
     SESSION_RECORDING_EVENT_TRIGGER_ACTIVATED_SESSION,
     SESSION_RECORDING_IS_SAMPLED,
-    SESSION_RECORDING_OVERRIDE_SAMPLING,
-    SESSION_RECORDING_OVERRIDE_LINKED_FLAG,
     SESSION_RECORDING_OVERRIDE_EVENT_TRIGGER,
+    SESSION_RECORDING_OVERRIDE_LINKED_FLAG,
+    SESSION_RECORDING_OVERRIDE_SAMPLING,
     SESSION_RECORDING_OVERRIDE_URL_TRIGGER,
     SESSION_RECORDING_PAST_MINIMUM_DURATION,
     SESSION_RECORDING_REMOTE_CONFIG,
@@ -1198,6 +1198,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             _noTruncate: true,
             _batchKey: SESSION_RECORDING_BATCH_KEY,
             skip_client_rate_limiting: true,
+            compression: this._instance.config.session_recording?.compress_snapshot_requests ?? 'best-available',
         })
     }
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -153,7 +153,10 @@ const defaultsThatVaryByConfig = (
 ): Pick<PostHogConfig, 'rageclick' | 'capture_pageview' | 'session_recording'> => ({
     rageclick: defaults && defaults >= '2025-11-30' ? { content_ignorelist: true } : true,
     capture_pageview: defaults && defaults >= '2025-05-24' ? 'history_change' : true,
-    session_recording: defaults && defaults >= '2025-11-30' ? { strictMinimumDuration: true } : {},
+    session_recording: {
+        ...(defaults && defaults >= '2025-11-30' ? { strictMinimumDuration: true } : {}),
+        ...(defaults && defaults >= '2026-01-01' ? { compress_snapshot_requests: Compression.None } : {}),
+    },
 })
 
 // NOTE: Remember to update `types.ts` when changing a default value
@@ -1205,7 +1208,7 @@ export class PostHog {
             method: 'POST',
             url: options?._url ?? this.requestRouter.endpointFor('api', this.analyticsDefaultEndpoint),
             data,
-            compression: 'best-available',
+            compression: options?.compression ?? 'best-available',
             batchKey: options?._batchKey,
         }
 

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -1358,6 +1358,13 @@ export interface SessionRecordingOptions {
      * @default false
      */
     strictMinimumDuration?: boolean
+
+    /**
+     * Controls HTTP compression for snapshot requests.
+     *
+     * @default 'gzip-js' ('none' for defaults >= '2026-01-01')
+     */
+    compress_snapshot_requests?: RequestWithOptions['compression']
 }
 
 export type SessionIdChangedCallback = (
@@ -1369,6 +1376,7 @@ export type SessionIdChangedCallback = (
 export enum Compression {
     GZipJS = 'gzip-js',
     Base64 = 'base64',
+    None = 'none',
 }
 
 // Request types - these should be kept minimal to what request.ts needs
@@ -1477,6 +1485,12 @@ export interface CaptureOptions {
      * If set, overrides the current timestamp
      */
     timestamp?: Date
+
+    /**
+     * Allow callers to override compression per event
+     * for example SessionReplay already compresses its contents so can skip compression
+     */
+    compression?: RequestWithOptions['compression']
 }
 
 export type FlagVariant = { flag: string; variant: string }


### PR DESCRIPTION
see: https://posthoghelp.zendesk.com/agent/tickets/43990 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/55566) where a user reports their canvas recording sees performance impact from event transport compression

we already partially compress replay data so we could opt replay events out of the event compression