### PR TITLE
feat(flags): add featureFlagsReloading event for tracking flag reload state

### DIFF
--- a/.changeset/funny-points-deny.md
+++ b/.changeset/funny-points-deny.md
@@ -2,4 +2,4 @@
 'posthog-js': minor
 ---
 
-add featureFlagsLoading event for tracking flag reload state
+add featureFlagsReloading event for tracking flag reload state

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -1042,7 +1042,7 @@ describe('featureflags', () => {
         })
     })
 
-    describe('featureFlagsLoading event', () => {
+    describe('featureFlagsReloading event', () => {
         beforeEach(() => {
             instance._send_request = jest.fn().mockImplementation(({ callback }) =>
                 callback({
@@ -1057,9 +1057,9 @@ describe('featureflags', () => {
             )
         })
 
-        it('should emit featureFlagsLoading event when reloadFeatureFlags is called', () => {
+        it('should emit featureFlagsReloading event when reloadFeatureFlags is called', () => {
             const loadingCallback = jest.fn()
-            instance.on('featureFlagsLoading', loadingCallback)
+            instance.on('featureFlagsReloading', loadingCallback)
 
             featureFlags.reloadFeatureFlags()
 
@@ -1067,9 +1067,9 @@ describe('featureflags', () => {
             expect(loadingCallback).toHaveBeenCalledWith(true)
         })
 
-        it('should not emit featureFlagsLoading event if already debouncing', () => {
+        it('should not emit featureFlagsReloading event if already debouncing', () => {
             const loadingCallback = jest.fn()
-            instance.on('featureFlagsLoading', loadingCallback)
+            instance.on('featureFlagsReloading', loadingCallback)
 
             featureFlags.reloadFeatureFlags()
             featureFlags.reloadFeatureFlags()
@@ -1079,10 +1079,10 @@ describe('featureflags', () => {
             expect(loadingCallback).toHaveBeenCalledTimes(1)
         })
 
-        it('should emit featureFlagsLoading before onFeatureFlags callback', () => {
+        it('should emit featureFlagsReloading before onFeatureFlags callback', () => {
             const callOrder: string[] = []
 
-            instance.on('featureFlagsLoading', () => {
+            instance.on('featureFlagsReloading', () => {
                 callOrder.push('loading')
             })
 
@@ -1096,9 +1096,9 @@ describe('featureflags', () => {
             expect(callOrder).toEqual(['loading', 'loaded'])
         })
 
-        it('should not emit featureFlagsLoading if reloading is disabled', () => {
+        it('should not emit featureFlagsReloading if reloading is disabled', () => {
             const loadingCallback = jest.fn()
-            instance.on('featureFlagsLoading', loadingCallback)
+            instance.on('featureFlagsReloading', loadingCallback)
 
             featureFlags.setReloadingPaused(true)
             featureFlags.reloadFeatureFlags()
@@ -1106,9 +1106,9 @@ describe('featureflags', () => {
             expect(loadingCallback).not.toHaveBeenCalled()
         })
 
-        it('should not emit featureFlagsLoading if feature flags are disabled', () => {
+        it('should not emit featureFlagsReloading if feature flags are disabled', () => {
             const loadingCallback = jest.fn()
-            instance.on('featureFlagsLoading', loadingCallback)
+            instance.on('featureFlagsReloading', loadingCallback)
 
             instance.config.advanced_disable_feature_flags = true
             featureFlags.reloadFeatureFlags()

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1936,7 +1936,7 @@ export class PostHog implements PostHogInterface {
      *
      * Available events:
      * - `eventCaptured`: Emitted immediately before trying to send an event
-     * - `featureFlagsLoading`: Emitted when feature flags are being reloaded (e.g. after `identify()`, `group()`, or `reloadFeatureFlags()`)
+     * - `featureFlagsReloading`: Emitted when feature flags are being reloaded (e.g. after `identify()`, `group()`, or `reloadFeatureFlags()`)
      *
      * {@label Capture}
      *
@@ -1949,8 +1949,8 @@ export class PostHog implements PostHogInterface {
      *
      * @example
      * ```js
-     * // Track when feature flags are loading to show a loading state
-     * posthog.on('featureFlagsLoading', () => {
+     * // Track when feature flags are reloading to show a loading state
+     * posthog.on('featureFlagsReloading', () => {
      *   console.log('Feature flags are being reloaded...')
      * })
      * ```
@@ -1961,7 +1961,7 @@ export class PostHog implements PostHogInterface {
      * @param {Function} cb The callback function to call when the event is emitted.
      * @returns {Function} A function that can be called to unsubscribe the listener.
      */
-    on(event: 'eventCaptured' | 'featureFlagsLoading', cb: (...args: any[]) => void): () => void {
+    on(event: 'eventCaptured' | 'featureFlagsReloading', cb: (...args: any[]) => void): () => void {
         return this._internalEventEmitter.on(event, cb)
     }
 

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -395,7 +395,7 @@ export class PostHogFeatureFlags {
         }
 
         // Emit event so consumers know flags are being reloaded
-        this._instance._internalEventEmitter.emit('featureFlagsLoading', true)
+        this._instance._internalEventEmitter.emit('featureFlagsReloading', true)
 
         // Debounce multiple calls on the same tick
         this._reloadDebouncer = setTimeout(() => {


### PR DESCRIPTION
## Problem

When users call `posthog.group()` to switch group context, feature flags are reloaded from the server. The `useFeatureFlagVariantKey` hook (and similar) updates when the new flags arrive, but there's no way to know when flags are *loading* vs *loaded*. This causes UI flicker when the flag value changes, rather than allowing users to show a proper loading state during the transition.

## Changes

Added a new `featureFlagsReloading` event that fires when feature flags begin reloading (e.g., after `group()`, `identify()`, or `reloadFeatureFlags()` calls). This pairs with the existing `onFeatureFlags` callback to give users full control over loading states:

```js
// Fires when flags start reloading
posthog.on('featureFlagsReloading', () => {
  setIsLoading(true)
})

// Fires when flags are done loading
posthog.onFeatureFlags(() => {
  setIsLoading(false)
})
```

Changes:
- Added `featureFlagsReloading` event emission in `reloadFeatureFlags()`
- Exposed the event via `posthog.on('featureFlagsLoading', callback)`
- Added internal `_emit()` method for cross-module event emission
- Added tests for the new event

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages