### PR TITLE
feat(browser): Tree shake additional extensions

### DIFF
--- a/.changeset/slick-parents-march.md
+++ b/.changeset/slick-parents-march.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+feat: Tree-shake surveys, toolbar, exceptions, conversations, logs, experiments

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -365,6 +365,33 @@ const entrypointTargets = entrypoints.map((file) => {
     }
 })
 
+/**
+ * rollup-plugin-dts doesn't resolve `declare module` augmentations that target
+ * modules being inlined. Relative paths like `'../types'` become dangling in
+ * the bundled output. This plugin repoints them to the package name so
+ * TypeScript's module augmentation merging works correctly for consumers.
+ */
+function fixDtsModuleAugmentation() {
+    const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf-8'))
+    const pkgDir = path.resolve('.')
+
+    return {
+        name: 'fix-dts-module-augmentation',
+        generateBundle(options, bundle) {
+            const outputDir = options.dir ? path.resolve(options.dir) : path.dirname(path.resolve(options.file))
+            for (const chunk of Object.values(bundle)) {
+                if (!chunk.code) continue
+                const chunkPath = path.resolve(outputDir, chunk.fileName)
+                const modulePath = `${pkg.name}/${path.relative(pkgDir, chunkPath).replace(/\.d\.ts$/, '')}`
+                chunk.code = chunk.code.replace(
+                    /declare module ['"]\.\.?\/[^'"]+['"]/g,
+                    `declare module '${modulePath}'`
+                )
+            }
+        },
+    }
+}
+
 const typeTargets = entrypoints
     .filter((file) => file.endsWith('.es.ts'))
     .map((file) => {
@@ -383,6 +410,7 @@ const typeTargets = entrypoints
                 dts({
                     exclude: [],
                 }),
+                fixDtsModuleAugmentation(),
             ],
         }
     })

--- a/packages/browser/src/__tests__/extension-classes.test.ts
+++ b/packages/browser/src/__tests__/extension-classes.test.ts
@@ -81,6 +81,32 @@ describe('__extensionClasses enrollment', () => {
         expect(posthog.autocapture).toBeInstanceOf(MockAutocapture)
     })
 
