### PR TITLE
fix(browser): Rate limiting responds to config changes

### DIFF
--- a/.changeset/tangy-camels-cut.md
+++ b/.changeset/tangy-camels-cut.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: Rate limiting configuration changes are respected

--- a/packages/browser/src/__tests__/rate-limiter.test.ts
+++ b/packages/browser/src/__tests__/rate-limiter.test.ts
@@ -149,6 +149,45 @@ describe('Rate Limiter', () => {
 
             expect(mockPostHog.capture).toBeCalledTimes(0)
         })
+
+        it('respects config changes after initialization', () => {
+            expect(rateLimiter.captureEventsPerSecond).toBe(10)
+            expect(rateLimiter.captureEventsBurstLimit).toBe(100)
+
+            mockPostHog.config.rate_limiting = {
+                events_per_second: 5,
+                events_burst_limit: 50,
+            }
+
+            expect(rateLimiter.captureEventsPerSecond).toBe(5)
+            expect(rateLimiter.captureEventsBurstLimit).toBe(50)
+        })
+
+        it('uses defaults when config is not set', () => {
+            mockPostHog.config.rate_limiting = undefined
+
+            expect(rateLimiter.captureEventsPerSecond).toBe(10)
+            expect(rateLimiter.captureEventsBurstLimit).toBe(100)
+        })
+
+        it('computes burst limit from events_per_second when only events_per_second is configured', () => {
+            mockPostHog.config.rate_limiting = {
+                events_per_second: 20,
+            }
+
+            expect(rateLimiter.captureEventsPerSecond).toBe(20)
+            expect(rateLimiter.captureEventsBurstLimit).toBe(200)
+        })
+
+        it('ensures burst limit is at least events_per_second', () => {
+            mockPostHog.config.rate_limiting = {
+                events_per_second: 50,
+                events_burst_limit: 10,
+            }
+
+            expect(rateLimiter.captureEventsPerSecond).toBe(50)
+            expect(rateLimiter.captureEventsBurstLimit).toBe(50)
+        })
     })
 
     describe('server side', () => {


### PR DESCRIPTION
## Problem

`rate_limiting` configuration options are being cached when the `PostHog` client is constructed, instead of when it is initialized, meaning we won't consider any rate limiting configuration changes.

via https://posthoghelp.zendesk.com/agent/tickets/47276 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50127)

## Changes

`captureEventsPerSecond` / `captureEventsBurstLimit` are now getters, so configuration changes are respected.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
