### PR TITLE
perf(browser): use async CompressionStream for gzip to avoid blocking main thread

### DIFF
--- a/.changeset/async-gzip-compression.md
+++ b/.changeset/async-gzip-compression.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/core': patch
+---
+
+Use async native CompressionStream for gzip compression to avoid blocking the main thread

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -8,6 +8,11 @@ import { AbortController, fetch, navigator, XMLHttpRequest } from './utils/globa
 import { gzipSync, strToU8 } from 'fflate'
 
 import { _base64Encode } from './utils/encode-utils'
+import { isGzipSupported } from '@posthog/core'
+
+interface RequestWithEncodedBody extends RequestWithOptions {
+    _encodedBody?: EncodedBody
+}
 
 // eslint-disable-next-line compat/compat
 export const SUPPORTS_REQUEST = !!XMLHttpRequest || !!fetch
@@ -68,7 +73,13 @@ const encodeToDataString = (data: string | Record<string, any>): string => {
     return 'data=' + encodeURIComponent(typeof data === 'string' ? data : jsonStringify(data))
 }
 
-const encodePostData = ({ data, compression }: RequestWithOptions): EncodedBody | undefined => {
+const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefined => {
+    // Use pre-encoded body if available (set by async compression in the request entrypoint)
+    if (options._encodedBody) {
+        return options._encodedBody
+    }
+
+    const { data, compression } = options
     if (!data) {
         return
     }
@@ -98,6 +109,30 @@ const encodePostData = ({ data, compression }: RequestWithOptions): EncodedBody 
         contentType: CONTENT_TYPE_JSON,
         body: jsonBody,
         estimatedSize: new Blob([jsonBody]).size,
+    }
+}
+
+/**
+ * Pre-encode the request body using async native CompressionStream.
+ * This avoids blocking the main thread with fflate's synchronous gzip,
+ * which can take 300ms+ on constrained devices.
+ *
+ * Callers must check preconditions (data exists, gzip compression, CompressionStream available)
+ * before calling this function. Uses `isGzipSupported` from @posthog/core.
+ */
+const preEncodeAsync = async (options: RequestWithEncodedBody): Promise<RequestWithEncodedBody> => {
+    const jsonData = jsonStringify(options.data)
+    // Pipe the JSON string directly through CompressionStream and read as ArrayBuffer,
+    // avoiding intermediate Blob allocations.
+    const stream = new Blob([jsonData]).stream().pipeThrough(new CompressionStream('gzip'))
+    const body = await new Response(stream).arrayBuffer()
+    return {
+        ...options,
+        _encodedBody: {
+            contentType: CONTENT_TYPE_PLAIN,
+            body,
+            estimatedSize: body.byteLength,
+        },
     }
 }
 
