### PR TITLE
fix: send $groupidentify for new groups even without properties (core SDK)

### DIFF
--- a/.changeset/gentle-foxes-rest.md
+++ b/.changeset/gentle-foxes-rest.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+fix: send $groupidentify for new groups even when no properties are provided

--- a/packages/core/src/__tests__/posthog.featureflags.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.spec.ts
@@ -728,8 +728,19 @@ describe('PostHog Feature Flags v4', () => {
       it('should reload if groups are set', async () => {
         posthog.group('my-group', 'is-great')
         await waitForPromises()
-        expect(mocks.fetch).toHaveBeenCalledTimes(2)
-        expect(JSON.parse((mocks.fetch.mock.calls[1][1].body as string) || '')).toMatchObject({
+        // 3 calls: 1 for flags reload, 1 for $groupidentify batch, 1 for flags decide
+        expect(mocks.fetch).toHaveBeenCalledTimes(3)
+        // The flags reload call contains the group
+        const flagsCall = mocks.fetch.mock.calls.find((call) => {
+          try {
+            const body = JSON.parse((call[1].body as string) || '')
+            return body.groups?.['my-group'] === 'is-great'
+          } catch {
+            return false
+          }
+        })
+        expect(flagsCall).toBeDefined()
+        expect(JSON.parse((flagsCall![1].body as string) || '')).toMatchObject({
           groups: { 'my-group': 'is-great' },
         })
       })

--- a/packages/core/src/__tests__/posthog.featureflags.v1.spec.ts
+++ b/packages/core/src/__tests__/posthog.featureflags.v1.spec.ts
@@ -411,8 +411,19 @@ describe('PostHog Feature Flags v1', () => {
       it('should reload if groups are set', async () => {
         posthog.group('my-group', 'is-great')
         await waitForPromises()
-        expect(mocks.fetch).toHaveBeenCalledTimes(2)
-        expect(JSON.parse((mocks.fetch.mock.calls[1][1].body as string) || '')).toMatchObject({
+        // 3 calls: 1 for flags reload, 1 for $groupidentify batch, 1 for flags decide
+        expect(mocks.fetch).toHaveBeenCalledTimes(3)
+        // The flags reload call contains the group
+        const flagsCall = mocks.fetch.mock.calls.find((call) => {
+          try {
+            const body = JSON.parse((call[1].body as string) || '')
+            return body.groups?.['my-group'] === 'is-great'
+          } catch {
+            return false
+          }
+        })
+        expect(flagsCall).toBeDefined()
+        expect(JSON.parse((flagsCall![1].body as string) || '')).toMatchObject({
           groups: { 'my-group': 'is-great' },
         })
       })

--- a/packages/core/src/__tests__/posthog.groups.spec.ts
+++ b/packages/core/src/__tests__/posthog.groups.spec.ts
@@ -64,6 +64,79 @@ describe('PostHog Core', () => {
         ],
       })
     })
+
+    it('should call groupIdentify for a new group even without properties', async () => {
+      posthog.group('other', 'team')
+      await waitForPromises()
+
+      expect(mocks.fetch).toHaveBeenCalledTimes(2) // 1 for flags, 1 for groupIdentify
+      const batchCall = mocks.fetch.mock.calls[1]
+      expect(batchCall[0]).toEqual('https://us.i.posthog.com/batch/')
+      expect(parseBody(batchCall)).toMatchObject({
+        batch: [
+          {
+            event: '$groupidentify',
+            distinct_id: posthog.getDistinctId(),
+            properties: {
+              $group_type: 'other',
+              $group_key: 'team',
+            },
+            type: 'capture',
+          },
+        ],
+      })
+    })
+
+    it('should not call groupIdentify when group already exists with same key and no properties', async () => {
+      posthog.group('other', 'team')
+      await waitForPromises()
+      mocks.fetch.mockClear()
+
+      posthog.group('other', 'team')
+      await waitForPromises()
+
+      // No new fetch calls for groupIdentify (only flags reload if needed)
+      const groupIdentifyCalls = mocks.fetch.mock.calls.filter((call) => {
+        try {
+          const body = parseBody(call)
+          return body.batch?.some((e: any) => e.event === '$groupidentify')
+        } catch {
+          return false
+        }
+      })
+      expect(groupIdentifyCalls).toHaveLength(0)
+    })
+
+    it('should call groupIdentify for an existing group when properties are provided', async () => {
+      posthog.group('other', 'team')
+      await waitForPromises()
+      mocks.fetch.mockClear()
+
+      posthog.group('other', 'team', { name: 'My Team' })
+      await waitForPromises()
+
+      const groupIdentifyCalls = mocks.fetch.mock.calls.filter((call) => {
+        try {
+          const body = parseBody(call)
+          return body.batch?.some((e: any) => e.event === '$groupidentify')
+        } catch {
+          return false
+        }
+      })
+      expect(groupIdentifyCalls).toHaveLength(1)
+      expect(parseBody(groupIdentifyCalls[0])).toMatchObject({
+        batch: [
+          {
+            event: '$groupidentify',
+            properties: {
+              $group_type: 'other',
+              $group_key: 'team',
+              $group_set: { name: 'My Team' },
+            },
+          },
+        ],
+      })
+    })
   })
 
   describe('groupIdentify', () => {

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -443,11 +443,17 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     options?: PostHogCaptureOptions
   ): void {
     this.wrap(() => {
+      const existingGroups = (this.props.$groups as PostHogGroupProperties) || {}
+      const isNewGroup = existingGroups[groupType] !== groupKey
+
       this.groups({
         [groupType]: groupKey,
       })
 
-      if (groupProperties) {
+      // Send $groupidentify when the group is new/changed OR when properties
+      // are provided. Skip only when the group already exists with the same
+      // key and no new properties are being set.
+      if (isNewGroup || groupProperties) {
         this.groupIdentify(groupType, groupKey, groupProperties, options)
       }
     })


### PR DESCRIPTION
## Problem

Follow-up to #3319 (browser SDK fix). The same bug exists in the core SDK (`@posthog/core`), which is used by React Native.

Calling `posthog.group("company", "company_id")` without properties does not send a `$groupidentify` event, meaning the group type and group are never created server-side. This is inconsistent with iOS, Android, Unity, and Flutter SDKs which all always send `$groupidentify`.

## Changes

**`packages/core/src/posthog-core.ts`**
- `group()` now checks whether the group key is new before calling `groups()`, and sends `$groupidentify` via `groupIdentify()` when the group is new/changed — even without properties.
- When the group already exists with the same key and no properties are provided, the event is skipped.

**`packages/core/src/__tests__/posthog.groups.spec.ts`**
- Added test: new group without properties sends `$groupidentify`
- Added test: existing group + same key + no properties does NOT send `$groupidentify`
- Added test: existing group + properties sends `$groupidentify` with `$group_set`

**`packages/core/src/__tests__/posthog.featureflags.spec.ts`** and **`posthog.featureflags.v1.spec.ts`**
- Updated "should reload if groups are set" to account for the additional `$groupidentify` fetch call.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages