### PR TITLE
feat(react-native): add $is_emulator property to detect emulator/simulator

### DIFF
--- a/.changeset/warm-wolves-glow.md
+++ b/.changeset/warm-wolves-glow.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': minor
+---
+
+Add $is_emulator property to detect emulator/simulator environments

--- a/packages/react-native/src/native-deps.tsx
+++ b/packages/react-native/src/native-deps.tsx
@@ -67,12 +67,14 @@ export const getAppProperties = (): PostHogCustomAppProperties => {
     }
 
     properties.$os_version = OptionalExpoDevice.osVersion
+    properties.$is_emulator = !OptionalExpoDevice.isDevice
   } else if (OptionalReactNativeDeviceInfo) {
     properties.$device_manufacturer = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getManufacturerSync())
     // react-native-device-info already maps the device model identifier to a human readable name
     properties.$device_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getModel())
     properties.$os_name = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getSystemName())
     properties.$os_version = returnPropertyIfNotUnknown(OptionalReactNativeDeviceInfo.getSystemVersion())
+    properties.$is_emulator = OptionalReactNativeDeviceInfo.isEmulatorSync()
   }
 
   if (OptionalExpoLocalization) {

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -88,6 +88,8 @@ export interface PostHogCustomAppProperties {
   $locale?: string | null
   /** Timezone of the device like "Europe/Berlin" */
   $timezone?: string | null
+  /** Whether the app is running on an emulator/simulator */
+  $is_emulator?: boolean | null
 }
 
 export type PostHogSessionReplayConfig = {

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -184,6 +184,7 @@ describe('PostHog React Native', () => {
       $device_manufacturer: 'mock',
       $device_type: 'Mobile',
       // $device_name: 'mock', (deleted)
+      $is_emulator: false,
       $os_name: 'mock',
       $os_version: 'mock',
       $locale: 'mock',


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog-js/issues/2146

Users need to distinguish between events coming from real devices vs emulators/simulators. This is useful for filtering out test data and understanding real user behavior.

## Changes

Adds a new `$is_emulator` boolean property to the React Native SDK's app properties. It leverages the existing optional dependencies:

- **expo-device**: uses `!isDevice` (synchronous boolean — `true` on real device, `false` on emulator/simulator)
- **react-native-device-info**: uses `isEmulatorSync()` (synchronous boolean)

No new dependencies are required.

### Files changed:
- `packages/react-native/src/types.ts` — Added `$is_emulator` to `PostHogCustomAppProperties`
- `packages/react-native/src/native-deps.tsx` — Set the property in both expo-device and react-native-device-info branches
- `packages/react-native/test/posthog.spec.ts` — Updated test expectation

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-react-native

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages