### PR TITLE
fix(sdk): add session recording types

### DIFF
--- a/.changeset/tall-owls-act.md
+++ b/.changeset/tall-owls-act.md
@@ -1,0 +1,6 @@
+---
+'@posthog/types': minor
+'posthog-js': minor
+---
+
+add missing sessionRecording types

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@
 - [ ] @posthog/nuxt
 - [ ] @posthog/rollup-plugin
 - [ ] @posthog/webpack-plugin
+- [ ] @posthog/types
 
 ## Checklist
 

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -364,6 +364,22 @@ export interface PostHog {
      */
     sessionRecordingStarted(): boolean
 
+    /**
+     * The session recording instance. May be undefined if session recording is not initialized.
+     */
+    sessionRecording?: {
+        /** Force allow network capture on localhost (for debugging) */
+        _forceAllowLocalhostNetworkCapture: boolean
+    }
+
+    /**
+     * The session manager instance. May be undefined in cookieless mode.
+     */
+    sessionManager?: {
+        /** Reset the session ID, creating a new session */
+        resetSessionId: () => void
+    }
+
     // ============================================================================
     // Consent & Opt-in/out
     // ============================================================================


### PR DESCRIPTION
## Problem

auto-bump has been failing in the main repo since 1.315.0 - https://github.com/PostHog/posthog/pull/44372

typechecks are failing because we're missing some replay-related stuff:

```
Error: src/loadPostHogJS.tsx(30,36): error TS2551: Property 'sessionRecording' does not exist on type 'PostHog'. Did you mean 'stopSessionRecording'?
Error: src/loadPostHogJS.tsx(31,36): error TS2551: Property 'sessionRecording' does not exist on type 'PostHog'. Did you mean 'stopSessionRecording'?
Error: src/loadPostHogJS.tsx(35,36): error TS2339: Property 'sessionManager' does not exist on type 'PostHog'.
Error: src/loadPostHogJS.tsx(107,36): error TS2339: Property 'sessionManager' does not exist on type 'PostHog'.
```

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- adds missing types to @posthog/types
- updates PR template to include @posthog/types
- minor bump on types + js

i am having immense trouble actually verifying this works with all the weird dependency stuff going on BUT it can't hurt, i think it's worth a shot

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->