### PR TITLE
fix: putting rrweb directly on window for 1.16x.x compatability

### DIFF
--- a/.changeset/bright-readers-work.md
+++ b/.changeset/bright-readers-work.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: no need to put rrweb and friends directly on window in posthog-recorder

--- a/packages/browser/src/entrypoints/posthog-recorder.ts
+++ b/packages/browser/src/entrypoints/posthog-recorder.ts
@@ -9,13 +9,4 @@ assignableWindow.__PosthogExtensions__.rrwebPlugins = { getRecordConsolePlugin, 
 assignableWindow.__PosthogExtensions__.rrweb = { record: rrwebRecord, version: 'v2' }
 assignableWindow.__PosthogExtensions__.initSessionRecording = (ph) => new LazyLoadedSessionRecording(ph)
 
-// we used to put all of these items directly on window, and now we put it on __PosthogExtensions__
-// but that means that old clients which lazily load this extension are looking in the wrong place
-// yuck,
-// so we also put them directly on the window
-// when 1.161.1 is the oldest version seen in production we can remove this
-assignableWindow.rrweb = { record: rrwebRecord, version: 'v2' }
-assignableWindow.rrwebConsoleRecord = { getRecordConsolePlugin }
-assignableWindow.getRecordNetworkPlugin = getRecordNetworkPlugin
-
 export default rrwebRecord


### PR DESCRIPTION
we used to put rrweb and friends directly on window and still do for backwards compatabilty

however, the old clients that look for it on window would never load posthog-recorder because they predate it

so we need to do this on the "old" recorder entrypoint but not the new posthog-recorder entrypoint