### PR TITLE
fix(product tours): fix tooltip positioning and size on mobile

### DIFF
--- a/.changeset/brave-guests-prove.md
+++ b/.changeset/brave-guests-prove.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix product tour tooltips on mobile

--- a/packages/browser/src/extensions/product-tours/components/ProductTourTooltip.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourTooltip.tsx
@@ -7,7 +7,13 @@ import {
     ProductTourStepButton,
 } from '../../../posthog-product-tours-types'
 import { isUndefined, SurveyPosition } from '@posthog/core'
-import { calculateTooltipPosition, getSpotlightStyle, TooltipPosition, TooltipDimensions } from '../product-tours-utils'
+import {
+    calculateTooltipPosition,
+    getSpotlightStyle,
+    TooltipPosition,
+    TooltipDimensions,
+    PositionResult,
+} from '../product-tours-utils'
 import { getPopoverPosition } from '../../surveys/surveys-extension-utils'
 import { addEventListener } from '../../../utils'
 import { window as _window } from '../../../utils/globals'
@@ -109,7 +115,7 @@ export function ProductTourTooltip({
     onButtonClick,
 }: ProductTourTooltipProps): h.JSX.Element {
     const [transitionState, setTransitionState] = useState<TransitionState>('entering')
-    const [position, setPosition] = useState<ReturnType<typeof calculateTooltipPosition> | null>(null)
+    const [position, setPosition] = useState<PositionResult | null>(null)
     const [spotlightStyle, setSpotlightStyle] = useState<ReturnType<typeof getSpotlightStyle> | null>(null)
     const [isMeasured, setIsMeasured] = useState(false)
 
@@ -278,8 +284,8 @@ export function ProductTourTooltip({
 
     const tooltipStyle = {
         ...(displayedStep.maxWidth && {
-            width: `${displayedStep.maxWidth}px`,
-            maxWidth: `${displayedStep.maxWidth}px`,
+            width: `min(${displayedStep.maxWidth}px, calc(100vw - 16px))`,
+            maxWidth: `min(${displayedStep.maxWidth}px, calc(100vw - 16px))`,
         }),
         ...(isScreenPositioned
             ? {
@@ -338,7 +344,14 @@ export function ProductTourTooltip({
                 onClick={handleTooltipClick}
             >
                 {!isScreenPositioned && position && (
-                    <div class={`ph-tour-arrow ph-tour-arrow--${getOppositePosition(position.position)}`} />
+                    <div
+                        class={`ph-tour-arrow ph-tour-arrow--${getOppositePosition(position.position)}`}
+                        style={
+                            position.arrowOffset !== 0
+                                ? { '--ph-tour-arrow-offset': `${position.arrowOffset}px` }
+                                : undefined
+                        }
+                    />
                 )}
 
                 {isSurvey ? (

--- a/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
@@ -64,6 +64,8 @@ export function ProductTourTooltipInner({
     const isInteractive = !!(onNext || onPrevious || onDismiss || onButtonClick)
     const cursorStyle = isInteractive ? undefined : { cursor: 'default' }
 
+    const showPostHogBranding = !whiteLabel && isFirstStep
+
     const handleButtonClick = (button: ProductTourStepButton) => {
         if (onButtonClick) {
             onButtonClick(button)
@@ -128,7 +130,7 @@ export function ProductTourTooltipInner({
                 </div>
             </div>
 
-            {!whiteLabel && (
+            {showPostHogBranding && (
                 <a
                     href={isInteractive ? 'https://posthog.com/product-tours' : undefined}
                     target={isInteractive ? '_blank' : undefined}

--- a/packages/browser/src/extensions/product-tours/product-tour.css
+++ b/packages/browser/src/extensions/product-tours/product-tour.css
@@ -69,8 +69,8 @@
     border: 1px solid var(--ph-tour-border-color);
     border-radius: var(--ph-tour-border-radius);
     box-shadow: var(--ph-tour-box-shadow);
-    min-width: 280px;
-    max-width: var(--ph-tour-max-width);
+    min-width: min(280px, calc(100vw - 16px));
+    max-width: min(var(--ph-tour-max-width), calc(100vw - 16px));
     padding: var(--ph-tour-padding);
     padding-top: calc(var(--ph-tour-padding) + 8px);
     pointer-events: auto;
@@ -83,6 +83,7 @@
 }
 
 .ph-tour-arrow {
+    --ph-tour-arrow-offset: 0px;
     position: absolute;
     width: 0;
     height: 0;
@@ -91,28 +92,28 @@
 
 .ph-tour-arrow--top {
     bottom: 100%;
-    left: 50%;
+    left: calc(50% + var(--ph-tour-arrow-offset));
     transform: translateX(-50%);
     border-bottom-color: var(--ph-tour-background-color);
 }
 
 .ph-tour-arrow--bottom {
     top: 100%;
-    left: 50%;
+    left: calc(50% + var(--ph-tour-arrow-offset));
     transform: translateX(-50%);
     border-top-color: var(--ph-tour-background-color);
 }
 
 .ph-tour-arrow--left {
     right: 100%;
-    top: 50%;
+    top: calc(50% + var(--ph-tour-arrow-offset));
     transform: translateY(-50%);
     border-right-color: var(--ph-tour-background-color);
 }
 
 .ph-tour-arrow--right {
     left: 100%;
-    top: 50%;
+    top: calc(50% + var(--ph-tour-arrow-offset));
     transform: translateY(-50%);
     border-left-color: var(--ph-tour-background-color);
 }
@@ -423,7 +424,7 @@
 
 /* Survey step styles */
 .ph-tour-survey-step {
-    min-width: 300px;
+    min-width: min(300px, calc(100vw - 16px));
 }
 
 .ph-tour-survey-question {


### PR DESCRIPTION
## Problem

product tours are a bit jank on mobile web:

1. we forced arrow to middle of tooltip every time, so that caused tooltips to shift off-screen in some cases
2. we did not apply a max-width to tooltips that overrides user-supplied width values

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

fixes the above!

| before | after |
| --- | --- |
| ![Screenshot 2026-01-16 at 8.44.50 AM.png](https://app.graphite.com/user-attachments/assets/9ce694d6-2b72-4a22-9c10-25fe543916f0.png)<br> | ![Screenshot 2026-01-16 at 8.48.58 AM.png](https://app.graphite.com/user-attachments/assets/7f8134e6-ed0a-437c-adeb-285cd53728c3.png)<br> |

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->