### PR TITLE
feat: add multi-language survey support with automatic language detection and fallback

### DIFF
--- a/packages/browser/playwright/mocked/surveys/translations.spec.ts
+++ b/packages/browser/playwright/mocked/surveys/translations.spec.ts
@@ -1,0 +1,752 @@
+import { pollUntilEventCaptured } from '../utils/event-capture-utils'
+import { expect, test } from '../utils/posthog-playwright-test-base'
+import { start } from '../utils/setup'
+
+const startOptions = {
+    options: {},
+    flagsResponseOverrides: {
+        surveys: true,
+    },
+    url: './playground/cypress/index.html',
+}
+
+const ratingQuestionWithTranslations = {
+    type: 'rating',
+    display: 'number',
+    scale: 5,
+    question: 'How satisfied are you with our product?',
+    description: 'Please rate from 1 to 5',
+    lowerBoundLabel: 'Not satisfied',
+    upperBoundLabel: 'Very satisfied',
+    id: 'rating_translated_1',
+    translations: {
+        fr: {
+            question: 'Dans quelle mesure êtes-vous satisfait de notre produit?',
+            description: 'Veuillez évaluer de 1 à 5',
+            lowerBoundLabel: 'Pas satisfait',
+            upperBoundLabel: 'Très satisfait',
+        },
+        es: {
+            question: '¿Qué tan satisfecho estás con nuestro producto?',
+            description: 'Por favor califica del 1 al 5',
+            lowerBoundLabel: 'No satisfecho',
+            upperBoundLabel: 'Muy satisfecho',
+        },
+    },
+}
+
+const multipleChoiceQuestionWithTranslations = {
+    type: 'multiple_choice',
+    question: 'Which features do you use?',
+    choices: ['Analytics', 'Session Replay', 'Feature Flags', 'Surveys'],
+    id: 'multiple_choice_translated_1',
+    translations: {
+        fr: {
+            question: 'Quelles fonctionnalités utilisez-vous?',
+            choices: ['Analytique', 'Relecture de session', 'Indicateurs de fonctionnalités', 'Enquêtes'],
+        },
+    },
+}
+
+const openTextQuestionWithTranslations = {
+    type: 'open',
+    question: 'What would you improve?',
+    description: 'Tell us your thoughts',
+    buttonText: 'Submit',
+    id: 'open_translated_1',
+    translations: {
+        fr: {
+            question: 'Que souhaiteriez-vous améliorer?',
+            description: 'Partagez vos pensées',
+            buttonText: 'Soumettre',
+        },
+    },
+}
+
+const appearanceWithTranslations = {
+    displayThankYouMessage: true,
+    thankYouMessageHeader: 'Thank you!',
+    thankYouMessageDescription: 'We appreciate your feedback',
+    thankYouMessageCloseButtonText: 'Close',
+}
+
+test.describe('surveys - translations', () => {
+    test('displays survey in French when language is set to fr', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: 'translation-test-fr',
+                            name: 'Product Feedback Survey',
+                            description: 'Help us improve',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [ratingQuestionWithTranslations],
+                            appearance: appearanceWithTranslations,
+                            translations: {
+                                fr: {
+                                    name: 'Enquête de satisfaction produit',
+                                    description: 'Aidez-nous à améliorer',
+                                    thankYouMessageHeader: 'Merci!',
+                                    thankYouMessageDescription: 'Nous apprécions vos commentaires',
+                                    thankYouMessageCloseButtonText: 'Fermer',
+                                },
+                            },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(
+            {
+                ...startOptions,
+                runBeforePostHogInit: (page) => {
+                    page.evaluate(() => {
+                        // Set person properties in localStorage before PostHog initializes
+                        localStorage.setItem(
+                            'ph_test token_posthog',
+                            JSON.stringify({
+                                $stored_person_properties: { language: 'fr' },
+                            })
+                        )
+                    })
+                },
+            },
+            page,
+            context
+        )
+
+        await surveysAPICall
+
+        // Wait for survey to appear
+        await expect(page.locator('.PostHogSurvey-translation-test-fr').locator('.survey-form')).toBeVisible()
+
+        // Check that French text is displayed
+        await expect(page.locator('.PostHogSurvey-translation-test-fr .survey-question')).toContainText(
+            'Dans quelle mesure êtes-vous satisfait de notre produit?'
+        )
+        await expect(page.locator('.PostHogSurvey-translation-test-fr .survey-question-description')).toContainText(
+            'Veuillez évaluer de 1 à 5'
+        )
+        await expect(page.locator('.PostHogSurvey-translation-test-fr .rating-text div').first()).toContainText(
+            'Pas satisfait'
+        )
+        await expect(page.locator('.PostHogSurvey-translation-test-fr .rating-text div').last()).toContainText(
+            'Très satisfait'
+        )
+
+        // Submit the survey
+        await page.locator('.PostHogSurvey-translation-test-fr .ratings-number').first().click()
+        await page.locator('.PostHogSurvey-translation-test-fr .form-submit').click()
+
+        // Check thank you message is in French
+        await expect(page.locator('.PostHogSurvey-translation-test-fr .thank-you-message-header')).toContainText(
+            'Merci!'
+        )
+        await expect(page.locator('.PostHogSurvey-translation-test-fr .thank-you-message-body')).toContainText(
+            'Nous apprécions vos commentaires'
+        )
+        await expect(page.locator('.PostHogSurvey-translation-test-fr .form-submit')).toContainText('Fermer')
+
+        // Verify $survey_language is tracked in the event
+        await pollUntilEventCaptured(page, 'survey sent')
+        const captures = await page.capturedEvents()
+        const surveyEvent = captures.find((c) => c.event === 'survey sent')
+        expect(surveyEvent?.properties.$survey_language).toBe('fr')
+    })
+
+    test('displays survey in Spanish when language is set to es', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: 'translation-test-es',
+                            name: 'Product Feedback Survey',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [ratingQuestionWithTranslations],
+                            appearance: { displayThankYouMessage: false },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(
+            {
+                ...startOptions,
+                runBeforePostHogInit: (page) => {
+                    page.evaluate(() => {
+                        localStorage.setItem(
+                            'ph_test token_posthog',
+                            JSON.stringify({
+                                $stored_person_properties: { language: 'es' },
+                            })
+                        )
+                    })
+                },
+            },
+            page,
+            context
+        )
+
+        await surveysAPICall
+
+        await expect(page.locator('.PostHogSurvey-translation-test-es').locator('.survey-form')).toBeVisible()
+
+        // Check Spanish translation
+        await expect(page.locator('.PostHogSurvey-translation-test-es .survey-question')).toContainText(
+            '¿Qué tan satisfecho estás con nuestro producto?'
+        )
+        await expect(page.locator('.PostHogSurvey-translation-test-es .survey-question-description')).toContainText(
+            'Por favor califica del 1 al 5'
+        )
+        await expect(page.locator('.PostHogSurvey-translation-test-es .rating-text div').first()).toContainText(
+            'No satisfecho'
+        )
+        await expect(page.locator('.PostHogSurvey-translation-test-es .rating-text div').last()).toContainText(
+            'Muy satisfecho'
+        )
+
+        // Submit and verify language tracking
+        await page.locator('.PostHogSurvey-translation-test-es .ratings-number').first().click()
+        await page.locator('.PostHogSurvey-translation-test-es .form-submit').click()
+
+        await pollUntilEventCaptured(page, 'survey sent')
+        const captures = await page.capturedEvents()
+        const surveyEvent = captures.find((c) => c.event === 'survey sent')
+        expect(surveyEvent?.properties.$survey_language).toBe('es')
+    })
+
+    test('falls back to base language when variant is set (fr-CA -> fr)', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: 'translation-test-fallback',
+                            name: 'Product Feedback Survey',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [ratingQuestionWithTranslations],
+                            appearance: { displayThankYouMessage: false },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(
+            {
+                ...startOptions,
+                runBeforePostHogInit: (page) => {
+                    page.evaluate(() => {
+                        localStorage.setItem(
+                            'ph_test token_posthog',
+                            JSON.stringify({
+                                $stored_person_properties: { language: 'fr-CA' },
+                            })
+                        )
+                    })
+                },
+            },
+            page,
+            context
+        )
+
+        await surveysAPICall
+
+        await expect(page.locator('.PostHogSurvey-translation-test-fallback').locator('.survey-form')).toBeVisible()
+
+        // Should display French (not English) because it falls back to 'fr'
+        await expect(page.locator('.PostHogSurvey-translation-test-fallback .survey-question')).toContainText(
+            'Dans quelle mesure êtes-vous satisfait de notre produit?'
+        )
+
+        // Submit and verify base language is tracked
+        await page.locator('.PostHogSurvey-translation-test-fallback .ratings-number').first().click()
+        await page.locator('.PostHogSurvey-translation-test-fallback .form-submit').click()
+
+        await pollUntilEventCaptured(page, 'survey sent')
+        const captures = await page.capturedEvents()
+        const surveyEvent = captures.find((c) => c.event === 'survey sent')
+        // Should track 'fr' (the matched base language) not 'fr-CA'
+        expect(surveyEvent?.properties.$survey_language).toBe('fr')
+    })
+
+    test('displays default language when no translation exists', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: 'translation-test-default',
+                            name: 'Product Feedback Survey',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [ratingQuestionWithTranslations],
+                            appearance: { displayThankYouMessage: false },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(
+            {
+                ...startOptions,
+                runBeforePostHogInit: (page) => {
+                    page.evaluate(() => {
+                        localStorage.setItem(
+                            'ph_test token_posthog',
+                            JSON.stringify({
+                                $stored_person_properties: { language: 'de' },
+                            })
+                        )
+                    })
+                },
+            },
+            page,
+            context
+        )
+
+        await surveysAPICall
+
+        await expect(page.locator('.PostHogSurvey-translation-test-default').locator('.survey-form')).toBeVisible()
+
+        // Should display English (default) since no German translation exists
+        await expect(page.locator('.PostHogSurvey-translation-test-default .survey-question')).toContainText(
+            'How satisfied are you with our product?'
+        )
+        await expect(page.locator('.PostHogSurvey-translation-test-default .rating-text div').first()).toContainText(
+            'Not satisfied'
+        )
+
+        // Submit and verify no language is tracked (null)
+        await page.locator('.PostHogSurvey-translation-test-default .ratings-number').first().click()
+        await page.locator('.PostHogSurvey-translation-test-default .form-submit').click()
+
+        await pollUntilEventCaptured(page, 'survey sent')
+        const captures = await page.capturedEvents()
+        const surveyEvent = captures.find((c) => c.event === 'survey sent')
+        // Should not have $survey_language property when using default
+        expect(surveyEvent?.properties.$survey_language).toBeUndefined()
+    })
+
+    test('translates multiple choice options correctly', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: 'translation-test-mcq',
+                            name: 'Feature Usage Survey',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [multipleChoiceQuestionWithTranslations],
+                            appearance: { displayThankYouMessage: false },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(
+            {
+                ...startOptions,
+                runBeforePostHogInit: (page) => {
+                    page.evaluate(() => {
+                        localStorage.setItem(
+                            'ph_test token_posthog',
+                            JSON.stringify({
+                                $stored_person_properties: { language: 'fr' },
+                            })
+                        )
+                    })
+                },
+            },
+            page,
+            context
+        )
+
+        await surveysAPICall
+
+        await expect(page.locator('.PostHogSurvey-translation-test-mcq').locator('.survey-form')).toBeVisible()
+
+        // Check question text
+        await expect(page.locator('.PostHogSurvey-translation-test-mcq .survey-question')).toContainText(
+            'Quelles fonctionnalités utilisez-vous?'
+        )
+
+        // Check all choices are translated
+        const choices = page.locator('.PostHogSurvey-translation-test-mcq .multiple-choice-options label')
+        await expect(choices).toHaveCount(4)
+        await expect(choices.nth(0)).toContainText('Analytique')
+        await expect(choices.nth(1)).toContainText('Relecture de session')
+        await expect(choices.nth(2)).toContainText('Indicateurs de fonctionnalités')
+        await expect(choices.nth(3)).toContainText('Enquêtes')
+    })
+
+    test('translates open text question with button text', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: 'translation-test-open',
+                            name: 'Feedback Survey',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [openTextQuestionWithTranslations],
+                            appearance: { displayThankYouMessage: false },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(
+            {
+                ...startOptions,
+                runBeforePostHogInit: (page) => {
+                    page.evaluate(() => {
+                        localStorage.setItem(
+                            'ph_test token_posthog',
+                            JSON.stringify({
+                                $stored_person_properties: { language: 'fr' },
+                            })
+                        )
+                    })
+                },
+            },
+            page,
+            context
+        )
+
+        await surveysAPICall
+
+        await expect(page.locator('.PostHogSurvey-translation-test-open').locator('.survey-form')).toBeVisible()
+
+        // Check question and description
+        await expect(page.locator('.PostHogSurvey-translation-test-open .survey-question')).toContainText(
+            'Que souhaiteriez-vous améliorer?'
+        )
+        await expect(page.locator('.PostHogSurvey-translation-test-open .survey-question-description')).toContainText(
+            'Partagez vos pensées'
+        )
+
+        // Check button text is translated
+        await expect(page.locator('.PostHogSurvey-translation-test-open .form-submit')).toContainText('Soumettre')
+    })
+
+    test('displays survey in default language when no language is set', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: 'translation-test-no-lang',
+                            name: 'Product Feedback Survey',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [ratingQuestionWithTranslations],
+                            appearance: { displayThankYouMessage: false },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(startOptions, page, context)
+
+        // Don't set any language - should use default (English)
+        await surveysAPICall
+
+        await expect(page.locator('.PostHogSurvey-translation-test-no-lang').locator('.survey-form')).toBeVisible()
+
+        // Should display English (default)
+        await expect(page.locator('.PostHogSurvey-translation-test-no-lang .survey-question')).toContainText(
+            'How satisfied are you with our product?'
+        )
+
+        // Submit and verify no language tracking
+        await page.locator('.PostHogSurvey-translation-test-no-lang .ratings-number').first().click()
+        await page.locator('.PostHogSurvey-translation-test-no-lang .form-submit').click()
+
+        await pollUntilEventCaptured(page, 'survey sent')
+        const captures = await page.capturedEvents()
+        const surveyEvent = captures.find((c) => c.event === 'survey sent')
+        expect(surveyEvent?.properties.$survey_language).toBeUndefined()
+    })
+
+    test('handles partial question translation (some fields missing)', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: 'partial-translation-test',
+                            name: 'Product Survey',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [
+                                {
+                                    type: 'rating',
+                                    display: 'number',
+                                    scale: 5,
+                                    question: 'How satisfied are you?',
+                                    description: 'Please rate us',
+                                    lowerBoundLabel: 'Bad',
+                                    upperBoundLabel: 'Great',
+                                    translations: {
+                                        fr: {
+                                            question: 'Êtes-vous satisfait?',
+                                            // Missing description, lowerBoundLabel, upperBoundLabel
+                                        },
+                                    },
+                                },
+                            ],
+                            appearance: { displayThankYouMessage: false },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(
+            {
+                ...startOptions,
+                runBeforePostHogInit: (page) => {
+                    page.evaluate(() => {
+                        localStorage.setItem(
+                            'ph_test token_posthog',
+                            JSON.stringify({
+                                $stored_person_properties: { language: 'fr' },
+                            })
+                        )
+                    })
+                },
+            },
+            page,
+            context
+        )
+
+        await surveysAPICall
+
+        await expect(page.locator('.PostHogSurvey-partial-translation-test').locator('.survey-form')).toBeVisible()
+
+        // Question should be in French
+        await expect(page.locator('.PostHogSurvey-partial-translation-test .survey-question')).toContainText(
+            'Êtes-vous satisfait?'
+        )
+
+        // Description should fall back to English (missing in French)
+        await expect(
+            page.locator('.PostHogSurvey-partial-translation-test .survey-question-description')
+        ).toContainText('Please rate us')
+
+        // Labels should fall back to English
+        await expect(page.locator('.PostHogSurvey-partial-translation-test .rating-text div').first()).toContainText(
+            'Bad'
+        )
+        await expect(page.locator('.PostHogSurvey-partial-translation-test .rating-text div').last()).toContainText(
+            'Great'
+        )
+    })
+
+    test('handles single choice question type', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: 'single-choice-test',
+                            name: 'Single Choice Survey',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [
+                                {
+                                    type: 'single_choice',
+                                    question: 'Which one do you prefer?',
+                                    choices: ['Option 1', 'Option 2', 'Option 3'],
+                                    translations: {
+                                        fr: {
+                                            question: 'Lequel préférez-vous?',
+                                            choices: ['Option 1 FR', 'Option 2 FR', 'Option 3 FR'],
+                                        },
+                                    },
+                                },
+                            ],
+                            appearance: { displayThankYouMessage: false },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(
+            {
+                ...startOptions,
+                runBeforePostHogInit: (page) => {
+                    page.evaluate(() => {
+                        localStorage.setItem(
+                            'ph_test token_posthog',
+                            JSON.stringify({
+                                $stored_person_properties: { language: 'fr' },
+                            })
+                        )
+                    })
+                },
+            },
+            page,
+            context
+        )
+
+        await surveysAPICall
+
+        await expect(page.locator('.PostHogSurvey-single-choice-test').locator('.survey-form')).toBeVisible()
+
+        // Question should be in French
+        await expect(page.locator('.PostHogSurvey-single-choice-test .survey-question')).toContainText(
+            'Lequel préférez-vous?'
+        )
+
+        // Should render radio buttons (not checkboxes)
+        const radioButtons = page.locator('.PostHogSurvey-single-choice-test input[type="radio"]')
+        await expect(radioButtons).toHaveCount(3)
+
+        // Choices should be translated
+        const choices = page.locator('.PostHogSurvey-single-choice-test .multiple-choice-options label')
+        await expect(choices.nth(0)).toContainText('Option 1 FR')
+        await expect(choices.nth(1)).toContainText('Option 2 FR')
+    })
+
+    test('handles link question type with translated link text', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: 'link-question-test',
+                            name: 'Link Survey',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [
+                                {
+                                    type: 'link',
+                                    question: 'Would you like to learn more?',
+                                    link: 'https://example.com',
+                                    buttonText: 'Learn More',
+                                    translations: {
+                                        fr: {
+                                            question: 'Voulez-vous en savoir plus?',
+                                            buttonText: 'En savoir plus',
+                                        },
+                                    },
+                                },
+                            ],
+                            appearance: { displayThankYouMessage: false },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(
+            {
+                ...startOptions,
+                runBeforePostHogInit: (page) => {
+                    page.evaluate(() => {
+                        localStorage.setItem(
+                            'ph_test token_posthog',
+                            JSON.stringify({
+                                $stored_person_properties: { language: 'fr' },
+                            })
+                        )
+                    })
+                },
+            },
+            page,
+            context
+        )
+
+        await surveysAPICall
+
+        await expect(page.locator('.PostHogSurvey-link-question-test').locator('.survey-form')).toBeVisible()
+
+        // Question should be in French
+        await expect(page.locator('.PostHogSurvey-link-question-test .survey-question')).toContainText(
+            'Voulez-vous en savoir plus?'
+        )
+
+        // Button text should be in French
+        await expect(page.locator('.PostHogSurvey-link-question-test .form-submit')).toContainText('En savoir plus')
+    })
+
+    test('handles HTML content in translated description', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: 'html-translation-test',
+                            name: 'HTML Survey',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [
+                                {
+                                    type: 'rating',
+                                    display: 'number',
+                                    scale: 5,
+                                    question: 'Rate us',
+                                    description: 'Please <strong>rate</strong> our service',
+                                    descriptionContentType: 'html',
+                                    translations: {
+                                        fr: {
+                                            description: 'Veuillez <strong>évaluer</strong> notre service',
+                                        },
+                                    },
+                                },
+                            ],
+                            appearance: { displayThankYouMessage: false },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(
+            {
+                ...startOptions,
+                runBeforePostHogInit: (page) => {
+                    page.evaluate(() => {
+                        localStorage.setItem(
+                            'ph_test token_posthog',
+                            JSON.stringify({
+                                $stored_person_properties: { language: 'fr' },
+                            })
+                        )
+                    })
+                },
+            },
+            page,
+            context
+        )
+
+        await surveysAPICall
+
+        await expect(page.locator('.PostHogSurvey-html-translation-test').locator('.survey-form')).toBeVisible()
+
+        // Check that HTML is rendered (not escaped)
+        const description = page.locator('.PostHogSurvey-html-translation-test .survey-question-description')
+        await expect(description).toContainText('évaluer')
+
+        // Check that <strong> tag is actually rendered as HTML
+        const strongTag = description.locator('strong')
+        await expect(strongTag).toHaveCount(1)
+        await expect(strongTag).toContainText('évaluer')
+    })
+})

