### PR TITLE
chore(product tours): enable element inference mode

### DIFF
--- a/.changeset/busy-monkeys-dream.md
+++ b/.changeset/busy-monkeys-dream.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+enable element inference for product tours

--- a/packages/browser/src/extensions/product-tours/product-tours-utils.ts
+++ b/packages/browser/src/extensions/product-tours/product-tours-utils.ts
@@ -6,6 +6,7 @@ import {
     ProductTourStep,
     DEFAULT_PRODUCT_TOUR_APPEARANCE,
 } from '../../posthog-product-tours-types'
+import { findElement } from './element-inference'
 import { prepareStylesheet } from '../utils/stylesheet-loader'
 import { document as _document, window as _window } from '../../utils/globals'
 import { getFontFamily, getContrastingTextColor, hexToRgba } from '../surveys/surveys-extension-utils'
@@ -49,6 +50,28 @@ export function findElementBySelector(selector: string): ElementFindResult {
     } catch {
         return { element: null, error: 'not_found', matchCount: 0 }
     }
+}
+
+/**
+ * Find element for a step based on its lookup mode.
+ * Default: use inference. If useManualSelector is true: use CSS selector.
+ */
+export function findStepElement(step: ProductTourStep): ElementFindResult {
+    const useManualSelector = step.useManualSelector ?? false
+
+    if (useManualSelector) {
+        if (!step.selector) {
+            return { element: null, error: 'not_found', matchCount: 0 }
+        }
+        return findElementBySelector(step.selector)
+    }
+
+    if (!step.inferenceData) {
+        return { element: null, error: 'not_found', matchCount: 0 }
+    }
+
+    const element = findElement(step.inferenceData)
+    return element ? { element, error: null, matchCount: 1 } : { element: null, error: 'not_found', matchCount: 0 }
 }
 
 export function isElementVisible(element: HTMLElement): boolean {

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -70,6 +70,8 @@ export interface ProductTourStep {
     linkedSurveyQuestionId?: string
     /** Enhanced element data for more reliable lookup at runtime */
     inferenceData?: InferredSelector
+    /** Use CSS selector instead of inference. Defaults to false (use inference). */
+    useManualSelector?: boolean
     /** Maximum tooltip width in pixels (defaults to 320px) */
     maxWidth?: number
     /** Position for modal/survey steps (defaults to middle_center) */


### PR DESCRIPTION
## Problem

product tours only allow element finding by css selector. "element inference" has been running in shadow mode for some time and seems to be working well

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

updates SDK to support "auto" mode - user configurable - to use element inference instead of css selectors

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->