### PR TITLE
feat(replay): property filtering on triggers

### DIFF
--- a/.changeset/early-numbers-mate.md
+++ b/.changeset/early-numbers-mate.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+Account for property filters on events in recording triggers for v2 triggers

--- a/packages/browser/playwright/mocked/session-recording/trigger-groups-v2.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/trigger-groups-v2.spec.ts
@@ -1,0 +1,218 @@
+import { RemoteConfig } from '@/types'
+import { expect, test, WindowWithPostHog } from '../utils/posthog-playwright-test-base'
+import { start, waitForRemoteConfig } from '../utils/setup'
+
+const baseOptions = {
+    options: {
+        session_recording: {
+            compress_events: false,
+        },
+    },
+    flagsResponseOverrides: {
+        sessionRecording: {
+            endpoint: '/ses/',
+        },
+        capturePerformance: true,
+        autocapture_opt_out: true,
+    },
+    url: '/playground/cypress/index.html',
+}
+
+test.describe('V2 Trigger Groups - session rotation', () => {
+    const v2EventTriggerOptions = {
+        ...baseOptions,
+        flagsResponseOverrides: {
+            ...baseOptions.flagsResponseOverrides,
+            sessionRecording: {
+                ...baseOptions.flagsResponseOverrides.sessionRecording,
+                version: 2,
+                triggerGroups: [
+                    {
+                        id: 'g-rot',
+                        name: 'rotation-test',
+                        sampleRate: 1,
+                        conditions: {
+                            matchType: 'all',
+                            events: [{ name: 'purchase' }],
+                        },
+                    },
+                ],
+            } satisfies RemoteConfig['sessionRecording'],
+        },
+    }
+
+    test.beforeEach(async ({ page, context }) => {
+        await page.waitingForNetworkCausedBy({
+            urlPatternsToWaitFor: ['**/*recorder.js*'],
+            action: async () => {
+                await start(v2EventTriggerOptions, page, context)
+            },
+        })
+        await waitForRemoteConfig(page)
+        await page.expectCapturedEventsToBe(['$pageview'])
+        await page.resetCapturedEvents()
+    })
+
+    test('clears trigger activation and re-samples on session rotation', async ({ page }) => {
+        // Verify initial state: buffering (trigger pending, not yet fired)
+        const initialStatus = await page.evaluate(() => {
+            return (window as WindowWithPostHog).posthog?.sessionRecording?.status
+        })
+        expect(initialStatus).toBe('buffering')
+
+        // Capture session A ID
+        const sessionA = await page.evaluate(() => {
+            return (window as WindowWithPostHog).posthog?.sessionRecording?.sessionId
+        })
+
+        // Activate the trigger
+        await page.evaluate(() => {
+            ;(window as WindowWithPostHog).posthog?.capture('purchase')
+        })
+
+        const afterActivate = await page.evaluate(() => {
+            return (window as WindowWithPostHog).posthog?.sessionRecording?.status
+        })
+        expect(afterActivate).toBe('sampled')
+
+        // Force session rotation
+        await page.evaluate(() => {
+            const ph = (window as WindowWithPostHog).posthog
+            ph?.sessionManager?.resetSessionId()
+            // Trigger a capture to force the session manager to issue a new ID
+            ph?.capture('$pageview')
+        })
+        await page.waitForTimeout(500)
+
+        // Verify new session ID
+        const sessionB = await page.evaluate(() => {
+            const ph = (window as WindowWithPostHog).posthog
+            return ph?.sessionManager?.checkAndGetSessionAndWindowId(true).sessionId
+        })
+        expect(sessionB).not.toBe(sessionA)
+
+        // Status should be buffering again — trigger needs to fire in the new session
+        const afterRotation = await page.evaluate(() => {
+            return (window as WindowWithPostHog).posthog?.sessionRecording?.status
+        })
+        expect(afterRotation).toBe('buffering')
+
+        // Activate trigger again in session B
+        await page.evaluate(() => {
+            ;(window as WindowWithPostHog).posthog?.capture('purchase')
+        })
+
+        const afterReactivate = await page.evaluate(() => {
+            return (window as WindowWithPostHog).posthog?.sessionRecording?.status
+        })
+        expect(afterReactivate).toBe('sampled')
+    })
+})
+
+test.describe('V2 Trigger Groups - URL blocklist interaction', () => {
+    const v2UrlTriggerWithBlocklistOptions = {
+        ...baseOptions,
+        flagsResponseOverrides: {
+            ...baseOptions.flagsResponseOverrides,
+            sessionRecording: {
+                ...baseOptions.flagsResponseOverrides.sessionRecording,
+                version: 2,
+                urlBlocklist: [{ url: '/blocked', matching: 'regex' as const }],
+                triggerGroups: [
+                    {
+                        id: 'g-bl',
+                        name: 'blocklist-test',
+                        sampleRate: 1,
+                        conditions: {
+                            matchType: 'any',
+                            urls: [{ url: '/app', matching: 'regex' as const }],
+                        },
+                    },
+                ],
+            } satisfies RemoteConfig['sessionRecording'],
+        },
+    }
+
+    test.beforeEach(async ({ page, context }) => {
+        await page.waitingForNetworkCausedBy({
+            urlPatternsToWaitFor: ['**/*recorder.js*'],
+            action: async () => {
+                await start(v2UrlTriggerWithBlocklistOptions, page, context)
+            },
+        })
+        await waitForRemoteConfig(page)
+        await page.expectCapturedEventsToBe(['$pageview'])
+        await page.resetCapturedEvents()
+    })
+
+    test('pauses on blocklisted URL and resumes with activation intact', async ({ page }) => {
+        // Initial: buffering (URL trigger pending)
+        const initialStatus = await page.evaluate(() => {
+            return (window as WindowWithPostHog).posthog?.sessionRecording?.status
+        })
+        expect(initialStatus).toBe('buffering')
+
+        // Navigate to a URL that matches the trigger
+        await page.evaluate(() => {
+            window.history.pushState({}, '', '/app/dashboard')
+        })
+        await page.locator('[data-cy-input]').fill('activating trigger')
+        await page.waitForTimeout(300)
+
+        const afterActivate = await page.evaluate(() => {
+            return (window as WindowWithPostHog).posthog?.sessionRecording?.status
+        })
+        expect(afterActivate).toBe('sampled')
+
+        // Navigate to a blocklisted URL — should pause
+        await page.evaluate(() => {
+            window.history.pushState({}, '', '/blocked/sensitive-page')
+        })
+        await page.locator('[data-cy-input]').fill('on blocked page')
+        await page.waitForTimeout(300)
+
+        const afterBlocked = await page.evaluate(() => {
+            return (window as WindowWithPostHog).posthog?.sessionRecording?.status
+        })
+        expect(afterBlocked).toBe('paused')
+
+        // Navigate back to a non-blocked URL — should resume as sampled (activation persists)
+        await page.evaluate(() => {
+            window.history.pushState({}, '', '/app/other-page')
+        })
+        await page.locator('[data-cy-input]').fill('back from blocked')
+        await page.waitForTimeout(300)
+
+        const afterResume = await page.evaluate(() => {
+            return (window as WindowWithPostHog).posthog?.sessionRecording?.status
+        })
+        expect(afterResume).toBe('sampled')
+    })
+
+    test('activation persists even when navigating to non-matching, non-blocked URLs', async ({ page }) => {
+        // Activate via URL trigger
+        await page.evaluate(() => {
+            window.history.pushState({}, '', '/app/dashboard')
+        })
+        await page.locator('[data-cy-input]').fill('activate')
+        await page.waitForTimeout(300)
+
+        const activated = await page.evaluate(() => {
+            return (window as WindowWithPostHog).posthog?.sessionRecording?.status
+        })
+        expect(activated).toBe('sampled')
+
+        // Navigate to a URL that matches neither trigger nor blocklist
+        await page.evaluate(() => {
+            window.history.pushState({}, '', '/settings/profile')
+        })
+        await page.locator('[data-cy-input]').fill('on settings')
+        await page.waitForTimeout(300)
+
+        // Should still be sampled — URL trigger activation is sticky for the session
+        const afterNav = await page.evaluate(() => {
+            return (window as WindowWithPostHog).posthog?.sessionRecording?.status
+        })
+        expect(afterNav).toBe('sampled')
+    })
+})

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -4494,6 +4494,223 @@ describe('Lazy SessionRecording', () => {
             expect(sessionRecording['_lazyLoadedSessionRecording']['_isBelowMinimumDuration']()).toBe(false)
         })
 
