### PR TITLE
chore(sdk): update z-index heirarchy for tours > surveys > conversations

### DIFF
--- a/.changeset/fuzzy-hounds-judge.md
+++ b/.changeset/fuzzy-hounds-judge.md
@@ -2,4 +2,4 @@
 'posthog-js': patch
 ---
 
-update z-index heirarchy for tours > surveys > conversations
+update z-index hierarchy for tours > surveys > conversations

--- a/.changeset/fuzzy-hounds-judge.md
+++ b/.changeset/fuzzy-hounds-judge.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+update z-index heirarchy for tours > surveys > conversations

--- a/packages/browser/playwright/mocked/z-index-hierarchy.spec.ts
+++ b/packages/browser/playwright/mocked/z-index-hierarchy.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from './utils/posthog-playwright-test-base'
+import { start } from './utils/setup'
+import { createTour, mockProductToursApi } from './product-tours/utils'
+import { Z_INDEX_TOURS, Z_INDEX_SURVEYS, Z_INDEX_CONVERSATIONS } from '@/constants'
+
+const startOptions = {
+    options: {
+        disable_product_tours: false,
+    },
+    flagsResponseOverrides: {
+        surveys: true,
+        productTours: true,
+    },
+    url: './playground/cypress/index.html',
+}
+
+const survey = {
+    id: 'zindex-survey',
+    name: 'Z-index test survey',
+    type: 'popover' as const,
+    start_date: '2021-01-01T00:00:00Z',
+    questions: [{ type: 'open', question: 'Feedback?', id: 'q1' }],
+}
+
+test.describe('z-index hierarchy', () => {
+    test('tours have higher z-index than surveys, surveys higher than support', async ({ page, context }) => {
+        // Mock surveys API
+        const surveysRoute = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({ json: { surveys: [survey] } })
+        })
+
+        // Mock product tours API
+        const tour = createTour({ id: 'zindex-tour' })
+        const toursRoute = mockProductToursApi(page, [tour])
+
+        await start(startOptions, page, context)
+        await surveysRoute
+        await toursRoute
+
+        // Wait for both to render
+        await expect(page.locator('.PostHogSurvey-zindex-survey .survey-form')).toBeVisible()
+        await expect(page.locator('.ph-product-tour-container-zindex-tour .ph-tour-tooltip')).toBeVisible()
+
+        // Enable conversations widget
+        await page.evaluate(() => {
+            const posthog = (window as any).posthog
+            if (posthog?.conversations) {
+                posthog.conversations.onRemoteConfig({
+                    conversations: {
+                        enabled: true,
+                        token: 'test-token',
+                        widgetEnabled: true,
+                    },
+                })
+            }
+        })
+
+        // Wait for conversations widget to render (container has no dimensions, check for the button inside)
+        await expect(page.locator('#ph-conversations-widget-container button')).toBeVisible()
+
+        // Read computed z-index values
+        const tourZIndex = await page
+            .locator('.ph-product-tour-container-zindex-tour .ph-tour-tooltip')
+            .evaluate((el) => parseInt(getComputedStyle(el).zIndex, 10))
+
+        const surveyZIndex = await page
+            .locator('.PostHogSurvey-zindex-survey .survey-form')
+            .evaluate((el) => parseInt(getComputedStyle(el).zIndex, 10))
+
+        const conversationsZIndex = await page
+            .locator('#ph-conversations-widget-container > div')
+            .evaluate((el) => parseInt(getComputedStyle(el).zIndex, 10))
+
+        // Assert hierarchy: tours > surveys > support
+        expect(tourZIndex).toBeGreaterThan(surveyZIndex)
+        expect(surveyZIndex).toBeGreaterThan(conversationsZIndex)
+
+        // Assert exact values match constants
+        expect(tourZIndex).toBe(Z_INDEX_TOURS + 1) // tooltip is calc(base + 1)
+        expect(surveyZIndex).toBe(Z_INDEX_SURVEYS)
+        expect(conversationsZIndex).toBe(Z_INDEX_CONVERSATIONS)
+    })
+})

--- a/packages/browser/src/constants.ts
+++ b/packages/browser/src/constants.ts
@@ -113,3 +113,8 @@ export const PERSISTENCE_RESERVED_PROPERTIES = [
 ]
 
 export const SURVEYS_REQUEST_TIMEOUT_MS = 10000
