### PR TITLE
fix(replay): fix infinite recursion loop

### DIFF
--- a/.changeset/mighty-wolves-relax.md
+++ b/.changeset/mighty-wolves-relax.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+add re-entrancy guard for cases where ALL + regex + event trigger matching is configured

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -231,6 +231,7 @@
         "_inputRef",
         "_internalEventEmitter",
         "_internalFlagCheckSatisfied",
+        "_isActivatingTrigger",
         "_isBelowMinimumDuration",
         "_isCalled",
         "_isConsoleLogCaptureEnabled",


### PR DESCRIPTION
## Problem

Loop found in stack trace of breakpoints: (claude helped summarize)   
  **Infinite Recursion Flow (with triggerMatchType: 'all'):**



  1. Event trigger fires → _activateTrigger('event')

  2. Checks status (line 695): TRIGGER_PENDING → enters if block

  3. Registers event trigger to persistence (line 699-703)

  4. Calls _reportStarted → addCustomEvent('event_trigger_matched')

  5. rrweb emits custom event → onRRwebEmit

  6. onRRwebEmit calls _pageViewFallBack() (line 991) → emits addCustomEvent('$url_changed')

  7. rrweb emits ANOTHER event → onRRwebEmit AGAIN

  8. onRRwebEmit calls checkUrlTriggerConditions (line 995-1000)

  9. URL matches → _activateTrigger('url')

  10. Checks status (line 695): **STILL TRIGGER_PENDING** (with 'all' mode, BOTH triggers must activate before status changes)

  11. Enters if block → registers URL trigger

  12. Calls _reportStarted → emits more custom events

  13. Those events → onRRwebEmit → can trigger _activateTrigger again

  14. **INFINITE RECURSION** - status remains TRIGGER_PENDING because activations happen during ongoing function executions



  **Key Issue:** With triggerMatchType: 'all', registering ONE trigger doesn't change the overall status from TRIGGER_PENDING. Recursive calls keep entering the if-block before both triggers fully complete activation, creating an infinite loop.



## Changes



add re-entrancy guard

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->