### PR TITLE
fix: add static/ prefix to S3 upload path

### DIFF
--- a/.github/scripts/upload-posthog-js-s3.sh
+++ b/.github/scripts/upload-posthog-js-s3.sh
@@ -27,8 +27,8 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-][a-zA-Z0-9.]+)?$ ]]; then
     exit 1
 fi
 
-echo "==> Uploading posthog-js v$VERSION to s3://$BUCKET/$VERSION/"
-aws s3 cp "$DIST_DIR/" "s3://$BUCKET/$VERSION/" \
+echo "==> Uploading posthog-js v$VERSION to s3://$BUCKET/static/$VERSION/"
+aws s3 cp "$DIST_DIR/" "s3://$BUCKET/static/$VERSION/" \
     --recursive \
     --exclude "*" \
     --include "*.js" \


### PR DESCRIPTION
## Problem

Versioned posthog-js bundles will be served via CDN at `/static/{version}/{file}.js`. The CDN proxies to S3 without rewriting the path, so S3 object keys need the `static/` prefix to match.

The `/static/` prefix ensures versioned asset paths are unambiguously distinguishable from API routes when served through reverse proxies on shared hosts.

## Changes

Upload path in `upload-posthog-js-s3.sh`: `s3://{bucket}/{version}/` → `s3://{bucket}/static/{version}/`

`versions.json` stays at the bucket root — it's private and never served by the CDN.

Companion to [PostHog/posthog#53351](https://github.com/PostHog/posthog/pull/53351) (backend `array_js_path` change).

## Release info Sub-libraries affected

### Libraries affected

None — this is a CI script change only, no library code affected.

## Checklist

- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size