### PR TITLE
fix(next): pass bootstrap flags via React context to fix SSR hydration

### DIFF
--- a/.changeset/fix-ssr-bootstrap-flags.md
+++ b/.changeset/fix-ssr-bootstrap-flags.md
@@ -1,0 +1,5 @@
+---
+'@posthog/next': patch
+---
+
+fix: pass bootstrap flags via React context so feature flag hooks return correct values during SSR

--- a/packages/next/src/client/ClientPostHogProvider.tsx
+++ b/packages/next/src/client/ClientPostHogProvider.tsx
@@ -47,9 +47,5 @@ export function ClientPostHogProvider({ apiKey, options, bootstrap, children }: 
         posthogJs.init(apiKey, mergedOptions)
     }
 
-    return (
-        <PostHogContext.Provider value={{ client: posthogJs, bootstrap }}>
-            {children}
-        </PostHogContext.Provider>
-    )
+    return <PostHogContext.Provider value={{ client: posthogJs, bootstrap }}>{children}</PostHogContext.Provider>
 }

--- a/packages/next/src/client/ClientPostHogProvider.tsx
+++ b/packages/next/src/client/ClientPostHogProvider.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import posthogJs from 'posthog-js'
-import { PostHogProvider as ReactPostHogProvider } from 'posthog-js/react'
+import { PostHogContext } from 'posthog-js/react'
 import type { BootstrapConfig, PostHogConfig } from 'posthog-js'
 
 export type { BootstrapConfig }
@@ -47,5 +47,9 @@ export function ClientPostHogProvider({ apiKey, options, bootstrap, children }: 
         posthogJs.init(apiKey, mergedOptions)
     }
 
-    return <ReactPostHogProvider client={posthogJs}>{children}</ReactPostHogProvider>
+    return (
+        <PostHogContext.Provider value={{ client: posthogJs, bootstrap }}>
+            {children}
+        </PostHogContext.Provider>
+    )
 }

--- a/packages/next/tests/ClientPostHogProvider.test.tsx
+++ b/packages/next/tests/ClientPostHogProvider.test.tsx
@@ -1,14 +1,7 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { render, screen } from '@testing-library/react'
 import { ClientPostHogProvider } from '../src/client/ClientPostHogProvider'
