### PR TITLE
fix: invert colors for bright widget

### DIFF
--- a/.changeset/tangy-turkeys-nail.md
+++ b/.changeset/tangy-turkeys-nail.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+Fix issue with contrast colors in support widget

--- a/packages/browser/src/extensions/conversations/external/components/styles.ts
+++ b/packages/browser/src/extensions/conversations/external/components/styles.ts
@@ -1,4 +1,22 @@
 // Inline styles following PostHog design system
+
+/**
+ * Calculate contrasting text color (black or white) based on background brightness
+ * Uses HSP (Highly Sensitive Purity) brightness formula
+ */
+function getContrastTextColor(hexColor: string): string {
+    const hex = hexColor.replace(/^#/, '')
+    const fullHex = hex.length === 3 ? hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2] : hex
+
+    const r = parseInt(fullHex.slice(0, 2), 16)
+    const g = parseInt(fullHex.slice(2, 4), 16)
+    const b = parseInt(fullHex.slice(4, 6), 16)
+
+    // HSP brightness formula
+    const hsp = Math.sqrt(0.299 * (r * r) + 0.587 * (g * g) + 0.114 * (b * b))
+    return hsp > 127.5 ? '#020617' : 'white'
+}
+
 export const getStyles = (primaryColor: string) => ({
     widget: {
         position: 'fixed' as const,
@@ -15,7 +33,7 @@ export const getStyles = (primaryColor: string) => ({
         height: '50px',
         borderRadius: '50%',
         background: primaryColor,
-        color: 'white',
+        color: getContrastTextColor(primaryColor),
         border: 'none',
         cursor: 'pointer',
         boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
@@ -64,7 +82,7 @@ export const getStyles = (primaryColor: string) => ({
     },
     header: {
         background: primaryColor,
-        color: 'white',
+        color: getContrastTextColor(primaryColor),
         padding: '8px 12px',
         display: 'flex',
         justifyContent: 'space-between',
@@ -82,7 +100,7 @@ export const getStyles = (primaryColor: string) => ({
     headerButton: {
         background: 'transparent',
         border: 'none',
-        color: 'white',
+        color: getContrastTextColor(primaryColor),
         cursor: 'pointer',
         padding: '6px 8px',
         fontSize: '16px',
@@ -130,7 +148,7 @@ export const getStyles = (primaryColor: string) => ({
     },
     messageContentCustomer: {
         background: primaryColor,
-        color: 'white',
+        color: getContrastTextColor(primaryColor),
         borderBottomRightRadius: '2px',
     },
     messageContentAgent: {
@@ -185,7 +203,7 @@ export const getStyles = (primaryColor: string) => ({
         height: '33px', // Match input minHeight for vertical alignment
         borderRadius: '10px',
         background: primaryColor,
-        color: 'white',
+        color: getContrastTextColor(primaryColor),
         border: 'none',
         cursor: 'pointer',
         display: 'flex',
@@ -252,7 +270,7 @@ export const getStyles = (primaryColor: string) => ({
         padding: '12px 16px',
         borderRadius: '6px',
         background: primaryColor,
-        color: 'white',
+        color: getContrastTextColor(primaryColor),
         border: 'none',
         cursor: 'pointer',
         fontSize: '14px',


### PR DESCRIPTION
## Problem

<img width="428" height="515" alt="Screenshot 2026-02-03 at 18 22 41" src="https://github.com/user-attachments/assets/f78f1b3f-1e10-4e59-bd78-eb8378f6210d" />


## Changes

<img width="462" height="622" alt="Screenshot 2026-02-03 at 18 34 50" src="https://github.com/user-attachments/assets/3253a2f9-5387-42dd-b165-bb7d6bbd5577" />


## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
