### PR TITLE
fix: track the last 6 full snapshot timestamps as a debug property

### DIFF
--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -327,6 +327,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     // as we make some decisions based on them without referencing LinkedFlag etc
     private _triggerMatching: TriggerStatusMatching = new PendingTriggerMatching()
     private _fullSnapshotTimer?: ReturnType<typeof setInterval>
+    private _fullSnapshotTimestamps: Array<[string, number]> = []
 
     private _windowId: string
     private _sessionId: string
@@ -1008,6 +1009,13 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             this._updateWindowAndSessionIds(event)
         }
 
+        if (rawEvent.type === EventType.FullSnapshot) {
+            this._fullSnapshotTimestamps.push([this._sessionId, rawEvent.timestamp])
+            if (this._fullSnapshotTimestamps.length > 6) {
+                this._fullSnapshotTimestamps = this._fullSnapshotTimestamps.slice(-6)
+            }
+        }
+
         // Route lifecycle events using their payload IDs:
         // - $session_ending uses currentSessionId (the old session it's ending)
         // - $session_starting uses nextSessionId (the new session it's starting)
@@ -1474,6 +1482,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             $sdk_debug_current_session_duration: this._sessionDuration,
             $sdk_debug_session_start: sessionStartTimestamp,
             $sdk_debug_replay_flushed_size: this._flushedSizeTracker?.currentTrackedSize,
+            $sdk_debug_replay_full_snapshots: this._fullSnapshotTimestamps,
         }
     }
 

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -150,6 +150,7 @@
         "_formatTime",
         "_fullSnapshotIntervalMillis",
         "_fullSnapshotTimer",
+        "_fullSnapshotTimestamps",
         "_gatherRRWebPlugins",
         "_get",
         "_getActionMatcher",

--- a/playground/nextjs/bin/localdev.sh
+++ b/playground/nextjs/bin/localdev.sh
@@ -26,6 +26,18 @@ echo ""
 echo -e "${GREEN}2. Creating tarballs...${NC}"
 pnpm package
 
+# Step 2b: If POSTHOG_REPO is set, link posthog-js to PostHog repo
+if [ -n "$POSTHOG_REPO" ]; then
+    echo ""
+    echo -e "${GREEN}2b. Linking posthog-js to PostHog repo...${NC}"
+    cd "$POSTHOG_REPO"
+    pnpm -r update "posthog-js@file:$REPO_ROOT/target/posthog-js.tgz"
+    pnpm install
+    cd frontend && pnpm run copy-scripts
+    cd "$REPO_ROOT"
+    echo "Linked posthog-js to $POSTHOG_REPO"
+fi
+
 # Step 3: Ensure .pnpmfile.cjs symlink exists
 echo ""
 echo -e "${GREEN}3. Setting up .pnpmfile.cjs symlink...${NC}"

--- a/playground/nextjs/pages/index.tsx
+++ b/playground/nextjs/pages/index.tsx
@@ -5,6 +5,7 @@ import { cookieConsentGiven, PERSON_PROCESSING_MODE } from '@/src/posthog'
 import { setAllPersonProfilePropertiesAsPersonPropertiesForFlags } from 'posthog-js/lib/src/customizations'
 import { STORED_PERSON_PROPERTIES_KEY } from 'posthog-js/lib/src/constants'
 import { DisplaySurveyType, Survey } from 'posthog-js'
+import { SessionInteractions } from '@/src/SessionInteractions'
 
 export default function Home() {
     const posthog = usePostHog()
@@ -115,6 +116,8 @@ export default function Home() {
                 </button>
                 <button onClick={() => setModalOpen(true)}>Open Modal</button>
             </div>
+
+            <SessionInteractions />
 
             {modalOpen && (
                 <div

--- a/playground/nextjs/src/SessionInteractions.tsx
+++ b/playground/nextjs/src/SessionInteractions.tsx
@@ -1,0 +1,83 @@
+import { usePostHog } from 'posthog-js/react'
+import { useEffect, useState } from 'react'
+
+interface SessionState {
+    sessionId: string | null
+    activityTime: string | null
+    startTime: string | null
+    sessionAge: string | null
+}
+
+export function SessionInteractions() {
+    const posthog = usePostHog()
+    const [sessionState, setSessionState] = useState<SessionState | null>(null)
+
+    useEffect(() => {
+        const refresh = () => {
+            const persistence = (posthog as any)?.persistence
+            const sesid = persistence?.props?.$sesid // [activityTs, sessionId, startTs]
+            const activityTs = sesid?.[0]
+            const sessionId = sesid?.[1]
+            const startTs = sesid?.[2]
+
+            setSessionState({
+                sessionId,
+                activityTime: activityTs ? new Date(activityTs).toISOString() : null,
+                startTime: startTs ? new Date(startTs).toISOString() : null,
+                sessionAge: startTs ? `${((Date.now() - startTs) / 1000 / 60 / 60).toFixed(2)} hours` : null,
+            })
+        }
+
+        refresh()
+        const t = setInterval(refresh, 1000)
+
+        return () => {
+            clearInterval(t)
+        }
+    }, [posthog])
+
+    return (
+        <div className="border-2 border-dashed border-orange-400 rounded p-4 my-4">
+            <h2 className="mt-0">Session interactions</h2>
+            <p className="text-sm text-gray-500 italic mb-2">Modifies session persistence to test session rotation</p>
+            <div className="flex items-center gap-2 flex-wrap">
+                <button
+                    onClick={() => {
+                        const persistence = (posthog as any).persistence
+                        const twentyFiveHoursAgo = Date.now() - 25 * 60 * 60 * 1000
+                        const currentSesid = persistence?.props?.$sesid
+
+                        if (persistence && currentSesid) {
+                            const sessionId = currentSesid[1]
+                            persistence.register({
+                                $sesid: [Date.now(), sessionId, twentyFiveHoursAgo],
+                            })
+                        }
+                    }}
+                >
+                    Set session start to 25 hours ago
+                </button>
+                <button
+                    onClick={() => {
+                        const persistence = (posthog as any).persistence
+                        const thirtyFiveMinutesAgo = Date.now() - 35 * 60 * 1000
+                        const currentSesid = persistence?.props?.$sesid
+
+                        if (persistence && currentSesid) {
+                            const sessionId = currentSesid[1]
+                            const startTs = currentSesid[2]
+                            persistence.register({
+                                $sesid: [thirtyFiveMinutesAgo, sessionId, startTs],
+                            })
+                        }
+                    }}
+                >
+                    Set last activity to 35 mins ago
+                </button>
+            </div>
+            <pre className="text-xs bg-gray-100 rounded border border-gray-300 p-2 mt-2 overflow-auto max-h-48">
+                {sessionState ? JSON.stringify(sessionState, null, 2) : 'Loading...'}
+            </pre>
+        </div>
+    )
+}


### PR DESCRIPTION
we do still see some sites sending recordings without full snapshots
we believe this is related to a race condition in handling resets

let's track fullsnapshot sessoin ids by timestamp as a debug property