### PR TITLE
feat(surveys): add shown tracking to useThumbSurvey

### DIFF
--- a/.changeset/common-ghosts-help.md
+++ b/.changeset/common-ghosts-help.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/react': patch
+---
+
+add survey shown tracking to useThumbSurvey + option to disable shown tracking in displaySurvey

--- a/packages/browser/src/__tests__/extensions/surveys/survey-popup.test.tsx
+++ b/packages/browser/src/__tests__/extensions/surveys/survey-popup.test.tsx
@@ -301,4 +301,42 @@ describe('SurveyPopup', () => {
         )
         expect(screen.getByRole('textbox')).toBeVisible()
     })
+
+    describe('survey shown event', () => {
+        test('emits survey shown event on mount by default', async () => {
+            render(
+                <SurveyPopup
+                    survey={mockSurvey}
+                    removeSurveyFromFocus={mockRemoveSurveyFromFocus}
+                    posthog={mockPosthog as any}
+                />
+            )
+
+            await waitFor(() => {
+                expect(mockPosthog.capture).toHaveBeenCalledWith(
+                    'survey shown',
+                    expect.objectContaining({
+                        $survey_id: mockSurvey.id,
+                        $survey_name: mockSurvey.name,
+                    })
+                )
+            })
+        })
+
+        test('does not emit survey shown event when skipShownEvent is true', async () => {
+            render(
+                <SurveyPopup
+                    survey={mockSurvey}
+                    removeSurveyFromFocus={mockRemoveSurveyFromFocus}
+                    posthog={mockPosthog as any}
+                    skipShownEvent={true}
+                />
+            )
+
+            // Give it a tick to run the effect
+            await new Promise((resolve) => setTimeout(resolve, 0))
+
+            expect(mockPosthog.capture).not.toHaveBeenCalledWith('survey shown', expect.anything())
+        })
+    })
 })

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -308,6 +308,8 @@ export interface DisplaySurveyPopoverOptions extends DisplaySurveyOptionsBase {
     position?: SurveyPosition
     /** CSS selector for the element to position the survey next to (when position is NextToTrigger) */
     selector?: string
+    /** When true, `survey shown` events will not be emitted automatically */
+    skipShownEvent?: boolean
 }
 
 interface DisplaySurveyInlineOptions extends DisplaySurveyOptionsBase {

--- a/packages/react/src/hooks/__tests__/useThumbSurvey.test.tsx
+++ b/packages/react/src/hooks/__tests__/useThumbSurvey.test.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { PostHogProvider, PostHog } from '../../context'
+import { useThumbSurvey } from '../useThumbSurvey'
+import { SurveyEventName, SurveyEventProperties } from 'posthog-js'
+import { isUndefined } from '../../utils/type-utils'
+
+jest.useFakeTimers()
+
+describe('useThumbSurvey hook', () => {
+    let posthog: PostHog
+    let captureMock: jest.Mock
+    let displaySurveyMock: jest.Mock
+    let wrapper: React.FC<{ children: React.ReactNode }>
+
+    beforeEach(() => {
+        captureMock = jest.fn()
+        displaySurveyMock = jest.fn()
+
+        posthog = {
+            capture: captureMock,
+            get_session_replay_url: () => 'https://app.posthog.com/replay/123',
+            surveys: { displaySurvey: displaySurveyMock },
+        } as unknown as PostHog
+
+        wrapper = ({ children }) => <PostHogProvider client={posthog}>{children}</PostHogProvider>
+    })
+
+    describe('survey shown tracking', () => {
+        it.each([
+            [false, true, false], // disableAutoShownTracking, shouldAutoTrack, shouldExposeTrackShown
+            [true, false, true],
+        ])(
+            'disableAutoShownTracking=%s: auto-tracks=%s, exposes trackShown=%s',
+            (disableAutoShownTracking, shouldAutoTrack, shouldExposeTrackShown) => {
+                const { result } = renderHook(
+                    () => useThumbSurvey({ surveyId: 'test-survey', disableAutoShownTracking }),
+                    { wrapper }
+                )
+
+                expect(captureMock).toHaveBeenCalledTimes(shouldAutoTrack ? 1 : 0)
+                expect(!isUndefined(result.current.trackShown)).toBe(shouldExposeTrackShown)
+            }
+        )
+
+        it('should only emit survey shown once when trackShown is called multiple times', () => {
+            const { result } = renderHook(
+                () => useThumbSurvey({ surveyId: 'test-survey', disableAutoShownTracking: true }),
+                { wrapper }
+            )
+
+            act(() => {
+                result.current.trackShown?.()
+                result.current.trackShown?.()
+            })
+
+            expect(captureMock).toHaveBeenCalledTimes(1)
+            expect(captureMock).toHaveBeenCalledWith(SurveyEventName.SHOWN, {
+                [SurveyEventProperties.SURVEY_ID]: 'test-survey',
+                sessionRecordingUrl: 'https://app.posthog.com/replay/123',
+            })
+        })
+    })
+
+    describe('respond', () => {
+        it.each([
+            ['up', 1],
+            ['down', 2],
+        ] as const)('respond("%s") calls displaySurvey with initialResponses: { 0: %d }', (value, expectedResponse) => {
+            const { result } = renderHook(() => useThumbSurvey({ surveyId: 'test-survey' }), { wrapper })
+
+            act(() => {
+                result.current.respond(value)
+            })
+
+            expect(displaySurveyMock).toHaveBeenCalledWith(
+                'test-survey',
+                expect.objectContaining({ initialResponses: { 0: expectedResponse } })
+            )
+        })
+
+        it('should only allow one response', () => {
+            const { result } = renderHook(() => useThumbSurvey({ surveyId: 'test-survey' }), { wrapper })
+
+            act(() => {
+                result.current.respond('up')
+                result.current.respond('down')
+            })
+
+            expect(displaySurveyMock).toHaveBeenCalledTimes(1)
+            expect(result.current.response).toBe('up')
+        })
+
+        it('should call onResponse callback', () => {
+            const onResponse = jest.fn()
+            const { result } = renderHook(() => useThumbSurvey({ surveyId: 'test-survey', onResponse }), { wrapper })
+
+            act(() => {
+                result.current.respond('down')
+            })
+
+            expect(onResponse).toHaveBeenCalledWith('down')
+        })
+    })
+})


### PR DESCRIPTION
## Problem
the `useThumbSurvey` never tracks `survey shown` events if there is no follow-up.

we might want to know when these surveys were "shown" in the UI.

particularly for LLMA, we want to be able to say "user saw the survey, but did not answer."

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
adds automatic `survey shown` tracking on mount for `useThumbSurvey`, with an option to `disableAutoShownTracking` and optionally manually call `trackShown` instead

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