+
+/* Z-INDEX HIERARCHY: tours > surveys > support */
+export const Z_INDEX_TOURS = 2147483646
+export const Z_INDEX_SURVEYS = 2147483645
+export const Z_INDEX_CONVERSATIONS = 2147483644

--- a/packages/browser/src/extensions/conversations/external/components/styles.ts
+++ b/packages/browser/src/extensions/conversations/external/components/styles.ts
@@ -1,6 +1,7 @@
 // Inline styles following PostHog design system
 
 import type { WidgetPosition } from '../../../../posthog-conversations-types'
+import { Z_INDEX_CONVERSATIONS } from '../../../../constants'
 
 /**
  * Calculate contrasting text color (black or white) based on background brightness
@@ -28,7 +29,7 @@ export const getStyles = (primaryColor: string, position: WidgetPosition = 'bott
             position: 'fixed' as const,
             ...(isTop ? { top: '20px' } : { bottom: '20px' }),
             ...(isLeft ? { left: '20px' } : { right: '20px' }),
-            zIndex: 2147483647,
+            zIndex: Z_INDEX_CONVERSATIONS,
             fontFamily:
                 '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif',
         },

--- a/packages/browser/src/extensions/product-tours/product-tour.css
+++ b/packages/browser/src/extensions/product-tours/product-tour.css
@@ -17,7 +17,7 @@
     --ph-tour-box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     --ph-tour-max-width: 320px;
     --ph-tour-padding: 16px;
-    --ph-tour-z-index: 2147483646;
+    --ph-tour-z-index: 2147483646; /* Z_INDEX_TOURS from constants.ts */
 
     --ph-tour-overlay-color: rgba(0, 0, 0, 0.5);
     --ph-tour-spotlight-padding: 8px;

--- a/packages/browser/src/extensions/surveys/survey.css
+++ b/packages/browser/src/extensions/surveys/survey.css
@@ -5,7 +5,7 @@
         'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
     --ph-survey-box-padding: 20px 24px;
     --ph-survey-max-width: 300px;
-    --ph-survey-z-index: 2147483647;
+    --ph-survey-z-index: 2147483645; /* Z_INDEX_SURVEYS from constants.ts */
     --ph-survey-border-color: #dcdcdc;
     --ph-survey-border-bottom: 1.5px solid var(--ph-survey-border-color);
     --ph-survey-border-radius: 10px;

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -26,6 +26,7 @@ import { isArray, isNullish } from '@posthog/core'
 import { detectDeviceType } from '@posthog/core'
 import { propertyComparisons } from '../../utils/property-utils'
 import { Properties, PropertyMatchType } from '../../types'
+import { Z_INDEX_SURVEYS } from '../../constants'
 import { prepareStylesheet } from '../utils/stylesheet-loader'
 // We cast the types here which is dangerous but protected by the top level generateSurveys call
 const window = _window as Window & typeof globalThis
@@ -66,7 +67,7 @@ export const defaultSurveyAppearance = {
     widgetType: SurveyWidgetType.Tab,
     widgetLabel: 'Feedback',
     widgetColor: 'black',
-    zIndex: '2147483647',
+    zIndex: String(Z_INDEX_SURVEYS),
     disabledButtonOpacity: '0.6',
     maxWidth: '300px',
     textSubtleColor: '#939393',

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -2,6 +2,7 @@ import { PropertyMatchType } from './types'
 import { SurveyActionType, SurveyEventWithFilters } from './posthog-surveys-types'
 import type { InferredSelector } from './extensions/product-tours/element-inference'
 import { SurveyPosition } from '@posthog/core'
+import { Z_INDEX_TOURS } from './constants'
 
 export interface JSONContent {
     type?: string
@@ -160,7 +161,7 @@ export const DEFAULT_PRODUCT_TOUR_APPEARANCE: Required<ProductTourAppearance> = 
     showOverlay: true,
     whiteLabel: false,
     dismissOnClickOutside: true,
-    zIndex: 2147483646,
+    zIndex: Z_INDEX_TOURS,
 }
 
 export interface ShowTourOptions {


### PR DESCRIPTION
## Problem

interactions between tours, surveys, and conversations are not intentional / unexpected

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

as a first pass at not breaking things, this PR simply updates z-index values to support a hierarchy of tours (2147483646, tooltips +1) > surveys (2147483645) > conversations (2147483644)

![Screenshot 2026-02-11 at 1.00.22 PM.png](https://app.graphite.com/user-attachments/assets/ecc32491-42c9-405c-82e8-2b397778d409.png)

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
