### PR TITLE
fix(product tours): fix stale element references in multi-page tours

### DIFF
--- a/.changeset/light-pigs-open.md
+++ b/.changeset/light-pigs-open.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix stale element references in multi-page product tours


### PR DESCRIPTION
## Problem

in multi-page product tours, sometimes the tour finds an element pre-navigation... which then causes the next tour step's tooltip to render in a weird place if navigation takes place after, because the originally-found element's reference is broken

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

checks `isConnected` before computing tooltip position :rocket:

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->