### PR TITLE
fix(ai): Use Proxy for Vercel model wrapper to fix streamObject with Anthropic

### DIFF
--- a/.changeset/fix-vercel-wrapper-proxy.md
+++ b/.changeset/fix-vercel-wrapper-proxy.md
@@ -1,0 +1,9 @@
+---
+"@posthog/ai": patch
+---
+
+fix(ai): Use Proxy for Vercel model wrapper to fix streamObject with Anthropic models
+
+Fixes issue #2848 where `withTracing` would cause `streamObject` to fail with Anthropic/Claude models when images were included. The error `TypeError: Cannot convert undefined or null to object at Function.entries` occurred because the previous implementation used object spread (`{ ...model }`) which only copied enumerable own properties, missing getter properties like `supportsObjectGeneration` that Anthropic models define.
+
+The fix replaces the object spread with a Proxy that properly delegates all property access (including getters, prototype methods, and non-enumerable properties) to the underlying model while intercepting only `doGenerate` and `doStream` for tracing.


### PR DESCRIPTION
## Problem

Issue #2848: `withTracing` breaks `streamObject` with Anthropic/Claude models and images in v7.3.0. Users get `TypeError: Cannot convert undefined or null to object at Function.entries`.

## Changes

The wrapper was using object spread (`{ ...model }`) which only copies enumerable own properties. Getter properties like `supportsObjectGeneration` (used by Anthropic models) were not accessible on the wrapped model.

Fixed by using a Proxy to properly delegate all property access to the underlying model while intercepting only `doGenerate` and `doStream` for tracing.

Added 3 tests for Proxy property delegation to prevent regression.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/ai

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

Fixes #2848