### PR TITLE
fix: session recording persisted config should have cache invalidation

### DIFF
--- a/.changeset/tricky-webs-arrive.md
+++ b/.changeset/tricky-webs-arrive.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: replay remote config cache should be invalidated periodically

--- a/packages/browser/src/extensions/replay/session-recording.ts
+++ b/packages/browser/src/extensions/replay/session-recording.ts
@@ -154,6 +154,7 @@ export class SessionRecording {
 
                 persistence.register({
                     [SESSION_RECORDING_REMOTE_CONFIG]: {
+                        cache_timestamp: Date.now(),
                         enabled: !!sessionRecordingConfigResponse,
                         ...sessionRecordingConfigResponse,
                         networkPayloadCapture: {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -152,6 +152,11 @@ export type SessionRecordingPersistedConfig = Omit<
     | 'sampleRate'
     | 'minimumDurationMilliseconds'
 > & {
+    /**
+     * Used to determine if the persisted config is still valid or we need to wait for a new one
+     * only accepts undefined since older versions of the library didn't set this.
+     */
+    cache_timestamp?: number
     enabled: boolean
     networkPayloadCapture: SessionRecordingRemoteConfig['networkPayloadCapture'] & {
         capturePerformance: RemoteConfig['capturePerformance']


### PR DESCRIPTION
session replay persists remote config and starts proactively when it is present

this is because it can be relatively slow to start recording and on a site with full page loads on navigation we would lose some recording

but it has no cache invalidation

Ruh-roh, Raggy!

This change

* tracks timetamp cache was written
* only accepts cached values with a timestamp
* only accepts cached values from the last five minutes

that means all existing caches are immediately invalidated but that's fine, it's a proactive prevention and will mean we just behave like a full page load from fresh

and it means all invalid caches will stop being respected which is causing unwanted recordings particularly obviously on high traffic sites