### PR TITLE
fix(llmo): sanitize base64 video inputs for OpenRouter chat completions

### DIFF
--- a/.changeset/dark-bikes-check.md
+++ b/.changeset/dark-bikes-check.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Sanitize inline base64 video_url's in chat completions calls, which is supported by OpenRouter for video understanding models

--- a/packages/ai/src/sanitization.ts
+++ b/packages/ai/src/sanitization.ts
@@ -112,6 +112,17 @@ const sanitizeOpenAIImage = (item: unknown): unknown => {
     }
   }
 
+  // Handle video_url format
+  if (item.type === 'video_url' && 'video_url' in item && isObject(item.video_url) && 'url' in item.video_url) {
+    return {
+      ...item,
+      video_url: {
+        ...item.video_url,
+        url: redactBase64DataUrl(item.video_url.url),
+      },
+    }
+  }
+
   // Handle audio format
   if (item.type === 'audio' && 'data' in item) {
     if (isMultimodalEnabled()) return item


### PR DESCRIPTION
## Problem

OpenRouter supports video inputs, but they're too large for posthog LLM observability

## Changes

This redacts video inputs just like image inputs

## Release info Sub-libraries affected

?

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
