### PR TITLE
fix(core): consume response body in _flush() and _capture() to prevent CF Workers warnings

### DIFF
--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -964,8 +964,16 @@ export abstract class PostHogCoreStateless {
     }
 
     try {
-      await this.fetchWithRetry(url, fetchOptions)
+      const res = await this.fetchWithRetry(url, fetchOptions)
+      // Consume the response body to prevent resource leaks in runtimes like
+      // Cloudflare Workers that require the body to be read before the handler completes.
+      // See: https://github.com/PostHog/posthog-js/issues/3173
+      await res.text().catch(() => {})
     } catch (err) {
+      // Consume the error response body to prevent resource leaks (see #3173)
+      if (err instanceof PostHogFetchHttpError) {
+        await err.response.text().catch(() => {})
+      }
       this._events.emit('error', err)
     }
   }
@@ -1139,8 +1147,17 @@ export abstract class PostHogCoreStateless {
       }
 
       try {
-        await this.fetchWithRetry(url, fetchOptions, retryOptions)
+        const res = await this.fetchWithRetry(url, fetchOptions, retryOptions)
+        // Consume the response body to prevent resource leaks in runtimes like
+        // Cloudflare Workers that require the body to be read before the handler completes.
+        // See: https://github.com/PostHog/posthog-js/issues/3173
+        await res.text().catch(() => {})
       } catch (err) {
+        // Consume the error response body to prevent resource leaks (see #3173)
+        if (err instanceof PostHogFetchHttpError) {
+          await err.response.text().catch(() => {})
+        }
+
         if (isPostHogFetchContentTooLargeError(err) && batchMessages.length > 1) {
           // if we get a 413 error, we want to reduce the batch size and try again
           this.maxBatchSize = Math.max(1, Math.floor(batchMessages.length / 2))


### PR DESCRIPTION
## Problem

`_flush()` and the single-event capture path in `posthog-core-stateless.ts` both call `fetchWithRetry()` but discard the returned response without reading the body. 

In Cloudflare Workers (and potentially other edge runtimes), an unconsumed response body forces the runtime to clean up the underlying connection later — potentially in a different request's context — which triggers:

```
Warning: A promise was resolved or rejected from a different request context than the one it was created in.
```

The runtime may also **cancel continuations** for the leaked promises, so post-flush error handling may silently not run.

This is the same class of bug the Sentry SDK had and fixed in [getsentry/sentry-javascript#18534](https://github.com/getsentry/sentry-javascript/issues/18534).

## Fix

Consume the response body at all sites where it was previously discarded:

### Success paths
- **`_flush()`** (~line 1142) — the batched event flush path
- **`_capture()`** (~line 967) — the single-event capture path (used when `flushAt: 1`)

### Error paths  
- Both `catch` blocks now also consume the response body held by `PostHogFetchHttpError`. This covers the 413 batch-size reduction path and other HTTP error paths where the error response was previously discarded.

The `fetchWithRetry()` return type is unchanged so callers that need the response body (e.g., the surveys API endpoint) can still read it normally.

**Note:** Intermediate retry attempts inside `retriable()` may still produce unconsumed error responses during the retry loop. This is a separate concern in the `retriable` utility and would be best addressed separately if needed.

## Changes

- `packages/core/src/posthog-core-stateless.ts` — 4 sites updated (+19 lines, -2 lines)

Fixes #3173