### PR TITLE
chore: update CODEOWNERS for network plugin to team-client-libraries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 packages/browser/src/entrypoints/recorder.ts           @PostHog/team-replay
 
 # Network recorder
-packages/browser/src/extensions/replay/external/network-plugin.ts @pauldambra
+packages/browser/src/extensions/replay/external/network-plugin.ts @PostHog/team-client-libraries
 
 # Surveys
 packages/browser/src/extensions/surveys/               @PostHog/team-surveys


### PR DESCRIPTION
## Problem

The network plugin code ownership needs to be updated to reflect the current team structure and responsibilities.

## Changes

Updated the CODEOWNERS file to assign the network plugin (`packages/browser/src/extensions/replay/external/network-plugin.ts`) from individual ownership (@pauldambra) to team ownership (@PostHog/team-client-libraries).

This change ensures that the network plugin is maintained by the client libraries team rather than being tied to a single individual.

## Release info

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

**Note:** This is a metadata-only change (CODEOWNERS) and does not require a version bump.

## Checklist

- [x] No code changes requiring tests
- [x] No impact on different platforms
- [x] No breaking changes
- [x] No bundle size impact

https://claude.ai/code/session_016TJFV3QUxtoJx1FAbyV4cM