### PR TITLE
chore: Sensitive data refactor part 2

### DIFF
--- a/packages/browser/playground/error-tracking/next-ts-app/src/app/provider.tsx
+++ b/packages/browser/playground/error-tracking/next-ts-app/src/app/provider.tsx
@@ -10,7 +10,7 @@ export default function LocalProvider({ debug, children }: { debug: boolean; chi
     useEffect(() => {
         const posthog = posthogJs.init(process.env.NEXT_PUBLIC_POSTHOG_KEY || '', {
             api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-            defaults: '2025-11-30',
+            defaults: '2025-12-11',
         })
         if (debug) {
             posthog.debug()

--- a/packages/browser/playground/error-tracking/react-ts-esbuild/src/main.tsx
+++ b/packages/browser/playground/error-tracking/react-ts-esbuild/src/main.tsx
@@ -6,7 +6,7 @@ import { posthog } from 'posthog-js'
 posthog.init(import.meta.env.VITE_POSTHOG_KEY || '', {
     api_host: import.meta.env.VITE_POSTHOG_HOST || 'http://localhost:8010',
     autocapture: true,
-    defaults: '2025-11-30',
+    defaults: '2025-12-11',
 })
 
 createRoot(document.getElementById('root')!).render(

--- a/packages/browser/playground/error-tracking/vue-ts-esbuild/src/main.ts
+++ b/packages/browser/playground/error-tracking/vue-ts-esbuild/src/main.ts
@@ -4,7 +4,7 @@ import { posthog } from 'posthog-js'
 
 posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
     api_host: import.meta.env.VITE_POSTHOG_HOST || 'http://localhost:8010/',
-    defaults: '2025-11-30',
+    defaults: '2025-12-11',
 })
 
 createApp(App).mount('#app')

--- a/packages/browser/src/__tests__/autocapture-utils.test.ts
+++ b/packages/browser/src/__tests__/autocapture-utils.test.ts
@@ -28,14 +28,14 @@ describe(`Autocapture utility functions`, () => {
             const el = document!.createElement(`div`)
 
             el.innerHTML = `  Why  hello  there  `
-            expect(getSafeText(el)).toBe(`Why hello there`)
+            expect(getSafeText(el, {})).toBe(`Why hello there`)
 
             el.innerHTML = `
           Why
           hello
           there
       `
-            expect(getSafeText(el)).toBe(`Why hello there`)
+            expect(getSafeText(el, {})).toBe(`Why hello there`)
 
             el.innerHTML = `
           Why
@@ -44,7 +44,7 @@ describe(`Autocapture utility functions`, () => {
           <p>not</p>
           there
       `
-            expect(getSafeText(el)).toBe(`Whyhellothere`)
+            expect(getSafeText(el, {})).toBe(`Whyhellothere`)
         })
 
         it(`shouldn't collect text from element children`, () => {
@@ -52,7 +52,7 @@ describe(`Autocapture utility functions`, () => {
             let safeText
 
             el.innerHTML = `<div>sensitive</div>`
-            safeText = getSafeText(el)
+            safeText = getSafeText(el, {})
             expect(safeText).toEqual(expect.not.arrayContaining([`sensitive`]))
             expect(safeText).toBe(``)
 
@@ -63,7 +63,7 @@ describe(`Autocapture utility functions`, () => {
           <p>sensitive</p>
           there
       `
-            safeText = getSafeText(el)
+            safeText = getSafeText(el, {})
             expect(safeText).toEqual(expect.not.arrayContaining([`sensitive`]))
             expect(safeText).toBe(`Whyhellothere`)
         })
@@ -73,52 +73,52 @@ describe(`Autocapture utility functions`, () => {
 
             el = document!.createElement(`input`)
             el.innerHTML = `Why hello there`
-            expect(getSafeText(el)).toBe(``)
+            expect(getSafeText(el, {})).toBe(``)
 
             el = document!.createElement(`textarea`)
             el.innerHTML = `Why hello there`
-            expect(getSafeText(el)).toBe(``)
+            expect(getSafeText(el, {})).toBe(``)
 
             el = document!.createElement(`select`)
             el.innerHTML = `Why hello there`
-            expect(getSafeText(el)).toBe(``)
+            expect(getSafeText(el, {})).toBe(``)
 
             el = document!.createElement(`div`)
             el.setAttribute(`contenteditable`, `true`)
             el.innerHTML = `Why hello there`
-            expect(getSafeText(el)).toBe(``)
+            expect(getSafeText(el, {})).toBe(``)
         })
 
         it(`shouldn't collect sensitive values`, () => {
             const el = document!.createElement(`div`)
 
             el.innerHTML = `Why 123-58-1321 hello there`
-            expect(getSafeText(el)).toBe(`Why hello there`)
+            expect(getSafeText(el, {})).toBe(`Why hello there`)
 
             el.innerHTML = `
         4111111111111111
         Why hello there
       `
-            expect(getSafeText(el)).toBe(`Why hello there`)
+            expect(getSafeText(el, {})).toBe(`Why hello there`)
 
             el.innerHTML = `
         Why hello there
         5105-1051-0510-5100
       `
-            expect(getSafeText(el)).toBe(`Why hello there`)
+            expect(getSafeText(el, {})).toBe(`Why hello there`)
         })
 
         it(`should handle text with quotation marks properly`, () => {
             const el = document!.createElement(`div`)
 
             el.innerHTML = `Text with "double quotes" in it`
-            expect(getSafeText(el)).toBe(`Text with "double quotes" in it`)
+            expect(getSafeText(el, {})).toBe(`Text with "double quotes" in it`)
 
             el.innerHTML = `Text with 'single quotes' in it`
-            expect(getSafeText(el)).toBe(`Text with 'single quotes' in it`)
+            expect(getSafeText(el, {})).toBe(`Text with 'single quotes' in it`)
 
             el.innerHTML = `Mixed "double" and 'single' quotes`
-            expect(getSafeText(el)).toBe(`Mixed "double" and 'single' quotes`)
+            expect(getSafeText(el, {})).toBe(`Mixed "double" and 'single' quotes`)
         })
 
         // TODO:@luke-belton make this test pass in future
@@ -366,25 +366,25 @@ describe(`Autocapture utility functions`, () => {
 
         it(`should include sensitive elements with class "ph-include"`, () => {
             el.className = `test1 ph-include test2`
-            expect(shouldCaptureElement(el)).toBe(true)
+            expect(shouldCaptureElement(el, {})).toBe(true)
         })
 
         it(`should never include inputs with class "ph-sensitive"`, () => {
             el.className = `test1 ph-include ph-sensitive test2`
-            expect(shouldCaptureElement(el)).toBe(false)
+            expect(shouldCaptureElement(el, {})).toBe(false)
         })
 
         it(`should not include elements with class "ph-no-capture" as properties`, () => {
             el.className = `test1 ph-no-capture test2`
-            expect(shouldCaptureElement(el)).toBe(false)
+            expect(shouldCaptureElement(el, {})).toBe(false)
         })
 
         it(`should not include elements with a parent that have class "ph-no-capture" as properties`, () => {
-            expect(shouldCaptureElement(el)).toBe(true)
+            expect(shouldCaptureElement(el, {})).toBe(true)
 
             parent2.className = `ph-no-capture`
 
-            expect(shouldCaptureElement(el)).toBe(false)
+            expect(shouldCaptureElement(el, {})).toBe(false)
         })
 
         // See https://github.com/posthog/posthog-js/issues/165
@@ -396,17 +396,17 @@ describe(`Autocapture utility functions`, () => {
 
             // test
             input.name = el as any
-            shouldCaptureElement(parent1) // previously this would cause el.replace to be called
+            shouldCaptureElement(parent1, {}) // previously this would cause el.replace to be called
             expect((el as any).replace.called).toBe(false)
             input.name = ''
 
             parent1.id = el as any
-            shouldCaptureElement(parent2) // previously this would cause el.replace to be called
+            shouldCaptureElement(parent2, {}) // previously this would cause el.replace to be called
             expect((el as any).replace.called).toBe(false)
             parent1.id = ''
 
             input.type = el as any
-            shouldCaptureElement(parent2) // previously this would cause el.replace to be called
+            shouldCaptureElement(parent2, {}) // previously this would cause el.replace to be called
             expect((el as any).replace.called).toBe(false)
             input.type = ''
 
@@ -459,7 +459,7 @@ describe(`Autocapture utility functions`, () => {
         it(`should return direct text on the element with no children`, () => {
             const el = document!.createElement(`button`)
             el.innerHTML = `test`
-            expect(getDirectAndNestedSpanText(el)).toBe('test')
+            expect(getDirectAndNestedSpanText(el, {})).toBe('test')
         })
         it(`should return the direct text on the el and text from child spans`, () => {
             const parent = document!.createElement(`button`)
@@ -467,20 +467,20 @@ describe(`Autocapture utility functions`, () => {
             const child = document!.createElement(`span`)
             child.innerHTML = `test 1`
             parent.appendChild(child)
-            expect(getDirectAndNestedSpanText(parent)).toBe('test test 1')
+            expect(getDirectAndNestedSpanText(parent, {})).toBe('test test 1')
         })
 
         it(`should properly handle quotation marks in link text`, () => {
             const link = document!.createElement('a')
             link.innerHTML = `Click here to "get started" today!`
 
-            expect(getDirectAndNestedSpanText(link)).toBe(`Click here to "get started" today!`)
+            expect(getDirectAndNestedSpanText(link, {})).toBe(`Click here to "get started" today!`)
 
             link.innerHTML = `Click here to 'get started' today!`
-            expect(getDirectAndNestedSpanText(link)).toBe(`Click here to 'get started' today!`)
+            expect(getDirectAndNestedSpanText(link, {})).toBe(`Click here to 'get started' today!`)
 
             link.innerHTML = `Click here to "get started" with our 'special offer'!`
-            expect(getDirectAndNestedSpanText(link)).toBe(`Click here to "get started" with our 'special offer'!`)
+            expect(getDirectAndNestedSpanText(link, {})).toBe(`Click here to "get started" with our 'special offer'!`)
         })
 
         it(`should properly handle complex titles with multiple quotes`, () => {
@@ -488,7 +488,7 @@ describe(`Autocapture utility functions`, () => {
             link.innerHTML = `Course Title: "Understanding the 'Creative Process' in Modern Design"`
 
             // Check that quotes are preserved in the extracted text
-            expect(getDirectAndNestedSpanText(link)).toBe(
+            expect(getDirectAndNestedSpanText(link, {})).toBe(
                 `Course Title: "Understanding the 'Creative Process' in Modern Design"`
             )
 
@@ -513,7 +513,7 @@ describe(`Autocapture utility functions`, () => {
             // Since we're creating direct text nodes, we need to check the actual output format
             // This matches how makeSafeText joins text segments without spaces between text nodes
             const expected = 'Course Title:"Understanding the \'Creative Process\' in Modern Design"'
-            expect(getDirectAndNestedSpanText(link)).toBe(expected)
+            expect(getDirectAndNestedSpanText(link, {})).toBe(expected)
         })
 
         it(`should handle link text with spans containing parts of quoted text`, () => {
@@ -529,7 +529,7 @@ describe(`Autocapture utility functions`, () => {
             link.appendChild(span)
 
             // Verify the text is properly collected and joined
-            expect(getDirectAndNestedSpanText(link)).toBe(
+            expect(getDirectAndNestedSpanText(link, {})).toBe(
                 `Course Title: "Understanding the 'Creative Process' in Modern Design"`
             )
         })
@@ -538,18 +538,18 @@ describe(`Autocapture utility functions`, () => {
     describe(`getNestedSpanText`, () => {
         it(`should return an empty string if there are no children or text`, () => {
             const el = document!.createElement(`button`)
-            expect(getNestedSpanText(el)).toBe('')
+            expect(getNestedSpanText(el, {})).toBe('')
         })
         it(`should return the text from sibling child spans`, () => {
             const parent = document!.createElement(`button`)
             const child1 = document!.createElement(`span`)
             child1.innerHTML = `test`
             parent.appendChild(child1)
-            expect(getNestedSpanText(parent)).toBe('test')
+            expect(getNestedSpanText(parent, {})).toBe('test')
             const child2 = document!.createElement(`span`)
             child2.innerHTML = `test2`
             parent.appendChild(child2)
-            expect(getNestedSpanText(parent)).toBe('test test2')
+            expect(getNestedSpanText(parent, {})).toBe('test test2')
         })
         it(`should return the text from nested child spans`, () => {
             const parent = document!.createElement(`button`)
@@ -559,7 +559,7 @@ describe(`Autocapture utility functions`, () => {
             const child2 = document!.createElement(`span`)
             child2.innerHTML = `test2`
             child1.appendChild(child2)
-            expect(getNestedSpanText(parent)).toBe('test test2')
+            expect(getNestedSpanText(parent, {})).toBe('test test2')
         })
     })
 

--- a/packages/browser/src/__tests__/autocapture.test.ts
+++ b/packages/browser/src/__tests__/autocapture.test.ts
@@ -288,7 +288,7 @@ describe('Autocapture system', () => {
         })
 
         it('should collect multiple augments from elements', () => {
-            const props = getAugmentPropertiesFromElement(div)
+            const props = getAugmentPropertiesFromElement(div, {})
 
             expect(props['one-on-the-div']).toBe('one')
             expect(props['two-on-the-div']).toBe('two')
@@ -297,7 +297,7 @@ describe('Autocapture system', () => {
         })
 
         it('should collect augment from input value', () => {
-            const props = getAugmentPropertiesFromElement(input)
+            const props = getAugmentPropertiesFromElement(input, {})
 
             expect(props['on-the-input']).toBe('is on the input')
         })
@@ -315,13 +315,13 @@ describe('Autocapture system', () => {
         })
 
         it('should not collect augment from the hidden element value', () => {
-            const props = getAugmentPropertiesFromElement(hidden)
+            const props = getAugmentPropertiesFromElement(hidden, {})
 
             expect(props).toStrictEqual({})
         })
 
         it('should collect augment from the password element value', () => {
-            const props = getAugmentPropertiesFromElement(password)
+            const props = getAugmentPropertiesFromElement(password, {})
 
             expect(props).toStrictEqual({})
         })
@@ -330,7 +330,7 @@ describe('Autocapture system', () => {
         describe('inconsistencies in the original implementation', () => {
             it('fails to collect attribute if sensitive data is detected in the element', () => {
                 password.setAttribute('data-ph-capture-attribute-on-the-div', 'my data to collect')
-                const props = getAugmentPropertiesFromElement(password)
+                const props = getAugmentPropertiesFromElement(password, {})
 
                 // we'd expect to capture the attribute, because the user has explicitly asked for it
                 // yet we don't in the original implementation

--- a/packages/browser/src/__tests__/sensitive-data-detection.test.ts
+++ b/packages/browser/src/__tests__/sensitive-data-detection.test.ts
@@ -7,15 +7,15 @@ import {
 describe('sensitive data detection', () => {
     describe(`isSensitiveElement`, () => {
         it(`should not include input elements`, () => {
-            expect(isSensitiveElement(document!.createElement(`input`))).toBe(true)
+            expect(isSensitiveElement(document!.createElement(`input`), {})).toBe(true)
         })
 
         it(`should not include select elements`, () => {
-            expect(isSensitiveElement(document!.createElement(`select`))).toBe(true)
+            expect(isSensitiveElement(document!.createElement(`select`), {})).toBe(true)
         })
 
         it(`should not include textarea elements`, () => {
-            expect(isSensitiveElement(document!.createElement(`textarea`))).toBe(true)
+            expect(isSensitiveElement(document!.createElement(`textarea`), {})).toBe(true)
         })
 
         it(`should not include elements where contenteditable="true"`, () => {
@@ -25,8 +25,8 @@ describe('sensitive data detection', () => {
             editable.setAttribute(`contenteditable`, `true`)
             noneditable.setAttribute(`contenteditable`, `false`)
 
-            expect(isSensitiveElement(editable)).toBe(true)
-            expect(isSensitiveElement(noneditable)).toBe(false)
+            expect(isSensitiveElement(editable, {})).toBe(true)
+            expect(isSensitiveElement(noneditable, {})).toBe(false)
         })
     })
 
@@ -76,12 +76,12 @@ describe('sensitive data detection', () => {
 
         it(`should not include hidden fields`, () => {
             input.type = `hidden`
-            expect(doesCaptureElementHaveSensitiveData(input)).toBe(true)
+            expect(doesCaptureElementHaveSensitiveData(input, {})).toBe(true)
         })
 
         it(`should not include password fields`, () => {
             input.type = `password`
-            expect(doesCaptureElementHaveSensitiveData(input)).toBe(true)
+            expect(doesCaptureElementHaveSensitiveData(input, {})).toBe(true)
         })
 
         it(`should not include fields with sensitive names`, () => {
@@ -106,10 +106,10 @@ describe('sensitive data detection', () => {
             ]
             sensitiveNames.forEach((name) => {
                 input.name = ''
-                expect(doesCaptureElementHaveSensitiveData(input)).toBe(false)
+                expect(doesCaptureElementHaveSensitiveData(input, {})).toBe(false)
 
                 input.name = name
-                expect(doesCaptureElementHaveSensitiveData(input)).toBe(true)
+                expect(doesCaptureElementHaveSensitiveData(input, {})).toBe(true)
             })
         })
 
@@ -117,19 +117,19 @@ describe('sensitive data detection', () => {
         describe('a bug with substring matching', () => {
             it(`matches 'cc' only at the start of the string`, () => {
                 input.name = `my_cc`
-                expect(doesCaptureElementHaveSensitiveData(input)).toBe(false)
+                expect(doesCaptureElementHaveSensitiveData(input, {})).toBe(false)
 
                 input.name = `cc_number`
-                expect(doesCaptureElementHaveSensitiveData(input)).toBe(true)
+                expect(doesCaptureElementHaveSensitiveData(input, {})).toBe(true)
             })
 
             it(`matches other sensitive substrings wherever they appear`, () => {
                 input.name = `expiration_date_cc`
-                expect(doesCaptureElementHaveSensitiveData(input)).toBe(true)
+                expect(doesCaptureElementHaveSensitiveData(input, {})).toBe(true)
 
                 // this is the bug!
                 input.name = `my_expert_view`
-                expect(doesCaptureElementHaveSensitiveData(input)).toBe(true)
+                expect(doesCaptureElementHaveSensitiveData(input, {})).toBe(true)
             })
         })
     })

--- a/packages/browser/src/entrypoints/dead-clicks-autocapture.ts
+++ b/packages/browser/src/entrypoints/dead-clicks-autocapture.ts
@@ -269,6 +269,7 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
                     elementAttributeIgnoreList: this._config.element_attribute_ignorelist,
                     // TRICKY: it appears that we were moving to elementsChainAsString, but the UI still depends on elements, so :shrug:
                     elementsChainAsString: false,
+                    sensitiveDataDetectionConfig: this.instance.config.sensitive_data_detection,
                 }).props,
                 $dead_click_scroll_delay_ms: click.scrollDelayMs,
                 $dead_click_mutation_delay_ms: click.mutationDelayMs,

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -153,10 +153,19 @@ let ENQUEUE_REQUESTS = !SUPPORTS_REQUEST && userAgent?.indexOf('MSIE') === -1 &&
 
 const defaultsThatVaryByConfig = (
     defaults?: ConfigDefaults
-): Pick<PostHogConfig, 'rageclick' | 'capture_pageview' | 'session_recording'> => ({
+): Pick<PostHogConfig, 'rageclick' | 'capture_pageview' | 'session_recording' | 'sensitive_data_detection'> => ({
     rageclick: defaults && defaults >= '2025-11-30' ? { content_ignorelist: true } : true,
     capture_pageview: defaults && defaults >= '2025-05-24' ? 'history_change' : true,
     session_recording: defaults && defaults >= '2025-11-30' ? { strictMinimumDuration: true } : {},
+    sensitive_data_detection:
+        defaults && defaults >= '2025-12-11'
+            ? {
+                  allowedInputTypes: ['button', 'checkbox', 'submit', 'reset'],
+                  sensitiveNameRegex: new RegExp(
+                      /^(cc|cardnum|ccnum|creditcard|csc|cvc|cvv|exp|pass|pwd|routing|seccode|securitycode|securitynum|socialsec|socsec|ssn)/i
+                  ),
+              }
+            : {},
 })
 
 // NOTE: Remember to update `types.ts` when changing a default value

--- a/packages/browser/src/utils/sensitive-data-detection.ts
+++ b/packages/browser/src/utils/sensitive-data-detection.ts
@@ -1,21 +1,17 @@
 import { isString, trim } from '@posthog/core'
 import { isTag } from './element-utils'
 import { toExactMatch } from './regex-utils'
+import { PostHogConfig } from '../types'
 
 // Define the core pattern for matching SSNs with optional dashes
-const CORE_SSN_PATTERN = `(\\d{3}-?\\d{2}-?\\d{4})`
-
-// The Unanchored version is essentially the core pattern itself, usable for partial matches
-export const UNANCHORED_SSN_REGEX = new RegExp(CORE_SSN_PATTERN)
+// unanchored version for substring matches - use toExactMatch to anchor if needed
+export const UNANCHORED_SSN_REGEX = new RegExp(`(\\d{3}-?\\d{2}-?\\d{4})`)
 
 // Define the core pattern for matching credit card numbers
-const CORE_CC_PATTERN = `(4[0-9]{12}(?:[0-9]{3})?)|(5[1-5][0-9]{14})|(6(?:011|5[0-9]{2})[0-9]{12})|(3[47][0-9]{13})|(3(?:0[0-5]|[68][0-9])[0-9]{11})|((?:2131|1800|35[0-9]{3})[0-9]{11})`
-
-// The Unanchored version is essentially the core pattern, usable as is for partial matches
-export const UNANCHORED_CC_REGEX = new RegExp(CORE_CC_PATTERN)
-
-// Default input types to consider safe and allow data capture from
-const ALLOWED_INPUT_TYPES = ['button', 'checkbox', 'submit', 'reset']
+// unanchored version for substring matches - use toExactMatch to anchor if needed
+export const UNANCHORED_CC_REGEX = new RegExp(
+    `(4[0-9]{12}(?:[0-9]{3})?)|(5[1-5][0-9]{14})|(6(?:011|5[0-9]{2})[0-9]{12})|(3[47][0-9]{13})|(3(?:0[0-5]|[68][0-9])[0-9]{11})|((?:2131|1800|35[0-9]{3})[0-9]{11})`
+)
 
 /*
  * Check whether a string value may contain sensitive data using a set of regexes
@@ -50,12 +46,11 @@ export function isSensitiveValue(value: string, anchorRegexes = true): boolean {
  * @param {Element} el - element to check
  * @returns {boolean} whether the element should be captured
  */
-export function isSensitiveElement(el: Element): boolean {
+export function isSensitiveElement(el: Element, config: PostHogConfig['sensitive_data_detection']): boolean {
     // don't send data from inputs or similar elements since there will always be
     // a risk of clientside javascript placing sensitive data in attributes
     if (
-        // TODO@luke-belton: derive ALLOWED_INPUT_TYPES from config
-        (isTag(el, 'input') && !ALLOWED_INPUT_TYPES.includes((el as HTMLInputElement).type)) ||
+        (isTag(el, 'input') && !config?.allowedInputTypes?.includes((el as HTMLInputElement).type)) ||
         isTag(el, 'select') ||
         isTag(el, 'textarea') ||
         el.getAttribute('contenteditable') === 'true'
@@ -71,8 +66,12 @@ export function isSensitiveElement(el: Element): boolean {
  * @returns {boolean} whether the element may contain sensitive data
  */
 // #TODO@luke-belton: should be combined with isSensitiveElement
-export function doesCaptureElementHaveSensitiveData(el: Element): boolean {
+export function doesCaptureElementHaveSensitiveData(
+    el: Element,
+    config: PostHogConfig['sensitive_data_detection']
+): boolean {
     // don't include hidden or password fields
+    //TODO@luke-belton: this is redundant with isSensitiveElement - should be combined
     const type = (el as HTMLInputElement).type || ''
     if (isString(type)) {
         // it's possible for el.type to be a DOM element if el is a form with a child input[name="type"]
@@ -84,6 +83,7 @@ export function doesCaptureElementHaveSensitiveData(el: Element): boolean {
         }
     }
 
+    // TODO@luke-belton: shift this into isSensitiveElement
     // filter out data from fields that look like sensitive fields
     const name = (el as HTMLInputElement).name || el.id || ''
     // See https://github.com/posthog/posthog-js/issues/165
@@ -94,6 +94,7 @@ export function doesCaptureElementHaveSensitiveData(el: Element): boolean {
         // names  will match if they're in the middle of a substring.
         // it's possible for el.name or el.id to be a DOM element if el is a form with a child input[name="name"]
         const sensitiveNameRegex =
+            config?.sensitiveNameRegex ||
             /^cc|cardnum|ccnum|creditcard|csc|cvc|cvv|exp|pass|pwd|routing|seccode|securitycode|securitynum|socialsec|socsec|ssn/i
         if (sensitiveNameRegex.test(name.replace(/[^a-zA-Z0-9]/g, ''))) {
             return true

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -282,6 +282,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
   ],
   "properties_string_max_length": "number",
   "defaults": [
+    "\\"2025-12-11\\"",
     "\\"2025-11-30\\"",
     "\\"2025-05-24\\"",
     "\\"unset\\""
@@ -289,6 +290,19 @@ exports[`config snapshot for PostHogConfig 1`] = `
   "__preview_deferred_init_extensions": [
     "false",
     "true"
+  ],
+  "sensitive_data_detection": [
+    "undefined",
+    {
+      "allowedInputTypes": [
+        "undefined",
+        "string[]"
+      ],
+      "sensitiveNameRegex": [
+        "undefined",
+        "RegExp"
+      ]
+    }
   ],
   "session_recording": {
     "blockClass": [

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -549,6 +549,24 @@ export interface LogsConfig {
 type NextOptions = { revalidate: false | 0 | number; tags: string[] }
 
 /**
+ * Configuration options for automatic sensitive data detection.
+
+ */
+export interface SensitiveDataDetectionOptions {
+    /**
+     * List of input types which will not be scanned for sensitive data.
+     *
+     * @default ['button', 'checkbox', 'submit', 'reset']
+     */
+    allowedInputTypes?: string[]
+
+    /**
+     * Regular expression to match sensitive field names (e.g., cc, ssn, password, etc.)
+     */
+    sensitiveNameRegex?: RegExp
+}
+
+/**
  * Configuration options for the PostHog JavaScript SDK.
  * @see https://posthog.com/docs/libraries/js#config
  */
@@ -971,6 +989,7 @@ export interface PostHogConfig {
      * - `'unset'`: Use legacy default behaviors
      * - `'2025-05-24'`: Use updated default behaviors (e.g. capture_pageview defaults to 'history_change')
      * - `'2025-11-30'`: Defaults from '2025-05-24' plus additional changes (e.g. strict minimum duration for replay and rageclick content ignore list defaults to active)
+     * - `'2025-12-11'`: Defaults from '2025-11-30' plus additional changes (improvements + configurability of sensitive data detection)
      *
      * @default 'unset'
      */
@@ -990,6 +1009,13 @@ export interface PostHogConfig {
      * @experimental
      */
     __preview_deferred_init_extensions: boolean
+
+    /**
+     * Determines the sensitive data detection options.
+     * @see `SensitiveDataDetectionOptions`
+     * @default {}
+     */
+    sensitive_data_detection?: SensitiveDataDetectionOptions
 
     /**
      * Determines the session recording options.


### PR DESCRIPTION
## Problem

Building off https://github.com/PostHog/posthog-js/pull/2647 and the feedback at https://posthog.slack.com/archives/C075D3C5HST/p1764603130371689.

Follows https://github.com/PostHog/posthog-js/pull/2886.

## Changes

This is part 2 of a refactor of how we handle sensitive data.

There are still no behavioral changes, basically in this PR we're preparing for config-driven sensitive data detection. It:

  1. Creates a new latest value in defaults to ensure we don't make breaking changes for existing users (we'll need to update its value for release)
  1. Create and passes around new sensitive data config parameters everywhere they'd be needed
  1. Passed empty objects {} to maintain existing behavior
  1. Prepares to use the config parameters in the final/part 3 of this refactor

The tests are failing I think due to a bad rebase which I've fixed in the final part of the refactor...

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
