### PR TITLE
chore: add Slack failure notification to version-bump job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,17 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
 
+            - name: Notify Slack - Failed
+              continue-on-error: true
+              if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
+              uses: PostHog/.github/.github/actions/slack-thread-reply@main
+              with:
+                  slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+                  slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
+                  thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
+                  message: '❌ Failed to bump versions for `posthog-js`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
+                  emoji_reaction: 'x'
+
     notify-rejected:
         name: Notify Slack - Rejected
         needs: [version-bump, notify-approval-needed]


### PR DESCRIPTION
## Problem

When the `version-bump` job fails for a non-rejection reason, nobody gets notified on Slack. The existing failure notification lives inside the `publish` job, but if `version-bump` fails, `publish` is skipped entirely and the notification never runs. Same issue fixed in [posthog-ios#508](https://github.com/PostHog/posthog-ios/pull/508), [posthog-android#451](https://github.com/PostHog/posthog-android/pull/451), and [posthog-react-native-session-replay#58](https://github.com/PostHog/posthog-react-native-session-replay/pull/58).

## Changes

Added an inline "Notify Slack - Failed" step at the end of the `version-bump` job using `${{ failure() }}`. Uses `continue-on-error: true` so the notification itself doesn't affect job status.

## Release info Sub-libraries affected

### Libraries affected

N/A — CI-only change.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size