### PR TITLE
feat: add disableFeatureFlagReload option to identify()

### DIFF
--- a/packages/browser/src/__tests__/posthog-core.identify.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.identify.test.ts
@@ -305,6 +305,21 @@ describe('identify()', () => {
 
             expect(instance.unregister).toHaveBeenCalledWith('$flag_call_reported')
         })
+
+        it('does not reload feature flags when disableFeatureFlagReload is true', () => {
+            instance.identify('a-new-id', undefined, undefined, { disableFeatureFlagReload: true })
+
+            expect(instance.featureFlags.reloadFeatureFlags).not.toHaveBeenCalled()
+            // should still clear flag calls and set anonymous distinct id
+            expect(instance.unregister).toHaveBeenCalledWith('$flag_call_reported')
+            expect(instance.featureFlags.setAnonymousDistinctId).toHaveBeenCalledWith('oldIdentity')
+        })
+
+        it('still reloads feature flags when disableFeatureFlagReload is false', () => {
+            instance.identify('a-new-id', undefined, undefined, { disableFeatureFlagReload: false })
+
+            expect(instance.featureFlags.reloadFeatureFlags).toHaveBeenCalled()
+        })
     })
 
     describe('setPersonProperties', () => {

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -2331,7 +2331,12 @@ export class PostHog implements PostHogInterface {
      *  it will be overwritten by the value in userPropertiesToSet.
      * @param {Object} [userPropertiesToSetOnce] Optional: An associative array of properties to store about the user. If property is previously set, this does not override that value.
      */
-    identify(new_distinct_id?: string, userPropertiesToSet?: Properties, userPropertiesToSetOnce?: Properties): void {
+    identify(
+        new_distinct_id?: string,
+        userPropertiesToSet?: Properties,
+        userPropertiesToSetOnce?: Properties,
+        options?: { disableFeatureFlagReload?: boolean }
+    ): void {
         if (!this.__loaded || !this.persistence) {
             return logger.uninitializedWarning('posthog.identify')
         }
@@ -2429,7 +2434,9 @@ export class PostHog implements PostHogInterface {
         // Reload active feature flags if the user identity changes.
         // Note we don't reload this on property changes as these get processed async
         if (new_distinct_id !== previous_distinct_id) {
-            this.reloadFeatureFlags()
+            if (!options?.disableFeatureFlagReload) {
+                this.reloadFeatureFlags()
+            }
             // also clear any stored flag calls
             this.unregister(FLAG_CALL_REPORTED)
         }

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -34,7 +34,14 @@ import type { PostHogLogs } from './posthog-logs'
 export type { Property, Properties, JsonType, JsonRecord } from '@posthog/types'
 
 // Capture types
-export type { KnownEventName, EventName, CaptureResult, CaptureOptions, BeforeSendFn } from '@posthog/types'
+export type {
+    KnownEventName,
+    EventName,
+    CaptureResult,
+    CaptureOptions,
+    IdentifyOptions,
+    BeforeSendFn,
+} from '@posthog/types'
 
 // Feature flag types
 export type {

--- a/packages/core/src/__tests__/posthog.identify.spec.ts
+++ b/packages/core/src/__tests__/posthog.identify.spec.ts
@@ -324,6 +324,22 @@ describe('PostHog Core', () => {
       expect(batchCalls.length).toBe(0)
     })
 
+    it('should not reload feature flags when disableFeatureFlagReload is true', async () => {
+      posthog.identify('id-1', { foo: 'bar' }, { disableFeatureFlagReload: true })
+      await waitForPromises()
+      // Only the batch call, no flags call
+      expect(mocks.fetch).toHaveBeenCalledTimes(1)
+      const batchCall = mocks.fetch.mock.calls[0]
+      expect(batchCall[0]).toEqual('https://us.i.posthog.com/batch/')
+    })
+
+    it('should still reload feature flags when disableFeatureFlagReload is false', async () => {
+      posthog.identify('id-1', { foo: 'bar' }, { disableFeatureFlagReload: false })
+      await waitForPromises()
+      // Both batch and flags calls
+      expect(mocks.fetch).toHaveBeenCalledTimes(2)
+    })
+
     it('should not send event when only distinct_id is provided (no properties)', async () => {
       // First identify
       posthog.identify('id-1')

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -5,6 +5,7 @@ import type {
   PostHogCoreOptions,
   PostHogEventProperties,
   PostHogCaptureOptions,
+  PostHogIdentifyOptions,
   JsonType,
   PostHogRemoteConfig,
   FeatureFlagValue,
@@ -295,7 +296,7 @@ export abstract class PostHogCore extends PostHogCoreStateless {
    *** TRACKING
    ***/
 
-  identify(distinctId?: string, properties?: PostHogEventProperties, options?: PostHogCaptureOptions): void {
+  identify(distinctId?: string, properties?: PostHogEventProperties, options?: PostHogIdentifyOptions): void {
     this.wrap(() => {
       if (!this._requirePersonProcessing('posthog.identify')) {
         return
@@ -331,7 +332,10 @@ export abstract class PostHogCore extends PostHogCoreStateless {
         this.setPersistedProperty(PostHogPersistedProperty.DistinctId, distinctId)
         // Mark the user as identified
         this.setPersistedProperty(PostHogPersistedProperty.PersonMode, 'identified')
-        this.reloadFeatureFlags()
+
+        if (!options?.disableFeatureFlagReload) {
+          this.reloadFeatureFlags()
+        }
 
         super.identifyStateless(distinctId, allProperties, options)
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -173,6 +173,18 @@ export type PostHogCaptureOptions = {
   _originatedFromCaptureException?: boolean
 }
 
+export type PostHogIdentifyOptions = PostHogCaptureOptions & {
+  /**
+   * When true, prevents the SDK from automatically reloading feature flags
+   * after the distinct_id changes. This is useful when the person merge
+   * triggered by identify may not have propagated server-side yet, which
+   * can cause the server to re-bucket the user under a different variant.
+   *
+   * @default false
+   */
+  disableFeatureFlagReload?: boolean
+}
+
 export type PostHogFetchResponse = {
   status: number
   text: () => Promise<string>

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -3,6 +3,7 @@ import { AppState, Dimensions, Linking, Platform } from 'react-native'
 import {
   JsonType,
   PostHogCaptureOptions,
+  PostHogIdentifyOptions,
   PostHogCore,
   PostHogCoreOptions,
   PostHogEventProperties,
@@ -1114,9 +1115,9 @@ export class PostHog extends PostHogCore {
    *
    * @param distinctId - A unique identifier for your user. Typically either their email or database ID.
    * @param properties - Optional dictionary with key:value pairs to set the person properties
-   * @param options - Optional capture options
+   * @param options - Optional identify options (extends capture options with disableFeatureFlagReload)
    */
-  identify(distinctId?: string, properties?: PostHogEventProperties, options?: PostHogCaptureOptions): void {
+  identify(distinctId?: string, properties?: PostHogEventProperties, options?: PostHogIdentifyOptions): void {
     const previousDistinctId = this.getDistinctId()
     super.identify(distinctId, properties, options)
 

--- a/packages/types/src/capture.ts
+++ b/packages/types/src/capture.ts
@@ -105,4 +105,16 @@ export interface CaptureOptions {
     _originatedFromCaptureException?: boolean
 }
 
+export interface IdentifyOptions {
+    /**
+     * When true, prevents the SDK from automatically reloading feature flags
+     * after the distinct_id changes. This is useful when the person merge
+     * triggered by identify may not have propagated server-side yet, which
+     * can cause the server to re-bucket the user under a different variant.
+     *
+     * @default false
+     */
+    disableFeatureFlagReload?: boolean
+}
+
 export type BeforeSendFn = (cr: CaptureResult | null) => CaptureResult | null

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,6 +18,7 @@ export type {
     EventName,
     CaptureResult,
     CaptureOptions,
+    IdentifyOptions,
     BeforeSendFn,
 } from './capture'
 

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -7,7 +7,7 @@
 
 import type { PostHogConfig } from './posthog-config'
 import type { Properties, JsonType } from './common'
-import type { CaptureResult, CaptureOptions } from './capture'
+import type { CaptureResult, CaptureOptions, IdentifyOptions } from './capture'
 import type {
     FeatureFlagsCallback,
     EarlyAccessFeatureCallback,
@@ -111,7 +111,12 @@ export interface PostHog {
      * @param userPropertiesToSet - Properties to set on the user (using $set)
      * @param userPropertiesToSetOnce - Properties to set once on the user (using $set_once)
      */
-    identify(new_distinct_id?: string, userPropertiesToSet?: Properties, userPropertiesToSetOnce?: Properties): void
+    identify(
+        new_distinct_id?: string,
+        userPropertiesToSet?: Properties,
+        userPropertiesToSetOnce?: Properties,
+        options?: IdentifyOptions
+    ): void
 
     /**
      * Set properties on the current user.


### PR DESCRIPTION
## Summary

- Adds a `disableFeatureFlagReload` option to `identify()` across browser, core, and React Native SDKs
- When `identify()` changes the distinct_id, the SDK unconditionally reloads feature flags. The `/flags` request fires before the person merge triggered by `$identify` has propagated server-side, which can cause the server to re-bucket the user under a different variant. This option lets callers suppress the automatic reload and let flags refresh on the next session when identities are fully merged.
- New `IdentifyOptions` type in `@posthog/types` and `PostHogIdentifyOptions` in the core package

### Usage

```typescript
// Browser SDK
posthog.identify('authenticated-user-id', userProperties, undefined, {
  disableFeatureFlagReload: true,
})

// React Native SDK
posthog.identify('authenticated-user-id', userProperties, {
  disableFeatureFlagReload: true,
})
```

## Test plan

- [x] Added browser SDK tests for `disableFeatureFlagReload: true` and `false`
- [x] Added core SDK tests verifying no `/flags` request when option is set
- [x] All existing identify tests continue to pass
- [x] React Native tests pass (inherits core behavior via `super.identify()`)
- [x] TypeScript compiles cleanly across all three packages