### PR TITLE
fix(ci): disable husky hooks in posthog-upgrade workflow

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -21,8 +21,6 @@ jobs:
     posthog-upgrade:
         name: Upgrade PostHog Package
         runs-on: ubuntu-latest
-        env:
-            HUSKY: '0'
 
         steps:
             - name: Get upgrader token
@@ -68,6 +66,8 @@ jobs:
             - name: Create main repo pull request
               id: main-repo-pr
               uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
+              env:
+                  HUSKY: '0'
               with:
                   token: ${{ steps.upgrader.outputs.token }}
                   commit-message: 'chore(deps): Update ${{ github.event.inputs.package_name }} to ${{ github.event.inputs.package_version }}'


### PR DESCRIPTION
## Problem

The `posthog-upgrade.yml` workflow fails when `peter-evans/create-pull-request` commits changes to the PostHog/posthog repo. The repo's husky pre-commit hook runs `bin/hogli format:yaml` which requires `uv`, which isn't available in the CI runner:

```
bin/hogli format:yaml:
/usr/bin/env: 'uv': No such file or directory
husky - pre-commit hook exited with code 1 (error)
```

## Fix

Set `HUSKY=0` at the job level to disable git hooks. This is a CI-only automation workflow — pre-commit hooks aren't needed here.