+        it('blocks event trigger activation when per-event property filters fail', () => {
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                        version: 2,
+                        triggerGroups: [
+                            {
+                                id: 'high-value-errors',
+                                name: 'High Value Errors',
+                                sampleRate: 1.0,
+                                conditions: {
+                                    matchType: 'any',
+                                    events: [
+                                        {
+                                            name: 'purchase_error',
+                                            properties: [
+                                                { key: 'amount', type: 'event', operator: 'gt', value: '100' },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                })
+            )
+
+            expect(sessionRecording.status).toBe('buffering')
+
+            // Event name matches but property filter fails
+            simpleEventEmitter.emit('eventCaptured', { event: 'purchase_error', properties: { amount: 50 } })
+            expect(sessionRecording.status).toBe('buffering')
+
+            // Event name matches and property filter passes
+            simpleEventEmitter.emit('eventCaptured', { event: 'purchase_error', properties: { amount: 200 } })
+            expect(sessionRecording.status).toBe('sampled')
+        })
+
+        it('treats multiple same-name event entries as a disjunction of property filters', () => {
+            // Regression: A group may list the same event name twice with different property
+            // filters to express OR between clauses (e.g. "purchase amount > 100" OR
+            // "purchase by a VIP"). An earlier .find()-based implementation only ever
+            // evaluated the first clause, making subsequent same-name entries unreachable.
+            posthog.persistence?.register({ $stored_person_properties: { tier: 'vip' } })
+
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                        version: 2,
+                        triggerGroups: [
+                            {
+                                id: 'high-value-or-vip',
+                                name: 'High Value Or VIP Purchases',
+                                sampleRate: 1.0,
+                                conditions: {
+                                    matchType: 'any',
+                                    events: [
+                                        {
+                                            name: 'purchase',
+                                            properties: [
+                                                { key: 'amount', type: 'event', operator: 'gt', value: '100' },
+                                            ],
+                                        },
+                                        {
+                                            name: 'purchase',
+                                            properties: [
+                                                { key: 'tier', type: 'person', operator: 'exact', value: 'vip' },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                })
+            )
+
+            expect(sessionRecording.status).toBe('buffering')
+
+            // First clause (amount > 100) fails, but second clause (tier = vip) matches.
+            // With .find() the first entry would be chosen and the group would never activate.
+            simpleEventEmitter.emit('eventCaptured', { event: 'purchase', properties: { amount: 50 } })
+            expect(sessionRecording.status).toBe('sampled')
+        })
+
+        it('does not activate when all same-name event clauses fail', () => {
+            // Companion regression: when no same-name clause passes, activation is still blocked.
+            posthog.persistence?.register({ $stored_person_properties: { tier: 'free' } })
+
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                        version: 2,
+                        triggerGroups: [
+                            {
+                                id: 'high-value-or-vip',
+                                name: 'High Value Or VIP Purchases',
+                                sampleRate: 1.0,
+                                conditions: {
+                                    matchType: 'any',
+                                    events: [
+                                        {
+                                            name: 'purchase',
+                                            properties: [
+                                                { key: 'amount', type: 'event', operator: 'gt', value: '100' },
+                                            ],
+                                        },
+                                        {
+                                            name: 'purchase',
+                                            properties: [
+                                                { key: 'tier', type: 'person', operator: 'exact', value: 'vip' },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                })
+            )
+
+            expect(sessionRecording.status).toBe('buffering')
+
+            // Neither clause matches: amount is 50 (< 100) and tier is free (not vip).
+            simpleEventEmitter.emit('eventCaptured', { event: 'purchase', properties: { amount: 50 } })
+            expect(sessionRecording.status).toBe('buffering')
+
+            // A later event that matches the second clause should still activate.
+            posthog.persistence?.register({ $stored_person_properties: { tier: 'vip' } })
+            simpleEventEmitter.emit('eventCaptured', { event: 'purchase', properties: { amount: 50 } })
+            expect(sessionRecording.status).toBe('sampled')
+        })
+
+        it('blocks trigger activation when group-level property filters fail', () => {
+            // Set person properties
+            posthog.persistence?.register({ $stored_person_properties: { country: 'DE' } })
+
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                        version: 2,
+                        triggerGroups: [
+                            {
+                                id: 'us-only',
+                                name: 'US Only',
+                                sampleRate: 1.0,
+                                conditions: {
+                                    matchType: 'any',
+                                    events: [{ name: '$exception' }],
+                                    properties: [{ key: 'country', type: 'person', operator: 'exact', value: 'US' }],
+                                },
+                            },
+                        ],
+                    },
+                })
+            )
+
+            expect(sessionRecording.status).toBe('buffering')
+
+            // Event name matches but group-level person property fails (country is DE, not US)
+            simpleEventEmitter.emit('eventCaptured', { event: '$exception' })
+            expect(sessionRecording.status).toBe('buffering')
+
+            // Update person properties to US
+            posthog.persistence?.register({ $stored_person_properties: { country: 'US' } })
+
+            // Now it should match
+            simpleEventEmitter.emit('eventCaptured', { event: '$exception' })
+            expect(sessionRecording.status).toBe('sampled')
+        })
+
+        it('checks both group-level and per-event properties (both must pass)', () => {
+            posthog.persistence?.register({ $stored_person_properties: { country: 'US' } })
+
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                        version: 2,
+                        triggerGroups: [
+                            {
+                                id: 'us-high-value',
+                                name: 'US High Value',
+                                sampleRate: 1.0,
+                                conditions: {
+                                    matchType: 'any',
+                                    events: [
+                                        {
+                                            name: 'purchase',
+                                            properties: [
+                                                { key: 'amount', type: 'event', operator: 'gt', value: '100' },
+                                            ],
+                                        },
+                                    ],
+                                    properties: [{ key: 'country', type: 'person', operator: 'exact', value: 'US' }],
+                                },
+                            },
+                        ],
+                    },
+                })
+            )
+
+            expect(sessionRecording.status).toBe('buffering')
+
+            // Group passes (US) but per-event fails (amount 50)
+            simpleEventEmitter.emit('eventCaptured', { event: 'purchase', properties: { amount: 50 } })
+            expect(sessionRecording.status).toBe('buffering')
+
+            // Both pass
+            simpleEventEmitter.emit('eventCaptured', { event: 'purchase', properties: { amount: 200 } })
+            expect(sessionRecording.status).toBe('sampled')
+        })
+
         it('stops checking triggers after initial buffer flush (performance optimization)', () => {
             sessionRecording.onRemoteConfig(
                 makeFlagsResponse({

--- a/packages/browser/src/__tests__/extensions/replay/triggerGroups.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/triggerGroups.test.ts
@@ -15,11 +15,13 @@ import {
     PAUSED,
 } from '../../../extensions/replay/external/triggerMatching'
 import { SessionRecordingTriggerGroup } from '../../../types'
+import { matchTriggerPropertyFilters } from '../../../utils/property-utils'
 import { createMockPostHog } from '../../helpers/posthog-instance'
 
 const fakePostHog = createMockPostHog({
     register_for_session: () => {},
     onFeatureFlags: () => () => {}, // Returns cleanup function
+    get_property: () => undefined,
 })
 
 // Shared test helper: Creates a mock TriggerGroupMatching with optional overrides
@@ -121,6 +123,267 @@ describe('V2 Trigger Groups', () => {
 
             const matcher = new TriggerGroupMatching(fakePostHog, group, () => {})
             expect(matcher.group.minDurationMs).toBe(0)
+        })
+    })
+
+    describe('matchTriggerPropertyFilters', () => {
+        it('returns true when no filters are provided', () => {
+            expect(matchTriggerPropertyFilters(undefined, {}, {})).toBe(true)
+            expect(matchTriggerPropertyFilters([], {}, {})).toBe(true)
+        })
+
+        it('matches event property with exact operator', () => {
+            const filters = [{ key: 'amount', type: 'event' as const, operator: 'exact' as const, value: '100' }]
+            expect(matchTriggerPropertyFilters(filters, { amount: '100' }, {})).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { amount: '200' }, {})).toBe(false)
+        })
+
+        it('matches person property with exact operator', () => {
+            const filters = [{ key: 'country', type: 'person' as const, operator: 'exact' as const, value: 'US' }]
+            expect(matchTriggerPropertyFilters(filters, {}, { country: 'US' })).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { country: 'US' }, {})).toBe(false) // wrong source
+        })
+
+        it('matches with icontains operator', () => {
+            const filters = [{ key: 'path', type: 'event' as const, operator: 'icontains' as const, value: 'checkout' }]
+            expect(matchTriggerPropertyFilters(filters, { path: '/CHECKOUT/step-1' }, {})).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { path: '/settings' }, {})).toBe(false)
+        })
+
+        it('matches with gt operator', () => {
+            const filters = [{ key: 'amount', type: 'event' as const, operator: 'gt' as const, value: '100' }]
+            expect(matchTriggerPropertyFilters(filters, { amount: 200 }, {})).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { amount: 50 }, {})).toBe(false)
+        })
+
+        it('matches with regex operator', () => {
+            const filters = [{ key: 'url', type: 'event' as const, operator: 'regex' as const, value: '^/checkout/.*' }]
+            expect(matchTriggerPropertyFilters(filters, { url: '/checkout/step-1' }, {})).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { url: '/settings' }, {})).toBe(false)
+        })
+
+        it('ANDs multiple filters together', () => {
+            const filters = [
+                { key: 'amount', type: 'event' as const, operator: 'gt' as const, value: '100' },
+                { key: 'country', type: 'person' as const, operator: 'exact' as const, value: 'US' },
+            ]
+            expect(matchTriggerPropertyFilters(filters, { amount: 200 }, { country: 'US' })).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { amount: 200 }, { country: 'UK' })).toBe(false) // person fails
+            expect(matchTriggerPropertyFilters(filters, { amount: 50 }, { country: 'US' })).toBe(false) // event fails
+        })
+
+        it('ORs multiple values within a single exact filter', () => {
+            const filters = [
+                { key: 'country', type: 'person' as const, operator: 'exact' as const, value: ['US', 'UK'] },
+            ]
+            expect(matchTriggerPropertyFilters(filters, {}, { country: 'US' })).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, {}, { country: 'UK' })).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, {}, { country: 'DE' })).toBe(false)
+        })
+
+        it('ORs multiple values within a single icontains filter', () => {
+            const filters = [
+                {
+                    key: '$current_url',
+                    type: 'event' as const,
+                    operator: 'icontains' as const,
+                    value: ['checkout.acme.com', 'payments.acme.com'],
+                },
+            ]
+            expect(matchTriggerPropertyFilters(filters, { $current_url: 'https://checkout.acme.com/step-1' }, {})).toBe(
+                true
+            )
+            expect(
+                matchTriggerPropertyFilters(filters, { $current_url: 'https://payments.acme.com/confirm' }, {})
+            ).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { $current_url: 'https://settings.acme.com' }, {})).toBe(false)
+        })
+
+        it('ANDs multiple filters with array values (authorized URLs + country)', () => {
+            const filters = [
+                {
+                    key: '$current_url',
+                    type: 'event' as const,
+                    operator: 'icontains' as const,
+                    value: ['checkout.acme.com', 'payments.acme.com'],
+                },
+                { key: 'country', type: 'person' as const, operator: 'exact' as const, value: ['US', 'UK'] },
+            ]
+            // URL matches and country matches
+            expect(
+                matchTriggerPropertyFilters(
+                    filters,
+                    { $current_url: 'https://checkout.acme.com/cart' },
+                    { country: 'US' }
+                )
+            ).toBe(true)
+            // URL matches but country doesn't
+            expect(
+                matchTriggerPropertyFilters(
+                    filters,
+                    { $current_url: 'https://checkout.acme.com/cart' },
+                    { country: 'DE' }
+                )
+            ).toBe(false)
+            // Country matches but URL doesn't
+            expect(
+                matchTriggerPropertyFilters(filters, { $current_url: 'https://settings.acme.com' }, { country: 'US' })
+            ).toBe(false)
+        })
+
+        it('returns false when property is missing', () => {
+            const filters = [{ key: 'amount', type: 'event' as const, operator: 'exact' as const, value: '100' }]
+            expect(matchTriggerPropertyFilters(filters, {}, {})).toBe(false)
+        })
+
+        it('returns true when property is missing for is_not (absence satisfies negation)', () => {
+            const filters = [{ key: 'region', type: 'event' as const, operator: 'is_not' as const, value: 'EU' }]
+            // missing event property — "not EU" is satisfied because there's nothing to equal EU
+            expect(matchTriggerPropertyFilters(filters, {}, {})).toBe(true)
+            // still rejects when the property IS present and matches the excluded value
+            expect(matchTriggerPropertyFilters(filters, { region: 'EU' }, {})).toBe(false)
+            // and accepts a present non-matching value
+            expect(matchTriggerPropertyFilters(filters, { region: 'US' }, {})).toBe(true)
+        })
+
+        it('returns true when property is explicitly null for is_not', () => {
+            const filters = [{ key: 'region', type: 'event' as const, operator: 'is_not' as const, value: 'EU' }]
+            expect(matchTriggerPropertyFilters(filters, { region: null } as any, {})).toBe(true)
+        })
+
+        it('returns true when property is missing for not_icontains', () => {
+            const filters = [
+                { key: 'path', type: 'event' as const, operator: 'not_icontains' as const, value: 'checkout' },
+            ]
+            expect(matchTriggerPropertyFilters(filters, {}, {})).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { path: '/CHECKOUT/step-1' }, {})).toBe(false)
+            expect(matchTriggerPropertyFilters(filters, { path: '/settings' }, {})).toBe(true)
+        })
+
+        it('returns true when property is missing for not_regex', () => {
+            const filters = [
+                { key: 'url', type: 'event' as const, operator: 'not_regex' as const, value: '^/checkout/.*' },
+            ]
+            expect(matchTriggerPropertyFilters(filters, {}, {})).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { url: '/checkout/step-1' }, {})).toBe(false)
+            expect(matchTriggerPropertyFilters(filters, { url: '/settings' }, {})).toBe(true)
+        })
+
+        it('returns true when person property is missing for is_not', () => {
+            const filters = [{ key: 'country', type: 'person' as const, operator: 'is_not' as const, value: 'US' }]
+            // no person properties at all
+            expect(matchTriggerPropertyFilters(filters, {}, {})).toBe(true)
+            // present and matching the excluded value
+            expect(matchTriggerPropertyFilters(filters, {}, { country: 'US' })).toBe(false)
+        })
+
+        it('returns true when property is missing for is_not with an array filter value', () => {
+            const filters = [
+                { key: 'country', type: 'person' as const, operator: 'is_not' as const, value: ['US', 'UK'] },
+            ]
+            // missing — the person is "not in US/UK" because they have no country at all
+            expect(matchTriggerPropertyFilters(filters, {}, {})).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, {}, { country: 'DE' })).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, {}, { country: 'US' })).toBe(false)
+            expect(matchTriggerPropertyFilters(filters, {}, { country: 'UK' })).toBe(false)
+        })
+
+        it('ANDs a positive filter with an is_not filter where the is_not prop is missing', () => {
+            const filters = [
+                { key: 'amount', type: 'event' as const, operator: 'gt' as const, value: '100' },
+                { key: 'region', type: 'event' as const, operator: 'is_not' as const, value: 'EU' },
+            ]
+            // gt passes + region missing → "not EU" satisfied → overall match
+            expect(matchTriggerPropertyFilters(filters, { amount: 200 }, {})).toBe(true)
+            // gt fails → overall rejected regardless of region
+            expect(matchTriggerPropertyFilters(filters, { amount: 50 }, {})).toBe(false)
+            // gt passes + region = EU → is_not rejects → overall rejected
+            expect(matchTriggerPropertyFilters(filters, { amount: 200, region: 'EU' }, {})).toBe(false)
+        })
+
+        it('defaults to exact when operator is not provided', () => {
+            const filters = [{ key: 'status', type: 'event' as const, value: 'error' }]
+            expect(matchTriggerPropertyFilters(filters, { status: 'error' }, {})).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { status: 'ok' }, {})).toBe(false)
+        })
+
+        it('matches when event property is an array and filter value matches any element', () => {
+            const filters = [{ key: 'tags', type: 'event' as const, operator: 'exact' as const, value: 'premium' }]
+            expect(matchTriggerPropertyFilters(filters, { tags: ['premium', 'vip'] }, {})).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { tags: ['basic', 'trial'] }, {})).toBe(false)
+        })
+
+        it('matches array property against array filter values', () => {
+            const filters = [
+                { key: 'tags', type: 'event' as const, operator: 'exact' as const, value: ['premium', 'enterprise'] },
+            ]
+            expect(matchTriggerPropertyFilters(filters, { tags: ['premium', 'vip'] }, {})).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { tags: ['enterprise'] }, {})).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, { tags: ['basic', 'trial'] }, {})).toBe(false)
+        })
+
+        it('matches array person property with icontains', () => {
+            const filters = [{ key: 'roles', type: 'person' as const, operator: 'icontains' as const, value: 'admin' }]
+            expect(matchTriggerPropertyFilters(filters, {}, { roles: ['Admin', 'User'] })).toBe(true)
+            expect(matchTriggerPropertyFilters(filters, {}, { roles: ['User', 'Guest'] })).toBe(false)
+        })
+    })
+
+    describe('Event trigger property evaluation', () => {
+        it('activates when event name matches and no properties', () => {
+            const group: SessionRecordingTriggerGroup = {
+                id: 'test',
+                name: 'Test',
+                sampleRate: 1.0,
+                conditions: {
+                    matchType: 'any',
+                    events: [{ name: 'purchase' }],
+                },
+            }
+
+            const matcher = new TriggerGroupMatching(fakePostHog, group, () => {})
+            const onActivate = jest.fn()
+            matcher.checkEventTriggerConditions('purchase', onActivate, 'session-1')
+            expect(onActivate).toHaveBeenCalledWith('event', 'purchase')
+        })
+
+        it('does not activate when event name does not match', () => {
+            const group: SessionRecordingTriggerGroup = {
+                id: 'test',
+                name: 'Test',
+                sampleRate: 1.0,
+                conditions: {
+                    matchType: 'any',
+                    events: [{ name: 'purchase' }],
+                },
+            }
+
+            const matcher = new TriggerGroupMatching(fakePostHog, group, () => {})
+            const onActivate = jest.fn()
+            matcher.checkEventTriggerConditions('pageview', onActivate, 'session-1')
+            expect(onActivate).not.toHaveBeenCalled()
+        })
+
+        it('activates on event name match regardless of properties (property filtering is in the strategy)', () => {
+            const group: SessionRecordingTriggerGroup = {
+                id: 'test',
+                name: 'Test',
+                sampleRate: 1.0,
+                conditions: {
+                    matchType: 'any',
+                    events: [
+                        {
+                            name: 'purchase',
+                            properties: [{ key: 'amount', type: 'event', operator: 'gt', value: '100' }],
+                        },
+                    ],
+                },
+            }
+
+            const matcher = new TriggerGroupMatching(fakePostHog, group, () => {})
+            const onActivate = jest.fn()
+            matcher.checkEventTriggerConditions('purchase', onActivate, 'session-1')
+            expect(onActivate).toHaveBeenCalledWith('event', 'purchase')
         })
     })
 

--- a/packages/browser/src/extensions/replay/external/recording-strategies.ts
+++ b/packages/browser/src/extensions/replay/external/recording-strategies.ts
@@ -13,6 +13,7 @@ import {
     SESSION_RECORDING_TRIGGER_V2_GROUP_EVENT_PREFIX,
     SESSION_RECORDING_TRIGGER_V2_GROUP_URL_PREFIX,
     SESSION_RECORDING_TRIGGER_V2_GROUP_SAMPLING_PREFIX,
+    STORED_PERSON_PROPERTIES_KEY,
 } from '../../../constants'
 import {
     EventTriggerMatching,
@@ -33,6 +34,7 @@ import {
 import { sampleOnProperty } from '../../sampling'
 import { isBoolean, isNull, isNullish, isNumber } from '@posthog/core'
 import { createLogger } from '../../../utils/logger'
+import { matchTriggerPropertyFilters } from '../../../utils/property-utils'
 
 const logger = createLogger('[SessionRecording]')
 
@@ -370,9 +372,12 @@ export class V2TriggerGroupStrategy implements RecordingStrategy {
                 onPause,
                 onResume,
                 (triggerType) => {
-                    // Use per-group activation instead of global V1 _activateTrigger
+                    // Check group-level property filters before activating
+                    if (!this._checkGroupLevelProperties(matcher, undefined)) {
+                        return
+                    }
+
                     matcher.activateTrigger(triggerType, sessionId)
-                    // Update session properties after activation
                     this.updateActiveTriggers(sessionId)
                 },
                 sessionId
@@ -403,6 +408,31 @@ export class V2TriggerGroupStrategy implements RecordingStrategy {
                     matcher.checkEventTriggerConditions(
                         event.event,
                         (triggerType) => {
+                            // Check group-level property filters
+                            if (!this._checkGroupLevelProperties(matcher, event.properties)) {
+                                return
+                            }
+
+                            // Check per-event property filters.
+                            // A group may contain multiple entries for the same event name with
+                            // different property filters — e.g. "purchase amount > 100" OR
+                            // "purchase by a VIP". Treat same-name entries as a disjunction:
+                            // activate if *any* matching clause's filters pass. An entry with no
+                            // properties is treated as an unconditional match (matching V1).
+                            const matchedTriggers = (matcher.group.conditions.events || []).filter(
+                                (t) => t.name === event.event
+                            )
+                            const personProperties = this._instance.get_property(STORED_PERSON_PROPERTIES_KEY)
+                            const anyMatched = matchedTriggers.some(
+                                (t) =>
+                                    !t.properties ||
+                                    t.properties.length === 0 ||
+                                    matchTriggerPropertyFilters(t.properties, event.properties, personProperties)
+                            )
+                            if (!anyMatched) {
+                                return
+                            }
+
                             matcher.activateTrigger(triggerType, sessionId)
                             this.updateActiveTriggers(sessionId)
                         },
@@ -519,6 +549,18 @@ export class V2TriggerGroupStrategy implements RecordingStrategy {
         this._triggerGroupMatchers = []
         this._triggerGroupSamplingResults.clear()
         this._urlTriggerMatching.stop()
+    }
+
+    private _checkGroupLevelProperties(
+        matcher: TriggerGroupMatching,
+        eventProperties: Record<string, any> | undefined
+    ): boolean {
+        const groupProperties = matcher.group.conditions.properties
+        if (!groupProperties || groupProperties.length === 0) {
+            return true
+        }
+        const personProperties = this._instance.get_property(STORED_PERSON_PROPERTIES_KEY)
+        return matchTriggerPropertyFilters(groupProperties, eventProperties, personProperties)
     }
 
     private _setupTriggerGroups(groups: SessionRecordingTriggerGroup[]) {

--- a/packages/browser/src/extensions/replay/external/triggerMatching.ts
+++ b/packages/browser/src/extensions/replay/external/triggerMatching.ts
@@ -338,7 +338,7 @@ export class URLTriggerMatching implements TriggerStatusMatching {
             onResume()
         }
 
-        // Check URL triggers (V1 only - V2 handles per-group)
+        // Check URL triggers
         const isActivated = this._urlTriggerStatus(sessionId) === TRIGGER_ACTIVATED
         const urlMatches = sessionRecordingUrlTriggerMatches(url, this._urlTriggers, this._compiledTriggerRegexes)
 
@@ -528,7 +528,7 @@ export class TriggerGroupMatching implements TriggerStatusMatching {
             this._combinedMatching = new AlwaysActivatedTriggerMatching()
         } else {
             // V2: Events arrive as objects {name, properties?} from the server.
-            // Extract just the names for now — property filter evaluation comes later.
+            // Extract just the names — property filter evaluation is handled by the strategy.
             const eventNames = (group.conditions.events || []).map((e) => e.name)
 
             // Convert group config to the format expected by the individual matchers
@@ -536,7 +536,7 @@ export class TriggerGroupMatching implements TriggerStatusMatching {
                 urlTriggers: group.conditions.urls || [],
                 eventTriggers: eventNames,
                 linkedFlag: group.conditions.flag || null,
-                urlBlocklist: [], // groups don't have blocklist
+                urlBlocklist: [],
             }
 
             this._urlTriggerMatching.onConfig(config)

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -552,6 +552,7 @@ export interface SessionRecordingTriggerGroup {
         events?: SessionRecordingEventTrigger[]
         urls?: SessionRecordingUrlTrigger[]
         flag?: string | FlagVariant
+        properties?: SessionRecordingTriggerPropertyFilter[]
     }
 }
 

--- a/packages/browser/src/utils/property-utils.ts
+++ b/packages/browser/src/utils/property-utils.ts
@@ -1,7 +1,7 @@
-import { isNull, isUndefined } from '@posthog/core'
+import { isArray, isNull, isUndefined } from '@posthog/core'
 import { jsonStringify } from '../request'
 import { PropertyFilters, PropertyOperator } from '../posthog-surveys-types'
-import type { Properties } from '../types'
+import type { Properties, SessionRecordingTriggerPropertyFilter } from '../types'
 import { isMatchingRegex } from './regex-utils'
 
 export function getPersonPropertiesHash(
@@ -34,6 +34,55 @@ export const propertyComparisons: Record<PropertyOperator, (targets: string[], v
 }
 
 const toLowerCase = (v: string): string => v.toLowerCase()
+
+// Operators whose semantics mean "property is not X". When the property being
+// filtered on is missing or null, these match — absence of the property
+// satisfies a "not equal to X" check. This aligns with how PostHog's feature
+// flag matchers (posthog/queries/base.py, rust/feature-flags) treat missing
+// properties for negative operators.
+const NEGATIVE_OPERATORS: ReadonlySet<string> = new Set(['is_not', 'not_icontains', 'not_regex'])
+
+/**
+ * Evaluate trigger property filters (WHERE clauses) against event and person properties.
+ * All filters must match (implicit AND). Returns true if no filters are present.
+ */
+export function matchTriggerPropertyFilters(
+    filters: SessionRecordingTriggerPropertyFilter[] | undefined,
+    eventProperties: Properties | undefined,
+    personProperties: Properties | undefined
+): boolean {
+    if (!filters || filters.length === 0) {
+        return true
+    }
+
+    return filters.every((filter) => {
+        const source = filter.type === 'person' ? personProperties : eventProperties
+        const propertyValue = source?.[filter.key]
+        const operator = filter.operator || 'exact'
+
+        // Missing or null property: for negative operators, absence counts as a
+        // match (nothing can't equal EU, so "is_not EU" is satisfied). For
+        // positive operators, we can't confirm a match without a value.
+        if (isUndefined(propertyValue) || isNull(propertyValue)) {
+            return NEGATIVE_OPERATORS.has(operator)
+        }
+
+        const comparisonFunction = propertyComparisons[operator as PropertyOperator]
+        if (!comparisonFunction) {
+            return false
+        }
+
+        if (isUndefined(filter.value) || isNull(filter.value)) {
+            return false
+        }
+
+        // Normalize filter value and property value to string arrays for comparison
+        const targetValues = isArray(filter.value) ? filter.value.map(String) : [String(filter.value)]
+        const actualValues = isArray(propertyValue) ? propertyValue.map(String) : [String(propertyValue)]
+
+        return comparisonFunction(targetValues, actualValues)
+    })
+}
 
 export function matchPropertyFilters(
     propertyFilters: PropertyFilters | undefined,

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -55,6 +55,7 @@
         "_checkClickTimer",
         "_checkClicks",
         "_checkFlags",
+        "_checkGroupLevelProperties",
         "_checkInterval",
         "_checkLocalStorageForDebug",
         "_checkOverride",


### PR DESCRIPTION
## Problem

we want to allow more flexibility and allow for "WHERE" clauses, or basically just property filtering (ie, EVENT where path=foo)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes  
  
NOTE: 

I implemented "group level" properties but dont plan on exposing it in the UI for a while because theres some funkiness to it.   
  
Logic flow:   
 Event captured  
→ For each trigger group:  
    → Does event name match any event trigger in this group?   
        → Yes → Check group-level property filters (AND logic across all filters)  
              → Pass → Check per-event property filters for the matched event trigger  
                  → Pass → Activate this group's trigger (persisted per-group)  
                  → Fail → Skip activation  
              → Fail → Skip activation  
        → No → Skip     

matchTriggerPropertyFilters does the actual comparison. It:

- Routes each filter to the right property source based on filter.type ('event' or 'person')
- ANDs all filters together (every filter must match, ie "path contains x" and "path doesnt contain y" must match all)
- ORs multiple values within a single filter (any value can match, ie "path contains x, y, z" can match on any of those)
- Handles array-valued properties by normalizing both sides to string arrays
- Delegates to the existing propertyComparisons operators (exact, icontains, regex, gt, lt, etc.)

:star2::warning: Person properties come from STORED_PERSON_PROPERTIES_KEY in persistence, They're not fetched on demand, so there's a timing gap on initial page load before they're available, and could possibly be "stale" later

see screen recording for testing locally. Conditions: 

![Screenshot 2026-04-08 at 4.24.38 PM.png](https://app.graphite.com/user-attachments/assets/d57638e3-eaec-45b7-a782-79982d1b0f62.png)

see via screen recording that recording does NOT start when i visit trigger flag (768) but DOES start when i visit Wizard flag (not contains 768) [trigger_conditons_2_conditions.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/7d691b5f-df88-47f7-808f-eb3e8e02abda.mov" />](https://app.graphite.com/user-attachments/video/7d691b5f-df88-47f7-808f-eb3e8e02abda.mov)

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->