### PR TITLE
fix: disable injection for react native web platform

### DIFF
--- a/.changeset/short-words-create.md
+++ b/.changeset/short-words-create.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': minor
+---
+
+disable injection for react native web platform

--- a/packages/react-native/src/tooling/posthogMetroSerializer.ts
+++ b/packages/react-native/src/tooling/posthogMetroSerializer.ts
@@ -18,6 +18,7 @@ const DEBUG_ID_COMMENT = '//# chunkId='
  * Adds PostHog Chunk ID polyfill module to the bundle.
  */
 export function unstableBeforeAssetSerializationDebugIdPlugin({
+  graph,
   premodules,
   debugId,
 }: {
@@ -25,6 +26,11 @@ export function unstableBeforeAssetSerializationDebugIdPlugin({
   premodules: Module[]
   debugId?: string
 }): Module[] {
+  // Skip for web platform - sourcemaps are handled differently for web builds
+  if (graph.transformOptions.platform === 'web') {
+    return premodules
+  }
+
   if (!debugId) {
     return premodules
   }


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C07AA937K9A/p1768230601091139

## Changes

Decided to disable injection for react native web platform. We will advise people to follow standard inject+upload flow.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types


### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
