### PR TITLE
fix: add featureFlags property and OverrideFeatureFlagsOptions type

### DIFF
--- a/.changeset/add-featureflags-and-set-config-types.md
+++ b/.changeset/add-featureflags-and-set-config-types.md
@@ -1,0 +1,6 @@
+---
+"@posthog/types": patch
+"posthog-js": patch
+---
+
+Add missing `featureFlags` property and `OverrideFeatureFlagsOptions` type to `PostHog` interface, restore `set_config` to the loaded callback type, and add `featureFlagsReloading` to `on()` event types

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -13,6 +13,7 @@ import {
     EarlyAccessFeatureStage,
     FeatureFlagDetail,
     FeatureFlagResult,
+    OverrideFeatureFlagsOptions,
 } from './types'
 import { PostHogPersistence } from './posthog-persistence'
 
@@ -155,26 +156,6 @@ const normalizeFlagsResponse = (response: Partial<FlagsResponse>): Partial<Flags
     }
     return response
 }
-
-type FeatureFlagOverrides = {
-    [flagName: string]: string | boolean
-}
-
-type FeatureFlagPayloadOverrides = {
-    [flagName: string]: JsonType
-}
-
-type FeatureFlagOverrideOptions = {
-    flags?: boolean | string[] | FeatureFlagOverrides
-    payloads?: FeatureFlagPayloadOverrides
-    suppressWarning?: boolean
-}
-
-type OverrideFeatureFlagsOptions =
-    | boolean // clear all overrides
-    | string[] // enable list of flags
-    | FeatureFlagOverrides // set variants directly
-    | FeatureFlagOverrideOptions
 
 export enum QuotaLimitedResource {
     FeatureFlags = 'feature_flags',

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -28,6 +28,10 @@ export type {
     EarlyAccessFeatureStage,
     EarlyAccessFeatureCallback,
     EarlyAccessFeatureResponse,
+    FeatureFlagOverrides,
+    FeatureFlagPayloadOverrides,
+    FeatureFlagOverrideOptions,
+    OverrideFeatureFlagsOptions,
 } from '@posthog/types'
 
 // Request types
@@ -96,7 +100,7 @@ import type {
  * This guarantees we'll be able to use `PostHogConfig` as implemented in the browser/src/posthog-core.ts file
  * using the proper `loaded` function signature.
  */
-export type PostHogInterface = Omit<BasePostHogInterface, 'config' | 'init' | 'set_config'>
+export type PostHogInterface = Omit<BasePostHogInterface, 'config' | 'init'>
 
 /*
  * Specify that `loaded` should be using the PostHog instance type

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -73,3 +73,32 @@ export type FeatureFlagResult = {
 export interface EarlyAccessFeatureResponse {
     earlyAccessFeatures: EarlyAccessFeature[]
 }
+
+export type FeatureFlagOverrides = {
+    [flagName: string]: string | boolean
+}
+
+export type FeatureFlagPayloadOverrides = {
+    [flagName: string]: JsonType
+}
+
+export type FeatureFlagOverrideOptions = {
+    flags?: boolean | string[] | FeatureFlagOverrides
+    payloads?: FeatureFlagPayloadOverrides
+    suppressWarning?: boolean
+}
+
+/**
+ * Options for overriding feature flags on the client-side.
+ *
+ * Can be:
+ * - `false` to clear all overrides
+ * - `string[]` to enable a list of flags
+ * - `FeatureFlagOverrides` to set variants directly
+ * - `FeatureFlagOverrideOptions` for granular control over flags and payloads
+ */
+export type OverrideFeatureFlagsOptions =
+    | boolean // clear all overrides
+    | string[] // enable list of flags
+    | FeatureFlagOverrides // set variants directly
+    | FeatureFlagOverrideOptions

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -33,6 +33,10 @@ export type {
     EarlyAccessFeatureStage,
     EarlyAccessFeatureCallback,
     EarlyAccessFeatureResponse,
+    FeatureFlagOverrides,
+    FeatureFlagPayloadOverrides,
+    FeatureFlagOverrideOptions,
+    OverrideFeatureFlagsOptions,
 } from './feature-flags'
 
 // Request types

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -13,6 +13,7 @@ import type {
     EarlyAccessFeatureCallback,
     EarlyAccessFeatureStage,
     FeatureFlagResult,
+    OverrideFeatureFlagsOptions,
 } from './feature-flags'
 import type { SessionIdChangedCallback } from './session-recording'
 import type { RequestCallback } from './request'
@@ -196,6 +197,34 @@ export interface PostHog {
     // ============================================================================
     // Feature Flags
     // ============================================================================
+
+    /**
+     * The feature flags instance. Provides access to feature flag override methods.
+     */
+    featureFlags: {
+        /**
+         * Override feature flags on the client-side. Useful for testing/debugging.
+         *
+         * @param overrideOptions - The override options
+         *
+         * @example
+         * ```typescript
+         * posthog.featureFlags.overrideFeatureFlags(false) // clear all overrides
+         * posthog.featureFlags.overrideFeatureFlags(['beta-feature']) // enable flags
+         * posthog.featureFlags.overrideFeatureFlags({'beta-feature': 'variant'}) // set variants
+         * posthog.featureFlags.overrideFeatureFlags({
+         *     flags: {'beta-feature': 'variant'},
+         *     payloads: { 'beta-feature': { someData: true } }
+         * })
+         * ```
+         */
+        overrideFeatureFlags(overrideOptions: OverrideFeatureFlagsOptions): void
+
+        /**
+         * @deprecated Use `overrideFeatureFlags` instead. This will be removed in a future version.
+         */
+        override(flags: boolean | string[] | Record<string, string | boolean>, suppressWarning?: boolean): void
+    }
 
     /**
      * Get the value of a feature flag.
@@ -555,7 +584,7 @@ export interface PostHog {
      * @param cb - The callback to call
      * @returns A function to unsubscribe
      */
-    on(event: 'eventCaptured', cb: (...args: any[]) => void): () => void
+    on(event: 'eventCaptured' | 'featureFlagsReloading', cb: (...args: any[]) => void): () => void
 
     // ============================================================================
     // Error Tracking


### PR DESCRIPTION
## Problem

The PostHog interface was missing the `featureFlags` property that provides access to feature flag override methods. Additionally, the `OverrideFeatureFlagsOptions` type was not exported from the types package, and the `set_config` method was incorrectly omitted from the loaded callback type. The `featureFlagsReloading` event was also missing from the `on()` event types.

## Changes

- **Exported `OverrideFeatureFlagsOptions` type** from `@posthog/types` package for public use
- **Added `featureFlags` property** to the `PostHog` interface with:
  - `overrideFeatureFlags()` method for client-side feature flag overrides
  - Deprecated `override()` method for backwards compatibility
- **Moved type definitions** for feature flag overrides from `posthog-featureflags.ts` to `@posthog/types/feature-flags.ts` for better organization and reusability
- **Restored `set_config`** to the `PostHogInterface` type definition (removed from Omit list)
- **Added `featureFlagsReloading` event** to the `on()` method's event type union
- **Added comprehensive JSDoc documentation** for the new `featureFlags` property with usage examples

## Release info

### Libraries affected

- [x] posthog-js (web)
- [x] @posthog/types

## Checklist

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] No breaking changes - all changes are additive or restore previously available functionality
- [x] Bundle size impact is minimal - only type definitions and documentation added
- [x] Backwards compatibility maintained with deprecated `override()` method

https://claude.ai/code/session_017rN4ZPhRNWbTA2WqxS21hX