### PR TITLE
fix: store debug flag as boolean instead of stringified value

### DIFF
--- a/.changeset/clever-beers-mix.md
+++ b/.changeset/clever-beers-mix.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: debug mode not persisting across page navigations

--- a/packages/browser/playwright/mocked/debug-mode.spec.ts
+++ b/packages/browser/playwright/mocked/debug-mode.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from './utils/posthog-playwright-test-base'
+import { start } from './utils/setup'
+
+test.describe('debug mode persistence', () => {
+    test('debug mode persists across page reload via localStorage', async ({ page, context }) => {
+        await start(
+            {
+                options: {},
+                url: '/playground/cypress/index.html',
+            },
+            page,
+            context
+        )
+
+        await page.evaluate(() => {
+            const win = window as any
+            win.posthog?.debug()
+        })
+
+        const storedValue = await page.evaluate(() => localStorage.getItem('ph_debug'))
+        expect(storedValue).not.toBeNull()
+
+        await start(
+            {
+                options: { debug: undefined },
+                type: 'reload',
+                url: '/playground/cypress/index.html',
+            },
+            page,
+            context
+        )
+
+        const debugAfterReload = await page.evaluate(() => {
+            const win = window as any
+            return win.posthog?.config?.debug
+        })
+        expect(debugAfterReload).toBe(true)
+    })
+})

--- a/packages/browser/src/__tests__/posthog-core.set_config.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.set_config.test.ts
@@ -50,7 +50,7 @@ describe('posthog.set_config', () => {
 
     describe('debug flag behavior', () => {
         it.each([
-            { initial: false, setValue: true, expectedDebug: true, expectedStorage: '"true"' },
+            { initial: false, setValue: true, expectedDebug: true, expectedStorage: 'true' },
             { initial: true, setValue: false, expectedDebug: false, expectedStorage: null },
         ])(
             'should set debug to $setValue when initially $initial',
@@ -84,7 +84,7 @@ describe('posthog.set_config', () => {
 
             posthog.set_config({ debug: true })
 
-            expect(localStorage.getItem('ph_debug')).toBe('"true"')
+            expect(localStorage.getItem('ph_debug')).toBe('true')
         })
 
         it('should remove ph_debug from localStorage when debug is set to false', () => {
@@ -105,7 +105,7 @@ describe('posthog.set_config', () => {
             posthog.set_config({ debug: true })
             expect(posthog.config.debug).toBe(true)
             expect(Config.DEBUG).toBe(true)
-            expect(localStorage.getItem('ph_debug')).toBe('"true"')
+            expect(localStorage.getItem('ph_debug')).toBe('true')
 
             posthog.set_config({ debug: false })
             expect(posthog.config.debug).toBe(false)
@@ -115,7 +115,7 @@ describe('posthog.set_config', () => {
             posthog.set_config({ debug: true })
             expect(posthog.config.debug).toBe(true)
             expect(Config.DEBUG).toBe(true)
-            expect(localStorage.getItem('ph_debug')).toBe('"true"')
+            expect(localStorage.getItem('ph_debug')).toBe('true')
         })
 
         it('should not modify debug if not a boolean', () => {

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -2525,7 +2525,7 @@ export class PostHog {
             if (isBoolean(this.config.debug)) {
                 if (this.config.debug) {
                     Config.DEBUG = true
-                    localStore._is_supported() && localStore._set('ph_debug', 'true')
+                    localStore._is_supported() && localStore._set('ph_debug', true)
                     logger.info('set_config', {
                         config,
                         oldConfig,


### PR DESCRIPTION
## Problem

Customer reported that debug mode is not persisting across page reloads.

This was due to us passing in `"true"` into our local storage, which stringified it to `'"true"'` before storing. 


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- Store debug flag as boolean instead of stringified value
- Add playwright test to make sure that this won't happen again

See also #2434 in which this issue was introduced

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages