### PR TITLE
fix(replay): do not reject while reading body

### DIFF
--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -492,14 +492,14 @@ function _checkForCannotReadResponseBody({
 function _tryReadBody(r: Request | Response): Promise<string> {
     // there are now already multiple places where we're using Promise...
     // eslint-disable-next-line compat/compat
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
         const timeout = setTimeout(() => resolve('[SessionReplay] Timeout while trying to read body'), 500)
         try {
             r.clone()
                 .text()
                 .then(
                     (txt) => resolve(txt),
-                    (reason) => reject(reason)
+                    (reason) => resolve('[SessionReplay] Failed to read body: ' + reason)
                 )
                 .finally(() => clearTimeout(timeout))
         } catch {


### PR DESCRIPTION
## Problem

When we fail to read request / response body, it throws an error that we capture and logs an error: "Uncaught (in promise)" "undefined".

## Changes

- do not reject the promise which mirrors the timeout branch