### PR TITLE
chore: Node engine constraint includes Node 20

### DIFF
--- a/.changeset/new-ducks-hope.md
+++ b/.changeset/new-ducks-hope.md
@@ -1,8 +1,8 @@
 ---
-'@posthog/nextjs-config': major
-'posthog-node': major
-'@posthog/nuxt': major
-'@posthog/ai': major
+'@posthog/nextjs-config': minor
+'posthog-node': minor
+'@posthog/nuxt': minor
+'@posthog/ai': minor
 ---
 
-chore: Bump node min. >= 22.22 due to https://nodejs.org/en/blog/vulnerability/january-2026-dos-mitigation-async-hooks
+chore: Bump node min. ^20.20.0 || >=22.22.0 due to https://nodejs.org/en/blog/vulnerability/january-2026-dos-mitigation-async-hooks

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: [20, 22, 24]
         typescript-version:
           - version: "4.7.4"
             extra-flags: "--moduleResolution node"

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -40,7 +40,7 @@
     "observability"
   ],
   "engines": {
-    "node": ">=22.22"
+    "node": "^20.20.0 || >=22.22.0"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",

--- a/packages/nextjs-config/package.json
+++ b/packages/nextjs-config/package.json
@@ -38,7 +38,7 @@
     }
   },
   "engines": {
-    "node": ">=22.22"
+    "node": "^20.20.0 || >=22.22.0"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -20,7 +20,7 @@
     "generate-references": "pnpm build && pnpm exec api-extractor run --config ./api-extractor.jsonc --local && node scripts/generate-docs.mjs"
   },
   "engines": {
-    "node": ">=22.22"
+    "node": "^20.20.0 || >=22.22.0"
   },
   "files": [
     "src",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=22.22"
+    "node": "^20.20.0 || >=22.22.0"
   },
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Problem

Follow on to https://github.com/PostHog/posthog-js/pull/2930

Node 20 LTS is in maintenance until ~mid April. This change retains support for recent versions of Node 20. 
https://nodejs.org/en/about/previous-releases

## Changes

Maintain support for Node 20, drop to `minor` version bump because we're no longer dropping support for a major version of Node.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [x] @posthog/nextjs-config
- [x] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types
