### PR TITLE
feat(node): Add Posthog NestJS Interceptor

### DIFF
--- a/.changeset/sunny-windows-build.md
+++ b/.changeset/sunny-windows-build.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': minor
+---
+
+Add nestjs integration with interceptor for context propagation

--- a/examples/example-nestjs/.env.example
+++ b/examples/example-nestjs/.env.example
@@ -1,0 +1,11 @@
+# PostHog API Configuration
+# Copy this file to .env and update with your actual values
+
+# Your project API key (found on the /setup page in PostHog)
+POSTHOG_PROJECT_API_KEY=phc_your_project_api_key_here
+
+# Your personal API key (for local evaluation and other advanced features)
+POSTHOG_PERSONAL_API_KEY=phx_your_personal_api_key_here
+
+# PostHog host URL (remove this line if using posthog.com)
+POSTHOG_HOST=https://app.posthog.com

--- a/examples/example-nestjs/.env.example
+++ b/examples/example-nestjs/.env.example
@@ -8,4 +8,4 @@ POSTHOG_PROJECT_API_KEY=phc_your_project_api_key_here
 POSTHOG_PERSONAL_API_KEY=phx_your_personal_api_key_here
 
 # PostHog host URL (remove this line if using posthog.com)
-POSTHOG_HOST=https://app.posthog.com
+POSTHOG_HOST=https://us.posthog.com

--- a/examples/example-nestjs/package.json
+++ b/examples/example-nestjs/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "example-nestjs",
+    "version": "1.0.0",
+    "engines": {
+        "node": ">=22.22"
+    },
+    "main": "src/main.ts",
+    "license": "MIT",
+    "packageManager": "pnpm@10.15.0",
+    "scripts": {
+        "start": "ts-node -r reflect-metadata src/main.ts"
+    },
+    "dependencies": {
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/platform-express": "^10.0.0",
+        "posthog-node": "*",
+        "reflect-metadata": "^0.2.0",
+        "rxjs": "^7.8.0"
+    },
+    "devDependencies": {
+        "@types/node": "20.19.7",
+        "ts-node": "^10.8.2",
+        "typescript": "^5.0.0"
+    }
+}

