### PR TITLE
feat(surveys): add last-seen survey date as person property

### DIFF
--- a/.changeset/afraid-mails-sleep.md
+++ b/.changeset/afraid-mails-sleep.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+adds person property for last-seen survey date, bringing more consistent behavior cross-browser/device/etc

--- a/packages/browser/src/__tests__/posthog-core.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.test.ts
@@ -336,6 +336,29 @@ describe('posthog core', () => {
                     },
                 })
             })
+            it('sending survey shown events should set the last seen survey date property', () => {
+                // arrange
+                const { posthog, beforeSendMock } = setup({ debug: false })
+                const survey = {
+                    id: 'testSurvey1',
+                    current_iteration: 1,
+                }
+
+                // act
+                posthog.capture(SurveyEventName.SHOWN, {
+                    [SurveyEventProperties.SURVEY_ID]: survey.id,
+                    [SurveyEventProperties.SURVEY_ITERATION]: survey.current_iteration,
+                })
+
+                // assert
+                const capturedEvent = beforeSendMock.mock.calls[0][0]
+                expect(capturedEvent.$set).toBeDefined()
+                expect(capturedEvent.$set[SurveyEventProperties.SURVEY_LAST_SEEN_DATE]).toBeDefined()
+                // Verify it's a valid ISO date string
+                expect(new Date(capturedEvent.$set[SurveyEventProperties.SURVEY_LAST_SEEN_DATE]).toISOString()).toBe(
+                    capturedEvent.$set[SurveyEventProperties.SURVEY_LAST_SEEN_DATE]
+                )
+            })
         })
     })
 })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1182,6 +1182,11 @@ export class PostHog {
                     event_name === SurveyEventName.SENT ? 'responded' : 'dismissed'
                 )]: true,
             }
+        } else if (event_name === SurveyEventName.SHOWN) {
+            data.$set = {
+                ...data.$set,
+                [SurveyEventProperties.SURVEY_LAST_SEEN_DATE]: new Date().toISOString(),
+            }
         }
 
         // Top-level $set overriding values from the one from properties is taken from the plugin-server normalizeEvent

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -285,6 +285,7 @@ export enum SurveyEventProperties {
     SURVEY_QUESTIONS = '$survey_questions',
     SURVEY_COMPLETED = '$survey_completed',
     PRODUCT_TOUR_ID = '$product_tour_id',
+    SURVEY_LAST_SEEN_DATE = '$survey_last_seen_date',
 }
 
 export enum DisplaySurveyType {


### PR DESCRIPTION
## Problem

we only track the 'last seen survey date' in local storage. this means users might see surveys too frequently across different devices, browsers, etc

closes https://github.com/PostHog/posthog/issues/44150

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

adds a new person property for this, so we can check both local storage + the new person property, which gives us more consistent behavior.

we will now include this person property in the survey internal targeting flags: https://github.com/PostHog/posthog/pull/44164

ultimately i'd prefer if this was in the plugin server so it works no matter what SDK, but this will do for now :+1:

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->