### PR TITLE
fix: add hover state for survey ratings

### DIFF
--- a/.changeset/fair-wombats-kick.md
+++ b/.changeset/fair-wombats-kick.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Add a hover state to numeric survey rating options so they provide clearer pointer feedback before selection.

--- a/packages/browser/src/extensions/surveys/survey.css
+++ b/packages/browser/src/extensions/surveys/survey.css
@@ -516,8 +516,16 @@
         background-color: var(--ph-survey-rating-active-bg-color);
     }
 
-    &:hover {
-        cursor: pointer;
+    cursor: pointer;
+
+    @media (hover: hover) and (pointer: fine) {
+        &:hover:not(.rating-active) {
+            background-color: color-mix(
+                in srgb,
+                var(--ph-survey-rating-active-bg-color) 14%,
+                var(--ph-survey-rating-bg-color)
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add a hover state for numeric survey rating buttons
- use a light mix of the active rating color so hover stays distinct from selected
- add a patch changeset for `posthog-js`

## Testing
- pnpm --filter=posthog-js exec jest --watchman=false src/__tests__/extensions/surveys/question-types.test.tsx