### PR TITLE
fix: Use lower case for `referrerpolicy`

### DIFF
--- a/.changeset/stale-coats-bake.md
+++ b/.changeset/stale-coats-bake.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+use lowercase `referrerpolicy` attribute for Preact compatibility

--- a/packages/browser/src/extensions/conversations/external/components/RichContent.tsx
+++ b/packages/browser/src/extensions/conversations/external/components/RichContent.tsx
@@ -167,7 +167,7 @@ function renderTextWithMarks(
                             href={safeUrl}
                             target="_blank"
                             rel="noopener noreferrer"
-                            referrerPolicy="no-referrer"
+                            referrerpolicy="no-referrer"
                             style={styles.link}
                         >
                             {element}


### PR DESCRIPTION
## Problem

Local builds were failing for me

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
