### PR TITLE
chore: add concurrency control to CI workflows

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -2,6 +2,10 @@ name: Bundled Size
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/check-posthog-major-version.yml
+++ b/.github/workflows/check-posthog-major-version.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-version-change-is-present-and-allowed:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '19 2 * * 3'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/es-check.yml
+++ b/.github/workflows/es-check.yml
@@ -3,6 +3,10 @@ name: ES5 support check
 on:
   - pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ssr:
     name: Build and check ES5/ES6 support

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   browsers:
     name: Test on ${{ matrix.tests.name }}

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     name: Unit tests

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-pr:
     name: Validate PR title against Conventional Commits

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     name: Check minimum TS version

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -4,6 +4,10 @@ on:
     pull_request:
         types: [opened, edited, reopened]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
     check-description:
         name: Check that PR has description

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -12,6 +12,10 @@ env:
   BROWSERSTACK_USE_AUTOMATE: "true"
   BROWSERSTACK_PROJECT_NAME: "PostHog JS SDK"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   browsers:
     name: Test on ${{ matrix.name }}


### PR DESCRIPTION
## Problem

PR workflows lack concurrency control, so pushing multiple commits to a PR triggers full parallel runs for each push. This wastes runner minutes — especially expensive with depot runners, BrowserStack, and 4-browser Playwright matrix jobs.

## Changes

Adds native GitHub Actions `concurrency` groups to 10 PR-triggered workflows, automatically cancelling in-progress runs when a new push arrives on the same PR:

| Workflow | Jobs cancelled |
|----------|---------------|
| **library-ci.yml** | 6 jobs (unit, integration, compat, functional, lint, mangled props) |
| **integration.yml** | 4 browser matrix jobs (Chromium, Firefox, Safari, Edge) |
| **testcafe.yml** | BrowserStack IE11 job |
| **minimum-version-ts-check.yaml** | 12 matrix jobs (3 node × 4 TS versions) |
| **bundled-size.yaml** | 1 job |
| **es-check.yml** | 1 job |
| **codeql.yml** | 2 matrix jobs |
| **check-posthog-major-version.yml** | 1 job |
| **lint-pr.yml** | 1 job |
| **new-pr.yml** | 1 job |

Workflows **not** changed (no benefit from concurrency control):
- `release.yml` — already has concurrency
- `dependabot-changeset.yml`, `label-alpha-release.yml`, `call-flags-project-board.yml` — event-driven, not push-based
- `generate-references.yml`, `posthog-*-upgrade.yml` — manual dispatch
- `stale.yaml` — scheduled
- `sdk-compliance-tests-*.yml` — path-filtered reusable workflows

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size