### PR TITLE
chore(browser): Clean up open handles when running Jest

### DIFF
--- a/packages/browser/src/__tests__/extensions/replay/external/fetch-wrapper-invariants.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/external/fetch-wrapper-invariants.test.ts
@@ -40,6 +40,11 @@ function setupWrappedFetch(downstreamFetch: typeof fetch): { wrappedFetch: typeo
 }
 
 describe('fetch wrapper', () => {
+    // Use fake timers to prevent getRequestPerformanceEntry retry timeouts
+    // from keeping the Jest worker alive after tests complete.
+    beforeEach(() => jest.useFakeTimers())
+    afterEach(() => jest.useRealTimers())
+
     describe('does not throw for valid inputs', () => {
         let wrappedFetch: typeof fetch
         let cleanup: () => void

--- a/packages/browser/src/__tests__/setup.js
+++ b/packages/browser/src/__tests__/setup.js
@@ -7,4 +7,10 @@ beforeEach(() => {
     console.warn = (...args) => {
         throw new Error(`Unexpected console.warn: ${args}`)
     }
+
+    // Prevent jsdom XHR requests from creating open handles (TLSWRAP/Timeout)
+    // that keep Jest from exiting. No unit tests need real HTTP responses.
+    if (typeof XMLHttpRequest !== 'undefined') {
+        jest.spyOn(XMLHttpRequest.prototype, 'send').mockImplementation(() => {})
+    }
 })


### PR DESCRIPTION
## Problem

`pnpm test` is always complaining about open handles and jest workers not shutting down gracefully. It slows things down and causes a lot of error log spam as some processes would retry after their test had already finished.

## Changes

- stub `XMLHttpRequest.send` by default
- use fake timers in fetch-wrapper-invariants.test.ts

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
