### PR TITLE
fix(node): fix flaky nestjs interceptor test

### DIFF
--- a/packages/node/src/__tests__/extensions/nestjs.spec.ts
+++ b/packages/node/src/__tests__/extensions/nestjs.spec.ts
@@ -2,16 +2,17 @@ import { of, throwError, lastValueFrom } from 'rxjs'
 
 import { PostHog } from '@/entrypoints/index.node'
 import { PostHogInterceptor } from '@/extensions/nestjs'
-import { waitForPromises } from '../utils'
 
 jest.mock('../../version', () => ({ version: '1.2.3' }))
 
 const mockedFetch = jest.spyOn(globalThis, 'fetch').mockImplementation()
 
-const waitForFlushTimer = async (): Promise<void> => {
-  await waitForPromises()
-  jest.runOnlyPendingTimers()
-  await waitForPromises()
+/**
+ * Deterministically drains all pending promises (including async chains like
+ * captureException's buildEventMessage) and flushes any remaining queued events.
+ */
+const waitForFlushTimer = async (posthog: PostHog): Promise<void> => {
+  await posthog.shutdown()
 }
 
 const getLastBatchEvents = (): any[] | undefined => {
@@ -129,7 +130,7 @@ describe('PostHogInterceptor', () => {
       }
 
       await lastValueFrom(interceptor.intercept(context, handler))
-      await waitForFlushTimer()
+      await waitForFlushTimer(posthog)
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toBeDefined()
@@ -155,7 +156,7 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext()
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-      await waitForFlushTimer()
+      await waitForFlushTimer(posthog)
 
       const batchCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/batch/'))
       expect(batchCalls.length).toBe(0)
@@ -203,7 +204,7 @@ describe('PostHogInterceptor', () => {
       })
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-      await waitForFlushTimer()
+      await waitForFlushTimer(posthog)
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toBeDefined()
@@ -228,7 +229,7 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext()
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-      await waitForFlushTimer()
+      await waitForFlushTimer(posthog)
 
       const batchCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/batch/'))
       expect(batchCalls.length).toBe(0)
@@ -246,7 +247,7 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext({ headers: {} })
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-      await waitForFlushTimer()
+      await waitForFlushTimer(posthog)
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toBeDefined()
@@ -267,7 +268,7 @@ describe('PostHogInterceptor', () => {
       })
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-      await waitForFlushTimer()
+      await waitForFlushTimer(posthog)
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents![0].properties.$ip).toBe('10.0.0.1')
@@ -280,7 +281,7 @@ describe('PostHogInterceptor', () => {
       })
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-      await waitForFlushTimer()
+      await waitForFlushTimer(posthog)
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents![0].properties.$ip).toBe('10.0.0.1')
@@ -292,7 +293,7 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext()
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-      await waitForFlushTimer()
+      await waitForFlushTimer(posthog)
 
       const batchCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/batch/'))
       expect(batchCalls.length).toBe(0)
@@ -304,7 +305,7 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext()
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-      await waitForFlushTimer()
+      await waitForFlushTimer(posthog)
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toBeDefined()
@@ -323,7 +324,7 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext()
 
       await expect(lastValueFrom(interceptor.intercept(context, createMockCallHandler(error)))).rejects.toThrow(error)
-      await waitForFlushTimer()
+      await waitForFlushTimer(posthog)
 
       const batchEvents = getLastBatchEvents()
       expect(batchEvents).toBeDefined()


### PR DESCRIPTION
## Problem

The NestJS interceptor test `should capture exception with correct properties` is flaky in CI. The `captureException` path adds a pending promise with an async chain (`buildEventMessage` resolves stack frames → `.then(capture)`). The old `waitForFlushTimer` helper relied on a fragile combination of `waitForPromises()` and `jest.runOnlyPendingTimers()` that could race with the async chain.

## Changes

Replaced the non-deterministic `waitForFlushTimer` with a deterministic approach using `posthog.shutdown()`, which calls `promiseQueue.join()` to drain all pending promises before flushing. This guarantees that async chains like `captureException`'s `buildEventMessage().then(capture)` are fully resolved before asserting on the batch output.

- Removed unused `waitForPromises` import
- `waitForFlushTimer` now takes the `posthog` instance and calls `shutdown()`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size