### PR TITLE
feat(product tours): support custom containers for banners

### DIFF
--- a/.changeset/clear-snakes-drop.md
+++ b/.changeset/clear-snakes-drop.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+support custom banner container for product tours

--- a/packages/browser/playground/cypress/index.html
+++ b/packages/browser/playground/cypress/index.html
@@ -6,6 +6,7 @@
 
 <body>
     <!-- Product tour test elements -->
+    <div id="custom-banner-container" style="border: 1px dashed #ccc; padding: 0; margin-bottom: 10px;"></div>
     <a id="nav-link" href="./page2.html" style="display: block; margin-bottom: 10px;">Go to Page 2</a>
     <button id="tour-target" style="margin-bottom: 10px;">Target Element</button>
     <button id="click-trigger-btn" style="margin-bottom: 10px;">Start Tour</button>

--- a/packages/browser/src/extensions/product-tours/components/ProductTourBanner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourBanner.tsx
@@ -67,7 +67,11 @@ export function ProductTourBanner({
     // "always" display frequency means no dismiss button
     const showDismissButton = displayFrequency !== 'always'
 
-    const classNames = ['ph-tour-banner', config.behavior === 'sticky' && 'ph-tour-banner--sticky']
+    const classNames = [
+        'ph-tour-banner',
+        config.behavior === 'sticky' && 'ph-tour-banner--sticky',
+        config.behavior === 'custom' && 'ph-tour-banner--custom',
+    ]
         .filter(Boolean)
         .join(' ')
 

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -14,7 +14,8 @@ export interface JSONContent {
 export type ProductTourStepType = 'element' | 'modal' | 'survey' | 'banner'
 
 export interface ProductTourBannerConfig {
-    behavior: 'sticky' | 'static'
+    behavior: 'sticky' | 'static' | 'custom'
+    selector?: string
     action?: {
         type: 'none' | 'link' | 'trigger_tour'
         link?: string
@@ -143,6 +144,7 @@ export type ProductTourDismissReason =
     | 'user_clicked_outside'
     | 'escape_key'
     | 'element_unavailable'
+    | 'container_unavailable'
 
 export type ProductTourRenderReason = 'auto' | 'api' | 'trigger' | 'event'
 

--- a/playground/nextjs/pages/_app.tsx
+++ b/playground/nextjs/pages/_app.tsx
@@ -64,6 +64,7 @@ export default function App({ Component, pageProps }: AppProps) {
                 />
             </Head>
 
+            <div id="ph-custom-banner-container"></div>
             <main className="max-w-full overflow-hidden">
                 <PageHeader />
                 <Component {...pageProps} />


### PR DESCRIPTION
## Problem

if a customer's site has any fixed-position elements, our banner breaks. example:

<!-- Who are we building for, what are their needs, why is this important? -->

## ![fixed-banner-bug.png](https://app.graphite.com/user-attachments/assets/53f36c81-7786-47ca-a4ae-be9409855264.png)



## Changes

adds support for a new `custom` banner behavior - in this case, we'll inject the banner into the existing element instead of positioning it top / fixed

<!-- What is changed and what information would be useful to a reviewer? -->

## ![Screenshot 2026-01-28 at 6.32.41 PM.png](https://app.graphite.com/user-attachments/assets/33220e2d-e1a1-4ce5-8702-99be89d03594.png)



## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->