### PR TITLE
fix: preserve _overrideSDKInfo from terser mangling

### DIFF
--- a/.changeset/warm-lions-glow.md
+++ b/.changeset/warm-lions-glow.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: preserve `_overrideSDKInfo` from terser mangling so wrapper SDKs can call it

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -209,6 +209,9 @@ const plugins = (es5, noExternal) => [
                               'surveys',
                               'calculateEventProperties',
 
+                              // used by wrapper SDKs (e.g. posthog-flutter, posthog-react-native) to override $lib and $lib_version
+                              '_overrideSDKInfo',
+
                               // possibly used by naughty users - we should decide if we want make these part of the public API, but be cautious for now
                               '_isIdentified',
                               '_is_bot',

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -355,7 +355,6 @@
         "_options",
         "_originalUserConfig",
         "_originatedFromCaptureException",
-        "_overrideSDKInfo",
         "_override_warning",
         "_pageHideListener",
         "_pageViewFallBack",


### PR DESCRIPTION
## Problem

Wrapper SDKs (e.g. posthog-flutter, posthog-react-native) need to call `_overrideSDKInfo` on the PostHog instance to set their own `$lib` and `$lib_version` properties. However, because the method name starts with a single underscore, terser's property mangling (regex `/^_(?!_)/`) renames it in the minified output, making it impossible for wrapper SDKs to call it.

## Changes

- Added `_overrideSDKInfo` to the terser `reserved` list in `packages/browser/rollup.config.mjs` so it is preserved in minified builds.
- Removed `_overrideSDKInfo` from `packages/browser/terser-mangled-names.json` since it should no longer be mangled.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages