### PR TITLE
ci: Escape new-pr.yml

### DIFF
--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -33,8 +33,6 @@ jobs:
               if: steps.is-shame-worthy.outputs.is-shame-worthy == 'true'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PR_AUTHOR: ${{ toJSON(github.actor) }}
-                  PR_NUMBER: ${{ github.event.pull_request.number }}
               run: |
-                  SHAME_BODY="Hey @${PR_AUTHOR}! 👋\nThis pull request seems to contain no description. Please add useful context, rationale, and/or any other information that will help make sense of this change now and in the distant Mars-based future."
-                  gh pr comment "$PR_NUMBER" --body "$SHAME_BODY"
+                  SHAME_BODY="Hey @${{ github.actor }}! 👋\nThis pull request seems to contain no description. Please add useful context, rationale, and/or any other information that will help make sense of this change now and in the distant Mars-based future."
+                  gh pr comment ${{ github.event.pull_request.number }} --body "$SHAME_BODY"


### PR DESCRIPTION
## Problem

The `new-pr.yml` GitHub workflow was off.

## Changes

Fix the workflow.