### PR TITLE
test(browser): add sendBeacon Content-Type test coverage

### DIFF
--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -455,6 +455,7 @@ describe('request', () => {
                     expect.any(Blob)
                 )
                 const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
+                expect(blob.type).toBe('application/json')
 
                 const reader = new FileReader()
                 const result = await new Promise((resolve) => {
@@ -480,6 +481,7 @@ describe('request', () => {
                     expect.any(Blob)
                 )
                 const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
+                expect(blob.type).toBe('application/x-www-form-urlencoded')
 
                 const reader = new FileReader()
                 const result = await new Promise((resolve) => {
@@ -517,6 +519,45 @@ describe('request', () => {
                    "
             `)
             })
+
+            it('should not call sendBeacon when body is undefined', () => {
+                request(
+                    createRequest({
+                        url: 'https://any.posthog-instance.com/',
+                        method: 'POST',
+                        data: undefined,
+                    })
+                )
+
+                expect(mockedNavigator?.sendBeacon).not.toHaveBeenCalled()
+            })
+
+            it.each([
+                ['no compression', undefined, 'application/json'],
+                ['base64 compression', Compression.Base64, 'application/x-www-form-urlencoded'],
+                ['gzip compression', Compression.GZipJS, 'text/plain'],
+            ])(
+                'always sends a Blob with correct Content-Type for %s',
+                (_name: string, compression: Compression | undefined, expectedContentType: string) => {
+                    request(
+                        createRequest({
+                            url: 'https://any.posthog-instance.com/',
+                            method: 'POST',
+                            compression,
+                            data: { event: 'test' },
+                        })
+                    )
+
+                    expect(mockedNavigator?.sendBeacon).toHaveBeenCalledTimes(1)
+                    const body = mockedNavigator?.sendBeacon.mock.calls[0][1]
+
+                    // The body must always be a Blob so the browser sets the Content-Type header.
+                    // Sending a raw ArrayBuffer (as happened before the fix in #3297) causes the
+                    // browser to omit Content-Type, which breaks proxies/WAFs/CDNs that require it.
+                    expect(body).toBeInstanceOf(Blob)
+                    expect((body as Blob).type).toBe(expectedContentType)
+                }
+            )
         })
     })
 })


### PR DESCRIPTION
## Problem

Follow-up from [#3297 review discussion](https://github.com/PostHog/posthog-js/pull/3297#pullrequestreview-2783506473) where I noted:

> Considering it broke, we might not have any meaningful test coverage that actually uses the real `sendBeacon` method. That'd be the easiest way. Open to adding something like this as a follow up.

The existing sendBeacon tests did not fully assert that the body is always a `Blob` with the correct `type` (which the browser uses as `Content-Type`). This gap allowed the bug fixed in #3297 to ship undetected.

## Changes

- **`packages/browser/src/__tests__/request.test.ts`**:
  - Added `blob.type` assertions to the existing JSON (`application/json`) and Base64 (`application/x-www-form-urlencoded`) sendBeacon tests — previously only the gzip test checked this.
  - Added a test verifying `sendBeacon` is **not called** when body is `undefined` (covers the early return guard added in #3297).
  - Added a parameterized regression test (`always sends a Blob with correct Content-Type for %s`) covering all three compression modes (none, base64, gzip), asserting the body is always a `Blob` instance with the expected `Content-Type`.

**Verified**: all 3 new tests [fail with the pre-fix code](https://github.com/PostHog/posthog-js/pull/3297/files) and catch the exact bug that #3297 fixed (gzip body sent as raw `ArrayBuffer` → no `Content-Type` header).

## Release info Sub-libraries affected

### Libraries affected

Test-only change, no library version bump needed.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size