### PR TITLE
chore(posthog-js): add identity verification

### DIFF
--- a/.changeset/gentle-grapes-kiss.md
+++ b/.changeset/gentle-grapes-kiss.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/types': minor
+---
+
+introduces identity verification concept for some posthog requests

--- a/packages/browser/src/constants.ts
+++ b/packages/browser/src/constants.ts
@@ -67,6 +67,7 @@ export const INITIAL_CAMPAIGN_PARAMS = '$initial_campaign_params'
 /** @deprecated Delete this when INITIAL_PERSON_INFO has been around for long enough to ignore backwards compat */
 export const INITIAL_REFERRER_INFO = '$initial_referrer_info'
 export const INITIAL_PERSON_INFO = '$initial_person_info'
+export const IDENTITY_VERIFICATION_SIGNATURE = '$identity_verification_signature'
 export const ENABLE_PERSON_PROCESSING = '$epp'
 export const TOOLBAR_ID = '__POSTHOG_TOOLBAR__'
 export const TOOLBAR_CONTAINER_CLASS = 'toolbar-global-fade-container'
@@ -104,6 +105,7 @@ export const PERSISTENCE_RESERVED_PROPERTIES = [
     INITIAL_CAMPAIGN_PARAMS,
     INITIAL_REFERRER_INFO,
     ENABLE_PERSON_PROCESSING,
+    IDENTITY_VERIFICATION_SIGNATURE,
     INITIAL_PERSON_INFO,
     // Conversations keys (defined in lazy-loaded extension)
     '$conversations_widget_session_id',

--- a/packages/browser/src/posthog-product-tours.ts
+++ b/packages/browser/src/posthog-product-tours.ts
@@ -1,6 +1,6 @@
 import { PostHog } from './posthog-core'
 import { ProductTour, ProductTourCallback } from './posthog-product-tours-types'
-import { PRODUCT_TOURS_ENABLED_SERVER_SIDE } from './constants'
+import { IDENTITY_VERIFICATION_SIGNATURE, PRODUCT_TOURS_ENABLED_SERVER_SIDE } from './constants'
 import { RemoteConfig } from './types'
 import { createLogger } from './utils/logger'
 import { isArray, isNullish } from '@posthog/core'
@@ -93,11 +93,14 @@ export class PostHogProductTours {
             }
         }
 
+        let path = `/api/product_tours/?token=${this._instance.config.token}&distinct_id=${encodeURIComponent(this._instance.get_distinct_id())}`
+        const signature = this._instance.get_property(IDENTITY_VERIFICATION_SIGNATURE)
+        if (signature) {
+            path += `&iv_signature=${encodeURIComponent(signature)}`
+        }
+
         this._instance._send_request({
-            url: this._instance.requestRouter.endpointFor(
-                'api',
-                `/api/product_tours/?token=${this._instance.config.token}`
-            ),
+            url: this._instance.requestRouter.endpointFor('api', path),
             method: 'GET',
             callback: (response) => {
                 const statusCode = response.statusCode

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -107,8 +107,14 @@ export interface PostHog {
      * @param new_distinct_id - The new distinct ID for the user
      * @param userPropertiesToSet - Properties to set on the user (using $set)
      * @param userPropertiesToSetOnce - Properties to set once on the user (using $set_once)
+     * @param options - Additional options (e.g., identity verification signature)
      */
-    identify(new_distinct_id?: string, userPropertiesToSet?: Properties, userPropertiesToSetOnce?: Properties): void
+    identify(
+        new_distinct_id?: string,
+        userPropertiesToSet?: Properties,
+        userPropertiesToSetOnce?: Properties,
+        options?: { identityVerification?: string }
+    ): void
 
     /**
      * Set properties on the current user.
@@ -144,6 +150,16 @@ export interface PostHog {
      * Create a person profile for the current user.
      */
     createPersonProfile(): void
+
+    /**
+     * Set or clear the identity verification signature (HMAC-SHA256).
+     *
+     * When set, the signature is included in certain requests to verify the
+     * caller is authorized to access person data for the current distinct ID.
+     *
+     * @param signature - The HMAC-SHA256 hex signature, or null to clear
+     */
+    setIdentityVerification(signature: string | null): void
 
     /**
      * Marks the current user as a test user by setting the `$internal_or_test_user` person property to `true`.


### PR DESCRIPTION
## Problem

the initial use-case here is we want users to be able to inject person properties into product tours step content

the current flow is:

- sdk hits tours api
- tour api returns all active tours, with precomputed html content

new proposed flow is:

- sdk hits tours api with distinct ID
- server fetches person properties
- server renders templated tour content with properties
- tour api returns all active tours, with rendered html content that maybe includes person properties

the security concern is that this effectively makes all person properties used in product tours public, if you have the site api key + distinct ID.

see https://posthog.slack.com/archives/C08SCAZ52S3/p1770777242381329

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

introduces a new identity verification concept. the flow will be:

- we provide customers with a secret
- customers use secret to compute HMAC of the user's ID
- customer pass HMAC through `identify`, or new method `setIdentityVerification`
- we can include HMAC in requests to posthog, e.g. the request to the tours API
- in the future, this could be used to validate other sorts of requests if needed :)

main app PR to follow

this PR doesn't actually change any behavior, because no api endpoints (yet) do anything with the verification key

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->