### PR TITLE
fix(convex): update example lockfile for rebuilt package

### DIFF
--- a/examples/example-convex/pnpm-lock.yaml
+++ b/examples/example-convex/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-N3riA/tbAnNXqNYCauSgZTrb8uBs1MMWnJDTJCSRm8c=
+pnpmfileChecksum: sha256-yVJZ6vhbVglHX96LCyXF5k3CRZo/MEv/K0owx+7kTTo=
 
 importers:
 
@@ -456,8 +456,8 @@ packages:
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@posthog/convex@file:../../target/posthog-convex.tgz':
-    resolution: {integrity: sha512-rpAo/UpmdmS2U8lrYHLJ/94niBUc7ZPHNJPZxX3MjiREeX6Lsi4X9QImWMWNnRAOMpVYumV5mgm3azY/i9uWBg==, tarball: file:../../target/posthog-convex.tgz}
-    version: 0.0.0
+    resolution: {integrity: sha512-eCRbDZv7N+V1xAzUqHZykiV8MZdO4ymT9NrPbURSXvaDmxI46O3ttbtxlJRu7iKWbJdciUliatZ+BU3BjAjCgA==, tarball: file:../../target/posthog-convex.tgz}
+    version: 0.1.8
     peerDependencies:
       convex: ^1.31.7
 


### PR DESCRIPTION
## Problem

Running `pnpm dev` in `examples/example-convex` fails with a TypeScript error because the lockfile references a stale tgz that still contains removed functions (`syncFeatureFlags`, `getCachedFlagDefinitions`, `upsertCachedFlagDefinitions`, `acquireFlagSyncLock`, `completeFlagSync`).

## Changes

Updated the example lockfile to point to the current rebuilt package.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [x] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size