### PR TITLE
feat(product tours): add position options to modal/survey-type steps

### DIFF
--- a/.changeset/swift-ways-enter.md
+++ b/.changeset/swift-ways-enter.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+add position options to modal and survey tour steps

--- a/packages/browser/src/extensions/product-tours/product-tour.css
+++ b/packages/browser/src/extensions/product-tours/product-tour.css
@@ -76,9 +76,6 @@
 }
 
 .ph-tour-tooltip--modal {
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2), 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -58,6 +58,7 @@ import {
     SurveyContext,
     getSurveyStylesheet,
     addSurveyCSSVariablesToElement,
+    getPopoverPosition,
 } from './surveys/surveys-extension-utils'
 import {
     extractPrefillParamsFromUrl,
@@ -946,41 +947,6 @@ interface SurveyPopupProps {
     onPreviewSubmit?: (res: string | string[] | number | null) => void
     onPopupSurveyDismissed?: () => void
     onCloseConfirmationMessage?: () => void
-}
-
-function getPopoverPosition(
-    type: SurveyType,
-    position: SurveyPosition = SurveyPosition.Right,
-    surveyWidgetType?: SurveyWidgetType
-) {
-    if (type === SurveyType.ExternalSurvey) {
-        return {}
-    }
-
-    switch (position) {
-        case SurveyPosition.TopLeft:
-            return { top: '0', left: '0', transform: 'translate(30px, 30px)' }
-        case SurveyPosition.TopRight:
-            return { top: '0', right: '0', transform: 'translate(-30px, 30px)' }
-        case SurveyPosition.TopCenter:
-            return { top: '0', left: '50%', transform: 'translate(-50%, 30px)' }
-        case SurveyPosition.MiddleLeft:
-            return { top: '50%', left: '0', transform: 'translate(30px, -50%)' }
-        case SurveyPosition.MiddleRight:
-            return { top: '50%', right: '0', transform: 'translate(-30px, -50%)' }
-        case SurveyPosition.MiddleCenter:
-            return { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }
-        case SurveyPosition.Left:
-            return { left: '30px' }
-        case SurveyPosition.Center:
-            return {
-                left: '50%',
-                transform: 'translateX(-50%)',
-            }
-        default:
-        case SurveyPosition.Right:
-            return { right: type === SurveyType.Widget && surveyWidgetType === SurveyWidgetType.Tab ? '60px' : '30px' }
-    }
 }
 
 function getTabPositionStyles(position: SurveyTabPosition = SurveyTabPosition.Right): JSX.CSSProperties {

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -756,3 +756,39 @@ export function getSurveyContainerClass(survey: Pick<Survey, 'id'>, asSelector =
     const className = `PostHogSurvey-${survey.id}`
     return asSelector ? `.${className}` : className
 }
+
+/**
+ * Get CSS position styles for a popover/modal based on SurveyPosition
+ * Used by both surveys and product tours for consistent positioning
+ */
+export function getPopoverPosition(
+    type?: SurveyType,
+    position: SurveyPosition = SurveyPosition.Right,
+    surveyWidgetType?: SurveyWidgetType
+): Record<string, string> {
+    if (type === SurveyType.ExternalSurvey) {
+        return {}
+    }
+
+    switch (position) {
+        case SurveyPosition.TopLeft:
+            return { top: '0', left: '0', transform: 'translate(30px, 30px)' }
+        case SurveyPosition.TopRight:
+            return { top: '0', right: '0', transform: 'translate(-30px, 30px)' }
+        case SurveyPosition.TopCenter:
+            return { top: '0', left: '50%', transform: 'translate(-50%, 30px)' }
+        case SurveyPosition.MiddleLeft:
+            return { top: '50%', left: '0', transform: 'translate(30px, -50%)' }
+        case SurveyPosition.MiddleRight:
+            return { top: '50%', right: '0', transform: 'translate(-30px, -50%)' }
+        case SurveyPosition.MiddleCenter:
+            return { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }
+        case SurveyPosition.Left:
+            return { left: '30px' }
+        case SurveyPosition.Center:
+            return { left: '50%', transform: 'translateX(-50%)' }
+        default:
+        case SurveyPosition.Right:
+            return { right: type === SurveyType.Widget && surveyWidgetType === SurveyWidgetType.Tab ? '60px' : '30px' }
+    }
+}

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -1,6 +1,7 @@
 import { PropertyMatchType } from './types'
 import { SurveyActionType, SurveyEventWithFilters } from './posthog-surveys-types'
 import type { InferredSelector } from './extensions/product-tours/element-inference'
+import { SurveyPosition } from '@posthog/core'
 
 export interface JSONContent {
     type?: string
@@ -45,6 +46,8 @@ export interface ProductTourStep {
     inferenceData?: InferredSelector
     /** Maximum tooltip width in pixels (defaults to 320px) */
     maxWidth?: number
+    /** Position for modal/survey steps (defaults to middle_center) */
+    modalPosition?: SurveyPosition
 }
 
 export interface ProductTourConditions {


### PR DESCRIPTION
## Problem

main app now supports configuring the position of a modal or survey step: https://github.com/PostHog/posthog/pull/44558

but the sdk does not

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

update the sdk to respect the position of modal and survey steps!

needs to merge before https://github.com/PostHog/posthog/pull/44558

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->