### PR TITLE
fix: add --no-git-checks to pnpm publish in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,7 +234,7 @@ jobs:
             - name: Publish ${{ matrix.package.name }} to NPM
               if: steps.check-package-version.outputs.is-new-version == 'true'
               run: |
-                  pnpm publish --filter=${{ matrix.package.name }} --access public
+                  pnpm publish --filter=${{ matrix.package.name }} --access public --no-git-checks
               env:
                   NPM_CONFIG_PROVENANCE: true
 


### PR DESCRIPTION
## Problem

The release workflow checks out a specific commit SHA (`ref: ${{ needs.version-bump.outputs.commit-hash }}`) which puts Git into detached HEAD state. pnpm's default `publish-branch` setting validates that HEAD is on `master|main` before publishing, causing all publish jobs to fail with:

```
ERR_PNPM_GIT_UNKNOWN_BRANCH  The Git HEAD may not attached to any branch, but your "publish-branch" is set to "master|main".
```

See: https://github.com/PostHog/posthog-js/actions/runs/23007501330/job/66840743684

i think its because of https://github.com/PostHog/posthog-js/pull/3223/ 

## Changes

Added `--no-git-checks` flag to the `pnpm publish` command in the release workflow. This is safe because:
1. The workflow only runs on PRs merged to `main` with the `release` label
2. The commit hash comes from the version-bump step that committed directly to `main`
3. Concurrency control ensures only one release runs at a time

## Release info Sub-libraries affected

### Libraries affected

None — CI-only change.

## Checklist

- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size