### PR TITLE
fix(ci): fix S3 upload skipped due to race with npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,10 +336,11 @@ jobs:
 
     build-s3-artifacts:
         name: Build posthog-js dist for S3
-        needs: [version-bump, publish, notify-approval-needed]
+        needs: [version-bump, notify-approval-needed]
         runs-on: ubuntu-latest
-        # Run as long as the version bump committed — even if some matrix publishes failed,
-        # posthog-js might have succeeded and we still want the artifacts in S3.
+        # Run in parallel with publish — must NOT wait for publish because
+        # check-package-version compares against npm. If publish finishes first,
+        # the version is already on the registry and is-new-version returns false.
         if: always() && needs.version-bump.outputs.commit-hash != ''
         permissions:
             contents: read


### PR DESCRIPTION
## Problem

The `Upload posthog-js dist to S3` job was being skipped on every release because of a race condition in the workflow dependency graph.

`build-s3-artifacts` depended on `publish`, so by the time it ran `PostHog/check-package-version@v2`, the npm publish had already completed. Since that action checks whether the local version exists on the npm registry, it returned `is-new-version: false` (the version was already there). This caused the downstream `upload-s3` job to be skipped.

Ref: https://github.com/PostHog/posthog-js/actions/runs/23919696194

## Changes

Remove `publish` from `build-s3-artifacts.needs` so it runs in parallel with `publish` instead of after it. The build job only needs the version-bump commit to checkout and build the dist. It has no dependency on npm.

`upload-s3` already depends on `build-s3-artifacts` (for the dist artifact) and `version-bump` (for the commit hash), so the overall ordering is still correct.

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size