### PR TITLE
revert: "chore: tag update PRs for review so they don't get missed"

### DIFF
--- a/.github/workflows/posthog-com-upgrade.yml
+++ b/.github/workflows/posthog-com-upgrade.yml
@@ -83,7 +83,6 @@ jobs:
                   branch: ${{ steps.generate-branch-name.outputs.branch_name }}
                   delete-branch: true
                   title: 'chore(deps): Update ${{ github.event.inputs.package_name }} to ${{ github.event.inputs.package_version }}'
-                  team-reviewers: PostHog/team-client-libraries
                   body: |
                       ## Changes
 

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -104,7 +104,6 @@ jobs:
                   branch: ${{ steps.generate-branch-name.outputs.branch_name }}
                   delete-branch: true
                   title: 'chore(deps): Update ${{ github.event.inputs.package_name }} to ${{ github.event.inputs.package_version }}'
-                  team-reviewers: PostHog/team-client-libraries
                   body: |
                       ## Changes
 


### PR DESCRIPTION
Reverts PostHog/posthog-js#2951

yuck 

```

Upgrade PostHog.com PackageValidation Failed: "Could not resolve to a node with the global id of 'T_kwDOA5iQ-M4As9wR'." - https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request
--
Upgrade PostHog.com PackageUnable to request reviewers. If requesting team reviewers a 'repo' scoped PAT is required.

[Upgrade PostHog.com Package](https://github.com/PostHog/posthog-js/actions/runs/21257412631/job/61175760752#step:8:112)
Validation Failed: "Could not resolve to a node with the global id of 'T_kwDOA5iQ-M4As9wR'." - https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request
[Upgrade PostHog.com Package](https://github.com/PostHog/posthog-js/actions/runs/21257412631/job/61175760752#step:8:111)
Unable to request reviewers. If requesting team reviewers a 'repo' scoped PAT is required.
```