### PR TITLE
feat(product tours): add device type targeting

### DIFF
--- a/.changeset/hungry-hornets-turn.md
+++ b/.changeset/hungry-hornets-turn.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+add product tours device type targeting

--- a/packages/browser/src/__tests__/extensions/matcher-utils.test.ts
+++ b/packages/browser/src/__tests__/extensions/matcher-utils.test.ts
@@ -1,0 +1,42 @@
+import { doesDeviceTypeMatch } from '../../extensions/utils/matcher-utils'
+import * as globals from '../../utils/globals'
+
+const DESKTOP_UA =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36'
+const MOBILE_UA =
+    'Mozilla/5.0 (Linux; U; Android-4.0.3; en-us; Galaxy Nexus Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.75 Mobile Safari/535.7'
+const TABLET_UA =
+    'Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1'
+
+function setUserAgent(ua: string | undefined) {
+    // @ts-expect-error - overriding readonly export for testing
+    globals['userAgent'] = ua
+}
+
+describe('doesDeviceTypeMatch', () => {
+    const originalUA = globals.userAgent
+    afterEach(() => setUserAgent(originalUA as string | undefined))
+
+    it.each([
+        ['no device types', undefined, DESKTOP_UA, true],
+        ['empty device types', [], DESKTOP_UA, true],
+        ['no userAgent', ['Desktop'], undefined, false],
+        ['Desktop matches desktop UA', ['Desktop'], DESKTOP_UA, true],
+        ['Mobile matches mobile UA', ['Mobile'], MOBILE_UA, true],
+        ['Tablet matches tablet UA', ['Tablet'], TABLET_UA, true],
+        ['Mobile does not match desktop UA', ['Mobile'], DESKTOP_UA, false],
+        ['Desktop does not match mobile UA', ['Desktop'], MOBILE_UA, false],
+        ['any match in list suffices', ['Desktop', 'Mobile'], MOBILE_UA, true],
+        ['no match in list', ['Mobile', 'Tablet'], DESKTOP_UA, false],
+        ['case-insensitive by default', ['desktop'], DESKTOP_UA, true],
+    ] as const)('%s → %s', (_label, deviceTypes, ua, expected) => {
+        setUserAgent(ua)
+        expect(doesDeviceTypeMatch(deviceTypes as string[] | undefined)).toBe(expected)
+    })
+
+    it('exact match type is case-sensitive', () => {
+        setUserAgent(DESKTOP_UA)
+        expect(doesDeviceTypeMatch(['Desktop'], 'exact')).toBe(true)
+        expect(doesDeviceTypeMatch(['desktop'], 'exact')).toBe(false)
+    })
+})

--- a/packages/browser/src/extensions/product-tours/product-tours.tsx
+++ b/packages/browser/src/extensions/product-tours/product-tours.tsx
@@ -42,6 +42,7 @@ import { doesTourActivateByAction, doesTourActivateByEvent } from '../../utils/p
 import { TOOLBAR_ID } from '../../constants'
 import { ProductTourEventReceiver } from '../../utils/product-tour-event-receiver'
 import { getBrowserLanguage } from '../../utils/event-utils'
+import { doesDeviceTypeMatch } from '../utils/matcher-utils'
 
 const logger = createLogger('[Product Tours]')
 
@@ -91,7 +92,7 @@ function isTourInDateRange(tour: ProductTour): boolean {
 }
 
 function checkTourConditions(tour: ProductTour): boolean {
-    return isTourInDateRange(tour) && doesTourUrlMatch(tour)
+    return isTourInDateRange(tour) && doesTourUrlMatch(tour) && doesDeviceTypeMatch(tour.conditions?.deviceTypes)
 }
 
 const CONTAINER_CLASS = 'ph-product-tour-container'

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -12,7 +12,7 @@ import {
     SurveyType,
     SurveyWidgetType,
 } from '../../posthog-surveys-types'
-import { document as _document, window as _window, userAgent } from '../../utils/globals'
+import { document as _document, window as _window } from '../../utils/globals'
 import {
     getSurveyInteractionProperty,
     getSurveySeenKey,
@@ -23,7 +23,6 @@ import {
 } from '../../utils/survey-utils'
 import { isArray, isNullish } from '@posthog/core'
 
-import { detectDeviceType } from '@posthog/core'
 import { propertyComparisons } from '../../utils/property-utils'
 import { Properties, PropertyMatchType } from '../../types'
 import { Z_INDEX_SURVEYS } from '../../constants'
@@ -33,6 +32,7 @@ const window = _window as Window & typeof globalThis
 const document = _document as Document
 import surveyStyles from './survey.css'
 import { useContext } from 'preact/hooks'
+import { doesDeviceTypeMatch } from '../utils/matcher-utils'
 
 export function getFontFamily(fontFamily?: string): string {
     if (fontFamily === 'inherit') {
@@ -686,19 +686,7 @@ export function doesSurveyUrlMatch(survey: Pick<Survey, 'conditions'>): boolean 
 }
 
 export function doesSurveyDeviceTypesMatch(survey: Survey): boolean {
-    if (!survey.conditions?.deviceTypes || survey.conditions?.deviceTypes.length === 0) {
-        return true
-    }
-    // if we dont know the device type, assume it is not a match
-    if (!userAgent) {
-        return false
-    }
-
-    const deviceType = detectDeviceType(userAgent)
-    return propertyComparisons[defaultMatchType(survey.conditions?.deviceTypesMatchType)](
-        survey.conditions.deviceTypes,
-        [deviceType]
-    )
+    return doesDeviceTypeMatch(survey.conditions?.deviceTypes, survey.conditions?.deviceTypesMatchType)
 }
 
 export function doesSurveyMatchSelector(survey: Survey): boolean {

--- a/packages/browser/src/extensions/utils/matcher-utils.ts
+++ b/packages/browser/src/extensions/utils/matcher-utils.ts
@@ -1,0 +1,15 @@
+import { detectDeviceType } from '@posthog/core'
+import { userAgent } from '../../utils/globals'
+import { propertyComparisons } from '../../utils/property-utils'
+import { PropertyMatchType } from '../../types'
+
+export function doesDeviceTypeMatch(deviceTypes?: string[], matchType?: PropertyMatchType): boolean {
+    if (!deviceTypes || deviceTypes.length === 0) {
+        return true
+    }
+    if (!userAgent) {
+        return false
+    }
+    const deviceType = detectDeviceType(userAgent)
+    return propertyComparisons[matchType ?? 'icontains'](deviceTypes, [deviceType])
+}

--- a/packages/browser/src/posthog-product-tours-types.ts
+++ b/packages/browser/src/posthog-product-tours-types.ts
@@ -117,6 +117,7 @@ export interface ProductTourConditions {
         values: SurveyActionType[]
     } | null
     linkedFlagVariant?: string
+    deviceTypes?: string[]
 }
 
 export interface ProductTourAppearance {


### PR DESCRIPTION
## Problem

closes https://github.com/PostHog/posthog/issues/48218#issue-3953966215

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
