### PR TITLE
feat(product tours): add banner animations

### DIFF
--- a/.changeset/wet-hands-roll.md
+++ b/.changeset/wet-hands-roll.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+add animation option for tour banners

--- a/packages/browser/src/extensions/product-tours/components/ProductTourBanner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourBanner.tsx
@@ -56,7 +56,17 @@ function StaticWrapper({ class: className, children }: BannerWrapperProps): h.JS
     return <div class={className}>{children}</div>
 }
 
-export function ProductTourBanner({
+export function ProductTourBanner(props: ProductTourBannerProps) {
+    return (
+        <div class="ph-tour-banner-wrapper">
+            <div class="ph-tour-banner-slide">
+                <ProductTourBannerInner {...props} />
+            </div>
+        </div>
+    )
+}
+
+function ProductTourBannerInner({
     step,
     onDismiss,
     onActionClick,

--- a/packages/browser/src/extensions/product-tours/product-tour.css
+++ b/packages/browser/src/extensions/product-tours/product-tour.css
@@ -560,6 +560,25 @@
 }
 
 /* Banner styles */
+@keyframes ph-tour-banner-slide-in {
+    from {
+        grid-template-rows: 0fr;
+    }
+    to {
+        grid-template-rows: 1fr;
+    }
+}
+
+.ph-tour-banner-wrapper {
+    display: grid;
+    animation: ph-tour-banner-slide-in var(--ph-tour-banner-animation-duration, 300ms) ease-out forwards;
+}
+
+.ph-tour-banner-slide {
+    overflow: hidden;
+    min-height: 0;
+}
+
 .ph-tour-banner {
     display: flex;
     align-items: center;

--- a/packages/browser/src/extensions/product-tours/product-tours.tsx
+++ b/packages/browser/src/extensions/product-tours/product-tours.tsx
@@ -30,7 +30,7 @@ import { createLogger } from '../../utils/logger'
 import { document as _document, window as _window } from '../../utils/globals'
 import { localStore, sessionStore } from '../../storage'
 import { addEventListener } from '../../utils'
-import { isNull, SurveyMatchType } from '@posthog/core'
+import { isNull, isUndefined, SurveyMatchType } from '@posthog/core'
 import { propertyComparisons } from '../../utils/property-utils'
 import {
     TOUR_SHOWN_KEY_PREFIX,
@@ -153,6 +153,10 @@ function retrieveBannerShadow(
     div.className = containerClass
 
     addProductTourCSSVariablesToElement(div, tour.appearance)
+
+    if (!isUndefined(bannerConfig?.animation?.duration)) {
+        div.style.setProperty('--ph-tour-banner-animation-duration', `${bannerConfig.animation.duration}ms`)
+    }
 
     const shadow = div.attachShadow({ mode: 'open' })
 

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -22,6 +22,9 @@ export interface ProductTourBannerConfig {
         link?: string
         tourId?: string
     }
+    animation?: {
+        duration?: number
+    }
 }
 
 /** Button actions available on modal steps */

--- a/playground/nextjs/pages/product-tours.tsx
+++ b/playground/nextjs/pages/product-tours.tsx
@@ -53,6 +53,8 @@ export default function ProductTours() {
 
     return (
         <div className="p-6 max-w-4xl mx-auto">
+            <div id="playground-banner-container"></div>
+
             <h1 className="text-2xl font-bold mb-6">Product Tours Playground</h1>
 
             {/* Tour Controls */}


### PR DESCRIPTION
## Problem

banners cause a pretty jarring layout shift when they appear

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

adds an animation option for banners :)

| normal sticky/static banners | custom injection banners |
| --- | --- |
| [banner-animations.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/1e13d546-08b6-40a8-bb37-3a17fc065d72.mp4" />](https://app.graphite.com/user-attachments/video/1e13d546-08b6-40a8-bb37-3a17fc065d72.mp4)<br> | [injected-banner-animation.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/8819e0d0-3732-4997-924d-4332373b23f1.mp4" />](https://app.graphite.com/user-attachments/video/8819e0d0-3732-4997-924d-4332373b23f1.mp4)<br> |

<!-- What is changed and what information would be useful to a reviewer? -->

main app pr: https://github.com/PostHog/posthog/pull/47980

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->