### PR TITLE
feat: switch to deferred init as default for 2026-01-30 defaults

### DIFF
--- a/.changeset/new-tigers-shout.md
+++ b/.changeset/new-tigers-shout.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/types': minor
+---
+
+feat: switch to deferred init to reduce impact on page perf of starting posthog

--- a/packages/browser/src/__tests__/config.test.ts
+++ b/packages/browser/src/__tests__/config.test.ts
@@ -16,14 +16,26 @@ describe('config', () => {
             expect(posthog.config.capture_pageview).toBe('history_change')
             expect(posthog.config.session_recording).toStrictEqual({})
             expect(posthog.config.rageclick).toBe(true)
+            expect(posthog.config.deferred_init_extensions).toBe(false)
         })
 
-        it('should set expected values when defaults is 2025-11', () => {
+        it('should set expected values when defaults is 2025-11-30', () => {
             const posthog = new PostHog()
             posthog._init('test-token', { defaults: '2025-11-30' })
             expect(posthog.config.capture_pageview).toBe('history_change')
             expect(posthog.config.session_recording.strictMinimumDuration).toBe(true)
             expect(posthog.config.rageclick).toStrictEqual({ content_ignorelist: true })
+            expect(posthog.config.deferred_init_extensions).toBe(false)
+        })
+
+        it('should set expected values when defaults is 2026-01-30', () => {
+            const posthog = new PostHog()
+            posthog._init('test-token', { defaults: '2026-01-30' })
+            expect(posthog.config.capture_pageview).toBe('history_change')
+            expect(posthog.config.session_recording.strictMinimumDuration).toBe(true)
+            expect(posthog.config.rageclick).toStrictEqual({ content_ignorelist: true })
+            expect(posthog.config.deferred_init_extensions).toBe(true)
+            expect(posthog.config.external_scripts_inject_target).toBe('head')
         })
 
         it('should preserve other default config values when setting defaults', () => {
@@ -38,7 +50,7 @@ describe('config', () => {
             // Check that all other config values remain the same
             const allKeys = new Set([...Object.keys(config1), ...Object.keys(config2)])
             allKeys.forEach((key) => {
-                if (!['capture_pageview', 'defaults'].includes(key)) {
+                if (!['capture_pageview', 'defaults', 'deferred_init_extensions'].includes(key)) {
                     const val1 = config1[key as keyof PostHogConfig]
                     const val2 = config2[key as keyof PostHogConfig]
                     if (isFunction(val1)) {

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -292,7 +292,12 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "\\"2025-05-24\\"",
     "\\"unset\\""
   ],
+  "deferred_init_extensions": [
+    "false",
+    "true"
+  ],
   "__preview_deferred_init_extensions": [
+    "undefined",
     "false",
     "true"
   ],

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -987,7 +987,7 @@ export interface PostHogConfig {
     defaults: ConfigDefaults
 
     /**
-     * EXPERIMENTAL: Defers initialization of non-critical extensions (autocapture, session recording, etc.)
+     * Defers initialization of non-critical extensions (autocapture, session recording, etc.)
      * to the next event loop tick using setTimeout. This reduces main thread blocking during SDK
      * initialization for better page load performance, while keeping critical functionality
      * (persistence, sessions, capture) available immediately.
@@ -996,10 +996,14 @@ export interface PostHogConfig {
      * - Persistence, sessions, and basic capture work immediately
      * - Extensions (autocapture, recording, heatmaps, etc.) start after yielding back to the browser
      *
-     * @default false (will be true for defaults >= '2025-11-06' in the future)
-     * @experimental
+     * @default true for defaults >= '2026-01-30', false otherwise
      */
-    __preview_deferred_init_extensions: boolean
+    deferred_init_extensions: boolean
+
+    /**
+     * @deprecated Use `deferred_init_extensions` instead. Will be removed in a future release.
+     */
+    __preview_deferred_init_extensions?: boolean
 
     /**
      * Determines the session recording options.


### PR DESCRIPTION
## Problem

we have tested deferred init and shown it is slightly better for web vitals than not having it

but it is opt in and in preview so nobody is benefitting

we've been running it on 50% of our sessions for >1 month with no negatives discovered

## Changes

make it the default from 2026-01-30
allow config level opt out

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
