### PR TITLE
fix: cache invalidation was _too_ aggressive

### DIFF
--- a/.changeset/stale-sheep-make.md
+++ b/.changeset/stale-sheep-make.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: remote config cache invalidation was too aggressive

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -700,8 +700,11 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         // Only check TTL if recording hasn't started yet
         // Once started, trust the config until a hard page load
         if (!this.isStarted) {
-            const cacheTimestamp = parsedConfig.cache_timestamp
-            if (!cacheTimestamp || Date.now() - cacheTimestamp > FIVE_MINUTES) {
+            // default to now so that older persisted configs without a cache_timestamp
+            // are treated as fresh instead of being cleared on every read
+            // they come from versions of the code that will never set a cache_timestamp
+            const cacheTimestamp = parsedConfig.cache_timestamp ?? Date.now()
+            if (Date.now() - cacheTimestamp > FIVE_MINUTES) {
                 logger.info('persisted remote config for session recording is stale and will be ignored', {
                     cacheTimestamp,
                     persistedConfig,


### PR DESCRIPTION
in https://github.com/PostHog/posthog-js/pull/3051 we added cache invalidation because we observed cached config being applied for too long

however, if someone has code that does not write the cache timestamp 

then we would check for it
not find it 
and clear their config
but they would _never_ write the cache_timestamp

in that case we should instead write a cache timestamp
so that we can use the config in the case where the parent recorder doesn't know about the cache timestamp