### PR TITLE
fix(node): restore before_send type inference for EventMessage

### DIFF
--- a/.changeset/three-regions-swim.md
+++ b/.changeset/three-regions-swim.md
@@ -2,4 +2,4 @@
 'posthog-node': patch
 ---
 
-fix: before_send in node infered the type as any instead of EventMessage or null
+fix: before_send in node inferred the type as any instead of EventMessage or null


### PR DESCRIPTION
follow up https://github.com/PostHog/posthog-js/pull/2986
forgot the changeset