### PR TITLE
fix(surveys): fix cancel button icon to be black

### DIFF
--- a/.changeset/calm-parrots-enjoy.md
+++ b/.changeset/calm-parrots-enjoy.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: update cancel button on surveys to be black

--- a/packages/browser/src/extensions/surveys/components/QuestionHeader.tsx
+++ b/packages/browser/src/extensions/surveys/components/QuestionHeader.tsx
@@ -40,7 +40,7 @@ export function Cancel({ onClick }: { onClick: () => void }) {
             aria-label="Close survey"
             type="button"
         >
-            {cancelSVG}
+            <span style={{ color: 'black' }}>{cancelSVG}</span>
         </button>
     )
 }


### PR DESCRIPTION
## Problem

we recently updated the `cancelSvg` to use `fill="currentColor"` instead of `fill="black"` as part of some product tours work

this svg needs to be customizable for tours, but for surveys, its background is always white, so it needs to always be black

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

wraps svg in a span with `color: 'black'` when used in survey question header

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
