### PR TITLE
feat(product tours): element inference - findElement in sdk

### DIFF
--- a/.changeset/green-lands-wash.md
+++ b/.changeset/green-lands-wash.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+add product tour element inference

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -54,6 +54,7 @@
         "core-js": "^3.38.1",
         "fflate": "^0.4.8",
         "preact": "^10.19.3",
+        "query-selector-shadow-dom": "^1.0.1",
         "web-vitals": "^4.2.4"
     },
     "devDependencies": {
@@ -86,6 +87,7 @@
         "@types/dotenv": "^8.2.3",
         "@types/jest": "catalog:",
         "@types/node": "^22.5.0",
+        "@types/query-selector-shadow-dom": "^1.0.4",
         "@types/sinon": "^17.0.1",
         "@types/web": "^0.0.222",
         "babel-jest": "^29.7.0",

--- a/packages/browser/src/entrypoints/element-inference.es.ts
+++ b/packages/browser/src/entrypoints/element-inference.es.ts
@@ -1,0 +1,1 @@
+export { findElement, getElementPath, elementIsVisible } from '../extensions/product-tours/element-inference'

--- a/packages/browser/src/entrypoints/product-tours.ts
+++ b/packages/browser/src/entrypoints/product-tours.ts
@@ -4,4 +4,7 @@ import { assignableWindow } from '../utils/globals'
 assignableWindow.__PosthogExtensions__ = assignableWindow.__PosthogExtensions__ || {}
 assignableWindow.__PosthogExtensions__.generateProductTours = generateProductTours
 
+export { findElement, getElementPath, elementIsVisible } from '../extensions/product-tours/element-inference'
+export type { InferredSelector, AutoData, SelectorGroup } from '../extensions/product-tours/element-inference'
+
 export default generateProductTours

--- a/packages/browser/src/extensions/product-tours/element-inference.ts
+++ b/packages/browser/src/extensions/product-tours/element-inference.ts
@@ -1,0 +1,240 @@
+import { querySelectorAllDeep } from 'query-selector-shadow-dom'
+import { window as _window } from '../../utils/globals'
+import { createLogger, isArray, isUndefined } from '@posthog/core'
+
+const window = _window as Window & typeof globalThis
+const logger = createLogger('[Element Inference]')
+
+// this is copied directly from the main repo: /frontend/src/toolbar/utils.ts
+// TODO: once this is deployed, we can have the main repo reference this instead
+export function elementIsVisible(element: HTMLElement, cache: WeakMap<HTMLElement, boolean>): boolean {
+    try {
+        const alreadyCached = cache.get(element)
+        if (!isUndefined(alreadyCached)) {
+            return alreadyCached
+        }
+
+        if (element.checkVisibility) {
+            const nativeIsVisible = element.checkVisibility({
+                checkOpacity: true,
+                checkVisibilityCSS: true,
+            })
+            cache.set(element, nativeIsVisible)
+            return nativeIsVisible
+        }
+
+        const style = window.getComputedStyle(element)
+        const isInvisible = style.display === 'none' || style.visibility === 'hidden' || parseFloat(style.opacity) === 0
+        if (isInvisible) {
+            cache.set(element, false)
+            return false
+        }
+
+        // Check parent chain for display/visibility
+        let parent = element.parentElement
+        while (parent) {
+            // Check cache first
+            const cached = cache.get(parent)
+            if (!isUndefined(cached)) {
+                if (!cached) {
+                    return false
+                }
+                // If cached as visible, skip to next parent
+                parent = parent.parentElement
+                continue
+            }
+
+            const parentStyle = window.getComputedStyle(parent)
+            const parentVisible = parentStyle.display !== 'none' && parentStyle.visibility !== 'hidden'
+
+            cache.set(parent, parentVisible)
+
+            if (!parentVisible) {
+                return false
+            }
+            parent = parent.parentElement
+        }
+
+        // Check if element has actual rendered dimensions
+        const rect = element.getBoundingClientRect()
+        const elementHasActualRenderedDimensions =
+            rect.width > 0 ||
+            rect.height > 0 ||
+            // Some elements might be 0x0 but still visible (e.g., inline elements with content)
+            element.getClientRects().length > 0
+        cache.set(element, elementHasActualRenderedDimensions)
+        return elementHasActualRenderedDimensions
+    } catch {
+        // if we can't get the computed style, we'll assume the element is visible
+        return true
+    }
+}
+
+export interface SelectorGroup {
+    cardinality: number
+    cssSelectors: Array<{
+        css: string
+        offset: number
+    }>
+}
+
+export interface AutoData {
+    notextGroups: SelectorGroup[]
+    textGroups: SelectorGroup[]
+}
+
+export interface InferredSelector {
+    autoData: string
+    text: string | null
+    excludeText?: boolean
+}
+
+function getElementText(element: HTMLElement): string | null {
+    const text = element.innerText?.trim()
+    // anything higher than 250 chars -> prob not a good selector / button / target
+    if (!text || text.length > 250) {
+        return null
+    }
+    return text
+}
+
+function elementMatchesText(element: HTMLElement, text: string): boolean {
+    const elementText = getElementText(element)
+    return elementText?.toLowerCase() === text.toLowerCase()
+}
+
+// generator to query elements, filtering by text and visibility
+function* queryElements(
+    selector: string,
+    text: string | null,
+    visibilityCache: WeakMap<HTMLElement, boolean>
+): Generator<HTMLElement, void, undefined> {
+    let elements: HTMLElement[]
+
+    try {
+        elements = querySelectorAllDeep(selector) as unknown as HTMLElement[]
+    } catch {
+        return
+    }
+
+    for (const el of elements) {
+        const element = el as HTMLElement
+        if (text && !elementMatchesText(element, text)) {
+            continue
+        }
+        if (!elementIsVisible(element, visibilityCache)) {
+            continue
+        }
+        yield element
+    }
+}
+
+// could be inlined, but wanna keep lazy eval from queryElements
+function nth<T>(iterable: Iterable<T>, n: number): T | null {
+    let idx = 0
+    for (const item of iterable) {
+        if (idx === n) {
+            return item
+        }
+        idx++
+    }
+    return null
+}
+
+/**
+ * if inferSelector is the sauce, this is the nugget
+ *
+ * find an element in the dom using the element inference data
+ *
+ * 1. try each group of selectors, starting with most specific (lowest cardinality)
+ * 2. try each selector in the group - run the css query, go to offset
+ * 3. "vote" for the element if it was found
+ * 4. return early if any element gets majority votes
+ * 5. return element w/ most votes
+ */
+export function findElement(selector: InferredSelector): HTMLElement | null {
+    try {
+        const autoData = JSON.parse(selector.autoData) as AutoData
+        if (!isArray(autoData?.textGroups) || !isArray(autoData?.notextGroups)) {
+            logger.error('Invalid autoData structure:', autoData)
+            return null
+        }
+        const { text, excludeText } = selector
+
+        // excludeText -> user setting, usually if the target element
+        // has dynamic/localized text
+        const useText = text != null && !excludeText
+
+        // choose appropriate group + sort
+        const groups = (useText ? autoData.textGroups : autoData.notextGroups).sort(
+            (a, b) => a.cardinality - b.cardinality
+        )
+
+        if (groups.length === 0) {
+            return null
+        }
+
+        const visibilityCache = new WeakMap<HTMLElement, boolean>()
+
+        // try each selector group, starting w/ most specific (lowest cardinality)
+        for (const group of groups) {
+            const votes = new Map<HTMLElement, number>()
+            let winner: HTMLElement | null = null
+            let maxVotes = 0
+
+            // test each selector in the group
+            for (const { css, offset } of group.cssSelectors) {
+                // get matches, jump to offset to find our target
+                const element = nth(queryElements(css, useText ? text : null, visibilityCache), offset)
+
+                if (!element) {
+                    continue
+                }
+
+                // if we found something, this element gets a vote
+                const voteCount = (votes.get(element) ?? 0) + 1
+                votes.set(element, voteCount)
+
+                if (voteCount > maxVotes) {
+                    maxVotes = voteCount
+                    winner = element
+
+                    // break early if we have a majority
+                    if (voteCount >= Math.ceil(group.cssSelectors.length / 2)) {
+                        return winner
+                    }
+                }
+            }
+
+            if (winner) {
+                return winner
+            }
+        }
+
+        return null
+    } catch (error) {
+        logger.error('Error finding element:', error)
+        return null
+    }
+}
+
+export function getElementPath(el: HTMLElement | null, depth = 4): string | null {
+    if (!el) {
+        return null
+    }
+    const parts: string[] = []
+    let current: HTMLElement | null = el
+
+    while (current && parts.length < depth && current.tagName !== 'BODY') {
+        let part = current.tagName.toLowerCase()
+        if (current.id) {
+            part += `#${current.id}`
+        } else if (current.classList.length) {
+            part += `.${current.classList[0]}`
+        }
+        parts.unshift(part)
+        current = current.parentElement
+    }
+
+    return parts.join(' > ')
+}

--- a/packages/browser/src/extensions/product-tours/index.ts
+++ b/packages/browser/src/extensions/product-tours/index.ts
@@ -4,6 +4,8 @@ import { ProductTourManager } from './product-tours'
 
 export { ProductTourManager } from './product-tours'
 export { findElementBySelector, getElementMetadata, getProductTourStylesheet } from './product-tours-utils'
+export { findElement, getElementPath } from './element-inference'
+export type { InferredSelector, AutoData, SelectorGroup } from './element-inference'
 
 export function generateProductTours(posthog: PostHog, isEnabled: boolean): ProductTourManager | undefined {
     if (!_document) {

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -1,5 +1,6 @@
 import { PropertyMatchType } from './types'
 import { SurveyActionType, SurveyEventWithFilters } from './posthog-surveys-types'
+import type { InferredSelector } from './extensions/product-tours/element-inference'
 
 export interface JSONContent {
     type?: string
@@ -38,6 +39,8 @@ export interface ProductTourStep {
     linkedSurveyId?: string
     /** ID of the survey question (set by backend, used for event tracking) */
     linkedSurveyQuestionId?: string
+    /** Enhanced element data for more reliable lookup at runtime */
+    inferenceData?: InferredSelector
 }
 
 export interface ProductTourConditions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       preact:
         specifier: ^10.19.3
         version: 10.19.3
+      query-selector-shadow-dom:
+        specifier: ^1.0.1
+        version: 1.0.1
       web-vitals:
         specifier: ^4.2.4
         version: 4.2.4
@@ -339,6 +342,9 @@ importers:
       '@types/node':
         specifier: ^22.5.0
         version: 22.5.0
+      '@types/query-selector-shadow-dom':
+        specifier: ^1.0.4
+        version: 1.0.4
       '@types/sinon':
         specifier: ^17.0.1
         version: 17.0.1
@@ -4110,6 +4116,9 @@ packages:
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/query-selector-shadow-dom@1.0.4':
+    resolution: {integrity: sha512-8jfGPD0wCMCdyBvrvOrWVn8bHL1UEjkPVJKsqNZpEXp+a7mIIvvGpJMd6n6dlNl7IkG2ryxIVqFI516RPE0uhQ==}
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
@@ -10549,6 +10558,9 @@ packages:
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   query-string@6.14.1:
     resolution: {integrity: sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==}
@@ -17522,6 +17534,8 @@ snapshots:
   '@types/prop-types@15.7.5': {}
 
   '@types/qs@6.14.0': {}
+
+  '@types/query-selector-shadow-dom@1.0.4': {}
 
   '@types/range-parser@1.2.7': {}
 
@@ -26237,6 +26251,8 @@ snapshots:
   qs@6.7.0: {}
 
   quansync@0.2.11: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   query-string@6.14.1:
     dependencies:


### PR DESCRIPTION
## Problem

it's a long story :) see https://github.com/PostHog/posthog/pull/43744

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
adds element inference to the SDK, mostly ripped from [this PR](https://github.com/PostHog/posthog/pull/43744)

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
