### PR TITLE
feat(product tours): enable linked feature flags

### DIFF
--- a/.changeset/chubby-jokes-repeat.md
+++ b/.changeset/chubby-jokes-repeat.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+enable linked flags for product tours

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -96,6 +96,7 @@ export interface ProductTourConditions {
     actions?: {
         values: SurveyActionType[]
     } | null
+    linkedFlagVariant?: string
 }
 
 export interface ProductTourAppearance {

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -235,6 +235,7 @@
         "_isPolling",
         "_isPostHogException",
         "_isPreviewMode",
+        "_isProductToursFeatureFlagEnabled",
         "_isReadonly",
         "_isRecordingEnabled",
         "_isResuming",


### PR DESCRIPTION
## Problem

cannot use an existing feature flag for product tours targeting

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

enables linked flags for tours, in addition to existing internal targeting flags

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->