### PR TITLE
chore(product tours): allow configurable z-index for tour steps

### DIFF
--- a/.changeset/clever-ghosts-study.md
+++ b/.changeset/clever-ghosts-study.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+support configurable z-index

--- a/packages/browser/src/extensions/product-tours/product-tours-utils.ts
+++ b/packages/browser/src/extensions/product-tours/product-tours-utils.ts
@@ -150,6 +150,7 @@ export function addProductTourCSSVariablesToElement(element: HTMLElement, appear
     style.setProperty('--ph-tour-button-text-color', getContrastingTextColor(merged.buttonColor))
     style.setProperty('--ph-tour-box-shadow', merged.boxShadow)
     style.setProperty('--ph-tour-overlay-color', merged.showOverlay ? 'rgba(0, 0, 0, 0.5)' : 'transparent')
+    style.setProperty('--ph-tour-z-index', String(merged.zIndex))
 
     // Internal styling variables (not customizable)
     style.setProperty('--ph-tour-button-secondary-color', 'transparent')

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -109,6 +109,7 @@ export interface ProductTourAppearance {
     whiteLabel?: boolean
     /** defaults to true, auto-set to false for announcements/banners */
     dismissOnClickOutside?: boolean
+    zIndex?: number
 }
 
 export interface ProductTour {
@@ -151,6 +152,7 @@ export const DEFAULT_PRODUCT_TOUR_APPEARANCE: Required<ProductTourAppearance> = 
     showOverlay: true,
     whiteLabel: false,
     dismissOnClickOutside: true,
+    zIndex: 2147483646,
 }
 
 export interface ShowTourOptions {


### PR DESCRIPTION
## Problem

z-index for tour steps is hard-coded -- this is problematic for previews, at least

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

adds configurable z-index

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->