### PR TITLE
fix(product tours): don't hijack clicks for broken tours

### DIFF
--- a/.changeset/yellow-points-relax.md
+++ b/.changeset/yellow-points-relax.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+do not intercept element clicks if a product tour fails to show

--- a/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
@@ -132,7 +132,7 @@ export function ProductTourTooltipInner({
 
             {showPostHogBranding && (
                 <a
-                    href={isInteractive ? 'https://posthog.com/product-tours' : undefined}
+                    href={isInteractive ? 'https://posthog.com/docs/product-tours' : undefined}
                     target={isInteractive ? '_blank' : undefined}
                     rel={isInteractive ? 'noopener noreferrer' : undefined}
                     class="ph-tour-branding"


### PR DESCRIPTION
## Problem

product tours can be attached to selectors manually for triggering them

this hijacks clicks on the element, which is intended - but if the tour fails to show, it _still_ hijacks the click, which can cause a button to just be completely broken since we hijack click -> try to show tour -> tour fails -> nothing happens

https://posthog.slack.com/archives/C0351B1DMUY/p1769802597606919

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

fixes that!

1. validates tour shows before completely hijacking the click
2. also reloads tours on page load so we don't end up with an infinite cache (cache busting would've fixed this too)

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->