### PR TITLE
chore(product tours): unify element+modal steps

### DIFF
--- a/.changeset/wild-moons-type.md
+++ b/.changeset/wild-moons-type.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+unify element<>modal steps for product tours, deprecate element steps

--- a/packages/browser/playwright/mocked/product-tours/utils.ts
+++ b/packages/browser/playwright/mocked/product-tours/utils.ts
@@ -52,9 +52,13 @@ export function createTour(overrides: Partial<ProductTour> = {}): ProductTour {
     }
 }
 
-export function createElementStep(selector: string, overrides: Partial<ProductTourStep> = {}): ProductTourStep {
+export function createElementStep(
+    selector: string,
+    overrides: Partial<ProductTourStep> = {},
+    asModal?: boolean
+): ProductTourStep {
     return createStep({
-        type: 'element',
+        type: asModal ? 'modal' : 'element',
         selector,
         useManualSelector: true,
         ...overrides,

--- a/packages/browser/src/extensions/product-tours/components/ProductTourTooltip.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourTooltip.tsx
@@ -14,6 +14,7 @@ import {
     TooltipDimensions,
     PositionResult,
     findStepElement,
+    hasElementTarget,
 } from '../product-tours-utils'
 import { getPopoverPosition } from '../../surveys/surveys-extension-utils'
 import { addEventListener } from '../../../utils'
@@ -128,8 +129,8 @@ export function ProductTourTooltip({
     const isTransitioningRef = useRef(false)
     const resolvedElementRef = useRef<HTMLElement | null>(targetElement)
 
-    // Modal and survey steps use screen positioning (not anchored to an element)
-    const isScreenPositioned = displayedStep.type === 'modal' || displayedStep.type === 'survey'
+    // Steps without element targeting use screen positioning
+    const isScreenPositioned = !hasElementTarget(displayedStep) || displayedStep.type === 'survey'
 
     useLayoutEffect(() => {
         resolvedElementRef.current = targetElement
@@ -168,8 +169,8 @@ export function ProductTourTooltip({
         }
 
         const enterStep = () => {
-            // Only scroll/position for element steps
-            if (resolvedElementRef.current && step.type === 'element') {
+            // Only scroll/position for steps with element targeting
+            if (resolvedElementRef.current && hasElementTarget(step)) {
                 if (!resolvedElementRef.current.isConnected) {
                     resolvedElementRef.current = findStepElement(step).element
                 }
@@ -201,8 +202,8 @@ export function ProductTourTooltip({
         setTimeout(() => {
             if (previousStepRef.current !== currentStepIndex) return
 
-            // Reset position for element steps to prevent flash at old position
-            if (step.type === 'element') {
+            // Reset position for element-targeted steps to prevent flash at old position
+            if (hasElementTarget(step)) {
                 setPosition(null)
                 setSpotlightStyle(null)
                 setIsMeasured(false)

--- a/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourTooltipInner.tsx
@@ -1,6 +1,6 @@
 import { h } from 'preact'
 import { ProductTourStep, ProductTourAppearance, ProductTourStepButton } from '../../../posthog-product-tours-types'
-import { getStepHtml } from '../product-tours-utils'
+import { getStepHtml, hasElementTarget } from '../product-tours-utils'
 import { IconPosthogLogo, cancelSVG } from '../../surveys/icons'
 
 interface TourButtonProps {
@@ -58,7 +58,7 @@ export function ProductTourTooltipInner({
     const whiteLabel = appearance?.whiteLabel ?? false
     const isLastStep = stepIndex >= totalSteps - 1
     const isFirstStep = stepIndex === 0
-    const showDefaultButtons = !step.buttons && (step.progressionTrigger === 'button' || step.type === 'modal')
+    const showDefaultButtons = !step.buttons && (step.progressionTrigger === 'button' || !hasElementTarget(step))
     const hasCustomButtons = !!step.buttons
 
     const isInteractive = !!(onNext || onPrevious || onDismiss || onButtonClick)

--- a/packages/browser/src/extensions/product-tours/preview.tsx
+++ b/packages/browser/src/extensions/product-tours/preview.tsx
@@ -5,7 +5,7 @@ import { document as _document } from '../../utils/globals'
 import { ProductTourBanner } from './components/ProductTourBanner'
 import { ProductTourSurveyStepInner } from './components/ProductTourSurveyStepInner'
 import { ProductTourTooltipInner } from './components/ProductTourTooltipInner'
-import { getProductTourStylesheet, addProductTourCSSVariablesToElement } from './product-tours-utils'
+import { getProductTourStylesheet, addProductTourCSSVariablesToElement, hasElementTarget } from './product-tours-utils'
 
 const document = _document as Document
 
@@ -43,7 +43,7 @@ export function renderProductTourPreview({
 
     const isSurveyStep = step.type === 'survey'
     const isBannerStep = step.type === 'banner'
-    const isModal = step.type === 'modal'
+    const isModal = !hasElementTarget(step)
     const tooltipClass = `ph-tour-tooltip${isModal ? ' ph-tour-tooltip--modal' : ''}${isSurveyStep ? ' ph-tour-survey-step' : ''}`
 
     if (isBannerStep) {

--- a/packages/browser/src/extensions/product-tours/product-tours-utils.ts
+++ b/packages/browser/src/extensions/product-tours/product-tours-utils.ts
@@ -28,6 +28,13 @@ export interface ElementFindResult {
     matchCount: number
 }
 
+export function hasElementTarget(step: ProductTourStep): boolean {
+    if (step.useManualSelector) {
+        return !!step.selector
+    }
+    return !!step.inferenceData
+}
+
 export function findElementBySelector(selector: string): ElementFindResult {
     try {
         const elements = document.querySelectorAll(selector)

--- a/packages/browser/src/extensions/product-tours/product-tours.tsx
+++ b/packages/browser/src/extensions/product-tours/product-tours.tsx
@@ -15,6 +15,7 @@ import {
     findStepElement,
     getElementMetadata,
     getProductTourStylesheet,
+    hasElementTarget,
     normalizeUrl,
 } from './product-tours-utils'
 import { ProductTourTooltip } from './components/ProductTourTooltip'
@@ -633,13 +634,13 @@ export class ProductTourManager {
             return false
         }
 
-        // Modal step (no selector) - render without a target element
-        if (step.type === 'modal') {
+        // Screen-positioned step (no element targeting) - render without a target element
+        if (!hasElementTarget(step)) {
             this._captureEvent('product tour step shown', {
                 $product_tour_id: this._activeTour.id,
                 $product_tour_step_id: step.id,
                 $product_tour_step_order: this._currentStepIndex,
-                $product_tour_step_type: 'modal',
+                $product_tour_step_type: step.type,
             })
 
             this._isResuming = false


### PR DESCRIPTION
## Problem

"element steps" vs. "modal steps" is confusing, and unnecessary

https://github.com/PostHog/posthog/pull/46347 unifies these two concepts in the main app

we need to do the same in the SDK!

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

unifies "modal"+"element" steps, effectively deprecating "element" steps, in favor of modal steps which may or may not have element targets

backwards compatible because we now check "has element target", which returns the expected value for the old structure of modal/element steps, but needs to be deployed before https://github.com/PostHog/posthog/pull/46347

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->