--- a/examples/example-nestjs/pnpm-lock.yaml
+++ b/examples/example-nestjs/pnpm-lock.yaml
@@ -1,0 +1,1226 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+pnpmfileChecksum: sha256-N3riA/tbAnNXqNYCauSgZTrb8uBs1MMWnJDTJCSRm8c=
+
+importers:
+
+  .:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^10.0.0
+        version: 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^10.0.0
+        version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/platform-express':
+        specifier: ^10.0.0
+        version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+      posthog-node:
+        specifier: file:../../target/posthog-node.tgz
+        version: file:../../target/posthog-node.tgz(rxjs@7.8.2)
+      reflect-metadata:
+        specifier: ^0.2.0
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.0
+        version: 7.8.2
+    devDependencies:
+      '@types/node':
+        specifier: 20.19.7
+        version: 20.19.7
+      ts-node:
+        specifier: ^10.8.2
+        version: 10.9.2(@types/node@20.19.7)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+packages:
+
+  '@borewit/text-codec@0.2.1':
+    resolution: {integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@lukeed/csprng@1.1.0':
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+
+  '@nestjs/common@10.4.22':
+    resolution: {integrity: sha512-fxJ4v85nDHaqT1PmfNCQ37b/jcv2OojtXTaK1P2uAXhzLf9qq6WNUOFvxBrV4fhQek1EQoT1o9oj5xAZmv3NRw==}
+    peerDependencies:
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+
+  '@nestjs/core@10.4.22':
+    resolution: {integrity: sha512-6IX9+VwjiKtCjx+mXVPncpkQ5ZjKfmssOZPFexmT+6T9H9wZ3svpYACAo7+9e7Nr9DZSoRZw3pffkJP7Z0UjaA==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0
+      '@nestjs/microservices': ^10.0.0
+      '@nestjs/platform-express': ^10.0.0
+      '@nestjs/websockets': ^10.0.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      '@nestjs/microservices':
+        optional: true
+      '@nestjs/platform-express':
+        optional: true
+      '@nestjs/websockets':
+        optional: true
+
+  '@nestjs/platform-express@10.4.22':
+    resolution: {integrity: sha512-ySSq7Py/DFozzZdNDH67m/vHoeVdphDniWBnl6q5QVoXldDdrZIHLXLRMPayTDh5A95nt7jjJzmD4qpTbNQ6tA==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0
+      '@nestjs/core': ^10.0.0
+
+  '@nuxtjs/opencollective@0.3.2':
+    resolution: {integrity: sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
+  '@posthog/core@file:../../target/posthog-core.tgz':
+    resolution: {integrity: sha512-Hsh18u7yUqCzP4yZ5HI2dS9/mftc/J286jUfZHTybivCNtQM5BsCOfsgrY3UY5xxMn4ndsyUJUZjVX8IQJTUdQ==, tarball: file:../../target/posthog-core.tgz}
+    version: 1.23.2
+
+  '@tokenizer/inflate@0.2.7':
+    resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@tsconfig/node10@1.0.12':
+    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/node@20.19.7':
+    resolution: {integrity: sha512-1GM9z6BJOv86qkPvzh2i6VW5+VVrXxCLknfmTkWEqz+6DqosiY28XUWCTmBcJ0ACzKqx/iwdIREfo1fwExIlkA==}
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  append-field@1.0.0:
+    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  body-parser@1.20.4:
+    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
+
+  consola@2.15.3:
+    resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
+  file-type@20.4.1:
+    resolution: {integrity: sha512-hw9gNZXUfZ02Jo0uafWLaFVPter5/k2rfcrjFJJHX/77xtSDOfJuEFb6oKlFV86FLP1SuyHMW1PSk0U9M5tKkQ==}
+    engines: {node: '>=18'}
+
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  iterare@1.2.1:
+    resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
+    engines: {node: '>=6'}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multer@2.0.2:
+    resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
+    engines: {node: '>= 10.16.0'}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
+  path-to-regexp@3.3.0:
+    resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
+
+  posthog-node@file:../../target/posthog-node.tgz:
+    resolution: {integrity: sha512-PgnDMP98sRyd28VkGcwlFs0wqQ9/ZQbYU9lDQu8cXnvZcqUDEKL2Vp/3PT6cI59ngvgujd6oPLxkJZGD3zqDkw==, tarball: file:../../target/posthog-node.tgz}
+    version: 5.26.2
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strtok3@10.3.4:
+    resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
+    engines: {node: '>=18'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uid@2.0.2:
+    resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
+    engines: {node: '>=8'}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
+snapshots:
+
+  '@borewit/text-codec@0.2.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lukeed/csprng@1.1.0': {}
+
+  '@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      file-type: 20.4.1
+      iterare: 1.2.1
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@nestjs/core@10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nuxtjs/opencollective': 0.3.2
+      fast-safe-stringify: 2.1.1
+      iterare: 1.2.1
+      path-to-regexp: 3.3.0
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    optionalDependencies:
+      '@nestjs/platform-express': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+    transitivePeerDependencies:
+      - encoding
+
+  '@nestjs/platform-express@10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)':
+    dependencies:
+      '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      body-parser: 1.20.4
+      cors: 2.8.5
+      express: 4.22.1
+      multer: 2.0.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@nuxtjs/opencollective@0.3.2':
+    dependencies:
+      chalk: 4.1.2
+      consola: 2.15.3
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@posthog/core@file:../../target/posthog-core.tgz':
+    dependencies:
+      cross-spawn: 7.0.6
+
+  '@tokenizer/inflate@0.2.7':
+    dependencies:
+      debug: 4.4.3
+      fflate: 0.8.2
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
+  '@tsconfig/node10@1.0.12': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@types/node@20.19.7':
+    dependencies:
+      undici-types: 6.21.0
+
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  append-field@1.0.0: {}
+
+  arg@4.1.3: {}
+
+  array-flatten@1.1.1: {}
+
+  body-parser@1.20.4:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.14.2
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  buffer-from@1.1.2: {}
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
+
+  consola@2.15.3: {}
+
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.0.7: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  create-require@1.1.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  depd@2.0.0: {}
+
+  destroy@1.2.0: {}
+
+  diff@4.0.4: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.4
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.14.2
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-safe-stringify@2.1.1: {}
+
+  fflate@0.8.2: {}
+
+  file-type@20.4.1:
+    dependencies:
+      '@tokenizer/inflate': 0.2.7
+      strtok3: 10.3.4
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
+
+  isexe@2.0.0: {}
+
+  iterare@1.2.1: {}
+
+  make-error@1.3.6: {}
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@0.3.0: {}
+
+  merge-descriptors@1.0.3: {}
+
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@1.6.0: {}
+
+  minimist@1.2.8: {}
+
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
+
+  ms@2.0.0: {}
+
+  ms@2.1.3: {}
+
+  multer@2.0.2:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      mkdirp: 0.5.6
+      object-assign: 4.1.1
+      type-is: 1.6.18
+      xtend: 4.0.2
+
+  negotiator@0.6.3: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@0.1.12: {}
+
+  path-to-regexp@3.3.0: {}
+
+  posthog-node@file:../../target/posthog-node.tgz(rxjs@7.8.2):
+    dependencies:
+      '@posthog/core': file:../../target/posthog-core.tgz
+    optionalDependencies:
+      rxjs: 7.8.2
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  reflect-metadata@0.2.2: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  statuses@2.0.2: {}
+
+  streamsearch@1.1.0: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strtok3@10.3.4:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  toidentifier@1.0.1: {}
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.1
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
+  tr46@0.0.3: {}
+
+  ts-node@10.9.2(@types/node@20.19.7)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.7
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  tslib@2.8.1: {}
+
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
+  typedarray@0.0.6: {}
+
+  typescript@5.9.3: {}
+
+  uid@2.0.2:
+    dependencies:
+      '@lukeed/csprng': 1.1.0
+
+  uint8array-extras@1.5.0: {}
+
+  undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
+
+  util-deprecate@1.0.2: {}
+
+  utils-merge@1.0.1: {}
+
+  v8-compile-cache-lib@3.0.1: {}
+
+  vary@1.1.2: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  xtend@4.0.2: {}
+
+  yn@3.1.1: {}

--- a/examples/example-nestjs/pnpm-workspace.yaml
+++ b/examples/example-nestjs/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/examples/example-nestjs/pnpm-workspace.yaml
+++ b/examples/example-nestjs/pnpm-workspace.yaml
@@ -1,1 +1,2 @@
-packages: []
+pnpmfile: ../.pnpmfile.cjs
+nodeLinker: "hoisted"

--- a/examples/example-nestjs/src/app.controller.ts
+++ b/examples/example-nestjs/src/app.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get } from '@nestjs/common'
+import { posthog } from './main'
+
+@Controller()
+export class AppController {
+    @Get()
+    index() {
+        posthog.capture({ distinctId: 'EXAMPLE_APP_GLOBAL', event: 'nestjs capture' })
+        return { hello: 'world' }
+    }
+
+    @Get('error')
+    error() {
+        throw new Error('example NestJS error')
+    }
+}

--- a/examples/example-nestjs/src/app.module.ts
+++ b/examples/example-nestjs/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common'
+import { AppController } from './app.controller'
+
+@Module({
+    controllers: [AppController],
+})
+export class AppModule {}

--- a/examples/example-nestjs/src/main.ts
+++ b/examples/example-nestjs/src/main.ts
@@ -1,0 +1,37 @@
+/* eslint-disable no-console */
+
+import 'reflect-metadata'
+import { NestFactory } from '@nestjs/core'
+import { PostHog } from 'posthog-node'
+import { PostHogExceptionFilter } from 'posthog-node/nestjs'
+import { AppModule } from './app.module'
+
+const { POSTHOG_PROJECT_API_KEY, POSTHOG_HOST } = process.env
+
+export const posthog = new PostHog(POSTHOG_PROJECT_API_KEY!, {
+    host: POSTHOG_HOST,
+    flushAt: 1,
+})
+
+posthog.debug()
+
+async function bootstrap() {
+    const app = await NestFactory.create(AppModule)
+
+    app.useGlobalFilters(new PostHogExceptionFilter(posthog))
+
+    await app.listen(8030)
+    console.log('⚡: NestJS server is running at http://localhost:8030')
+}
+
+bootstrap()
+
+async function handleExit(signal: string) {
+    console.log(`Received ${signal}. Flushing...`)
+    await posthog.shutdown()
+    console.log('Flush complete')
+    process.exit(0)
+}
+process.on('SIGINT', handleExit)
+process.on('SIGQUIT', handleExit)
+process.on('SIGTERM', handleExit)

--- a/examples/example-nestjs/src/main.ts
+++ b/examples/example-nestjs/src/main.ts
@@ -3,7 +3,7 @@
 import 'reflect-metadata'
 import { NestFactory } from '@nestjs/core'
 import { PostHog } from 'posthog-node'
-import { PostHogExceptionInterceptor } from 'posthog-node/nestjs'
+import { PostHogInterceptor } from 'posthog-node/nestjs'
 import { AppModule } from './app.module'
 
 const { POSTHOG_PROJECT_API_KEY, POSTHOG_HOST } = process.env
@@ -18,7 +18,7 @@ posthog.debug()
 async function bootstrap() {
     const app = await NestFactory.create(AppModule)
 
-    app.useGlobalInterceptors(new PostHogExceptionInterceptor(posthog))
+    app.useGlobalInterceptors(new PostHogInterceptor(posthog))
 
     await app.listen(8030)
     console.log('⚡: NestJS server is running at http://localhost:8030')

--- a/examples/example-nestjs/src/main.ts
+++ b/examples/example-nestjs/src/main.ts
@@ -3,7 +3,7 @@
 import 'reflect-metadata'
 import { NestFactory } from '@nestjs/core'
 import { PostHog } from 'posthog-node'
-import { PostHogExceptionFilter } from 'posthog-node/nestjs'
+import { PostHogExceptionInterceptor } from 'posthog-node/nestjs'
 import { AppModule } from './app.module'
 
 const { POSTHOG_PROJECT_API_KEY, POSTHOG_HOST } = process.env
@@ -18,7 +18,7 @@ posthog.debug()
 async function bootstrap() {
     const app = await NestFactory.create(AppModule)
 
-    app.useGlobalFilters(new PostHogExceptionFilter(posthog))
+    app.useGlobalInterceptors(new PostHogExceptionInterceptor(posthog))
 
     await app.listen(8030)
     console.log('⚡: NestJS server is running at http://localhost:8030')

--- a/examples/example-nestjs/src/main.ts
+++ b/examples/example-nestjs/src/main.ts
@@ -18,7 +18,7 @@ posthog.debug()
 async function bootstrap() {
     const app = await NestFactory.create(AppModule)
 
-    app.useGlobalInterceptors(new PostHogInterceptor(posthog))
+    app.useGlobalInterceptors(new PostHogInterceptor(posthog, { captureExceptions: true }))
 
     await app.listen(8030)
     console.log('⚡: NestJS server is running at http://localhost:8030')

--- a/examples/example-nestjs/tsconfig.json
+++ b/examples/example-nestjs/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "declaration": true,
+        "removeComments": true,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "allowSyntheticDefaultImports": true,
+        "target": "ES2021",
+        "sourceMap": true,
+        "outDir": "./dist",
+        "baseUrl": "./",
+        "incremental": true,
+        "skipLibCheck": true,
+        "strictNullChecks": true,
+        "noImplicitAny": false,
+        "strictBindCallApply": false,
+        "forceConsistentCasingInFileNames": false,
+        "noFallthroughCasesInSwitch": false
+    }
+}

--- a/examples/example-nestjs/tsconfig.json
+++ b/examples/example-nestjs/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "Node16",
         "declaration": true,
         "removeComments": true,
         "emitDecoratorMetadata": true,
@@ -9,6 +9,7 @@
         "target": "ES2021",
         "sourceMap": true,
         "outDir": "./dist",
+        "moduleResolution": "nodenext",
         "baseUrl": "./",
         "incremental": true,
         "skipLibCheck": true,

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -45,7 +45,16 @@
     "@types/express": "^5.0.5",
     "@types/jest": "catalog:",
     "@types/node": "^20.0.0",
-    "jest": "catalog:"
+    "jest": "catalog:",
+    "rxjs": "^7.8.0"
+  },
+  "peerDependencies": {
+    "rxjs": "^7.0.0"
+  },
+  "peerDependenciesMeta": {
+    "rxjs": {
+      "optional": true
+    }
   },
   "keywords": [
     "posthog",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -85,6 +85,11 @@
       "require": "./dist/entrypoints/index.edge.js",
       "default": "./dist/entrypoints/index.edge.js"
     },
+    "./nestjs": {
+      "types": "./dist/entrypoints/nestjs.d.ts",
+      "import": "./dist/entrypoints/nestjs.mjs",
+      "require": "./dist/entrypoints/nestjs.js"
+    },
     "./experimental": {
       "types": "./dist/experimental.d.ts"
     }

--- a/packages/node/src/__tests__/extensions/nestjs.spec.ts
+++ b/packages/node/src/__tests__/extensions/nestjs.spec.ts
@@ -8,6 +8,12 @@ jest.mock('../../version', () => ({ version: '1.2.3' }))
 
 const mockedFetch = jest.spyOn(globalThis, 'fetch').mockImplementation()
 
+const waitForFlushTimer = async (): Promise<void> => {
+  await waitForPromises()
+  jest.runOnlyPendingTimers()
+  await waitForPromises()
+}
+
 const getLastBatchEvents = (): any[] | undefined => {
   expect(mockedFetch).toHaveBeenCalledWith('http://example.com/batch/', expect.objectContaining({ method: 'POST' }))
 
@@ -51,13 +57,13 @@ const createMockCallHandler = (error?: Error) => ({
 describe('PostHogInterceptor', () => {
   let posthog: PostHog
 
-  jest.useFakeTimers()
-
   beforeEach(() => {
     posthog = new PostHog('TEST_API_KEY', {
       host: 'http://example.com',
       fetchRetryCount: 0,
       disableCompression: true,
+      flushAt: 1,
+      flushInterval: 0,
     })
 
     mockedFetch.mockResolvedValue({
@@ -123,10 +129,7 @@ describe('PostHogInterceptor', () => {
       }
 
       await lastValueFrom(interceptor.intercept(context, handler))
-
-      await waitForPromises()
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toBeDefined()
@@ -152,10 +155,7 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext()
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-
-      await waitForPromises()
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
 
       const batchCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/batch/'))
       expect(batchCalls.length).toBe(0)
@@ -203,10 +203,7 @@ describe('PostHogInterceptor', () => {
       })
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-
-      await waitForPromises()
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toBeDefined()
@@ -231,6 +228,8 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext()
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
+      await waitForFlushTimer()
+
       const batchCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/batch/'))
       expect(batchCalls.length).toBe(0)
     })
@@ -247,10 +246,7 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext({ headers: {} })
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-
-      await waitForPromises()
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toBeDefined()
@@ -271,10 +267,7 @@ describe('PostHogInterceptor', () => {
       })
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-
-      await waitForPromises()
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents![0].properties.$ip).toBe('10.0.0.1')
@@ -287,10 +280,7 @@ describe('PostHogInterceptor', () => {
       })
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-
-      await waitForPromises()
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents![0].properties.$ip).toBe('10.0.0.1')
@@ -302,10 +292,7 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext()
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-
-      await waitForPromises()
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
 
       const batchCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/batch/'))
       expect(batchCalls.length).toBe(0)
@@ -317,10 +304,7 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext()
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-
-      await waitForPromises()
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toBeDefined()
@@ -339,10 +323,7 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext()
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-
-      await waitForPromises()
-      jest.runOnlyPendingTimers()
-      await waitForPromises()
+      await waitForFlushTimer()
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toBeDefined()

--- a/packages/node/src/__tests__/extensions/nestjs.spec.ts
+++ b/packages/node/src/__tests__/extensions/nestjs.spec.ts
@@ -1,5 +1,7 @@
+import { of, throwError, lastValueFrom } from 'rxjs'
+
 import { PostHog } from '@/entrypoints/index.node'
-import { PostHogExceptionFilter } from '@/extensions/nestjs'
+import { PostHogExceptionInterceptor } from '@/extensions/nestjs'
 import { waitForPromises } from '../utils'
 
 jest.mock('../../version', () => ({ version: '1.2.3' }))
@@ -16,7 +18,7 @@ const getLastBatchEvents = (): any[] | undefined => {
   return JSON.parse((call[1] as any).body as any).batch
 }
 
-const createMockHost = (overrides?: {
+const createMockContext = (overrides?: {
   headers?: Record<string, string>
   url?: string
   method?: string
@@ -42,9 +44,13 @@ const createMockHost = (overrides?: {
   }
 }
 
-describe('PostHogExceptionFilter', () => {
+const createMockCallHandler = (error?: Error) => ({
+  handle: () => (error ? throwError(() => error) : of(undefined)),
+})
+
+describe('PostHogExceptionInterceptor', () => {
   let posthog: PostHog
-  let filter: PostHogExceptionFilter
+  let interceptor: PostHogExceptionInterceptor
 
   jest.useFakeTimers()
 
@@ -55,7 +61,7 @@ describe('PostHogExceptionFilter', () => {
       disableCompression: true,
     })
 
-    filter = new PostHogExceptionFilter(posthog)
+    interceptor = new PostHogExceptionInterceptor(posthog)
 
     mockedFetch.mockResolvedValue({
       status: 200,
@@ -70,7 +76,7 @@ describe('PostHogExceptionFilter', () => {
 
   it('should capture exception with correct properties', async () => {
     const error = new Error('test NestJS error')
-    const host = createMockHost({
+    const context = createMockContext({
       headers: {
         'x-posthog-session-id': 'session-123',
         'x-posthog-distinct-id': 'user-456',
@@ -83,7 +89,7 @@ describe('PostHogExceptionFilter', () => {
       remoteAddress: '192.168.1.1',
     })
 
-    expect(() => filter.catch(error, host)).toThrow(error)
+    await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
 
     await waitForPromises()
     jest.runOnlyPendingTimers()
@@ -106,27 +112,36 @@ describe('PostHogExceptionFilter', () => {
     expect(event.properties.$exception_list).toBeDefined()
   })
 
-  it('should skip previously captured errors', () => {
+  it('should skip previously captured errors', async () => {
     const error = new Error('already captured') as any
     error.__posthog_previously_captured_error = true
-    const host = createMockHost()
+    const context = createMockContext()
 
-    expect(() => filter.catch(error, host)).toThrow(error)
+    await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
     expect(mockedFetch).not.toHaveBeenCalled()
   })
 
-  it('should re-throw the exception', () => {
+  it('should re-throw the exception', async () => {
     const error = new Error('should be re-thrown')
-    const host = createMockHost()
+    const context = createMockContext()
 
-    expect(() => filter.catch(error, host)).toThrow(error)
+    await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
+  })
+
+  it('should pass through successful responses', async () => {
+    const context = createMockContext()
+    const handler = { handle: () => of({ success: true }) }
+
+    const result = await lastValueFrom(interceptor.intercept(context, handler))
+    expect(result).toEqual({ success: true })
+    expect(mockedFetch).not.toHaveBeenCalled()
   })
 
   it('should handle missing headers gracefully', async () => {
     const error = new Error('no headers error')
-    const host = createMockHost({ headers: {} })
+    const context = createMockContext({ headers: {} })
 
-    expect(() => filter.catch(error, host)).toThrow(error)
+    await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
 
     await waitForPromises()
     jest.runOnlyPendingTimers()
@@ -138,7 +153,6 @@ describe('PostHogExceptionFilter', () => {
 
     const event = batchEvents![0]
     expect(event.event).toBe('$exception')
-    // Without distinct_id header, should use generated UUID
     expect(event.distinct_id).toBeDefined()
     expect(event.properties.$session_id).toBeUndefined()
     expect(event.properties.$user_agent).toBeUndefined()
@@ -146,12 +160,12 @@ describe('PostHogExceptionFilter', () => {
 
   it('should use x-forwarded-for over socket remoteAddress', async () => {
     const error = new Error('ip test error')
-    const host = createMockHost({
+    const context = createMockContext({
       headers: { 'x-forwarded-for': '10.0.0.1' },
       remoteAddress: '127.0.0.1',
     })
 
-    expect(() => filter.catch(error, host)).toThrow(error)
+    await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
 
     await waitForPromises()
     jest.runOnlyPendingTimers()

--- a/packages/node/src/__tests__/extensions/nestjs.spec.ts
+++ b/packages/node/src/__tests__/extensions/nestjs.spec.ts
@@ -1,0 +1,163 @@
+import { PostHog } from '@/entrypoints/index.node'
+import { PostHogExceptionFilter } from '@/extensions/nestjs'
+import { waitForPromises } from '../utils'
+
+jest.mock('../../version', () => ({ version: '1.2.3' }))
+
+const mockedFetch = jest.spyOn(globalThis, 'fetch').mockImplementation()
+
+const getLastBatchEvents = (): any[] | undefined => {
+  expect(mockedFetch).toHaveBeenCalledWith('http://example.com/batch/', expect.objectContaining({ method: 'POST' }))
+
+  const call = mockedFetch.mock.calls.reverse().find((x) => (x[0] as string).includes('/batch/'))
+  if (!call) {
+    return undefined
+  }
+  return JSON.parse((call[1] as any).body as any).batch
+}
+
+const createMockHost = (overrides?: {
+  headers?: Record<string, string>
+  url?: string
+  method?: string
+  path?: string
+  statusCode?: number
+  remoteAddress?: string
+}) => {
+  const request = {
+    url: overrides?.url ?? '/test-path',
+    method: overrides?.method ?? 'GET',
+    path: overrides?.path ?? '/test-path',
+    headers: overrides?.headers ?? {},
+    socket: { remoteAddress: overrides?.remoteAddress ?? '127.0.0.1' },
+  }
+  const response = {
+    statusCode: overrides?.statusCode ?? 500,
+  }
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => response,
+    }),
+  }
+}
+
+describe('PostHogExceptionFilter', () => {
+  let posthog: PostHog
+  let filter: PostHogExceptionFilter
+
+  jest.useFakeTimers()
+
+  beforeEach(() => {
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      fetchRetryCount: 0,
+      disableCompression: true,
+    })
+
+    filter = new PostHogExceptionFilter(posthog)
+
+    mockedFetch.mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve('ok'),
+      json: () => Promise.resolve({ status: 'ok' }),
+    } as any)
+  })
+
+  afterEach(async () => {
+    await posthog.shutdown()
+  })
+
+  it('should capture exception with correct properties', async () => {
+    const error = new Error('test NestJS error')
+    const host = createMockHost({
+      headers: {
+        'x-posthog-session-id': 'session-123',
+        'x-posthog-distinct-id': 'user-456',
+        'user-agent': 'TestAgent/1.0',
+      },
+      url: '/api/test',
+      method: 'POST',
+      path: '/api/test',
+      statusCode: 500,
+      remoteAddress: '192.168.1.1',
+    })
+
+    expect(() => filter.catch(error, host)).toThrow(error)
+
+    await waitForPromises()
+    jest.runOnlyPendingTimers()
+    await waitForPromises()
+
+    const batchEvents = getLastBatchEvents()
+    expect(batchEvents).toBeDefined()
+    expect(batchEvents!.length).toBe(1)
+
+    const event = batchEvents![0]
+    expect(event.event).toBe('$exception')
+    expect(event.distinct_id).toBe('user-456')
+    expect(event.properties.$session_id).toBe('session-123')
+    expect(event.properties.$current_url).toBe('/api/test')
+    expect(event.properties.$request_method).toBe('POST')
+    expect(event.properties.$request_path).toBe('/api/test')
+    expect(event.properties.$user_agent).toBe('TestAgent/1.0')
+    expect(event.properties.$response_status_code).toBe(500)
+    expect(event.properties.$ip).toBe('192.168.1.1')
+    expect(event.properties.$exception_list).toBeDefined()
+  })
+
+  it('should skip previously captured errors', () => {
+    const error = new Error('already captured') as any
+    error.__posthog_previously_captured_error = true
+    const host = createMockHost()
+
+    expect(() => filter.catch(error, host)).toThrow(error)
+    expect(mockedFetch).not.toHaveBeenCalled()
+  })
+
+  it('should re-throw the exception', () => {
+    const error = new Error('should be re-thrown')
+    const host = createMockHost()
+
+    expect(() => filter.catch(error, host)).toThrow(error)
+  })
+
+  it('should handle missing headers gracefully', async () => {
+    const error = new Error('no headers error')
+    const host = createMockHost({ headers: {} })
+
+    expect(() => filter.catch(error, host)).toThrow(error)
+
+    await waitForPromises()
+    jest.runOnlyPendingTimers()
+    await waitForPromises()
+
+    const batchEvents = getLastBatchEvents()
+    expect(batchEvents).toBeDefined()
+    expect(batchEvents!.length).toBe(1)
+
+    const event = batchEvents![0]
+    expect(event.event).toBe('$exception')
+    // Without distinct_id header, should use generated UUID
+    expect(event.distinct_id).toBeDefined()
+    expect(event.properties.$session_id).toBeUndefined()
+    expect(event.properties.$user_agent).toBeUndefined()
+  })
+
+  it('should use x-forwarded-for over socket remoteAddress', async () => {
+    const error = new Error('ip test error')
+    const host = createMockHost({
+      headers: { 'x-forwarded-for': '10.0.0.1' },
+      remoteAddress: '127.0.0.1',
+    })
+
+    expect(() => filter.catch(error, host)).toThrow(error)
+
+    await waitForPromises()
+    jest.runOnlyPendingTimers()
+    await waitForPromises()
+
+    const batchEvents = getLastBatchEvents()
+    expect(batchEvents![0].properties.$ip).toBe('10.0.0.1')
+  })
+})

--- a/packages/node/src/__tests__/extensions/nestjs.spec.ts
+++ b/packages/node/src/__tests__/extensions/nestjs.spec.ts
@@ -50,7 +50,6 @@ const createMockCallHandler = (error?: Error) => ({
 
 describe('PostHogInterceptor', () => {
   let posthog: PostHog
-  let interceptor: PostHogInterceptor
 
   jest.useFakeTimers()
 
@@ -60,8 +59,6 @@ describe('PostHogInterceptor', () => {
       fetchRetryCount: 0,
       disableCompression: true,
     })
-
-    interceptor = new PostHogInterceptor(posthog)
 
     mockedFetch.mockResolvedValue({
       status: 200,
@@ -76,6 +73,7 @@ describe('PostHogInterceptor', () => {
 
   describe('context propagation', () => {
     it('should set context from request headers', async () => {
+      const interceptor = new PostHogInterceptor(posthog)
       const context = createMockContext({
         headers: {
           'x-posthog-session-id': 'session-123',
@@ -109,6 +107,7 @@ describe('PostHogInterceptor', () => {
     })
 
     it('should propagate context to capture calls in handler', async () => {
+      const interceptor = new PostHogInterceptor(posthog)
       const context = createMockContext({
         headers: {
           'x-posthog-session-id': 'session-abc',
@@ -137,9 +136,57 @@ describe('PostHogInterceptor', () => {
       expect(event.distinct_id).toBe('user-xyz')
       expect(event.properties.$session_id).toBe('session-abc')
     })
+
+    it('should pass through successful responses', async () => {
+      const interceptor = new PostHogInterceptor(posthog)
+      const context = createMockContext()
+      const handler = { handle: () => of({ success: true }) }
+
+      const result = await lastValueFrom(interceptor.intercept(context, handler))
+      expect(result).toEqual({ success: true })
+    })
+
+    it('should not capture exceptions by default', async () => {
+      const interceptor = new PostHogInterceptor(posthog)
+      const error = new Error('should not be captured')
+      const context = createMockContext()
+
+      await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
+
+      await waitForPromises()
+      jest.runOnlyPendingTimers()
+      await waitForPromises()
+
+      const batchCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/batch/'))
+      expect(batchCalls.length).toBe(0)
+    })
+
+    it('should extract first IP from comma-separated x-forwarded-for', async () => {
+      const interceptor = new PostHogInterceptor(posthog)
+      const context = createMockContext({
+        headers: { 'x-forwarded-for': '10.0.0.1, 172.16.0.1, 192.168.1.1' },
+      })
+
+      let capturedContext: any
+      const handler = {
+        handle: () => {
+          capturedContext = posthog.getContext()
+          return of({ success: true })
+        },
+      }
+
+      await lastValueFrom(interceptor.intercept(context, handler))
+      expect(capturedContext.properties.$ip).toBe('10.0.0.1')
+    })
   })
 
-  describe('exception capture', () => {
+  describe('exception capture (captureExceptions: true)', () => {
+    let interceptor: PostHogInterceptor
+
+    beforeEach(() => {
+      interceptor = new PostHogInterceptor(posthog, { captureExceptions: true })
+    })
+
     it('should capture exception with correct properties', async () => {
       const error = new Error('test NestJS error')
       const context = createMockContext({
@@ -184,7 +231,6 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext()
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-      // Only the /batch/ call from context setup, no exception capture
       const batchCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/batch/'))
       expect(batchCalls.length).toBe(0)
     })
@@ -233,17 +279,29 @@ describe('PostHogInterceptor', () => {
       const batchEvents = getLastBatchEvents()
       expect(batchEvents![0].properties.$ip).toBe('10.0.0.1')
     })
-  })
 
-  describe('captureExceptions option', () => {
-    it('should not capture exceptions when captureExceptions is false', async () => {
-      const noExceptionInterceptor = new PostHogInterceptor(posthog, { captureExceptions: false })
-      const error = new Error('should not be captured')
+    it('should extract first IP from comma-separated x-forwarded-for', async () => {
+      const error = new Error('multi ip error')
+      const context = createMockContext({
+        headers: { 'x-forwarded-for': '10.0.0.1, 172.16.0.1, 192.168.1.1' },
+      })
+
+      await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
+
+      await waitForPromises()
+      jest.runOnlyPendingTimers()
+      await waitForPromises()
+
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents![0].properties.$ip).toBe('10.0.0.1')
+    })
+
+    it('should skip 4xx HttpException-like errors by default', async () => {
+      const error: any = new Error('Not Found')
+      error.getStatus = () => 404
       const context = createMockContext()
 
-      await expect(
-        lastValueFrom(noExceptionInterceptor.intercept(context, createMockCallHandler(error)))
-      ).rejects.toThrow(error)
+      await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
 
       await waitForPromises()
       jest.runOnlyPendingTimers()
@@ -253,36 +311,42 @@ describe('PostHogInterceptor', () => {
       expect(batchCalls.length).toBe(0)
     })
 
-    it('should still set context when captureExceptions is false', async () => {
-      const noExceptionInterceptor = new PostHogInterceptor(posthog, { captureExceptions: false })
-      const context = createMockContext({
-        headers: {
-          'x-posthog-session-id': 'session-ctx',
-          'x-posthog-distinct-id': 'user-ctx',
-        },
-      })
-
-      let capturedContext: any
-      const handler = {
-        handle: () => {
-          capturedContext = posthog.getContext()
-          return of({ success: true })
-        },
-      }
-
-      await lastValueFrom(noExceptionInterceptor.intercept(context, handler))
-
-      expect(capturedContext).toBeDefined()
-      expect(capturedContext.sessionId).toBe('session-ctx')
-      expect(capturedContext.distinctId).toBe('user-ctx')
-    })
-
-    it('should pass through successful responses', async () => {
+    it('should capture 5xx HttpException-like errors', async () => {
+      const error: any = new Error('Internal Server Error')
+      error.getStatus = () => 500
       const context = createMockContext()
-      const handler = { handle: () => of({ success: true }) }
 
-      const result = await lastValueFrom(interceptor.intercept(context, handler))
-      expect(result).toEqual({ success: true })
+      await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
+
+      await waitForPromises()
+      jest.runOnlyPendingTimers()
+      await waitForPromises()
+
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents).toBeDefined()
+      expect(batchEvents![0].event).toBe('$exception')
+      expect(batchEvents![0].properties.$response_status_code).toBe(500)
+    })
+  })
+
+  describe('exception capture with custom minStatusToCapture', () => {
+    it('should capture 4xx when minStatusToCapture is set to 400', async () => {
+      const interceptor = new PostHogInterceptor(posthog, {
+        captureExceptions: { minStatusToCapture: 400 },
+      })
+      const error: any = new Error('Not Found')
+      error.getStatus = () => 404
+      const context = createMockContext()
+
+      await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
+
+      await waitForPromises()
+      jest.runOnlyPendingTimers()
+      await waitForPromises()
+
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents).toBeDefined()
+      expect(batchEvents![0].event).toBe('$exception')
     })
   })
 })

--- a/packages/node/src/__tests__/extensions/nestjs.spec.ts
+++ b/packages/node/src/__tests__/extensions/nestjs.spec.ts
@@ -1,7 +1,7 @@
 import { of, throwError, lastValueFrom } from 'rxjs'
 
 import { PostHog } from '@/entrypoints/index.node'
-import { PostHogExceptionInterceptor } from '@/extensions/nestjs'
+import { PostHogInterceptor } from '@/extensions/nestjs'
 import { waitForPromises } from '../utils'
 
 jest.mock('../../version', () => ({ version: '1.2.3' }))
@@ -48,9 +48,9 @@ const createMockCallHandler = (error?: Error) => ({
   handle: () => (error ? throwError(() => error) : of(undefined)),
 })
 
-describe('PostHogExceptionInterceptor', () => {
+describe('PostHogInterceptor', () => {
   let posthog: PostHog
-  let interceptor: PostHogExceptionInterceptor
+  let interceptor: PostHogInterceptor
 
   jest.useFakeTimers()
 
@@ -61,7 +61,7 @@ describe('PostHogExceptionInterceptor', () => {
       disableCompression: true,
     })
 
-    interceptor = new PostHogExceptionInterceptor(posthog)
+    interceptor = new PostHogInterceptor(posthog)
 
     mockedFetch.mockResolvedValue({
       status: 200,
@@ -74,104 +74,215 @@ describe('PostHogExceptionInterceptor', () => {
     await posthog.shutdown()
   })
 
-  it('should capture exception with correct properties', async () => {
-    const error = new Error('test NestJS error')
-    const context = createMockContext({
-      headers: {
-        'x-posthog-session-id': 'session-123',
-        'x-posthog-distinct-id': 'user-456',
-        'user-agent': 'TestAgent/1.0',
-      },
-      url: '/api/test',
-      method: 'POST',
-      path: '/api/test',
-      statusCode: 500,
-      remoteAddress: '192.168.1.1',
+  describe('context propagation', () => {
+    it('should set context from request headers', async () => {
+      const context = createMockContext({
+        headers: {
+          'x-posthog-session-id': 'session-123',
+          'x-posthog-distinct-id': 'user-456',
+          'user-agent': 'TestAgent/1.0',
+        },
+        url: '/api/test',
+        method: 'POST',
+        path: '/api/test',
+        remoteAddress: '192.168.1.1',
+      })
+
+      let capturedContext: any
+      const handler = {
+        handle: () => {
+          capturedContext = posthog.getContext()
+          return of({ success: true })
+        },
+      }
+
+      await lastValueFrom(interceptor.intercept(context, handler))
+
+      expect(capturedContext).toBeDefined()
+      expect(capturedContext.sessionId).toBe('session-123')
+      expect(capturedContext.distinctId).toBe('user-456')
+      expect(capturedContext.properties.$current_url).toBe('/api/test')
+      expect(capturedContext.properties.$request_method).toBe('POST')
+      expect(capturedContext.properties.$request_path).toBe('/api/test')
+      expect(capturedContext.properties.$user_agent).toBe('TestAgent/1.0')
+      expect(capturedContext.properties.$ip).toBe('192.168.1.1')
     })
 
-    await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
+    it('should propagate context to capture calls in handler', async () => {
+      const context = createMockContext({
+        headers: {
+          'x-posthog-session-id': 'session-abc',
+          'x-posthog-distinct-id': 'user-xyz',
+        },
+      })
 
-    await waitForPromises()
-    jest.runOnlyPendingTimers()
-    await waitForPromises()
+      const handler = {
+        handle: () => {
+          posthog.capture({ event: 'handler_event' })
+          return of({ success: true })
+        },
+      }
 
-    const batchEvents = getLastBatchEvents()
-    expect(batchEvents).toBeDefined()
-    expect(batchEvents!.length).toBe(1)
+      await lastValueFrom(interceptor.intercept(context, handler))
 
-    const event = batchEvents![0]
-    expect(event.event).toBe('$exception')
-    expect(event.distinct_id).toBe('user-456')
-    expect(event.properties.$session_id).toBe('session-123')
-    expect(event.properties.$current_url).toBe('/api/test')
-    expect(event.properties.$request_method).toBe('POST')
-    expect(event.properties.$request_path).toBe('/api/test')
-    expect(event.properties.$user_agent).toBe('TestAgent/1.0')
-    expect(event.properties.$response_status_code).toBe(500)
-    expect(event.properties.$ip).toBe('192.168.1.1')
-    expect(event.properties.$exception_list).toBeDefined()
+      await waitForPromises()
+      jest.runOnlyPendingTimers()
+      await waitForPromises()
+
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents).toBeDefined()
+
+      const event = batchEvents!.find((e: any) => e.event === 'handler_event')
+      expect(event).toBeDefined()
+      expect(event.distinct_id).toBe('user-xyz')
+      expect(event.properties.$session_id).toBe('session-abc')
+    })
   })
 
-  it('should skip previously captured errors', async () => {
-    const error = new Error('already captured') as any
-    error.__posthog_previously_captured_error = true
-    const context = createMockContext()
+  describe('exception capture', () => {
+    it('should capture exception with correct properties', async () => {
+      const error = new Error('test NestJS error')
+      const context = createMockContext({
+        headers: {
+          'x-posthog-session-id': 'session-123',
+          'x-posthog-distinct-id': 'user-456',
+          'user-agent': 'TestAgent/1.0',
+        },
+        url: '/api/test',
+        method: 'POST',
+        path: '/api/test',
+        statusCode: 500,
+        remoteAddress: '192.168.1.1',
+      })
 
-    await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-    expect(mockedFetch).not.toHaveBeenCalled()
-  })
+      await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
 
-  it('should re-throw the exception', async () => {
-    const error = new Error('should be re-thrown')
-    const context = createMockContext()
+      await waitForPromises()
+      jest.runOnlyPendingTimers()
+      await waitForPromises()
 
-    await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-  })
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents).toBeDefined()
+      expect(batchEvents!.length).toBe(1)
 
-  it('should pass through successful responses', async () => {
-    const context = createMockContext()
-    const handler = { handle: () => of({ success: true }) }
-
-    const result = await lastValueFrom(interceptor.intercept(context, handler))
-    expect(result).toEqual({ success: true })
-    expect(mockedFetch).not.toHaveBeenCalled()
-  })
-
-  it('should handle missing headers gracefully', async () => {
-    const error = new Error('no headers error')
-    const context = createMockContext({ headers: {} })
-
-    await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-
-    await waitForPromises()
-    jest.runOnlyPendingTimers()
-    await waitForPromises()
-
-    const batchEvents = getLastBatchEvents()
-    expect(batchEvents).toBeDefined()
-    expect(batchEvents!.length).toBe(1)
-
-    const event = batchEvents![0]
-    expect(event.event).toBe('$exception')
-    expect(event.distinct_id).toBeDefined()
-    expect(event.properties.$session_id).toBeUndefined()
-    expect(event.properties.$user_agent).toBeUndefined()
-  })
-
-  it('should use x-forwarded-for over socket remoteAddress', async () => {
-    const error = new Error('ip test error')
-    const context = createMockContext({
-      headers: { 'x-forwarded-for': '10.0.0.1' },
-      remoteAddress: '127.0.0.1',
+      const event = batchEvents![0]
+      expect(event.event).toBe('$exception')
+      expect(event.distinct_id).toBe('user-456')
+      expect(event.properties.$session_id).toBe('session-123')
+      expect(event.properties.$current_url).toBe('/api/test')
+      expect(event.properties.$request_method).toBe('POST')
+      expect(event.properties.$request_path).toBe('/api/test')
+      expect(event.properties.$user_agent).toBe('TestAgent/1.0')
+      expect(event.properties.$response_status_code).toBe(500)
+      expect(event.properties.$ip).toBe('192.168.1.1')
+      expect(event.properties.$exception_list).toBeDefined()
     })
 
-    await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
+    it('should skip previously captured errors', async () => {
+      const error = new Error('already captured') as any
+      error.__posthog_previously_captured_error = true
+      const context = createMockContext()
 
-    await waitForPromises()
-    jest.runOnlyPendingTimers()
-    await waitForPromises()
+      await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
+      // Only the /batch/ call from context setup, no exception capture
+      const batchCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/batch/'))
+      expect(batchCalls.length).toBe(0)
+    })
 
-    const batchEvents = getLastBatchEvents()
-    expect(batchEvents![0].properties.$ip).toBe('10.0.0.1')
+    it('should re-throw the exception', async () => {
+      const error = new Error('should be re-thrown')
+      const context = createMockContext()
+
+      await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
+    })
+
+    it('should handle missing headers gracefully', async () => {
+      const error = new Error('no headers error')
+      const context = createMockContext({ headers: {} })
+
+      await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
+
+      await waitForPromises()
+      jest.runOnlyPendingTimers()
+      await waitForPromises()
+
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents).toBeDefined()
+      expect(batchEvents!.length).toBe(1)
+
+      const event = batchEvents![0]
+      expect(event.event).toBe('$exception')
+      expect(event.distinct_id).toBeDefined()
+      expect(event.properties.$session_id).toBeUndefined()
+      expect(event.properties.$user_agent).toBeUndefined()
+    })
+
+    it('should use x-forwarded-for over socket remoteAddress', async () => {
+      const error = new Error('ip test error')
+      const context = createMockContext({
+        headers: { 'x-forwarded-for': '10.0.0.1' },
+        remoteAddress: '127.0.0.1',
+      })
+
+      await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
+
+      await waitForPromises()
+      jest.runOnlyPendingTimers()
+      await waitForPromises()
+
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents![0].properties.$ip).toBe('10.0.0.1')
+    })
+  })
+
+  describe('captureExceptions option', () => {
+    it('should not capture exceptions when captureExceptions is false', async () => {
+      const noExceptionInterceptor = new PostHogInterceptor(posthog, { captureExceptions: false })
+      const error = new Error('should not be captured')
+      const context = createMockContext()
+
+      await expect(
+        lastValueFrom(noExceptionInterceptor.intercept(context, createMockCallHandler(error)))
+      ).rejects.toThrow(error)
+
+      await waitForPromises()
+      jest.runOnlyPendingTimers()
+      await waitForPromises()
+
+      const batchCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/batch/'))
+      expect(batchCalls.length).toBe(0)
+    })
+
+    it('should still set context when captureExceptions is false', async () => {
+      const noExceptionInterceptor = new PostHogInterceptor(posthog, { captureExceptions: false })
+      const context = createMockContext({
+        headers: {
+          'x-posthog-session-id': 'session-ctx',
+          'x-posthog-distinct-id': 'user-ctx',
+        },
+      })
+
+      let capturedContext: any
+      const handler = {
+        handle: () => {
+          capturedContext = posthog.getContext()
+          return of({ success: true })
+        },
+      }
+
+      await lastValueFrom(noExceptionInterceptor.intercept(context, handler))
+
+      expect(capturedContext).toBeDefined()
+      expect(capturedContext.sessionId).toBe('session-ctx')
+      expect(capturedContext.distinctId).toBe('user-ctx')
+    })
+
+    it('should pass through successful responses', async () => {
+      const context = createMockContext()
+      const handler = { handle: () => of({ success: true }) }
+
+      const result = await lastValueFrom(interceptor.intercept(context, handler))
+      expect(result).toEqual({ success: true })
+    })
   })
 })

--- a/packages/node/src/entrypoints/nestjs.ts
+++ b/packages/node/src/entrypoints/nestjs.ts
@@ -1,0 +1,1 @@
+export * from '../extensions/nestjs'

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -23,24 +23,47 @@ interface NestInterceptor<T = any, R = any> {
   intercept(context: ExecutionContext, next: CallHandler<T>): Observable<R>
 }
 
-export class PostHogExceptionInterceptor implements NestInterceptor {
-  private posthog: PostHogBackendClient
+export interface PostHogInterceptorOptions {
+  captureExceptions?: boolean
+}
 
-  constructor(posthog: PostHogBackendClient) {
+export class PostHogInterceptor implements NestInterceptor {
+  private posthog: PostHogBackendClient
+  private captureExceptions: boolean
+
+  constructor(posthog: PostHogBackendClient, options?: PostHogInterceptorOptions) {
     this.posthog = posthog
+    this.captureExceptions = options?.captureExceptions ?? true
   }
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const httpHost = context.switchToHttp()
+    const request = httpHost.getRequest()
+    const response = httpHost.getResponse()
+
+    const headers = request?.headers ?? {}
+    const sessionId: string | undefined = headers['x-posthog-session-id']
+    const distinctId: string | undefined = headers['x-posthog-distinct-id']
+
+    this.posthog.enterContext({
+      sessionId,
+      distinctId,
+      properties: {
+        $current_url: request?.url,
+        $request_method: request?.method,
+        $request_path: request?.path ?? request?.url,
+        $user_agent: headers['user-agent'],
+        $ip: headers['x-forwarded-for'] || request?.socket?.remoteAddress,
+      },
+    })
+
+    if (!this.captureExceptions) {
+      return next.handle()
+    }
+
     return next.handle().pipe(
       catchError((exception: unknown) => {
         if (!ErrorTracking.isPreviouslyCapturedError(exception)) {
-          const httpHost = context.switchToHttp()
-          const request = httpHost.getRequest()
-          const response = httpHost.getResponse()
-
-          const headers = request?.headers ?? {}
-          const sessionId: string | undefined = headers['x-posthog-session-id']
-          const distinctId: string | undefined = headers['x-posthog-distinct-id']
           const syntheticException = new Error('Synthetic exception')
           const hint: CoreErrorTracking.EventHint = {
             mechanism: { type: 'middleware', handled: false },

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -1,3 +1,6 @@
+import { Observable, throwError } from 'rxjs'
+import { catchError } from 'rxjs/operators'
+
 import ErrorTracking from './error-tracking'
 import { PostHogBackendClient } from '../client'
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
@@ -8,50 +11,59 @@ interface HttpArgumentsHost {
   getResponse<T = any>(): T
 }
 
-interface ArgumentsHost {
+interface ExecutionContext {
   switchToHttp(): HttpArgumentsHost
 }
 
-interface ExceptionFilter {
-  catch(exception: unknown, host: ArgumentsHost): void
+interface CallHandler<T = any> {
+  handle(): Observable<T>
 }
 
-export class PostHogExceptionFilter implements ExceptionFilter {
+interface NestInterceptor<T = any, R = any> {
+  intercept(context: ExecutionContext, next: CallHandler<T>): Observable<R>
+}
+
+export class PostHogExceptionInterceptor implements NestInterceptor {
   private posthog: PostHogBackendClient
 
   constructor(posthog: PostHogBackendClient) {
     this.posthog = posthog
   }
 
-  catch(exception: unknown, host: ArgumentsHost): void {
-    if (ErrorTracking.isPreviouslyCapturedError(exception)) {
-      throw exception
-    }
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    return next.handle().pipe(
+      catchError((exception: unknown) => {
+        if (!ErrorTracking.isPreviouslyCapturedError(exception)) {
+          const httpHost = context.switchToHttp()
+          const request = httpHost.getRequest()
+          const response = httpHost.getResponse()
 
-    const httpHost = host.switchToHttp()
-    const request = httpHost.getRequest()
-    const response = httpHost.getResponse()
+          const headers = request?.headers ?? {}
+          const sessionId: string | undefined = headers['x-posthog-session-id']
+          const distinctId: string | undefined = headers['x-posthog-distinct-id']
+          const syntheticException = new Error('Synthetic exception')
+          const hint: CoreErrorTracking.EventHint = {
+            mechanism: { type: 'middleware', handled: false },
+            syntheticException,
+          }
 
-    const headers = request?.headers ?? {}
-    const sessionId: string | undefined = headers['x-posthog-session-id']
-    const distinctId: string | undefined = headers['x-posthog-distinct-id']
-    const syntheticException = new Error('Synthetic exception')
-    const hint: CoreErrorTracking.EventHint = { mechanism: { type: 'middleware', handled: false }, syntheticException }
+          this.posthog.addPendingPromise(
+            ErrorTracking.buildEventMessage(exception, hint, distinctId, {
+              $session_id: sessionId,
+              $current_url: request?.url,
+              $request_method: request?.method,
+              $request_path: request?.path ?? request?.url,
+              $user_agent: headers['user-agent'],
+              $response_status_code: response?.statusCode,
+              $ip: headers['x-forwarded-for'] || request?.socket?.remoteAddress,
+            }).then((msg) => {
+              this.posthog.capture(msg)
+            })
+          )
+        }
 
-    this.posthog.addPendingPromise(
-      ErrorTracking.buildEventMessage(exception, hint, distinctId, {
-        $session_id: sessionId,
-        $current_url: request?.url,
-        $request_method: request?.method,
-        $request_path: request?.path ?? request?.url,
-        $user_agent: headers['user-agent'],
-        $response_status_code: response?.statusCode,
-        $ip: headers['x-forwarded-for'] || request?.socket?.remoteAddress,
-      }).then((msg) => {
-        this.posthog.capture(msg)
+        return throwError(() => exception)
       })
     )
-
-    throw exception
   }
 }

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -70,10 +70,10 @@ export class PostHogInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const httpHost = context.switchToHttp()
     const request = httpHost.getRequest()
-    const response = httpHost.getResponse()
 
     const headers = request?.headers ?? {}
     const sessionId: string | undefined = headers['x-posthog-session-id']
+    const windowId: string | undefined = headers['x-posthog-window-id']
     const distinctId: string | undefined = headers['x-posthog-distinct-id']
 
     const contextData = {
@@ -83,12 +83,13 @@ export class PostHogInterceptor implements NestInterceptor {
         $current_url: request?.url,
         $request_method: request?.method,
         $request_path: request?.path ?? request?.url,
+        $window_id: windowId,
         $user_agent: headers['user-agent'],
         $ip: getClientIp(headers, request),
       },
     }
 
-    const buildPipeline = () => {
+    return this.posthog.withContext(contextData, () => {
       let source = next.handle()
 
       if (this.captureExceptions) {
@@ -97,48 +98,16 @@ export class PostHogInterceptor implements NestInterceptor {
             if (ErrorTracking.isPreviouslyCapturedError(exception)) {
               return throwError(() => exception)
             }
-
             const status = getExceptionStatus(exception)
             if (status !== undefined && status < this.minStatusToCapture) {
               return throwError(() => exception)
             }
-
-            const syntheticException = new Error('Synthetic exception')
-            const hint: CoreErrorTracking.EventHint = {
-              mechanism: { type: 'middleware', handled: false },
-              syntheticException,
-            }
-
-            this.posthog.addPendingPromise(
-              ErrorTracking.buildEventMessage(exception, hint, distinctId, {
-                $session_id: sessionId,
-                $current_url: request?.url,
-                $request_method: request?.method,
-                $request_path: request?.path ?? request?.url,
-                $user_agent: headers['user-agent'],
-                $response_status_code: status ?? response?.statusCode,
-                $ip: getClientIp(headers, request),
-              }).then((msg) => {
-                this.posthog.capture(msg)
-              })
-            )
-
+            this.posthog.captureException(exception, distinctId)
             return throwError(() => exception)
           })
         )
       }
-
       return source
-    }
-
-    // Wrap in a new Observable so that subscription (and the entire handler
-    // execution) runs inside withContext's AsyncLocalStorage.run() scope.
-    // This ensures context is properly isolated per request and cleaned up
-    // automatically, unlike enterContext which can leak across requests.
-    return new Observable((subscriber) => {
-      this.posthog.withContext(contextData, () => {
-        buildPipeline().subscribe(subscriber)
-      })
     })
   }
 }

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -3,7 +3,6 @@ import { catchError } from 'rxjs/operators'
 
 import ErrorTracking from './error-tracking'
 import { PostHogBackendClient } from '../client'
-import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 
 // Local interfaces to avoid runtime dependency on @nestjs/common
 interface HttpArgumentsHost {

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -1,0 +1,57 @@
+import ErrorTracking from './error-tracking'
+import { PostHogBackendClient } from '../client'
+import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
+
+// Local interfaces to avoid runtime dependency on @nestjs/common
+interface HttpArgumentsHost {
+  getRequest<T = any>(): T
+  getResponse<T = any>(): T
+}
+
+interface ArgumentsHost {
+  switchToHttp(): HttpArgumentsHost
+}
+
+interface ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost): void
+}
+
+export class PostHogExceptionFilter implements ExceptionFilter {
+  private posthog: PostHogBackendClient
+
+  constructor(posthog: PostHogBackendClient) {
+    this.posthog = posthog
+  }
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    if (ErrorTracking.isPreviouslyCapturedError(exception)) {
+      throw exception
+    }
+
+    const httpHost = host.switchToHttp()
+    const request = httpHost.getRequest()
+    const response = httpHost.getResponse()
+
+    const headers = request?.headers ?? {}
+    const sessionId: string | undefined = headers['x-posthog-session-id']
+    const distinctId: string | undefined = headers['x-posthog-distinct-id']
+    const syntheticException = new Error('Synthetic exception')
+    const hint: CoreErrorTracking.EventHint = { mechanism: { type: 'middleware', handled: false }, syntheticException }
+
+    this.posthog.addPendingPromise(
+      ErrorTracking.buildEventMessage(exception, hint, distinctId, {
+        $session_id: sessionId,
+        $current_url: request?.url,
+        $request_method: request?.method,
+        $request_path: request?.path ?? request?.url,
+        $user_agent: headers['user-agent'],
+        $response_status_code: response?.statusCode,
+        $ip: headers['x-forwarded-for'] || request?.socket?.remoteAddress,
+      }).then((msg) => {
+        this.posthog.capture(msg)
+      })
+    )
+
+    throw exception
+  }
+}

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -23,17 +23,47 @@ interface NestInterceptor<T = any, R = any> {
   intercept(context: ExecutionContext, next: CallHandler<T>): Observable<R>
 }
 
+export interface ExceptionCaptureOptions {
+  /** Minimum HTTP status code to capture. Exceptions with a lower status (e.g. 4xx) are skipped. @default 500 */
+  minStatusToCapture?: number
+}
+
 export interface PostHogInterceptorOptions {
-  captureExceptions?: boolean
+  /** Enable exception capture. Pass `true` for defaults or an object to configure. @default false */
+  captureExceptions?: boolean | ExceptionCaptureOptions
+}
+
+function getClientIp(headers: Record<string, any>, request: any): string | undefined {
+  const forwarded = headers['x-forwarded-for']
+  if (forwarded) {
+    return String(forwarded).split(',')[0]?.trim()
+  }
+  return request?.socket?.remoteAddress
+}
+
+function getExceptionStatus(exception: unknown): number | undefined {
+  if (
+    exception &&
+    typeof exception === 'object' &&
+    'getStatus' in exception &&
+    typeof (exception as any).getStatus === 'function'
+  ) {
+    const status = (exception as any).getStatus()
+    return typeof status === 'number' ? status : undefined
+  }
+  return undefined
 }
 
 export class PostHogInterceptor implements NestInterceptor {
   private posthog: PostHogBackendClient
   private captureExceptions: boolean
+  private minStatusToCapture: number
 
   constructor(posthog: PostHogBackendClient, options?: PostHogInterceptorOptions) {
     this.posthog = posthog
-    this.captureExceptions = options?.captureExceptions ?? true
+    const capture = options?.captureExceptions
+    this.captureExceptions = !!capture
+    this.minStatusToCapture = (typeof capture === 'object' ? capture.minStatusToCapture : undefined) ?? 500
   }
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
@@ -53,7 +83,7 @@ export class PostHogInterceptor implements NestInterceptor {
         $request_method: request?.method,
         $request_path: request?.path ?? request?.url,
         $user_agent: headers['user-agent'],
-        $ip: headers['x-forwarded-for'] || request?.socket?.remoteAddress,
+        $ip: getClientIp(headers, request),
       },
     })
 
@@ -63,27 +93,34 @@ export class PostHogInterceptor implements NestInterceptor {
 
     return next.handle().pipe(
       catchError((exception: unknown) => {
-        if (!ErrorTracking.isPreviouslyCapturedError(exception)) {
-          const syntheticException = new Error('Synthetic exception')
-          const hint: CoreErrorTracking.EventHint = {
-            mechanism: { type: 'middleware', handled: false },
-            syntheticException,
-          }
-
-          this.posthog.addPendingPromise(
-            ErrorTracking.buildEventMessage(exception, hint, distinctId, {
-              $session_id: sessionId,
-              $current_url: request?.url,
-              $request_method: request?.method,
-              $request_path: request?.path ?? request?.url,
-              $user_agent: headers['user-agent'],
-              $response_status_code: response?.statusCode,
-              $ip: headers['x-forwarded-for'] || request?.socket?.remoteAddress,
-            }).then((msg) => {
-              this.posthog.capture(msg)
-            })
-          )
+        if (ErrorTracking.isPreviouslyCapturedError(exception)) {
+          return throwError(() => exception)
         }
+
+        const status = getExceptionStatus(exception)
+        if (status !== undefined && status < this.minStatusToCapture) {
+          return throwError(() => exception)
+        }
+
+        const syntheticException = new Error('Synthetic exception')
+        const hint: CoreErrorTracking.EventHint = {
+          mechanism: { type: 'middleware', handled: false },
+          syntheticException,
+        }
+
+        this.posthog.addPendingPromise(
+          ErrorTracking.buildEventMessage(exception, hint, distinctId, {
+            $session_id: sessionId,
+            $current_url: request?.url,
+            $request_method: request?.method,
+            $request_path: request?.path ?? request?.url,
+            $user_agent: headers['user-agent'],
+            $response_status_code: status ?? response?.statusCode,
+            $ip: getClientIp(headers, request),
+          }).then((msg) => {
+            this.posthog.capture(msg)
+          })
+        )
 
         return throwError(() => exception)
       })

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -69,6 +69,7 @@ export class PostHogInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const httpHost = context.switchToHttp()
     const request = httpHost.getRequest()
+    const response = httpHost.getResponse()
 
     const headers = request?.headers ?? {}
     const sessionId: string | undefined = headers['x-posthog-session-id']
@@ -88,25 +89,30 @@ export class PostHogInterceptor implements NestInterceptor {
       },
     }
 
-    return this.posthog.withContext(contextData, () => {
-      let source = next.handle()
+    // Use enterContext so the context propagates through RxJS Observable
+    // subscription and catchError handlers, not just the synchronous callback.
+    this.posthog.enterContext(contextData)
 
-      if (this.captureExceptions) {
-        source = source.pipe(
-          catchError((exception: unknown) => {
-            if (ErrorTracking.isPreviouslyCapturedError(exception)) {
-              return throwError(() => exception)
-            }
-            const status = getExceptionStatus(exception)
-            if (status !== undefined && status < this.minStatusToCapture) {
-              return throwError(() => exception)
-            }
-            this.posthog.captureException(exception, distinctId)
+    let source = next.handle()
+
+    if (this.captureExceptions) {
+      source = source.pipe(
+        catchError((exception: unknown) => {
+          if (ErrorTracking.isPreviouslyCapturedError(exception)) {
             return throwError(() => exception)
-          })
-        )
-      }
-      return source
-    })
+          }
+          const status = getExceptionStatus(exception)
+          if (status !== undefined && status < this.minStatusToCapture) {
+            return throwError(() => exception)
+          }
+          const responseStatus = status ?? response?.statusCode
+          const additionalProperties: Record<string, any> | undefined =
+            responseStatus !== undefined ? { $response_status_code: responseStatus } : undefined
+          this.posthog.captureException(exception, distinctId, additionalProperties)
+          return throwError(() => exception)
+        })
+      )
+    }
+    return source
   }
 }

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -36,7 +36,8 @@ export interface PostHogInterceptorOptions {
 function getClientIp(headers: Record<string, any>, request: any): string | undefined {
   const forwarded = headers['x-forwarded-for']
   if (forwarded) {
-    return String(forwarded).split(',')[0]?.trim()
+    const ip = String(forwarded).split(',')[0].trim()
+    if (ip) return ip
   }
   return request?.socket?.remoteAddress
 }

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -75,7 +75,7 @@ export class PostHogInterceptor implements NestInterceptor {
     const sessionId: string | undefined = headers['x-posthog-session-id']
     const distinctId: string | undefined = headers['x-posthog-distinct-id']
 
-    this.posthog.enterContext({
+    const contextData = {
       sessionId,
       distinctId,
       properties: {
@@ -85,45 +85,59 @@ export class PostHogInterceptor implements NestInterceptor {
         $user_agent: headers['user-agent'],
         $ip: getClientIp(headers, request),
       },
-    })
-
-    if (!this.captureExceptions) {
-      return next.handle()
     }
 
-    return next.handle().pipe(
-      catchError((exception: unknown) => {
-        if (ErrorTracking.isPreviouslyCapturedError(exception)) {
-          return throwError(() => exception)
-        }
+    const buildPipeline = () => {
+      let source = next.handle()
 
-        const status = getExceptionStatus(exception)
-        if (status !== undefined && status < this.minStatusToCapture) {
-          return throwError(() => exception)
-        }
+      if (this.captureExceptions) {
+        source = source.pipe(
+          catchError((exception: unknown) => {
+            if (ErrorTracking.isPreviouslyCapturedError(exception)) {
+              return throwError(() => exception)
+            }
 
-        const syntheticException = new Error('Synthetic exception')
-        const hint: CoreErrorTracking.EventHint = {
-          mechanism: { type: 'middleware', handled: false },
-          syntheticException,
-        }
+            const status = getExceptionStatus(exception)
+            if (status !== undefined && status < this.minStatusToCapture) {
+              return throwError(() => exception)
+            }
 
-        this.posthog.addPendingPromise(
-          ErrorTracking.buildEventMessage(exception, hint, distinctId, {
-            $session_id: sessionId,
-            $current_url: request?.url,
-            $request_method: request?.method,
-            $request_path: request?.path ?? request?.url,
-            $user_agent: headers['user-agent'],
-            $response_status_code: status ?? response?.statusCode,
-            $ip: getClientIp(headers, request),
-          }).then((msg) => {
-            this.posthog.capture(msg)
+            const syntheticException = new Error('Synthetic exception')
+            const hint: CoreErrorTracking.EventHint = {
+              mechanism: { type: 'middleware', handled: false },
+              syntheticException,
+            }
+
+            this.posthog.addPendingPromise(
+              ErrorTracking.buildEventMessage(exception, hint, distinctId, {
+                $session_id: sessionId,
+                $current_url: request?.url,
+                $request_method: request?.method,
+                $request_path: request?.path ?? request?.url,
+                $user_agent: headers['user-agent'],
+                $response_status_code: status ?? response?.statusCode,
+                $ip: getClientIp(headers, request),
+              }).then((msg) => {
+                this.posthog.capture(msg)
+              })
+            )
+
+            return throwError(() => exception)
           })
         )
+      }
 
-        return throwError(() => exception)
+      return source
+    }
+
+    // Wrap in a new Observable so that subscription (and the entire handler
+    // execution) runs inside withContext's AsyncLocalStorage.run() scope.
+    // This ensures context is properly isolated per request and cleaned up
+    // automatically, unlike enterContext which can leak across requests.
+    return new Observable((subscriber) => {
+      this.posthog.withContext(contextData, () => {
+        buildPipeline().subscribe(subscriber)
       })
-    )
+    })
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,7 +235,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -498,7 +498,7 @@ importers:
     devDependencies:
       '@convex-dev/eslint-plugin':
         specifier: ^1.1.1
-        version: 1.1.1(convex@1.31.7(react@19.2.1))(eslint@8.57.0)(typescript@5.8.2)
+        version: 1.1.1(convex@1.31.7(react@19.2.1))(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
       '@edge-runtime/vm':
         specifier: ^5.0.0
         version: 5.0.0
@@ -575,7 +575,7 @@ importers:
         version: link:../../tooling/tsconfig-base
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.10.6(@microsoft/api-extractor@7.55.1(@types/node@22.16.5))(typescript@5.8.2)
+        version: 0.10.6(@microsoft/api-extractor@7.55.1(@types/node@22.16.5))(typescript@5.9.3)
       '@types/jest':
         specifier: 'catalog:'
         version: 29.5.14
@@ -587,13 +587,13 @@ importers:
         version: 7.7.0
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+        version: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       next:
         specifier: ^15.5.7
         version: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       ts-jest:
         specifier: 'catalog:'
-        version: 29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)))(typescript@5.8.2)
+        version: 29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)))(typescript@5.9.3)
 
   packages/node:
     dependencies:
@@ -619,6 +619,9 @@ importers:
       jest:
         specifier: 'catalog:'
         version: 29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3))
+      rxjs:
+        specifier: ^7.8.0
+        version: 7.8.2
 
   packages/nuxt:
     dependencies:
@@ -640,13 +643,13 @@ importers:
     devDependencies:
       '@nuxt/devtools':
         specifier: ^2.6.5
-        version: 2.6.5(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.8.2))
+        version: 2.6.5(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.9.3))
       '@nuxt/eslint-config':
         specifier: ^1.9.0
-        version: 1.9.0(@typescript-eslint/utils@8.49.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2))(@vue/compiler-sfc@3.5.22)(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
+        version: 1.9.0(@typescript-eslint/utils@8.49.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.22)(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       '@nuxt/module-builder':
         specifier: ^1.0.2
-        version: 1.0.2(@nuxt/cli@3.29.0(magicast@0.3.5))(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(typescript@5.8.2)(vue@3.5.22(typescript@5.8.2))
+        version: 1.0.2(@nuxt/cli@3.29.0(magicast@0.3.5))(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))
       '@nuxt/schema':
         specifier: ^4.1.2
         version: 4.1.3
@@ -658,7 +661,7 @@ importers:
         version: 9.37.0(jiti@2.6.1)
       nuxt:
         specifier: ^4.1.2
-        version: 4.1.3(@parcel/watcher@2.5.1)(@types/node@20.19.9)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.1)(lightningcss@1.27.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.8.2)(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(yaml@2.8.0)
+        version: 4.1.3(@parcel/watcher@2.5.1)(@types/node@20.19.9)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.1)(lightningcss@1.27.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(yaml@2.8.0)
 
   packages/react:
     devDependencies:
@@ -919,7 +922,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@25.3.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@25.3.2)(typescript@5.8.2))
+        version: 29.7.0(@types/node@25.3.2)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@25.3.2)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: 'catalog:'
         version: 29.7.0
@@ -2648,7 +2651,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.1.7':
     resolution: {integrity: sha512-F81fPthpT7QtVu1P7QeZMezGn0tCcalCh3ANIzWBaQZNG4vly7mo2dp3PMGzNdmXq6yt93bJ4HbfS+0/NpKl7g==}
@@ -11688,9 +11691,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  rxjs@7.8.1:
-    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
-
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
@@ -15002,9 +15002,9 @@ snapshots:
       exec-sh: 0.3.4
       minimist: 1.2.8
 
-  '@convex-dev/eslint-plugin@1.1.1(convex@1.31.7(react@19.2.1))(eslint@8.57.0)(typescript@5.8.2)':
+  '@convex-dev/eslint-plugin@1.1.1(convex@1.31.7(react@19.2.1))(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)':
     dependencies:
-      '@typescript-eslint/utils': 8.49.0(eslint@8.57.0)(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.49.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
       convex: 1.31.7(react@19.2.1)
     transitivePeerDependencies:
       - eslint
@@ -16021,7 +16021,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))':
+  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0(node-notifier@8.0.2)
@@ -16035,7 +16035,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -16073,6 +16073,44 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
       jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
+  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0(node-notifier@8.0.2)
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.19.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -16819,12 +16857,12 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.3
 
-  '@nuxt/devtools@2.6.5(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.8.2))':
+  '@nuxt/devtools@2.6.5(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@nuxt/devtools-kit': 2.6.5(magicast@0.3.5)(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))
       '@nuxt/devtools-wizard': 2.6.5
       '@nuxt/kit': 3.19.3(magicast@0.3.5)
-      '@vue/devtools-core': 7.7.7(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.8.2))
+      '@vue/devtools-core': 7.7.7(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.9.3))
       '@vue/devtools-kit': 7.7.7
       birpc: 2.6.1
       consola: 3.4.2
@@ -16851,7 +16889,7 @@ snapshots:
       tinyglobby: 0.2.15
       vite: 7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0)
       vite-plugin-inspect: 11.3.3(@nuxt/kit@3.19.3(magicast@0.3.5))(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))
-      vite-plugin-vue-tracer: 1.0.1(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.8.2))
+      vite-plugin-vue-tracer: 1.0.1(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.9.3))
       which: 5.0.0
       ws: 8.18.3
     transitivePeerDependencies:
@@ -16860,25 +16898,25 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/eslint-config@1.9.0(@typescript-eslint/utils@8.49.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2))(@vue/compiler-sfc@3.5.22)(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)':
+  '@nuxt/eslint-config@1.9.0(@typescript-eslint/utils@8.49.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.22)(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 0.11.0
       '@eslint/js': 9.37.0
-      '@nuxt/eslint-plugin': 1.9.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
+      '@nuxt/eslint-plugin': 1.9.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       '@stylistic/eslint-plugin': 5.4.0(eslint@9.37.0(jiti@2.6.1))
-      '@typescript-eslint/eslint-plugin': 8.48.1(@typescript-eslint/parser@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2))(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
-      '@typescript-eslint/parser': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 8.48.1(@typescript-eslint/parser@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.37.0(jiti@2.6.1)
       eslint-config-flat-gitignore: 2.1.0(eslint@9.37.0(jiti@2.6.1))
       eslint-flat-config-utils: 2.1.4
       eslint-merge-processors: 2.0.0(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-import-lite: 0.3.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
-      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.49.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2))(eslint@9.37.0(jiti@2.6.1))
+      eslint-plugin-import-lite: 0.3.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-import-x: 4.16.1(@typescript-eslint/utils@8.49.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-jsdoc: 54.7.0(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-regexp: 2.10.0(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-unicorn: 60.0.0(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-vue: 10.5.0(@stylistic/eslint-plugin@5.4.0(eslint@9.37.0(jiti@2.6.1)))(@typescript-eslint/parser@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2))(eslint@9.37.0(jiti@2.6.1))(vue-eslint-parser@10.2.0(eslint@9.37.0(jiti@2.6.1)))
+      eslint-plugin-vue: 10.5.0(@stylistic/eslint-plugin@5.4.0(eslint@9.37.0(jiti@2.6.1)))(@typescript-eslint/parser@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(vue-eslint-parser@10.2.0(eslint@9.37.0(jiti@2.6.1)))
       eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.22)(eslint@9.37.0(jiti@2.6.1))
       globals: 16.4.0
       local-pkg: 1.1.2
@@ -16891,10 +16929,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint-plugin@1.9.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)':
+  '@nuxt/eslint-plugin@1.9.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/utils': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.37.0(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
@@ -16955,7 +16993,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.29.0(magicast@0.3.5))(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(typescript@5.8.2)(vue@3.5.22(typescript@5.8.2))':
+  '@nuxt/module-builder@1.0.2(@nuxt/cli@3.29.0(magicast@0.3.5))(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@nuxt/cli': 3.29.0(magicast@0.3.5)
       citty: 0.1.6
@@ -16963,14 +17001,14 @@ snapshots:
       defu: 6.1.4
       jiti: 2.6.1
       magic-regexp: 0.10.0
-      mkdist: 2.4.1(typescript@5.8.2)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.8.2)))(vue@3.5.22(typescript@5.8.2))
+      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
-      tsconfck: 3.1.6(typescript@5.8.2)
-      typescript: 5.8.2
-      unbuild: 3.6.1(typescript@5.8.2)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.8.2)))(vue@3.5.22(typescript@5.8.2))
-      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.8.2))
+      tsconfck: 3.1.6(typescript@5.9.3)
+      typescript: 5.9.3
+      unbuild: 3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
+      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/compiler-core'
       - esbuild
@@ -17005,12 +17043,12 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/vite-builder@4.1.3(@types/node@20.19.9)(eslint@9.37.0(jiti@2.6.1))(lightningcss@1.27.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.8.2)(vue@3.5.22(typescript@5.8.2))(yaml@2.8.0)':
+  '@nuxt/vite-builder@4.1.3(@types/node@20.19.9)(eslint@9.37.0(jiti@2.6.1))(lightningcss@1.27.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))(yaml@2.8.0)':
     dependencies:
       '@nuxt/kit': 4.1.3(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.53.3)
-      '@vitejs/plugin-vue': 6.0.1(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.8.2))
-      '@vitejs/plugin-vue-jsx': 5.1.1(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.8.2))
+      '@vitejs/plugin-vue': 6.0.1(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.1(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.9.3))
       autoprefixer: 10.4.21(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.1.1(postcss@8.5.6)
@@ -17034,8 +17072,8 @@ snapshots:
       unenv: 2.0.0-rc.21
       vite: 7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0)
       vite-node: 3.2.4(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0)
-      vite-plugin-checker: 0.11.0(eslint@9.37.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.8.2)(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))
-      vue: 3.5.22(typescript@5.8.2)
+      vite-plugin-checker: 0.11.0(eslint@9.37.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))
+      vue: 3.5.22(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     transitivePeerDependencies:
       - '@biomejs/biome'
@@ -17911,14 +17949,14 @@ snapshots:
       '@microsoft/api-extractor': 7.55.1(@types/node@20.19.9)
       typescript: 5.9.3
 
-  '@rslib/core@0.10.6(@microsoft/api-extractor@7.55.1(@types/node@22.16.5))(typescript@5.8.2)':
+  '@rslib/core@0.10.6(@microsoft/api-extractor@7.55.1(@types/node@22.16.5))(typescript@5.9.3)':
     dependencies:
       '@rsbuild/core': 1.4.8
-      rsbuild-plugin-dts: 0.10.6(@microsoft/api-extractor@7.55.1(@types/node@22.16.5))(@rsbuild/core@1.4.8)(typescript@5.8.2)
+      rsbuild-plugin-dts: 0.10.6(@microsoft/api-extractor@7.55.1(@types/node@22.16.5))(@rsbuild/core@1.4.8)(typescript@5.9.3)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@microsoft/api-extractor': 7.55.1(@types/node@22.16.5)
-      typescript: 5.8.2
+      typescript: 5.9.3
 
   '@rslib/core@0.10.6(@microsoft/api-extractor@7.55.1(@types/node@25.3.2))(typescript@5.8.2)':
     dependencies:
@@ -18565,20 +18603,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.48.1(@typescript-eslint/parser@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2))(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)':
+  '@typescript-eslint/eslint-plugin@8.48.1(@typescript-eslint/parser@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.48.1
-      '@typescript-eslint/type-utils': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
+      '@typescript-eslint/type-utils': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.48.1
       eslint: 9.37.0(jiti@2.6.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.8.2)
-      typescript: 5.8.2
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -18594,15 +18632,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)':
+  '@typescript-eslint/parser@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.48.1
       '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.8.2)
+      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.48.1
       debug: 4.4.3
       eslint: 9.37.0(jiti@2.6.1)
-      typescript: 5.8.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -18615,6 +18653,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.48.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.48.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.48.1
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.49.0(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.49.0(typescript@5.8.2)
@@ -18623,6 +18670,16 @@ snapshots:
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
+
+  '@typescript-eslint/project-service@8.49.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.49.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.49.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@typescript-eslint/scope-manager@8.48.1':
     dependencies:
@@ -18638,9 +18695,18 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
+  '@typescript-eslint/tsconfig-utils@8.48.1(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
   '@typescript-eslint/tsconfig-utils@8.49.0(typescript@5.8.2)':
     dependencies:
       typescript: 5.8.2
+
+  '@typescript-eslint/tsconfig-utils@8.49.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+    optional: true
 
   '@typescript-eslint/type-utils@8.48.1(eslint@8.57.0)(typescript@5.8.2)':
     dependencies:
@@ -18654,15 +18720,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)':
+  '@typescript-eslint/type-utils@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.8.2)
-      '@typescript-eslint/utils': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
+      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.37.0(jiti@2.6.1)
-      ts-api-utils: 2.1.0(typescript@5.8.2)
-      typescript: 5.8.2
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -18685,6 +18751,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.48.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.48.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.48.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.48.1
+      '@typescript-eslint/visitor-keys': 8.48.1
+      debug: 4.4.3
+      minimatch: 9.0.5
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@8.49.0(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/project-service': 8.49.0(typescript@5.8.2)
@@ -18700,6 +18781,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.49.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.49.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.49.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.49.0
+      '@typescript-eslint/visitor-keys': 8.49.0
+      debug: 4.4.3
+      minimatch: 9.0.5
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@typescript-eslint/utils@8.48.1(eslint@8.57.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.0)
@@ -18711,25 +18808,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)':
+  '@typescript-eslint/utils@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.48.1
       '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.8.2)
+      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.9.3)
       eslint: 9.37.0(jiti@2.6.1)
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.49.0(eslint@8.57.0)(typescript@5.8.2)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.0)
-      '@typescript-eslint/scope-manager': 8.49.0
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.8.2)
-      eslint: 8.57.0
-      typescript: 5.8.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -18741,6 +18827,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.8.2)
       eslint: 9.37.0(jiti@2.6.1)
       typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.49.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.49.0
+      '@typescript-eslint/types': 8.49.0
+      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
+      eslint: 9.37.0(jiti@2.6.1)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -18757,11 +18854,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@unhead/vue@2.0.18(vue@3.5.22(typescript@5.8.2))':
+  '@unhead/vue@2.0.18(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       hookable: 5.5.3
       unhead: 2.0.18
-      vue: 3.5.22(typescript@5.8.2)
+      vue: 3.5.22(typescript@5.9.3)
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -18860,7 +18957,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.8.2))':
+  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
@@ -18868,15 +18965,15 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.42
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.5)
       vite: 7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0)
-      vue: 3.5.22(typescript@5.8.2)
+      vue: 3.5.22(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.1(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.8.2))':
+  '@vitejs/plugin-vue@6.0.1(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0)
-      vue: 3.5.22(typescript@5.8.2)
+      vue: 3.5.22(typescript@5.9.3)
 
   '@volar/language-core@2.4.23':
     dependencies:
@@ -18884,7 +18981,7 @@ snapshots:
 
   '@volar/source-map@2.4.23': {}
 
-  '@vue-macros/common@3.0.0-beta.16(vue@3.5.22(typescript@5.8.2))':
+  '@vue-macros/common@3.0.0-beta.16(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.22
       ast-kit: 2.1.3
@@ -18892,7 +18989,7 @@ snapshots:
       magic-string-ast: 1.0.3
       unplugin-utils: 0.2.5
     optionalDependencies:
-      vue: 3.5.22(typescript@5.8.2)
+      vue: 3.5.22(typescript@5.9.3)
 
   '@vue/babel-helper-vue-transform-on@1.5.0': {}
 
@@ -18955,7 +19052,7 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
-  '@vue/devtools-core@7.7.7(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.8.2))':
+  '@vue/devtools-core@7.7.7(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@vue/devtools-kit': 7.7.7
       '@vue/devtools-shared': 7.7.7
@@ -18963,7 +19060,7 @@ snapshots:
       nanoid: 5.1.6
       pathe: 2.0.3
       vite-hot-client: 2.1.0(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))
-      vue: 3.5.22(typescript@5.8.2)
+      vue: 3.5.22(typescript@5.9.3)
     transitivePeerDependencies:
       - vite
 
@@ -18981,7 +19078,7 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/language-core@3.1.1(typescript@5.8.2)':
+  '@vue/language-core@3.1.1(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.23
       '@vue/compiler-dom': 3.5.22
@@ -18991,7 +19088,7 @@ snapshots:
       path-browserify: 1.0.1
       picomatch: 4.0.3
     optionalDependencies:
-      typescript: 5.8.2
+      typescript: 5.9.3
 
   '@vue/reactivity@3.5.22':
     dependencies:
@@ -19009,11 +19106,11 @@ snapshots:
       '@vue/shared': 3.5.22
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.22(vue@3.5.22(typescript@5.8.2))':
+  '@vue/server-renderer@3.5.22(vue@3.5.22(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.22
       '@vue/shared': 3.5.22
-      vue: 3.5.22(typescript@5.8.2)
+      vue: 3.5.22(typescript@5.9.3)
 
   '@vue/shared@3.5.22': {}
 
@@ -20379,13 +20476,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+  create-jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -20401,6 +20498,22 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
+  create-jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -21407,15 +21520,15 @@ snapshots:
       lodash.memoize: 4.1.2
       semver: 7.7.3
 
-  eslint-plugin-import-lite@0.3.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2):
+  eslint-plugin-import-lite@0.3.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.1))
       '@typescript-eslint/types': 8.48.1
       eslint: 9.37.0(jiti@2.6.1)
     optionalDependencies:
-      typescript: 5.8.2
+      typescript: 5.9.3
 
-  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.49.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.49.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@typescript-eslint/types': 8.48.1
       comment-parser: 1.4.1
@@ -21428,7 +21541,7 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.49.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.49.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -21530,7 +21643,7 @@ snapshots:
       semver: 7.7.3
       strip-indent: 4.1.0
 
-  eslint-plugin-vue@10.5.0(@stylistic/eslint-plugin@5.4.0(eslint@9.37.0(jiti@2.6.1)))(@typescript-eslint/parser@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2))(eslint@9.37.0(jiti@2.6.1))(vue-eslint-parser@10.2.0(eslint@9.37.0(jiti@2.6.1))):
+  eslint-plugin-vue@10.5.0(@stylistic/eslint-plugin@5.4.0(eslint@9.37.0(jiti@2.6.1)))(@typescript-eslint/parser@8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(vue-eslint-parser@10.2.0(eslint@9.37.0(jiti@2.6.1))):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.1))
       eslint: 9.37.0(jiti@2.6.1)
@@ -21542,7 +21655,7 @@ snapshots:
       xml-name-validator: 4.0.0
     optionalDependencies:
       '@stylistic/eslint-plugin': 5.4.0(eslint@9.37.0(jiti@2.6.1))
-      '@typescript-eslint/parser': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.8.2)
+      '@typescript-eslint/parser': 8.48.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
 
   eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.22)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
@@ -22925,7 +23038,7 @@ snapshots:
       mute-stream: 0.0.8
       ora: 5.4.1
       run-async: 2.4.1
-      rxjs: 7.8.1
+      rxjs: 7.8.2
       string-width: 4.2.3
       strip-ansi: 6.0.1
       through: 2.3.8
@@ -23418,16 +23531,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+  jest-cli@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      create-jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -23449,6 +23562,28 @@ snapshots:
       exit: 0.1.2
       import-local: 3.2.0
       jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
+  jest-cli@29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -23575,7 +23710,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+  jest-config@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
@@ -23601,7 +23736,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.16.5
-      ts-node: 10.9.2(@types/node@22.16.5)(typescript@5.8.2)
+      ts-node: 10.9.2(@types/node@22.16.5)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -23637,7 +23772,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+  jest-config@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
@@ -23663,7 +23798,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.1
-      ts-node: 10.9.2(@types/node@22.16.5)(typescript@5.8.2)
+      ts-node: 10.9.2(@types/node@22.16.5)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -23695,6 +23830,38 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.1
       ts-node: 10.9.2(@types/node@22.19.1)(typescript@5.8.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    optional: true
+
+  jest-config@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.1
+      ts-node: 10.9.2(@types/node@22.19.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -24339,12 +24506,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)):
+  jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      jest-cli: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -24359,6 +24526,21 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
+  jest@29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -25629,7 +25811,7 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
-  mkdist@2.4.1(typescript@5.8.2)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.8.2)))(vue@3.5.22(typescript@5.8.2)):
+  mkdist@2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3)):
     dependencies:
       autoprefixer: 10.4.21(postcss@8.5.6)
       citty: 0.1.6
@@ -25645,9 +25827,9 @@ snapshots:
       semver: 7.7.3
       tinyglobby: 0.2.15
     optionalDependencies:
-      typescript: 5.8.2
-      vue: 3.5.22(typescript@5.8.2)
-      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.8.2))
+      typescript: 5.9.3
+      vue: 3.5.22(typescript@5.9.3)
+      vue-sfc-transformer: 0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.9.3))
 
   mlly@1.8.0:
     dependencies:
@@ -25997,16 +26179,16 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuxt@4.1.3(@parcel/watcher@2.5.1)(@types/node@20.19.9)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.1)(lightningcss@1.27.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.8.2)(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(yaml@2.8.0):
+  nuxt@4.1.3(@parcel/watcher@2.5.1)(@types/node@20.19.9)(@vue/compiler-sfc@3.5.22)(db0@0.3.4)(eslint@9.37.0(jiti@2.6.1))(ioredis@5.8.1)(lightningcss@1.27.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(yaml@2.8.0):
     dependencies:
       '@nuxt/cli': 3.29.0(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 2.6.5(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.8.2))
+      '@nuxt/devtools': 2.6.5(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.9.3))
       '@nuxt/kit': 4.1.3(magicast@0.3.5)
       '@nuxt/schema': 4.1.3
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 4.1.3(@types/node@20.19.9)(eslint@9.37.0(jiti@2.6.1))(lightningcss@1.27.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.8.2)(vue@3.5.22(typescript@5.8.2))(yaml@2.8.0)
-      '@unhead/vue': 2.0.18(vue@3.5.22(typescript@5.8.2))
+      '@nuxt/vite-builder': 4.1.3(@types/node@20.19.9)(eslint@9.37.0(jiti@2.6.1))(lightningcss@1.27.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.53.3)(terser@5.44.1)(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))(yaml@2.8.0)
+      '@unhead/vue': 2.0.18(vue@3.5.22(typescript@5.9.3))
       '@vue/shared': 3.5.22
       c12: 3.3.0(magicast@0.3.5)
       chokidar: 4.0.3
@@ -26055,13 +26237,13 @@ snapshots:
       unctx: 2.4.1
       unimport: 5.4.1
       unplugin: 2.3.10
-      unplugin-vue-router: 0.15.0(@vue/compiler-sfc@3.5.22)(typescript@5.8.2)(vue-router@4.5.1(vue@3.5.22(typescript@5.8.2)))(vue@3.5.22(typescript@5.8.2))
+      unplugin-vue-router: 0.15.0(@vue/compiler-sfc@3.5.22)(typescript@5.9.3)(vue-router@4.5.1(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
       unstorage: 1.17.1(db0@0.3.4)(ioredis@5.8.1)
       untyped: 2.0.0
-      vue: 3.5.22(typescript@5.8.2)
+      vue: 3.5.22(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
-      vue-router: 4.5.1(vue@3.5.22(typescript@5.8.2))
+      vue-router: 4.5.1(vue@3.5.22(typescript@5.9.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.1
       '@types/node': 20.19.9
@@ -27818,6 +28000,14 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.27.1
 
+  rollup-plugin-dts@6.2.3(rollup@4.53.3)(typescript@5.9.3):
+    dependencies:
+      magic-string: 0.30.19
+      rollup: 4.53.3
+      typescript: 5.9.3
+    optionalDependencies:
+      '@babel/code-frame': 7.27.1
+
   rollup-plugin-postcss@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.2)):
     dependencies:
       chalk: 4.1.2
@@ -27922,7 +28112,7 @@ snapshots:
       '@microsoft/api-extractor': 7.55.1(@types/node@20.19.9)
       typescript: 5.9.3
 
-  rsbuild-plugin-dts@0.10.6(@microsoft/api-extractor@7.55.1(@types/node@22.16.5))(@rsbuild/core@1.4.8)(typescript@5.8.2):
+  rsbuild-plugin-dts@0.10.6(@microsoft/api-extractor@7.55.1(@types/node@22.16.5))(@rsbuild/core@1.4.8)(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.4.8
@@ -27932,7 +28122,7 @@ snapshots:
       tsconfig-paths: 4.2.0
     optionalDependencies:
       '@microsoft/api-extractor': 7.55.1(@types/node@22.16.5)
-      typescript: 5.8.2
+      typescript: 5.9.3
 
   rsbuild-plugin-dts@0.10.6(@microsoft/api-extractor@7.55.1(@types/node@25.3.2))(@rsbuild/core@1.4.8)(typescript@5.8.2):
     dependencies:
@@ -27969,10 +28159,6 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-
-  rxjs@7.8.1:
-    dependencies:
-      tslib: 2.8.1
 
   rxjs@7.8.2:
     dependencies:
@@ -29251,20 +29437,24 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
+  ts-api-utils@2.1.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2)))(typescript@5.8.2):
+  ts-jest@29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2))
+      jest: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.7.3
       type-fest: 4.41.0
-      typescript: 5.8.2
+      typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.28.5
@@ -29332,7 +29522,7 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@22.16.5)(typescript@5.8.2):
+  ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -29346,7 +29536,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.8.2
+      typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -29368,6 +29558,25 @@ snapshots:
       typescript: 5.8.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.19.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.2):
     dependencies:
@@ -29444,9 +29653,9 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  tsconfck@3.1.6(typescript@5.8.2):
+  tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
-      typescript: 5.8.2
+      typescript: 5.9.3
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -29576,8 +29785,7 @@ snapshots:
 
   typescript@5.8.2: {}
 
-  typescript@5.9.3:
-    optional: true
+  typescript@5.9.3: {}
 
   ua-parser-js@0.7.40: {}
 
@@ -29599,7 +29807,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  unbuild@3.6.1(typescript@5.8.2)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.8.2)))(vue@3.5.22(typescript@5.8.2)):
+  unbuild@3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3)):
     dependencies:
       '@rollup/plugin-alias': 5.1.1(rollup@4.53.3)
       '@rollup/plugin-commonjs': 28.0.6(rollup@4.53.3)
@@ -29615,18 +29823,18 @@ snapshots:
       hookable: 5.5.3
       jiti: 2.6.1
       magic-string: 0.30.19
-      mkdist: 2.4.1(typescript@5.8.2)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.8.2)))(vue@3.5.22(typescript@5.8.2))
+      mkdist: 2.4.1(typescript@5.9.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
       mlly: 1.8.0
       pathe: 2.0.3
       pkg-types: 2.3.0
       pretty-bytes: 7.1.0
       rollup: 4.53.3
-      rollup-plugin-dts: 6.2.3(rollup@4.53.3)(typescript@5.8.2)
+      rollup-plugin-dts: 6.2.3(rollup@4.53.3)(typescript@5.9.3)
       scule: 1.3.0
       tinyglobby: 0.2.15
       untyped: 2.0.0
     optionalDependencies:
-      typescript: 5.8.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - sass
       - vue
@@ -29746,11 +29954,11 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.3
 
-  unplugin-vue-router@0.15.0(@vue/compiler-sfc@3.5.22)(typescript@5.8.2)(vue-router@4.5.1(vue@3.5.22(typescript@5.8.2)))(vue@3.5.22(typescript@5.8.2)):
+  unplugin-vue-router@0.15.0(@vue/compiler-sfc@3.5.22)(typescript@5.9.3)(vue-router@4.5.1(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3)):
     dependencies:
-      '@vue-macros/common': 3.0.0-beta.16(vue@3.5.22(typescript@5.8.2))
+      '@vue-macros/common': 3.0.0-beta.16(vue@3.5.22(typescript@5.9.3))
       '@vue/compiler-sfc': 3.5.22
-      '@vue/language-core': 3.1.1(typescript@5.8.2)
+      '@vue/language-core': 3.1.1(typescript@5.9.3)
       ast-walker-scope: 0.8.3
       chokidar: 4.0.3
       json5: 2.2.3
@@ -29766,7 +29974,7 @@ snapshots:
       unplugin-utils: 0.2.5
       yaml: 2.8.0
     optionalDependencies:
-      vue-router: 4.5.1(vue@3.5.22(typescript@5.8.2))
+      vue-router: 4.5.1(vue@3.5.22(typescript@5.9.3))
     transitivePeerDependencies:
       - typescript
       - vue
@@ -29956,7 +30164,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.11.0(eslint@9.37.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.8.2)(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0)):
+  vite-plugin-checker@0.11.0(eslint@9.37.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chokidar: 4.0.3
@@ -29970,7 +30178,7 @@ snapshots:
     optionalDependencies:
       eslint: 9.37.0(jiti@2.6.1)
       optionator: 0.9.4
-      typescript: 5.8.2
+      typescript: 5.9.3
 
   vite-plugin-inspect@11.3.3(@nuxt/kit@3.19.3(magicast@0.3.5))(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0)):
     dependencies:
@@ -29989,7 +30197,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.0.1(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.8.2)):
+  vite-plugin-vue-tracer@1.0.1(vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0))(vue@3.5.22(typescript@5.9.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.7
@@ -29997,7 +30205,7 @@ snapshots:
       pathe: 2.0.3
       source-map-js: 1.2.1
       vite: 7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0)
-      vue: 3.5.22(typescript@5.8.2)
+      vue: 3.5.22(typescript@5.9.3)
 
   vite@7.3.1(@types/node@20.19.9)(jiti@2.6.1)(lightningcss@1.27.0)(terser@5.44.1)(yaml@2.8.0):
     dependencies:
@@ -30053,27 +30261,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@4.5.1(vue@3.5.22(typescript@5.8.2)):
+  vue-router@4.5.1(vue@3.5.22(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.22(typescript@5.8.2)
+      vue: 3.5.22(typescript@5.9.3)
 
-  vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.8.2)):
+  vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.22)(esbuild@0.27.3)(vue@3.5.22(typescript@5.9.3)):
     dependencies:
       '@babel/parser': 7.28.5
       '@vue/compiler-core': 3.5.22
       esbuild: 0.27.3
-      vue: 3.5.22(typescript@5.8.2)
+      vue: 3.5.22(typescript@5.9.3)
 
-  vue@3.5.22(typescript@5.8.2):
+  vue@3.5.22(typescript@5.9.3):
     dependencies:
       '@vue/compiler-dom': 3.5.22
       '@vue/compiler-sfc': 3.5.22
       '@vue/runtime-dom': 3.5.22
-      '@vue/server-renderer': 3.5.22(vue@3.5.22(typescript@5.8.2))
+      '@vue/server-renderer': 3.5.22(vue@3.5.22(typescript@5.9.3))
       '@vue/shared': 3.5.22
     optionalDependencies:
-      typescript: 5.8.2
+      typescript: 5.9.3
 
   w3c-hr-time@1.0.2:
     dependencies:


### PR DESCRIPTION
## Problem

Users integrating PostHog with NestJS have no built-in support for context propagation or error tracking. They need to manually wire up session/user context and exception capture on every request.

Fix: https://posthoghelp.zendesk.com/agent/tickets/52288 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/53735)

## Changes

- Add a `PostHogInterceptor` class in `packages/node/src/extensions/nestjs.ts` exposed via a dedicated `posthog-node/nestjs` entrypoint
- **Context propagation**: Wraps the request handler inside `withContext()` to automatically attach `sessionId`, `distinctId`, and request metadata (`$current_url`, `$request_method`, `$ip`, etc.) from request headers to all `posthog.capture()` calls downstream. Uses `AsyncLocalStorage.run()` for proper per-request isolation.
- **Optional exception capture** (disabled by default): When enabled, captures unhandled exceptions via RxJS `catchError`, skipping 4xx `HttpException`s (duck-typed via `getStatus()`) and previously captured errors. Configurable `minStatusToCapture` threshold.
- Parses `x-forwarded-for` to extract only the first (client) IP from comma-separated proxy chains
- Uses an interceptor (not an exception filter) so it observes errors transparently without interfering with NestJS's exception filter pipeline
- Defines local NestJS interfaces — no runtime dependency on `@nestjs/common`
- `rxjs` added as optional peer dependency (NestJS users already have it)
- 14 tests covering: context propagation, exception capture, 4xx skipping, `minStatusToCapture`, missing headers, `x-forwarded-for` parsing
- NestJS example app in `examples/example-nestjs/`

Usage:
```typescript
import { PostHog } from 'posthog-node'
import { PostHogInterceptor } from 'posthog-node/nestjs'

const posthog = new PostHog(apiKey, { host })

// Context propagation only (default)
app.useGlobalInterceptors(new PostHogInterceptor(posthog))

// With exception capture
app.useGlobalInterceptors(new PostHogInterceptor(posthog, { captureExceptions: true }))

// With custom min status (capture 4xx too)
app.useGlobalInterceptors(new PostHogInterceptor(posthog, {
  captureExceptions: { minStatusToCapture: 400 }
}))
```

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages