### PR TITLE
feat(product tours): add button action options

### DIFF
--- a/.changeset/wicked-dogs-say.md
+++ b/.changeset/wicked-dogs-say.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+add button actions to product tour steps

--- a/packages/browser/src/extensions/product-tours/components/ProductTourTooltip.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourTooltip.tsx
@@ -1,6 +1,11 @@
 import { h } from 'preact'
 import { useEffect, useState, useCallback, useRef } from 'preact/hooks'
-import { ProductTour, ProductTourStep, ProductTourDismissReason } from '../../../posthog-product-tours-types'
+import {
+    ProductTour,
+    ProductTourStep,
+    ProductTourDismissReason,
+    ProductTourStepButton,
+} from '../../../posthog-product-tours-types'
 import { SurveyPosition } from '@posthog/core'
 import { calculateTooltipPosition, getSpotlightStyle, TooltipPosition } from '../product-tours-utils'
 import { getPopoverPosition } from '../../surveys/surveys-extension-utils'
@@ -24,6 +29,7 @@ export interface ProductTourTooltipProps {
     onPrevious: () => void
     onDismiss: (reason: ProductTourDismissReason) => void
     onSurveySubmit?: (response: string | number | null) => void
+    onButtonClick?: (button: ProductTourStepButton) => void
 }
 
 function getOppositePosition(position: TooltipPosition): TooltipPosition {
@@ -101,6 +107,7 @@ export function ProductTourTooltip({
     onPrevious,
     onDismiss,
     onSurveySubmit,
+    onButtonClick,
 }: ProductTourTooltipProps): h.JSX.Element {
     const [transitionState, setTransitionState] = useState<TransitionState>('entering')
     const [position, setPosition] = useState<ReturnType<typeof calculateTooltipPosition> | null>(null)
@@ -255,7 +262,9 @@ export function ProductTourTooltip({
 
     return (
         <div class="ph-tour-container">
-            <div class="ph-tour-click-overlay" onClick={handleOverlayClick} />
+            {tour.appearance?.dismissOnClickOutside !== false && (
+                <div class="ph-tour-click-overlay" onClick={handleOverlayClick} />
+            )}
 
             {/* Modal overlay - visible for non-element steps */}
             <div
@@ -321,6 +330,7 @@ export function ProductTourTooltip({
                         onNext={onNext}
                         onPrevious={onPrevious}
                         onDismiss={() => onDismiss('user_clicked_skip')}
+                        onButtonClick={onButtonClick}
                     />
                 )}
             </div>

--- a/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact'
-import { ProductTourStep, ProductTourAppearance } from '../../../posthog-product-tours-types'
+import { ProductTourStep, ProductTourAppearance, ProductTourStepButton } from '../../../posthog-product-tours-types'
 import { getStepHtml } from '../product-tours-utils'
 import { IconPosthogLogo, cancelSVG } from '../../surveys/icons'
 
@@ -11,6 +11,7 @@ export interface ProductTourTooltipInnerProps {
     onNext?: () => void
     onPrevious?: () => void
     onDismiss?: () => void
+    onButtonClick?: (button: ProductTourStepButton) => void
 }
 
 export function ProductTourTooltipInner({
@@ -21,14 +22,22 @@ export function ProductTourTooltipInner({
     onNext,
     onPrevious,
     onDismiss,
+    onButtonClick,
 }: ProductTourTooltipInnerProps): h.JSX.Element {
     const whiteLabel = appearance?.whiteLabel ?? false
     const isLastStep = stepIndex >= totalSteps - 1
     const isFirstStep = stepIndex === 0
-    const showNextButton = step.progressionTrigger === 'button' || step.type === 'modal'
+    const showDefaultButtons = !step.buttons && (step.progressionTrigger === 'button' || step.type === 'modal')
+    const hasCustomButtons = !!step.buttons
 
-    const isInteractive = !!(onNext || onPrevious || onDismiss)
+    const isInteractive = !!(onNext || onPrevious || onDismiss || onButtonClick)
     const cursorStyle = isInteractive ? undefined : { cursor: 'default' }
+
+    const handleButtonClick = (button: ProductTourStepButton) => {
+        if (onButtonClick) {
+            onButtonClick(button)
+        }
+    }
 
     return (
         <>
@@ -39,24 +48,53 @@ export function ProductTourTooltipInner({
             <div class="ph-tour-content" dangerouslySetInnerHTML={{ __html: getStepHtml(step) }} />
 
             <div class="ph-tour-footer">
-                <span class="ph-tour-progress">
-                    {stepIndex + 1} of {totalSteps}
-                </span>
+                {totalSteps > 1 && (
+                    <span class="ph-tour-progress">
+                        {stepIndex + 1} of {totalSteps}
+                    </span>
+                )}
 
                 <div class="ph-tour-buttons">
-                    {!isFirstStep && (
-                        <button
-                            class="ph-tour-button ph-tour-button--secondary"
-                            onClick={onPrevious}
-                            style={cursorStyle}
-                        >
-                            Back
-                        </button>
+                    {/* Default buttons for tours without custom buttons */}
+                    {showDefaultButtons && (
+                        <>
+                            {!isFirstStep && (
+                                <button
+                                    class="ph-tour-button ph-tour-button--secondary"
+                                    onClick={onPrevious}
+                                    style={cursorStyle}
+                                >
+                                    Back
+                                </button>
+                            )}
+                            <button class="ph-tour-button ph-tour-button--primary" onClick={onNext} style={cursorStyle}>
+                                {isLastStep ? 'Done' : 'Next'}
+                            </button>
+                        </>
                     )}
-                    {showNextButton && (
-                        <button class="ph-tour-button ph-tour-button--primary" onClick={onNext} style={cursorStyle}>
-                            {isLastStep ? 'Done' : 'Next'}
-                        </button>
+
+                    {/* Custom buttons */}
+                    {hasCustomButtons && (
+                        <>
+                            {step.buttons?.secondary && (
+                                <button
+                                    class="ph-tour-button ph-tour-button--secondary"
+                                    onClick={() => handleButtonClick(step.buttons!.secondary!)}
+                                    style={cursorStyle}
+                                >
+                                    {step.buttons.secondary.text}
+                                </button>
+                            )}
+                            {step.buttons?.primary && (
+                                <button
+                                    class="ph-tour-button ph-tour-button--primary"
+                                    onClick={() => handleButtonClick(step.buttons!.primary!)}
+                                    style={cursorStyle}
+                                >
+                                    {step.buttons.primary.text}
+                                </button>
+                            )}
+                        </>
                     )}
                 </div>
             </div>

--- a/packages/browser/src/extensions/product-tours/product-tour.css
+++ b/packages/browser/src/extensions/product-tours/product-tour.css
@@ -329,6 +329,7 @@
 .ph-tour-buttons {
     display: flex;
     gap: 8px;
+    margin-left: auto;
 }
 
 .ph-tour-button {

--- a/packages/browser/src/extensions/product-tours/product-tours.tsx
+++ b/packages/browser/src/extensions/product-tours/product-tours.tsx
@@ -5,6 +5,7 @@ import {
     ProductTourCallback,
     ProductTourDismissReason,
     ProductTourRenderReason,
+    ProductTourStepButton,
     ShowTourOptions,
 } from '../../posthog-product-tours-types'
 import { SurveyEventName, SurveyEventProperties } from '../../posthog-surveys-types'
@@ -505,6 +506,31 @@ export class ProductTourManager {
         this._cleanup()
     }
 
+    private _handleButtonClick = (button: ProductTourStepButton): void => {
+        switch (button.action) {
+            case 'dismiss':
+                this.dismissTour('user_clicked_skip')
+                break
+            case 'next_step':
+                this.nextStep()
+                break
+            case 'previous_step':
+                this.previousStep()
+                break
+            case 'link':
+                if (button.link) {
+                    window.open(button.link, '_blank')
+                }
+                break
+            case 'trigger_tour':
+                if (button.tourId) {
+                    this._cleanup()
+                    this.showTourById(button.tourId)
+                }
+                break
+        }
+    }
+
     private _completeTour(): void {
         if (!this._activeTour) {
             return
@@ -687,6 +713,7 @@ export class ProductTourManager {
                 onPrevious={this.previousStep}
                 onDismiss={onDismissOverride || this.dismissTour}
                 onSurveySubmit={onSurveySubmit}
+                onButtonClick={this._handleButtonClick}
             />,
             shadow
         )

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -13,6 +13,23 @@ export interface JSONContent {
 
 export type ProductTourStepType = 'element' | 'modal' | 'survey'
 
+/** Button actions available on modal steps */
+export type ProductTourButtonAction = 'dismiss' | 'link' | 'next_step' | 'previous_step' | 'trigger_tour'
+
+export interface ProductTourStepButton {
+    text: string
+    action: ProductTourButtonAction
+    /** URL to open when action is 'link' */
+    link?: string
+    /** Tour ID to trigger when action is 'trigger_tour' */
+    tourId?: string
+}
+
+export interface ProductTourStepButtons {
+    primary?: ProductTourStepButton
+    secondary?: ProductTourStepButton
+}
+
 export type ProductTourSurveyQuestionType = 'open' | 'rating'
 
 export interface ProductTourSurveyQuestion {
@@ -48,6 +65,8 @@ export interface ProductTourStep {
     maxWidth?: number
     /** Position for modal/survey steps (defaults to middle_center) */
     modalPosition?: SurveyPosition
+    /** Button configuration for modal steps */
+    buttons?: ProductTourStepButtons
 }
 
 export interface ProductTourConditions {
@@ -77,6 +96,8 @@ export interface ProductTourAppearance {
     boxShadow?: string
     showOverlay?: boolean
     whiteLabel?: boolean
+    /** defaults to true, auto-set to false for announcements/banners */
+    dismissOnClickOutside?: boolean
 }
 
 export interface ProductTour {
@@ -118,6 +139,7 @@ export const DEFAULT_PRODUCT_TOUR_APPEARANCE: Required<ProductTourAppearance> = 
     boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
     showOverlay: true,
     whiteLabel: false,
+    dismissOnClickOutside: true,
 }
 
 export interface ShowTourOptions {

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -155,6 +155,7 @@
         "_getToolbarState",
         "_getValidEvaluationEnvironments",
         "_getWindowId",
+        "_handleButtonClick",
         "_handleClose",
         "_handleDistinctIdChange",
         "_handleFormEmailChange",


### PR DESCRIPTION
## Problem

want the ability to customize what the buttons in a product tour do. main app adds this for announcements here: https://github.com/PostHog/posthog/pull/44579

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

updates sdk to support custom buttons in tour steps, including some actions (next/prev/trigger_tour) that are not in the main app yet (soon)

also fixes a bug with click-outside-to-dismiss, and adds an explicit setting for this at the tour level. type added in this PR: https://github.com/PostHog/posthog/pull/44573 but not user-configurable yet... defaults to false for announcements so clicking outside won't get rid of them

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->