### PR TITLE
chore: add CODEOWNERS entry for network plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,9 @@
 # the recorder file can have unexpected impact on users' sites
 packages/browser/src/entrypoints/recorder.ts           @PostHog/team-replay
 
+# Network recorder
+packages/browser/src/extensions/replay/external/network-plugin.ts @pauldambra
+
 # Surveys
 packages/browser/src/extensions/surveys/               @PostHog/team-surveys
 packages/browser/src/extensions/surveys.tsx            @PostHog/team-surveys


### PR DESCRIPTION
## Problem

The network plugin file in the replay extension needs clear ownership assignment for code review and maintenance purposes.

## Changes

Added a CODEOWNERS entry for `packages/browser/src/extensions/replay/external/network-plugin.ts` assigning ownership to @pauldambra. This ensures that changes to the network recorder plugin are reviewed by the appropriate maintainer.

## Release info

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] No code changes requiring tests
- [x] No impact on different platforms
- [x] No breaking changes
- [x] No bundle size impact

https://claude.ai/code/session_01M8prhWCePk36MLha6rLqAX