### PR TITLE
fix(node): captureExceptionImmediate does not return a promise to await

### DIFF
--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1970,7 +1970,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   ): Promise<void> {
     if (!ErrorTracking.isPreviouslyCapturedError(error)) {
       const syntheticException = new Error('PostHog syntheticException')
-      this.addPendingPromise(
+      return this.addPendingPromise(
         ErrorTracking.buildEventMessage(error, { syntheticException }, distinctId, additionalProperties).then((msg) =>
           this.captureImmediate(msg)
         )


### PR DESCRIPTION
## Problem

We hit an issue in production where server-side exceptions appeared in Vercel logs but never arrived in PostHog Error Tracking. After digging in, something smells wrong in `captureExceptionImmediate` -- there's no `return` statement on the promise. This is the same class of bug as #2225, which fixed a missing `return` inside `captureImmediate` (if this PR is accepted, it would be wise to do a quick scan of any other `*Immediate` functions and see if there are similar bugs in other function variations)

Without return, `await captureExceptionImmediate(...)` resolves immediately, so when the serverless function context exits, the event is lost (Vercel, Cloudflare Workers). PostHog docs recommend `await posthog.captureExceptionImmediate(...)` e.g. 
  * [NextJS Example Code](https://github.com/PostHog/posthog-js/blob/main/examples/example-nextjs/src/app/actions.ts)
  * [captureExceptionImmediate documentation](https://github.com/PostHog/posthog-js/blob/main/packages/node/src/client.ts#L1941)



Caveat: This was diagnosed with AI assistance, so I could be wrong about something If the missing `return` is intentional and there's a mechanism we've missed, I'd appreciate knowing why.



## Changes

```typescript
// before
async captureExceptionImmediate(error, distinctId?, additionalProperties?): Promise<void> {
  if (!ErrorTracking.isPreviouslyCapturedError(error)) {
    const syntheticException = new Error('PostHog syntheticException')
    this.addPendingPromise(   // ← no return; is this intentional?
      ErrorTracking.buildEventMessage(...).then((msg) => this.captureImmediate(msg))
    )
  }
}


// after
async captureExceptionImmediate(error, distinctId?, additionalProperties?): Promise<void> {
  if (!ErrorTracking.isPreviouslyCapturedError(error)) {
    const syntheticException = new Error('PostHog syntheticException')
    return this.addPendingPromise(
      ErrorTracking.buildEventMessage(...).then((msg) => this.captureImmediate(msg))
    )
  }
}
```

## Release info

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size