### PR TITLE
feat(product tours): enable image preload on tour fetch

### DIFF
--- a/.changeset/moody-clouds-obey.md
+++ b/.changeset/moody-clouds-obey.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+enable product tour image preload

--- a/packages/browser/src/extensions/product-tours/product-tours-utils.ts
+++ b/packages/browser/src/extensions/product-tours/product-tours-utils.ts
@@ -1,6 +1,7 @@
 import DOMPurify from 'dompurify'
 
 import {
+    JSONContent,
     ProductTourAppearance,
     ProductTourSelectorError,
     ProductTourStep,
@@ -281,6 +282,20 @@ function escapeHtml(text: string): string {
     const div = document.createElement('div')
     div.textContent = text
     return div.innerHTML
+}
+
+export function getStepImageUrls(step: ProductTourStep): string[] {
+    const urls: string[] = []
+    function walk(node: JSONContent) {
+        if (node.type === 'image' && node.attrs?.src) {
+            urls.push(node.attrs.src)
+        }
+        node.content?.forEach(walk)
+    }
+    if (step.content) {
+        walk(step.content)
+    }
+    return urls
 }
 
 export function getStepHtml(step: ProductTourStep): string {

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -134,6 +134,7 @@ export interface ProductTour {
     internal_targeting_flag_key?: string
     linked_flag_key?: string
     display_frequency?: ProductTourDisplayFrequency
+    disable_image_preload?: boolean
 }
 
 export type ProductTourCallback = (tours: ProductTour[], context?: { isLoaded: boolean; error?: string }) => void

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -346,6 +346,8 @@
         "_poller",
         "_popstateListener",
         "_prefillHandledSurveys",
+        "_preloadTourImages",
+        "_preloadedImageUrls",
         "_prepareFeatureFlagsForCallbacks",
         "_previousPageViewProperties",
         "_primary_window_exists_storage_key",


### PR DESCRIPTION
## Problem

product tour steps with images don't load their images until the step actually appears, meaning there's a visual shift/flash when they do load

<!-- Who are we building for, what are their needs, why is this important? -->

## [tour-image-preload-issue.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/4886fa16-3cae-497c-9dd1-af2e1e814fec.mp4" />](https://app.graphite.com/user-attachments/video/4886fa16-3cae-497c-9dd1-af2e1e814fec.mp4)



## Changes

adds image preloading to tours on pageload, plus an option to disable image preload per tour

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->