--- a/packages/browser/src/__tests__/helpers/posthog-instance.ts
+++ b/packages/browser/src/__tests__/helpers/posthog-instance.ts
@@ -65,6 +65,7 @@ export const createMockPostHog = (overrides: Partial<PostHog> = {}): PostHog =>
             api_host: 'https://test.com',
         } as PostHogConfig,
         get_distinct_id: () => 'test-distinct-id',
+        get_property: jest.fn().mockReturnValue({}),
         capture: jest.fn(),
         _send_request: jest.fn(),
         ...overrides,

--- a/packages/browser/src/__tests__/utils/survey-translations.test.ts
+++ b/packages/browser/src/__tests__/utils/survey-translations.test.ts
@@ -1,0 +1,428 @@
+/// <reference lib="dom" />
+
+import { describe, it, expect, beforeEach } from '@jest/globals'
+import { detectUserLanguage, applySurveyTranslationForUser } from '../../utils/survey-translations'
+import { Survey, SurveyType, SurveyQuestionType } from '../../posthog-surveys-types'
+import { PostHog } from '../../posthog-core'
+import { STORED_PERSON_PROPERTIES_KEY } from '../../constants'
+
+describe('Survey Translations', () => {
+    let mockPostHog: PostHog
+
+    beforeEach(() => {
+        mockPostHog = {
+            get_property: jest.fn(),
+        } as unknown as PostHog
+    })
+
+    describe('detectUserLanguage', () => {
+        it('should return language from person properties', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({
+                language: 'fr',
+            })
+
+            const result = detectUserLanguage(mockPostHog)
+
+            expect(result).toBe('fr')
+            expect(mockPostHog.get_property).toHaveBeenCalledWith(STORED_PERSON_PROPERTIES_KEY)
+        })
+
+        it('should return null when language property is not set', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({
+                some_other_property: 'value',
+            })
+
+            const result = detectUserLanguage(mockPostHog)
+
+            expect(result).toBeNull()
+        })
+
+        it('should return null when person properties is empty', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({})
+
+            const result = detectUserLanguage(mockPostHog)
+
+            expect(result).toBeNull()
+        })
+
+        it('should return null when person properties is undefined', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue(undefined)
+
+            const result = detectUserLanguage(mockPostHog)
+
+            expect(result).toBeNull()
+        })
+
+        it('should trim whitespace from language value', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({
+                language: '  es  ',
+            })
+
+            const result = detectUserLanguage(mockPostHog)
+
+            expect(result).toBe('es')
+        })
+
+        it('should return null for empty string language', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({
+                language: '   ',
+            })
+
+            const result = detectUserLanguage(mockPostHog)
+
+            expect(result).toBeNull()
+        })
+
+        it('should return null for non-string language values', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({
+                language: 123,
+            })
+
+            const result = detectUserLanguage(mockPostHog)
+
+            expect(result).toBeNull()
+        })
+    })
+
+    describe('applySurveyTranslationForUser', () => {
+        const createBaseSurvey = (): Survey => ({
+            id: 'test-survey',
+            name: 'Test Survey',
+            description: 'Test Description',
+            type: SurveyType.Popover,
+            questions: [
+                {
+                    type: SurveyQuestionType.Open,
+                    question: 'What do you think?',
+                    id: 'q1',
+                },
+            ],
+            appearance: {
+                thankYouMessageHeader: 'Thank you!',
+                thankYouMessageDescription: 'We appreciate your feedback',
+                thankYouMessageCloseButtonText: 'Close',
+            },
+            conditions: null,
+            start_date: '2024-01-01',
+            end_date: null,
+            current_iteration: null,
+            current_iteration_start_date: null,
+            feature_flag_keys: null,
+            linked_flag_key: null,
+            targeting_flag_key: null,
+            internal_targeting_flag_key: null,
+        })
+
+        it('should return original survey when no language is detected', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({})
+            const survey = createBaseSurvey()
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey).toEqual(survey)
+            expect(result.language).toBeNull()
+        })
+
+        it('should return original survey when no translations exist', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr' })
+            const survey = createBaseSurvey()
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey).toEqual(survey)
+            expect(result.language).toBeNull()
+        })
+
+        it('should apply exact match translation', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                fr: {
+                    name: 'Enquête Test',
+                    description: 'Description Test',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Enquête Test')
+            expect(result.survey.description).toBe('Description Test')
+            expect(result.language).toBe('fr')
+        })
+
+        it('should apply case-insensitive match', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'FR' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                fr: {
+                    name: 'Enquête Test',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Enquête Test')
+            expect(result.language).toBe('fr')
+        })
+
+        it('should fallback to base language for language variants', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr-CA' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                fr: {
+                    name: 'Enquête Française',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Enquête Française')
+            expect(result.language).toBe('fr')
+        })
+
+        it('should prefer exact match over base language', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr-CA' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                fr: {
+                    name: 'Français Standard',
+                },
+                'fr-CA': {
+                    name: 'Français Canadien',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Français Canadien')
+            expect(result.language).toBe('fr-CA')
+        })
+
+        it('should translate question text', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'es' })
+            const survey = createBaseSurvey()
+            survey.questions[0].translations = {
+                es: {
+                    question: '¿Qué piensas?',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.questions[0].question).toBe('¿Qué piensas?')
+        })
+
+        it('should translate question description', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'es' })
+            const survey = createBaseSurvey()
+            survey.questions[0].description = 'Please tell us'
+            survey.questions[0].translations = {
+                es: {
+                    description: 'Por favor díganos',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.questions[0].description).toBe('Por favor díganos')
+        })
+
+        it('should translate button text', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'es' })
+            const survey = createBaseSurvey()
+            survey.questions[0].buttonText = 'Submit'
+            survey.questions[0].translations = {
+                es: {
+                    buttonText: 'Enviar',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.questions[0].buttonText).toBe('Enviar')
+        })
+
+        it('should translate multiple choice options', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'de' })
+            const survey = createBaseSurvey()
+            survey.questions[0] = {
+                type: SurveyQuestionType.MultipleChoice,
+                question: 'Choose options',
+                choices: ['Option 1', 'Option 2', 'Option 3'],
+                id: 'q1',
+                translations: {
+                    de: {
+                        question: 'Wählen Sie Optionen',
+                        choices: ['Option 1', 'Option 2', 'Option 3'],
+                    },
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.questions[0].question).toBe('Wählen Sie Optionen')
+            expect((result.survey.questions[0] as any).choices).toEqual(['Option 1', 'Option 2', 'Option 3'])
+        })
+
+        it('should translate rating question labels', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'ja' })
+            const survey = createBaseSurvey()
+            survey.questions[0] = {
+                type: SurveyQuestionType.Rating,
+                question: 'Rate us',
+                scale: 5,
+                display: 'number',
+                lowerBoundLabel: 'Poor',
+                upperBoundLabel: 'Excellent',
+                id: 'q1',
+                translations: {
+                    ja: {
+                        question: '評価してください',
+                        lowerBoundLabel: '悪い',
+                        upperBoundLabel: '優秀',
+                    },
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.questions[0].question).toBe('評価してください')
+            expect((result.survey.questions[0] as any).lowerBoundLabel).toBe('悪い')
+            expect((result.survey.questions[0] as any).upperBoundLabel).toBe('優秀')
+        })
+
+        it('should translate link question URL', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'es' })
+            const survey = createBaseSurvey()
+            survey.questions[0] = {
+                type: SurveyQuestionType.Link,
+                question: 'Click here',
+                link: 'https://example.com/en',
+                id: 'q1',
+                translations: {
+                    es: {
+                        question: 'Haga clic aquí',
+                        link: 'https://example.com/es',
+                    },
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.questions[0].question).toBe('Haga clic aquí')
+            expect((result.survey.questions[0] as any).link).toBe('https://example.com/es')
+        })
+
+        it('should translate thank you message', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'pt' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                pt: {
+                    thankYouMessageHeader: 'Obrigado!',
+                    thankYouMessageDescription: 'Agradecemos seu feedback',
+                    thankYouMessageCloseButtonText: 'Fechar',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.appearance?.thankYouMessageHeader).toBe('Obrigado!')
+            expect(result.survey.appearance?.thankYouMessageDescription).toBe('Agradecemos seu feedback')
+            expect(result.survey.appearance?.thankYouMessageCloseButtonText).toBe('Fechar')
+        })
+
+        it('should handle partial translations gracefully', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                fr: {
+                    name: 'Enquête', // Only name translated
+                    // description not translated
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Enquête')
+            expect(result.survey.description).toBe('Test Description') // Original
+        })
+
+        it('should translate multiple questions independently', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'es' })
+            const survey = createBaseSurvey()
+            survey.questions = [
+                {
+                    type: SurveyQuestionType.Open,
+                    question: 'Question 1',
+                    id: 'q1',
+                    translations: {
+                        es: {
+                            question: 'Pregunta 1',
+                        },
+                    },
+                },
+                {
+                    type: SurveyQuestionType.Open,
+                    question: 'Question 2',
+                    id: 'q2',
+                    translations: {
+                        es: {
+                            question: 'Pregunta 2',
+                        },
+                    },
+                },
+            ]
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.questions[0].question).toBe('Pregunta 1')
+            expect(result.survey.questions[1].question).toBe('Pregunta 2')
+        })
+
+        it('should not mutate the original survey object', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr' })
+            const survey = createBaseSurvey()
+            const originalName = survey.name
+            survey.translations = {
+                fr: {
+                    name: 'Nom Traduit',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Nom Traduit')
+            expect(survey.name).toBe(originalName) // Original unchanged
+        })
+
+        it('should handle surveys without appearance object', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr' })
+            const survey = createBaseSurvey()
+            survey.appearance = null
+            survey.translations = {
+                fr: {
+                    name: 'Enquête',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Enquête')
+            expect(result.survey.appearance).toBeNull()
+        })
+
+        it('should return original language code that matched', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'zh-CN' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                'zh-CN': {
+                    name: '测试调查',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.language).toBe('zh-CN')
+        })
+    })
+})

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -1183,7 +1183,17 @@ export function SurveyPopup({
             properties,
             surveyLanguage,
         }
-    }, [isPreviewMode, previewPageIndex, isPopup, posthog, survey, onPopupSurveyDismissed, onPreviewSubmit, properties, surveyLanguage])
+    }, [
+        isPreviewMode,
+        previewPageIndex,
+        isPopup,
+        posthog,
+        survey,
+        onPopupSurveyDismissed,
+        onPreviewSubmit,
+        properties,
+        surveyLanguage,
+    ])
 
     if (!isPopupVisible) {
         return null

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -443,7 +443,7 @@ export const sendSurveyEvent = ({
         })),
         [SurveyEventProperties.SURVEY_SUBMISSION_ID]: surveySubmissionId,
         [SurveyEventProperties.SURVEY_COMPLETED]: isSurveyCompleted,
