### PR TITLE
chore: this _should_ fix a flaky playwright test

### DIFF
--- a/packages/browser/playwright/mocked/tracing-headers.spec.ts
+++ b/packages/browser/playwright/mocked/tracing-headers.spec.ts
@@ -1,251 +1,91 @@
 import { expect, test } from './utils/posthog-playwright-test-base'
 import { start } from './utils/setup'
-import { Request } from '@playwright/test'
+import { Page, BrowserContext, Request } from '@playwright/test'
 
-const startOptions = {
+const baseOptions = {
     options: {
         __add_tracing_headers: ['example.com', 'no-session.com', 'xhr-test.com'],
     },
     url: '/playground/cypress/index.html',
 }
 
-test.describe('tracing headers', () => {
-    test('adds PostHog tracing headers to fetch requests', async ({ page, context }) => {
-        const fetchRequests: Request[] = []
+async function setupAndTriggerRequest(
+    page: Page,
+    context: BrowserContext,
+    config: {
+        domain: string
+        method?: 'fetch' | 'xhr'
+        startOptions?: typeof baseOptions
+    }
+): Promise<Record<string, string>> {
+    const { domain, method = 'fetch', startOptions = baseOptions } = config
+    let capturedHeaders: Record<string, string> = {}
 
-        page.on('request', (request) => {
-            if (request.method() === 'GET' && request.url().includes('example.com')) {
-                fetchRequests.push(request)
-            }
-        })
-
-        await context.route('**/example.com/**', (route) => {
-            route.fulfill({
-                status: 200,
-                contentType: 'text/plain',
-                body: 'test response',
-            })
-        })
-
-        await page.waitingForNetworkCausedBy({
-            urlPatternsToWaitFor: ['**/tracing-headers.js*'],
-            action: async () => {
-                await start(startOptions, page, context)
-            },
-        })
-
-        // Trigger a fetch request
-        await page.evaluate(() => {
-            fetch('https://example.com/api/test')
-        })
-
-        // Wait for the request
-        await page.waitForTimeout(500)
-
-        expect(fetchRequests.length).toBeGreaterThanOrEqual(1)
-        const request = fetchRequests[0]
-        const headers = request.headers()
-
-        expect(headers).toMatchObject({
-            'x-posthog-distinct-id': expect.any(String),
-            'x-posthog-session-id': expect.any(String),
-            'x-posthog-window-id': expect.any(String),
-        })
+    page.on('request', (request: Request) => {
+        if (request.url().includes(domain)) {
+            capturedHeaders = request.headers()
+        }
     })
 
-    // XHR test fails... needs more testing
-    test.skip('adds PostHog tracing headers to XMLHttpRequest', async ({ page, context }) => {
-        const xhrRequests: Request[] = []
+    await context.route(`**/${domain}/**`, (route) => {
+        route.fulfill({ status: 200, contentType: 'text/plain', body: 'ok' })
+    })
 
-        page.on('request', (request) => {
-            if (request.method() === 'GET' && request.url().includes('xhr-test.com')) {
-                xhrRequests.push(request)
-            }
-        })
+    await start(startOptions, page, context)
 
-        await context.route('**/xhr-test.com/**', (route) => {
-            route.fulfill({
-                status: 200,
-                contentType: 'text/plain',
-                body: 'xhr response',
-            })
-        })
+    await page.waitForFunction(() => {
+        const win = window as any
+        return win.__PosthogExtensions__?.tracingHeadersPatchFns && win.posthog
+    })
 
-        await start(startOptions, page, context)
-
-        // Trigger an XMLHttpRequest
-        await page.evaluate(() => {
+    if (method === 'fetch') {
+        await page.evaluate((d) => fetch(`https://${d}/api/test`), domain)
+    } else {
+        await page.evaluate((d) => {
             const xhr = new XMLHttpRequest()
-            xhr.open('GET', 'https://xhr-test.com/api/test')
+            xhr.open('GET', `https://${d}/api/test`)
             xhr.send()
-        })
+        }, domain)
+    }
 
-        // Wait for tracing headers to be loaded and active
-        await page.waitForFunction(() => {
-            const win = window as any
-            return win.__PosthogExtensions__?.tracingHeadersPatchFns && win.posthog
-        })
+    await page.waitForTimeout(500)
+    return capturedHeaders
+}
 
-        // Wait for the request
-        await page.waitForTimeout(500)
+test.describe('tracing headers', () => {
+    const casesWithHeaders = [
+        { name: 'fetch to listed domain', domain: 'example.com' },
+        { name: 'fetch without session manager', domain: 'no-session.com', disableSession: true },
+    ]
 
-        expect(xhrRequests.length).toEqual(1)
-        const request = xhrRequests[0]
-        const headers = request.headers()
+    for (const { name, domain, disableSession } of casesWithHeaders) {
+        test(`adds tracing headers: ${name}`, async ({ page, context }) => {
+            const startOptions = disableSession
+                ? { ...baseOptions, options: { ...baseOptions.options, disable_session_recording: true } }
+                : baseOptions
 
-        expect(headers['x-posthog-distinct-id']).toBeTruthy()
-        expect(headers['x-posthog-session-id']).toBeTruthy()
-        expect(headers['x-posthog-window-id']).toBeTruthy()
-    })
+            const headers = await setupAndTriggerRequest(page, context, { domain, startOptions })
 
-    test('works without session manager', async ({ page, context }) => {
-        const fetchRequests: Request[] = []
-
-        page.on('request', (request) => {
-            if (request.method() === 'GET' && request.url().includes('no-session.com')) {
-                fetchRequests.push(request)
+            expect(headers['x-posthog-distinct-id']).toBeTruthy()
+            if (!disableSession) {
+                expect(headers['x-posthog-session-id']).toBeTruthy()
+                expect(headers['x-posthog-window-id']).toBeTruthy()
             }
         })
+    }
 
-        await context.route('**/no-session.com/**', (route) => {
-            route.fulfill({
-                status: 200,
-                contentType: 'text/plain',
-                body: 'test response',
-            })
+    const casesWithoutHeaders = [
+        { name: 'fetch to unlisted domain', domain: 'unlisted.com', method: 'fetch' as const },
+        { name: 'XHR to unlisted domain', domain: 'unlisted-xhr.com', method: 'xhr' as const },
+    ]
+
+    for (const { name, domain, method } of casesWithoutHeaders) {
+        test(`does NOT add tracing headers: ${name}`, async ({ page, context }) => {
+            const headers = await setupAndTriggerRequest(page, context, { domain, method })
+
+            expect(headers['x-posthog-distinct-id']).toBeUndefined()
+            expect(headers['x-posthog-session-id']).toBeUndefined()
+            expect(headers['x-posthog-window-id']).toBeUndefined()
         })
-
-        await start(
-            {
-                ...startOptions,
-                options: {
-                    ...startOptions.options,
-                    disable_session_recording: true,
-                },
-            },
-            page,
-            context
-        )
-
-        // Trigger a fetch request
-        await page.evaluate(() => {
-            fetch('https://no-session.com/api/test')
-        })
-
-        // Wait for tracing headers to be loaded and active
-        await page.waitForFunction(() => {
-            const win = window as any
-            return win.__PosthogExtensions__?.tracingHeadersPatchFns && win.posthog
-        })
-
-        // Wait for the request
-        await page.waitForTimeout(500)
-
-        expect(fetchRequests.length).toBeGreaterThanOrEqual(1)
-        const request = fetchRequests[0]
-        const headers = request.headers()
-
-        expect(headers).toMatchObject({
-            'x-posthog-distinct-id': expect.any(String),
-        })
-    })
-
-    test('does NOT add tracing headers to unlisted domains', async ({ page, context }) => {
-        const unlistedDomainRequests: Request[] = []
-
-        page.on('request', (request) => {
-            if (request.method() === 'GET' && request.url().includes('unlisted.com')) {
-                unlistedDomainRequests.push(request)
-            }
-        })
-
-        await context.route('**/unlisted.com/**', (route) => {
-            route.fulfill({
-                status: 200,
-                contentType: 'text/plain',
-                body: 'test response from unlisted domain',
-            })
-        })
-
-        await page.waitingForNetworkCausedBy({
-            urlPatternsToWaitFor: ['**/tracing-headers.js*'],
-            action: async () => {
-                await start(startOptions, page, context)
-            },
-        })
-
-        // Wait for tracing headers to be loaded and active
-        await page.waitForFunction(() => {
-            const win = window as any
-            return win.__PosthogExtensions__?.tracingHeadersPatchFns && win.posthog
-        })
-
-        // Trigger a fetch request to an unlisted domain
-        await page.evaluate(() => {
-            fetch('https://unlisted.com/api/test')
-        })
-
-        // Wait for the request
-        await page.waitForTimeout(500)
-
-        expect(unlistedDomainRequests.length).toBeGreaterThanOrEqual(1)
-        const request = unlistedDomainRequests[0]
-        const headers = request.headers()
-
-        // Assert that PostHog tracing headers are NOT present
-        expect(headers['x-posthog-distinct-id']).toBeUndefined()
-        expect(headers['x-posthog-session-id']).toBeUndefined()
-        expect(headers['x-posthog-window-id']).toBeUndefined()
-    })
-
-    test('does NOT add tracing headers to unlisted domains via XMLHttpRequest', async ({ page, context }) => {
-        const unlistedDomainRequests: Request[] = []
-
-        page.on('request', (request) => {
-            if (request.method() === 'POST' && request.url().includes('unlisted-xhr.com')) {
-                unlistedDomainRequests.push(request)
-            }
-        })
-
-        await context.route('**/unlisted-xhr.com/**', (route) => {
-            route.fulfill({
-                status: 200,
-                contentType: 'application/json',
-                body: '{"message": "xhr response from unlisted domain"}',
-            })
-        })
-
-        await page.waitingForNetworkCausedBy({
-            urlPatternsToWaitFor: ['**/tracing-headers.js*'],
-            action: async () => {
-                await start(startOptions, page, context)
-            },
-        })
-
-        // Wait for tracing headers to be loaded and active
-        await page.waitForFunction(() => {
-            const win = window as any
-            return win.__PosthogExtensions__?.tracingHeadersPatchFns && win.posthog
-        })
-
-        // Trigger an XMLHttpRequest to an unlisted domain
-        await page.evaluate(() => {
-            const xhr = new XMLHttpRequest()
-            xhr.open('POST', 'https://unlisted-xhr.com/api/test')
-            xhr.setRequestHeader('Content-Type', 'application/json')
-            xhr.send(JSON.stringify({ test: 'data' }))
-        })
-
-        // Wait for the request
-        await page.waitForTimeout(500)
-
-        expect(unlistedDomainRequests.length).toBeGreaterThanOrEqual(1)
-        const request = unlistedDomainRequests[0]
-        const headers = request.headers()
-
-        // Assert that PostHog tracing headers are NOT present
-        expect(headers['x-posthog-distinct-id']).toBeUndefined()
-        expect(headers['x-posthog-session-id']).toBeUndefined()
-        expect(headers['x-posthog-window-id']).toBeUndefined()
-    })
+    }
 })


### PR DESCRIPTION
the tracing header tests need to wait until tracing is set up before testing it

but not every test was

refactored so all the tests run through one setup function