### PR TITLE
chore: build toolbar from posthog/posthog during release for S3 upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,7 +409,9 @@ jobs:
                     echo "❌ toolbar.js not found after build"
                     exit 1
                   fi
+                  TOOLBAR_SHA=$(git rev-parse HEAD)
                   echo "✓ toolbar.js built successfully ($(wc -c < frontend/dist/toolbar.js) bytes)"
+                  echo "  Built from PostHog/posthog@${TOOLBAR_SHA}"
 
             - name: Upload toolbar artifact
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem

When posthog-js is served from our CDN (S3), the toolbar needs to be available at the same versioned path (`$VERSION/toolbar.js`). Currently the toolbar is only built and served from the posthog/posthog app, but for the S3-based CDN delivery to work, we need to include `toolbar.js` alongside the other posthog-js dist files.

## Changes

Adds a new `build-toolbar` job to the release workflow that:

1. **Clones `PostHog/posthog`** (shallow, depth 1) at `master`
2. **Sets up Node 24** (required by posthog/posthog frontend)
3. **Installs only frontend dependencies** via `pnpm --filter=@posthog/frontend... install` (much faster than a full monorepo install)
4. **Builds just the toolbar** using the existing `frontend/bin/build-toolbar.mjs` script
5. **Uploads `toolbar.js`** as a build artifact

The `upload-s3` job is updated to:
- Wait for both `build-s3-artifacts` and `build-toolbar`
- Download and merge the toolbar artifact into the dist directory
- The toolbar download is conditional (`if: needs.build-toolbar.result == 'success'`) so a toolbar build failure does **not** block the S3 upload of posthog-js dist files

In a future change it probably makes sense to look at moving the toolbar into this repo.

### Job dependency graph

```
version-bump
  ├── build-s3-artifacts (posthog-js dist/*.js)
  ├── build-toolbar      (posthog/posthog toolbar.js)  ← NEW
  ├── publish            (npm)
  └──→ upload-s3         (waits for both build jobs, merges artifacts, uploads)
```

### Libraries affected

- None — this is a CI-only change (no library code modified)

## Checklist

- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size