### PR TITLE
fix: Use taze to upgrade catalog entry

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -77,7 +77,7 @@ jobs:
 
                       ${{ github.event.inputs.package_name }} version ${{ github.event.inputs.package_version }} has been released. This updates PostHog to use it.
 
-                      https://github.com/PostHog/posthog-js/compare/${{ github.event.inputs.package_name }}@${{ steps.pnpm-upgrade.outputs.outgoing-version }}...${{ github.event.inputs.package_name }}@${{ github.event.inputs.package_version }} • [GitHub releases](https://github.com/PostHog/posthog-js/releases) • [npm releases](https://www.npmjs.com/package/${{ github.event.inputs.package_name }}?activeTab=version)
+                      [GitHub releases](https://github.com/PostHog/posthog-js/releases) • [npm releases](https://www.npmjs.com/package/${{ github.event.inputs.package_name }}?activeTab=version)
 
             - name: Output pull request result
               shell: bash


### PR DESCRIPTION
The current approach is NOT upgrading posthog-js inside the `pnpm-workspace.yaml` file in the main repo but instead just updating it in each individual package.json file which isn't ideal. I've tested and taze does what I expect it to do, so let's change it