### PR TITLE
fix: undefined constructor error

### DIFF
--- a/.changeset/smart-otters-throw.md
+++ b/.changeset/smart-otters-throw.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Fixes an error with certain AI imports when using CJS (`TypeError: Class extends value undefined is not a constructor or null`)

--- a/packages/ai/rollup.config.mjs
+++ b/packages/ai/rollup.config.mjs
@@ -13,6 +13,7 @@ configs.push({
       sourcemap: true,
       exports: 'named',
       format: `cjs`,
+      interop: 'auto',
     },
     {
       file: packageJson.module,
@@ -43,6 +44,7 @@ providers.forEach((provider) => {
         sourcemap: true,
         exports: 'named',
         format: 'cjs',
+        interop: 'auto',
       },
       {
         file: `./dist/${provider}/index.mjs`,


### PR DESCRIPTION
Fixes the following error with certain AI imports when using CJS:
```
TypeError: Class extends value undefined is not a constructor or null
```

[Related community question](https://posthog.com/questions/posthog-ai-incompatible-with-google-genai).