### PR TITLE
fix(surveys): fix autosubmit bug for hosted surveys

### DIFF
--- a/.changeset/short-news-argue.md
+++ b/.changeset/short-news-argue.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix autofill bug in hosted surveys


### PR DESCRIPTION
## Problem

hosted surveys do not properly proceed to the confirmation page when they are completed via autofill params

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

adds that logic :)

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
