### PR TITLE
chore: assign team reviewers on posthog upgrade PR

### DIFF
--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -98,6 +98,13 @@ jobs:
               run: |
                   gh pr merge "$PR_NUMBER" --auto --squash
 
+            - name: Assign reviewers
+              env:
+                  GH_TOKEN: ${{ steps.upgrader.outputs.token }}
+                  PR_NUMBER: ${{ steps.main-repo-pr.outputs.pull-request-number }}
+              run: |
+                  gh pr edit "$PR_NUMBER" --repo PostHog/posthog --add-reviewer PostHog/client-libraries-approvers --add-reviewer PostHog/team-client-libraries
+
             # https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
             - name: Send failure event to PostHog
               if: ${{ failure() }}


### PR DESCRIPTION
## Problem

When the posthog-upgrade workflow creates a PR in the PostHog/posthog repo, it enables automerge but doesn't assign any reviewers. This means the PR sits without review assignments, requiring manual intervention.

## Changes

Added a new "Assign reviewers" step to the `posthog-upgrade.yml` workflow that runs after enabling automerge. It assigns both `PostHog/client-libraries-approvers` and `PostHog/team-client-libraries` as reviewers on the upgrade PR using `gh pr edit`.

## Release info Sub-libraries affected

### Libraries affected

No libraries affected — this is a CI workflow change only.

## Checklist

- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)