### PR TITLE
fix(react-native): pass --no-fail to posthog-cli in Gradle source map upload

### DIFF
--- a/packages/react-native/tooling/posthog.gradle
+++ b/packages/react-native/tooling/posthog.gradle
@@ -85,7 +85,7 @@ plugins.withId('com.android.application') {
                                 def cliPackage = resolvePostHogCliPackagePath(reactRoot)
                                 def args = [cliPackage]
 
-                                args.addAll(["exp", "hermes", "clone",
+                                args.addAll(["--no-fail", "exp", "hermes", "clone",
                                     "--minified-map-path", packagerSourcemapOutput, // The path to a sourcemap
                                     "--composed-map-path", sourcemapOutput          // The path of the composed source map
                                 ])
@@ -107,7 +107,7 @@ plugins.withId('com.android.application') {
                                 def args = [cliPackage]
 
                                 def sourcemapDir = sourcemapOutput.getParent()
-                                args.addAll(["exp", "hermes", "upload",
+                                args.addAll(["--no-fail", "exp", "hermes", "upload",
                                     "--directory", sourcemapDir        // The path to a sourcemap that should be uploaded.
                                 ])
 


### PR DESCRIPTION
## Problem

App developers using `posthog-react-native` for error tracking source map uploads on Android have their entire native build fail when the PostHog CLI encounters a non-fatal upload error.

We hit this in production with a `release_id_mismatch` error. We bumped our app version from 1.0.5 to 1.0.6 without meaningful JS code changes (only the version number in our Expo config changed - the rest was app config related). Because the JS bundle was nearly identical, the source map produced the same content hash / symbol set ID. The PostHog server rejected the upload since that symbol set was already associated with the previous release — and the Gradle exec block propagated the CLI's non-zero exit as a build failure:

```
  FAILURE: Build failed with an exception.
  * Where:
  Script '.../node_modules/posthog-react-native/tooling/posthog.gradle' line: 103
  * What went wrong:
  Execution failed for task ':app:createBundleReleaseJsAndAssets_PostHogUpload_...'
  > Process 'command '.../node_modules/@posthog/cli/run-posthog-cli.js'' finished with non-zero exit value 1
```

This is a reasonably common scenario for us. Version bumps without meaningful JS changes happen regularly (config changes, native-only fixes, metadata updates, etc.). We ran into this on our second or third expo build that uploaded sourcemaps - a build whose only change involved modifying initialization of an API key was the culprit.

Source map uploads are a best-effort optimization for error tracking and should never prevent an app from being built and shipped.

I used [`pnpm patch`](https://mikebifulco.com/posts/patching-npm-dependencies-with-pnpm-patch) to patch the posthog-react-native library for now - this isn't currently a blocking issue for us, but I thought it'd be helpful to pass upstream.

## Changes

Passes `--no-fail` to both posthog-cli invocations in `posthog.gradle` (clone and upload steps). 

This flag is designed for exactly this purpose — it logs errors to stderr (so they're still visible in build logs) but exits with code 0 so the build isn't blocked.

  - Clone step: `posthog-cli --no-fail exp hermes clone ...`
  - Upload step: `posthog-cli --no-fail exp hermes upload ...`

Successful uploads still work exactly as before. Errors are still logged and visible in build output.

Note: the iOS upload path (`posthog-xcode.sh`) may have the same issue but we haven't investigated it. The extraArgs array in the Gradle
  plugin is initialized empty and never populated, so there's currently no way for consumers to pass flags like `--no-fail` without patching.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!) (not certain about this one!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
