### PR TITLE
fix(ai): expose all GoogleGenAI constructor parameters

### DIFF
--- a/.changeset/fix-gemini-config-types.md
+++ b/.changeset/fix-gemini-config-types.md
@@ -1,0 +1,7 @@
+---
+"@posthog/ai": patch
+---
+
+fix(gemini): expose all GoogleGenAI constructor parameters in wrapper
+
+The `MonitoringGeminiConfig` interface now extends `GoogleGenAIOptions` from `@google/genai`, allowing users to pass all available constructor parameters like `googleAuthOptions` and `httpOptions` without TypeScript errors.

--- a/packages/ai/src/gemini/index.ts
+++ b/packages/ai/src/gemini/index.ts
@@ -5,6 +5,7 @@ import {
   Part,
   GenerateContentResponseUsageMetadata,
 } from '@google/genai'
+import type { GoogleGenAIOptions } from '@google/genai'
 import { PostHog } from 'posthog-node'
 import {
   MonitoringParams,
@@ -18,12 +19,7 @@ import { sanitizeGemini } from '../sanitization'
 import type { TokenUsage, FormattedContent, FormattedContentItem, FormattedMessage } from '../types'
 import { isString } from '../typeGuards'
 
-interface MonitoringGeminiConfig {
-  apiKey?: string
-  vertexai?: boolean
-  project?: string
-  location?: string
-  apiVersion?: string
+interface MonitoringGeminiConfig extends GoogleGenAIOptions {
   posthog: PostHog
 }
 


### PR DESCRIPTION
## Problem

Fixes #2830

The `MonitoringGeminiConfig` interface only exposed a subset of the `GoogleGenAI` constructor parameters, causing TypeScript errors when users tried to use parameters like `googleAuthOptions` or `httpOptions`.

## Changes

- Extended `MonitoringGeminiConfig` from `GoogleGenAIOptions` (from `@google/genai`) instead of manually defining a subset of properties
- This follows the same pattern used by the OpenAI wrapper which extends `ClientOptions`

## How did you test this code?

- Build passes
- All existing tests pass