### PR TITLE
fix(product tours): preventDefault on tour trigger clicks

### DIFF
--- a/.changeset/humble-llamas-call.md
+++ b/.changeset/humble-llamas-call.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+replace stopPropagation with preventDefault for tour manaul click triggers

--- a/packages/browser/src/extensions/product-tours/product-tours.tsx
+++ b/packages/browser/src/extensions/product-tours/product-tours.tsx
@@ -951,7 +951,7 @@ export class ProductTourManager {
                 logger.info(`Tour ${tour.id} triggered by click on ${selector}`)
 
                 if (this.showTour(currentTour, { reason: 'trigger' })) {
-                    event.stopPropagation()
+                    event.preventDefault()
                 } else {
                     logger.info(`Tour ${tour.id} failed to show; not intercepting click.`)
                 }


### PR DESCRIPTION
## Problem

tl;dr we probably want `e.preventDefault()` for tours instead of `e.stopPropagation()`

https://posthog.slack.com/archives/C08499A7REU/p1770313150124169?thread_ts=1770305358.315979&cid=C08499A7REU

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->