### PR TITLE
fix(product tours): add element precision, only mark tours as shown if first element was found

### DIFF
--- a/.changeset/eighty-heads-pick.md
+++ b/.changeset/eighty-heads-pick.md
@@ -2,4 +2,4 @@
 'posthog-js': patch
 ---
 
-add element infeerence precision to tours; do not mark as shown until we know first step rendered successfully
+add element inference precision to tours; do not mark as shown until we know first step rendered successfully

--- a/.changeset/eighty-heads-pick.md
+++ b/.changeset/eighty-heads-pick.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+add element infeerence precision to tours; do not mark as shown until we know first step rendered successfully

--- a/packages/browser/src/extensions/product-tours/element-inference.ts
+++ b/packages/browser/src/extensions/product-tours/element-inference.ts
@@ -87,6 +87,7 @@ export interface InferredSelector {
     autoData: string
     text: string | null
     excludeText?: boolean
+    precision?: number
 }
 
 function getElementText(element: HTMLElement): string | null {
@@ -159,7 +160,7 @@ export function findElement(selector: InferredSelector): HTMLElement | null {
             logger.error('Invalid autoData structure:', autoData)
             return null
         }
-        const { text, excludeText } = selector
+        const { text, excludeText, precision = 1 } = selector
 
         // excludeText -> user setting, usually if the target element
         // has dynamic/localized text
@@ -174,10 +175,15 @@ export function findElement(selector: InferredSelector): HTMLElement | null {
             return null
         }
 
+        // precision controls how many groups to search
+        // 1 = strict (only most specific group), 0 = loose (all groups)
+        const maxGroups = Math.max(1, Math.ceil((1 - precision) * groups.length))
+
         const visibilityCache = new WeakMap<HTMLElement, boolean>()
 
         // try each selector group, starting w/ most specific (lowest cardinality)
-        for (const group of groups) {
+        for (let i = 0; i < maxGroups; i++) {
+            const group = groups[i]
             const votes = new Map<HTMLElement, number>()
             let winner: HTMLElement | null = null
             let maxVotes = 0


### PR DESCRIPTION
## Problem

two issues:

1. the element inference is too good at finding _something_, even when it's a "bad" something, which means tours are sometimes showing when they shouldn't. this also makes tour building feel wonky. see https://posthog.slack.com/archives/C07QD3LT8U9/p1769930669658259
2. we mark tours as shown before we know if the first step successfully rendered, meaning tour attempts could be "wasted" - see https://posthog.slack.com/archives/C07QD3LT8U9/p1769893805876789?thread_ts=1769725713.960099&cid=C07QD3LT8U9

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- adds `precision` param to inferred selectors. this is a number 0-1 that controls how many groups we check during element lookup. a future main app PR will put this in a slider for users, but for now, we default to 1, which means we'll only check the most specific group
- reorder the logic on tour start so we don't mark tours as shown until we actually know the first step successfully rendered

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->