@@ -258,7 +293,7 @@ if (navigator?.sendBeacon) {
 // This is the entrypoint. It takes care of sanitizing the options and then calls the appropriate request method.
 export const request = (_options: RequestWithOptions) => {
     // Clone the options so we don't modify the original object
-    const options = { ..._options }
+    const options: RequestWithEncodedBody = { ..._options }
     options.timeout = options.timeout || 60000
 
     options.url = extendURLParams(options.url, {
@@ -280,5 +315,19 @@ export const request = (_options: RequestWithOptions) => {
         throw new Error('No available transport method')
     }
 
-    transportMethod(options)
+    // For non-sendBeacon transports, use async native CompressionStream when available
+    // to avoid blocking the main thread with fflate's synchronous gzip (which can take 300ms+).
+    // sendBeacon must remain synchronous as it's used during page unload.
+    if (transport !== 'sendBeacon' && options.compression === Compression.GZipJS && isGzipSupported()) {
+        preEncodeAsync(options)
+            .then((encodedOptions) => {
+                transportMethod(encodedOptions)
+            })
+            .catch(() => {
+                // If async compression fails, fall back to the synchronous fflate path
+                transportMethod(options)
+            })
+    } else {
+        transportMethod(options)
+    }
 }

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -122,8 +122,8 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
  */
 const preEncodeAsync = async (options: RequestWithEncodedBody): Promise<RequestWithEncodedBody> => {
     const jsonData = jsonStringify(options.data)
-    // Pipe the JSON string directly through CompressionStream and read as ArrayBuffer,
-    // avoiding intermediate Blob allocations.
+    // Create an input Blob to get a ReadableStream, pipe through CompressionStream,
+    // and read the compressed output directly as an ArrayBuffer (no output Blob needed).
     const stream = new Blob([jsonData]).stream().pipeThrough(new CompressionStream('gzip'))
     const body = await new Response(stream).arrayBuffer()
     return {

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -318,7 +318,7 @@ export const request = (_options: RequestWithOptions) => {
     // For non-sendBeacon transports, use async native CompressionStream when available
     // to avoid blocking the main thread with fflate's synchronous gzip (which can take 300ms+).
     // sendBeacon must remain synchronous as it's used during page unload.
-    if (transport !== 'sendBeacon' && options.compression === Compression.GZipJS && isGzipSupported()) {
+    if (transport !== 'sendBeacon' && options.data && options.compression === Compression.GZipJS && isGzipSupported()) {
         preEncodeAsync(options)
             .then((encodedOptions) => {
                 transportMethod(encodedOptions)

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -122,7 +122,7 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
  */
 const preEncodeAsync = async (options: RequestWithEncodedBody): Promise<RequestWithEncodedBody> => {
     const jsonData = jsonStringify(options.data)
-    const compressed = await gzipCompress(jsonData, false)
+    const compressed = await gzipCompress(jsonData, Config.DEBUG)
     if (!compressed) {
         return options
     }

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -8,7 +8,7 @@ import { AbortController, fetch, navigator, XMLHttpRequest } from './utils/globa
 import { gzipSync, strToU8 } from 'fflate'
 
 import { _base64Encode } from './utils/encode-utils'
-import { isGzipSupported } from '@posthog/core'
+import { gzipCompress, isGzipSupported } from '@posthog/core'
 
 interface RequestWithEncodedBody extends RequestWithOptions {
     _encodedBody?: EncodedBody
@@ -122,10 +122,11 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
  */
 const preEncodeAsync = async (options: RequestWithEncodedBody): Promise<RequestWithEncodedBody> => {
     const jsonData = jsonStringify(options.data)
-    // Create an input Blob to get a ReadableStream, pipe through CompressionStream,
-    // and read the compressed output directly as an ArrayBuffer (no output Blob needed).
-    const stream = new Blob([jsonData]).stream().pipeThrough(new CompressionStream('gzip'))
-    const body = await new Response(stream).arrayBuffer()
+    const compressed = await gzipCompress(jsonData, false)
+    if (!compressed) {
+        return options
+    }
+    const body = await compressed.arrayBuffer()
     return {
         ...options,
         _encodedBody: {

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -4,11 +4,11 @@ import { Compression, RequestWithOptions, RequestResponse } from './types'
 import { formDataToQuery } from './utils/request-utils'
 
 import { logger } from './utils/logger'
-import { AbortController, fetch, navigator, XMLHttpRequest } from './utils/globals'
+import { AbortController, CompressionStream, fetch, navigator, XMLHttpRequest } from './utils/globals'
 import { gzipSync, strToU8 } from 'fflate'
 
 import { _base64Encode } from './utils/encode-utils'
-import { gzipCompress, isGzipSupported } from '@posthog/core'
+import { gzipCompress } from '@posthog/core'
 
 interface RequestWithEncodedBody extends RequestWithOptions {
     _encodedBody?: EncodedBody
@@ -118,7 +118,7 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
  * which can take 300ms+ on constrained devices.
  *
  * Callers must check preconditions (data exists, gzip compression, CompressionStream available)
- * before calling this function. Uses `isGzipSupported` from @posthog/core.
+ * before calling this function. Uses `gzipCompress` from @posthog/core.
  */
 const preEncodeAsync = async (options: RequestWithEncodedBody): Promise<RequestWithEncodedBody> => {
     const jsonData = jsonStringify(options.data)
@@ -319,7 +319,12 @@ export const request = (_options: RequestWithOptions) => {
     // For non-sendBeacon transports, use async native CompressionStream when available
     // to avoid blocking the main thread with fflate's synchronous gzip (which can take 300ms+).
     // sendBeacon must remain synchronous as it's used during page unload.
-    if (transport !== 'sendBeacon' && options.data && options.compression === Compression.GZipJS && isGzipSupported()) {
+    if (
+        transport !== 'sendBeacon' &&
+        options.data &&
+        options.compression === Compression.GZipJS &&
+        !!CompressionStream
+    ) {
         preEncodeAsync(options)
             .then((encodedOptions) => {
                 transportMethod(encodedOptions)

--- a/packages/browser/src/utils/globals.ts
+++ b/packages/browser/src/utils/globals.ts
@@ -285,6 +285,7 @@ export const fetch = global?.fetch
 export const XMLHttpRequest =
     global?.XMLHttpRequest && 'withCredentials' in new global.XMLHttpRequest() ? global.XMLHttpRequest : undefined
 export const AbortController = global?.AbortController
+export const CompressionStream = global?.CompressionStream
 export const userAgent = navigator?.userAgent
 export const assignableWindow: AssignableWindow = win ?? ({} as any)
 

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -113,6 +113,7 @@
         "_elementSelectors",
         "_elementsChainAsString",
         "_enabledServerSide",
+        "_encodedBody",
         "_endpoint",
         "_enforceIdleTimeout",
         "_enqueue",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { getFeatureFlagValue } from './featureFlagUtils'
-export { isGzipSupported } from './gzip'
+export { gzipCompress, isGzipSupported } from './gzip'
 export * from './utils'
 export * as ErrorTracking from './error-tracking'
 export { uuidv7 } from './vendor/uuidv7'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { getFeatureFlagValue } from './featureFlagUtils'
+export { isGzipSupported } from './gzip'
 export * from './utils'
 export * as ErrorTracking from './error-tracking'
 export { uuidv7 } from './vendor/uuidv7'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { getFeatureFlagValue } from './featureFlagUtils'
-export { gzipCompress, isGzipSupported } from './gzip'
+export { gzipCompress } from './gzip'
 export * from './utils'
 export * as ErrorTracking from './error-tracking'
 export { uuidv7 } from './vendor/uuidv7'


### PR DESCRIPTION
## Problem

Users running PostHog in performance-constrained environments (e.g., real-time browser games in iframes) experience significant frame drops caused by `gzipSync` from fflate blocking the main thread for **300ms+** during request compression. This is especially impactful with session recordings + canvas recording, where compressed payloads are sent frequently.

Related: https://posthoghelp.zendesk.com/agent/tickets/43990 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/55566)
but also https://github.com/PostHog/posthog-js/pull/2823 and some other PRs

## Changes

Uses the native [CompressionStream API](https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream) for gzip compression when available on `fetch`/`XHR` transports. This is async and non-blocking, handled by the browser's built-in compression engine.

**How it works:**
- The `request()` entry point checks if `CompressionStream` is available (safely imported from `globals.ts`)
- For `fetch`/`XHR` with gzip compression, it pre-encodes the body asynchronously via `gzipCompress` from `@posthog/core`, storing the result in `_encodedBody`
- `encodePostData()` checks for `_encodedBody` first, skipping the synchronous fflate path entirely
- If async compression fails, falls back to the existing synchronous fflate path via `.catch()`
- `sendBeacon` always uses the synchronous fflate path (required — runs during page unload)

**Fallback behavior:**
- Browsers **with** `CompressionStream` (Chrome 80+, Firefox 113+, Safari 16.4+): async native compression ✅
- Browsers **without** `CompressionStream`: existing `gzipSync` from fflate (unchanged behavior)
- `sendBeacon` transport: always uses sync fflate (required for `beforeunload`)

**Files changed:**
- `packages/browser/src/request.ts` — async pre-encoding with `CompressionStream` via `gzipCompress` from `@posthog/core`, fallback to sync fflate
- `packages/browser/src/utils/globals.ts` — export `CompressionStream` with safe `global?.` access pattern
- `packages/core/src/index.ts` — export `gzipCompress` for reuse

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)
- [x] @posthog/core

## Checklist

- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages