### PR TITLE
fix(surveys): respect branching logic in URL prefill

### DIFF
--- a/.changeset/spicy-ducks-dance.md
+++ b/.changeset/spicy-ducks-dance.md
@@ -1,0 +1,7 @@
+---
+'posthog-js': patch
+---
+
+Fix survey URL prefill to respect branching/skip logic
+
+When using URL parameters to prefill survey responses (e.g., `?q0=9`), the SDK now correctly respects the survey's branching configuration. Previously, prefilled answers would always advance to the next sequential question, ignoring any skip logic.

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -64,6 +64,10 @@ import {
     convertPrefillToResponses,
     calculatePrefillStartIndex,
 } from '../utils/survey-url-prefill'
+import { getNextSurveyStep } from '../utils/survey-branching'
+
+// Re-export for surveys-preview entrypoint
+export { getNextSurveyStep }
 
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const window = _window as Window & typeof globalThis
@@ -71,115 +75,6 @@ const document = _document as Document
 
 const DISPATCH_FEEDBACK_WIDGET_EVENT = 'ph:show_survey_widget'
 const WIDGET_LISTENER_ATTRIBUTE = 'PHWidgetSurveyClickListener'
-
-function getRatingBucketForResponseValue(responseValue: number, scale: number) {
-    if (scale === 3) {
-        if (responseValue < 1 || responseValue > 3) {
-            throw new Error('The response must be in range 1-3')
-        }
-
-        return responseValue === 1 ? 'negative' : responseValue === 2 ? 'neutral' : 'positive'
-    } else if (scale === 5) {
-        if (responseValue < 1 || responseValue > 5) {
-            throw new Error('The response must be in range 1-5')
-        }
-
-        return responseValue <= 2 ? 'negative' : responseValue === 3 ? 'neutral' : 'positive'
-    } else if (scale === 7) {
-        if (responseValue < 1 || responseValue > 7) {
-            throw new Error('The response must be in range 1-7')
-        }
-
-        return responseValue <= 3 ? 'negative' : responseValue === 4 ? 'neutral' : 'positive'
-    } else if (scale === 10) {
-        if (responseValue < 0 || responseValue > 10) {
-            throw new Error('The response must be in range 0-10')
-        }
-
-        return responseValue <= 6 ? 'detractors' : responseValue <= 8 ? 'passives' : 'promoters'
-    }
-
-    throw new Error('The scale must be one of: 3, 5, 7, 10')
-}
-
-export function getNextSurveyStep(
-    survey: Survey,
-    currentQuestionIndex: number,
-    response: string | string[] | number | null
-) {
-    const question = survey.questions[currentQuestionIndex]
-    const nextQuestionIndex = currentQuestionIndex + 1
-
-    if (!question.branching?.type) {
-        if (currentQuestionIndex === survey.questions.length - 1) {
-            return SurveyQuestionBranchingType.End
-        }
-
-        return nextQuestionIndex
-    }
-
-    if (question.branching.type === SurveyQuestionBranchingType.End) {
-        return SurveyQuestionBranchingType.End
-    } else if (question.branching.type === SurveyQuestionBranchingType.SpecificQuestion) {
-        if (Number.isInteger(question.branching.index)) {
-            return question.branching.index
-        }
-    } else if (question.branching.type === SurveyQuestionBranchingType.ResponseBased) {
-        // Single choice
-        if (question.type === SurveyQuestionType.SingleChoice) {
-            // :KLUDGE: for now, look up the choiceIndex based on the response
-            // TODO: once QuestionTypes.MultipleChoiceQuestion is refactored, pass the selected choiceIndex into this method
-            let selectedChoiceIndex = question.choices.indexOf(`${response}`)
-
-            if (selectedChoiceIndex === -1 && question.hasOpenChoice) {
-                // if the response is not found in the choices, it must be the open choice,
-                // which is always the last choice
-                selectedChoiceIndex = question.choices.length - 1
-            }
-
-            if (question.branching?.responseValues?.hasOwnProperty(selectedChoiceIndex)) {
-                const nextStep = question.branching.responseValues[selectedChoiceIndex]
-
-                // Specific question
-                if (Number.isInteger(nextStep)) {
-                    return nextStep
-                }
-
-                if (nextStep === SurveyQuestionBranchingType.End) {
-                    return SurveyQuestionBranchingType.End
-                }
-
-                return nextQuestionIndex
-            }
-        } else if (question.type === SurveyQuestionType.Rating) {
-            if (typeof response !== 'number' || !Number.isInteger(response)) {
-                throw new Error('The response type must be an integer')
-            }
-
-            const ratingBucket = getRatingBucketForResponseValue(response, question.scale)
-
-            if (question.branching?.responseValues?.hasOwnProperty(ratingBucket)) {
-                const nextStep = question.branching.responseValues[ratingBucket]
-
-                // Specific question
-                if (Number.isInteger(nextStep)) {
-                    return nextStep
-                }
-
-                if (nextStep === SurveyQuestionBranchingType.End) {
-                    return SurveyQuestionBranchingType.End
-                }
-
-                return nextQuestionIndex
-            }
-        }
-
-        return nextQuestionIndex
-    }
-
-    logger.warn('Falling back to next question index due to unexpected branching type')
-    return nextQuestionIndex
-}
 
 const SURVEY_NEXT_TO_TRIGGER_PARAMS = {
     ESTIMATED_MIN_HEIGHT: 250,
@@ -471,7 +366,7 @@ export class SurveyManager {
             // calculate which question to start at based on prefilled questions
             const prefilledIndices = Object.keys(params).map((k) => parseInt(k, 10))
             const { startQuestionIndex, skippedResponses } = calculatePrefillStartIndex(
-                survey.questions,
+                survey,
                 prefilledIndices,
                 responses
             )

--- a/packages/browser/src/utils/survey-branching.ts
+++ b/packages/browser/src/utils/survey-branching.ts
@@ -1,0 +1,121 @@
+import { Survey, SurveyQuestionBranchingType, SurveyQuestionType } from '../posthog-surveys-types'
+import { createLogger } from './logger'
+
+const logger = createLogger('[Surveys]')
+
+/**
+ * Get the rating bucket (detractors/passives/promoters or negative/neutral/positive)
+ * based on the response value and scale.
+ */
+export function getRatingBucketForResponseValue(responseValue: number, scale: number): string {
+    if (scale === 3) {
+        if (responseValue < 1 || responseValue > 3) {
+            throw new Error('The response must be in range 1-3')
+        }
+
+        return responseValue === 1 ? 'negative' : responseValue === 2 ? 'neutral' : 'positive'
+    } else if (scale === 5) {
+        if (responseValue < 1 || responseValue > 5) {
+            throw new Error('The response must be in range 1-5')
+        }
+
+        return responseValue <= 2 ? 'negative' : responseValue === 3 ? 'neutral' : 'positive'
+    } else if (scale === 7) {
+        if (responseValue < 1 || responseValue > 7) {
+            throw new Error('The response must be in range 1-7')
+        }
+
+        return responseValue <= 3 ? 'negative' : responseValue === 4 ? 'neutral' : 'positive'
+    } else if (scale === 10) {
+        if (responseValue < 0 || responseValue > 10) {
+            throw new Error('The response must be in range 0-10')
+        }
+
+        return responseValue <= 6 ? 'detractors' : responseValue <= 8 ? 'passives' : 'promoters'
+    }
+
+    throw new Error('The scale must be one of: 3, 5, 7, 10')
+}
+
+/**
+ * Determine the next survey step based on branching configuration.
+ * Returns the next question index, or SurveyQuestionBranchingType.End if the survey should end.
+ */
+export function getNextSurveyStep(
+    survey: Survey,
+    currentQuestionIndex: number,
+    response: string | string[] | number | null
+): number | SurveyQuestionBranchingType.End {
+    const question = survey.questions[currentQuestionIndex]
+    const nextQuestionIndex = currentQuestionIndex + 1
+
+    if (!question.branching?.type) {
+        if (currentQuestionIndex === survey.questions.length - 1) {
+            return SurveyQuestionBranchingType.End
+        }
+
+        return nextQuestionIndex
+    }
+
+    if (question.branching.type === SurveyQuestionBranchingType.End) {
+        return SurveyQuestionBranchingType.End
+    } else if (question.branching.type === SurveyQuestionBranchingType.SpecificQuestion) {
+        if (Number.isInteger(question.branching.index)) {
+            return question.branching.index
+        }
+    } else if (question.branching.type === SurveyQuestionBranchingType.ResponseBased) {
+        // Single choice
+        if (question.type === SurveyQuestionType.SingleChoice) {
+            // KLUDGE: for now, look up the choiceIndex based on the response
+            // TODO: once QuestionTypes.MultipleChoiceQuestion is refactored, pass the selected choiceIndex into this method
+            let selectedChoiceIndex = question.choices.indexOf(`${response}`)
+
+            if (selectedChoiceIndex === -1 && question.hasOpenChoice) {
+                // if the response is not found in the choices, it must be the open choice,
+                // which is always the last choice
+                selectedChoiceIndex = question.choices.length - 1
+            }
+
+            if (question.branching?.responseValues?.hasOwnProperty(selectedChoiceIndex)) {
+                const nextStep = question.branching.responseValues[selectedChoiceIndex]
+
+                // Specific question
+                if (Number.isInteger(nextStep)) {
+                    return nextStep
+                }
+
+                if (nextStep === SurveyQuestionBranchingType.End) {
+                    return SurveyQuestionBranchingType.End
+                }
+
+                return nextQuestionIndex
+            }
+        } else if (question.type === SurveyQuestionType.Rating) {
+            if (typeof response !== 'number' || !Number.isInteger(response)) {
+                throw new Error('The response type must be an integer')
+            }
+
+            const ratingBucket = getRatingBucketForResponseValue(response, question.scale)
+
+            if (question.branching?.responseValues?.hasOwnProperty(ratingBucket)) {
+                const nextStep = question.branching.responseValues[ratingBucket]
+
+                // Specific question
+                if (Number.isInteger(nextStep)) {
+                    return nextStep
+                }
+
+                if (nextStep === SurveyQuestionBranchingType.End) {
+                    return SurveyQuestionBranchingType.End
+                }
+
+                return nextQuestionIndex
+            }
+        }
+
+        return nextQuestionIndex
+    }
+
+    logger.warn('Falling back to next question index due to unexpected branching type')
+    return nextQuestionIndex
+}

--- a/packages/browser/src/utils/survey-url-prefill.ts
+++ b/packages/browser/src/utils/survey-url-prefill.ts
@@ -156,7 +156,9 @@ export function calculatePrefillStartIndex(
     let currentIndex = 0
     const skippedResponses: Record<string, any> = {}
 
-    while (currentIndex < survey.questions.length) {
+  const MAX_ITERATIONS = survey.questions.length + 1
+  let iterations = 0
+  while (currentIndex < survey.questions.length && iterations < MAX_ITERATIONS) {
         // Stop if current question is not prefilled
         if (!prefilledIndices.includes(currentIndex)) {
             break

--- a/packages/browser/src/utils/survey-url-prefill.ts
+++ b/packages/browser/src/utils/survey-url-prefill.ts
@@ -156,9 +156,9 @@ export function calculatePrefillStartIndex(
     let currentIndex = 0
     const skippedResponses: Record<string, any> = {}
 
-  const MAX_ITERATIONS = survey.questions.length + 1
-  let iterations = 0
-  while (currentIndex < survey.questions.length && iterations < MAX_ITERATIONS) {
+    const MAX_ITERATIONS = survey.questions.length + 1
+    const iterations = 0
+    while (currentIndex < survey.questions.length && iterations < MAX_ITERATIONS) {
         // Stop if current question is not prefilled
         if (!prefilledIndices.includes(currentIndex)) {
             break


### PR DESCRIPTION
## Problem

When using URL parameters to prefill survey responses, the SDK now correctly respects the survey's branching configuration. Previously, prefilled answers would always advance to the next sequential question, ignoring any skip logic configured on the question.

## Changes

- Extract getNextSurveyStep to shared utility (survey-branching.ts)
- Update calculatePrefillStartIndex to use branching logic
- Add tests for response-based, end, and specific-question branching

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
