### PR TITLE
refactor(node): apply evaluation context pattern across flag evaluation

### DIFF
--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -19,6 +19,7 @@ import {
   FeatureFlagErrorType,
   FeatureFlagOverrideOptions,
   FeatureFlagResult,
+  BaseFlagEvaluationOptions,
   GroupIdentifyMessage,
   IdentifyMessage,
   IPostHog,
@@ -30,6 +31,7 @@ import {
 } from './types'
 import {
   FeatureFlagsPoller,
+  createFeatureFlagEvaluationContext,
   type FeatureFlagEvaluationContext,
   RequiresServerEvaluation,
   InconclusiveMatchError,
@@ -636,14 +638,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   private async _getFeatureFlagResult(
     key: string,
     distinctId: string,
-    options: {
-      groups?: Record<string, string>
-      personProperties?: Record<string, string>
-      groupProperties?: Record<string, Record<string, string>>
-      onlyEvaluateLocally?: boolean
-      sendFeatureFlagEvents?: boolean
-      disableGeoip?: boolean
-    } = {},
+    options: FlagEvaluationOptions = {},
     matchValue?: FeatureFlagValue
   ): Promise<FeatureFlagResult | undefined> {
     const sendFeatureFlagEvents = options.sendFeatureFlagEvents ?? true
@@ -663,29 +658,10 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       }
     }
 
-    const { groups, disableGeoip } = options
-    let { onlyEvaluateLocally, personProperties, groupProperties } = options
-
-    const adjustedProperties = this.addLocalPersonAndGroupProperties(
+    const { evaluationContext, groups, disableGeoip, onlyEvaluateLocally } = this.prepareFeatureFlagEvaluationContext(
       distinctId,
-      groups,
-      personProperties,
-      groupProperties
+      options
     )
-
-    personProperties = adjustedProperties.allPersonProperties
-    groupProperties = adjustedProperties.allGroupProperties
-    const evaluationContext = this.createFeatureFlagEvaluationContext(
-      distinctId,
-      groups,
-      personProperties,
-      groupProperties
-    )
-
-    // set defaults
-    if (onlyEvaluateLocally == undefined) {
-      onlyEvaluateLocally = this.options.strictLocalEvaluation ?? false
-    }
 
     let result: FeatureFlagResult | undefined = undefined
     let flagWasLocallyEvaluated = false
@@ -700,47 +676,33 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     // Try local evaluation first
     const localEvaluationEnabled = this.featureFlagsPoller !== undefined
     if (localEvaluationEnabled) {
-      await this.featureFlagsPoller?.loadFeatureFlags()
-
-      const flag = this.featureFlagsPoller?.featureFlagsByKey[key]
-      if (flag) {
-        try {
-          const localResult = await this.featureFlagsPoller?.computeFlagAndPayloadLocally(flag, evaluationContext, {
-            matchValue,
-          })
-          if (localResult) {
-            flagWasLocallyEvaluated = true
-            const value = localResult.value
-            flagId = flag.id
-            flagReason = 'Evaluated locally'
-            result = {
-              key,
-              enabled: value !== false,
-              variant: typeof value === 'string' ? value : undefined,
-              payload: localResult.payload ?? undefined,
-            }
+      try {
+        const localResult = await this.featureFlagsPoller?.getFeatureFlagResult(key, evaluationContext, { matchValue })
+        if (localResult) {
+          flagWasLocallyEvaluated = true
+          const value = localResult.value
+          flagId = localResult.flag.id
+          flagReason = 'Evaluated locally'
+          result = {
+            key,
+            enabled: value !== false,
+            variant: typeof value === 'string' ? value : undefined,
+            payload: localResult.payload ?? undefined,
           }
-        } catch (e) {
-          if (e instanceof RequiresServerEvaluation || e instanceof InconclusiveMatchError) {
-            // Fall through to server evaluation
-            this._logger?.info(`${e.name} when computing flag locally: ${key}: ${e.message}`)
-          } else {
-            throw e
-          }
+        }
+      } catch (e) {
+        if (e instanceof RequiresServerEvaluation || e instanceof InconclusiveMatchError) {
+          // Fall through to server evaluation
+          this._logger?.info(`${e.name} when computing flag locally: ${key}: ${e.message}`)
+        } else {
+          throw e
         }
       }
     }
 
     // Fall back to remote evaluation if needed
     if (!flagWasLocallyEvaluated && !onlyEvaluateLocally) {
-      const flagsResponse = await super.getFeatureFlagDetailsStateless(
-        evaluationContext.distinctId,
-        evaluationContext.groups,
-        evaluationContext.personProperties,
-        evaluationContext.groupProperties,
-        disableGeoip,
-        [key]
-      )
+      const flagsResponse = await this.getFeatureFlagDetailsForEvaluationContext(evaluationContext, disableGeoip, [key])
 
       if (flagsResponse === undefined) {
         featureFlagError = FeatureFlagError.UNKNOWN_ERROR
@@ -903,14 +865,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   async getFeatureFlag(
     key: string,
     distinctId: string,
-    options?: {
-      groups?: Record<string, string>
-      personProperties?: Record<string, string>
-      groupProperties?: Record<string, Record<string, string>>
-      onlyEvaluateLocally?: boolean
-      sendFeatureFlagEvents?: boolean
-      disableGeoip?: boolean
-    }
+    options?: FlagEvaluationOptions
   ): Promise<FeatureFlagValue | undefined> {
     const result = await this._getFeatureFlagResult(key, distinctId, {
       ...options,
@@ -1136,14 +1091,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   async isFeatureEnabled(
     key: string,
     distinctId: string,
-    options?: {
-      groups?: Record<string, string>
-      personProperties?: Record<string, string>
-      groupProperties?: Record<string, Record<string, string>>
-      onlyEvaluateLocally?: boolean
-      sendFeatureFlagEvents?: boolean
-      disableGeoip?: boolean
-    }
+    options?: FlagEvaluationOptions
   ): Promise<boolean | undefined> {
     const feat = await this.getFeatureFlag(key, distinctId, options)
     if (feat === undefined) {
@@ -1257,29 +1205,11 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       return { featureFlags: {}, featureFlagPayloads: {} }
     }
 
-    const { groups, disableGeoip, flagKeys } = resolvedOptions || {}
-    let { onlyEvaluateLocally, personProperties, groupProperties } = resolvedOptions || {}
-
-    const adjustedProperties = this.addLocalPersonAndGroupProperties(
+    const flagKeys = resolvedOptions?.flagKeys
+    const { evaluationContext, disableGeoip, onlyEvaluateLocally } = this.prepareFeatureFlagEvaluationContext(
       resolvedDistinctId,
-      groups,
-      personProperties,
-      groupProperties
+      resolvedOptions
     )
-
-    personProperties = adjustedProperties.allPersonProperties
-    groupProperties = adjustedProperties.allGroupProperties
-    const evaluationContext = this.createFeatureFlagEvaluationContext(
-      resolvedDistinctId,
-      groups,
-      personProperties,
-      groupProperties
-    )
-
-    // set defaults
-    if (onlyEvaluateLocally == undefined) {
-      onlyEvaluateLocally = this.options.strictLocalEvaluation ?? false
-    }
 
     const localEvaluationResult = await this.featureFlagsPoller?.getAllFlagsAndPayloads(evaluationContext, flagKeys)
 
@@ -1293,11 +1223,8 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     }
 
     if (fallbackToFlags && !onlyEvaluateLocally) {
-      const remoteEvaluationResult = await super.getFeatureFlagsAndPayloadsStateless(
-        evaluationContext.distinctId,
-        evaluationContext.groups,
-        evaluationContext.personProperties,
-        evaluationContext.groupProperties,
+      const remoteEvaluationResult = await this.getFeatureFlagsAndPayloadsForEvaluationContext(
+        evaluationContext,
         disableGeoip,
         flagKeys
       )
@@ -1680,34 +1607,9 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     const onlyEvaluateLocally =
       sendFeatureFlagsOptions?.onlyEvaluateLocally ?? this.options.strictLocalEvaluation ?? false
 
-    // If onlyEvaluateLocally is true, only use local evaluation
-    if (onlyEvaluateLocally) {
-      if ((this.featureFlagsPoller?.featureFlags?.length || 0) > 0) {
-        const groupsWithStringValues: Record<string, string> = {}
-        for (const [key, value] of Object.entries(groups || {})) {
-          groupsWithStringValues[key] = String(value)
-        }
-
-        return await this.getAllFlags(distinctId, {
-          groups: groupsWithStringValues,
-          personProperties: finalPersonProperties,
-          groupProperties: finalGroupProperties,
-          disableGeoip,
-          onlyEvaluateLocally: true,
-          flagKeys,
-        })
-      } else {
-        // If onlyEvaluateLocally is true but we don't have local flags, return empty
-        return {}
-      }
-    }
-
-    // Prefer local evaluation if available (default behavior; I'd rather not penalize users who haven't updated to the new API but still want to use local evaluation)
-    if ((this.featureFlagsPoller?.featureFlags?.length || 0) > 0) {
-      const groupsWithStringValues: Record<string, string> = {}
-      for (const [key, value] of Object.entries(groups || {})) {
-        groupsWithStringValues[key] = String(value)
-      }
+    const localFlagsAvailable = (this.featureFlagsPoller?.featureFlags?.length || 0) > 0
+    if (localFlagsAvailable) {
+      const groupsWithStringValues = this.stringifyGroupValues(groups)
 
       return await this.getAllFlags(distinctId, {
         groups: groupsWithStringValues,
@@ -1717,6 +1619,11 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
         onlyEvaluateLocally: true,
         flagKeys,
       })
+    }
+
+    // If local-only evaluation is requested but local definitions are unavailable, return empty.
+    if (onlyEvaluateLocally) {
+      return {}
     }
 
     // Fall back to remote evaluation if local evaluation is not available
@@ -1729,6 +1636,16 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
         disableGeoip
       )
     ).flags
+  }
+
+  private stringifyGroupValues(groups?: Record<string, string | number>): Record<string, string> {
+    const stringifiedGroups: Record<string, string> = {}
+
+    for (const [key, value] of Object.entries(groups || {})) {
+      stringifiedGroups[key] = String(value)
+    }
+
+    return stringifiedGroups
   }
 
   private addLocalPersonAndGroupProperties(
@@ -1752,19 +1669,66 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     return { allPersonProperties, allGroupProperties }
   }
 
-  private createFeatureFlagEvaluationContext(
+  private prepareFeatureFlagEvaluationContext(
     distinctId: string,
-    groups?: Record<string, string>,
-    personProperties?: Record<string, any>,
-    groupProperties?: Record<string, Record<string, any>>
-  ): FeatureFlagEvaluationContext {
-    return {
+    options: BaseFlagEvaluationOptions = {}
+  ): {
+    evaluationContext: FeatureFlagEvaluationContext
+    groups?: Record<string, string>
+    disableGeoip?: boolean
+    onlyEvaluateLocally: boolean
+  } {
+    const { groups, disableGeoip, onlyEvaluateLocally, personProperties, groupProperties } = options
+    const adjustedProperties = this.addLocalPersonAndGroupProperties(
       distinctId,
-      groups: groups || {},
-      personProperties: personProperties || {},
-      groupProperties: groupProperties || {},
-      evaluationCache: {},
+      groups,
+      personProperties,
+      groupProperties
+    )
+
+    const evaluationContext = createFeatureFlagEvaluationContext(
+      distinctId,
+      groups,
+      adjustedProperties.allPersonProperties,
+      adjustedProperties.allGroupProperties
+    )
+
+    return {
+      evaluationContext,
+      groups,
+      disableGeoip,
+      onlyEvaluateLocally: onlyEvaluateLocally ?? this.options.strictLocalEvaluation ?? false,
     }
+  }
+
+  private getFeatureFlagDetailsForEvaluationContext(
+    evaluationContext: FeatureFlagEvaluationContext,
+    disableGeoip?: boolean,
+    flagKeys?: string[]
+  ) {
+    return super.getFeatureFlagDetailsStateless(
+      evaluationContext.distinctId,
+      evaluationContext.groups,
+      evaluationContext.personProperties,
+      evaluationContext.groupProperties,
+      disableGeoip,
+      flagKeys
+    )
+  }
+
+  private getFeatureFlagsAndPayloadsForEvaluationContext(
+    evaluationContext: FeatureFlagEvaluationContext,
+    disableGeoip?: boolean,
+    flagKeys?: string[]
+  ) {
+    return super.getFeatureFlagsAndPayloadsStateless(
+      evaluationContext.distinctId,
+      evaluationContext.groups,
+      evaluationContext.personProperties,
+      evaluationContext.groupProperties,
+      disableGeoip,
+      flagKeys
+    )
   }
 
   /**

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -66,6 +66,22 @@ export type FeatureFlagEvaluationContext = {
   evaluationCache: Record<string, FeatureFlagValue>
 }
 
+export function createFeatureFlagEvaluationContext(
+  distinctId: string,
+  groups: Record<string, string> = {},
+  personProperties: Record<string, any> = {},
+  groupProperties: Record<string, Record<string, any>> = {},
+  evaluationCache: Record<string, FeatureFlagValue> = {}
+): FeatureFlagEvaluationContext {
+  return {
+    distinctId,
+    groups,
+    personProperties,
+    groupProperties,
+    evaluationCache,
+  }
+}
+
 type ComputeFlagAndPayloadOptions = {
   matchValue?: FeatureFlagValue
   skipLoadCheck?: boolean
@@ -136,22 +152,6 @@ class FeatureFlagsPoller {
     }
   }
 
-  private createEvaluationContext(
-    distinctId: string,
-    groups: Record<string, string> = {},
-    personProperties: Record<string, any> = {},
-    groupProperties: Record<string, Record<string, any>> = {},
-    evaluationCache: Record<string, FeatureFlagValue> = {}
-  ): FeatureFlagEvaluationContext {
-    return {
-      distinctId,
-      groups,
-      personProperties,
-      groupProperties,
-      evaluationCache,
-    }
-  }
-
   async getFeatureFlag(
     key: string,
     distinctId: string,
@@ -162,30 +162,62 @@ class FeatureFlagsPoller {
     await this.loadFeatureFlags()
 
     let response: FeatureFlagValue | undefined = undefined
-    let featureFlag = undefined
 
     if (!this.loadedSuccessfullyOnce) {
       return response
     }
 
-    featureFlag = this.featureFlagsByKey[key]
-
-    if (featureFlag !== undefined) {
-      const evaluationContext = this.createEvaluationContext(distinctId, groups, personProperties, groupProperties)
-      try {
-        const result = await this.computeFlagAndPayloadLocally(featureFlag, evaluationContext)
-        response = result.value
+    const evaluationContext = createFeatureFlagEvaluationContext(distinctId, groups, personProperties, groupProperties)
+    try {
+      const result = await this.getFeatureFlagResult(key, evaluationContext, { skipLoadCheck: true })
+      response = result?.value
+      if (result !== undefined) {
         this.logMsgIfDebug(() => console.debug(`Successfully computed flag locally: ${key} -> ${response}`))
-      } catch (e) {
-        if (e instanceof RequiresServerEvaluation || e instanceof InconclusiveMatchError) {
-          this.logMsgIfDebug(() => console.debug(`${e.name} when computing flag locally: ${key}: ${e.message}`))
-        } else if (e instanceof Error) {
-          this.onError?.(new Error(`Error computing flag locally: ${key}: ${e}`))
-        }
+      }
+    } catch (e) {
+      if (e instanceof RequiresServerEvaluation || e instanceof InconclusiveMatchError) {
+        this.logMsgIfDebug(() => console.debug(`${e.name} when computing flag locally: ${key}: ${e.message}`))
+      } else if (e instanceof Error) {
+        this.onError?.(new Error(`Error computing flag locally: ${key}: ${e}`))
       }
     }
 
     return response
+  }
+
+  async getFeatureFlagResult(
+    key: string,
+    evaluationContext: FeatureFlagEvaluationContext,
+    options: ComputeFlagAndPayloadOptions = {}
+  ): Promise<
+    | {
+        flag: PostHogFeatureFlag
+        value: FeatureFlagValue
+        payload: JsonType | null
+      }
+    | undefined
+  > {
+    const { skipLoadCheck = false } = options
+
+    if (!skipLoadCheck) {
+      await this.loadFeatureFlags()
+    }
+
+    if (!this.loadedSuccessfullyOnce) {
+      return undefined
+    }
+
+    const flag = this.featureFlagsByKey[key]
+    if (!flag) {
+      return undefined
+    }
+
+    const result = await this.computeFlagAndPayloadLocally(flag, evaluationContext, {
+      ...options,
+      skipLoadCheck: true,
+    })
+
+    return { flag, ...result }
   }
 
   async getAllFlagsAndPayloads(


### PR DESCRIPTION
## Summary
- centralize feature flag evaluation context construction in shared helpers
- apply the context pattern to single-flag and all-flags evaluation flows
- remove duplicated local/remote evaluation plumbing and group normalization logic

## Testing
- pnpm --filter=posthog-node lint
- pnpm --filter=posthog-node test:unit -- src/__tests__/context.spec.ts src/__tests__/feature-flags.flags.spec.ts
- pnpm --filter=posthog-node test:unit -- src/__tests__/posthog-node.spec.ts
- pnpm --filter=posthog-node test:unit -- src/__tests__/feature-flags.dependencies.spec.ts
- pnpm --filter=posthog-node test:unit -- src/__tests__/feature-flags.spec.ts