### PR TITLE
chore(ci): sign release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
-                  ref: main
+                  ref: ${{ needs.version-bump.outputs.commit-hash }}
                   fetch-depth: 0
 
             - name: Setup environment


### PR DESCRIPTION
This is a prerequisite to enforcing commit signing in this repo.