### PR TITLE
chore: even more tests on the wrapper

### DIFF
--- a/packages/browser/src/__tests__/extensions/replay/external/fetch-wrapper-invariants.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/external/fetch-wrapper-invariants.test.ts
@@ -95,15 +95,10 @@ describe('fetch wrapper', () => {
                     return fd
                 },
             ],
+            ['null', () => null],
+            ['undefined', () => undefined],
         ])('handles %s body', async (_name, createBody) => {
             await expectNotToThrow(wrappedFetch('https://example.com/api', { method: 'POST', body: createBody() }))
-        })
-
-        it.each([
-            ['null', null],
-            ['undefined', undefined],
-        ])('handles %s body', async (_name, body) => {
-            await expectNotToThrow(wrappedFetch('https://example.com/api', { method: 'POST', body }))
         })
 
         it('handles custom headers', async () => {


### PR DESCRIPTION
maybe wandering into false confidence territory since i'm guessing at problems

but this extends the fetch wrapper tests to try and give more general cover