### PR TITLE
feat(analytics-platform): Add function setTestUser

### DIFF
--- a/.changeset/chatty-weeks-knock.md
+++ b/.changeset/chatty-weeks-knock.md
@@ -3,4 +3,4 @@
 '@posthog/types': minor
 ---
 
-Add a function isTestUser() and config option testuser_hostname
+Add a function isTestUser() and config option test_user_hostname

--- a/packages/browser/src/__tests__/posthog-core.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.test.ts
@@ -423,12 +423,12 @@ describe('posthog core', () => {
             expect(beforeSendMock).toHaveBeenCalledTimes(1)
         })
 
-        describe('test_hostname config', () => {
+        describe('test_user_hostname config', () => {
             it('should call setTestUser automatically when hostname matches regex', async () => {
                 mockHostName.mockReturnValue('localhost')
                 const { beforeSendMock } = setup({
                     person_profiles: 'identified_only',
-                    testuser_hostname: /^(localhost|127\.0\.0\.1)$/,
+                    test_user_hostname: /^(localhost|127\.0\.0\.1)$/,
                 })
 
                 const setEvents = beforeSendMock.mock.calls.filter((call) => call[0].event === '$set')
@@ -440,7 +440,7 @@ describe('posthog core', () => {
                 mockHostName.mockReturnValue('localhost')
                 const { beforeSendMock } = setup({
                     person_profiles: 'identified_only',
-                    testuser_hostname: 'localhost',
+                    test_user_hostname: 'localhost',
                 })
 
                 const setEvents = beforeSendMock.mock.calls.filter((call) => call[0].event === '$set')
@@ -451,7 +451,7 @@ describe('posthog core', () => {
                 mockHostName.mockReturnValue('localhost.example.com')
                 const { beforeSendMock } = setup({
                     person_profiles: 'identified_only',
-                    testuser_hostname: 'localhost',
+                    test_user_hostname: 'localhost',
                 })
 
                 const setEvents = beforeSendMock.mock.calls.filter((call) => call[0].event === '$set')
@@ -462,7 +462,7 @@ describe('posthog core', () => {
                 mockHostName.mockReturnValue('production.example.com')
                 const { beforeSendMock } = setup({
                     person_profiles: 'identified_only',
-                    testuser_hostname: /^localhost$/,
+                    test_user_hostname: /^localhost$/,
                 })
 
                 const setEvents = beforeSendMock.mock.calls.filter((call) => call[0].event === '$set')
@@ -474,10 +474,10 @@ describe('posthog core', () => {
                 const { posthog, beforeSendMock } = setup({
                     person_profiles: 'identified_only',
                     defaults: '2026-01-30',
-                    testuser_hostname: null,
+                    test_user_hostname: null,
                 })
 
-                expect(posthog.config.testuser_hostname).toBeNull()
+                expect(posthog.config.test_user_hostname).toBeNull()
                 const setEvents = beforeSendMock.mock.calls.filter((call) => call[0].event === '$set')
                 expect(setEvents.length).toEqual(0)
             })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -155,13 +155,13 @@ const defaultsThatVaryByConfig = (
     defaults?: ConfigDefaults
 ): Pick<
     PostHogConfig,
-    'rageclick' | 'capture_pageview' | 'session_recording' | 'external_scripts_inject_target' | 'testuser_hostname'
+    'rageclick' | 'capture_pageview' | 'session_recording' | 'external_scripts_inject_target' | 'test_user_hostname'
 > => ({
     rageclick: defaults && defaults >= '2025-11-30' ? { content_ignorelist: true } : true,
     capture_pageview: defaults && defaults >= '2025-05-24' ? 'history_change' : true,
     session_recording: defaults && defaults >= '2025-11-30' ? { strictMinimumDuration: true } : {},
     external_scripts_inject_target: defaults && defaults >= '2026-01-30' ? 'head' : 'body',
-    testuser_hostname: defaults && defaults >= '2026-01-30' ? /^(localhost|127\.0\.0\.1)$/ : undefined,
+    test_user_hostname: defaults && defaults >= '2026-01-30' ? /^(localhost|127\.0\.0\.1)$/ : undefined,
 })
 
 // NOTE: Remember to update `types.ts` when changing a default value
@@ -866,10 +866,10 @@ export class PostHog implements PostHogInterface {
 
         this._start_queue_if_opted_in()
 
-        // Check if current hostname matches test_hostname pattern and mark as test user before any events
-        if (this.config.testuser_hostname && location?.hostname) {
+        // Check if current hostname matches test_user_hostname pattern and mark as test user before any events
+        if (this.config.test_user_hostname && location?.hostname) {
             const hostname = location.hostname
-            const pattern = this.config.testuser_hostname
+            const pattern = this.config.test_user_hostname
             const matches = typeof pattern === 'string' ? hostname === pattern : pattern.test(hostname)
             if (matches) {
                 this.setTestUser()
@@ -3163,8 +3163,8 @@ export class PostHog implements PostHogInterface {
      * // Manually mark as test user
      * posthog.setTestUser()
      *
-     * // Or use test_hostname config for automatic detection
-     * posthog.init('token', { test_hostname: 'localhost' })
+     * // Or use test_user_hostname config for automatic detection
+     * posthog.init('token', { test_user_hostname: 'localhost' })
      * ```
      *
      * @public

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -639,7 +639,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "\\"always\\"",
     "\\"on_reject\\""
   ],
-  "testuser_hostname": [
+  "test_user_hostname": [
     "undefined",
     "null",
     "string",

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1379,16 +1379,16 @@ export interface PostHogConfig {
      * @example
      * ```js
      * // Exact match
-     * posthog.init('token', { test_hostname: 'example.com' })
+     * posthog.init('token', { test_user_hostname: 'example.com' })
      *
      * // Regex pattern
-     * posthog.init('token', { test_hostname: /\.local$/ })
+     * posthog.init('token', { test_user_hostname: /\.local$/ })
      *
      * // Disable
-     * posthog.init('token', { test_hostname: null })
+     * posthog.init('token', { test_user_hostname: null })
      * ```
      */
-    testuser_hostname?: string | RegExp | null
+    test_user_hostname?: string | RegExp | null
 
     // ------- PREVIEW CONFIGS -------
 

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -155,8 +155,8 @@ export interface PostHog {
      * // Manually mark as test user
      * posthog.setTestUser()
      *
-     * // Or use test_hostname config for automatic detection
-     * posthog.init('token', { test_hostname: 'localhost' })
+     * // Or use test_user_hostname config for automatic detection
+     * posthog.init('token', { test_user_hostname: 'localhost' })
      * ```
      *
      * @public


### PR DESCRIPTION
## Problem

We want to make it easier for people to use cohorts for internal test filters, as from a query performance perspective, checking presence of a user in a small cohort is basically free, whereas checking the host / email column for every row can double the number of bytes read on disk of every query.

The problem is that it's very useful to be able to specify a hostname for test users! The problem with this is that it doesn't work with cohorts, because event properties can't be used in a cohort definition. This PR effectively changes this into a person property so that it can be used with cohorts


## Changes


## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
