### PR TITLE
fix(ai): guard mapVercelOutput against undefined content in generateObject

### DIFF
--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -194,7 +194,10 @@ const mapVercelPrompt = (messages: LanguageModelPrompt): PostHogInput[] => {
   return inputs
 }
 
-const mapVercelOutput = (result: LanguageModelContent[]): PostHogInput[] => {
+const mapVercelOutput = (result: LanguageModelContent[] | undefined): PostHogInput[] => {
+  if (!result || !Array.isArray(result)) {
+    return []
+  }
   const content: OutputContentItem[] = result.map((item) => {
     if (item.type === 'text') {
       return { type: 'text', text: truncate(item.text) }


### PR DESCRIPTION
## Problem

`withTracing` from `@posthog/ai/vercel` crashes when used with the Vercel AI SDK's `generateObject` function:

```
TypeError: Cannot read properties of undefined (reading 'map')
  at mapVercelOutput (packages/ai/src/vercel/middleware.ts:198)
```

When `generateObject` is used, the model's `doGenerate` returns `content: undefined` since structured output doesn't produce text/tool-call content. `mapVercelOutput` calls `result.map()` without checking, crashing PostHog's wrapper and making it look like the model itself failed.

This affects both V2 and V3 models.

## Fix

Add a null/array guard at the top of `mapVercelOutput`:

```typescript
const mapVercelOutput = (result: LanguageModelContent[] | undefined): PostHogInput[] => {
  if (!result || !Array.isArray(result)) {
    return []
  }
  // ...existing code
}
```

## Test

Added test covering the `generateObject` case for both V2 and V3 models, verifying that:
- `doGenerate` returning no `content` field does not throw
- PostHog capture is still called (with empty output choices)
- No error is recorded

Fixes #3091