### PR TITLE
chore: upgrade GitHub Actions from node20 to node24-compatible versions

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -27,7 +27,7 @@ runs:
       run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ inputs.node_version }}
         registry-url: https://registry.npmjs.org
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: npm install -g npm@11.6.4
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: pnpm-cache
       with:
         path: ${{ steps.pnpm-cache-dir.outputs.PNPM_STORE_PATH }}

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -16,12 +16,12 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup
 
       - name: Upload bundle size visualization
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         id: viz-upload
         with:
           name: bundle-stats-array.html

--- a/.github/workflows/check-posthog-major-version.yml
+++ b/.github/workflows/check-posthog-major-version.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
         

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/es-check.yml
+++ b/.github/workflows/es-check.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and check ES5/ES6 support
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,7 +39,7 @@ jobs:
             install: "chromium"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/label-alpha-release.yml
+++ b/.github/workflows/label-alpha-release.yml
@@ -39,7 +39,7 @@ jobs:
       id-token: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup environment
         uses: ./.github/actions/setup
@@ -29,7 +29,7 @@ jobs:
     name: Playwright E2E tests
     runs-on: depot-ubuntu-latest-8
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
         run: pnpm exec playwright test --workers=5
         working-directory: packages/browser
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: ${{ !cancelled() && steps.is-affected.outputs.is-affected == 'true' }}
         with:
           name: playwright-report
@@ -69,7 +69,7 @@ jobs:
     runs-on: depot-ubuntu-latest-8
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -207,7 +207,7 @@ jobs:
               comment_id: process.env.COMMENT_ID
             })
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: ${{ !cancelled() && steps.is-affected.outputs.is-affected == 'true' }}
         with:
           name: playwright-compat-report
@@ -218,7 +218,7 @@ jobs:
     name: Functional tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup environment
         uses: ./.github/actions/setup
         with:
@@ -229,7 +229,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup environment
         uses: ./.github/actions/setup
       - name: Lint all packages
@@ -241,7 +241,7 @@ jobs:
     name: Write mangled property names
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup environment
         uses: ./.github/actions/setup

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -28,7 +28,7 @@ jobs:
             extra-flags: "--ignoreConfig"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/posthog-com-upgrade.yml
+++ b/.github/workflows/posthog-com-upgrade.yml
@@ -39,7 +39,7 @@ jobs:
             - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # pin v4.2.0
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 22
                   cache: pnpm

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -39,7 +39,7 @@ jobs:
             - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # pin v4.2.0
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 22
                   cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
             has-changesets: ${{ steps.check.outputs.has-changesets }}
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   ref: main
                   fetch-depth: 0
@@ -89,7 +89,7 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_JS_RELEASER_PRIVATE_KEY }} # Secrets available only inside the `NPM Release` environment, requires approval from a maintainer
 
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   ref: main
                   fetch-depth: 0
@@ -204,7 +204,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   ref: ${{ needs.version-bump.outputs.commit-hash }}
                   fetch-depth: 0
@@ -340,7 +340,7 @@ jobs:
         if: always() && needs.publish.result == 'success' && needs.notify-approval-needed.outputs.slack_ts != ''
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Notify Slack - Released
               continue-on-error: true # Slack failure shouldn't mark release as failed

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -30,7 +30,7 @@ jobs:
             name: IE11
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Problem

Node.js 20 actions are deprecated and will be forced to run with Node.js 24 starting June 2nd, 2026. CI workflows are showing deprecation warnings.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Changes

Upgraded GitHub Actions across all workflow files to versions that support Node.js 24:

- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v5`
- `actions/cache@v4` → `@v5`
- `actions/upload-artifact@v4` → `@v5`

13 files updated. `github/codeql-action@v4` remains as-is (latest major). `PostHog/check-package-version@v2.1.0` is being updated separately in https://github.com/PostHog/check-package-version/pull/118.

## Release info Sub-libraries affected

### Libraries affected

No library changes — CI only.

## Checklist

- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size