### PR TITLE
fix(core): use typeof check in isEvent to prevent ReferenceError in non-browser runtimes

### DIFF
--- a/.changeset/common-clubs-juggle.md
+++ b/.changeset/common-clubs-juggle.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+fix: use typeof check in isEvent to avoid ReferenceError in non-browser runtimes (React Native/Hermes)

--- a/packages/core/src/utils/type-utils.spec.ts
+++ b/packages/core/src/utils/type-utils.spec.ts
@@ -1,4 +1,4 @@
-import { isNumber, isPositiveNumber } from './type-utils'
+import { isEvent, isNumber, isPositiveNumber } from './type-utils'
 
 describe('type-utils', () => {
   describe('isNumber', () => {
@@ -16,6 +16,33 @@ describe('type-utils', () => {
       [{}, false],
     ])('isNumber(%p) returns %p', (value, expected) => {
       expect(isNumber(value)).toBe(expected)
+    })
+  })
+
+  describe('isEvent', () => {
+    it('returns false without throwing when Event global is undefined', () => {
+      const originalEvent = globalThis.Event
+      try {
+        delete globalThis.Event
+        expect(() => isEvent(new Error('test'))).not.toThrow()
+        expect(isEvent(new Error('test'))).toBe(false)
+      } finally {
+        globalThis.Event = originalEvent
+      }
+    })
+
+    it('returns true for Event instances when Event global exists', () => {
+      if (typeof Event !== 'undefined') {
+        expect(isEvent(new Event('test'))).toBe(true)
+      }
+    })
+
+    it('returns false for non-Event values', () => {
+      expect(isEvent(new Error('test'))).toBe(false)
+      expect(isEvent('string')).toBe(false)
+      expect(isEvent({})).toBe(false)
+      expect(isEvent(null)).toBe(false)
+      expect(isEvent(undefined)).toBe(false)
     })
   })
 

--- a/packages/core/src/utils/type-utils.ts
+++ b/packages/core/src/utils/type-utils.ts
@@ -119,7 +119,7 @@ export function isErrorEvent(event: unknown): boolean {
 }
 
 export function isEvent(candidate: unknown): candidate is Event {
-  return !isUndefined(Event) && isInstanceOf(candidate, Event)
+  return typeof Event !== 'undefined' && isInstanceOf(candidate, Event)
 }
 
 export function isPlainObject(candidate: unknown): candidate is Record<string, unknown> {


### PR DESCRIPTION
## Problem

Error tracking in `posthog-react-native` is non-functional. When initializing PostHog with error tracking autocapture enabled:

```ts
new PostHog("phc_", {
  errorTracking: {
    autocapture: {
      console: [],
      uncaughtExceptions: true,
      unhandledRejections: true,
    },
  },
});
```

No `$exception` events are ever sent. The `isEvent()` utility in `@posthog/core` directly references the Event global, which doesn't exist in React Native's Hermes runtime. The resulting error surfaces as:

```
ERROR [PostHog] [ErrorTracking] An error occurred while capturing an $exception event: [ReferenceError: Property 'Event' doesn't exist]
```

## Changes

- Use `typeof Event !== 'undefined'` instead of `!isUndefined(Event)` in [`isEvent()`](https://github.com/PostHog/posthog-js/blob/e5ef5201bf764aac11a765549f9561010d3b4329/packages/core/src/utils/type-utils.ts#L121) to safely handle runtimes where Event doesn't exist.
- Added tests for `isEvent()`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
