### PR TITLE
chore: remove failure emoji from slack thread on successful release retry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,3 +351,4 @@ jobs:
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
                   message: '🚀 All packages released successfully!'
                   emoji_reaction: 'rocket'
+                  remove_emoji_reaction: 'x'


### PR DESCRIPTION
## Problem

When the release workflow fails, a ❌ (`x`) emoji reaction is added to the Slack notification thread. If the workflow is retried and succeeds, a 🚀 (`rocket`) emoji is added but the ❌ is never removed — leaving the thread with both emojis, which is confusing.

## Changes

Pass `remove_emoji_reaction: 'x'` to the `slack-thread-reply` action in the `notify-released` job so that the failure emoji is removed before the success emoji is added.

> **Note:** This depends on a corresponding change in `PostHog/.github` to add the `remove_emoji_reaction` input to the `slack-thread-reply` shared action.

### Libraries affected

- No library changes — CI workflow only

## Checklist

- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size