### PR TITLE
fix(web-vitals): prevent memory leak by updating webvitals

### DIFF
--- a/.changeset/quick-lions-smile.md
+++ b/.changeset/quick-lions-smile.md
@@ -1,7 +1,12 @@
 ---
-"posthog-js": patch
+'posthog-js': patch
 ---
 
-fix(web-vitals): prevent memory leak by cleaning up PerformanceObservers
+fix(web-vitals): reduce memory leak in SPAs
 
-Store and invoke cleanup functions returned by web-vitals library callbacks to prevent DOM references from being retained across page navigations in SPAs.
+- Upgrade web-vitals from v4.2.4 to v5.1.0 (includes internal memory fixes from v5.0.3)
+- Remove duplicate observer creation on URL change
+
+Note: web-vitals has inherent memory accumulation in SPAs due to internal state.
+The v5 upgrade reduces this but doesn't fully eliminate it since web-vitals
+doesn't provide cleanup functions (Issue #629 was closed as "not planned").

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -57,7 +57,7 @@
         "fflate": "^0.4.8",
         "preact": "^10.28.0",
         "query-selector-shadow-dom": "^1.0.1",
-        "web-vitals": "^4.2.4",
+        "web-vitals": "^5.1.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.208.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",

--- a/packages/browser/src/__tests__/extensions/web-vitals.test.ts
+++ b/packages/browser/src/__tests__/extensions/web-vitals.test.ts
@@ -124,24 +124,19 @@ describe('web vitals', () => {
 
                 loadScriptMock.mockImplementation((_ph, _path, callback) => {
                     // we need a set of fake web vitals handlers, so we can manually trigger the events
-                    // The real web-vitals library returns cleanup functions
                     assignableWindow.__PosthogExtensions__ = {}
                     assignableWindow.__PosthogExtensions__.postHogWebVitalsCallbacks = {
                         onLCP: (cb: any) => {
                             onLCPCallback = cb
-                            return jest.fn() // cleanup function
                         },
                         onCLS: (cb: any) => {
                             onCLSCallback = cb
-                            return jest.fn() // cleanup function
                         },
                         onFCP: (cb: any) => {
                             onFCPCallback = cb
-                            return jest.fn() // cleanup function
                         },
                         onINP: (cb: any) => {
                             onINPCallback = cb
-                            return jest.fn() // cleanup function
                         },
                     }
                     callback()
@@ -228,15 +223,6 @@ describe('web vitals', () => {
                 jest.advanceTimersByTime(DEFAULT_FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS + 1)
 
                 expect(beforeSendMock).toBeCalledTimes(1)
-            })
-
-            it('should have a stop() method that can be called without errors', async () => {
-                // The stop() method should exist and be callable
-                expect(posthog.webVitalsAutocapture!.stop).toBeDefined()
-                expect(typeof posthog.webVitalsAutocapture!.stop).toBe('function')
-
-                // Calling stop() should not throw and should flush any pending metrics
-                expect(() => posthog.webVitalsAutocapture!.stop()).not.toThrow()
             })
         }
     )

--- a/packages/browser/src/extensions/web-vitals/index.ts
+++ b/packages/browser/src/extensions/web-vitals/index.ts
@@ -18,17 +18,12 @@ export const FIFTEEN_MINUTES_IN_MILLIS = 15 * ONE_MINUTE_IN_MILLIS
 
 type WebVitalsEventBuffer = { url: string | undefined; metrics: any[]; firstMetricTimestamp: number | undefined }
 
-type CleanupFunction = () => void
-
 export class WebVitalsAutocapture {
     private _enabledServerSide: boolean = false
     private _initialized = false
 
     private _buffer: WebVitalsEventBuffer = { url: undefined, metrics: [], firstMetricTimestamp: undefined }
     private _delayedFlushTimer: ReturnType<typeof setTimeout> | undefined
-
-    // Store cleanup functions returned by web-vitals library to prevent memory leaks
-    private _cleanupFunctions: CleanupFunction[] = []
 
     constructor(private readonly _instance: PostHog) {
         this._enabledServerSide = !!this._instance.persistence?.props[WEB_VITALS_ENABLED_SERVER_SIDE]
@@ -89,17 +84,6 @@ export class WebVitalsAutocapture {
         }
     }
 
-    /**
-     * Stop capturing and clean up all observers.
-     * Call this when the PostHog instance is being destroyed to prevent memory leaks.
-     */
-    public stop(): void {
-        this._flushToCapture()
-        this._stopCapturing()
-        this._initialized = false
-        logger.info('stopped')
-    }
-
     public onRemoteConfig(response: RemoteConfig) {
         const webVitalsOptIn = isObject(response.capturePerformance) && !!response.capturePerformance.web_vitals
 
@@ -126,6 +110,7 @@ export class WebVitalsAutocapture {
         if (assignableWindow.__PosthogExtensions__?.postHogWebVitalsCallbacks) {
             // already loaded
             cb()
+            return
         }
         assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this._instance, 'web-vitals', (err) => {
             if (err) {
@@ -207,12 +192,6 @@ export class WebVitalsAutocapture {
             // we need to send what we have
             this._flushToCapture()
 
-            // Reset observers on URL change to prevent memory leaks.
-            // The web-vitals library can hold DOM references in its internal state.
-            // By stopping and restarting, we allow the old state to be garbage collected.
-            this._stopCapturing()
-            this._startCapturing()
-
             // poor performance is >4s, we wait twice that time to send
             // this is in case we haven't received all metrics
             // we'll at least gather some
@@ -250,16 +229,18 @@ export class WebVitalsAutocapture {
     }
 
     private _startCapturing = () => {
-        // Clean up any existing observers before starting new ones
-        this._stopCapturing()
+        // IMPORTANT: web-vitals does not provide cleanup functions and warns against
+        // calling functions more than once per page load. Each call creates new
+        // PerformanceObservers that persist for the page lifetime.
+        // See: https://github.com/GoogleChrome/web-vitals/issues/629
+        if (this._initialized) {
+            return
+        }
 
-        // The web-vitals library functions return cleanup functions that can be called
-        // to stop observing and free internal state. The return type is optional as older
-        // versions or mocks might not return cleanup functions.
-        let onLCP: ((callback: WebVitalsMetricCallback) => CleanupFunction | void) | undefined
-        let onCLS: ((callback: WebVitalsMetricCallback) => CleanupFunction | void) | undefined
-        let onFCP: ((callback: WebVitalsMetricCallback) => CleanupFunction | void) | undefined
-        let onINP: ((callback: WebVitalsMetricCallback) => CleanupFunction | void) | undefined
+        let onLCP: WebVitalsMetricCallback | undefined
+        let onCLS: WebVitalsMetricCallback | undefined
+        let onFCP: WebVitalsMetricCallback | undefined
+        let onINP: WebVitalsMetricCallback | undefined
 
         const posthogExtensions = assignableWindow.__PosthogExtensions__
         if (!isUndefined(posthogExtensions) && !isUndefined(posthogExtensions.postHogWebVitalsCallbacks)) {
@@ -271,50 +252,20 @@ export class WebVitalsAutocapture {
             return
         }
 
-        // Register performance observers and store cleanup functions
-        // The web-vitals library returns cleanup functions that must be called
-        // to stop observing and free internal state (which can hold DOM references)
+        // register performance observers
         if (this.allowedMetrics.indexOf('LCP') > -1) {
-            const cleanup = onLCP(this._addToBuffer.bind(this))
-            if (cleanup) {
-                this._cleanupFunctions.push(cleanup)
-            }
+            onLCP(this._addToBuffer.bind(this))
         }
         if (this.allowedMetrics.indexOf('CLS') > -1) {
-            const cleanup = onCLS(this._addToBuffer.bind(this))
-            if (cleanup) {
-                this._cleanupFunctions.push(cleanup)
-            }
+            onCLS(this._addToBuffer.bind(this))
         }
         if (this.allowedMetrics.indexOf('FCP') > -1) {
-            const cleanup = onFCP(this._addToBuffer.bind(this))
-            if (cleanup) {
-                this._cleanupFunctions.push(cleanup)
-            }
+            onFCP(this._addToBuffer.bind(this))
         }
         if (this.allowedMetrics.indexOf('INP') > -1) {
-            const cleanup = onINP(this._addToBuffer.bind(this))
-            if (cleanup) {
-                this._cleanupFunctions.push(cleanup)
-            }
+            onINP(this._addToBuffer.bind(this))
         }
 
         this._initialized = true
-    }
-
-    /**
-     * Stop capturing web vitals and clean up observers.
-     * This releases internal state in the web-vitals library that can hold DOM references.
-     */
-    private _stopCapturing = () => {
-        // Call all cleanup functions to stop PerformanceObservers and free internal state
-        for (const cleanup of this._cleanupFunctions) {
-            try {
-                cleanup()
-            } catch (e) {
-                logger.error('Error cleaning up web vitals observer', e)
-            }
-        }
-        this._cleanupFunctions = []
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,8 +270,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       web-vitals:
-        specifier: ^4.2.4
-        version: 4.2.4
+        specifier: ^5.1.0
+        version: 5.1.0
     devDependencies:
       '@babel/core':
         specifier: 'catalog:'
@@ -12816,8 +12816,8 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-vitals@4.2.4:
-    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
+  web-vitals@5.1.0:
+    resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -29194,7 +29194,7 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-vitals@4.2.4: {}
+  web-vitals@5.1.0: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
## Problem
The web-vitals library maintains internal state that can hold references to DOM elements (particularly `onINP` which stores interaction targets). In single-page applications where URLs change without full page reloads, this causes memory leaks of 159-204KB per page view as the old DOM elements cannot be garbage collected.

This was identified via memlab heap snapshot analysis showing retained DOM trees via:
```
onINP callback → Map → DOM elements
```

## Solution
The web-vitals library does not return cleanup functions, instead you must only call its functions once per page load

see  https://github.com/GoogleChrome/web-vitals/issues/629

we want to upgrade to get the fixes to these

- onLCP leak - https://github.com/GoogleChrome/web-vitals/issues/551
- onINP leak - https://github.com/GoogleChrome/web-vitals/issues/594   
     
 and be extra careful to only call the setup functions once