### PR TITLE
fix(replay): treat legacy configs without cache_timestamp as fresh

### DIFF
--- a/.changeset/fix-replay-cache-timestamp-default.md
+++ b/.changeset/fix-replay-cache-timestamp-default.md
@@ -1,0 +1,10 @@
+---
+'posthog-js': patch
+---
+
+fix(replay): treat legacy configs without cache_timestamp as fresh
+
+Configs persisted by older SDK versions never include a cache_timestamp.
+Defaulting to 0 treats them as always stale, causing the persisted config
+to be cleared before start() runs — so recording never starts for
+customers on older core SDK versions paired with the latest CDN recorder.

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -399,7 +399,7 @@ describe('Lazy SessionRecording', () => {
                 }
             })
 
-            it('treats legacy config without cache_timestamp as stale', () => {
+            it('treats legacy config without cache_timestamp as fresh', () => {
                 sessionRecording.stopRecording()
 
                 posthog.persistence?.register({
@@ -407,7 +407,7 @@ describe('Lazy SessionRecording', () => {
                 })
 
                 const result = sessionRecording['_lazyLoadedSessionRecording']['_remoteConfig']
-                expect(result).toBeUndefined()
+                expect(result?.enabled).toBe(true)
             })
 
             it('trusts stale config once recording has started (long-lived SPA)', () => {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -730,7 +730,9 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         // Only check TTL if recording hasn't started yet
         // Once started, trust the config until a hard page load
         if (!this.isStarted) {
-            const cacheTimestamp = parsedConfig.cache_timestamp ?? 0
+            // default to now so that configs persisted by older SDK versions
+            // (which never set cache_timestamp) are treated as fresh
+            const cacheTimestamp = parsedConfig.cache_timestamp ?? Date.now()
             if (Date.now() - cacheTimestamp > RECORDING_REMOTE_CONFIG_TTL_MS) {
                 logger.info('persisted remote config for session recording is stale and will be ignored', {
                     cacheTimestamp,

--- a/packages/browser/src/extensions/replay/session-recording.ts
+++ b/packages/browser/src/extensions/replay/session-recording.ts
@@ -261,7 +261,9 @@ export class SessionRecording implements Extension {
             return false
         }
         const config = typeof persistedConfig === 'object' ? persistedConfig : JSON.parse(persistedConfig)
-        const cacheTimestamp = config.cache_timestamp ?? 0
+        // default to now so that configs persisted by older SDK versions
+        // (which never set cache_timestamp) are treated as fresh
+        const cacheTimestamp = config.cache_timestamp ?? Date.now()
         return Date.now() - cacheTimestamp <= RECORDING_REMOTE_CONFIG_TTL_MS
     }
 


### PR DESCRIPTION
## Summary

- Reverts the `cache_timestamp ?? 0` default introduced in #3191 back to `cache_timestamp ?? Date.now()`
- Fixes both `lazy-loaded-session-recorder.ts` (CDN-loaded recorder) and `session-recording.ts` (core bundle)

## Problem

#3191 intentionally changed the default for missing `cache_timestamp` from `Date.now()` (fresh) to `0` (stale), reasoning that legacy configs should force a refresh. However, this breaks customers on older core SDK versions (e.g. 1.335.4) that **never** set `cache_timestamp` when persisting config.

The failure sequence:
1. Older core SDK persists config without `cache_timestamp`
2. Latest CDN recorder reads config, defaults `cache_timestamp` to `0`
3. `Date.now() - 0` is always > 1 hour TTL → config treated as stale → deleted from persistence
4. `start()` bails because `_remoteConfig` returns `undefined` (config was just deleted)
5. Recording never starts for the entire page session

**Impact**: Observed ~90% drop in `active` recordings and corresponding spike in `buffering` sessions for affected customers (confirmed via ClickHouse `$recording_status` data for team 55348).

## Fix

Default `cache_timestamp ?? Date.now()` — treat configs from older SDK versions as fresh. These versions will use the config once and get a fresh one from the server on the next page load regardless.

## Test plan

- [x] Updated test: "treats legacy config without cache_timestamp as fresh"
- [x] All 187 lazy-sessionrecording tests pass
- [x] All 26 sessionRecording-onRemoteConfig tests pass