### PR TITLE
fix(ai): bind prompt reads to project token

### DIFF
--- a/.changeset/dry-dragons-push.md
+++ b/.changeset/dry-dragons-push.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Bind prompt fetches to both credentials by requiring `projectApiKey` and adding `token=<projectApiKey>` to prompt API reads.

--- a/packages/ai/src/prompts.ts
+++ b/packages/ai/src/prompts.ts
@@ -36,6 +36,7 @@ function isPromptsWithPostHog(options: PromptsOptions): options is PromptsWithPo
  * // Or with direct options (no PostHog client needed)
  * const prompts = new Prompts({
  *   personalApiKey: 'phx_xxx',
+ *   projectApiKey: 'phc_xxx',
  *   host: 'https://us.posthog.com',
  * })
  *
@@ -54,6 +55,7 @@ function isPromptsWithPostHog(options: PromptsOptions): options is PromptsWithPo
  */
 export class Prompts {
   private personalApiKey: string
+  private projectApiKey: string
   private host: string
   private defaultCacheTtlSeconds: number
   private cache: Map<string, CachedPrompt> = new Map()
@@ -63,10 +65,12 @@ export class Prompts {
 
     if (isPromptsWithPostHog(options)) {
       this.personalApiKey = options.posthog.options.personalApiKey ?? ''
+      this.projectApiKey = options.posthog.apiKey ?? ''
       this.host = options.posthog.host
     } else {
       // Direct options
       this.personalApiKey = options.personalApiKey
+      this.projectApiKey = options.projectApiKey
       this.host = options.host ?? 'https://us.posthog.com'
     }
   }
@@ -166,8 +170,16 @@ export class Prompts {
           'Please provide it when initializing the Prompts instance.'
       )
     }
+    if (!this.projectApiKey) {
+      throw new Error(
+        '[PostHog Prompts] projectApiKey is required to fetch prompts. ' +
+          'Please provide it when initializing the Prompts instance.'
+      )
+    }
 
-    const url = `${this.host}/api/environments/@current/llm_prompts/name/${encodeURIComponent(name)}/`
+    const encodedPromptName = encodeURIComponent(name)
+    const encodedProjectApiKey = encodeURIComponent(this.projectApiKey)
+    const url = `${this.host}/api/environments/@current/llm_prompts/name/${encodedPromptName}/?token=${encodedProjectApiKey}`
 
     const response = await fetch(url, {
       method: 'GET',

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -135,6 +135,7 @@ export type PromptVariables = Record<string, string | number | boolean>
  */
 export interface PromptsDirectOptions {
   personalApiKey: string
+  projectApiKey: string
   host?: string
   defaultCacheTtlSeconds?: number
 }


### PR DESCRIPTION
## Problem

Prompt fetches using `@current` could resolve against a user-selected team when no project token was included, which made prompt reads non-deterministic.

## Changes

- Added `projectApiKey` to direct `Prompts` options and derived it from `posthog.apiKey` when initialized with a PostHog client
- Added `?token=<projectApiKey>` to prompt fetch URLs
- Kept Bearer auth with personal API key unchanged
- Updated prompt tests for tokenized URLs and missing project key validation
- Updated tests/docs examples and added an `@posthog/ai` changeset

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
