### PR TITLE
feat(err): make chunk id generation deterministic

### DIFF
--- a/packages/core/src/process/chunk-id.spec.ts
+++ b/packages/core/src/process/chunk-id.spec.ts
@@ -1,0 +1,81 @@
+import {
+  computeChunkId,
+  buildCodeSnippet,
+  buildChunkComment,
+  CHUNKID_PLACEHOLDER,
+  CODE_SNIPPET_TEMPLATE,
+  CHUNKID_COMMENT_PREFIX,
+} from './chunk-id'
+
+describe('chunk-id', () => {
+  describe('computeChunkId', () => {
+    it('returns a 32-char hex string', () => {
+      const result = computeChunkId('console.log("hello")', '{"mappings":"AAAA"}')
+      expect(result).toHaveLength(32)
+      expect(result).toMatch(/^[0-9a-f]{32}$/)
+    })
+
+    it('is deterministic for the same input', () => {
+      const js = 'var x = 1;'
+      const map = '{"mappings":"AAAA"}'
+      expect(computeChunkId(js, map)).toBe(computeChunkId(js, map))
+    })
+
+    it('changes when JS content changes', () => {
+      const map = '{"mappings":"AAAA"}'
+      const id1 = computeChunkId('var x = 1;', map)
+      const id2 = computeChunkId('var x = 2;', map)
+      expect(id1).not.toBe(id2)
+    })
+
+    it('changes when source map content changes', () => {
+      const js = 'var x = 1;'
+      const id1 = computeChunkId(js, '{"mappings":"AAAA"}')
+      const id2 = computeChunkId(js, '{"mappings":"BBBB"}')
+      expect(id1).not.toBe(id2)
+    })
+
+    it('accepts Buffer inputs', () => {
+      const js = 'var x = 1;'
+      const map = '{"mappings":"AAAA"}'
+      const fromString = computeChunkId(js, map)
+      const fromBuffer = computeChunkId(Buffer.from(js), Buffer.from(map))
+      expect(fromString).toBe(fromBuffer)
+    })
+
+    it('matches Rust CLI implementation', () => {
+      // This value is verified against the Rust chunk_id_hash function
+      // in cli/src/utils/files/content.rs with the same inputs
+      const result = computeChunkId('var x = 1;', '{"mappings":"AAAA"}')
+      expect(result).toBe('c1b08c52e81d19e59bfcb02180762bea')
+    })
+  })
+
+  describe('buildCodeSnippet', () => {
+    it('replaces placeholder with chunk ID', () => {
+      const result = buildCodeSnippet('abc123')
+      expect(result).toContain('abc123')
+      expect(result).not.toContain(CHUNKID_PLACEHOLDER)
+      expect(result).toContain('_posthogChunkIds')
+    })
+  })
+
+  describe('buildChunkComment', () => {
+    it('replaces placeholder with chunk ID', () => {
+      const result = buildChunkComment('abc123')
+      expect(result).toBe('\n//# chunkId=abc123')
+    })
+  })
+
+  describe('constants match CLI', () => {
+    it('snippet template matches Rust constant', () => {
+      expect(CODE_SNIPPET_TEMPLATE).toBe(
+        '!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._posthogChunkIds=e._posthogChunkIds||{},e._posthogChunkIds[n]="__POSTHOG_CHUNK_ID__")}catch(e){}}();'
+      )
+    })
+
+    it('comment prefix matches Rust constant', () => {
+      expect(CHUNKID_COMMENT_PREFIX).toBe('\n//# chunkId=__POSTHOG_CHUNK_ID__')
+    })
+  })
+})

--- a/packages/core/src/process/chunk-id.ts
+++ b/packages/core/src/process/chunk-id.ts
@@ -1,0 +1,34 @@
+import { createHash } from 'node:crypto'
+
+export const CODE_SNIPPET_TEMPLATE =
+  '!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._posthogChunkIds=e._posthogChunkIds||{},e._posthogChunkIds[n]="__POSTHOG_CHUNK_ID__")}catch(e){}}();'
+
+export const CHUNKID_COMMENT_PREFIX = '\n//# chunkId=__POSTHOG_CHUNK_ID__'
+
+export const CHUNKID_PLACEHOLDER = '__POSTHOG_CHUNK_ID__'
+
+/**
+ * Computes a deterministic chunk ID from pre-injection JS and source map content.
+ * Uses SHA-256(jsContent || sourcemapContent) truncated to 32 hex chars.
+ * Must match the Rust CLI implementation in cli/src/utils/files/content.rs.
+ */
+export function computeChunkId(jsContent: string | Buffer, sourcemapContent: string | Buffer): string {
+  const hash = createHash('sha256')
+  hash.update(jsContent)
+  hash.update(sourcemapContent)
+  return hash.digest('hex').slice(0, 32)
+}
+
+/**
+ * Returns the JS snippet with the chunk ID placeholder replaced.
+ */
+export function buildCodeSnippet(chunkId: string): string {
+  return CODE_SNIPPET_TEMPLATE.replace(CHUNKID_PLACEHOLDER, chunkId)
+}
+
+/**
+ * Returns the chunk ID comment with the placeholder replaced.
+ */
+export function buildChunkComment(chunkId: string): string {
+  return CHUNKID_COMMENT_PREFIX.replace(CHUNKID_PLACEHOLDER, chunkId)
+}

--- a/packages/core/src/process/index.ts
+++ b/packages/core/src/process/index.ts
@@ -1,4 +1,5 @@
 export * from './spawn-local'
 export { resolveBinaryPath } from './utils'
+export { computeChunkId, buildCodeSnippet, buildChunkComment } from './chunk-id'
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'


### PR DESCRIPTION
## Changes

- chunk id injection is now handled by the bundlers and fallbacks to the cli.
- make chunk id generation deterministic
- Use a hash of the chunk + sourcemap content

Related PR: https://github.com/PostHog/posthog/pull/49240