### PR TITLE
fix(browser): add tree-shakeable ESM extension-bundles entry point

### DIFF
--- a/.changeset/slim-extension-bundles.md
+++ b/.changeset/slim-extension-bundles.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Add tree-shakeable ESM extension-bundles entry point for slim builds

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -379,9 +379,14 @@ const typeTargets = entrypoints
     .filter((file) => file.endsWith('.es.ts'))
     .map((file) => {
         const source = `./lib/src/entrypoints/${file.replace('.ts', '.d.ts')}`
+        const isExtensionBundles = file === 'extension-bundles.es.ts'
         /** @type {import('rollup').RollupOptions} */
         return {
             input: source,
+            // extension-bundles types must reference module.slim rather than inlining
+            // their own copies — classes with private fields are nominally typed, so
+            // duplicate declarations across .d.ts files are incompatible.
+            ...(isExtensionBundles ? { external: [/module\.slim/] } : {}),
             output: [
                 {
                     dir: path.resolve('./dist'),
@@ -392,7 +397,20 @@ const typeTargets = entrypoints
                 json(),
                 dts({
                     exclude: [],
+                    ...(isExtensionBundles ? { respectExternal: true } : {}),
                 }),
+                // dts preserves the tsc-era path (e.g. './module.slim.es') but the
+                // output has been renamed to module.slim.d.ts — fix the reference.
+                ...(isExtensionBundles
+                    ? [
+                          {
+                              name: 'fix-dts-external-paths',
+                              renderChunk(code) {
+                                  return code.replace(/\.\/module\.slim\.es(?=['"])/g, './module.slim')
+                              },
+                          },
+                      ]
+                    : []),
             ],
         }
     })

--- a/packages/browser/src/entrypoints/extension-bundles.es.ts
+++ b/packages/browser/src/entrypoints/extension-bundles.es.ts
@@ -1,0 +1,15 @@
+import type { BundleTypes } from './module.slim.es'
+import * as bundles from '../extensions/extension-bundles'
+export const AllExtensions = bundles.AllExtensions as typeof BundleTypes.AllExtensions
+export const FeatureFlagsExtensions = bundles.FeatureFlagsExtensions as typeof BundleTypes.FeatureFlagsExtensions
+export const SessionReplayExtensions = bundles.SessionReplayExtensions as typeof BundleTypes.SessionReplayExtensions
+export const AnalyticsExtensions = bundles.AnalyticsExtensions as typeof BundleTypes.AnalyticsExtensions
+export const ErrorTrackingExtensions = bundles.ErrorTrackingExtensions as typeof BundleTypes.ErrorTrackingExtensions
+export const ProductToursExtensions = bundles.ProductToursExtensions as typeof BundleTypes.ProductToursExtensions
+export const SiteAppsExtensions = bundles.SiteAppsExtensions as typeof BundleTypes.SiteAppsExtensions
+export const SurveysExtensions = bundles.SurveysExtensions as typeof BundleTypes.SurveysExtensions
+export const TracingExtensions = bundles.TracingExtensions as typeof BundleTypes.TracingExtensions
+export const ToolbarExtensions = bundles.ToolbarExtensions as typeof BundleTypes.ToolbarExtensions
+export const ExperimentsExtensions = bundles.ExperimentsExtensions as typeof BundleTypes.ExperimentsExtensions
+export const ConversationsExtensions = bundles.ConversationsExtensions as typeof BundleTypes.ConversationsExtensions
+export const LogsExtensions = bundles.LogsExtensions as typeof BundleTypes.LogsExtensions

--- a/packages/browser/src/entrypoints/module.slim.no-external.es.ts
+++ b/packages/browser/src/entrypoints/module.slim.no-external.es.ts
@@ -11,5 +11,6 @@ export * from '../types'
 export * from '../posthog-surveys-types'
 export * from '../posthog-product-tours-types'
 export * from '../posthog-conversations-types'
+export type * as BundleTypes from '../extensions/extension-bundles'
 export const posthog = init_as_module()
 export default posthog


### PR DESCRIPTION
## Problem

Users following the [tree-shaking docs](https://posthog.com/docs/libraries/js#tree-shaking) import extension bundles from `posthog-js/lib/src/extensions/extension-bundles`. This path is raw `tsc` CommonJS output. Bundlers like Vite/Rollup cannot tree-shake CJS, so importing just `FeatureFlagsExtensions` pulls in **all** extensions (797 KB, same as the full bundle).

Additionally, the `lib/src/` types declare their own `PostHog` class (separate from `dist/module.slim.d.ts`), and TypeScript treats classes with `private` fields as nominally distinct across declaration files, causing type errors.

Partially fixes #3277 (tree-shaking portion; the `posthog-js/react` provider is a separate issue since it unconditionally imports from `posthog-js`, pulling in the full module's type universe).

## Changes

**1 new file:** `src/entrypoints/extension-bundles.es.ts` is an ESM entry point that re-exports extension bundle constants, with types cast to `module.slim`'s type universe.

**1 line added to** `module.slim.no-external.es.ts`:
```ts
export type * as BundleTypes from '../extensions/extension-bundles'
```
This pulls the extension bundle types into `module.slim.d.ts` (zero runtime cost, `export type` is erased).

**rollup.config.mjs:** For the `extension-bundles` type target, mark `module.slim` as external so `rollup-plugin-dts` keeps the import reference instead of inlining a duplicate type universe. A small `renderChunk` plugin fixes up the `.es` suffix that dts preserves from the tsc-era path.

The result is a 3-line `dist/extension-bundles.d.ts`:
```ts
import { BundleTypes } from './module.slim';
declare const ExtensionBundles: typeof BundleTypes;
export { ExtensionBundles };
```

**Usage:**
```ts
import posthog from 'posthog-js/dist/module.slim'
import { ExtensionBundles } from 'posthog-js/dist/extension-bundles'

posthog.init('ph_key', {
  __extensionClasses: {
    ...ExtensionBundles.FeatureFlagsExtensions,
  },
})
```

**Bundle size (Vite production build, feature flags only):**
| Scenario | Size |
|---|---|
| Slim only (baseline) | 282 KB |
| **Slim + FeatureFlagsExtensions (this PR)** | **376 KB** |
| Original `lib/src` path (no tree shaking) | 797 KB |

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages