### PR TITLE
feat(product tours): support banner rendering

### DIFF
--- a/.changeset/free-vans-wink.md
+++ b/.changeset/free-vans-wink.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+support banner rendering for product tours

--- a/packages/browser/src/extensions/product-tours/components/ProductTourBanner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourBanner.tsx
@@ -1,0 +1,100 @@
+import { h, ComponentChildren } from 'preact'
+import { ProductTourStep } from '../../../posthog-product-tours-types'
+import { getStepHtml } from '../product-tours-utils'
+import { cancelSVG } from '../../surveys/icons'
+
+export interface ProductTourBannerProps {
+    step: ProductTourStep
+    onDismiss: () => void
+    onTriggerTour?: () => void
+}
+
+interface BannerWrapperProps {
+    class: string
+    children: ComponentChildren
+}
+
+interface LinkWrapperProps extends BannerWrapperProps {
+    href: string
+}
+
+interface ButtonWrapperProps extends BannerWrapperProps {
+    onClick: () => void
+}
+
+function LinkWrapper({ class: className, href, children }: LinkWrapperProps): h.JSX.Element {
+    return (
+        <a class={className} href={href} target="_blank" rel="noopener noreferrer">
+            {children}
+        </a>
+    )
+}
+
+function ButtonWrapper({ class: className, onClick, children }: ButtonWrapperProps): h.JSX.Element {
+    return (
+        <div
+            class={className}
+            role="button"
+            tabIndex={0}
+            onClick={onClick}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    onClick()
+                }
+            }}
+            style={{ cursor: 'pointer' }}
+        >
+            {children}
+        </div>
+    )
+}
+
+function StaticWrapper({ class: className, children }: BannerWrapperProps): h.JSX.Element {
+    return <div class={className}>{children}</div>
+}
+
+export function ProductTourBanner({ step, onDismiss, onTriggerTour }: ProductTourBannerProps): h.JSX.Element {
+    const config = step.bannerConfig ?? { behavior: 'sticky' }
+    const action = config.action
+
+    const classNames = ['ph-tour-banner', config.behavior === 'sticky' && 'ph-tour-banner--sticky']
+        .filter(Boolean)
+        .join(' ')
+
+    const content = (
+        <>
+            <div class="ph-tour-banner-content" dangerouslySetInnerHTML={{ __html: getStepHtml(step) }} />
+
+            <button
+                class="ph-tour-banner-dismiss"
+                onClick={(e) => {
+                    e.stopPropagation()
+                    e.preventDefault()
+                    onDismiss()
+                }}
+                aria-label="Close banner"
+            >
+                {cancelSVG}
+            </button>
+        </>
+    )
+
+    if (action?.type === 'link' && action.link) {
+        return (
+            <LinkWrapper class={classNames} href={action.link}>
+                {content}
+            </LinkWrapper>
+        )
+    }
+
+    if (action?.type === 'trigger_tour' && onTriggerTour) {
+        return (
+            <ButtonWrapper class={classNames} onClick={onTriggerTour}>
+                {content}
+            </ButtonWrapper>
+        )
+    }
+
+    return <StaticWrapper class={classNames}>{content}</StaticWrapper>
+}

--- a/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
@@ -3,6 +3,31 @@ import { ProductTourStep, ProductTourAppearance, ProductTourStepButton } from '.
 import { getStepHtml } from '../product-tours-utils'
 import { IconPosthogLogo, cancelSVG } from '../../surveys/icons'
 
+interface TourButtonProps {
+    button: ProductTourStepButton
+    variant: 'primary' | 'secondary'
+    onClick: (button: ProductTourStepButton) => void
+    cursorStyle?: h.JSX.CSSProperties
+}
+
+function TourButton({ button, variant, onClick, cursorStyle }: TourButtonProps): h.JSX.Element {
+    const className = `ph-tour-button ph-tour-button--${variant}`
+
+    if (button.action === 'link' && button.link) {
+        return (
+            <a href={button.link} target="_blank" rel="noopener noreferrer" class={className}>
+                {button.text}
+            </a>
+        )
+    }
+
+    return (
+        <button class={className} onClick={() => onClick(button)} style={cursorStyle}>
+            {button.text}
+        </button>
+    )
+}
+
 export interface ProductTourTooltipInnerProps {
     step: ProductTourStep
     appearance?: ProductTourAppearance
@@ -77,22 +102,20 @@ export function ProductTourTooltipInner({
                     {hasCustomButtons && (
                         <>
                             {step.buttons?.secondary && (
-                                <button
-                                    class="ph-tour-button ph-tour-button--secondary"
-                                    onClick={() => handleButtonClick(step.buttons!.secondary!)}
-                                    style={cursorStyle}
-                                >
-                                    {step.buttons.secondary.text}
-                                </button>
+                                <TourButton
+                                    button={step.buttons.secondary}
+                                    variant="secondary"
+                                    onClick={handleButtonClick}
+                                    cursorStyle={cursorStyle}
+                                />
                             )}
                             {step.buttons?.primary && (
-                                <button
-                                    class="ph-tour-button ph-tour-button--primary"
-                                    onClick={() => handleButtonClick(step.buttons!.primary!)}
-                                    style={cursorStyle}
-                                >
-                                    {step.buttons.primary.text}
-                                </button>
+                                <TourButton
+                                    button={step.buttons.primary}
+                                    variant="primary"
+                                    onClick={handleButtonClick}
+                                    cursorStyle={cursorStyle}
+                                />
                             )}
                         </>
                     )}

--- a/packages/browser/src/extensions/product-tours/preview.tsx
+++ b/packages/browser/src/extensions/product-tours/preview.tsx
@@ -2,6 +2,7 @@ import { render, JSX } from 'preact'
 
 import { ProductTourStep, ProductTourAppearance } from '../../posthog-product-tours-types'
 import { document as _document } from '../../utils/globals'
+import { ProductTourBanner } from './components/ProductTourBanner'
 import { ProductTourSurveyStepInner } from './components/ProductTourSurveyStepInner'
 import { ProductTourTooltipInner } from './components/ProductTourTooltipInner'
 import { getProductTourStylesheet, addProductTourCSSVariablesToElement } from './product-tours-utils'
@@ -41,7 +42,18 @@ export function renderProductTourPreview({
     shadow.appendChild(renderTarget)
 
     const isSurveyStep = step.type === 'survey'
+    const isBannerStep = step.type === 'banner'
     const tooltipClass = isSurveyStep ? 'ph-tour-tooltip ph-tour-survey-step' : 'ph-tour-tooltip'
+
+    if (isBannerStep) {
+        render(
+            <div class="ph-tour-container">
+                <ProductTourBanner step={step} onDismiss={() => {}} />
+            </div>,
+            renderTarget
+        )
+        return
+    }
 
     render(
         <div class="ph-tour-container">

--- a/packages/browser/src/extensions/product-tours/product-tour.css
+++ b/packages/browser/src/extensions/product-tours/product-tour.css
@@ -167,10 +167,10 @@
     margin-bottom: 8px;
 }
 
-/* Links */
+/* Links - inherit text color to avoid default browser blue */
 .ph-tour-content a,
 .ph-tour-content .ph-tour-link {
-    color: var(--ph-tour-button-color);
+    color: inherit;
     text-decoration: underline;
 }
 
@@ -558,3 +558,75 @@
     background: var(--ph-tour-button-color);
     color: var(--ph-tour-button-text-color);
 }
+
+/* Banner styles */
+.ph-tour-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 12px 16px;
+    background: var(--ph-tour-background-color);
+    border-bottom: 1px solid var(--ph-tour-border-color);
+    box-shadow: var(--ph-tour-box-shadow);
+    font-family: var(--ph-tour-font-family);
+}
+
+/* Remove default link underline when banner is wrapped in an anchor */
+a.ph-tour-banner {
+    text-decoration: none;
+    color: inherit;
+}
+
+:host:has(.ph-tour-banner--sticky) {
+    position: sticky;
+    top: 0;
+    z-index: var(--ph-tour-z-index);
+}
+
+.ph-tour-banner-content {
+    flex: 1;
+    min-width: 0;
+    color: var(--ph-tour-text-color);
+    font-size: 14px;
+    line-height: 1.5;
+    text-align: center;
+}
+
+.ph-tour-banner-content p {
+    margin: 0;
+}
+
+.ph-tour-banner-content strong {
+    font-weight: 600;
+}
+
+.ph-tour-banner-content em {
+    font-style: italic;
+}
+
+.ph-tour-banner-content a {
+    color: inherit;
+    text-decoration: underline;
+}
+
+.ph-tour-banner-dismiss {
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--ph-tour-text-secondary-color);
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.ph-tour-banner-dismiss:hover {
+    background: rgba(0, 0, 0, 0.08);
+    color: var(--ph-tour-text-color);
+}
+

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -11,7 +11,16 @@ export interface JSONContent {
     text?: string
 }
 
-export type ProductTourStepType = 'element' | 'modal' | 'survey'
+export type ProductTourStepType = 'element' | 'modal' | 'survey' | 'banner'
+
+export interface ProductTourBannerConfig {
+    behavior: 'sticky' | 'static'
+    action?: {
+        type: 'none' | 'link' | 'trigger_tour'
+        link?: string
+        tourId?: string
+    }
+}
 
 /** Button actions available on modal steps */
 export type ProductTourButtonAction = 'dismiss' | 'link' | 'next_step' | 'previous_step' | 'trigger_tour'
@@ -67,6 +76,8 @@ export interface ProductTourStep {
     modalPosition?: SurveyPosition
     /** Button configuration for modal steps */
     buttons?: ProductTourStepButtons
+    /** Banner configuration (only for banner steps) */
+    bannerConfig?: ProductTourBannerConfig
 }
 
 export interface ProductTourConditions {

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -376,6 +376,7 @@
         "_removeSurveyFromFocus",
         "_removeTriggerSelectorListener",
         "_removeWidgetSelectorListener",
+        "_renderBanner",
         "_renderCurrentStep",
         "_renderIdentificationForm",
         "_renderMessage",


### PR DESCRIPTION
## Problem

sdk needs to render banners for product tours 😎

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

adds support for rendering banners:

- always at the top of the page, with behavior options:
    - **static**: stays up there when you scroll down
    - **sticky**: stays at the top while you scroll
- click action options:
    - **tour**: trigger a product tour
    - **link**: link to something


![Screenshot 2026-01-09 at 12.22.53 PM.png](https://app.graphite.com/user-attachments/assets/cfcf491b-5d56-40a6-9b89-d36fc43b1b2e.png)

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->