### PR TITLE
feat(convex): add throw error button to convex example

### DIFF
--- a/examples/example-convex/convex/example.ts
+++ b/examples/example-convex/convex/example.ts
@@ -115,6 +115,15 @@ export const testCaptureException = mutation({
   },
 })
 
+export const testThrowError = mutation({
+  args: {
+    errorMessage: v.string(),
+  },
+  handler: async (_ctx, args) => {
+    throw new Error(args.errorMessage)
+  },
+})
+
 // --- Feature flag methods (actions) ---
 
 const featureFlagArgs = {

--- a/examples/example-convex/src/App.tsx
+++ b/examples/example-convex/src/App.tsx
@@ -122,6 +122,7 @@ function App() {
   const groupIdentifyM = useMutation(api.example.testGroupIdentify)
   const aliasM = useMutation(api.example.testAlias)
   const captureExceptionM = useMutation(api.example.testCaptureException)
+  const throwErrorM = useMutation(api.example.testThrowError)
 
   const agentManualA = useAction(api.convexAgent.manualCapture.generate)
   const agentTracedA = useAction(api.convexAgent.withTracing.generate)
@@ -430,6 +431,18 @@ function App() {
               }
             >
               Capture Exception
+            </button>
+            <button
+              {...btnProps('throwError')}
+              onClick={() =>
+                run('throwError', () =>
+                  throwErrorM({
+                    errorMessage: errorMsg,
+                  })
+                )
+              }
+            >
+              Throw Error
             </button>
           </div>
         </Section>


### PR DESCRIPTION
## Problem

When testing PostHog error tracking's first-party Convex integration, we currently only have a `captureException` button which explicitly calls `posthog.captureException`. We need a way to test that unhandled errors thrown in Convex mutations are also captured automatically.

## Changes

- Add a `testThrowError` mutation in `convex/example.ts` that simply throws an error with a configurable message
- Add a "Throw Error" button in `App.tsx` that calls this mutation

This lets us verify the error tracking integration works for unhandled errors without depending on `posthog.captureException`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size