### PR TITLE
fix(core): export getRemoteConfigBool, getRemoteConfigNumber, and isValidSampleRate

### DIFF
--- a/.changeset/fix-remote-config-bool-export.md
+++ b/.changeset/fix-remote-config-bool-export.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-react-native': patch
+---
+
+fix: export getRemoteConfigBool, getRemoteConfigNumber, and isValidSampleRate from @posthog/core


### PR DESCRIPTION
## Problem

Users of `posthog-react-native@4.37.0` encounter a runtime error:

```
Error while flushing PostHog
TypeError: 0, _utils2.getRemoteConfigBool is not a function (it is undefined)
```

This happens because `posthog-react-native@4.37.0` imports `getRemoteConfigBool` from `@posthog/core`, but the published `@posthog/core@1.23.1` does not include `getRemoteConfigBool`, `getRemoteConfigNumber`, or `isValidSampleRate` in its build output. These functions were added in commit `eb12d0cd` (PR #3134) but `@posthog/core` was not version-bumped and republished afterward.

Closes https://github.com/PostHog/posthog-js/issues/3183

## Changes

Adds a changeset to bump `@posthog/core` (patch) and `posthog-react-native` (patch) so the missing exports are included in the next published versions.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-react-native
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages