### PR TITLE
chore(deps): bump preact from 10.19.3 to 10.28.0

### DIFF
--- a/.changeset/bump-preact-security.md
+++ b/.changeset/bump-preact-security.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+chore(deps): bump preact from 10.19.3 to 10.28.0 to fix security vulnerability

--- a/packages/browser/jest.config.js
+++ b/packages/browser/jest.config.js
@@ -1,3 +1,14 @@
+const path = require('path')
+
+// Dynamically resolve package paths so config doesn't need updating on version bumps.
+// We need explicit CJS paths because Jest doesn't handle ESM well without extra config.
+// require.resolve returns the main entry point, so we navigate relative to that.
+const preactMain = require.resolve('preact') // .../preact/dist/preact.js
+const preactRoot = path.resolve(preactMain, '../..') // .../preact/
+
+const testingLibraryPreactMain = require.resolve('@testing-library/preact') // .../dist/cjs/index.js
+const testingLibraryPreactCjs = path.dirname(testingLibraryPreactMain) // .../dist/cjs/
+
 module.exports = {
     testPathIgnorePatterns: ['/node_modules/', '/cypress/', '/react/', '/test_data/', '/testcafe/'],
     moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
@@ -8,14 +19,11 @@ module.exports = {
     prettierPath: null,
     moduleNameMapper: {
         '\\.css$': 'identity-obj-proxy',
-        '^preact$': '<rootDir>/../../node_modules/.pnpm/preact@10.19.3/node_modules/preact/dist/preact.js',
-        '^preact/hooks$': '<rootDir>/../../node_modules/.pnpm/preact@10.19.3/node_modules/preact/hooks/dist/hooks.js',
-        '^preact/jsx-runtime$':
-            '<rootDir>/../../node_modules/.pnpm/preact@10.19.3/node_modules/preact/jsx-runtime/dist/jsxRuntime.js',
-        '^preact/test-utils$':
-            '<rootDir>/../../node_modules/.pnpm/preact@10.19.3/node_modules/preact/test-utils/dist/testUtils.js',
-        '^@testing-library/preact$':
-            '<rootDir>/../../node_modules/.pnpm/@testing-library+preact@3.2.4_preact@10.19.3/node_modules/@testing-library/preact/dist/cjs/index.js',
+        '^preact$': path.join(preactRoot, 'dist/preact.js'),
+        '^preact/hooks$': path.join(preactRoot, 'hooks/dist/hooks.js'),
+        '^preact/jsx-runtime$': path.join(preactRoot, 'jsx-runtime/dist/jsxRuntime.js'),
+        '^preact/test-utils$': path.join(preactRoot, 'test-utils/dist/testUtils.js'),
+        '^@testing-library/preact$': path.join(testingLibraryPreactCjs, 'index.js'),
     },
     transform: {
         '^.+\\.(js|jsx|ts|tsx|mjs)$': 'babel-jest',

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -54,7 +54,7 @@
         "core-js": "^3.38.1",
         "dompurify": "^3.3.1",
         "fflate": "^0.4.8",
-        "preact": "^10.19.3",
+        "preact": "^10.28.0",
         "query-selector-shadow-dom": "^1.0.1",
         "web-vitals": "^4.2.4",
         "@opentelemetry/api": "^1.9.0",

--- a/packages/browser/playwright/mocked/surveys/question-types.spec.ts
+++ b/packages/browser/playwright/mocked/surveys/question-types.spec.ts
@@ -139,7 +139,8 @@ test.describe('surveys - core display logic', () => {
         await page.locator('.PostHogSurvey-123').locator('.ratings-number').first().click()
         await page.locator('.PostHogSurvey-123').locator('.form-submit').click()
 
-        await expect(page.locator('.PostHogSurvey-123').locator('.ratings-number').first()).toHaveText('0')
+        // After submitting, we're on question 2 (scale 5), which starts at 1
+        await expect(page.locator('.PostHogSurvey-123').locator('.ratings-number').first()).toHaveText('1')
     })
 
     test('multiple question surveys', async ({ page, context }) => {

--- a/packages/browser/src/extensions/conversations/external/components/ConversationsWidget.tsx
+++ b/packages/browser/src/extensions/conversations/external/components/ConversationsWidget.tsx
@@ -463,7 +463,11 @@ export class ConversationsWidget extends Component<WidgetProps, WidgetState> {
                                         </div>
                                     </div>
                                 )}
-                                <div ref={(el) => (this._messagesEndRef = el)} />
+                                <div
+                                    ref={(el) => {
+                                        this._messagesEndRef = el
+                                    }}
+                                />
                             </div>
 
                             {/* Error message */}
@@ -472,7 +476,9 @@ export class ConversationsWidget extends Component<WidgetProps, WidgetState> {
                             {/* Input */}
                             <div style={styles.inputContainer}>
                                 <textarea
-                                    ref={(el) => (this._inputRef = el)}
+                                    ref={(el) => {
+                                        this._inputRef = el
+                                    }}
                                     style={styles.input}
                                     placeholder={placeholderText}
                                     value={inputValue}

--- a/packages/browser/src/extensions/product-tours/product-tour.css
+++ b/packages/browser/src/extensions/product-tours/product-tour.css
@@ -1,6 +1,7 @@
 :host {
-    --ph-tour-font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', Helvetica, Arial,
-        sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    --ph-tour-font-family:
+        -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', Helvetica, Arial, sans-serif,
+        'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 
     --ph-tour-background-color: #ffffff;
     --ph-tour-text-color: #1d1f27;
@@ -76,7 +77,9 @@
 }
 
 .ph-tour-tooltip--modal {
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2), 0 2px 8px rgba(0, 0, 0, 0.1);
+    box-shadow:
+        0 8px 32px rgba(0, 0, 0, 0.2),
+        0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .ph-tour-arrow {
@@ -554,4 +557,3 @@
     background: var(--ph-tour-button-color);
     color: var(--ph-tour-button-text-color);
 }
-

--- a/packages/browser/src/extensions/surveys/survey.css
+++ b/packages/browser/src/extensions/surveys/survey.css
@@ -1,7 +1,8 @@
 :host {
     /* Define CSS Variables with defaults */
-    --ph-survey-font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', Helvetica, Arial,
-        sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    --ph-survey-font-family:
+        -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', Helvetica, Arial, sans-serif,
+        'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
     --ph-survey-box-padding: 20px 24px;
     --ph-survey-max-width: 300px;
     --ph-survey-z-index: 2147483647;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,8 +264,8 @@ importers:
         specifier: ^0.4.8
         version: 0.4.8
       preact:
-        specifier: ^10.19.3
-        version: 10.19.3
+        specifier: ^10.28.0
+        version: 10.28.2
       query-selector-shadow-dom:
         specifier: ^1.0.1
         version: 1.0.1
@@ -350,7 +350,7 @@ importers:
         version: 6.9.1
       '@testing-library/preact':
         specifier: 'catalog:'
-        version: 3.2.4(preact@10.19.3)
+        version: 3.2.4(preact@10.28.2)
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
@@ -440,7 +440,7 @@ importers:
         version: 'link:'
       preact-render-to-string:
         specifier: ^6.3.1
-        version: 6.3.1(preact@10.19.3)
+        version: 6.3.1(preact@10.28.2)
       rollup:
         specifier: 'catalog:'
         version: 4.53.3
@@ -10526,8 +10526,8 @@ packages:
     peerDependencies:
       preact: '>=10'
 
-  preact@10.19.3:
-    resolution: {integrity: sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==}
+  preact@10.28.2:
+    resolution: {integrity: sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -17539,10 +17539,10 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/preact@3.2.4(preact@10.19.3)':
+  '@testing-library/preact@3.2.4(preact@10.28.2)':
     dependencies:
       '@testing-library/dom': 8.20.1
-      preact: 10.19.3
+      preact: 10.28.2
 
   '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
@@ -26335,12 +26335,12 @@ snapshots:
       react: 18.2.0
       react-native: 0.69.12(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.2.0)
 
-  preact-render-to-string@6.3.1(preact@10.19.3):
+  preact-render-to-string@6.3.1(preact@10.28.2):
     dependencies:
-      preact: 10.19.3
+      preact: 10.28.2
       pretty-format: 3.8.0
 
-  preact@10.19.3: {}
+  preact@10.28.2: {}
 
   prebuild-install@7.1.3:
     dependencies:


### PR DESCRIPTION
## Summary
- Bump preact from `^10.19.3` to `^10.28.0`
- Includes memory leak fix (10.27.2) and other bug fixes
- Update jest.config.js to dynamically resolve preact paths (no more manual updates on version bumps)

Closes https://github.com/PostHog/posthog-js/issues/2872

## Test plan
- [x] Survey unit tests pass (360 tests)