### PR TITLE
feat(surveys): allow custom survey event properties for API surveys

### DIFF
--- a/.changeset/humble-baths-hang.md
+++ b/.changeset/humble-baths-hang.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+allow custom properties in API survey events

--- a/packages/browser/src/__tests__/surveys.test.ts
+++ b/packages/browser/src/__tests__/surveys.test.ts
@@ -840,7 +840,11 @@ describe('surveys', () => {
 
             surveys.renderSurvey('in-app-survey', '#test-survey-container')
 
-            expect(mockRenderSurvey).toHaveBeenCalledWith(inAppSurvey, document.querySelector('#test-survey-container'))
+            expect(mockRenderSurvey).toHaveBeenCalledWith(
+                inAppSurvey,
+                document.querySelector('#test-survey-container'),
+                undefined
+            )
             expect(loggerWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining('cannot be rendered in the app'))
         })
 

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -25,7 +25,7 @@ import { isArray, isNullish } from '@posthog/core'
 
 import { detectDeviceType } from '@posthog/core'
 import { propertyComparisons } from '../../utils/property-utils'
-import { PropertyMatchType } from '../../types'
+import { Properties, PropertyMatchType } from '../../types'
 import { prepareStylesheet } from '../utils/stylesheet-loader'
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const window = _window as Window & typeof globalThis
@@ -399,6 +399,8 @@ interface SendSurveyEventArgs {
     surveySubmissionId: string
     isSurveyCompleted: boolean
     posthog?: PostHog
+    /** Additional properties to include in the survey event */
+    properties?: Properties
 }
 
 const getSurveyResponseValue = (responses: Record<string, string | number | string[] | null>, questionId?: string) => {
@@ -418,6 +420,7 @@ export const sendSurveyEvent = ({
     surveySubmissionId,
     posthog,
     isSurveyCompleted,
+    properties,
 }: SendSurveyEventArgs) => {
     if (!posthog) {
         logger.error('[survey sent] event not captured, PostHog instance not found.')
@@ -438,6 +441,7 @@ export const sendSurveyEvent = ({
         [SurveyEventProperties.SURVEY_COMPLETED]: isSurveyCompleted,
         sessionRecordingUrl: posthog.get_session_replay_url?.(),
         ...responses,
+        ...properties,
         $set: {
             [getSurveyInteractionProperty(survey, 'responded')]: true,
         },
@@ -624,6 +628,8 @@ interface SurveyContextProps {
     isPopup: boolean
     onPreviewSubmit: (res: string | string[] | number | null) => void
     surveySubmissionId: string
+    /** Additional properties to include in all survey events */
+    properties?: Properties
 }
 
 export const SurveyContext = createContext<SurveyContextProps>({
@@ -633,6 +639,7 @@ export const SurveyContext = createContext<SurveyContextProps>({
     isPopup: true,
     onPreviewSubmit: () => {},
     surveySubmissionId: '',
+    properties: undefined,
 })
 
 export const useSurveyContext = () => {

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -4,7 +4,7 @@
  * See https://github.com/PostHog/posthog-js/issues/698
  */
 
-import type { PropertyMatchType } from './types'
+import type { Properties, PropertyMatchType } from './types'
 import type { SurveyAppearance as CoreSurveyAppearance } from '@posthog/core'
 
 export enum SurveyEventType {
@@ -297,6 +297,8 @@ interface DisplaySurveyOptionsBase {
     ignoreConditions: boolean
     ignoreDelay: boolean
     displayType: DisplaySurveyType
+    /** Additional properties to include in all survey events (shown, sent, dismissed) */
+    properties?: Properties
 }
 
 interface DisplaySurveyPopoverOptions extends DisplaySurveyOptionsBase {

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -8,7 +8,7 @@ import {
     SurveyCallback,
     SurveyRenderReason,
 } from './posthog-surveys-types'
-import { RemoteConfig } from './types'
+import { Properties, RemoteConfig } from './types'
 import { assignableWindow, document } from './utils/globals'
 import { SurveyEventReceiver } from './utils/survey-event-receiver'
 import {
@@ -336,7 +336,7 @@ export class PostHogSurveys {
         })
     }
 
-    renderSurvey(surveyId: string | Survey, selector: string) {
+    renderSurvey(surveyId: string | Survey, selector: string, properties?: Properties) {
         if (isNullish(this._surveyManager)) {
             logger.warn('init was not called')
             return
@@ -363,12 +363,12 @@ export class PostHogSurveys {
                 logger.info(
                     `Rendering survey ${survey.id} with delay of ${survey.appearance?.surveyPopupDelaySeconds} seconds`
                 )
-                this._surveyManager?.renderSurvey(survey, elem)
+                this._surveyManager?.renderSurvey(survey, elem, properties)
                 logger.info(`Survey ${survey.id} rendered`)
             }, survey.appearance.surveyPopupDelaySeconds * 1000)
             return
         }
-        this._surveyManager.renderSurvey(survey, elem)
+        this._surveyManager.renderSurvey(survey, elem, properties)
     }
 
     displaySurvey(surveyId: string, options: DisplaySurveyOptions) {
@@ -399,10 +399,10 @@ export class PostHogSurveys {
             }
         }
         if (options.displayType === DisplaySurveyType.Inline) {
-            this.renderSurvey(surveyToDisplay, options.selector)
+            this.renderSurvey(surveyToDisplay, options.selector, options.properties)
             return
         }
-        this._surveyManager.handlePopoverSurvey(surveyToDisplay)
+        this._surveyManager.handlePopoverSurvey(surveyToDisplay, options.properties)
     }
 
     cancelPendingSurvey(surveyId: string): void {

--- a/playground/nextjs/pages/survey.tsx
+++ b/playground/nextjs/pages/survey.tsx
@@ -1,4 +1,4 @@
-import type { Survey } from 'posthog-js'
+import { DisplaySurveyType, type Survey } from 'posthog-js'
 import { usePostHog } from 'posthog-js/react'
 import { useEffect, useState } from 'react'
 
@@ -36,14 +36,24 @@ export default function SurveyForm() {
                     {arraySurveyItems}
                 </select>
                 <button
-                    onClick={() => posthog.renderSurvey(selectedSurvey, '#survey-container')}
+                    onClick={() =>
+                        posthog.displaySurvey(selectedSurvey, {
+                            displayType: DisplaySurveyType.Inline,
+                            selector: '#survey-container',
+                            ignoreConditions: true,
+                            ignoreDelay: true,
+                            properties: {
+                                custom_foo: 'bar',
+                            },
+                        })
+                    }
                     disabled={!selectedSurvey}
                 >
                     Render Survey below
                 </button>
                 <button
-                    onClick={() => {
-                        const renderReason = posthog.canRenderSurvey(selectedSurvey)
+                    onClick={async () => {
+                        const renderReason = await posthog.canRenderSurveyAsync(selectedSurvey)
                         const message = renderReason?.visible
                             ? `Survey can be rendered: Yes`
                             : `Survey cannot be rendered: ${renderReason?.disabledReason || 'No reason provided'}`


### PR DESCRIPTION
## Problem

with API surveys, there's no way to pass custom metadata. e.g. you might want to survey users every time they create X in your platform, with a reference to each instance of X

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

adds `properties` to `DisplaySurveyOptionsBase`, usage like:

```typescript
posthog.displaySurvey('my-survey-id', {
    displayType: DisplaySurveyType.Popover,
    ignoreConditions: true,
    ignoreDelay: true,
    properties: {
        custom_foo: 'bar'
    }
})
```

<!-- What is changed and what information would be useful to a reviewer? -->

...this will attach a new event property `foo=bar` to all `survey sent` events emitted from this point (shown, response, dismissed, etc)

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected package