### PR TITLE
fix(toolbar): do not run the toolbar on the toolbar

### DIFF
--- a/.changeset/grumpy-fans-repair.md
+++ b/.changeset/grumpy-fans-repair.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+do not attempt to load the toolbar from the toolbar itself

--- a/packages/browser/src/extensions/toolbar.ts
+++ b/packages/browser/src/extensions/toolbar.ts
@@ -49,6 +49,10 @@ export class Toolbar {
         localStorage: Storage | undefined = undefined,
         history: History | undefined = undefined
     ): boolean {
+        // don't load the toolbar on the toolbar :)
+        if (this.instance.config.name && this.instance.config.name === 'ph_toolbar_internal') {
+            return false
+        }
         if (!window || !document) {
             return false
         }


### PR DESCRIPTION
## Problem

when running the toolbar locally or internal prod, all ui host requests (e.g. opening a feature flag, saving a tour & redirecting to posthog) were hitting `internal-j.posthog.com` instead of the expected us/eu.posthog.com

_this is not impacting customers_

root cause tldr:
- we recently upgraded the toolbar to use posthog-js instead of posthog-js-lite
- the toolbar's posthog-js instance was attempting to load the toolbar, and succeeding because its api key matches the api key on posthog prod
- you'd think the main app's posthog instance would fire first, load the toolbar, and then the toolbar's instance fails because the toolbar already exists... BUT the main app has some scenes which import the toolbar logic, which imports toolbarPosthogJS, which calls posthog.init at the module scope
- therefore toolbarPosthogJS is the first posthog instance to attempt to load the toolbar, it succeeds internally when api keys match, and the main app's posthog instance sees "toolbar already loaded" and quits early

this fixes the problem locally -- my logs show the `uiHost` selector in the toolbar and the `ph_load_toolbar` params, both reference a posthog instance named `"posthog"`

not impacting customers because:
1. they are (hopefully) only loading one posthog-js instance on pageload - it calls maybeLoadToolbar, and maybe loads the toolbar. if so, the toolbar instance's call to maybeLoadToolbar simply fails because the toolbar exists
2. if somehow something crazy is happening and the toolbar's instance _does_ manage to call maybeLoadToolbar _before_ the main app, it would still fail, because of the api key check (posthog instance key must match the provided api key from the launch)

https://posthog.slack.com/archives/C0113360FFV/p1770115689166869

## debug log

to validate the theory of toolbar on toolbar violence, i added logs in the `toolbarConfigLogic`'s `uiHost` selector and `win['ph_load_toolbar']` definition to log the toolbar params and posthog config

- toolbar params include `apiURL: "http://localhost:8010`
- posthog config from `ph_load_toolbar` includes `name: "ph_toolbar_internal"`
- uiHost selector logs show `props.posthog.config.name` is also `"ph_toolbar_internal"`

attempting to nail down the exact sequence of events here, i added logs to `maybeLoadToolbar` and launched the toolbar from localhost:8010 onto localhost:8010 (like opening the toolbar on us.posthog.com)

- logs immediately on page load:
  - log comes in with config.name = "ph_toolbar_internal" from toolbarPosthogJS.ts
  - log comes in with config.name = "posthog" from loadPostHogJS.tsx
  - log comes in with config.name = "ph_toolbar_internal" from the sdk toolbar.js
- some time elapses, more logs:
  - ph_toolbar_internal again from toolbarPosthogJS.ts
  - posthog again from loadPostHogJS.tsx

the robot has been _awful_ about debugging this, but i fed it those logs and it thinks this:

```
⏺ Your logs just cracked it! toolbarPosthogJS.ts is somehow in the main app's module graph — it runs at module scope (calling posthog.init()) BEFORE
  loadPostHogJS(). That means ph_toolbar_internal grabs the UNINITIALIZED state first, loads toolbar.js via loadExternalDependency, and its callback passes
  ph_toolbar_internal to ph_load_toolbar.

  The question is: what imports toolbarPosthogJS.ts into the main app? Let me find the import chain.

⏺ Explore(Find toolbar import chain)
  ⎿  Done (23 tool uses · 26.1k tokens · 32s)

⏺ Found it! There are two import chains pulling toolbarPosthogJS.ts into the main app:

  Chain 1 (HedgehogBuddy):
  index.tsx → App.tsx → GlobalModals.tsx → HedgehogBuddyWithLogic.tsx
    → hedgehogBuddyLogic.ts → toolbarConfigLogic.ts → toolbarPosthogJS.ts

  Chain 2 (Heatmaps):
  index.tsx → App.tsx → appScenes.ts → HeatmapScene.tsx
    → heatmapLogic.ts → heatmapDataLogic.ts → toolbarConfigLogic.ts → toolbarPosthogJS.ts

  Both chains converge at toolbarConfigLogic.ts which imports toolbarPosthogJS.ts. Since toolbarPosthogJS.ts calls posthog.init() at module scope, it runs
  during the main app's import resolution — before loadPostHogJS() at line 17 of index.tsx.

  So the full flow is:
  1. Main app imports resolve → toolbarPosthogJS.ts runs → ph_toolbar_internal.init() → maybeLoadToolbar() → state UNINITIALIZED → sets LOADING →
  loadExternalDependency loads toolbar.js
  2. loadPostHogJS() runs → phMain.init() → maybeLoadToolbar() → state is already LOADING → noop
  3. toolbar.js IIFE loads → another ph_toolbar_internal init → state LOADING → noop
  4. loadExternalDependency callback fires → _callLoadToolbar(params) with ph_toolbar_internal → wrong instance passed to ph_load_toolbar

  The fix in posthog-js (early return for ph_toolbar_internal in maybeLoadToolbar) is correct — it prevents step 1 from ever entering loadToolbar. But you
  might also want to break the import chain from the main app to toolbarPosthogJS.ts, since the main app shouldn't be creating ph_toolbar_internal at all.
```

i **think** i believe it. this posthog-js fix is still correct, but i may send another PR to fix that other situation so the toolbar isn't loading up in heatmaps and hedgehog buddy....


## Changes

adds explicit check in `maybeLoadToolbar` to _not_ attempt loading when the given instance is named `ph_toolbar_internal`

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
