### PR TITLE
fix: release.yml should use var names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,10 +243,11 @@ jobs:
               env:
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   curl -f -X POST \
                        -H "Accept: application/vnd.github+json" \
-                       -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                       -H "Authorization: Bearer $GITHUB_TOKEN" \
                        https://api.github.com/repos/posthog/posthog-js/actions/workflows/posthog-upgrade.yml/dispatches \
                        -d '{
                          "ref": "main",
@@ -261,10 +262,11 @@ jobs:
               env:
                   PACKAGE_NAME: ${{ matrix.package.name }}
                   PACKAGE_VERSION: ${{ steps.check-package-version.outputs.committed-version }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   curl -f -X POST \
                        -H "Accept: application/vnd.github+json" \
-                       -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                       -H "Authorization: Bearer $GITHUB_TOKEN" \
                        https://api.github.com/repos/posthog/posthog-js/actions/workflows/posthog-com-upgrade.yml/dispatches \
                        -d '{
                          "ref": "main",


### PR DESCRIPTION
## Problem

Release.yml scripts were blocked by security.yml

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
