### PR TITLE
fix(err): fix console errors capturing

### DIFF
--- a/.changeset/neat-chairs-yell.md
+++ b/.changeset/neat-chairs-yell.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/core': patch
+---
+
+fix(err): fix console error capturing

--- a/examples/example-nextjs/pnpm-lock.yaml
+++ b/examples/example-nextjs/pnpm-lock.yaml
@@ -12,13 +12,13 @@ importers:
     dependencies:
       '@posthog/nextjs-config':
         specifier: file:../../target/posthog-nextjs-config.tgz
-        version: file:../../target/posthog-nextjs-config.tgz(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(webpack@5.103.0)
+        version: file:../../target/posthog-nextjs-config.tgz(next@15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(webpack@5.103.0)
       '@posthog/react':
         specifier: file:../../target/posthog-react.tgz
         version: file:../../target/posthog-react.tgz(@types/react@19.2.7)(posthog-js@file:../../target/posthog-js.tgz)(react@19.2.3)
       next:
         specifier: ^15
-        version: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       posthog-js:
         specifier: file:../../target/posthog-js.tgz
         version: file:../../target/posthog-js.tgz
@@ -373,25 +373,97 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@posthog/cli@0.5.17':
-    resolution: {integrity: sha512-PHwUEBNxIZvR4h/v2fJF2WciHW4nEpOInv/AIR+SjCjnkSaxtScaDrGtJ7NEITB/FYYxQOU51bYca9bK780xUQ==}
+  '@opentelemetry/api-logs@0.208.0':
+    resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.2.0':
+    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.5.0':
+    resolution: {integrity: sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0':
+    resolution: {integrity: sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.208.0':
+    resolution: {integrity: sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.208.0':
+    resolution: {integrity: sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.2.0':
+    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.5.0':
+    resolution: {integrity: sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.208.0':
+    resolution: {integrity: sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.2.0':
+    resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.2.0':
+    resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.39.0':
+    resolution: {integrity: sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==}
+    engines: {node: '>=14'}
+
+  '@posthog/cli@0.5.26':
+    resolution: {integrity: sha512-X3k2jtSaR7CGghcBlduU2qZdqu8iSYmMx/Uy2XxJCXCsnyiD/jcuNSwUrH2y3IbNPmxb0kTWKEtcR+HCvP/zcg==}
     engines: {node: '>=14', npm: '>=6'}
     hasBin: true
 
   '@posthog/core@file:../../target/posthog-core.tgz':
-    resolution: {integrity: sha512-jtTmi1dPAcGA50p5iBhMS887gQ0UZJ3caByjEVAA65VDYlDIOzlkbauCU62V3UFO5ybGAzTbsfHxQcX3exA1Lw==, tarball: file:../../target/posthog-core.tgz}
-    version: 1.8.1
+    resolution: {integrity: sha512-wxrlnk/kYric1q9/NqK1YlEvOaJCpaJ3gNVlsWSkQczRts53j0BRY9wSIMTSFFU2FdiNGYrQcV4lhlBw69o13w==, tarball: file:../../target/posthog-core.tgz}
+    version: 1.20.0
 
   '@posthog/nextjs-config@file:../../target/posthog-nextjs-config.tgz':
-    resolution: {integrity: sha512-Xvl4u8dNFOd+dC+1ZlZMZhYFKwsH5zPQtIwYuYi8iuHhXq7/l3q2/eqA8itoKWM0+YAGmqHQFpwARI5C/iXupQ==, tarball: file:../../target/posthog-nextjs-config.tgz}
-    version: 1.7.3
-    engines: {node: '>=20'}
+    resolution: {integrity: sha512-eWojFZv1f0jj1hJseusDK/I6EgskvIyoOU0gAjUFu3/vu9xFKu02xHa3cjwjiNAWssVLoYwwrSWp2XTklEiggA==, tarball: file:../../target/posthog-nextjs-config.tgz}
+    version: 1.8.11
+    engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       next: '>12.1.0'
 
   '@posthog/react@file:../../target/posthog-react.tgz':
-    resolution: {integrity: sha512-2oPbBodzBM0Ei86KHTRt9i1MW/bscMiWQWF/zSNVJbqkXCgH3yFirMhO0VGzBXcZrWKy4bmpx6NN5A1jWHEKtg==, tarball: file:../../target/posthog-react.tgz}
-    version: 1.5.2
+    resolution: {integrity: sha512-5TJWEsVPXNmAqQ6qYyswLxHXrBEMGEVrwCZMAJ4IMq/j4t+bDFhRN1B+84V29V9EeSRTelxaNBl2/jbN1ZpodQ==, tarball: file:../../target/posthog-react.tgz}
+    version: 1.7.0
     peerDependencies:
       '@types/react': '>=16.8.0'
       posthog-js: '>=1.257.2'
@@ -400,11 +472,45 @@ packages:
       '@types/react':
         optional: true
 
+  '@posthog/types@file:../../target/posthog-types.tgz':
+    resolution: {integrity: sha512-k4q6m9VNtG4BmH+ekrJXrnqlSSaONcZek5+7ze6GUnuYzOFnVWLIWPZQSbbHFkbf7EnOO+bL4ORIbfy+avJ6oA==, tarball: file:../../target/posthog-types.tgz}
+    version: 1.341.0
+
   '@posthog/webpack-plugin@file:../../target/posthog-webpack-plugin.tgz':
-    resolution: {integrity: sha512-Bjy1u/2J3lq6jAoCfMK/B7HAYMoS/dcj6Z5eCBIKKux4P+aINjiXeWdstiI3gljOzxofl8VezIa9BQNh5J+0VA==, tarball: file:../../target/posthog-webpack-plugin.tgz}
-    version: 1.2.3
+    resolution: {integrity: sha512-DOnDS1KZ19invYgkBp6Xi7T5kslygYDoY7Gi5gM6P/rBralYp5S6JQw8QhU3CZ7Ec8Ai/8hWdELabwBXEmWusA==, tarball: file:../../target/posthog-webpack-plugin.tgz}
+    version: 1.2.17
     peerDependencies:
       webpack: ^5
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -443,6 +549,9 @@ packages:
 
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@8.49.0':
     resolution: {integrity: sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==}
@@ -910,6 +1019,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dompurify@3.3.1:
+    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1444,6 +1556,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1626,16 +1741,16 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
 
   posthog-js@file:../../target/posthog-js.tgz:
-    resolution: {integrity: sha512-wPfrZRfGQMHoZ8Us/YmPfZM8NMm+3bR1/i+SorSXRcY3d3O+WuOocJ0kH3yIykl+h0uZNH8eJ9Jt3pNpM938tg==, tarball: file:../../target/posthog-js.tgz}
-    version: 1.309.1
+    resolution: {integrity: sha512-4KajrVPx6eSGZn3M4fVuuRxHfLU2rhoq2s3W03+wQHwqo9d/chYjZcWQsc/A0QkzSmtBkQKJIHF/aWCSqOBGHA==, tarball: file:../../target/posthog-js.tgz}
+    version: 1.341.0
 
   posthog-node@file:../../target/posthog-node.tgz:
-    resolution: {integrity: sha512-sgf6fFhmNJSPhOEXdicFTBuVTQHFfmZGsmqTtOu7j92INJB9rcgkqIDoU9w2tx7MJc+LacJPRKYz3KWOSmvvnQ==, tarball: file:../../target/posthog-node.tgz}
-    version: 5.17.4
-    engines: {node: '>=20'}
+    resolution: {integrity: sha512-V466mRrWViehXr3fhqHn9GobL8OEZyNRHjlCVGgjU7IPlxWT9gzGHWsf1KYpgV0ZgKxxb8CxBHp+Tv8GnSZGWw==, tarball: file:../../target/posthog-node.tgz}
+    version: 5.24.10
+    engines: {node: ^20.20.0 || >=22.22.0}
 
-  preact@10.28.0:
-    resolution: {integrity: sha512-rytDAoiXr3+t6OIP3WGlDd0ouCUG1iCWzkcY3++Nreuoi17y6T5i/zRhe6uYfoVcxq6YU+sBtJouuRDsq8vvqA==}
+  preact@10.28.3:
+    resolution: {integrity: sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1644,12 +1759,19 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -1957,8 +2079,8 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
-  web-vitals@4.2.4:
-    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
+  web-vitals@5.1.0:
+    resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
@@ -2251,7 +2373,83 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@posthog/cli@0.5.17':
+  '@opentelemetry/api-logs@0.208.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
+      protobufjs: 7.5.4
+
+  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/resources@2.5.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.39.0
+
+  '@opentelemetry/semantic-conventions@1.39.0': {}
+
+  '@posthog/cli@0.5.26':
     dependencies:
       axios: 1.13.2
       axios-proxy-builder: 0.1.2
@@ -2265,12 +2463,12 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@posthog/nextjs-config@file:../../target/posthog-nextjs-config.tgz(next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(webpack@5.103.0)':
+  '@posthog/nextjs-config@file:../../target/posthog-nextjs-config.tgz(next@15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(webpack@5.103.0)':
     dependencies:
-      '@posthog/cli': 0.5.17
+      '@posthog/cli': 0.5.26
       '@posthog/core': file:../../target/posthog-core.tgz
       '@posthog/webpack-plugin': file:../../target/posthog-webpack-plugin.tgz(webpack@5.103.0)
-      next: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       semver: 7.7.3
     transitivePeerDependencies:
       - debug
@@ -2283,13 +2481,38 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@posthog/types@file:../../target/posthog-types.tgz': {}
+
   '@posthog/webpack-plugin@file:../../target/posthog-webpack-plugin.tgz(webpack@5.103.0)':
     dependencies:
-      '@posthog/cli': 0.5.17
+      '@posthog/cli': 0.5.26
       '@posthog/core': file:../../target/posthog-core.tgz
       webpack: 5.103.0
     transitivePeerDependencies:
       - debug
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -2331,6 +2554,9 @@ snapshots:
   '@types/react@19.2.7':
     dependencies:
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3)':
     dependencies:
@@ -2838,6 +3064,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.3.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3518,6 +3748,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  long@5.3.2: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -3567,7 +3799,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 15.5.9
       '@swc/helpers': 0.5.15
@@ -3585,6 +3817,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.7
       '@next/swc-win32-arm64-msvc': 15.5.7
       '@next/swc-win32-x64-msvc': 15.5.7
+      '@opentelemetry/api': 1.9.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -3690,17 +3923,25 @@ snapshots:
 
   posthog-js@file:../../target/posthog-js.tgz:
     dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@posthog/core': file:../../target/posthog-core.tgz
+      '@posthog/types': file:../../target/posthog-types.tgz
       core-js: 3.47.0
+      dompurify: 3.3.1
       fflate: 0.4.8
-      preact: 10.28.0
-      web-vitals: 4.2.4
+      preact: 10.28.3
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.1.0
 
   posthog-node@file:../../target/posthog-node.tgz:
     dependencies:
       '@posthog/core': file:../../target/posthog-core.tgz
 
-  preact@10.28.0: {}
+  preact@10.28.3: {}
 
   prelude-ls@1.2.1: {}
 
@@ -3710,9 +3951,26 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 20.19.26
+      long: 5.3.2
+
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -4123,7 +4381,7 @@ snapshots:
       defaults: 1.0.4
     optional: true
 
-  web-vitals@4.2.4: {}
+  web-vitals@5.1.0: {}
 
   webpack-sources@3.3.3: {}
 

--- a/examples/example-nextjs/src/app/page.tsx
+++ b/examples/example-nextjs/src/app/page.tsx
@@ -21,7 +21,21 @@ export default function Home() {
                     }}
                 >
                     <button onClick={() => posthog.captureException(new Error('exception captured'))}>
-                        Create client exception!
+                        Capture error manually
+                    </button>
+                    <button
+                        onClick={() => {
+                            throw new Error('exception captured')
+                        }}
+                    >
+                        Capture error automatically
+                    </button>
+                    <button
+                        onClick={() => {
+                            Promise.reject(new Error('promise rejection captured'))
+                        }}
+                    >
+                        Capture promise rejection automatically
                     </button>
                     <button onClick={() => captureServerError()}>Create server exception!</button>
                     <button
@@ -33,15 +47,7 @@ export default function Home() {
                     >
                         Create custom fingerprint!
                     </button>
-                    <button
-                        onClick={() =>
-                            console.warn(
-                                'a really long string that exceeds the maximum length of a log message and is longer than the maximum length of a log message and is longer than the maximum length of a log message'
-                            )
-                        }
-                    >
-                        Log something large
-                    </button>
+                    <button onClick={() => console.error('This is an error message')}>Error log something</button>
                 </div>
             </main>
         </div>

--- a/examples/example-nextjs/src/app/posthog.tsx
+++ b/examples/example-nextjs/src/app/posthog.tsx
@@ -6,6 +6,11 @@ import { PostHogProvider } from 'posthog-js/react'
 const posthogConfig: Partial<PostHogConfig> = {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_API_HOST,
     debug: process.env.NODE_ENV === 'development',
+    capture_exceptions: {
+        capture_console_errors: true,
+        capture_unhandled_rejections: true,
+        capture_unhandled_errors: true,
+    },
 }
 
 export default function PHProvider({

--- a/packages/browser/playwright/fixtures/network.ts
+++ b/packages/browser/playwright/fixtures/network.ts
@@ -9,6 +9,7 @@ const files = fs.readdirSync(path.join(__dirname, '../../dist'))
 
 export const testNetwork = testPage.extend<{
     network: NetworkPage
+    mockIngestion: boolean
     flagsOverrides: Partial<FlagsResponse>
     staticOverrides: Record<string, string>
 }>({
@@ -21,12 +22,16 @@ export const testNetwork = testPage.extend<{
         },
         { option: true },
     ],
+    mockIngestion: true,
     network: [
-        async ({ page, flagsOverrides, staticOverrides }, use) => {
+        async ({ page, flagsOverrides, mockIngestion, staticOverrides }, use) => {
             const networkPage = new NetworkPage(page)
             await networkPage.mockStatic(staticOverrides)
             if (flagsOverrides) {
                 await networkPage.mockFlags(flagsOverrides)
+            }
+            if (mockIngestion) {
+                await networkPage.mockIngestion()
             }
             await use(networkPage)
             networkPage.expectNoFailed()

--- a/packages/browser/playwright/fixtures/network.ts
+++ b/packages/browser/playwright/fixtures/network.ts
@@ -106,6 +106,7 @@ export class NetworkPage {
         await this.page.route('**/e/**', async (route) => {
             await route.fulfill({
                 headers: { loaded: 'mock captured' },
+                json: {},
             })
         })
     }

--- a/packages/browser/playwright/fixtures/network.ts
+++ b/packages/browser/playwright/fixtures/network.ts
@@ -97,6 +97,14 @@ export class NetworkPage {
         })
     }
 
+    async mockIngestion() {
+        await this.page.route('**/e/**', async (route) => {
+            await route.fulfill({
+                headers: { loaded: 'mock captured' },
+            })
+        })
+    }
+
     async waitForSurveys() {
         await this.page.waitForResponse('**/surveys/**')
     }

--- a/packages/browser/playwright/integration/e2e.spec.ts
+++ b/packages/browser/playwright/integration/e2e.spec.ts
@@ -16,6 +16,7 @@ test.describe('ingestion', () => {
             },
             opt_out_useragent_filter: true,
         },
+        mockIngestion: false,
     })
 
     test('Custom events work and are accessible via /api/event', async ({ page, events, posthog, ingestion }) => {

--- a/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
+++ b/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
@@ -207,13 +207,13 @@ test.describe('ErrorTracking autocapture', () => {
             await network.waitForFlags()
             await page.evaluate(() => {
                 //eslint-disable-next-line no-console
-                console.error('This error shoud be captured with a stack')
+                console.error('This error should be captured with a stack')
             })
 
             const event = await events.waitForEvent('$exception')
             const first_exception = event.properties.$exception_list[0]
             expect(first_exception.type).toBe('Error')
-            expect(first_exception.value).toBe('This error shoud be captured with a stack')
+            expect(first_exception.value).toBe('This error should be captured with a stack')
             expect(first_exception.stacktrace).toBeDefined()
             expect(first_exception.mechanism.handled).toBe(false)
         })

--- a/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
+++ b/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
@@ -197,7 +197,6 @@ test.describe('ErrorTracking autocapture', () => {
         })
 
         test('should capture console errors', async ({ posthog, network, page, events }) => {
-            await network.mockIngestion()
             await posthog.init({
                 capture_exceptions: {
                     capture_console_errors: true,

--- a/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
+++ b/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
@@ -209,12 +209,13 @@ test.describe('ErrorTracking autocapture', () => {
                 //eslint-disable-next-line no-console
                 console.error('This error shoud be captured with a stack')
             })
+
             const event = await events.waitForEvent('$exception')
             const first_exception = event.properties.$exception_list[0]
             expect(first_exception.type).toBe('Error')
             expect(first_exception.value).toBe('This error shoud be captured with a stack')
             expect(first_exception.stacktrace).toBeDefined()
-            expect(first_exception.stacktrace.frames).toHaveLength(5)
+            expect(first_exception.stacktrace.frames).toHaveLength(3)
             expect(first_exception.mechanism.handled).toBe(false)
         })
     })

--- a/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
+++ b/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
@@ -215,8 +215,6 @@ test.describe('ErrorTracking autocapture', () => {
             expect(first_exception.type).toBe('Error')
             expect(first_exception.value).toBe('This error shoud be captured with a stack')
             expect(first_exception.stacktrace).toBeDefined()
-            // Numbers of frames varies depending on browser
-            expect(first_exception.stacktrace.frames.length).toBeGreaterThan(3)
             expect(first_exception.mechanism.handled).toBe(false)
         })
     })

--- a/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
+++ b/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
@@ -195,5 +195,27 @@ test.describe('ErrorTracking autocapture', () => {
                     break
             }
         })
+
+        test('should capture console errors', async ({ posthog, network, page, events }) => {
+            await posthog.init({
+                capture_exceptions: {
+                    capture_console_errors: true,
+                    capture_unhandled_errors: false,
+                    capture_unhandled_rejections: false,
+                },
+            })
+            await network.waitForFlags()
+            await page.evaluate(() => {
+                //eslint-disable-next-line no-console
+                console.error('This error shoud be captured with a stack')
+            })
+            const event = await events.waitForEvent('$exception')
+            const first_exception = event.properties.$exception_list[0]
+            expect(first_exception.type).toBe('Error')
+            expect(first_exception.value).toBe('This error shoud be captured with a stack')
+            expect(first_exception.stacktrace).toBeDefined()
+            expect(first_exception.stacktrace.frames).toHaveLength(5)
+            expect(first_exception.mechanism.handled).toBe(false)
+        })
     })
 })

--- a/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
+++ b/packages/browser/playwright/mocked/error-tracking/autocapture.spec.ts
@@ -197,6 +197,7 @@ test.describe('ErrorTracking autocapture', () => {
         })
 
         test('should capture console errors', async ({ posthog, network, page, events }) => {
+            await network.mockIngestion()
             await posthog.init({
                 capture_exceptions: {
                     capture_console_errors: true,
@@ -215,7 +216,8 @@ test.describe('ErrorTracking autocapture', () => {
             expect(first_exception.type).toBe('Error')
             expect(first_exception.value).toBe('This error shoud be captured with a stack')
             expect(first_exception.stacktrace).toBeDefined()
-            expect(first_exception.stacktrace.frames).toHaveLength(3)
+            // Numbers of frames varies depending on browser
+            expect(first_exception.stacktrace.frames.length).toBeGreaterThan(3)
             expect(first_exception.mechanism.handled).toBe(false)
         })
     })

--- a/packages/browser/src/entrypoints/exception-autocapture.ts
+++ b/packages/browser/src/entrypoints/exception-autocapture.ts
@@ -68,6 +68,7 @@ const wrapConsoleError = (captureFn: (props: ErrorTracking.ErrorProperties) => v
         const errorProperties = errorPropertiesBuilder.buildFromUnknown(error || event, {
             mechanism: { handled: false },
             syntheticException: new Error('PostHog syntheticException'),
+            skipFirstLines: 2,
         })
         captureFn(errorProperties)
         return originalConsoleError?.(...args)

--- a/packages/browser/src/entrypoints/exception-autocapture.ts
+++ b/packages/browser/src/entrypoints/exception-autocapture.ts
@@ -63,7 +63,12 @@ const wrapConsoleError = (captureFn: (props: ErrorTracking.ErrorProperties) => v
     const originalConsoleError = con.error
 
     con.error = function (...args: any[]): void {
-        const event = args.join(' ')
+        let event
+        if (args.length == 1) {
+            event = args[0]
+        } else {
+            event = args.join(' ')
+        }
         const error = args.find((arg) => arg instanceof Error)
         const errorProperties = errorPropertiesBuilder.buildFromUnknown(error || event, {
             mechanism: { handled: false },

--- a/packages/core/src/error-tracking/error-properties-builder.coerce.spec.ts
+++ b/packages/core/src/error-tracking/error-properties-builder.coerce.spec.ts
@@ -2,6 +2,7 @@ import { DOMExceptionCoercer, ErrorEventCoercer, ErrorCoercer, ObjectCoercer, St
 import { PrimitiveCoercer } from './coercers/primitive-coercer'
 import { PromiseRejectionEventCoercer } from './coercers/promise-rejection-event'
 import { ErrorPropertiesBuilder } from './error-properties-builder'
+import { createStackParser } from './parsers'
 import { ExceptionLike } from './types'
 
 describe('ErrorPropertiesBuilder', () => {
@@ -24,7 +25,7 @@ describe('ErrorPropertiesBuilder', () => {
         new StringCoercer(),
         new PrimitiveCoercer(),
       ],
-      [],
+      createStackParser('web:javascript'),
       []
     )
 

--- a/packages/core/src/error-tracking/error-properties-builder.parse.spec.ts
+++ b/packages/core/src/error-tracking/error-properties-builder.parse.spec.ts
@@ -11,7 +11,7 @@ describe('ErrorPropertiesBuilder', () => {
     )
 
     function parseStack(error: Error): StackFrame[] | undefined {
-      const ctx = {}
+      const ctx = { skipFirstLines: 1 }
       //@ts-expect-error: testing private method
       const exception = errorPropertiesBuilder.parseStacktrace(
         {

--- a/packages/core/src/error-tracking/types.ts
+++ b/packages/core/src/error-tracking/types.ts
@@ -19,6 +19,7 @@ export interface PolymorphicEvent {
 export interface EventHint {
   mechanism?: Partial<Mechanism>
   syntheticException?: Error | null
+  skipFirstLines?: number
 }
 
 export interface PreviouslyCapturedError {
@@ -86,6 +87,7 @@ export type ChunkIdMapType = Record<string, string>
 
 export interface ParsingContext {
   chunkIdMap?: ChunkIdMapType
+  skipFirstLines: number
 }
 
 interface Coercer<T, U, C> {


### PR DESCRIPTION
## Problem

- console errors (with strings) on not captured anymore because the stack associated contains SDK frames

Fix: https://posthoghelp.zendesk.com/agent/tickets/49104 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/52080)

## Changes

- Skip 1 more frame
- Add playwright test for console errors
- Mock ingestion endpoint during playwright e2e tests

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
