### PR TITLE
chore(ci): send PostHog failure events for version bump and S3 upload jobs

### DIFF
--- a/.github/workflows/posthog-com-upgrade.yml
+++ b/.github/workflows/posthog-com-upgrade.yml
@@ -109,7 +109,7 @@ jobs:
             # https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
             - name: Send failure event to PostHog
               if: ${{ failure() }}
-              uses: PostHog/posthog-github-action@v0.1
+              uses: PostHog/posthog-github-action@v1
               with:
                   posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
                   event: 'posthog-js-github-release-workflow-failure'

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -108,7 +108,7 @@ jobs:
             # https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
             - name: Send failure event to PostHog
               if: ${{ failure() }}
-              uses: PostHog/posthog-github-action@v0.1
+              uses: PostHog/posthog-github-action@v1
               with:
                   posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
                   event: 'posthog-js-github-release-workflow-failure'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,8 +137,22 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
 
+            - name: Send failure event to PostHog
+              if: ${{ failure() }}
+              uses: PostHog/posthog-github-action@v1
+              with:
+                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
+                  event: 'posthog-js-github-release-workflow-failure'
+                  properties: >-
+                      {
+                        "commitSha": "${{ github.sha }}",
+                        "jobStatus": "${{ job.status }}",
+                        "ref": "${{ github.ref }}",
+                        "jobName": "version-bump",
+                        "packageName": "posthog-js"
+                      }
+
             - name: Notify Slack - Failed
-              continue-on-error: true
               if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
               uses: PostHog/.github/.github/actions/slack-thread-reply@main
               with:
@@ -325,7 +339,7 @@ jobs:
             # https://us.posthog.com/project/11213/functions/019ae9c0-03ee-0000-2f32-971f64be8ffe
             - name: Send failure event to PostHog
               if: ${{ failure() }}
-              uses: PostHog/posthog-github-action@v0.1
+              uses: PostHog/posthog-github-action@v1
               with:
                   posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
                   event: 'posthog-js-github-release-workflow-failure'
@@ -592,6 +606,24 @@ jobs:
               env:
                   VERSION: ${{ needs.build-s3-artifacts.outputs.committed-version }}
               run: .github/scripts/upload-posthog-js-s3.sh ${{ matrix.region.bucket }}
+
+            - name: Send failure event to PostHog
+              if: ${{ failure() }}
+              uses: PostHog/posthog-github-action@v1
+              with:
+                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
+                  event: 'posthog-js-github-release-workflow-failure'
+                  properties: >-
+                      {
+                        "commitSha": "${{ github.sha }}",
+                        "jobStatus": "${{ job.status }}",
+                        "ref": "${{ github.ref }}",
+                        "jobName": "upload-s3",
+                        "packageName": "posthog-js",
+                        "packageVersion": "${{ needs.build-s3-artifacts.outputs.committed-version }}",
+                        "region": "${{ matrix.region.name }}",
+                        "bucket": "${{ matrix.region.bucket }}"
+                      }
 
             - name: Notify Slack - S3 Upload Failed
               continue-on-error: true


### PR DESCRIPTION
## Problem

We already send Slack failure notifications for release failures, but not all failing release jobs emit the PostHog failure event used for external alerting and debugging. In particular, `version-bump` and `upload-s3` could fail without the same PostHog event coverage that `publish` already has.

## Changes

- add `Send failure event to PostHog` to the `version-bump` job
- add `Send failure event to PostHog` to the `upload-s3` job
- include job-specific properties like `jobName`, and for S3 uploads also `packageVersion`, `region`, and `bucket`
- align existing workflow usages of `PostHog/posthog-github-action` to `@v1`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
