### PR TITLE
chore: release export rn masking

### DIFF
--- a/.changeset/yellow-comics-hug.md
+++ b/.changeset/yellow-comics-hug.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+fix: export PostHogMaskView


### PR DESCRIPTION
## Problem

Release https://github.com/PostHog/posthog-js/pull/3068

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [X] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [X] Ran `pnpm changeset` to generate a changeset file
- [X] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
