### PR TITLE
feat(product tours): support customizable survey step button texts

### DIFF
--- a/.changeset/red-tools-sink.md
+++ b/.changeset/red-tools-sink.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+support customizable survey step button texts in product tours

--- a/packages/browser/src/extensions/product-tours/components/ProductTourSurveyStepInner.tsx
+++ b/packages/browser/src/extensions/product-tours/components/ProductTourSurveyStepInner.tsx
@@ -220,7 +220,7 @@ export function ProductTourSurveyStepInner({
                             onClick={onPrevious}
                             style={cursorStyle}
                         >
-                            Back
+                            {survey.backButtonText || 'Back'}
                         </button>
                     )}
                     {isOpenText && (
@@ -229,7 +229,7 @@ export function ProductTourSurveyStepInner({
                             onClick={handleTextSubmit}
                             style={cursorStyle}
                         >
-                            Submit
+                            {survey.submitButtonText || 'Submit'}
                         </button>
                     )}
                 </div>

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -54,6 +54,8 @@ export interface ProductTourSurveyQuestion {
     lowerBoundLabel?: string
     /** Label for high end of rating scale (e.g., "Very likely") */
     upperBoundLabel?: string
+    submitButtonText?: string
+    backButtonText?: string
 }
 
 export interface ProductTourStep {


### PR DESCRIPTION
## Problem

survey steps in product tours have hard-coded button texts

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

supports customizable button text in survey steps

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
