### PR TITLE
fix: log warning instead of throwing error when session recording script is blocked

### DIFF
--- a/.changeset/warm-lions-glow.md
+++ b/.changeset/warm-lions-glow.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Log warning instead of throwing error when session recording script is blocked by ad blockers

--- a/packages/browser/src/extensions/replay/session-recording.ts
+++ b/packages/browser/src/extensions/replay/session-recording.ts
@@ -269,7 +269,10 @@ export class SessionRecording implements Extension {
 
     private _onScriptLoaded(startReason?: SessionStartReason) {
         if (!assignableWindow.__PosthogExtensions__?.initSessionRecording) {
-            throw Error('Called on script loaded before session recording is available')
+            logger.warn(
+                'Session recording script not loaded - this may be due to an ad blocker blocking the recording script'
+            )
+            return
         }
 
         if (!this._lazyLoadedSessionRecording) {


### PR DESCRIPTION
## Problem

When ad blockers block the PostHog session recording script, `_onScriptLoaded` throws an error (`Called on script loaded before session recording is available`). This error gets captured by error reporting tools like Sentry and PostHog, creating noise for users who can't do anything about ad blockers blocking their recording script.

https://posthog.slack.com/archives/C08NRMKKJCU/p1773736203071499

## Changes

In `_onScriptLoaded`, replaced the `throw Error(...)` with `logger.warn(...)` and an early return. This reduces noise in error reporting while still providing a signal that recording may be blocked.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages