### PR TITLE
fix(surveys): (actually) fix survey close button color

### DIFF
--- a/.changeset/salty-queens-try.md
+++ b/.changeset/salty-queens-try.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix survey close button color

--- a/packages/browser/src/extensions/product-tours/components/ProductTourBanner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourBanner.tsx
@@ -85,7 +85,7 @@ export function ProductTourBanner({
                     }}
                     aria-label="Close banner"
                 >
-                    {cancelSVG}
+                    {cancelSVG()}
                 </button>
             )}
         </>

--- a/packages/browser/src/extensions/product-tours/components/ProductTourSurveyStepInner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourSurveyStepInner.tsx
@@ -192,7 +192,7 @@ export function ProductTourSurveyStepInner({
     return (
         <>
             <button class="ph-tour-dismiss" onClick={onDismiss} aria-label="Close survey" style={cursorStyle}>
-                {cancelSVG}
+                {cancelSVG()}
             </button>
 
             <div class="ph-tour-survey-question">{survey.questionText}</div>

--- a/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
@@ -75,7 +75,7 @@ export function ProductTourTooltipInner({
     return (
         <>
             <button class="ph-tour-dismiss" onClick={onDismiss} aria-label="Close tour" style={cursorStyle}>
-                {cancelSVG}
+                {cancelSVG()}
             </button>
 
             <div class="ph-tour-content" dangerouslySetInnerHTML={{ __html: getStepHtml(step) }} />

--- a/packages/browser/src/extensions/surveys/components/QuestionHeader.tsx
+++ b/packages/browser/src/extensions/surveys/components/QuestionHeader.tsx
@@ -40,7 +40,7 @@ export function Cancel({ onClick }: { onClick: () => void }) {
             aria-label="Close survey"
             type="button"
         >
-            <span style={{ color: 'black' }}>{cancelSVG}</span>
+            {cancelSVG({ fill: 'black' })}
         </button>
     )
 }

--- a/packages/browser/src/extensions/surveys/icons.tsx
+++ b/packages/browser/src/extensions/surveys/icons.tsx
@@ -33,21 +33,23 @@ export const thumbsDownEmoji = (
         <path d="M22 4h-2c-.55 0-1 .45-1 1v9c0 .55.45 1 1 1h2V4zM2.17 11.12c-.11.25-.17.52-.17.8V13c0 1.1.9 2 2 2h5.5l-.92 4.65c-.05.22-.02.46.08.66.23.45.52.86.88 1.22L10 22l6.41-6.41c.38-.38.59-.89.59-1.42V6.34C17 5.05 15.95 4 14.66 4H6.55c-.7 0-1.36.37-1.72.97l-2.66 6.15z" />
     </svg>
 )
-export const cancelSVG = (
+export const cancelSVG = ({ fill = 'currentColor' }: { fill?: string } = {}) => (
     <svg
         width="12"
         height="12"
         viewBox="0 0 12 12"
-        fill="none"
+        fill={fill}
         xmlns="http://www.w3.org/2000/svg"
-        aria-labelledby="close-survey-title"
+        aria-labelledby="close-survey-title-adam"
     >
-        <title id="close-survey-title">Close survey</title>
+        <title id="close-survey-title" className="adam-testing">
+            Close survey
+        </title>
         <path
             fill-rule="evenodd"
             clip-rule="evenodd"
             d="M0.164752 0.164752C0.384422 -0.0549175 0.740578 -0.0549175 0.960248 0.164752L6 5.20451L11.0398 0.164752C11.2594 -0.0549175 11.6156 -0.0549175 11.8352 0.164752C12.0549 0.384422 12.0549 0.740578 11.8352 0.960248L6.79549 6L11.8352 11.0398C12.0549 11.2594 12.0549 11.6156 11.8352 11.8352C11.6156 12.0549 11.2594 12.0549 11.0398 11.8352L6 6.79549L0.960248 11.8352C0.740578 12.0549 0.384422 12.0549 0.164752 11.8352C-0.0549175 11.6156 -0.0549175 11.2594 0.164752 11.0398L5.20451 6L0.164752 0.960248C-0.0549175 0.740578 -0.0549175 0.384422 0.164752 0.164752Z"
-            fill="currentColor"
+            fill={fill}
         />
     </svg>
 )


### PR DESCRIPTION
## Problem

bug-fix on survey close button color https://posthoghelp.zendesk.com/agent/tickets/48096 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/50624)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->