### PR TITLE
chore(product tours): export utils for use in main app

### DIFF
--- a/.changeset/dark-flies-bow.md
+++ b/.changeset/dark-flies-bow.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+exporting some utils

--- a/packages/browser/src/entrypoints/product-tours-preview.es.ts
+++ b/packages/browser/src/entrypoints/product-tours-preview.es.ts
@@ -1,1 +1,2 @@
 export { renderProductTourPreview } from '../extensions/product-tours/preview'
+export { addProductTourCSSVariablesToElement } from '../extensions/product-tours/product-tours-utils'


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->