### PR TITLE
chore(product tours): emit event on tour button clicks

### DIFF
--- a/.changeset/better-symbols-build.md
+++ b/.changeset/better-symbols-build.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+add "product tour button clicked" events

--- a/packages/browser/src/extensions/product-tours/product-tours.tsx
+++ b/packages/browser/src/extensions/product-tours/product-tours.tsx
@@ -550,6 +550,23 @@ export class ProductTourManager {
     }
 
     private _handleButtonClick = (button: ProductTourStepButton): void => {
+        if (this._activeTour) {
+            const currentStep = this._activeTour.steps[this._currentStepIndex]
+            if (currentStep) {
+                this._captureEvent('product tour button clicked', {
+                    $product_tour_id: this._activeTour.id,
+                    $product_tour_name: this._activeTour.name,
+                    $product_tour_iteration: this._activeTour.current_iteration || 1,
+                    $product_tour_step_id: currentStep.id,
+                    $product_tour_step_order: this._currentStepIndex,
+                    $product_tour_button_text: button.text,
+                    $product_tour_button_action: button.action,
+                    ...(button.link && { $product_tour_button_link: button.link }),
+                    ...(button.tourId && { $product_tour_button_tour_id: button.tourId }),
+                })
+            }
+        }
+
         switch (button.action) {
             case 'dismiss':
                 this.dismissTour('user_clicked_skip')


### PR DESCRIPTION
## Problem

i want to make a workflow based on a tour button click, but it's impossible to know when that happens!

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

adding `product tour button clicked` events :)

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->