### PR TITLE
fix: groups and groupidentify is a no-op if person profiles is set to never

### DIFF
--- a/.changeset/soft-dogs-know.md
+++ b/.changeset/soft-dogs-know.md
@@ -1,0 +1,7 @@
+---
+'@posthog/core': patch
+'posthog-react-native': patch
+'posthog-js-lite': patch
+---
+
+fix: groups and groupidentify is a no-op if person profiles is set to never

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -372,6 +372,10 @@ export abstract class PostHogCore extends PostHogCoreStateless {
 
   groups(groups: PostHogGroupProperties): void {
     this.wrap(() => {
+      if (!this._requirePersonProcessing('posthog.group')) {
+        return
+      }
+
       // Get persisted groups
       const existingGroups = this.props.$groups || {}
 
@@ -412,6 +416,10 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     options?: PostHogCaptureOptions
   ): void {
     this.wrap(() => {
+      if (!this._requirePersonProcessing('posthog.groupIdentify')) {
+        return
+      }
+
       const distinctId = this.getDistinctId()
       const eventProperties = this.enrichProperties({})
       super.groupIdentifyStateless(groupType, groupKey, groupProperties, options, distinctId, eventProperties)


### PR DESCRIPTION
## Problem

follow up https://github.com/PostHog/posthog-js/pull/2917 and https://posthog.slack.com/archives/C0368RPHLQH/p1769246301234469?thread_ts=1768920312.303459&cid=C0368RPHLQH

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [X] posthog-js-lite (web lite)
- [ ] posthog-node
- [X] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [X] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [X] Ran `pnpm changeset` to generate a changeset file
- [X] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
