### PR TITLE
fix: double counting anthropic langchain

### DIFF
--- a/.changeset/crisp-chairs-read.md
+++ b/.changeset/crisp-chairs-read.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Fixes cache creation cost for Langchain with Anthropic


### PR DESCRIPTION
We were counting cache write tokens incorrectly when using Anthropic with Langchain.

Furthermore, we were sending read tokens under the wrong property name.