### PR TITLE
fix(ci): replace taze with sed to avoid reformatting files

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -49,8 +49,9 @@ jobs:
               shell: bash
               env:
                   PACKAGE_NAME: ${{ github.event.inputs.package_name }}
+                  PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
               run: |
-                  pnpx taze -r --include "$PACKAGE_NAME" -w
+                  sed -i "s|${PACKAGE_NAME}:.*|${PACKAGE_NAME}: ^${PACKAGE_VERSION}|" pnpm-workspace.yaml
                   pnpm i --no-frozen-lockfile
 
             - name: Generate branch name


### PR DESCRIPTION
## Problem

The `posthog-upgrade.yml` workflow uses `taze` to update the posthog-js version in the PostHog/posthog repo's pnpm catalog. However, `taze` reformats `pnpm-workspace.yaml` and `package.json` when writing, causing lint failures in the PostHog repo CI.

## Fix

Replace `taze` with a targeted `sed` that only updates the version string in `pnpm-workspace.yaml` without touching any formatting. This changes:

```diff
- pnpx taze -r --include "$PACKAGE_NAME" -w
+ sed -i "s|${PACKAGE_NAME}:.*|${PACKAGE_NAME}: ^${PACKAGE_VERSION}|" pnpm-workspace.yaml
```

Since we already know the exact package version from the workflow input, there's no need for `taze` to query npm for the latest version.