### PR TITLE
fix(ai): Convert null messageMetadata to undefined in Vercel AI SDK streaming

### DIFF
--- a/.changeset/fix-ai-message-metadata-null.md
+++ b/.changeset/fix-ai-message-metadata-null.md
@@ -1,0 +1,18 @@
+---
+"@posthog/ai": patch
+---
+
+fix(ai): Convert null messageMetadata to undefined in Vercel AI SDK streaming
+
+Adds defensive handling for `messageMetadata: null` in stream chunks when using withTracing with the Vercel AI SDK.
+
+**Problem:**
+The AI SDK's `mergeObjects` function guards against `undefined` but not `null`. When certain model providers (particularly with file attachments) send stream chunks with `messageMetadata: null`, the AI SDK throws "Cannot convert undefined or null to object" when attempting to spread the null value.
+
+**Solution:**
+In the doStream TransformStream, check for `messageMetadata === null` and convert it to `undefined` before passing the chunk through. This allows the AI SDK's existing guards to work correctly.
+
+**Context:**
+- Reported via support ticket with ToolLoopAgent and file attachments
+- Root cause is in AI SDK's mergeObjects function which only handles undefined
+- This is a defensive fix - the exact reproduction conditions are environment-specific


### PR DESCRIPTION
## Summary

Adds defensive handling for `messageMetadata: null` in stream chunks when using `withTracing` with the Vercel AI SDK.

## Problem

A user reported the error "Cannot convert undefined or null to object" when using `withTracing` with:
- Vercel AI SDK v6
- `ToolLoopAgent`
- File attachments

**Root cause:** The AI SDK's `mergeObjects` function (at `node_modules/ai/dist/index.js:3120`) only guards against `undefined`, not `null`:

```javascript
function mergeObjects(base, overrides) {
  if (base === void 0 && overrides === void 0) { return void 0; }
  if (base === void 0) { return overrides; }
  if (overrides === void 0) { return base; }
  const result = { ...base };  // ← Throws if base is null
  // ...
}
```

When certain model providers send stream chunks with `messageMetadata: null` (potentially with file attachments), this error is thrown.

## Solution

In the `doStream` TransformStream, check for `messageMetadata === null` and convert it to `undefined` before passing the chunk through:

```typescript
const chunkAny = chunk as any
if ('messageMetadata' in chunkAny && chunkAny.messageMetadata === null) {
  chunk = { ...chunk, messageMetadata: undefined } as LanguageModelStreamPart
}
```

## Investigation Notes

- The exact reproduction conditions are environment-specific
- Tests with current SDK versions (PostHog AI v6.6.0, AI SDK v6) pass
- This is a defensive fix that ensures the AI SDK's existing guards work correctly
- The fix is low-risk and doesn't change behavior for valid messageMetadata values

## Test Plan

- [x] Added unit tests for null messageMetadata handling
- [x] Added unit tests for valid messageMetadata preservation  
- [x] Added unit tests for missing messageMetadata
- [x] All existing tests pass

## Related

- Closes #2877