### PR TITLE
chore: remove core package from mobile team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,6 @@ packages/browser/src/utils/survey-utils.ts             @PostHog/team-surveys
 # Mobile
 packages/react-native/                                 @PostHog/team-mobile
 examples/example_rn_macos/                             @PostHog/team-mobile
-packages/core/                                         @PostHog/team-mobile
 packages/example-expo-53/                              @PostHog/team-mobile
 
 # AI


### PR DESCRIPTION
## Problem

this is blocking PRs for no reason
the idea was to find possible breaking changes for react native, but not to block PRs

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
