### PR TITLE
fix(product tours): ignore URL condition for manual trigger tours

### DIFF
--- a/.changeset/witty-garlics-tan.md
+++ b/.changeset/witty-garlics-tan.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+remove URL check from manually-triggered product tours

--- a/packages/browser/src/extensions/product-tours/product-tours.tsx
+++ b/packages/browser/src/extensions/product-tours/product-tours.tsx
@@ -787,9 +787,9 @@ export class ProductTourManager {
                     return
                 }
 
-                // manual triggers only check launch status + URL, no other conditions
-                if (!checkTourConditions(tour)) {
-                    logger.warn(`Tour ${tour.id} trigger clicked but failed conditions check`)
+                // manual triggers only check launch status, no other conditions
+                if (!isTourInDateRange(tour)) {
+                    logger.warn(`Tour ${tour.id} trigger clicked, but tour is not launched - not showing tour.`)
                     return
                 }
 


### PR DESCRIPTION
## Problem
moved URL targeting to only apply to auto-show tours, but the sdk still checks the URL for manual triggers
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
remove URL check from manual trigger - these now ONLY check the date range (if the tour is "launched")

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
