### PR TITLE
fix(product tours): fix buggy element tooltip positioning

### DIFF
--- a/.changeset/slow-places-shave.md
+++ b/.changeset/slow-places-shave.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+more robust element-based tooltip positioning for product tours

--- a/packages/browser/src/extensions/product-tours/product-tours-utils.ts
+++ b/packages/browser/src/extensions/product-tours/product-tours-utils.ts
@@ -83,46 +83,43 @@ export function getElementMetadata(element: HTMLElement): {
 export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right'
 
 export interface PositionResult {
-    top: number
-    left: number
     position: TooltipPosition
+    top?: number
+    bottom?: number
+    left?: number
+    right?: number
 }
 
 const TOOLTIP_MARGIN = 12
-const TOOLTIP_WIDTH = 320
-const TOOLTIP_HEIGHT_ESTIMATE = 180
 
-export function calculateTooltipPosition(targetRect: DOMRect): PositionResult {
+export interface TooltipDimensions {
+    width: number
+    height: number
+}
+
+export function calculateTooltipPosition(targetRect: DOMRect, tooltipDimensions: TooltipDimensions): PositionResult {
     const viewportWidth = window.innerWidth
     const viewportHeight = window.innerHeight
 
+    const { width, height } = tooltipDimensions
+    const spaceAbove = targetRect.top
     const spaceBelow = viewportHeight - targetRect.bottom
     const spaceLeft = targetRect.left
     const spaceRight = viewportWidth - targetRect.right
 
-    let position: TooltipPosition
-    let top: number
-    let left: number
+    const targetCenterY = targetRect.top + targetRect.height / 2
+    const targetCenterX = targetRect.left + targetRect.width / 2
 
-    if (spaceRight >= TOOLTIP_WIDTH + TOOLTIP_MARGIN) {
-        position = 'right'
-        top = targetRect.top + targetRect.height / 2 - TOOLTIP_HEIGHT_ESTIMATE / 2
-        left = targetRect.right + TOOLTIP_MARGIN
-    } else if (spaceLeft >= TOOLTIP_WIDTH + TOOLTIP_MARGIN) {
-        position = 'left'
-        top = targetRect.top + targetRect.height / 2 - TOOLTIP_HEIGHT_ESTIMATE / 2
-        left = targetRect.left - TOOLTIP_WIDTH - TOOLTIP_MARGIN
-    } else if (spaceBelow >= TOOLTIP_HEIGHT_ESTIMATE + TOOLTIP_MARGIN) {
-        position = 'bottom'
-        top = targetRect.bottom + TOOLTIP_MARGIN
-        left = targetRect.left + targetRect.width / 2 - TOOLTIP_WIDTH / 2
-    } else {
-        position = 'top'
-        top = targetRect.top - TOOLTIP_HEIGHT_ESTIMATE - TOOLTIP_MARGIN
-        left = targetRect.left + targetRect.width / 2 - TOOLTIP_WIDTH / 2
+    if (spaceRight >= width + TOOLTIP_MARGIN) {
+        return { position: 'right', top: targetCenterY, left: targetRect.right + TOOLTIP_MARGIN }
     }
-
-    return { top, left, position }
+    if (spaceLeft >= width + TOOLTIP_MARGIN) {
+        return { position: 'left', top: targetCenterY, right: viewportWidth - targetRect.left + TOOLTIP_MARGIN }
+    }
+    if (spaceAbove >= height + TOOLTIP_MARGIN && spaceBelow < height + TOOLTIP_MARGIN) {
+        return { position: 'top', bottom: viewportHeight - targetRect.top + TOOLTIP_MARGIN, left: targetCenterX }
+    }
+    return { position: 'bottom', top: targetRect.bottom + TOOLTIP_MARGIN, left: targetCenterX }
 }
 
 export function getSpotlightStyle(targetRect: DOMRect, padding: number = 8): Record<string, string> {


### PR DESCRIPTION
## Problem

product tour toolip positioning is pretty buggy overall, and does not support the now-customizable step widths

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

make element-based tooltip positioning more robust and support dynamic widths

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->