### PR TITLE
feat: allow recording masking with a view wrapper and without accessibilitylabel

### DIFF
--- a/.changeset/long-shirts-decide.md
+++ b/.changeset/long-shirts-decide.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': minor
+---
+
+feat: allow recording masking with a view wrapper and without accessibilitylabel

--- a/packages/react-native/src/PostHogMaskView.tsx
+++ b/packages/react-native/src/PostHogMaskView.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { View, ViewProps } from 'react-native'
+
+/**
+ * Props for the PostHogMaskView component.
+ *
+ * @public
+ */
+export interface PostHogMaskViewProps extends ViewProps {
+  /** The child components to mask from PostHog capture */
+  children: React.ReactNode
+}
+
+/**
+ * PostHogMaskView is a wrapper component that hides its children from PostHog
+ * session recordings without compromising accessibility.
+ *
+ * It works by:
+ * - Setting `accessibilityLabel` to `"ph-no-capture"` to hide the content from session recordings
+ * - Setting `importantForAccessibility` to `"no"` to prevent the wrapper View from hiding
+ *   accessible content on Android (since `accessibilityLabel` would otherwise interfere)
+ *
+ * @example
+ * ```jsx
+ * import { PostHogMaskView } from 'posthog-react-native'
+ *
+ * function SensitiveForm() {
+ *   return (
+ *     <PostHogMaskView>
+ *       <TextInput placeholder="Credit card number" />
+ *       <TextInput placeholder="CVV" />
+ *     </PostHogMaskView>
+ *   )
+ * }
+ * ```
+ *
+ * @public
+ */
+export const PostHogMaskView = ({ children, ...viewProps }: PostHogMaskViewProps): JSX.Element => (
+  <View {...viewProps} accessibilityLabel="ph-no-capture" importantForAccessibility="no">
+    {children}
+  </View>
+)


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog-js/issues/2168

sample app:

```
      <PostHogMaskView>
        <ThemedView style={styles.stepContainer}>
          <ThemedText type="subtitle">Step 1: Try it (Masked)</ThemedText>
          <ThemedText>
            Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes. Press{' '}
            <ThemedText type="defaultSemiBold">
              {Platform.select({
                ios: 'cmd + d',
                android: 'cmd + m',
                web: 'F12',
              })}
            </ThemedText>{' '}
            to open developer tools.
          </ThemedText>
        </ThemedView>
      </PostHogMaskView>
```

result:
<img width="442" height="422" alt="Screenshot 2026-01-28 at 13 10 54" src="https://github.com/user-attachments/assets/a9944936-e890-4227-82a9-028a513e4ffa" />



## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [X] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [X] Tests for new code
- [X] Accounted for the impact of any changes across different platforms
- [X] Accounted for backwards compatibility of any changes (no breaking changes!)
- [X] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [X] Ran `pnpm changeset` to generate a changeset file
- [X] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
