### PR TITLE
fix: re-evaluate persistent store when config changes

### DIFF
--- a/.changeset/old-plums-bow.md
+++ b/.changeset/old-plums-bow.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Re-evaluate consent persistent store when config changes to support cross-subdomain consent sharing

--- a/packages/browser/src/__tests__/consent.test.ts
+++ b/packages/browser/src/__tests__/consent.test.ts
@@ -301,4 +301,37 @@ describe('consentManager', () => {
             })
         }
     )
+
+    describe('consent storage cache invalidation', () => {
+        it('should write consent to cookie when opt_out_capturing_persistence_type is cookie, even if consent was accessed before init', async () => {
+            // Simulate the bug: the primary instance's consent._storage is accessed
+            // before init() is called (this happens in bundled apps where _dom_loaded()
+            // fires during module load, before the user calls posthog.init()).
+            const ph = new PostHog()
+
+            // At this point, ph.config = defaultConfig() which has
+            // opt_out_capturing_persistence_type: 'localStorage'.
+            // Trigger consent._storage initialization with the default config,
+            // simulating what _dom_loaded() -> is_capturing() does.
+            ph.consent.isOptedOut()
+
+            // Now init on the SAME instance (no name = primary instance),
+            // which is what users do: posthog.init(token, config)
+            const token = uuidv7()
+            await new Promise<void>((resolve) =>
+                ph.init(token, {
+                    opt_out_capturing_persistence_type: 'cookie',
+                    request_batching: false,
+                    api_host: 'http://localhost',
+                    loaded: () => resolve(),
+                })
+            )
+
+            ph.opt_out_capturing()
+
+            const consentKey = DEFAULT_PERSISTENCE_PREFIX + token
+            // Consent should be in the cookie, not just in localStorage
+            expect(document!.cookie).toContain(consentKey + '=0')
+        })
+    })
 })

--- a/packages/browser/src/consent.ts
+++ b/packages/browser/src/consent.ts
@@ -93,6 +93,9 @@ export class ConsentManager {
     }
 
     private get _storage() {
+        // Re-evaluate the store on every access so that a config change after the first
+        // access (e.g. init() called after _dom_loaded() fires in bundled apps) is picked
+        // up and any value already stored under the old backend is migrated across.
         const persistenceType = this._config.opt_out_capturing_persistence_type
         const expectedStore = persistenceType === 'localStorage' ? localStore : cookieStore
 

--- a/packages/browser/src/consent.ts
+++ b/packages/browser/src/consent.ts
@@ -93,9 +93,11 @@ export class ConsentManager {
     }
 
     private get _storage() {
-        if (!this._persistentStore) {
-            const persistenceType = this._config.opt_out_capturing_persistence_type
-            this._persistentStore = persistenceType === 'localStorage' ? localStore : cookieStore
+        const persistenceType = this._config.opt_out_capturing_persistence_type
+        const expectedStore = persistenceType === 'localStorage' ? localStore : cookieStore
+
+        if (!this._persistentStore || this._persistentStore !== expectedStore) {
+            this._persistentStore = expectedStore
             const otherStorage = persistenceType === 'localStorage' ? cookieStore : localStore
 
             if (otherStorage._get(this._storageKey)) {


### PR DESCRIPTION
## Problem

When `opt_out_capturing_persistence_type: 'cookie'` is configured, the consent value still gets written to `localStorage` instead of cookies. This breaks cross-subdomain consent sharing when using `cookieless_mode: 'on_reject'`, causing each subdomain to generate a different UUID for the same user.

**Root cause:** When posthog-js loads in a bundled app (webpack, Vite, CRA, etc.), the DOM is already `complete` by the time the module executes. This causes `init_as_module()` → `add_dom_loaded_handler()` → `_dom_loaded()` → `is_capturing()` → `consent._storage` to fire during module initialization, *before* the user calls `posthog.init()`. At that point, the config still has the default `opt_out_capturing_persistence_type: 'localStorage'`, so `_persistentStore` gets cached as `localStore`. When `init()` later sets the config to `'cookie'`, the stale cache means consent always writes to `localStorage` regardless.

This effectively makes `opt_out_capturing_persistence_type: 'cookie'` broken for all bundled apps.

**Customer impact:** https://posthoghelp.zendesk.com/agent/tickets/51789 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/57464)

## Changes

In `consent.ts`, the `_storage` getter now validates that the cached `_persistentStore` matches the expected store based on the current config. If the config has changed (e.g., from default `'localStorage'` to user-configured `'cookie'` after `init()`), the store is re-initialized with the correct backend.

The migration logic (moving consent values between localStorage and cookies) still runs when the store changes, ensuring a smooth transition.

## How was this tested?

- Added a unit test that reproduces the exact bug: accesses `consent.isOptedOut()` before `init()` (simulating `_dom_loaded()`), then calls `init()` with `opt_out_capturing_persistence_type: 'cookie'`. Without the fix, consent writes to localStorage. With the fix, it writes to the cookie.
- Manually tested with a multi-subdomain app (`site.lvh.me` / `sub.site.lvh.me`) confirming same UUID across subdomains after consent.
- All existing consent tests pass.

## Release info

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size