### PR TITLE
feat(product tours): support tour content localization

### DIFF
--- a/.changeset/two-ideas-rule.md
+++ b/.changeset/two-ideas-rule.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/types': minor
+---
+
+add support for product tours localization

--- a/packages/browser/src/extensions/product-tours/product-tours-utils.ts
+++ b/packages/browser/src/extensions/product-tours/product-tours-utils.ts
@@ -11,8 +11,12 @@ import { findElement } from './element-inference'
 import { prepareStylesheet } from '../utils/stylesheet-loader'
 import { document as _document, window as _window } from '../../utils/globals'
 import { getFontFamily, getContrastingTextColor, hexToRgba } from '../surveys/surveys-extension-utils'
+import { createLogger } from '../../utils/logger'
 
 import productTourStyles from './product-tour.css'
+import { isUndefined } from '@posthog/core'
+
+const logger = createLogger('[Product Tours]')
 
 const document = _document as Document
 const window = _window as Window & typeof globalThis
@@ -282,6 +286,45 @@ function escapeHtml(text: string): string {
     const div = document.createElement('div')
     div.textContent = text
     return div.innerHTML
+}
+
+export function resolveStepTranslation(step: ProductTourStep, lang: string | null): ProductTourStep {
+    if (!lang || !step.translations) {
+        return step
+    }
+
+    const translations = step.translations
+
+    // exact match (en-US === en-US), then base match (en-US falls back to en)
+    const t = translations[lang] ?? translations[lang.split('-')[0]]
+
+    if (!t) {
+        logger.info(`No matching translation for "${lang}" in step ${step.id}, using default`)
+        return step
+    }
+
+    const resolved = { ...step }
+
+    if (!isUndefined(t.content)) {
+        resolved.content = t.content
+    }
+
+    if (!isUndefined(t.contentHtml)) {
+        resolved.contentHtml = t.contentHtml
+    }
+
+    if (t.buttons && resolved.buttons) {
+        resolved.buttons = {
+            primary: resolved.buttons.primary && { ...resolved.buttons.primary, ...t.buttons.primary },
+            secondary: resolved.buttons.secondary && { ...resolved.buttons.secondary, ...t.buttons.secondary },
+        }
+    }
+
+    if (t.survey && resolved.survey) {
+        resolved.survey = { ...resolved.survey, ...t.survey }
+    }
+
+    return resolved
 }
 
 export function getStepImageUrls(step: ProductTourStep): string[] {

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -84,6 +84,22 @@ export interface ProductTourStep {
     buttons?: ProductTourStepButtons
     /** Banner configuration (only for banner steps) */
     bannerConfig?: ProductTourBannerConfig
+    /** translation data for this tour step */
+    translations?: Record<string, ProductTourStepTranslation>
+}
+
+/** all translatable content for a given tour step */
+export interface ProductTourStepTranslation {
+    content?: ProductTourStep['content']
+    contentHtml?: ProductTourStep['contentHtml']
+    buttons?: {
+        primary?: Pick<ProductTourStepButton, 'text'>
+        secondary?: Pick<ProductTourStepButton, 'text'>
+    }
+    survey?: Pick<
+        ProductTourSurveyQuestion,
+        'questionText' | 'lowerBoundLabel' | 'upperBoundLabel' | 'submitButtonText' | 'backButtonText'
+    >
 }
 
 export interface ProductTourConditions {

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -160,6 +160,7 @@
         "_getActivatedKey",
         "_getBufferDuration",
         "_getContextManager",
+        "_getCurrentStep",
         "_getDelegate",
         "_getDelegateLogger",
         "_getDnt",

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -645,6 +645,11 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "string",
     "RegExp"
   ],
+  "override_display_language": [
+    "undefined",
+    "null",
+    "string"
+  ],
   "__add_tracing_headers": [
     "undefined",
     "string[]"

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1390,6 +1390,16 @@ export interface PostHogConfig {
      */
     internal_or_test_user_hostname?: string | RegExp | null
 
+    /**
+     * Display language override for Product Tours.
+     *
+     * Must be a valid BCP 47 language code.
+     *
+     * In the future this will be used for Surveys and other products that
+     * deliver in-app experiences to end-users.
+     */
+    override_display_language?: string | null
+
     // ------- PREVIEW CONFIGS -------
 
     /**


### PR DESCRIPTION
## Problem

product tours only support one language

closes https://github.com/PostHog/posthog/issues/47968#issue-3940215543

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- adds sdk support for tour content translations
- adds a new config field `override_display_language`, which i expect we can also use for surveys, and more in the future

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->