### PR TITLE
fix: fetch the actual config when user has stale config

### DIFF
--- a/packages/browser/src/extensions/replay/session-recording.ts
+++ b/packages/browser/src/extensions/replay/session-recording.ts
@@ -7,7 +7,13 @@ import {
     SESSION_RECORDING_REMOTE_CONFIG,
 } from '../../constants'
 import { PostHog } from '../../posthog-core'
-import { Properties, RemoteConfig, SessionRecordingPersistedConfig, SessionStartReason } from '../../types'
+import {
+    Properties,
+    RemoteConfig,
+    SessionRecordingPersistedConfig,
+    SessionRecordingRemoteConfig,
+    SessionStartReason,
+} from '../../types'
 import { type eventWithTime } from './types/rrweb-types'
 
 import { isNullish, isUndefined } from '@posthog/core'
@@ -69,9 +75,16 @@ export class SessionRecording {
         return window && enabled_server_side && enabled_client_side && !isDisabled
     }
 
-    startIfEnabledOrStop(startReason?: SessionStartReason) {
+    startIfEnabledOrStop(startReason?: SessionStartReason, triggerConfigChanged?: boolean) {
         if (this._isRecordingEnabled && this._lazyLoadedSessionRecording?.isStarted) {
-            return
+            if (triggerConfigChanged) {
+                // Recording is already running but trigger config changed - stop and restart
+                // This handles the race condition where recording started with stale cached config
+                this.stopRecording()
+            } else {
+                // Recording is already running and config hasn't changed - nothing to do
+                return
+            }
         }
 
         // According to the rrweb docs, rrweb is not supported on IE11 and below:
@@ -186,6 +199,24 @@ export class SessionRecording {
         }
     }
 
+    private _hasTriggerConfigChanged(newConfig: SessionRecordingRemoteConfig | undefined): boolean {
+        const existingConfig = this._instance.get_property(SESSION_RECORDING_REMOTE_CONFIG) as
+            | SessionRecordingPersistedConfig
+            | undefined
+
+        if (!existingConfig || !newConfig) {
+            return false
+        }
+
+        return (
+            JSON.stringify(existingConfig.urlTriggers) !== JSON.stringify(newConfig.urlTriggers) ||
+            JSON.stringify(existingConfig.urlBlocklist) !== JSON.stringify(newConfig.urlBlocklist) ||
+            JSON.stringify(existingConfig.eventTriggers) !== JSON.stringify(newConfig.eventTriggers) ||
+            JSON.stringify(existingConfig.linkedFlag) !== JSON.stringify(newConfig.linkedFlag) ||
+            existingConfig.triggerMatchType !== newConfig.triggerMatchType
+        )
+    }
+
     onRemoteConfig(response: RemoteConfig) {
         if (!('sessionRecording' in response)) {
             // if sessionRecording is not in the response, we do nothing
@@ -198,9 +229,13 @@ export class SessionRecording {
             return
         }
 
+        // Check if trigger config changed - handles race condition where recording
+        // started with stale cached config before new decide response arrived
+        const triggerConfigChanged = this._hasTriggerConfigChanged(response.sessionRecording)
+
         this._persistRemoteConfig(response)
         this._receivedFlags = true
-        this.startIfEnabledOrStop()
+        this.startIfEnabledOrStop(undefined, triggerConfigChanged)
     }
 
     log(message: string, level: 'log' | 'warn' | 'error' = 'log') {

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -202,6 +202,7 @@
         "_hasLoggedDeprecationWarning",
         "_hasPassedMinimumDuration",
         "_hasPersonProcessing",
+        "_hasTriggerConfigChanged",
         "_ignoreClick",
         "_initExtensions",
         "_initialPageviewCaptured",


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We kept seeing replays that does not match the recording conditions (url match trigger etc), seeing their replays the actual config seems to be not loaded at all for only some users. Perhaps stale cached config was used at startup and new triggers from fresh decide responses were never applied to the running recorder.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->
Reload the config so the user always gets proper configurations for replay settings

<!-- For more details check RELEASING.md -->
