### PR TITLE
fix(node): restore before_send type inference for EventMessage

### DIFF
--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -94,7 +94,7 @@ export type FeatureFlagCondition = {
 
 export type BeforeSendFn = (event: EventMessage | null) => EventMessage | null
 
-export type PostHogOptions = PostHogCoreOptions & {
+export type PostHogOptions = Omit<PostHogCoreOptions, 'before_send'> & {
   persistence?: 'memory'
   personalApiKey?: string
   privacyMode?: boolean


### PR DESCRIPTION
The before_send callback parameter was incorrectly typed as 'any' after PR #2931 added before_send to @posthog/core's PostHogCoreOptions.

When PostHogOptions extended PostHogCoreOptions, TypeScript created a type intersection between the core's BeforeSendFn (expecting CaptureEvent) and node's BeforeSendFn (expecting EventMessage), causing the event parameter to be inferred as 'any'.

Fix: Use Omit to exclude before_send from PostHogCoreOptions before extending, ensuring posthog-node's BeforeSendFn type is used exclusively.

Fixes type regression reported in #2931

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [X] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [X] Accounted for the impact of any changes across different platforms
- [X] Accounted for backwards compatibility of any changes (no breaking changes!)
- [X] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [X] Ran `pnpm changeset` to generate a changeset file
- [X] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