+    it('eagerly constructs extensions from defaults before init()', () => {
+        PostHog.__defaultExtensionClasses = AllExtensions
+
+        const posthog = new PostHog()
+
+        expect(posthog.toolbar).toBeDefined()
+        expect(posthog.surveys).toBeDefined()
+        expect(posthog.conversations).toBeDefined()
+        expect(posthog.logs).toBeDefined()
+        expect(posthog.experiments).toBeDefined()
+        expect(posthog.exceptions).toBeDefined()
+    })
+
+    it('does not eagerly construct extensions when no defaults exist', () => {
+        PostHog.__defaultExtensionClasses = {}
+
+        const posthog = new PostHog()
+
+        expect(posthog.toolbar).toBeUndefined()
+        expect(posthog.surveys).toBeUndefined()
+        expect(posthog.conversations).toBeUndefined()
+        expect(posthog.logs).toBeUndefined()
+        expect(posthog.experiments).toBeUndefined()
+        expect(posthog.exceptions).toBeUndefined()
+    })
+
     it('default extensions are used when __extensionClasses is not provided', async () => {
         PostHog.__defaultExtensionClasses = AllExtensions
 

--- a/packages/browser/src/__tests__/extension-classes.test.ts
+++ b/packages/browser/src/__tests__/extension-classes.test.ts
@@ -35,6 +35,12 @@ describe('__extensionClasses enrollment', () => {
         expect(posthog.webVitalsAutocapture).toBeUndefined()
         expect(posthog.productTours).toBeUndefined()
         expect(posthog.siteApps).toBeUndefined()
+        expect(posthog.surveys).toBeUndefined()
+        expect(posthog.toolbar).toBeUndefined()
+        expect(posthog.exceptions).toBeUndefined()
+        expect(posthog.conversations).toBeUndefined()
+        expect(posthog.logs).toBeUndefined()
+        expect(posthog.experiments).toBeUndefined()
     })
 
     it('initializes no extensions when none are provided and no defaults exist', async () => {
@@ -53,6 +59,12 @@ describe('__extensionClasses enrollment', () => {
         expect(posthog.webVitalsAutocapture).toBeUndefined()
         expect(posthog.productTours).toBeUndefined()
         expect(posthog.siteApps).toBeUndefined()
+        expect(posthog.surveys).toBeUndefined()
+        expect(posthog.toolbar).toBeUndefined()
+        expect(posthog.exceptions).toBeUndefined()
+        expect(posthog.conversations).toBeUndefined()
+        expect(posthog.logs).toBeUndefined()
+        expect(posthog.experiments).toBeUndefined()
     })
 
     it('__extensionClasses overrides __defaultExtensionClasses', async () => {
@@ -85,6 +97,12 @@ describe('__extensionClasses enrollment', () => {
         expect(posthog.webVitalsAutocapture).toBeDefined()
         expect(posthog.productTours).toBeDefined()
         expect(posthog.siteApps).toBeDefined()
+        expect(posthog.surveys).toBeDefined()
+        expect(posthog.toolbar).toBeDefined()
+        expect(posthog.exceptions).toBeDefined()
+        expect(posthog.conversations).toBeDefined()
+        expect(posthog.logs).toBeDefined()
+        expect(posthog.experiments).toBeDefined()
     })
 })
 
@@ -107,13 +125,19 @@ describe('extension lifecycle', () => {
             const allKeys = Object.keys(AllExtensions).sort()
             expect(allKeys).toEqual([
                 'autocapture',
+                'conversations',
                 'deadClicksAutocapture',
                 'exceptionObserver',
+                'exceptions',
+                'experiments',
                 'heatmaps',
                 'historyAutocapture',
+                'logs',
                 'productTours',
                 'sessionRecording',
                 'siteApps',
+                'surveys',
+                'toolbar',
                 'tracingHeaders',
                 'webVitalsAutocapture',
             ])
@@ -173,13 +197,11 @@ describe('extension lifecycle', () => {
                 }
             }
 
-            // Use extension keys that don't have hardcoded method calls
-            // in set_config, so a spy class works without needing stubs.
             const posthog = await createPosthogInstance(undefined, {
                 __preview_deferred_init_extensions: false,
                 __extensionClasses: {
-                    historyAutocapture: SpyExtension as any,
-                    siteApps: SpyExtension as any,
+                    toolbar: SpyExtension as any,
+                    conversations: SpyExtension as any,
                 },
                 capture_pageview: false,
             })
@@ -193,6 +215,50 @@ describe('extension lifecycle', () => {
             // Two extensions, each should get onRemoteConfig called once
             expect(onRemoteConfigSpy).toHaveBeenCalledTimes(2)
             expect(onRemoteConfigSpy).toHaveBeenCalledWith(remoteConfig)
+        })
+    })
+
+    describe('graceful degradation without extensions (slim bundle)', () => {
+        it('onSurveysLoaded calls back with error when extension is not loaded', async () => {
+            PostHog.__defaultExtensionClasses = {}
+
+            const posthog = await createPosthogInstance(undefined, {
+                __preview_deferred_init_extensions: false,
+                capture_pageview: false,
+            })
+
+            const callback = jest.fn()
+            posthog.onSurveysLoaded(callback)
+
+            expect(callback).toHaveBeenCalledWith([], { isLoaded: false, error: 'Surveys module not available' })
+        })
+
+        it('getSurveys calls back with error when extension is not loaded', async () => {
+            PostHog.__defaultExtensionClasses = {}
+
+            const posthog = await createPosthogInstance(undefined, {
+                __preview_deferred_init_extensions: false,
+                capture_pageview: false,
+            })
+
+            const callback = jest.fn()
+            posthog.getSurveys(callback)
+
+            expect(callback).toHaveBeenCalledWith([], { isLoaded: false, error: 'Surveys module not available' })
+        })
+
+        it('getActiveMatchingSurveys calls back with error when extension is not loaded', async () => {
+            PostHog.__defaultExtensionClasses = {}
+
+            const posthog = await createPosthogInstance(undefined, {
+                __preview_deferred_init_extensions: false,
+                capture_pageview: false,
+            })
+
+            const callback = jest.fn()
+            posthog.getActiveMatchingSurveys(callback)
+
+            expect(callback).toHaveBeenCalledWith([], { isLoaded: false, error: 'Surveys module not available' })
         })
     })
 })

--- a/packages/browser/src/entrypoints/module.slim.no-external.es.ts
+++ b/packages/browser/src/entrypoints/module.slim.no-external.es.ts
@@ -1,4 +1,11 @@
 import { init_as_module } from '../posthog-core'
+
+declare module '../types' {
+    interface TreeShakeableConfig {
+        optional: true
+    }
+}
+
 export { PostHog } from '../posthog-core'
 export * from '../types'
 export * from '../posthog-surveys-types'

--- a/packages/browser/src/extensions/conversations/posthog-conversations.ts
+++ b/packages/browser/src/extensions/conversations/posthog-conversations.ts
@@ -15,12 +15,13 @@ import { assignableWindow, LazyLoadedConversationsInterface } from '../../utils/
 import { createLogger } from '../../utils/logger'
 import { isNullish, isUndefined, isBoolean, isNull } from '@posthog/core'
 import { isToolbarInstance } from '../../utils'
+import { Extension } from '../types'
 
 const logger = createLogger('[Conversations]')
 
 export type ConversationsManager = LazyLoadedConversationsInterface
 
-export class PostHogConversations {
+export class PostHogConversations implements Extension {
     // This is set to undefined until the remote config is loaded
     // then it's set to true if conversations are enabled
     // or false if conversations are disabled in the project settings
@@ -30,6 +31,10 @@ export class PostHogConversations {
     private _remoteConfig: ConversationsRemoteConfig | null = null
 
     constructor(private _instance: PostHog) {}
+
+    initialize() {
+        this.loadIfEnabled()
+    }
 
     onRemoteConfig(response: RemoteConfig) {
         // Don't load conversations if disabled via config

--- a/packages/browser/src/extensions/exception-autocapture/index.ts
+++ b/packages/browser/src/extensions/exception-autocapture/index.ts
@@ -161,6 +161,6 @@ export class ExceptionObserver {
             return
         }
 
-        this._instance.exceptions.sendExceptionEvent(errorProperties)
+        this._instance.exceptions?.sendExceptionEvent(errorProperties)
     }
 }

--- a/packages/browser/src/extensions/extension-bundles.ts
+++ b/packages/browser/src/extensions/extension-bundles.ts
@@ -32,10 +32,16 @@ import { Heatmaps } from '../heatmaps'
 import { PostHogProductTours } from '../posthog-product-tours'
 import { SiteApps } from '../site-apps'
 import { PostHogConfig } from '../types'
+import { PostHogSurveys } from '../posthog-surveys'
+import { Toolbar } from './toolbar'
+import { PostHogExceptions } from '../posthog-exceptions'
+import { WebExperiments } from '../web-experiments'
+import { PostHogConversations } from './conversations/posthog-conversations'
+import { PostHogLogs } from '../posthog-logs'
 
 type ExtensionClasses = NonNullable<PostHogConfig['__extensionClasses']>
 
-/** Session replay and related extensions. */
+/** Session replay. */
 export const SessionReplayExtensions = {
     sessionRecording: SessionRecording,
 } as const satisfies ExtensionClasses
@@ -52,6 +58,7 @@ export const AnalyticsExtensions = {
 /** Automatic exception and error capture. */
 export const ErrorTrackingExtensions = {
     exceptionObserver: ExceptionObserver,
+    exceptions: PostHogExceptions,
 } as const satisfies ExtensionClasses
 
 /** In-app product tours. */
@@ -69,6 +76,31 @@ export const TracingExtensions = {
     tracingHeaders: TracingHeaders,
 } as const satisfies ExtensionClasses
 
+/** In-app surveys. */
+export const SurveysExtensions = {
+    surveys: PostHogSurveys,
+} as const satisfies ExtensionClasses
+
+/** PostHog toolbar for visual element inspection and action setup. */
+export const ToolbarExtensions = {
+    toolbar: Toolbar,
+} as const satisfies ExtensionClasses
+
+/** Web experiments. */
+export const ExperimentsExtensions = {
+    experiments: WebExperiments,
+} as const satisfies ExtensionClasses
+
+/** In-app conversations. */
+export const ConversationsExtensions = {
+    conversations: PostHogConversations,
+} as const satisfies ExtensionClasses
+
+/** Console log capture. */
+export const LogsExtensions = {
+    logs: PostHogLogs,
+} as const satisfies ExtensionClasses
+
 /** All extensions — equivalent to the default `posthog-js` bundle. */
 export const AllExtensions = {
     ...SessionReplayExtensions,
@@ -77,4 +109,9 @@ export const AllExtensions = {
     ...ProductToursExtensions,
     ...SiteAppsExtensions,
     ...TracingExtensions,
+    ...SurveysExtensions,
+    ...ToolbarExtensions,
+    ...ExperimentsExtensions,
+    ...ConversationsExtensions,
+    ...LogsExtensions,
 } as const satisfies ExtensionClasses

--- a/packages/browser/src/extensions/sentry-integration.ts
+++ b/packages/browser/src/extensions/sentry-integration.ts
@@ -142,7 +142,7 @@ export function createEventProcessor(
         }
 
         if (sendExceptionsToPostHog) {
-            _posthog.exceptions.sendExceptionEvent(data)
+            _posthog.exceptions?.sendExceptionEvent(data)
         }
 
         return event

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -614,7 +614,7 @@ export class SurveyManager {
             return true
         }
         const surveysActivatedByEventsOrActions: string[] | undefined =
-            this._posthog.surveys._surveyEventReceiver?.getSurveys()
+            this._posthog.surveys?._surveyEventReceiver?.getSurveys()
         return !!surveysActivatedByEventsOrActions?.includes(survey.id)
     }
 
@@ -632,7 +632,7 @@ export class SurveyManager {
     }
 
     public getActiveMatchingSurveys = (callback: SurveyCallback, forceReload = false): void => {
-        this._posthog?.surveys.getSurveys((surveys) => {
+        this._posthog?.surveys?.getSurveys((surveys) => {
             const targetingMatchedSurveys = surveys.filter((survey) => {
                 const eligibility = this.checkSurveyEligibility(survey)
                 return (

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -84,7 +84,11 @@ export const defaultSurveyAppearance = {
     scrollbarTrackColor: 'var(--ph-survey-background-color)',
 } as const
 
-const BOTTOM_BORDER_SURVEY_POSITIONS: SurveyPosition[] = [SurveyPosition.Center, SurveyPosition.Left, SurveyPosition.Right]
+const BOTTOM_BORDER_SURVEY_POSITIONS: SurveyPosition[] = [
+    SurveyPosition.Center,
+    SurveyPosition.Left,
+    SurveyPosition.Right,
+]
 
 export const addSurveyCSSVariablesToElement = (
     element: HTMLElement,

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -84,6 +84,8 @@ export const defaultSurveyAppearance = {
     scrollbarTrackColor: 'var(--ph-survey-background-color)',
 } as const
 
+const BOTTOM_BORDER_SURVEY_POSITIONS: SurveyPosition[] = [SurveyPosition.Center, SurveyPosition.Left, SurveyPosition.Right]
+
 export const addSurveyCSSVariablesToElement = (
     element: HTMLElement,
     type: SurveyType,
@@ -93,7 +95,7 @@ export const addSurveyCSSVariablesToElement = (
     const hostStyle = element.style
 
     const surveyHasBottomBorder =
-        ![SurveyPosition.Center, SurveyPosition.Left, SurveyPosition.Right].includes(effectiveAppearance.position) ||
+        !BOTTOM_BORDER_SURVEY_POSITIONS.includes(effectiveAppearance.position) ||
         (type === SurveyType.Widget && appearance?.widgetType === SurveyWidgetType.Tab)
 
     hostStyle.setProperty('--ph-survey-font-family', getFontFamily(effectiveAppearance.fontFamily))

--- a/packages/browser/src/extensions/toolbar.ts
+++ b/packages/browser/src/extensions/toolbar.ts
@@ -6,6 +6,7 @@ import { createLogger } from '../utils/logger'
 import { window, document, assignableWindow } from '../utils/globals'
 import { TOOLBAR_ID } from '../constants'
 import { isFunction, isNullish } from '@posthog/core'
+import { Extension } from './types'
 
 // TRICKY: Many web frameworks will modify the route on load, potentially before posthog is initialized.
 // To get ahead of this we grab it as soon as the posthog-js is parsed
@@ -23,7 +24,7 @@ enum ToolbarState {
     LOADED = 2,
 }
 
-export class Toolbar {
+export class Toolbar implements Extension {
     instance: PostHog
 
     constructor(instance: PostHog) {
@@ -37,6 +38,10 @@ export class Toolbar {
 
     private _getToolbarState(): ToolbarState {
         return assignableWindow['ph_toolbar_state'] ?? ToolbarState.UNINITIALIZED
+    }
+
+    initialize(): boolean {
+        return this.maybeLoadToolbar()
     }
 
     /**

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -436,6 +436,17 @@ export class PostHog implements PostHogInterface {
         this.requestRouter = new RequestRouter(this)
         this.consent = new ConsentManager(this)
         this.externalIntegrations = new ExternalIntegrations(this)
+
+        // Eagerly construct extensions from default classes so they're available before init().
+        // For the slim bundle, these remain undefined until _initExtensions sets them from config.
+        const ext = PostHog.__defaultExtensionClasses ?? {}
+        this.toolbar = ext.toolbar && new ext.toolbar(this)
+        this.surveys = ext.surveys && new ext.surveys(this)
+        this.conversations = ext.conversations && new ext.conversations(this)
+        this.logs = ext.logs && new ext.logs(this)
+        this.experiments = ext.experiments && new ext.experiments(this)
+        this.exceptions = ext.exceptions && new ext.exceptions(this)
+
         // NOTE: See the property definition for deprecation notice
         this.people = {
             set: (prop: string | Properties, to?: string, callback?: RequestCallback) => {
@@ -713,7 +724,7 @@ export class PostHog implements PostHogInterface {
         // Due to name mangling, we can't easily iterate and assign these extensions
         // The assignment needs to also be mangled. Thus, the loop is unrolled.
         if (ext.exceptions) {
-            this._extensions.push((this.exceptions = new ext.exceptions(this)))
+            this._extensions.push((this.exceptions = this.exceptions ?? new ext.exceptions(this)))
         }
         if (ext.historyAutocapture) {
             this._extensions.push((this.historyAutocapture = new ext.historyAutocapture(this)))
@@ -736,13 +747,13 @@ export class PostHog implements PostHogInterface {
             this._extensions.push((this.autocapture = new ext.autocapture(this)))
         }
         if (ext.surveys) {
-            this._extensions.push((this.surveys = new ext.surveys(this)))
+            this._extensions.push((this.surveys = this.surveys ?? new ext.surveys(this)))
         }
         if (ext.logs) {
-            this._extensions.push((this.logs = new ext.logs(this)))
+            this._extensions.push((this.logs = this.logs ?? new ext.logs(this)))
         }
         if (ext.conversations) {
-            this._extensions.push((this.conversations = new ext.conversations(this)))
+            this._extensions.push((this.conversations = this.conversations ?? new ext.conversations(this)))
         }
         if (ext.productTours) {
             this._extensions.push((this.productTours = new ext.productTours(this)))
@@ -762,10 +773,10 @@ export class PostHog implements PostHogInterface {
             )
         }
         if (ext.toolbar) {
-            this._extensions.push((this.toolbar = new ext.toolbar(this)))
+            this._extensions.push((this.toolbar = this.toolbar ?? new ext.toolbar(this)))
         }
         if (ext.experiments) {
-            this._extensions.push((this.experiments = new ext.experiments(this)))
+            this._extensions.push((this.experiments = this.experiments ?? new ext.experiments(this)))
         }
 
         this._extensions.forEach((extension) => {

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -2258,6 +2258,7 @@ export class PostHog implements PostHogInterface {
     canRenderSurveyAsync(surveyId: string, forceReload = false): Promise<SurveyRenderReason> {
         return (
             this.surveys?.canRenderSurveyAsync(surveyId, forceReload) ??
+            // eslint-disable-next-line compat/compat
             Promise.resolve({ visible: false, disabledReason: 'Surveys module not available' })
         )
     }

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -13,22 +13,17 @@ import {
 import { isDeadClicksEnabledForAutocapture } from './extensions/dead-clicks-autocapture'
 import { setupSegmentIntegration } from './extensions/segment-integration'
 import { SentryIntegration, sentryIntegration, SentryIntegrationOptions } from './extensions/sentry-integration'
-import { Toolbar } from './extensions/toolbar'
 import { PageViewManager } from './page-view'
-import { PostHogExceptions } from './posthog-exceptions'
 import { PostHogFeatureFlags } from './posthog-featureflags'
 import { PostHogPersistence } from './posthog-persistence'
-import { PostHogSurveys } from './posthog-surveys'
-import { PostHogConversations } from './extensions/conversations/posthog-conversations'
 import {
-    DisplaySurveyOptions,
-    SurveyCallback,
+    type DisplaySurveyOptions,
+    type SurveyCallback,
     SurveyEventName,
     SurveyEventProperties,
-    SurveyRenderReason,
+    type SurveyRenderReason,
 } from './posthog-surveys-types'
 import { ProductTourEventName, ProductTourEventProperties } from './posthog-product-tours-types'
-import { PostHogLogs } from './posthog-logs'
 import { RateLimiter } from './rate-limiter'
 import { RemoteConfigLoader } from './remote-config'
 import { extendURLParams, request, SUPPORTS_REQUEST } from './request'
@@ -102,7 +97,6 @@ import {
     isBoolean,
 } from '@posthog/core'
 import { uuidv7 } from './uuidv7'
-import { WebExperiments } from './web-experiments'
 import { ExternalIntegrations } from './extensions/external-integration'
 import type { Extension } from './extensions/types'
 import type { Autocapture } from './autocapture'
@@ -111,9 +105,15 @@ import type { ExceptionObserver } from './extensions/exception-autocapture'
 import type { HistoryAutocapture } from './extensions/history-autocapture'
 import type { WebVitalsAutocapture } from './extensions/web-vitals'
 import type { Heatmaps } from './heatmaps'
+import type { PostHogConversations } from './extensions/conversations/posthog-conversations'
+import type { PostHogExceptions } from './posthog-exceptions'
+import type { PostHogLogs } from './posthog-logs'
 import type { PostHogProductTours } from './posthog-product-tours'
+import type { PostHogSurveys } from './posthog-surveys'
 import type { SiteApps } from './site-apps'
 import type { SessionRecording } from './extensions/replay/session-recording'
+import type { Toolbar } from './extensions/toolbar'
+import type { WebExperiments } from './web-experiments'
 
 /*
 SIMPLE STYLE GUIDE:
@@ -340,12 +340,12 @@ export class PostHog implements PostHogInterface {
     scrollManager: ScrollManager
     pageViewManager: PageViewManager
     featureFlags: PostHogFeatureFlags
-    surveys: PostHogSurveys
-    conversations: PostHogConversations
-    logs: PostHogLogs
-    experiments: WebExperiments
-    toolbar: Toolbar
-    exceptions: PostHogExceptions
+    surveys?: PostHogSurveys
+    conversations?: PostHogConversations
+    logs?: PostHogLogs
+    experiments?: WebExperiments
+    toolbar?: Toolbar
+    exceptions?: PostHogExceptions
     consent: ConsentManager
 
     // These are instance-specific state created after initialisation
@@ -430,14 +430,8 @@ export class PostHog implements PostHogInterface {
         this._initialPersonProfilesConfig = null
         this._cachedPersonProperties = null
         this.featureFlags = new PostHogFeatureFlags(this)
-        this.toolbar = new Toolbar(this)
         this.scrollManager = new ScrollManager(this)
         this.pageViewManager = new PageViewManager(this)
-        this.surveys = new PostHogSurveys(this)
-        this.conversations = new PostHogConversations(this)
-        this.logs = new PostHogLogs(this)
-        this.experiments = new WebExperiments(this)
-        this.exceptions = new PostHogExceptions(this)
         this.rateLimiter = new RateLimiter(this)
         this.requestRouter = new RequestRouter(this)
         this.consent = new ConsentManager(this)
@@ -688,8 +682,6 @@ export class PostHog implements PostHogInterface {
             passive: false,
         })
 
-        this.toolbar.maybeLoadToolbar()
-
         // We want to avoid promises for IE11 compatibility, so we use callbacks here
         if (config.segment) {
             setupSegmentIntegration(this, () => this._loaded())
@@ -720,6 +712,9 @@ export class PostHog implements PostHogInterface {
 
         // Due to name mangling, we can't easily iterate and assign these extensions
         // The assignment needs to also be mangled. Thus, the loop is unrolled.
+        if (ext.exceptions) {
+            this._extensions.push((this.exceptions = new ext.exceptions(this)))
+        }
         if (ext.historyAutocapture) {
             this._extensions.push((this.historyAutocapture = new ext.historyAutocapture(this)))
         }
@@ -740,6 +735,15 @@ export class PostHog implements PostHogInterface {
         if (ext.autocapture) {
             this._extensions.push((this.autocapture = new ext.autocapture(this)))
         }
+        if (ext.surveys) {
+            this._extensions.push((this.surveys = new ext.surveys(this)))
+        }
+        if (ext.logs) {
+            this._extensions.push((this.logs = new ext.logs(this)))
+        }
+        if (ext.conversations) {
+            this._extensions.push((this.conversations = new ext.conversations(this)))
+        }
         if (ext.productTours) {
             this._extensions.push((this.productTours = new ext.productTours(this)))
         }
@@ -757,23 +761,18 @@ export class PostHog implements PostHogInterface {
                 (this.deadClicksAutocapture = new ext.deadClicksAutocapture(this, isDeadClicksEnabledForAutocapture))
             )
         }
+        if (ext.toolbar) {
+            this._extensions.push((this.toolbar = new ext.toolbar(this)))
+        }
+        if (ext.experiments) {
+            this._extensions.push((this.experiments = new ext.experiments(this)))
+        }
 
         this._extensions.forEach((extension) => {
             if (!extension.initialize) return
             initTasks.push(() => {
                 extension.initialize?.()
             })
-        })
-
-        // Init hardcoded extensions (not yet tree-shakable)
-        initTasks.push(() => {
-            this.surveys.loadIfEnabled()
-        })
-        initTasks.push(() => {
-            this.logs.loadIfEnabled()
-        })
-        initTasks.push(() => {
-            this.conversations.loadIfEnabled()
         })
 
         // Replay any pending remote config that arrived before extensions were ready
@@ -867,12 +866,6 @@ export class PostHog implements PostHogInterface {
         })
 
         this._extensions.forEach((ext) => ext.onRemoteConfig?.(config))
-
-        // Hardcoded extensions (not yet tree-shakable)
-        this.surveys.onRemoteConfig(config)
-        this.logs.onRemoteConfig(config)
-        this.conversations.onRemoteConfig(config)
-        this.exceptions.onRemoteConfig(config)
     }
 
     _loaded(): void {
@@ -927,7 +920,7 @@ export class PostHog implements PostHogInterface {
     }
 
     _handle_unload(): void {
-        this.surveys.handlePageUnload()
+        this.surveys?.handlePageUnload()
 
         if (!this.config.request_batching) {
             if (this._shouldCapturePageleave()) {
@@ -2067,6 +2060,10 @@ export class PostHog implements PostHogInterface {
      * @returns {Function} A function that can be called to unsubscribe the listener.
      */
     onSurveysLoaded(callback: SurveyCallback): () => void {
+        if (!this.surveys) {
+            callback([], { isLoaded: false, error: 'Surveys module not available' })
+            return () => {}
+        }
         return this.surveys.onSurveysLoaded(callback)
     }
 
@@ -2112,7 +2109,9 @@ export class PostHog implements PostHogInterface {
      * @param {Boolean} [forceReload] Optional boolean to force an API call for updated surveys
      */
     getSurveys(callback: SurveyCallback, forceReload = false): void {
-        this.surveys.getSurveys(callback, forceReload)
+        this.surveys
+            ? this.surveys.getSurveys(callback, forceReload)
+            : callback([], { isLoaded: false, error: 'Surveys module not available' })
     }
 
     /**
@@ -2133,7 +2132,9 @@ export class PostHog implements PostHogInterface {
      * @param {Boolean} [forceReload] Whether to force a reload of the surveys.
      */
     getActiveMatchingSurveys(callback: SurveyCallback, forceReload = false): void {
-        this.surveys.getActiveMatchingSurveys(callback, forceReload)
+        this.surveys
+            ? this.surveys.getActiveMatchingSurveys(callback, forceReload)
+            : callback([], { isLoaded: false, error: 'Surveys module not available' })
     }
 
     /**
@@ -2159,7 +2160,7 @@ export class PostHog implements PostHogInterface {
      * @param {String} selector The selector of the HTML element to render the survey on.
      */
     renderSurvey(surveyId: string, selector: string): void {
-        this.surveys.renderSurvey(surveyId, selector)
+        this.surveys?.renderSurvey(surveyId, selector)
     }
 
     /**
@@ -2196,7 +2197,7 @@ export class PostHog implements PostHogInterface {
      * {@label Surveys}
      */
     displaySurvey(surveyId: string, options: DisplaySurveyOptions = DEFAULT_DISPLAY_SURVEY_OPTIONS): void {
-        this.surveys.displaySurvey(surveyId, options)
+        this.surveys?.displaySurvey(surveyId, options)
     }
 
     /**
@@ -2205,7 +2206,7 @@ export class PostHog implements PostHogInterface {
      * {@label Surveys}
      */
     cancelPendingSurvey(surveyId: string): void {
-        this.surveys.cancelPendingSurvey(surveyId)
+        this.surveys?.cancelPendingSurvey(surveyId)
     }
 
     /**
@@ -2222,7 +2223,12 @@ export class PostHog implements PostHogInterface {
      * @returns A SurveyRenderReason object indicating if the survey can be rendered.
      */
     canRenderSurvey(surveyId: string): SurveyRenderReason | null {
-        return this.surveys.canRenderSurvey(surveyId)
+        return (
+            this.surveys?.canRenderSurvey(surveyId) ?? {
+                visible: false,
+                disabledReason: 'Surveys module not available',
+            }
+        )
     }
 
     /**
@@ -2250,7 +2256,10 @@ export class PostHog implements PostHogInterface {
      * @returns A SurveyRenderReason object indicating if the survey can be rendered.
      */
     canRenderSurveyAsync(surveyId: string, forceReload = false): Promise<SurveyRenderReason> {
-        return this.surveys.canRenderSurveyAsync(surveyId, forceReload)
+        return (
+            this.surveys?.canRenderSurveyAsync(surveyId, forceReload) ??
+            Promise.resolve({ visible: false, disabledReason: 'Surveys module not available' })
+        )
     }
 
     /**
@@ -2668,7 +2677,7 @@ export class PostHog implements PostHogInterface {
         this.consent.reset()
         this.persistence?.clear()
         this.sessionPersistence?.clear()
-        this.surveys.reset()
+        this.surveys?.reset()
         // Stop the refresh interval before resetting flags — featureFlags.reset() clears
         // the debouncer, so if the order were reversed a pending refresh could fire after reset.
         this._remoteConfigLoader?.stop()
@@ -2918,7 +2927,7 @@ export class PostHog implements PostHogInterface {
             this.heatmaps?.startIfEnabled()
             this.exceptionObserver?.startIfEnabledOrStop()
             this.deadClicksAutocapture?.startIfEnabledOrStop()
-            this.surveys.loadIfEnabled()
+            this.surveys?.loadIfEnabled()
             this._sync_opt_out_with_persistence()
             this.externalIntegrations?.startIfEnabledOrStop()
         }
@@ -3060,6 +3069,8 @@ export class PostHog implements PostHogInterface {
      * @returns {CaptureResult} The result of the capture
      */
     captureException(error: unknown, additionalProperties?: Properties): CaptureResult | undefined {
+        if (!this.exceptions) return
+
         const syntheticException = new Error('PostHog syntheticException')
         const errorToProperties = this.exceptions.buildProperties(error, {
             handled: true,
@@ -3130,7 +3141,7 @@ export class PostHog implements PostHogInterface {
      */
 
     loadToolbar(params: ToolbarParams): boolean {
-        return this.toolbar.loadToolbar(params)
+        return this.toolbar?.loadToolbar(params) ?? false
     }
 
     /**
@@ -3402,7 +3413,7 @@ export class PostHog implements PostHogInterface {
 
         // Reinitialize surveys if we're in cookieless mode and just opted in
         if (this.config.cookieless_mode == 'on_reject') {
-            this.surveys.loadIfEnabled()
+            this.surveys?.loadIfEnabled()
         }
 
         // Don't capture if captureEventName is null or false

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -58,6 +58,7 @@ import {
     SnippetArrayItem,
     ToolbarParams,
     PostHogInterface,
+    TreeShakeable,
 } from './types'
 import {
     _copyAndTruncateStrings,
@@ -340,12 +341,12 @@ export class PostHog implements PostHogInterface {
     scrollManager: ScrollManager
     pageViewManager: PageViewManager
     featureFlags: PostHogFeatureFlags
-    surveys?: PostHogSurveys
-    conversations?: PostHogConversations
-    logs?: PostHogLogs
-    experiments?: WebExperiments
-    toolbar?: Toolbar
-    exceptions?: PostHogExceptions
+    surveys: TreeShakeable<PostHogSurveys>
+    conversations: TreeShakeable<PostHogConversations>
+    logs: TreeShakeable<PostHogLogs>
+    experiments: TreeShakeable<WebExperiments>
+    toolbar: TreeShakeable<Toolbar>
+    exceptions: TreeShakeable<PostHogExceptions>
     consent: ConsentManager
 
     // These are instance-specific state created after initialisation

--- a/packages/browser/src/posthog-exceptions.ts
+++ b/packages/browser/src/posthog-exceptions.ts
@@ -1,4 +1,5 @@
 import { ERROR_TRACKING_CAPTURE_EXTENSION_EXCEPTIONS, ERROR_TRACKING_SUPPRESSION_RULES } from './constants'
+import { Extension } from './extensions/types'
 import { PostHog } from './posthog-core'
 import { CaptureResult, ErrorTrackingSuppressionRule, Properties, RemoteConfig } from './types'
 import { createLogger } from './utils/logger'
@@ -22,7 +23,7 @@ export function buildErrorPropertiesBuilder() {
         ErrorTracking.createDefaultStackParser()
     )
 }
-export class PostHogExceptions {
+export class PostHogExceptions implements Extension {
     private readonly _instance: PostHog
     private _suppressionRules: ErrorTrackingSuppressionRule[] = []
     private _errorPropertiesBuilder: ErrorTracking.ErrorPropertiesBuilder = buildErrorPropertiesBuilder()

--- a/packages/browser/src/posthog-logs.ts
+++ b/packages/browser/src/posthog-logs.ts
@@ -3,8 +3,9 @@ import { RemoteConfig } from './types'
 import { isNullish } from '@posthog/core'
 import { assignableWindow } from './utils/globals'
 import { createLogger } from './utils/logger'
+import { Extension } from './extensions/types'
 
-export class PostHogLogs {
+export class PostHogLogs implements Extension {
     private _isLogsEnabled: boolean = false
     private _isLoaded: boolean = false
 
@@ -12,6 +13,10 @@ export class PostHogLogs {
         if (this._instance && this._instance.config.logs?.captureConsoleLogs) {
             this._isLogsEnabled = true
         }
+    }
+
+    initialize() {
+        this.loadIfEnabled()
     }
 
     onRemoteConfig(response: RemoteConfig) {

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -7,11 +7,6 @@
 import type { Properties, PropertyMatchType } from './types'
 import type { SurveyAppearance as CoreSurveyAppearance, SurveyValidationRule } from '@posthog/core'
 
-export enum SurveyEventType {
-    Activation = 'events',
-    Cancellation = 'cancelEvents',
-}
-
 // Extended operator type to include numeric operators not in PropertyMatchType
 export type PropertyOperator = PropertyMatchType | 'gt' | 'lt'
 
@@ -27,35 +22,9 @@ export interface SurveyEventWithFilters {
     propertyFilters?: PropertyFilters
 }
 
-export enum SurveyWidgetType {
-    Button = 'button',
-    Tab = 'tab',
-    Selector = 'selector',
-}
-
-export enum SurveyPosition {
-    TopLeft = 'top_left',
-    TopRight = 'top_right',
-    TopCenter = 'top_center',
-    MiddleLeft = 'middle_left',
-    MiddleRight = 'middle_right',
-    MiddleCenter = 'middle_center',
-    Left = 'left',
-    Center = 'center',
-    Right = 'right',
-    NextToTrigger = 'next_to_trigger',
-}
-
-export enum SurveyTabPosition {
-    Top = 'top',
-    Left = 'left',
-    Right = 'right',
-    Bottom = 'bottom',
-}
-
 // Extends core SurveyAppearance with browser-specific fields
 // Omit 'position' from core because browser's SurveyPosition has additional values (e.g., NextToTrigger)
-export interface SurveyAppearance extends Omit<CoreSurveyAppearance, 'position'> {
+export interface SurveyAppearance extends Omit<CoreSurveyAppearance, 'position' | 'widgetType'> {
     // Browser-specific fields not in core
     /** @deprecated - not currently used */
     descriptionTextColor?: string
@@ -73,13 +42,7 @@ export interface SurveyAppearance extends Omit<CoreSurveyAppearance, 'position'>
     hideCancelButton?: boolean
     // Browser's SurveyPosition has more options than core (e.g., NextToTrigger)
     position?: SurveyPosition
-}
-
-export enum SurveyType {
-    Popover = 'popover',
-    API = 'api',
-    Widget = 'widget',
-    ExternalSurvey = 'external_survey',
+    widgetType?: SurveyWidgetType
 }
 
 export type SurveyQuestion = BasicSurveyQuestion | LinkSurveyQuestion | RatingSurveyQuestion | MultipleSurveyQuestion
@@ -98,16 +61,16 @@ interface SurveyQuestionBase {
 }
 
 export interface BasicSurveyQuestion extends SurveyQuestionBase {
-    type: SurveyQuestionType.Open
+    type: typeof SurveyQuestionType.Open
 }
 
 export interface LinkSurveyQuestion extends SurveyQuestionBase {
-    type: SurveyQuestionType.Link
+    type: typeof SurveyQuestionType.Link
     link?: string | null
 }
 
 export interface RatingSurveyQuestion extends SurveyQuestionBase {
-    type: SurveyQuestionType.Rating
+    type: typeof SurveyQuestionType.Rating
     display: 'number' | 'emoji'
     scale: 2 | 3 | 5 | 7 | 10
     lowerBoundLabel: string
@@ -116,43 +79,28 @@ export interface RatingSurveyQuestion extends SurveyQuestionBase {
 }
 
 export interface MultipleSurveyQuestion extends SurveyQuestionBase {
-    type: SurveyQuestionType.SingleChoice | SurveyQuestionType.MultipleChoice
+    type: typeof SurveyQuestionType.SingleChoice | typeof SurveyQuestionType.MultipleChoice
     choices: string[]
     hasOpenChoice?: boolean
     shuffleOptions?: boolean
     skipSubmitButton?: boolean
 }
 
-export enum SurveyQuestionType {
-    Open = 'open',
-    MultipleChoice = 'multiple_choice',
-    SingleChoice = 'single_choice',
-    Rating = 'rating',
-    Link = 'link',
-}
-
-export enum SurveyQuestionBranchingType {
-    NextQuestion = 'next_question',
-    End = 'end',
-    ResponseBased = 'response_based',
-    SpecificQuestion = 'specific_question',
-}
-
 interface NextQuestionBranching {
-    type: SurveyQuestionBranchingType.NextQuestion
+    type: typeof SurveyQuestionBranchingType.NextQuestion
 }
 
 interface EndBranching {
-    type: SurveyQuestionBranchingType.End
+    type: typeof SurveyQuestionBranchingType.End
 }
 
 interface ResponseBasedBranching {
-    type: SurveyQuestionBranchingType.ResponseBased
+    type: typeof SurveyQuestionBranchingType.ResponseBased
     responseValues: Record<string, any>
 }
 
 interface SpecificQuestionBranching {
-    type: SurveyQuestionBranchingType.SpecificQuestion
+    type: typeof SurveyQuestionBranchingType.SpecificQuestion
     index: number
 }
 
@@ -175,12 +123,6 @@ export interface SurveyElement {
 
 // Re-export from @posthog/types to avoid duplication
 export type { SurveyRenderReason } from '@posthog/types'
-
-export enum SurveySchedule {
-    Once = 'once',
-    Recurring = 'recurring',
-    Always = 'always',
-}
 
 export interface Survey {
     // Sync this with the backend's SurveyAPISerializer!
@@ -267,32 +209,6 @@ export interface ActionStepType {
     }[]
 }
 
-export enum SurveyEventName {
-    SHOWN = 'survey shown',
-    DISMISSED = 'survey dismissed',
-    SENT = 'survey sent',
-    ABANDONED = 'survey abandoned',
-}
-
-export enum SurveyEventProperties {
-    SURVEY_ID = '$survey_id',
-    SURVEY_NAME = '$survey_name',
-    SURVEY_RESPONSE = '$survey_response',
-    SURVEY_ITERATION = '$survey_iteration',
-    SURVEY_ITERATION_START_DATE = '$survey_iteration_start_date',
-    SURVEY_PARTIALLY_COMPLETED = '$survey_partially_completed',
-    SURVEY_SUBMISSION_ID = '$survey_submission_id',
-    SURVEY_QUESTIONS = '$survey_questions',
-    SURVEY_COMPLETED = '$survey_completed',
-    PRODUCT_TOUR_ID = '$product_tour_id',
-    SURVEY_LAST_SEEN_DATE = '$survey_last_seen_date',
-}
-
-export enum DisplaySurveyType {
-    Popover = 'popover',
-    Inline = 'inline',
-}
-
 interface DisplaySurveyOptionsBase {
     ignoreConditions: boolean
     ignoreDelay: boolean
@@ -304,7 +220,7 @@ interface DisplaySurveyOptionsBase {
 }
 
 export interface DisplaySurveyPopoverOptions extends DisplaySurveyOptionsBase {
-    displayType: DisplaySurveyType.Popover
+    displayType: typeof DisplaySurveyType.Popover
     /** Override the survey's configured position */
     position?: SurveyPosition
     /** CSS selector for the element to position the survey next to (when position is NextToTrigger) */
@@ -314,7 +230,7 @@ export interface DisplaySurveyPopoverOptions extends DisplaySurveyOptionsBase {
 }
 
 interface DisplaySurveyInlineOptions extends DisplaySurveyOptionsBase {
-    displayType: DisplaySurveyType.Inline
+    displayType: typeof DisplaySurveyType.Inline
     selector: string
 }
 
@@ -338,3 +254,104 @@ export interface SurveyConfig {
 }
 
 export type SurveyResponseValue = string | number | string[] | null
+
+/**
+ * Surveys related enums and constants.
+ * We use const objects instead of TypeScript enums to allow for easier tree-shaking and to avoid issues with enum imports in JavaScript.
+ */
+
+export const SurveyEventType = {
+    Activation: 'events',
+    Cancellation: 'cancelEvents',
+} as const
+export type SurveyEventType = (typeof SurveyEventType)[keyof typeof SurveyEventType]
+
+export const SurveyWidgetType = {
+    Button: 'button',
+    Tab: 'tab',
+    Selector: 'selector',
+} as const
+export type SurveyWidgetType = (typeof SurveyWidgetType)[keyof typeof SurveyWidgetType]
+
+export const SurveyPosition = {
+    TopLeft: 'top_left',
+    TopRight: 'top_right',
+    TopCenter: 'top_center',
+    MiddleLeft: 'middle_left',
+    MiddleRight: 'middle_right',
+    MiddleCenter: 'middle_center',
+    Left: 'left',
+    Center: 'center',
+    Right: 'right',
+    NextToTrigger: 'next_to_trigger',
+} as const
+export type SurveyPosition = (typeof SurveyPosition)[keyof typeof SurveyPosition]
+
+export const SurveyTabPosition = {
+    Top: 'top',
+    Left: 'left',
+    Right: 'right',
+    Bottom: 'bottom',
+} as const
+export type SurveyTabPosition = (typeof SurveyTabPosition)[keyof typeof SurveyTabPosition]
+
+export const SurveyType = {
+    Popover: 'popover',
+    API: 'api',
+    Widget: 'widget',
+    ExternalSurvey: 'external_survey',
+} as const
+export type SurveyType = (typeof SurveyType)[keyof typeof SurveyType]
+
+export const SurveyQuestionType = {
+    Open: 'open',
+    MultipleChoice: 'multiple_choice',
+    SingleChoice: 'single_choice',
+    Rating: 'rating',
+    Link: 'link',
+} as const
+export type SurveyQuestionType = (typeof SurveyQuestionType)[keyof typeof SurveyQuestionType]
+
+export const SurveyQuestionBranchingType = {
+    NextQuestion: 'next_question',
+    End: 'end',
+    ResponseBased: 'response_based',
+    SpecificQuestion: 'specific_question',
+} as const
+export type SurveyQuestionBranchingType = (typeof SurveyQuestionBranchingType)[keyof typeof SurveyQuestionBranchingType]
+
+export const SurveySchedule = {
+    Once: 'once',
+    Recurring: 'recurring',
+    Always: 'always',
+} as const
+export type SurveySchedule = (typeof SurveySchedule)[keyof typeof SurveySchedule]
+
+export const SurveyEventName = {
+    SHOWN: 'survey shown',
+    DISMISSED: 'survey dismissed',
+    SENT: 'survey sent',
+    ABANDONED: 'survey abandoned',
+} as const
+export type SurveyEventName = (typeof SurveyEventName)[keyof typeof SurveyEventName]
+
+export const SurveyEventProperties = {
+    SURVEY_ID: '$survey_id',
+    SURVEY_NAME: '$survey_name',
+    SURVEY_RESPONSE: '$survey_response',
+    SURVEY_ITERATION: '$survey_iteration',
+    SURVEY_ITERATION_START_DATE: '$survey_iteration_start_date',
+    SURVEY_PARTIALLY_COMPLETED: '$survey_partially_completed',
+    SURVEY_SUBMISSION_ID: '$survey_submission_id',
+    SURVEY_QUESTIONS: '$survey_questions',
+    SURVEY_COMPLETED: '$survey_completed',
+    PRODUCT_TOUR_ID: '$product_tour_id',
+    SURVEY_LAST_SEEN_DATE: '$survey_last_seen_date',
+} as const
+export type SurveyEventProperties = (typeof SurveyEventProperties)[keyof typeof SurveyEventProperties]
+
+export const DisplaySurveyType = {
+    Popover: 'popover',
+    Inline: 'inline',
+} as const
+export type DisplaySurveyType = (typeof DisplaySurveyType)[keyof typeof DisplaySurveyType]

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -1,5 +1,6 @@
 import { SURVEYS } from './constants'
 import { SurveyManager } from './extensions/surveys'
+import type { Extension } from './extensions/types'
 import { PostHog } from './posthog-core'
 import {
     DisplaySurveyOptions,
@@ -22,7 +23,7 @@ import {
 } from './utils/survey-utils'
 import { isNullish, isUndefined, isArray } from '@posthog/core'
 
-export class PostHogSurveys {
+export class PostHogSurveys implements Extension {
     // this is set to undefined until the remote config is loaded
     // then it's set to true if there are surveys to load
     // or false if there are no surveys to load
@@ -42,6 +43,10 @@ export class PostHogSurveys {
         // we set this to undefined here because we need the persistence storage for this type
         // but that's not initialized until loadIfEnabled is called.
         this._surveyEventReceiver = null
+    }
+
+    initialize() {
+        this.loadIfEnabled()
     }
 
     onRemoteConfig(response: RemoteConfig) {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -18,6 +18,12 @@ import type { SessionRecording } from './extensions/replay/session-recording'
 import type { Heatmaps } from './heatmaps'
 import type { PostHogProductTours } from './posthog-product-tours'
 import type { SiteApps } from './site-apps'
+import type { PostHogSurveys } from './posthog-surveys'
+import type { Toolbar } from './extensions/toolbar'
+import type { PostHogExceptions } from './posthog-exceptions'
+import type { WebExperiments } from './web-experiments'
+import type { PostHogConversations } from './extensions/conversations/posthog-conversations'
+import type { PostHogLogs } from './posthog-logs'
 
 // ============================================================================
 // Re-export public types from @posthog/types
@@ -141,6 +147,12 @@ export type PostHogConfig = Omit<BasePostHogConfig, 'loaded'> & {
         webVitalsAutocapture?: ExtensionConstructor<WebVitalsAutocapture>
         exceptionObserver?: ExtensionConstructor<ExceptionObserver>
         deadClicksAutocapture?: ExtensionConstructor<DeadClicksAutocapture>
+        exceptions?: ExtensionConstructor<PostHogExceptions>
+        surveys?: ExtensionConstructor<PostHogSurveys>
+        toolbar?: ExtensionConstructor<Toolbar>
+        experiments?: ExtensionConstructor<WebExperiments>
+        conversations?: ExtensionConstructor<PostHogConversations>
+        logs?: ExtensionConstructor<PostHogLogs>
     }
 }
 

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -33,6 +33,7 @@ import type { PostHogLogs } from './posthog-logs'
  * Augmented by the slim bundle entry point to mark tree-shakeable extensions
  * as optional. Empty by default (full bundle), meaning extensions are guaranteed.
  */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface TreeShakeableConfig {}
 
 /**

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -26,6 +26,22 @@ import type { PostHogConversations } from './extensions/conversations/posthog-co
 import type { PostHogLogs } from './posthog-logs'
 
 // ============================================================================
+// Tree-shakeable extension types
+// ============================================================================
+
+/**
+ * Augmented by the slim bundle entry point to mark tree-shakeable extensions
+ * as optional. Empty by default (full bundle), meaning extensions are guaranteed.
+ */
+export interface TreeShakeableConfig {}
+
+/**
+ * For the full bundle (default), resolves to T (extensions guaranteed present).
+ * For the slim bundle (augmented with { optional: true }), resolves to T | undefined.
+ */
+export type TreeShakeable<T> = 'optional' extends keyof TreeShakeableConfig ? T | undefined : T
+
+// ============================================================================
 // Re-export public types from @posthog/types
 // ============================================================================
 

--- a/packages/browser/src/utils/survey-branching.ts
+++ b/packages/browser/src/utils/survey-branching.ts
@@ -50,7 +50,7 @@ export function getNextSurveyStep(
     survey: Survey,
     currentQuestionIndex: number,
     response: string | string[] | number | null
-): number | SurveyQuestionBranchingType.End {
+): number | typeof SurveyQuestionBranchingType.End {
     const question = survey.questions[currentQuestionIndex]
     const nextQuestionIndex = currentQuestionIndex + 1
 

--- a/packages/browser/src/utils/survey-utils.ts
+++ b/packages/browser/src/utils/survey-utils.ts
@@ -1,4 +1,4 @@
-import { DisplaySurveyOptions, DisplaySurveyType, Survey, SurveyType } from '../posthog-surveys-types'
+import { DisplaySurveyOptions, Survey, SurveyType, DisplaySurveyType } from '../posthog-surveys-types'
 import { createLogger } from '../utils/logger'
 
 export const SURVEY_LOGGER = createLogger('[Surveys]')
@@ -59,7 +59,7 @@ export const setSurveySeenOnLocalStorage = (survey: Pick<Survey, 'id' | 'current
 
 // These surveys are relevant for the getActiveMatchingSurveys method. They are used to
 // display surveys in our customer's application. Any new in-app survey type should be added here.
-export const IN_APP_SURVEY_TYPES = [SurveyType.Popover, SurveyType.Widget, SurveyType.API]
+export const IN_APP_SURVEY_TYPES: SurveyType[] = [SurveyType.Popover, SurveyType.Widget, SurveyType.API]
 
 export const DEFAULT_DISPLAY_SURVEY_OPTIONS: DisplaySurveyOptions = {
     ignoreConditions: false,

--- a/packages/browser/src/web-experiments.ts
+++ b/packages/browser/src/web-experiments.ts
@@ -14,6 +14,7 @@ import { isMatchingRegex } from './utils/regex-utils'
 import { logger } from './utils/logger'
 import { isLikelyBot } from './utils/blocked-uas'
 import { getCampaignParams } from './utils/event-utils'
+import { Extension } from './extensions/types'
 
 export const webExperimentUrlValidationMap: Record<
     WebExperimentUrlMatchType,
@@ -29,7 +30,7 @@ export const webExperimentUrlValidationMap: Record<
     is_not: (conditionsUrl, location) => location.href !== conditionsUrl,
 }
 
-export class WebExperiments {
+export class WebExperiments implements Extension {
     private _flagToExperiments?: Map<string, WebExperiment>
 
     constructor(private _instance: PostHog) {
@@ -37,6 +38,9 @@ export class WebExperiments {
             this.onFeatureFlags(flags)
         })
     }
+
+    // No-op: activation is driven by the onFeatureFlags callback registered in the constructor
+    initialize() {}
 
     onFeatureFlags(flags: string[]) {
         if (this._is_bot()) {


### PR DESCRIPTION
## Problem

Six classes are always constructed in the PostHog constructor regardless of whether they're needed: Surveys, Toolbar, PostHogExceptions, Conversations, Logs, and WebExperiments. This means they can't be tree-shaken out of slim/custom bundles.

This is PR 2/3
1. https://github.com/PostHog/posthog-js/pull/3164
2. https://github.com/PostHog/posthog-js/pull/3165 **<<< you are here**
3. https://github.com/PostHog/posthog-js/pull/3166


## Changes

Makes all six classes conditionally constructed via `__extensionClasses`, matching the pattern already used for autocapture, session recording, heatmaps, etc.

- **Imports changed to type-only**: Hard imports of 6 classes replaced with `import type` in posthog-core.ts. Classes are only referenced through the `__extensionClasses` config.
- **Properties made optional**: `surveys?`, `toolbar?`, `exceptions?`, `conversations?`, `logs?`, `experiments?` — all use optional chaining at call sites (~15 locations).
- **Graceful degradation**: Survey methods (`getSurveys`, `getActiveMatchingSurveys`, `canRenderSurvey`, etc.) call the error callback when the surveys module isn't loaded. `captureException` returns early. `loadToolbar` returns false.
- **`_onRemoteConfig` fully unified**: Removes the remaining hardcoded dispatch calls — everything now goes through `this.extensions.forEach(ext => ext.onRemoteConfig?.(config))`.
- **6 classes** now `implement Extension` with appropriate `initialize()` methods.
- **Survey enums → const objects**: All TypeScript `enum` declarations in `posthog-surveys-types.ts` converted to `as const` objects with type aliases. Enums compile to IIFEs that bundlers can't tree-shake; const objects are plain property access.
- **Extension bundles updated**: New exports `SurveysExtensions`, `ToolbarExtensions`, `ExperimentsExtensions`, `ConversationsExtensions`, `LogsExtensions`, and `ErrorTrackingExtensions` now includes `exceptions`.

## Bundle size

| | module.js | module.slim.js | module.js (gz) | module.slim.js (gz) |
|---|---|---|---|---|
| **main** | 177.1 kB | 142.2 kB | 56.8 kB | 46.3 kB |
| **this PR** | 177.5 kB (+0.2%) | 107.0 kB (-24.8%) | 56.9 kB (+0.3%) | 36.4 kB (-21.4%) |

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
