### PR TITLE
feat: coordinate in-app product interactions, first pass

### DIFF
--- a/.changeset/lemon-showers-train.md
+++ b/.changeset/lemon-showers-train.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+implement lightweight coordinator logic for tours, surveys, conversations interactions

--- a/packages/browser/playwright/mocked/product-tours/utils.ts
+++ b/packages/browser/playwright/mocked/product-tours/utils.ts
@@ -52,6 +52,23 @@ export function createTour(overrides: Partial<ProductTour> = {}): ProductTour {
     }
 }
 
+export function createEventTriggeredTour(
+    id: string,
+    eventName: string,
+    overrides: Partial<ProductTour> = {}
+): ProductTour {
+    return createTour({
+        id,
+        auto_launch: false,
+        conditions: {
+            events: {
+                values: [{ name: eventName }],
+            },
+        },
+        ...overrides,
+    })
+}
+
 export function createElementStep(selector: string, overrides: Partial<ProductTourStep> = {}): ProductTourStep {
     return createStep({
         type: 'element',

--- a/packages/browser/playwright/mocked/widget-coordination/utils.ts
+++ b/packages/browser/playwright/mocked/widget-coordination/utils.ts
@@ -1,0 +1,168 @@
+import { Page, BrowserContext } from '@playwright/test'
+import { Survey } from '@/posthog-surveys-types'
+import { start, StartOptions } from '../utils/setup'
+import { expect } from '../utils/posthog-playwright-test-base'
+
+export function surveyForm(page: Page, surveyId: string) {
+    return page.locator(`.PostHogSurvey-${surveyId}`).locator('.survey-form')
+}
+
+export function createPopoverSurvey(id: string, overrides: Partial<Survey> = {}): Survey {
+    return {
+        id,
+        name: `Test survey ${id}`,
+        type: 'popover',
+        start_date: '2021-01-01T00:00:00Z',
+        end_date: null,
+        questions: [{ type: 'open', question: 'Feedback?', id: `q_${id}` }],
+        ...overrides,
+    } as Survey
+}
+
+export function createEventTriggeredSurvey(id: string, eventName: string, overrides: Partial<Survey> = {}): Survey {
+    return createPopoverSurvey(id, {
+        conditions: {
+            events: {
+                values: [{ name: eventName }],
+            },
+            actions: { values: [] },
+            cancelEvents: { values: [] },
+        },
+        ...overrides,
+    })
+}
+
+export async function captureEvent(page: Page, eventName: string) {
+    await page.evaluate((name) => {
+        ;(window as any).posthog.capture(name)
+    }, eventName)
+}
+
+export function mockSurveysApi(page: Page, surveys: Survey[]) {
+    return page.route('**/surveys/**', async (route) => {
+        await route.fulfill({
+            json: { surveys },
+        })
+    })
+}
+
+export const conversationsConfig = {
+    enabled: true,
+    widgetEnabled: true,
+    token: 'test-token',
+}
+
+function conversationsWidgetButton(page: Page) {
+    return page.locator('#ph-conversations-widget-container button').first()
+}
+
+async function enableConversations(page: Page) {
+    await page.evaluate(() => {
+        const posthog = (window as any).posthog
+        if (posthog && posthog.conversations) {
+            posthog.conversations.onRemoteConfig({
+                conversations: {
+                    enabled: true,
+                    token: 'test-conversations-token',
+                    widgetEnabled: true,
+                },
+            })
+        }
+    })
+}
+
+async function openConversationsWidget(page: Page) {
+    await conversationsWidgetButton(page).click()
+}
+
+export async function enableAndOpenConversations(page: Page) {
+    await enableConversations(page)
+    await expect(conversationsWidgetButton(page)).toBeVisible({ timeout: 10000 })
+    await openConversationsWidget(page)
+}
+
+/**
+ * Opens conversations widget, then reloads the page so conversations auto-opens from persisted state.
+ * Use this to test that surveys/tours are blocked when conversations is already open on page load.
+ */
+export async function openConversationsThenReload(
+    page: Page,
+    context: BrowserContext,
+    reloadFlags: Record<string, unknown> = {}
+) {
+    // First load: just open conversations to persist the open state
+    await start(
+        {
+            options: {},
+            flagsResponseOverrides: {},
+            url: './playground/cypress/index.html',
+        },
+        page,
+        context
+    )
+    await enableAndOpenConversations(page)
+
+    // Reload the page - conversations should auto-open from persisted state
+    await start(
+        {
+            options: {},
+            flagsResponseOverrides: {
+                conversations: conversationsConfig,
+                ...reloadFlags,
+            },
+            url: './playground/cypress/index.html',
+            type: 'reload',
+        },
+        page,
+        context
+    )
+}
+
+export async function dispatchConversationsOpenedEvent(page: Page) {
+    await page.evaluate(() => {
+        window.dispatchEvent(new CustomEvent('PHConversationsWidgetOpened'))
+    })
+}
+
+export async function displaySurveyWhenLoaded(page: Page, surveyId: string, respectWidgetCoordination = false) {
+    await page.evaluate(
+        ({ id, respect }) => {
+            ;(window as any).posthog.onSurveysLoaded(() => {
+                ;(window as any).posthog.displaySurvey(id, {
+                    displayType: 'popover',
+                    ignoreConditions: true,
+                    respectWidgetCoordination: respect,
+                })
+            })
+        },
+        { id: surveyId, respect: respectWidgetCoordination }
+    )
+}
+
+export const startOptionsWithSurveys: StartOptions = {
+    options: {
+        disable_surveys_automatic_display: true,
+    },
+    flagsResponseOverrides: {
+        surveys: true,
+    },
+    url: './playground/cypress/index.html',
+}
+
+export async function startWithSurveys(
+    page: Page,
+    context: BrowserContext,
+    surveys: Survey[],
+    options: { startOptions?: StartOptions } = {}
+): Promise<void> {
+    const { startOptions = startOptionsWithSurveys } = options
+
+    const surveysApiRoute = page.route('**/surveys/**', async (route) => {
+        await route.fulfill({
+            json: { surveys },
+        })
+    })
+
+    await start(startOptions, page, context)
+    await surveysApiRoute
+}

--- a/packages/browser/playwright/mocked/widget-coordination/widget-coordination.spec.ts
+++ b/packages/browser/playwright/mocked/widget-coordination/widget-coordination.spec.ts
@@ -1,0 +1,388 @@
+import { expect, test } from '../utils/posthog-playwright-test-base'
+import { start } from '../utils/setup'
+import {
+    createPopoverSurvey,
+    createEventTriggeredSurvey,
+    captureEvent,
+    surveyForm,
+    dispatchConversationsOpenedEvent,
+    mockSurveysApi,
+    startWithSurveys,
+    displaySurveyWhenLoaded,
+    enableAndOpenConversations,
+    openConversationsThenReload,
+    conversationsConfig,
+} from './utils'
+import {
+    createTour,
+    createEventTriggeredTour,
+    createBannerStep,
+    tourTooltip,
+    tourContainer,
+    startWithTours,
+    startOptionsWithProductTours,
+    mockProductToursApi,
+} from 'mocked/product-tours/utils'
+
+const startOptionsWithAutoSurveys = {
+    options: {},
+    flagsResponseOverrides: {
+        surveys: true,
+    },
+    url: './playground/cypress/index.html',
+}
+
+const startOptionsWithBothAuto = {
+    options: {
+        disable_product_tours: false,
+    },
+    flagsResponseOverrides: {
+        surveys: true,
+        productTours: true,
+    },
+    url: './playground/cypress/index.html',
+}
+
+test.describe('widget coordination', () => {
+    test.describe('blocking by conversations widget', () => {
+        test('event-triggered tour does not show when conversations widget is already open', async ({
+            page,
+            context,
+        }) => {
+            const tour = createEventTriggeredTour('tour-blocked', 'trigger_tour')
+            const toursApiRoute = mockProductToursApi(page, [tour])
+
+            await start(startOptionsWithProductTours, page, context)
+            await toursApiRoute
+
+            await enableAndOpenConversations(page)
+
+            await captureEvent(page, 'trigger_tour')
+            await page.waitForTimeout(1000)
+
+            await expect(tourTooltip(page, 'tour-blocked')).not.toBeVisible()
+        })
+
+        test('event-triggered survey does not show when conversations widget is already open', async ({
+            page,
+            context,
+        }) => {
+            const survey = createEventTriggeredSurvey('survey-blocked', 'trigger_survey')
+            const surveysApiRoute = mockSurveysApi(page, [survey])
+
+            await start(startOptionsWithAutoSurveys, page, context)
+            await surveysApiRoute
+
+            await enableAndOpenConversations(page)
+
+            await captureEvent(page, 'trigger_survey')
+            await page.waitForTimeout(1000)
+
+            await expect(surveyForm(page, 'survey-blocked')).not.toBeVisible()
+        })
+    })
+
+    test.describe('mutual exclusion (tour/survey)', () => {
+        test('event-triggered tour does not show when survey is already displaying', async ({ page, context }) => {
+            const survey = createPopoverSurvey('survey-first')
+            const tour = createEventTriggeredTour('tour-second', 'trigger_tour')
+
+            const surveysApiRoute = mockSurveysApi(page, [survey])
+            const toursApiRoute = mockProductToursApi(page, [tour])
+
+            await start(startOptionsWithBothAuto, page, context)
+            await surveysApiRoute
+            await toursApiRoute
+
+            await expect(surveyForm(page, 'survey-first')).toBeVisible({ timeout: 5000 })
+
+            await captureEvent(page, 'trigger_tour')
+            await page.waitForTimeout(1000)
+
+            await expect(tourTooltip(page, 'tour-second')).not.toBeVisible()
+        })
+
+        test('event-triggered survey does not show when tour is already displaying', async ({ page, context }) => {
+            const tour = createTour({ id: 'tour-first', auto_launch: true })
+            const survey = createEventTriggeredSurvey('survey-second', 'trigger_survey')
+
+            const surveysApiRoute = mockSurveysApi(page, [survey])
+            const toursApiRoute = mockProductToursApi(page, [tour])
+
+            await start(startOptionsWithBothAuto, page, context)
+            await toursApiRoute
+            await surveysApiRoute
+
+            await expect(tourTooltip(page, 'tour-first')).toBeVisible({ timeout: 5000 })
+
+            await captureEvent(page, 'trigger_survey')
+            await page.waitForTimeout(1000)
+
+            await expect(surveyForm(page, 'survey-second')).not.toBeVisible()
+        })
+    })
+
+    test.describe('auto-dismiss on conversations open', () => {
+        test('active tour is dismissed when conversations widget opens', async ({ page, context }) => {
+            const tour = createTour({ id: 'tour-dismiss', auto_launch: true })
+            await startWithTours(page, context, [tour])
+
+            await expect(tourTooltip(page, 'tour-dismiss')).toBeVisible({ timeout: 5000 })
+
+            await dispatchConversationsOpenedEvent(page)
+
+            await expect(tourTooltip(page, 'tour-dismiss')).not.toBeVisible()
+
+            const events = await page.capturedEvents()
+            const dismissEvent = events.find(
+                (e) =>
+                    e.event === 'product tour dismissed' &&
+                    e.properties?.$product_tour_dismiss_reason === 'widget_conflict'
+            )
+            expect(dismissEvent).toBeTruthy()
+        })
+
+        test('active survey is dismissed when conversations widget opens', async ({ page, context }) => {
+            const survey = createPopoverSurvey('survey-dismiss')
+            const surveysApiRoute = mockSurveysApi(page, [survey])
+
+            await start(startOptionsWithAutoSurveys, page, context)
+            await surveysApiRoute
+
+            await expect(surveyForm(page, 'survey-dismiss')).toBeVisible({ timeout: 5000 })
+
+            await dispatchConversationsOpenedEvent(page)
+
+            await expect(surveyForm(page, 'survey-dismiss')).not.toBeVisible()
+        })
+    })
+
+    test.describe('banner tour exemptions', () => {
+        test('banner tour shows even when conversations widget is open', async ({ page, context }) => {
+            const bannerTour = createTour({
+                id: 'banner-tour',
+                auto_launch: true,
+                steps: [createBannerStep({ contentHtml: '<p>Banner content</p>' })],
+            })
+
+            const toursApiRoute = mockProductToursApi(page, [bannerTour])
+
+            await start(startOptionsWithProductTours, page, context)
+            await toursApiRoute
+
+            await enableAndOpenConversations(page)
+
+            await expect(tourContainer(page, 'banner-tour')).toBeVisible({ timeout: 5000 })
+        })
+
+        test('survey auto-shows while banner tour is active', async ({ page, context }) => {
+            const bannerTour = createTour({
+                id: 'banner-with-survey',
+                auto_launch: true,
+                steps: [createBannerStep({ contentHtml: '<p>Banner content</p>' })],
+            })
+            const survey = createPopoverSurvey('survey-with-banner')
+
+            const toursApiRoute = mockProductToursApi(page, [bannerTour])
+            const surveysApiRoute = mockSurveysApi(page, [survey])
+
+            await start(startOptionsWithBothAuto, page, context)
+            await toursApiRoute
+            await surveysApiRoute
+
+            await expect(tourContainer(page, 'banner-with-survey')).toBeVisible({ timeout: 5000 })
+            await expect(surveyForm(page, 'survey-with-banner')).toBeVisible({ timeout: 5000 })
+        })
+
+        test('banner tour is NOT auto-dismissed when conversations opens', async ({ page, context }) => {
+            const bannerTour = createTour({
+                id: 'banner-persist',
+                auto_launch: true,
+                steps: [createBannerStep({ contentHtml: '<p>Banner content</p>' })],
+            })
+            await startWithTours(page, context, [bannerTour])
+
+            await expect(tourContainer(page, 'banner-persist')).toBeVisible({ timeout: 5000 })
+
+            await dispatchConversationsOpenedEvent(page)
+            await page.waitForTimeout(500)
+
+            await expect(tourContainer(page, 'banner-persist')).toBeVisible()
+        })
+    })
+
+    test.describe('delayed survey coordination', () => {
+        test('delayed survey is cancelled when conversations opens during delay', async ({ page, context }) => {
+            const survey = createPopoverSurvey('delayed-survey', {
+                appearance: { surveyPopupDelaySeconds: 2 },
+            })
+
+            const surveysApiRoute = mockSurveysApi(page, [survey])
+
+            await start(startOptionsWithAutoSurveys, page, context)
+            await surveysApiRoute
+
+            await expect(surveyForm(page, 'delayed-survey')).not.toBeVisible()
+
+            await page.waitForTimeout(500)
+            await dispatchConversationsOpenedEvent(page)
+
+            await page.waitForTimeout(2000)
+
+            await expect(surveyForm(page, 'delayed-survey')).not.toBeVisible()
+        })
+    })
+
+    test.describe('programmatic display', () => {
+        test('programmatic survey display ignores coordination by default', async ({ page, context }) => {
+            const survey = createPopoverSurvey('survey-programmatic')
+
+            await startWithSurveys(page, context, [survey])
+
+            await enableAndOpenConversations(page)
+
+            await displaySurveyWhenLoaded(page, 'survey-programmatic', false)
+
+            await expect(surveyForm(page, 'survey-programmatic')).toBeVisible()
+        })
+
+        test('programmatic survey display respects coordination when opted in', async ({ page, context }) => {
+            const survey = createPopoverSurvey('survey-coordinated')
+
+            await startWithSurveys(page, context, [survey])
+
+            await enableAndOpenConversations(page)
+
+            await displaySurveyWhenLoaded(page, 'survey-coordinated', true)
+
+            await page.waitForTimeout(1000)
+            await expect(surveyForm(page, 'survey-coordinated')).not.toBeVisible()
+        })
+
+        test('programmatic tour display is blocked when conversations panel is open', async ({ page, context }) => {
+            const tour = createTour({ id: 'tour-programmatic', auto_launch: false })
+
+            await startWithTours(page, context, [tour])
+
+            await enableAndOpenConversations(page)
+
+            await page.evaluate(() => (window as any).posthog.productTours.showProductTour('tour-programmatic'))
+
+            await expect(tourTooltip(page, 'tour-programmatic')).not.toBeVisible({ timeout: 5000 })
+        })
+    })
+
+    test.describe('startup coordination', () => {
+        test('survey is blocked when conversations auto-opens from persisted state', async ({ page, context }) => {
+            const survey = createPopoverSurvey('survey-startup-blocked')
+            const surveysApiRoute = mockSurveysApi(page, [survey])
+
+            await openConversationsThenReload(page, context, { surveys: true })
+
+            await surveysApiRoute
+            await page.waitForTimeout(2000)
+
+            await expect(surveyForm(page, 'survey-startup-blocked')).not.toBeVisible()
+        })
+
+        test('survey shows normally when conversations is ready but not open', async ({ page, context }) => {
+            const survey = createPopoverSurvey('survey-startup-allowed')
+            const surveysApiRoute = mockSurveysApi(page, [survey])
+
+            await start(
+                {
+                    options: {},
+                    flagsResponseOverrides: {
+                        surveys: true,
+                        conversations: conversationsConfig,
+                    },
+                    url: './playground/cypress/index.html',
+                },
+                page,
+                context
+            )
+
+            await surveysApiRoute
+
+            await expect(surveyForm(page, 'survey-startup-allowed')).toBeVisible({ timeout: 5000 })
+        })
+
+        test('tour is blocked when conversations auto-opens from persisted state', async ({ page, context }) => {
+            const tour = createTour({ id: 'tour-startup-blocked', auto_launch: true })
+            const toursApiRoute = mockProductToursApi(page, [tour])
+
+            await openConversationsThenReload(page, context, { productTours: true })
+
+            await toursApiRoute
+            await page.waitForTimeout(2000)
+
+            await expect(tourTooltip(page, 'tour-startup-blocked')).not.toBeVisible()
+        })
+
+        test('survey shows when conversations is disabled via config', async ({ page, context }) => {
+            const survey = createPopoverSurvey('survey-convos-disabled')
+            const surveysApiRoute = mockSurveysApi(page, [survey])
+
+            await start(
+                {
+                    options: {
+                        disable_conversations: true,
+                    },
+                    flagsResponseOverrides: {
+                        surveys: true,
+                    },
+                    url: './playground/cypress/index.html',
+                },
+                page,
+                context
+            )
+
+            await surveysApiRoute
+
+            await expect(surveyForm(page, 'survey-convos-disabled')).toBeVisible({ timeout: 5000 })
+        })
+
+        test('survey shows when conversations is not in remote config', async ({ page, context }) => {
+            const survey = createPopoverSurvey('survey-no-convos-config')
+            const surveysApiRoute = mockSurveysApi(page, [survey])
+
+            await start(
+                {
+                    options: {},
+                    flagsResponseOverrides: {
+                        surveys: true,
+                    },
+                    url: './playground/cypress/index.html',
+                },
+                page,
+                context
+            )
+
+            await surveysApiRoute
+
+            await expect(surveyForm(page, 'survey-no-convos-config')).toBeVisible({ timeout: 5000 })
+        })
+
+        test('survey shows when conversations is explicitly disabled in remote config', async ({ page, context }) => {
+            const survey = createPopoverSurvey('survey-convos-false')
+            const surveysApiRoute = mockSurveysApi(page, [survey])
+
+            await start(
+                {
+                    options: {},
+                    flagsResponseOverrides: {
+                        surveys: true,
+                        conversations: false,
+                    },
+                    url: './playground/cypress/index.html',
+                },
+                page,
+                context
+            )
+
+            await surveysApiRoute
+
+            await expect(surveyForm(page, 'survey-convos-false')).toBeVisible({ timeout: 5000 })
+        })
+    })
+})

--- a/packages/browser/src/__tests__/helpers/posthog-instance.ts
+++ b/packages/browser/src/__tests__/helpers/posthog-instance.ts
@@ -66,6 +66,10 @@ export const createMockPostHog = (overrides: Partial<PostHog> = {}): PostHog =>
         get_distinct_id: () => 'test-distinct-id',
         capture: jest.fn(),
         _send_request: jest.fn(),
+        conversations: {
+            isReady: () => true,
+            isWidgetOpen: () => false,
+        },
         ...overrides,
     }) as PostHog
 

--- a/packages/browser/src/extensions/conversations/external/index.tsx
+++ b/packages/browser/src/extensions/conversations/external/index.tsx
@@ -520,6 +520,8 @@ export class ConversationsManager implements ConversationsManagerInterface {
 
         // Mark messages as read when widget opens
         if (state === 'open') {
+            window?.dispatchEvent(new CustomEvent('PHConversationsWidgetOpened'))
+
             if (this._unreadCount > 0 && this._currentTicketId) {
                 this._markMessagesAsRead()
             }
@@ -717,6 +719,13 @@ export class ConversationsManager implements ConversationsManagerInterface {
      */
     isVisible(): boolean {
         return this._isWidgetRendered
+    }
+
+    /**
+     * Check if the chat widget pane is currently open (expanded)
+     */
+    isWidgetOpen(): boolean {
+        return this._isWidgetOpen()
     }
 
     /** Get tickets list for the current widget session */

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -145,6 +145,7 @@ export type ProductTourDismissReason =
     | 'escape_key'
     | 'element_unavailable'
     | 'container_unavailable'
+    | 'widget_conflict'
 
 export type ProductTourRenderReason = 'auto' | 'api' | 'trigger' | 'event'
 

--- a/packages/browser/src/posthog-product-tours.ts
+++ b/packages/browser/src/posthog-product-tours.ts
@@ -22,6 +22,7 @@ interface ProductTourManagerInterface {
     resetTour: (tourId: string) => void
     resetAllTours: () => void
     cancelPendingTour: (tourId: string) => void
+    hasActiveTour: () => boolean
 }
 
 const isProductToursEnabled = (instance: PostHog): boolean => {
@@ -173,5 +174,11 @@ export class PostHogProductTours {
 
     cancelPendingTour(tourId: string): void {
         this._productTourManager?.cancelPendingTour(tourId)
+    }
+
+    // the underlying implementation excludes banners, so this will
+    // return false even if a banner is active.
+    hasActiveTour(): boolean {
+        return this._productTourManager?.hasActiveTour?.() ?? false
     }
 }

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -300,6 +300,12 @@ interface DisplaySurveyOptionsBase {
     properties?: Properties
     /** Pre-filled responses by question index (0-based) */
     initialResponses?: Record<number, SurveyResponseValue>
+    /**
+     * If true, respects widget coordination rules (won't show if conversations widget
+     * is open or a tour is active). Defaults to false - programmatic display assumes
+     * the caller knows what they're doing.
+     */
+    respectWidgetCoordination?: boolean
 }
 
 export interface DisplaySurveyPopoverOptions extends DisplaySurveyOptionsBase {

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -20,6 +20,7 @@ import {
     SURVEY_IN_PROGRESS_PREFIX,
     SURVEY_SEEN_PREFIX,
 } from './utils/survey-utils'
+import { canShowSurvey } from './utils/widget-lock'
 import { isNullish, isUndefined, isArray } from '@posthog/core'
 
 export class PostHogSurveys {
@@ -405,6 +406,10 @@ export class PostHogSurveys {
             this.renderSurvey(surveyToDisplay, options.selector, options.properties)
             return
         }
+        if (options.respectWidgetCoordination && !canShowSurvey(this._instance)) {
+            logger.info('Survey blocked by widget coordination (conversations open or tour active)')
+            return
+        }
         this._surveyManager.handlePopoverSurvey(surveyToDisplay, options)
     }
 
@@ -418,5 +423,9 @@ export class PostHogSurveys {
 
     handlePageUnload(): void {
         this._surveyManager?.handlePageUnload()
+    }
+
+    hasSurveyInFocus(): boolean {
+        return this._surveyManager?.hasSurveyInFocus?.() ?? false
     }
 }

--- a/packages/browser/src/utils/globals.ts
+++ b/packages/browser/src/utils/globals.ts
@@ -201,6 +201,7 @@ export interface LazyLoadedConversationsInterface {
     show: () => void
     hide: () => void
     isVisible: () => boolean
+    isWidgetOpen: () => boolean
 
     // Lifecycle
     reset: () => void

--- a/packages/browser/src/utils/widget-lock.ts
+++ b/packages/browser/src/utils/widget-lock.ts
@@ -1,0 +1,27 @@
+import type { PostHog } from '../posthog-core'
+
+/**
+ * lightweight in-app widget coordinator
+ *
+ * current implementation rules:
+ * - tours and surveys cannot render if the conversations chat pane is open
+ * - tours and surveys are dismissed if the conversations chat pane becomes open
+ * - tours and surveys cannot render at the same time
+ * - banner "tours" are exempt from all of the above (not blocked, not blocking, and no auto-dismiss)
+ */
+
+export function canShowSurvey(posthog: PostHog): boolean {
+    if (!posthog.conversations?.isReady()) return false
+
+    const widgetOpen = posthog.conversations?.isWidgetOpen?.() ?? false
+    const tourActive = posthog.productTours?.hasActiveTour?.() ?? false
+    return !widgetOpen && !tourActive
+}
+
+export function canShowTour(posthog: PostHog): boolean {
+    if (!posthog.conversations?.isReady()) return false
+
+    const widgetOpen = posthog.conversations?.isWidgetOpen?.() ?? false
+    const surveyActive = posthog.surveys?.hasSurveyInFocus?.() ?? false
+    return !widgetOpen && !surveyActive
+}

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -212,6 +212,7 @@
         "_inputRef",
         "_internalEventEmitter",
         "_internalFlagCheckSatisfied",
+        "_isBannerTour",
         "_isBelowMinimumDuration",
         "_isCalled",
         "_isConsoleLogCaptureEnabled",


### PR DESCRIPTION
## Problem

see https://github.com/PostHog/requests-for-comments-internal/pull/968

tl;dr we need to ensure there are no unexpected conflicts between tours, surveys, and conversations

this is _not_ the ideal long-term solution, the rfc covers that, but this does at least ensure we don't break things in the meantime

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

adds new lightweight "widget coordinator" logic:
- tours and surveys are blocked from rendering if the conversation chat pane is expanded
- tours and surveys are auto-dismissed if the conversation chat pane becomes open
- tours and surveys cannot render at the same time
- banners are exempt from all of the above (not blocked, non-blocking, no auto-dismiss)

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