-
-const mockPostHogProvider = jest.fn(({ children }: { children: React.ReactNode }) => (
-    <div data-testid="posthog-provider">{children}</div>
-))
-jest.mock('posthog-js/react', () => ({
-    PostHogProvider: (props: any) => mockPostHogProvider(props),
-}))
-
+import { PostHogContext, useFeatureFlagEnabled } from 'posthog-js/react'
 import posthogJs from 'posthog-js'
 
 jest.mock('posthog-js', () => ({
@@ -16,14 +9,22 @@ jest.mock('posthog-js', () => ({
     default: {
         __loaded: false,
         init: jest.fn(),
+        isFeatureEnabled: jest.fn(() => undefined),
+        onFeatureFlags: jest.fn(() => () => {}),
     },
 }))
 
 const mockPostHogJs = posthogJs as jest.Mocked<typeof posthogJs> & { __loaded: boolean }
 
+/** Helper component that exposes the PostHogContext value for assertions. */
+function ContextReader({ onContext }: { onContext: (ctx: { client: any; bootstrap?: any }) => void }) {
+    const ctx = useContext(PostHogContext)
+    onContext(ctx)
+    return null
+}
+
 describe('ClientPostHogProvider', () => {
     beforeEach(() => {
-        mockPostHogProvider.mockClear()
         ;(mockPostHogJs.init as jest.Mock).mockClear()
         mockPostHogJs.__loaded = false
     })
@@ -47,13 +48,14 @@ describe('ClientPostHogProvider', () => {
         expect(mockPostHogJs.init).toHaveBeenCalledWith('phc_test123', options)
     })
 
-    it('passes client to upstream provider', () => {
+    it('provides posthog client via context', () => {
+        let contextValue: any
         render(
             <ClientPostHogProvider apiKey="phc_test123">
-                <div>Child</div>
+                <ContextReader onContext={(ctx) => (contextValue = ctx)} />
             </ClientPostHogProvider>
         )
-        expect(mockPostHogProvider).toHaveBeenCalledWith(expect.objectContaining({ client: mockPostHogJs }))
+        expect(contextValue.client).toBe(mockPostHogJs)
     })
 
     it('merges bootstrap into options when provided', () => {
@@ -112,6 +114,30 @@ describe('ClientPostHogProvider', () => {
         )
     })
 
+    it('provides bootstrap via context for SSR hook access', () => {
+        const bootstrap = {
+            featureFlags: { 'flag-a': true, 'flag-b': 'variant-1' },
+            featureFlagPayloads: { 'flag-b': { key: 'value' } },
+        }
+        let contextValue: any
+        render(
+            <ClientPostHogProvider apiKey="phc_test123" bootstrap={bootstrap}>
+                <ContextReader onContext={(ctx) => (contextValue = ctx)} />
+            </ClientPostHogProvider>
+        )
+        expect(contextValue.bootstrap).toEqual(bootstrap)
+    })
+
+    it('context bootstrap is undefined when no bootstrap prop provided', () => {
+        let contextValue: any
+        render(
+            <ClientPostHogProvider apiKey="phc_test123">
+                <ContextReader onContext={(ctx) => (contextValue = ctx)} />
+            </ClientPostHogProvider>
+        )
+        expect(contextValue.bootstrap).toBeUndefined()
+    })
+
     it('does not call init when already loaded', () => {
         mockPostHogJs.__loaded = true
         render(
@@ -120,6 +146,43 @@ describe('ClientPostHogProvider', () => {
             </ClientPostHogProvider>
         )
         expect(mockPostHogJs.init).not.toHaveBeenCalled()
+    })
+
+    it('useFeatureFlagEnabled returns bootstrapped value before client loads flags', () => {
+        // Simulates SSR: posthog-js has no loaded flags, but bootstrap is provided.
+        // The hook should fall back to the bootstrap value from context.
+        const bootstrap = {
+            featureFlags: { 'my-flag': true, 'my-experiment': 'variant-a' },
+        }
+        let flagValue: boolean | undefined
+        function FlagReader() {
+            flagValue = useFeatureFlagEnabled('my-flag')
+            return <div data-testid="flag">{String(flagValue)}</div>
+        }
+        render(
+            <ClientPostHogProvider apiKey="phc_test123" bootstrap={bootstrap}>
+                <FlagReader />
+            </ClientPostHogProvider>
+        )
+        expect(flagValue).toBe(true)
+        expect(screen.getByTestId('flag')).toHaveTextContent('true')
+    })
+
+    it('useFeatureFlagEnabled returns undefined for unknown flag even with bootstrap', () => {
+        const bootstrap = {
+            featureFlags: { 'my-flag': true },
+        }
+        let flagValue: boolean | undefined
+        function FlagReader() {
+            flagValue = useFeatureFlagEnabled('unknown-flag')
+            return null
+        }
+        render(
+            <ClientPostHogProvider apiKey="phc_test123" bootstrap={bootstrap}>
+                <FlagReader />
+            </ClientPostHogProvider>
+        )
+        expect(flagValue).toBeUndefined()
     })
 
     it('renders children and warns when apiKey is empty', () => {

--- a/packages/next/tests/ClientPostHogProvider.test.tsx
+++ b/packages/next/tests/ClientPostHogProvider.test.tsx
@@ -26,6 +26,8 @@ function ContextReader({ onContext }: { onContext: (ctx: { client: any; bootstra
 describe('ClientPostHogProvider', () => {
     beforeEach(() => {
         ;(mockPostHogJs.init as jest.Mock).mockClear()
+        ;(mockPostHogJs.isFeatureEnabled as jest.Mock).mockClear()
+        ;(mockPostHogJs.onFeatureFlags as jest.Mock).mockClear()
         mockPostHogJs.__loaded = false
     })
 


### PR DESCRIPTION
## Problem

Users of `@posthog/next` with Next.js App Router experience hydration errors when using server-evaluated feature flags via the `PostHogProvider`'s bootstrap mechanism.

The root cause: `ClientPostHogProvider` passed the `posthog-js` singleton to `ReactPostHogProvider` via the `client` prop. The React provider reads bootstrap from `client.config.bootstrap`, which is only populated after `init()` runs. Since `init()` is guarded by a `typeof window` check (browser-only), bootstrap was always `undefined` during SSR causing feature flag hooks like `useFeatureFlagEnabled` to return `undefined` on the server but real values on the client, resulting in hydration mismatches.

Based on the investigation in #3268. Thanks to @firstarcprime for identifying the issue.

## Changes

- **`ClientPostHogProvider`**: Use `PostHogContext.Provider` directly instead of wrapping with `ReactPostHogProvider`. This passes bootstrap as a context value so hooks can read bootstrapped flag values during SSR without needing `init()` to have run. The eager `init()` during render (client-side only) is preserved unchanged.
- **Tests**: Added end-to-end tests that render `useFeatureFlagEnabled` inside `ClientPostHogProvider` with bootstrap and assert the hook returns the correct value before the client loads flags (simulating SSR). Confirmed these tests fail without the fix.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/next

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages