### PR TITLE
feat(ai): add $ai_tokens_source property to detect token value overrides

### DIFF
--- a/.changeset/ai-tokens-source.md
+++ b/.changeset/ai-tokens-source.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Add `$ai_tokens_source` property ("sdk" or "passthrough") to all `$ai_generation` events to detect when token values are externally overridden via `posthogProperties`

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -389,6 +389,25 @@ describe('PostHogAnthropic', () => {
       const [captureArgs] = captureMock.mock.calls
       const { properties } = captureArgs[0]
       expect(properties['$ai_usage']).toBeDefined()
+      expect(properties['$ai_tokens_source']).toBe('sdk')
+    })
+
+    conditionalTest('should set tokens_source to passthrough when token properties are overridden', async () => {
+      const response = await client.messages.create({
+        model: 'claude-3-opus-20240229',
+        messages: [{ role: 'user', content: 'Hello Claude' }],
+        max_tokens: 100,
+        posthogDistinctId: 'test-user-123',
+        posthogProperties: { $ai_input_tokens: 99999 },
+      })
+
+      expect(response).toEqual(mockResponse)
+
+      const captureMock = mockPostHogClient.capture as jest.Mock
+      const [captureArgs] = captureMock.mock.calls
+      const { properties } = captureArgs[0]
+      expect(properties['$ai_tokens_source']).toBe('passthrough')
+      expect(properties['$ai_input_tokens']).toBe(99999)
     })
 
     conditionalTest('should handle system prompts correctly', async () => {

--- a/packages/ai/tests/utils.test.ts
+++ b/packages/ai/tests/utils.test.ts
@@ -1,4 +1,21 @@
-import { toContentString } from '../src/utils'
+import { toContentString, getTokensSource } from '../src/utils'
+
+describe('getTokensSource', () => {
+  it.each([
+    ['undefined properties', undefined, 'sdk'],
+    ['empty properties', {}, 'sdk'],
+    ['unrelated properties', { foo: 'bar' }, 'sdk'],
+    ['$ai_input_tokens override', { $ai_input_tokens: 999 }, 'passthrough'],
+    ['$ai_output_tokens override', { $ai_output_tokens: 999 }, 'passthrough'],
+    ['$ai_total_tokens override', { $ai_total_tokens: 999 }, 'passthrough'],
+    ['$ai_cache_read_input_tokens override', { $ai_cache_read_input_tokens: 500 }, 'passthrough'],
+    ['$ai_cache_creation_input_tokens override', { $ai_cache_creation_input_tokens: 200 }, 'passthrough'],
+    ['$ai_reasoning_tokens override', { $ai_reasoning_tokens: 300 }, 'passthrough'],
+    ['mixed override and custom', { $ai_input_tokens: 999, custom_key: 'value' }, 'passthrough'],
+  ])('%s → %s', (_name, props, expected) => {
+    expect(getTokensSource(props)).toBe(expected)
+  })
+})
 
 describe('toContentString', () => {
   describe('string inputs', () => {


### PR DESCRIPTION
## Summary

- Adds `$ai_tokens_source` property (`"sdk"` or `"passthrough"`) to all `$ai_generation` events in `@posthog/ai`
- When a user overrides any token property (`$ai_input_tokens`, `$ai_output_tokens`, `$ai_total_tokens`, etc.) via `posthogProperties`, the property is set to `"passthrough"` -- otherwise `"sdk"`
- Companion PR to PostHog/posthog-python#444 which adds the same property to the Python SDK

## Test plan

- [x] Unit tests for `getTokensSource` helper (10 parameterized cases covering undefined, empty, unrelated, and each token key)
- [x] Integration test for passthrough detection in Anthropic non-streaming path
- [x] Assertion added to existing Anthropic non-streaming test for `"sdk"` value
- [x] Utils test suite passes (36 tests)