### PR TITLE
chore(surveys): expose current question index on survey-box

### DIFF
--- a/.changeset/surveys-expose-question-index.md
+++ b/.changeset/surveys-expose-question-index.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Expose the current question index on `.survey-box` via a `data-question-index` attribute. This gives consumers rendering surveys via the API a reliable way to know which question is currently displayed without parsing input ids or class names — works for every question type, including link questions which render no input or rating element.

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -598,6 +598,18 @@ describe('SurveyManager', () => {
             const descriptionElement = surveyDiv.querySelector('.survey-question-description')
             expect(descriptionElement).not.toBeNull()
         })
+
+        it('exposes the current question index on .survey-box for embedders', () => {
+            // Embedders rendering surveys via the API (e.g. the standalone hosted survey page)
+            // need a reliable way to know which question is currently displayed so they can drive
+            // their own progress UI. Reading data-question-index works for every question type,
+            // including link questions which render no input/rating element.
+            const surveyDiv = document.createElement('div')
+            surveyManager.renderSurvey(mockSurvey, surveyDiv)
+            const surveyBox = surveyDiv.querySelector('.survey-box')
+            expect(surveyBox).not.toBeNull()
+            expect(surveyBox?.getAttribute('data-question-index')).toBe('0')
+        })
     })
 
     describe('renderSurvey with URL prefill that completes the survey', () => {

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -610,6 +610,41 @@ describe('SurveyManager', () => {
             expect(surveyBox).not.toBeNull()
             expect(surveyBox?.getAttribute('data-question-index')).toBe('0')
         })
+
+        it('updates data-question-index when navigating to the next question', async () => {
+            const multiQuestionSurvey = {
+                ...mockSurvey,
+                questions: [
+                    {
+                        id: 'q1',
+                        question: 'Question 1',
+                        type: SurveyQuestionType.Open,
+                        optional: true,
+                    },
+                    {
+                        id: 'q2',
+                        question: 'Question 2',
+                        type: SurveyQuestionType.Open,
+                        optional: true,
+                    },
+                ],
+            } as unknown as Survey
+
+            const surveyDiv = document.createElement('div')
+            document.body.appendChild(surveyDiv)
+            surveyManager.renderSurvey(multiQuestionSurvey, surveyDiv)
+
+            expect(surveyDiv.querySelector('.survey-box')?.getAttribute('data-question-index')).toBe('0')
+
+            const submitButton = surveyDiv.querySelector<HTMLButtonElement>('.form-submit')
+            await act(async () => {
+                fireEvent.click(submitButton!)
+            })
+
+            expect(surveyDiv.querySelector('.survey-box')?.getAttribute('data-question-index')).toBe('1')
+
+            document.body.removeChild(surveyDiv)
+        })
     })
 
     describe('renderSurvey with URL prefill that completes the survey', () => {

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -1290,7 +1290,7 @@ export function Questions({
                     }}
                 />
             )}
-            <div className="survey-box">
+            <div className="survey-box" data-question-index={currentQuestionIndex}>
                 {getQuestionComponent({
                     question: currentQuestion,
                     forceDisableHtml,


### PR DESCRIPTION
## Summary
- Adds a `data-question-index` attribute to the `.survey-box` wrapper so consumers rendering surveys via the API can reliably tell which question is currently displayed.
- Works for every question type, including link questions which render no input or rating element.

## Test plan
- [x] Unit test added in `surveys.test.ts` covering the new attribute
- [x] Manually verify the attribute updates when navigating between questions