### PR TITLE
fix(browser): keep cookie-backed session and identity across subdomains

### DIFF
--- a/packages/browser/src/__tests__/posthog-persistence.test.ts
+++ b/packages/browser/src/__tests__/posthog-persistence.test.ts
@@ -332,6 +332,42 @@ describe('persistence', () => {
             })
         })
 
+        it('should prefer cookie-backed identity and session properties over stale localStorage values', () => {
+            const cookieSource = new PostHogPersistence(makePostHogConfig('test', 'localStorage+cookie'))
+            cookieSource.register({
+                distinct_id: 'fresh-distinct-id',
+                [DEVICE_ID]: 'fresh-device-id',
+                [SESSION_ID]: [2_000, 'fresh-session-id', 1_500],
+                [INITIAL_PERSON_INFO]: { u: 'https://fresh.example.com', r: 'https://ref.example.com' },
+                [USER_STATE]: 'identified',
+            })
+
+            // Simulate stale per-subdomain localStorage from an old visit while cookie values
+            // were refreshed recently on a different subdomain.
+            localStorage.setItem(
+                'ph__posthog',
+                JSON.stringify({
+                    distinct_id: 'stale-distinct-id',
+                    [DEVICE_ID]: 'stale-device-id',
+                    [SESSION_ID]: [1_000, 'stale-session-id', 900],
+                    [INITIAL_PERSON_INFO]: { u: 'https://stale.example.com', r: 'https://stale-ref.example.com' },
+                    [USER_STATE]: 'anonymous',
+                    stale_local_only_prop: 'kept',
+                })
+            )
+
+            const hydrated = new PostHogPersistence(makePostHogConfig('test', 'localStorage+cookie'))
+
+            expect(hydrated.props).toEqual({
+                distinct_id: 'fresh-distinct-id',
+                [DEVICE_ID]: 'fresh-device-id',
+                [SESSION_ID]: [2_000, 'fresh-session-id', 1_500],
+                [INITIAL_PERSON_INFO]: { u: 'https://fresh.example.com', r: 'https://ref.example.com' },
+                [USER_STATE]: 'identified',
+                stale_local_only_prop: 'kept',
+            })
+        })
+
         it('should persist custom properties to cookies when using localStorage+cookie', () => {
             const customProp = 'my_custom_prop'
             const token = uuidv7()

--- a/packages/browser/src/storage.ts
+++ b/packages/browser/src/storage.ts
@@ -285,7 +285,13 @@ export const createLocalPlusCookieStore = (customCookieProperties: readonly stri
                     // See if there's a cookie stored with data.
                     cookieProperties = cookieStore._parse(name) || {}
                 } catch {}
-                const value = extend(cookieProperties, JSON.parse(localStore._get(name) || '{}'))
+                const value = extend(
+                    {},
+                    JSON.parse(localStore._get(name) || '{}'),
+                    // Cookie-persisted properties must win over localStorage to keep
+                    // cross-subdomain identity/session values consistent.
+                    cookieProperties
+                )
                 localStore._set(name, value)
                 return value
             } catch {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users who move between marketing and app subdomains can end up with stale subdomain `localStorage` data overriding fresher cross-subdomain cookie-persisted identity/session values (`distinct_id`, `$device_id`, `$sesid`, etc.).

In practice this can split sessions unexpectedly (new `$session_id`) even when visits are minutes apart, especially after prior identified activity on another subdomain.

## Changes

- Updated `createLocalPlusCookieStore()._parse` merge precedence in `packages/browser/src/storage.ts`.
  - Previous behavior: cookie data was merged first, then localStorage overwrote it.
  - New behavior: localStorage is merged first, then cookie-persisted values overwrite corresponding keys.
- Added regression test in `packages/browser/src/__tests__/posthog-persistence.test.ts`:
  - Simulates stale per-subdomain localStorage and fresher cookie-backed session/identity values.
  - Verifies cookie-backed identity/session keys win while local-only keys are still preserved.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3289571b-f261-4a73-a8da-e53414e04a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3289571b-f261-4a73-a8da-e53414e04a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

