### PR TITLE
fix(ci): use --no-frozen-lockfile in posthog-upgrade workflow

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -51,7 +51,7 @@ jobs:
                   PACKAGE_NAME: ${{ github.event.inputs.package_name }}
               run: |
                   pnpx taze -r --include "$PACKAGE_NAME" -w
-                  pnpm i
+                  pnpm i --no-frozen-lockfile
 
             - name: Generate branch name
               id: generate-branch-name


### PR DESCRIPTION
## Problem

The `posthog-upgrade.yml` workflow is failing with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "catalogs" configuration doesn't match the value found in the lockfile
```

After `taze` updates the posthog-js version in the pnpm catalog (`pnpm-workspace.yaml`), `pnpm i` refuses to proceed because frozen-lockfile mode is enabled and the catalog no longer matches the lockfile.

## Fix

Use `pnpm i --no-frozen-lockfile` since the whole purpose of this step is to update the dependency and regenerate the lockfile.