### PR TITLE
fix: strip `workspace:*` refs from lib/package.json after build

### DIFF
--- a/.changeset/quiet-pens-kneel.md
+++ b/.changeset/quiet-pens-kneel.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Strip workspace:* references from lib/package.json after build

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -12,6 +12,7 @@
         "start": "pnpm build-react && NODE_OPTIONS=\"--max-old-space-size=8192\" pnpm build-rollup -w",
         "dev": "tsc -b && NODE_OPTIONS=\"--max-old-space-size=8192\" rollup -cw",
         "build": "tsc -b && rollup -c",
+        "postbuild": "node scripts/strip-lib-package-json.js",
         "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz",
         "lint": "eslint src && eslint playwright",
         "lint:fix": "eslint src --fix && eslint playwright --fix",

--- a/packages/browser/scripts/strip-lib-package-json.js
+++ b/packages/browser/scripts/strip-lib-package-json.js
@@ -1,0 +1,19 @@
+// TypeScript copies package.json into lib/ (due to resolveJsonModule + the import in src/config.ts).
+// The copy retains unresolved workspace:* references which break npm audit fix for consumers.
+// This script strips dependencies and devDependencies from the build artifact.
+// See: https://github.com/PostHog/posthog-js/issues/3290
+
+const fs = require('fs')
+const path = require('path')
+
+const filePath = path.resolve(__dirname, '..', 'lib', 'package.json')
+
+if (!fs.existsSync(filePath)) {
+    console.warn('warn: lib/package.json no longer exists — this postbuild script can be removed')
+    process.exit(0)
+}
+
+const pkg = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+delete pkg.dependencies
+delete pkg.devDependencies
+fs.writeFileSync(filePath, JSON.stringify(pkg, null, 4) + '\n')


### PR DESCRIPTION
## Problem

The published `posthog-js` package ships a `lib/package.json` with unresolved `workspace:*` references in `dependencies` and `devDependencies`. This breaks `npm audit fix` for consumers with:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

Closes #3290

## Changes

Adds a `postbuild` script that strips `dependencies` and `devDependencies` from `lib/package.json` after TypeScript compilation.

TypeScript copies the full `package.json` into `lib/` because `src/config.ts` imports `../package.json` (with `resolveJsonModule: true`). The `version` field it reads is preserved — only the dependency fields containing `workspace:*` are removed.

After build, `grep -E "dependencies|workspace" lib/package.json` returns no results.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages