### PR TITLE
fix(ci): extract version from pnpm-lock.yaml in upgrade workflows

### DIFF
--- a/.github/workflows/posthog-com-upgrade.yml
+++ b/.github/workflows/posthog-com-upgrade.yml
@@ -53,7 +53,7 @@ jobs:
                   PACKAGE_NAME: ${{ github.event.inputs.package_name }}
                   PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
               run: |
-                  OUTGOING_VERSION=$(jq ".dependencies[\"$PACKAGE_NAME\"]" package.json -r)
+                  OUTGOING_VERSION=$(grep -A1 "${PACKAGE_NAME}:" pnpm-lock.yaml | grep specifier | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
                   echo "outgoing-version=$OUTGOING_VERSION" >> "$GITHUB_OUTPUT"
                   for i in $(seq 1 $RETRY_TIMES); do
                       # Retry loop because of npm being _eventually_ consistent

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -53,7 +53,7 @@ jobs:
                   PACKAGE_NAME: ${{ github.event.inputs.package_name }}
                   PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
               run: |
-                  OUTGOING_VERSION=$(jq ".dependencies[\"$PACKAGE_NAME\"]" package.json -r)
+                  OUTGOING_VERSION=$(grep -A1 "${PACKAGE_NAME}:" pnpm-lock.yaml | grep specifier | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
                   echo "outgoing-version=$OUTGOING_VERSION" >> "$GITHUB_OUTPUT"
                   for i in $(seq 1 $RETRY_TIMES); do
                       # Retry loop because of npm being _eventually_ consistent


### PR DESCRIPTION
## Problem

The upgrade workflows extracted the outgoing version from `package.json`, which returns `null` in monorepos where the package is in a sub-package or uses `catalog:` protocol.

## Solution

Extract the version from `pnpm-lock.yaml` importers section instead, which always has the resolved version.