### PR TITLE
docs: remove Android-only restriction from captureLog comment

### DIFF
--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -110,8 +110,7 @@ export type PostHogSessionReplayConfig = {
    */
   maskAllSandboxedViews?: boolean
   /**
-   * Enable capturing of logcat as console events
-   * Android only
+   * Enable capturing of logs as console events
    * Default: true
    */
   captureLog?: boolean


### PR DESCRIPTION
## Problem


## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