-        ...(surveyLanguage && { $survey_language: surveyLanguage }),
+        $survey_language: surveyLanguage,
         sessionRecordingUrl: posthog.get_session_replay_url?.(),
         ...responses,
         ...properties,

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -95,6 +95,7 @@ interface SurveyQuestionBase {
     buttonText?: string
     branching?: NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching
     validation?: SurveyValidationRule[]
+    translations?: Record<string, SurveyQuestionTranslation>
 }
 
 export interface BasicSurveyQuestion extends SurveyQuestionBase {
@@ -182,12 +183,33 @@ export enum SurveySchedule {
     Always = 'always',
 }
 
+export interface SurveyTranslation {
+    name?: string
+    description?: string
+    thankYouMessageHeader?: string
+    thankYouMessageDescription?: string
+    thankYouMessageCloseButtonText?: string
+}
+
+export interface SurveyQuestionTranslation {
+    question?: string
+    description?: string
+    buttonText?: string
+    link?: string
+    // For rating questions
+    lowerBoundLabel?: string
+    upperBoundLabel?: string
+    // For multiple choice questions
+    choices?: string[]
+}
+
 export interface Survey {
     // Sync this with the backend's SurveyAPISerializer!
     id: string
     name: string
     description: string
     type: SurveyType
+    translations?: Record<string, SurveyTranslation>
     feature_flag_keys:
         | {
               key: string
@@ -286,6 +308,7 @@ export enum SurveyEventProperties {
     SURVEY_COMPLETED = '$survey_completed',
     PRODUCT_TOUR_ID = '$product_tour_id',
     SURVEY_LAST_SEEN_DATE = '$survey_last_seen_date',
+    SURVEY_LANGUAGE = '$survey_language',
 }
 
 export enum DisplaySurveyType {

--- a/packages/browser/src/utils/language-utils.ts
+++ b/packages/browser/src/utils/language-utils.ts
@@ -1,0 +1,58 @@
+import { createLogger } from './logger'
+
+const logger = createLogger('[LanguageUtils]')
+
+/**
+ * Normalizes a language code to lowercase for consistent matching
+ * @param languageCode - The language code to normalize (e.g., 'FR', 'en-US')
+ * @returns Normalized language code (e.g., 'fr', 'en-us')
+ */
+export function normalizeLanguageCode(languageCode: string): string {
+    return languageCode.toLowerCase()
+}
+
+/**
+ * Extracts the base language from a language variant
+ * @param languageCode - The full language code (e.g., 'en-US', 'fr-CA')
+ * @returns The base language code (e.g., 'en', 'fr')
+ */
+export function getBaseLanguage(languageCode: string): string {
+    return languageCode.split('-')[0]
+}
+
+/**
+ * Finds the best matching translation for a given language code
+ * Tries: exact match -> base language fallback -> null
+ * @param translations - Available translations object
+ * @param targetLanguage - The target language code
+ * @returns The best matching language key or null
+ */
+export function findBestTranslationMatch(
+    translations: Record<string, any> | undefined,
+    targetLanguage: string
+): string | null {
+    if (!translations || !targetLanguage) {
+        return null
+    }
+
+    const normalizedTarget = normalizeLanguageCode(targetLanguage)
+
+    // Try exact match first (case-insensitive)
+    const exactMatch = Object.keys(translations).find((key) => normalizeLanguageCode(key) === normalizedTarget)
+    if (exactMatch) {
+        logger.info(`Found exact translation match: ${exactMatch}`)
+        return exactMatch
+    }
+
+    // Try base language fallback (e.g., fr-CA -> fr)
+    if (normalizedTarget.includes('-')) {
+        const baseLanguage = getBaseLanguage(normalizedTarget)
+        const baseMatch = Object.keys(translations).find((key) => normalizeLanguageCode(key) === baseLanguage)
+        if (baseMatch) {
+            logger.info(`Found base language translation match: ${baseMatch} (from ${targetLanguage})`)
+            return baseMatch
+        }
+    }
+
+    return null
+}

--- a/packages/browser/src/utils/survey-translations.ts
+++ b/packages/browser/src/utils/survey-translations.ts
@@ -1,0 +1,213 @@
+import { PostHog } from '../posthog-core'
+import { Survey, SurveyQuestion } from '../posthog-surveys-types'
+import { STORED_PERSON_PROPERTIES_KEY } from '../constants'
+import { createLogger } from './logger'
+
+const logger = createLogger('[SurveyTranslations]')
+
+/**
+ * Detects the user's language from person properties
+ * @param instance - PostHog instance to retrieve person properties
+ * @returns The detected language code (e.g., 'fr', 'es', 'en-US') or null if not found
+ */
+export function detectUserLanguage(instance: PostHog): string | null {
+    const personProperties = instance.get_property(STORED_PERSON_PROPERTIES_KEY) || {}
+    const language = personProperties['language']
+
+    if (typeof language === 'string' && language.trim()) {
+        return language.trim()
+    }
+
+    return null
+}
+
+/**
+ * Normalizes a language code to lowercase for consistent matching
+ * @param languageCode - The language code to normalize (e.g., 'FR', 'en-US')
+ * @returns Normalized language code (e.g., 'fr', 'en-us')
+ */
+function normalizeLanguageCode(languageCode: string): string {
+    return languageCode.toLowerCase()
+}
+
+/**
+ * Extracts the base language from a language variant
+ * @param languageCode - The full language code (e.g., 'en-US', 'fr-CA')
+ * @returns The base language code (e.g., 'en', 'fr')
+ */
+function getBaseLanguage(languageCode: string): string {
+    return languageCode.split('-')[0]
+}
+
+/**
+ * Finds the best matching translation for a given language code
+ * Tries: exact match -> base language fallback -> null
+ * @param translations - Available translations object
+ * @param targetLanguage - The target language code
+ * @returns The best matching language key or null
+ */
+function findBestTranslationMatch(
+    translations: Record<string, any> | undefined,
+    targetLanguage: string
+): string | null {
+    if (!translations || !targetLanguage) {
+        return null
+    }
+
+    const normalizedTarget = normalizeLanguageCode(targetLanguage)
+
+    // Try exact match first (case-insensitive)
+    const exactMatch = Object.keys(translations).find(
+        (key) => normalizeLanguageCode(key) === normalizedTarget
+    )
+    if (exactMatch) {
+        logger.info(`Found exact translation match: ${exactMatch}`)
+        return exactMatch
+    }
+
+    // Try base language fallback (e.g., fr-CA -> fr)
+    if (normalizedTarget.includes('-')) {
+        const baseLanguage = getBaseLanguage(normalizedTarget)
+        const baseMatch = Object.keys(translations).find(
+            (key) => normalizeLanguageCode(key) === baseLanguage
+        )
+        if (baseMatch) {
+            logger.info(`Found base language translation match: ${baseMatch} (from ${targetLanguage})`)
+            return baseMatch
+        }
+    }
+
+    return null
+}
+
+/**
+ * Merges translated question fields on top of default question fields
+ * @param question - The original question object
+ * @param targetLanguage - The target language code
+ * @returns A new question object with translated fields merged
+ */
+function mergeQuestionTranslation(question: SurveyQuestion, targetLanguage: string): SurveyQuestion {
+    const translationKey = findBestTranslationMatch(question.translations, targetLanguage)
+    if (!translationKey) {
+        return question
+    }
+
+    const questionTranslation = question.translations?.[translationKey]
+    if (!questionTranslation) {
+        return question
+    }
+
+    const translated = { ...question }
+
+    if (questionTranslation.question) {
+        translated.question = questionTranslation.question
+    }
+    if (questionTranslation.description !== undefined) {
+        translated.description = questionTranslation.description
+    }
+    if (questionTranslation.buttonText) {
+        translated.buttonText = questionTranslation.buttonText
+    }
+
+    if ('link' in question && questionTranslation.link !== undefined) {
+        ;(translated as any).link = questionTranslation.link
+    }
+
+    if ('lowerBoundLabel' in question && questionTranslation.lowerBoundLabel) {
+        ;(translated as any).lowerBoundLabel = questionTranslation.lowerBoundLabel
+    }
+    if ('upperBoundLabel' in question && questionTranslation.upperBoundLabel) {
+        ;(translated as any).upperBoundLabel = questionTranslation.upperBoundLabel
+    }
+
+    if ('choices' in question && questionTranslation.choices && Array.isArray(questionTranslation.choices)) {
+        ;(translated as any).choices = questionTranslation.choices
+    }
+
+    return translated
+}
+
+/**
+ * Applies translations to a survey based on the target language
+ * @param survey - The original survey object
+ * @param targetLanguage - The target language code
+ * @returns An object with the translated survey and the matched language key (or null if no match)
+ */
+export function applySurveyTranslation(
+    survey: Survey,
+    targetLanguage: string
+): { survey: Survey; matchedKey: string | null } {
+    const translationKey = findBestTranslationMatch(survey.translations, targetLanguage)
+
+    const translated = { ...survey }
+    let hasTranslation = false
+
+    if (translationKey) {
+        const translation = survey.translations?.[translationKey]
+        if (translation) {
+            logger.info(`Applying survey-level translation for language: ${translationKey}`)
+            hasTranslation = true
+
+            if (translation.name) {
+                translated.name = translation.name
+            }
+            if (translation.description) {
+                translated.description = translation.description
+            }
+
+            if (translated.appearance) {
+                translated.appearance = { ...translated.appearance }
+
+                if (translation.thankYouMessageHeader) {
+                    translated.appearance.thankYouMessageHeader = translation.thankYouMessageHeader
+                }
+                if (translation.thankYouMessageDescription) {
+                    translated.appearance.thankYouMessageDescription = translation.thankYouMessageDescription
+                }
+                if (translation.thankYouMessageCloseButtonText) {
+                    translated.appearance.thankYouMessageCloseButtonText = translation.thankYouMessageCloseButtonText
+                }
+            }
+        }
+    }
+
+    // Always try to apply question-level translations
+    const translatedQuestions = survey.questions.map((question) => mergeQuestionTranslation(question, targetLanguage))
+    const anyQuestionTranslated = translatedQuestions.some((q, i) => q !== survey.questions[i])
+    
+    if (anyQuestionTranslated) {
+        translated.questions = translatedQuestions
+        hasTranslation = true
+        logger.info(`Applied question-level translations for language: ${targetLanguage}`)
+    }
+
+    return {
+        survey: translated,
+        matchedKey: hasTranslation ? (translationKey || targetLanguage) : null,
+    }
+}
+
+/**
+ * Applies translations to a survey based on the user's language from person properties
+ * @param survey - The original survey object
+ * @param instance - PostHog instance to retrieve person properties
+ * @returns An object containing the translated survey and the language used (or null if no translation applied)
+ */
+export function applySurveyTranslationForUser(
+    survey: Survey,
+    instance: PostHog
+): { survey: Survey; language: string | null } {
+    const userLanguage = detectUserLanguage(instance)
+
+    if (!userLanguage) {
+        logger.info('No user language detected from person properties')
+        return { survey, language: null }
+    }
+
+    const result = applySurveyTranslation(survey, userLanguage)
+
+    return {
+        survey: result.survey,
+        language: result.matchedKey,
+    }
+}


### PR DESCRIPTION
## Problem

Teams running global products need to collect feedback from users who speak different languages. Currently, surveys only support one language per survey, forcing teams to either create duplicate surveys for each language (maintenance nightmare, fragmented analytics) or use English-only surveys (low response rates from non-English speakers).

This implements the final piece of the surveys translation epic, enabling one survey to automatically display in multiple languages based on the user's language preference.

Related:
- Backend PR: https://github.com/PostHog/posthog/pull/45096 (now https://github.com/PostHog/posthog/pull/47934)
- Frontend PR: https://github.com/PostHog/posthog/pull/45281
- Issue: https://github.com/PostHog/posthog/issues/42154

## Changes

Added multi-language survey support to posthog-js with automatic language detection and intelligent fallback:

**Core functionality:**
- Detects user language from person properties (`$stored_person_properties.language`)
- Applies translations with fallback logic: exact match → base language (e.g., `fr-CA` → `fr`) → default
- Merges translated fields on top of default survey/question fields
- Tracks `$survey_language` in survey events for analytics

**Translation scope:**
- Survey-level: name, description, thank you message (header, description, close button)
- Question-level: question text, description, button text, link URLs, rating labels, multiple choice options

## Release info

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages