### PR TITLE
fix(core): consume flush response body to avoid leaked streams

### DIFF
--- a/packages/core/src/__tests__/posthog.flush.spec.ts
+++ b/packages/core/src/__tests__/posthog.flush.spec.ts
@@ -49,6 +49,20 @@ describe('PostHog Core', () => {
       ])
     })
 
+    it('consumes successful flush response bodies', async () => {
+      const textSpy = jest.fn(async () => 'ok')
+
+      mocks.fetch.mockResolvedValue({
+        status: 200,
+        text: textSpy,
+        json: async () => ({ status: 'ok' }),
+      })
+
+      posthog.capture('test-event-1')
+      await expect(posthog.flush()).resolves.not.toThrow()
+      expect(textSpy).toHaveBeenCalledTimes(1)
+    })
+
     it.each([400, 500])('responds with an error after retries with %s error', async (status) => {
       mocks.fetch.mockImplementation(() => {
         return Promise.resolve({

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -1139,7 +1139,8 @@ export abstract class PostHogCoreStateless {
       }
 
       try {
-        await this.fetchWithRetry(url, fetchOptions, retryOptions)
+        const response = await this.fetchWithRetry(url, fetchOptions, retryOptions)
+        await response.text().catch(() => '')
       } catch (err) {
         if (isPostHogFetchContentTooLargeError(err) && batchMessages.length > 1) {
           // if we get a 413 error, we want to reduce the batch size and try again


### PR DESCRIPTION
## Problem

In `@posthog/core`, `_flush()` awaited `fetchWithRetry()` but discarded the returned response. In Cloudflare Workers this leaves response streams unconsumed, which triggers cross-request promise warnings and can cancel request continuations.

Closes #3173.

## Changes

- Consume the successful batch flush response body in `_flush()` via `await response.text().catch(() => '')`
- Add a regression test in `posthog.flush.spec.ts` that asserts response `text()` is called during flush

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages