### PR TITLE
chore: dummy PR to trigger RN release

### DIFF
--- a/.changeset/rich-bears-switch.md
+++ b/.changeset/rich-bears-switch.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+release trigger

--- a/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
+++ b/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
@@ -67,7 +67,7 @@ export type PostHogSurveyProviderProps = {
   overrideAppearanceWithDefault?: boolean
 
   /**
-   * The keyboard avoiding behavior for the survey modal (KeyboardAvoidingView), applied only to Android devices.
+   * The keyboard avoiding behavior for the survey modal (KeyboardAvoidingView) - applied only to Android devices.
    * - 'padding': Adds padding to avoid keyboard (recommended)
    * - 'height': Resizes the view height (default, for legacy - may cause flickering on some Android devices)
    * @default 'height'


### PR DESCRIPTION
## Problem

dummy PR to trigger release :sadge:

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->