### PR TITLE
feat(ai): add OpenAI Agents SDK tracing support

### DIFF
--- a/.changeset/openai-agents-sdk.md
+++ b/.changeset/openai-agents-sdk.md
@@ -1,0 +1,5 @@
+---
+"@posthog/ai": minor
+---
+
+Add OpenAI Agents SDK tracing support via `@posthog/ai/openai-agents`. Implements `PostHogTracingProcessor` that captures agent traces, spans, and LLM generations as PostHog LLM analytics events. Supports all span types including generation, response, function/tool, agent, handoff, guardrail, custom, audio, and MCP.

--- a/examples/example-ai-openai-agents/multi-agent.ts
+++ b/examples/example-ai-openai-agents/multi-agent.ts
@@ -9,8 +9,6 @@ const phClient = new PostHog(process.env.POSTHOG_API_KEY!, {
   host: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
 })
 
-instrument({ client: phClient, distinctId: 'example-user' })
-
 const getWeather = tool({
   name: 'get_weather',
   description: 'Get current weather for a city',
@@ -62,6 +60,8 @@ const triageAgent = new Agent({
 })
 
 async function main() {
+  await instrument({ client: phClient, distinctId: 'example-user' })
+
   const result = await run(triageAgent, "What's the weather in Tokyo?")
   console.log(result.finalOutput)
   await phClient.shutdown()

--- a/examples/example-ai-openai-agents/multi-agent.ts
+++ b/examples/example-ai-openai-agents/multi-agent.ts
@@ -1,0 +1,69 @@
+/** OpenAI Agents SDK multi-agent with handoffs, tracked by PostHog. */
+
+import { PostHog } from 'posthog-node'
+import { instrument } from '@posthog/ai/openai-agents'
+import { Agent, run, tool } from '@openai/agents'
+import { z } from 'zod'
+
+const phClient = new PostHog(process.env.POSTHOG_API_KEY!, {
+  host: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
+})
+
+instrument({ client: phClient, distinctId: 'example-user' })
+
+const getWeather = tool({
+  name: 'get_weather',
+  description: 'Get current weather for a city',
+  parameters: z.object({
+    city: z.string().describe('The city to get weather for'),
+  }),
+  execute: async ({ city }) => {
+    return `Weather in ${city}: 18°C, partly cloudy, humidity 65%`
+  },
+})
+
+const calculate = tool({
+  name: 'calculate',
+  description: 'Evaluate a mathematical expression',
+  parameters: z.object({
+    expression: z.string().describe('A math expression to evaluate'),
+  }),
+  execute: async ({ expression }) => {
+    return `Result: ${eval(expression)}`
+  },
+})
+
+const weatherAgent = new Agent({
+  name: 'WeatherAgent',
+  instructions: 'You handle weather queries. Use the get_weather tool.',
+  model: 'gpt-4o-mini',
+  tools: [getWeather],
+})
+
+const mathAgent = new Agent({
+  name: 'MathAgent',
+  instructions: 'You handle math problems. Use the calculate tool.',
+  model: 'gpt-4o-mini',
+  tools: [calculate],
+})
+
+const generalAgent = new Agent({
+  name: 'GeneralAgent',
+  instructions: 'You handle general questions and conversation.',
+  model: 'gpt-4o-mini',
+})
+
+const triageAgent = new Agent({
+  name: 'TriageAgent',
+  instructions: 'Route to WeatherAgent for weather, MathAgent for math, GeneralAgent for everything else.',
+  model: 'gpt-4o-mini',
+  handoffs: [weatherAgent, mathAgent, generalAgent],
+})
+
+async function main() {
+  const result = await run(triageAgent, "What's the weather in Tokyo?")
+  console.log(result.finalOutput)
+  await phClient.shutdown()
+}
+
+main()

--- a/examples/example-ai-openai-agents/multi-agent.ts
+++ b/examples/example-ai-openai-agents/multi-agent.ts
@@ -29,7 +29,8 @@ const calculate = tool({
     expression: z.string().describe('A math expression to evaluate'),
   }),
   execute: async ({ expression }) => {
-    return `Result: ${eval(expression)}`
+    // Stub: replace with a real math library (e.g. mathjs) in production
+    return `Result of "${expression}": (math evaluation not implemented in this example)`
   },
 })
 

--- a/examples/example-ai-openai-agents/package.json
+++ b/examples/example-ai-openai-agents/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "example-ai-openai-agents",
+  "version": "0.1.0",
+  "private": true,
+  "packageManager": "pnpm@10.15.0",
+  "scripts": {
+    "single-agent": "tsx --require dotenv/config single-agent.ts",
+    "multi-agent": "tsx --require dotenv/config multi-agent.ts"
+  },
+  "dependencies": {
+    "posthog-node": "*",
+    "@posthog/ai": "*",
+    "@openai/agents": "^0.8.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "dotenv": "^16.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/example-ai-openai-agents/pnpm-workspace.yaml
+++ b/examples/example-ai-openai-agents/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/examples/example-ai-openai-agents/single-agent.ts
+++ b/examples/example-ai-openai-agents/single-agent.ts
@@ -9,8 +9,6 @@ const phClient = new PostHog(process.env.POSTHOG_API_KEY!, {
   host: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
 })
 
-instrument({ client: phClient, distinctId: 'example-user' })
-
 const getWeather = tool({
   name: 'get_weather',
   description: 'Get current weather for a city',
@@ -42,6 +40,8 @@ const agent = new Agent({
 })
 
 async function main() {
+  await instrument({ client: phClient, distinctId: 'example-user' })
+
   const result = await run(agent, "What's 15% of 280?")
   console.log(result.finalOutput)
   await phClient.shutdown()

--- a/examples/example-ai-openai-agents/single-agent.ts
+++ b/examples/example-ai-openai-agents/single-agent.ts
@@ -1,0 +1,49 @@
+/** OpenAI Agents SDK single agent with tools, tracked by PostHog. */
+
+import { PostHog } from 'posthog-node'
+import { instrument } from '@posthog/ai/openai-agents'
+import { Agent, run, tool } from '@openai/agents'
+import { z } from 'zod'
+
+const phClient = new PostHog(process.env.POSTHOG_API_KEY!, {
+  host: process.env.POSTHOG_HOST || 'https://us.i.posthog.com',
+})
+
+instrument({ client: phClient, distinctId: 'example-user' })
+
+const getWeather = tool({
+  name: 'get_weather',
+  description: 'Get current weather for a city',
+  parameters: z.object({
+    city: z.string().describe('The city to get weather for'),
+  }),
+  execute: async ({ city }) => {
+    return `Weather in ${city}: 22°C, clear skies, humidity 45%`
+  },
+})
+
+const calculate = tool({
+  name: 'calculate',
+  description: 'Evaluate a mathematical expression',
+  parameters: z.object({
+    expression: z.string().describe('A math expression to evaluate'),
+  }),
+  execute: async ({ expression }) => {
+    return `Result: ${eval(expression)}`
+  },
+})
+
+const agent = new Agent({
+  name: 'Assistant',
+  instructions: 'You are a helpful assistant with weather and math tools.',
+  model: 'gpt-4o-mini',
+  tools: [getWeather, calculate],
+})
+
+async function main() {
+  const result = await run(agent, "What's 15% of 280?")
+  console.log(result.finalOutput)
+  await phClient.shutdown()
+}
+
+main()

--- a/examples/example-ai-openai-agents/single-agent.ts
+++ b/examples/example-ai-openai-agents/single-agent.ts
@@ -29,7 +29,8 @@ const calculate = tool({
     expression: z.string().describe('A math expression to evaluate'),
   }),
   execute: async ({ expression }) => {
-    return `Result: ${eval(expression)}`
+    // Stub: replace with a real math library (e.g. mathjs) in production
+    return `Result of "${expression}": (math evaluation not implemented in this example)`
   },
 })
 

--- a/examples/example-ai-openai-agents/tsconfig.json
+++ b/examples/example-ai-openai-agents/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@ai-sdk/provider": "^3.0.8",
+    "@openai/agents-core": "^0.8.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
     "@babel/preset-env": "catalog:",
@@ -41,7 +42,8 @@
     "anthropic",
     "gemini",
     "llm",
-    "observability"
+    "observability",
+    "agents"
   ],
   "engines": {
     "node": "^20.20.0 || >=22.22.0"
@@ -60,6 +62,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
     "@ai-sdk/provider": "^2.0.0 || ^3.0.0",
+    "@openai/agents-core": "^0.8.0",
     "posthog-node": "^5.0.0"
   },
   "peerDependenciesMeta": {
@@ -70,6 +73,9 @@
       "optional": true
     },
     "@ai-sdk/provider": {
+      "optional": true
+    },
+    "@openai/agents-core": {
       "optional": true
     }
   },
@@ -111,6 +117,11 @@
       "require": "./dist/langchain/index.cjs",
       "import": "./dist/langchain/index.mjs",
       "types": "./dist/langchain/index.d.ts"
+    },
+    "./openai-agents": {
+      "require": "./dist/openai-agents/index.cjs",
+      "import": "./dist/openai-agents/index.mjs",
+      "types": "./dist/openai-agents/index.d.ts"
     }
   },
   "directories": {

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@ai-sdk/provider": "^3.0.8",
+    "@openai/agents": "^0.8.0",
     "@openai/agents-core": "^0.8.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
@@ -62,7 +63,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
     "@ai-sdk/provider": "^2.0.0 || ^3.0.0",
-    "@openai/agents-core": "^0.8.0",
+    "@openai/agents": "^0.8.0",
     "posthog-node": "^5.0.0"
   },
   "peerDependenciesMeta": {
@@ -75,7 +76,7 @@
     "@ai-sdk/provider": {
       "optional": true
     },
-    "@openai/agents-core": {
+    "@openai/agents": {
       "optional": true
     }
   },

--- a/packages/ai/rollup.config.mjs
+++ b/packages/ai/rollup.config.mjs
@@ -33,7 +33,7 @@ configs.push({
 })
 
 // Add submodule builds for posthog-ai
-const providers = ['anthropic', 'openai', 'vercel', 'langchain', 'gemini', 'otel']
+const providers = ['anthropic', 'openai', 'vercel', 'langchain', 'gemini', 'otel', 'openai-agents']
 
 providers.forEach((provider) => {
   configs.push({

--- a/packages/ai/src/openai-agents/index.ts
+++ b/packages/ai/src/openai-agents/index.ts
@@ -1,0 +1,64 @@
+import type { PostHog } from 'posthog-node'
+import { PostHogTracingProcessor } from './processor'
+import type { DistinctIdResolver } from './processor'
+
+export { PostHogTracingProcessor } from './processor'
+export type { PostHogTracingProcessorOptions, DistinctIdResolver } from './processor'
+
+export interface InstrumentOptions {
+  client: PostHog
+  distinctId?: DistinctIdResolver
+  privacyMode?: boolean
+  groups?: Record<string, any>
+  properties?: Record<string, any>
+}
+
+/**
+ * One-liner to instrument OpenAI Agents SDK with PostHog tracing.
+ *
+ * This registers a PostHogTracingProcessor with the OpenAI Agents SDK,
+ * automatically capturing traces, spans, and LLM generations.
+ *
+ * @param options - Configuration options
+ * @returns The registered processor instance
+ *
+ * @example
+ * ```typescript
+ * import { instrument } from '@posthog/ai/openai-agents'
+ * import PostHog from 'posthog-node'
+ *
+ * const phClient = new PostHog('<API_KEY>')
+ *
+ * // Simple setup
+ * instrument({ client: phClient, distinctId: 'user@example.com' })
+ *
+ * // With dynamic distinct ID
+ * instrument({
+ *   client: phClient,
+ *   distinctId: (trace) => trace.metadata?.userId,
+ *   privacyMode: true,
+ *   properties: { environment: 'production' },
+ * })
+ *
+ * // Now run agents as normal - traces automatically sent to PostHog
+ * import { Agent, run } from '@openai/agents'
+ * const agent = new Agent({ name: 'Assistant', instructions: 'You are helpful.' })
+ * const result = await run(agent, 'Hello!')
+ * ```
+ */
+export function instrument(options: InstrumentOptions): PostHogTracingProcessor {
+  // Dynamic import to avoid requiring @openai/agents-core at module load time
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { addTraceProcessor } = require('@openai/agents-core')
+
+  const processor = new PostHogTracingProcessor({
+    client: options.client,
+    distinctId: options.distinctId,
+    privacyMode: options.privacyMode,
+    groups: options.groups,
+    properties: options.properties,
+  })
+
+  addTraceProcessor(processor)
+  return processor
+}

--- a/packages/ai/src/openai-agents/index.ts
+++ b/packages/ai/src/openai-agents/index.ts
@@ -46,10 +46,8 @@ export interface InstrumentOptions {
  * const result = await run(agent, 'Hello!')
  * ```
  */
-export function instrument(options: InstrumentOptions): PostHogTracingProcessor {
-  // Dynamic import to avoid requiring @openai/agents-core at module load time
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { addTraceProcessor } = require('@openai/agents-core')
+export async function instrument(options: InstrumentOptions): Promise<PostHogTracingProcessor> {
+  const { addTraceProcessor } = await import('@openai/agents-core')
 
   const processor = new PostHogTracingProcessor({
     client: options.client,

--- a/packages/ai/src/openai-agents/index.ts
+++ b/packages/ai/src/openai-agents/index.ts
@@ -29,11 +29,11 @@ export interface InstrumentOptions {
  *
  * const phClient = new PostHog('<API_KEY>')
  *
- * // Simple setup
- * instrument({ client: phClient, distinctId: 'user@example.com' })
+ * // Simple setup — await before running agents
+ * await instrument({ client: phClient, distinctId: 'user@example.com' })
  *
  * // With dynamic distinct ID
- * instrument({
+ * await instrument({
  *   client: phClient,
  *   distinctId: (trace) => trace.metadata?.userId,
  *   privacyMode: true,

--- a/packages/ai/src/openai-agents/index.ts
+++ b/packages/ai/src/openai-agents/index.ts
@@ -1,17 +1,10 @@
-import type { PostHog } from 'posthog-node'
 import { PostHogTracingProcessor } from './processor'
-import type { DistinctIdResolver } from './processor'
+import type { PostHogTracingProcessorOptions } from './processor'
 
 export { PostHogTracingProcessor } from './processor'
 export type { PostHogTracingProcessorOptions, DistinctIdResolver } from './processor'
 
-export interface InstrumentOptions {
-  client: PostHog
-  distinctId?: DistinctIdResolver
-  privacyMode?: boolean
-  groups?: Record<string, any>
-  properties?: Record<string, any>
-}
+export type InstrumentOptions = PostHogTracingProcessorOptions
 
 /**
  * One-liner to instrument OpenAI Agents SDK with PostHog tracing.

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -18,6 +18,28 @@ import type {
   MCPListToolsSpanData,
 } from '@openai/agents-core'
 
+/**
+ * Normalize OpenAI Responses API input items to include a `role` field.
+ * Items like `function_call` and `function_call_result` don't have a role,
+ * causing PostHog's trace viewer to default them to "user".
+ */
+function normalizeInputRoles(input: unknown): unknown {
+  if (!Array.isArray(input)) {
+    return input
+  }
+  return input.map((item) => {
+    if (item && typeof item === 'object' && !('role' in item) && 'type' in item) {
+      if (item.type === 'function_call') {
+        return { ...item, role: 'assistant' }
+      }
+      if (item.type === 'function_call_result') {
+        return { ...item, role: 'tool' }
+      }
+    }
+    return item
+  })
+}
+
 function ensureSerializable(obj: unknown): unknown {
   if (obj === null || obj === undefined) {
     return obj
@@ -417,7 +439,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
       ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
       $ai_model: spanData.model,
       $ai_model_parameters: Object.keys(modelParams).length > 0 ? modelParams : null,
-      $ai_input: this._withPrivacyMode(ensureSerializable(spanData.input)),
+      $ai_input: this._withPrivacyMode(ensureSerializable(normalizeInputRoles(spanData.input))),
       $ai_output_choices: this._withPrivacyMode(ensureSerializable(spanData.output)),
       $ai_input_tokens: inputTokens,
       $ai_output_tokens: outputTokens,
@@ -476,7 +498,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
       ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
       $ai_model: model,
       $ai_response_id: responseId,
-      $ai_input: this._withPrivacyMode(ensureSerializable((spanData as any)._input)),
+      $ai_input: this._withPrivacyMode(ensureSerializable(normalizeInputRoles((spanData as any)._input))),
       $ai_input_tokens: inputTokens,
       $ai_output_tokens: outputTokens,
       $ai_total_tokens: inputTokens + outputTokens,

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -17,6 +17,8 @@ import type {
   SpeechGroupSpanData,
   MCPListToolsSpanData,
 } from '@openai/agents-core'
+import { withPrivacyMode } from '../utils'
+import { version } from '../../package.json'
 
 /**
  * Normalize OpenAI Responses API input items to include a `role` field.
@@ -135,10 +137,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
   }
 
   private _withPrivacyMode(value: unknown): unknown {
-    if (this._privacyMode || (this._client as any).privacy_mode) {
-      return null
-    }
-    return value
+    return withPrivacyMode(this._client, this._privacyMode, value)
   }
 
   private _evictStaleEntries(): void {
@@ -192,6 +191,8 @@ export class PostHogTracingProcessor implements TracingProcessor {
     errorProperties: Record<string, any>
   ): Record<string, any> {
     const properties: Record<string, any> = {
+      $ai_lib: 'posthog-ai',
+      $ai_lib_version: version,
       $ai_trace_id: traceId,
       $ai_span_id: spanId,
       $ai_parent_id: parentId,
@@ -274,6 +275,8 @@ export class PostHogTracingProcessor implements TracingProcessor {
       const latency = startTime != null ? Date.now() / 1000 - startTime : undefined
 
       const properties: Record<string, any> = {
+        $ai_lib: 'posthog-ai',
+        $ai_lib_version: version,
         $ai_trace_id: traceId,
         $ai_trace_name: traceName,
         $ai_provider: 'openai',

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -17,7 +17,7 @@ import type {
   SpeechGroupSpanData,
   MCPListToolsSpanData,
 } from '@openai/agents-core'
-import { withPrivacyMode } from '../utils'
+import { MAX_OUTPUT_SIZE, truncate, withPrivacyMode } from '../utils'
 import { version } from '../../package.json'
 
 /**
@@ -51,6 +51,19 @@ function ensureSerializable(obj: unknown): unknown {
     return obj
   } catch {
     return String(obj)
+  }
+}
+
+function exceedsMaxOutputSize(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false
+  }
+
+  try {
+    const serializedValue = typeof value === 'string' ? value : JSON.stringify(value)
+    return new TextEncoder().encode(serializedValue).length > MAX_OUTPUT_SIZE
+  } catch {
+    return false
   }
 }
 
@@ -138,6 +151,12 @@ export class PostHogTracingProcessor implements TracingProcessor {
 
   private _withPrivacyMode(value: unknown): unknown {
     return withPrivacyMode(this._client, this._privacyMode, value)
+  }
+
+  private _prepareCapturedValue(value: unknown): unknown {
+    const serializableValue = ensureSerializable(value)
+    const boundedValue = exceedsMaxOutputSize(serializableValue) ? truncate(serializableValue) : serializableValue
+    return this._withPrivacyMode(boundedValue)
   }
 
   private _evictStaleEntries(): void {
@@ -292,7 +311,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
       }
 
       if (metadata && Object.keys(metadata).length > 0) {
-        properties.$ai_trace_metadata = ensureSerializable(metadata)
+        properties.$ai_trace_metadata = this._prepareCapturedValue(metadata)
       }
 
       if (distinctId == null) {
@@ -440,11 +459,11 @@ export class PostHogTracingProcessor implements TracingProcessor {
       ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
       $ai_model: spanData.model,
       $ai_model_parameters: Object.keys(modelParams).length > 0 ? modelParams : null,
-      $ai_input: this._withPrivacyMode(ensureSerializable(normalizeInputRoles(spanData.input))),
-      $ai_output_choices: this._withPrivacyMode(ensureSerializable(spanData.output)),
+      $ai_input: this._prepareCapturedValue(normalizeInputRoles(spanData.input)),
+      $ai_output_choices: this._prepareCapturedValue(spanData.output),
       $ai_input_tokens: inputTokens,
       $ai_output_tokens: outputTokens,
-      $ai_total_tokens: (inputTokens || 0) + (outputTokens || 0),
+      $ai_total_tokens: inputTokens + outputTokens,
     }
 
     if (usage.details) {
@@ -484,7 +503,10 @@ export class PostHogTracingProcessor implements TracingProcessor {
     groupId: string | null,
     errorProperties: Record<string, any>
   ): void {
-    const response = (spanData as any)._response
+    // The OpenAI Agents SDK exposes these underscored fields for non-OpenAI tracing providers.
+    // Treat them as best-effort and avoid assuming they are always present.
+    const responseSpanData = spanData as ResponseSpanData & { _input?: unknown; _response?: Record<string, any> }
+    const response = responseSpanData._response
     const responseId = spanData.response_id ?? (response?.id as string | undefined)
 
     // Extract usage from response
@@ -499,7 +521,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
       ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
       $ai_model: model,
       $ai_response_id: responseId,
-      $ai_input: this._withPrivacyMode(ensureSerializable(normalizeInputRoles((spanData as any)._input))),
+      $ai_input: this._prepareCapturedValue(normalizeInputRoles(responseSpanData._input)),
       $ai_input_tokens: inputTokens,
       $ai_output_tokens: outputTokens,
       $ai_total_tokens: inputTokens + outputTokens,
@@ -507,7 +529,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
 
     // Extract output from response
     if (response?.output) {
-      properties.$ai_output_choices = this._withPrivacyMode(ensureSerializable(response.output))
+      properties.$ai_output_choices = this._prepareCapturedValue(response.output)
     }
 
     this._captureEvent('$ai_generation', properties, distinctId)
@@ -527,12 +549,12 @@ export class PostHogTracingProcessor implements TracingProcessor {
       ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
       $ai_span_name: spanData.name,
       $ai_span_type: 'tool',
-      $ai_input_state: this._withPrivacyMode(ensureSerializable(spanData.input)),
-      $ai_output_state: this._withPrivacyMode(ensureSerializable(spanData.output)),
+      $ai_input_state: this._prepareCapturedValue(spanData.input),
+      $ai_output_state: this._prepareCapturedValue(spanData.output),
     }
 
     if (spanData.mcp_data) {
-      properties.$ai_mcp_data = ensureSerializable(spanData.mcp_data)
+      properties.$ai_mcp_data = this._prepareCapturedValue(spanData.mcp_data)
     }
 
     this._captureEvent('$ai_span', properties, distinctId)
@@ -622,7 +644,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
       ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
       $ai_span_name: spanData.name,
       $ai_span_type: 'custom',
-      $ai_custom_data: this._withPrivacyMode(ensureSerializable(spanData.data)),
+      $ai_custom_data: this._prepareCapturedValue(spanData.data),
     }
 
     this._captureEvent('$ai_span', properties, distinctId)
@@ -653,32 +675,32 @@ export class PostHogTracingProcessor implements TracingProcessor {
 
     // Add model config if available
     if ('model_config' in spanData && spanData.model_config) {
-      properties.model_config = ensureSerializable(spanData.model_config)
+      properties.$ai_model_config = this._prepareCapturedValue(spanData.model_config)
     }
 
     // Add audio format info
     if (spanData.type === 'transcription') {
       const transcription = spanData as TranscriptionSpanData
       if (transcription.input?.format) {
-        properties.audio_input_format = transcription.input.format
+        properties.$ai_audio_input_format = transcription.input.format
       }
       // Transcription output is text
       if (transcription.output) {
-        properties.$ai_output_state = this._withPrivacyMode(transcription.output)
+        properties.$ai_output_state = this._prepareCapturedValue(transcription.output)
       }
     } else if (spanData.type === 'speech') {
       const speech = spanData as SpeechSpanData
       if (speech.output?.format) {
-        properties.audio_output_format = speech.output.format
+        properties.$ai_audio_output_format = speech.output.format
       }
       // Text input for TTS
       if (speech.input) {
-        properties.$ai_input = this._withPrivacyMode(speech.input)
+        properties.$ai_input = this._prepareCapturedValue(speech.input)
       }
     } else if (spanData.type === 'speech_group') {
       const speechGroup = spanData as SpeechGroupSpanData
       if (speechGroup.input) {
-        properties.$ai_input = this._withPrivacyMode(speechGroup.input)
+        properties.$ai_input = this._prepareCapturedValue(speechGroup.input)
       }
     }
 
@@ -700,7 +722,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
       $ai_span_name: `mcp:${spanData.server}`,
       $ai_span_type: 'mcp_tools',
       $ai_mcp_server: spanData.server,
-      $ai_mcp_tools: spanData.result,
+      $ai_mcp_tools: this._prepareCapturedValue(spanData.result),
     }
 
     this._captureEvent('$ai_span', properties, distinctId)

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -166,8 +166,8 @@ export class PostHogTracingProcessor implements TracingProcessor {
       }
 
       const finalProperties = {
-        ...properties,
         ...this._properties,
+        ...properties,
       }
 
       const eventMessage: EventMessage = {
@@ -671,6 +671,11 @@ export class PostHogTracingProcessor implements TracingProcessor {
       // Text input for TTS
       if (speech.input) {
         properties.$ai_input = this._withPrivacyMode(speech.input)
+      }
+    } else if (spanData.type === 'speech_group') {
+      const speechGroup = spanData as SpeechGroupSpanData
+      if (speechGroup.input) {
+        properties.$ai_input = this._withPrivacyMode(speechGroup.input)
       }
     }
 

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -422,10 +422,8 @@ export class PostHogTracingProcessor implements TracingProcessor {
     errorProperties: Record<string, any>
   ): void {
     const usage = spanData.usage ?? {}
-    const inputTokens =
-      (usage.input_tokens as number) || (usage as any).prompt_tokens || 0
-    const outputTokens =
-      (usage.output_tokens as number) || (usage as any).completion_tokens || 0
+    const inputTokens = (usage.input_tokens as number) || (usage as any).prompt_tokens || 0
+    const outputTokens = (usage.output_tokens as number) || (usage as any).completion_tokens || 0
 
     const modelConfig = spanData.model_config ?? {}
     const modelParams: Record<string, any> = {}

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -1,0 +1,701 @@
+import type { PostHog, EventMessage } from 'posthog-node'
+import type {
+  TracingProcessor,
+  Trace,
+  Span,
+  SpanData,
+  SpanError,
+  AgentSpanData,
+  FunctionSpanData,
+  GenerationSpanData,
+  ResponseSpanData,
+  HandoffSpanData,
+  CustomSpanData,
+  GuardrailSpanData,
+  TranscriptionSpanData,
+  SpeechSpanData,
+  SpeechGroupSpanData,
+  MCPListToolsSpanData,
+} from '@openai/agents-core'
+
+function ensureSerializable(obj: unknown): unknown {
+  if (obj === null || obj === undefined) {
+    return obj
+  }
+  try {
+    JSON.stringify(obj)
+    return obj
+  } catch {
+    return String(obj)
+  }
+}
+
+function parseIsoTimestamp(isoStr: string | null | undefined): number | null {
+  if (!isoStr) {
+    return null
+  }
+  try {
+    const ts = new Date(isoStr).getTime()
+    return isNaN(ts) ? null : ts / 1000
+  } catch {
+    return null
+  }
+}
+
+interface TraceMetadata {
+  name: string
+  groupId: string | null
+  metadata: Record<string, any> | undefined
+  distinctId: string | undefined
+  startTime: number
+}
+
+export type DistinctIdResolver = string | ((trace: Trace) => string | null | undefined)
+
+export interface PostHogTracingProcessorOptions {
+  client: PostHog
+  distinctId?: DistinctIdResolver
+  privacyMode?: boolean
+  groups?: Record<string, any>
+  properties?: Record<string, any>
+}
+
+/**
+ * A tracing processor that sends OpenAI Agents SDK traces to PostHog.
+ *
+ * Implements the TracingProcessor interface from the OpenAI Agents SDK
+ * and maps agent traces, spans, and generations to PostHog's LLM analytics events.
+ *
+ * @example
+ * ```typescript
+ * import { PostHogTracingProcessor } from '@posthog/ai/openai-agents'
+ * import { addTraceProcessor } from '@openai/agents'
+ *
+ * const processor = new PostHogTracingProcessor({
+ *   client: posthog,
+ *   distinctId: 'user@example.com',
+ * })
+ * addTraceProcessor(processor)
+ * ```
+ */
+export class PostHogTracingProcessor implements TracingProcessor {
+  private _client: PostHog
+  private _distinctId: DistinctIdResolver | undefined
+  private _privacyMode: boolean
+  private _groups: Record<string, any>
+  private _properties: Record<string, any>
+
+  private _spanStartTimes: Map<string, number> = new Map()
+  private _traceMetadata: Map<string, TraceMetadata> = new Map()
+  private _maxTrackedEntries = 10000
+
+  constructor(options: PostHogTracingProcessorOptions) {
+    this._client = options.client
+    this._distinctId = options.distinctId
+    this._privacyMode = options.privacyMode ?? false
+    this._groups = options.groups ?? {}
+    this._properties = options.properties ?? {}
+  }
+
+  private _getDistinctId(trace: Trace | null): string | undefined {
+    if (typeof this._distinctId === 'function') {
+      if (trace) {
+        const result = this._distinctId(trace)
+        if (result) {
+          return String(result)
+        }
+      }
+      return undefined
+    } else if (this._distinctId) {
+      return String(this._distinctId)
+    }
+    return undefined
+  }
+
+  private _withPrivacyMode(value: unknown): unknown {
+    if (this._privacyMode || (this._client as any).privacy_mode) {
+      return null
+    }
+    return value
+  }
+
+  private _evictStaleEntries(): void {
+    if (this._spanStartTimes.size > this._maxTrackedEntries) {
+      const entries = [...this._spanStartTimes.entries()].sort((a, b) => a[1] - b[1])
+      const toRemove = entries.slice(0, Math.floor(entries.length / 2))
+      for (const [key] of toRemove) {
+        this._spanStartTimes.delete(key)
+      }
+    }
+
+    if (this._traceMetadata.size > this._maxTrackedEntries) {
+      const keys = [...this._traceMetadata.keys()]
+      const toRemove = keys.slice(0, Math.floor(keys.length / 2))
+      for (const key of toRemove) {
+        this._traceMetadata.delete(key)
+      }
+    }
+  }
+
+  private _captureEvent(event: string, properties: Record<string, any>, distinctId?: string): void {
+    try {
+      if (!this._client?.capture) {
+        return
+      }
+
+      const finalProperties = {
+        ...properties,
+        ...this._properties,
+      }
+
+      const eventMessage: EventMessage = {
+        distinctId: distinctId || 'unknown',
+        event,
+        properties: finalProperties,
+        groups: Object.keys(this._groups).length > 0 ? this._groups : undefined,
+      }
+
+      this._client.capture(eventMessage)
+    } catch {
+      // Silently ignore capture errors
+    }
+  }
+
+  private _baseProperties(
+    traceId: string,
+    spanId: string,
+    parentId: string | null,
+    latency: number,
+    groupId: string | null,
+    errorProperties: Record<string, any>
+  ): Record<string, any> {
+    const properties: Record<string, any> = {
+      $ai_trace_id: traceId,
+      $ai_span_id: spanId,
+      $ai_parent_id: parentId,
+      $ai_provider: 'openai',
+      $ai_framework: 'openai-agents',
+      $ai_latency: latency,
+      ...errorProperties,
+    }
+    if (groupId) {
+      properties.$ai_group_id = groupId
+    }
+    return properties
+  }
+
+  private _getErrorProperties(error: SpanError | null): Record<string, any> {
+    if (!error) {
+      return {}
+    }
+
+    const errorMessage = error.message || String(error)
+
+    let errorType = 'unknown'
+    if (errorMessage.includes('ModelBehaviorError')) {
+      errorType = 'model_behavior_error'
+    } else if (errorMessage.includes('UserError')) {
+      errorType = 'user_error'
+    } else if (errorMessage.includes('InputGuardrailTripwireTriggered')) {
+      errorType = 'input_guardrail_triggered'
+    } else if (errorMessage.includes('OutputGuardrailTripwireTriggered')) {
+      errorType = 'output_guardrail_triggered'
+    } else if (errorMessage.includes('MaxTurnsExceeded')) {
+      errorType = 'max_turns_exceeded'
+    }
+
+    return {
+      $ai_is_error: true,
+      $ai_error: errorMessage,
+      $ai_error_type: errorType,
+    }
+  }
+
+  // --- TracingProcessor interface ---
+
+  async onTraceStart(trace: Trace): Promise<void> {
+    try {
+      this._evictStaleEntries()
+
+      const traceId = trace.traceId
+      const traceName = trace.name
+      const groupId = trace.groupId ?? null
+      const metadata = trace.metadata
+
+      const distinctId = this._getDistinctId(trace)
+
+      this._traceMetadata.set(traceId, {
+        name: traceName,
+        groupId,
+        metadata,
+        distinctId,
+        startTime: Date.now() / 1000,
+      })
+    } catch {
+      // Silently ignore errors
+    }
+  }
+
+  async onTraceEnd(trace: Trace): Promise<void> {
+    try {
+      const traceId = trace.traceId
+
+      const traceInfo = this._traceMetadata.get(traceId)
+      this._traceMetadata.delete(traceId)
+
+      const traceName = traceInfo?.name ?? trace.name
+      const groupId = traceInfo?.groupId ?? trace.groupId ?? null
+      const metadata = traceInfo?.metadata ?? trace.metadata
+      const distinctId = traceInfo?.distinctId ?? this._getDistinctId(trace)
+
+      const startTime = traceInfo?.startTime
+      const latency = startTime != null ? Date.now() / 1000 - startTime : undefined
+
+      const properties: Record<string, any> = {
+        $ai_trace_id: traceId,
+        $ai_trace_name: traceName,
+        $ai_provider: 'openai',
+        $ai_framework: 'openai-agents',
+      }
+
+      if (latency != null) {
+        properties.$ai_latency = latency
+      }
+
+      if (groupId) {
+        properties.$ai_group_id = groupId
+      }
+
+      if (metadata && Object.keys(metadata).length > 0) {
+        properties.$ai_trace_metadata = ensureSerializable(metadata)
+      }
+
+      if (distinctId == null) {
+        properties.$process_person_profile = false
+      }
+
+      this._captureEvent('$ai_trace', properties, distinctId ?? traceId)
+    } catch {
+      // Silently ignore errors
+    }
+  }
+
+  async onSpanStart(span: Span<SpanData>): Promise<void> {
+    try {
+      this._evictStaleEntries()
+      this._spanStartTimes.set(span.spanId, Date.now() / 1000)
+    } catch {
+      // Silently ignore errors
+    }
+  }
+
+  async onSpanEnd(span: Span<SpanData>): Promise<void> {
+    try {
+      const spanId = span.spanId
+      const traceId = span.traceId
+      const parentId = span.parentId
+      const spanData = span.spanData
+
+      // Calculate latency
+      const startTime = this._spanStartTimes.get(spanId)
+      this._spanStartTimes.delete(spanId)
+      let latency: number
+      if (startTime != null) {
+        latency = Date.now() / 1000 - startTime
+      } else {
+        const started = parseIsoTimestamp(span.startedAt)
+        const ended = parseIsoTimestamp(span.endedAt)
+        latency = started != null && ended != null ? ended - started : 0
+      }
+
+      // Get distinct ID from trace metadata
+      const traceInfo = this._traceMetadata.get(traceId)
+      const userDistinctId = traceInfo?.distinctId ?? this._getDistinctId(null)
+
+      // Get group_id from trace metadata
+      const groupId = traceInfo?.groupId ?? null
+
+      // Get error properties
+      const errorProperties = this._getErrorProperties(span.error)
+
+      // Personless mode: no user-provided distinct_id, fallback to trace_id
+      if (userDistinctId == null) {
+        errorProperties.$process_person_profile = false
+      }
+      const distinctId: string = userDistinctId ?? traceId
+
+      // Dispatch based on span data type
+      switch (spanData.type) {
+        case 'generation':
+          this._handleGenerationSpan(spanData, traceId, spanId, parentId, latency, distinctId, groupId, errorProperties)
+          break
+        case 'response':
+          this._handleResponseSpan(spanData, traceId, spanId, parentId, latency, distinctId, groupId, errorProperties)
+          break
+        case 'function':
+          this._handleFunctionSpan(spanData, traceId, spanId, parentId, latency, distinctId, groupId, errorProperties)
+          break
+        case 'agent':
+          this._handleAgentSpan(spanData, traceId, spanId, parentId, latency, distinctId, groupId, errorProperties)
+          break
+        case 'handoff':
+          this._handleHandoffSpan(spanData, traceId, spanId, parentId, latency, distinctId, groupId, errorProperties)
+          break
+        case 'guardrail':
+          this._handleGuardrailSpan(spanData, traceId, spanId, parentId, latency, distinctId, groupId, errorProperties)
+          break
+        case 'custom':
+          this._handleCustomSpan(spanData, traceId, spanId, parentId, latency, distinctId, groupId, errorProperties)
+          break
+        case 'transcription':
+        case 'speech':
+        case 'speech_group':
+          this._handleAudioSpan(spanData, traceId, spanId, parentId, latency, distinctId, groupId, errorProperties)
+          break
+        case 'mcp_tools':
+          this._handleMcpSpan(spanData, traceId, spanId, parentId, latency, distinctId, groupId, errorProperties)
+          break
+        default:
+          this._handleGenericSpan(spanData, traceId, spanId, parentId, latency, distinctId, groupId, errorProperties)
+          break
+      }
+    } catch {
+      // Silently ignore errors
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    try {
+      this._spanStartTimes.clear()
+      this._traceMetadata.clear()
+
+      if (typeof this._client?.flush === 'function') {
+        await this._client.flush()
+      }
+    } catch {
+      // Silently ignore errors
+    }
+  }
+
+  async forceFlush(): Promise<void> {
+    try {
+      if (typeof this._client?.flush === 'function') {
+        await this._client.flush()
+      }
+    } catch {
+      // Silently ignore errors
+    }
+  }
+
+  // --- Span handlers ---
+
+  private _handleGenerationSpan(
+    spanData: GenerationSpanData,
+    traceId: string,
+    spanId: string,
+    parentId: string | null,
+    latency: number,
+    distinctId: string,
+    groupId: string | null,
+    errorProperties: Record<string, any>
+  ): void {
+    const usage = spanData.usage ?? {}
+    const inputTokens =
+      (usage.input_tokens as number) || (usage as any).prompt_tokens || 0
+    const outputTokens =
+      (usage.output_tokens as number) || (usage as any).completion_tokens || 0
+
+    const modelConfig = spanData.model_config ?? {}
+    const modelParams: Record<string, any> = {}
+    for (const param of ['temperature', 'max_tokens', 'top_p', 'frequency_penalty', 'presence_penalty']) {
+      if (param in modelConfig) {
+        modelParams[param] = modelConfig[param]
+      }
+    }
+
+    const properties: Record<string, any> = {
+      ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
+      $ai_model: spanData.model,
+      $ai_model_parameters: Object.keys(modelParams).length > 0 ? modelParams : null,
+      $ai_input: this._withPrivacyMode(ensureSerializable(spanData.input)),
+      $ai_output_choices: this._withPrivacyMode(ensureSerializable(spanData.output)),
+      $ai_input_tokens: inputTokens,
+      $ai_output_tokens: outputTokens,
+      $ai_total_tokens: (inputTokens || 0) + (outputTokens || 0),
+    }
+
+    if (usage.details) {
+      const details = usage.details as Record<string, unknown>
+      if (details.reasoning_tokens) {
+        properties.$ai_reasoning_tokens = details.reasoning_tokens
+      }
+      if (details.cache_read_input_tokens) {
+        properties.$ai_cache_read_input_tokens = details.cache_read_input_tokens
+      }
+      if (details.cache_creation_input_tokens) {
+        properties.$ai_cache_creation_input_tokens = details.cache_creation_input_tokens
+      }
+    }
+
+    // Also check top-level usage for reasoning/cache tokens (flexible schema)
+    if ((usage as any).reasoning_tokens) {
+      properties.$ai_reasoning_tokens = (usage as any).reasoning_tokens
+    }
+    if ((usage as any).cache_read_input_tokens) {
+      properties.$ai_cache_read_input_tokens = (usage as any).cache_read_input_tokens
+    }
+    if ((usage as any).cache_creation_input_tokens) {
+      properties.$ai_cache_creation_input_tokens = (usage as any).cache_creation_input_tokens
+    }
+
+    this._captureEvent('$ai_generation', properties, distinctId)
+  }
+
+  private _handleResponseSpan(
+    spanData: ResponseSpanData,
+    traceId: string,
+    spanId: string,
+    parentId: string | null,
+    latency: number,
+    distinctId: string,
+    groupId: string | null,
+    errorProperties: Record<string, any>
+  ): void {
+    const response = (spanData as any)._response
+    const responseId = spanData.response_id ?? (response?.id as string | undefined)
+
+    // Extract usage from response
+    const usage = response?.usage ?? {}
+    const inputTokens = usage?.input_tokens ?? 0
+    const outputTokens = usage?.output_tokens ?? 0
+
+    // Extract model from response
+    const model = response?.model as string | undefined
+
+    const properties: Record<string, any> = {
+      ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
+      $ai_model: model,
+      $ai_response_id: responseId,
+      $ai_input: this._withPrivacyMode(ensureSerializable((spanData as any)._input)),
+      $ai_input_tokens: inputTokens,
+      $ai_output_tokens: outputTokens,
+      $ai_total_tokens: inputTokens + outputTokens,
+    }
+
+    // Extract output from response
+    if (response?.output) {
+      properties.$ai_output_choices = this._withPrivacyMode(ensureSerializable(response.output))
+    }
+
+    this._captureEvent('$ai_generation', properties, distinctId)
+  }
+
+  private _handleFunctionSpan(
+    spanData: FunctionSpanData,
+    traceId: string,
+    spanId: string,
+    parentId: string | null,
+    latency: number,
+    distinctId: string,
+    groupId: string | null,
+    errorProperties: Record<string, any>
+  ): void {
+    const properties: Record<string, any> = {
+      ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
+      $ai_span_name: spanData.name,
+      $ai_span_type: 'tool',
+      $ai_input_state: this._withPrivacyMode(ensureSerializable(spanData.input)),
+      $ai_output_state: this._withPrivacyMode(ensureSerializable(spanData.output)),
+    }
+
+    if (spanData.mcp_data) {
+      properties.$ai_mcp_data = ensureSerializable(spanData.mcp_data)
+    }
+
+    this._captureEvent('$ai_span', properties, distinctId)
+  }
+
+  private _handleAgentSpan(
+    spanData: AgentSpanData,
+    traceId: string,
+    spanId: string,
+    parentId: string | null,
+    latency: number,
+    distinctId: string,
+    groupId: string | null,
+    errorProperties: Record<string, any>
+  ): void {
+    const properties: Record<string, any> = {
+      ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
+      $ai_span_name: spanData.name,
+      $ai_span_type: 'agent',
+    }
+
+    if (spanData.handoffs) {
+      properties.$ai_agent_handoffs = spanData.handoffs
+    }
+    if (spanData.tools) {
+      properties.$ai_agent_tools = spanData.tools
+    }
+    if (spanData.output_type) {
+      properties.$ai_agent_output_type = spanData.output_type
+    }
+
+    this._captureEvent('$ai_span', properties, distinctId)
+  }
+
+  private _handleHandoffSpan(
+    spanData: HandoffSpanData,
+    traceId: string,
+    spanId: string,
+    parentId: string | null,
+    latency: number,
+    distinctId: string,
+    groupId: string | null,
+    errorProperties: Record<string, any>
+  ): void {
+    const properties: Record<string, any> = {
+      ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
+      $ai_span_name: `${spanData.from_agent} -> ${spanData.to_agent}`,
+      $ai_span_type: 'handoff',
+      $ai_handoff_from_agent: spanData.from_agent,
+      $ai_handoff_to_agent: spanData.to_agent,
+    }
+
+    this._captureEvent('$ai_span', properties, distinctId)
+  }
+
+  private _handleGuardrailSpan(
+    spanData: GuardrailSpanData,
+    traceId: string,
+    spanId: string,
+    parentId: string | null,
+    latency: number,
+    distinctId: string,
+    groupId: string | null,
+    errorProperties: Record<string, any>
+  ): void {
+    const properties: Record<string, any> = {
+      ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
+      $ai_span_name: spanData.name,
+      $ai_span_type: 'guardrail',
+      $ai_guardrail_triggered: spanData.triggered,
+    }
+
+    this._captureEvent('$ai_span', properties, distinctId)
+  }
+
+  private _handleCustomSpan(
+    spanData: CustomSpanData,
+    traceId: string,
+    spanId: string,
+    parentId: string | null,
+    latency: number,
+    distinctId: string,
+    groupId: string | null,
+    errorProperties: Record<string, any>
+  ): void {
+    const properties: Record<string, any> = {
+      ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
+      $ai_span_name: spanData.name,
+      $ai_span_type: 'custom',
+      $ai_custom_data: this._withPrivacyMode(ensureSerializable(spanData.data)),
+    }
+
+    this._captureEvent('$ai_span', properties, distinctId)
+  }
+
+  private _handleAudioSpan(
+    spanData: TranscriptionSpanData | SpeechSpanData | SpeechGroupSpanData,
+    traceId: string,
+    spanId: string,
+    parentId: string | null,
+    latency: number,
+    distinctId: string,
+    groupId: string | null,
+    errorProperties: Record<string, any>
+  ): void {
+    const spanType = spanData.type
+
+    const properties: Record<string, any> = {
+      ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
+      $ai_span_name: spanType,
+      $ai_span_type: spanType,
+    }
+
+    // Add model info if available
+    if ('model' in spanData && spanData.model) {
+      properties.$ai_model = spanData.model
+    }
+
+    // Add model config if available
+    if ('model_config' in spanData && spanData.model_config) {
+      properties.model_config = ensureSerializable(spanData.model_config)
+    }
+
+    // Add audio format info
+    if (spanData.type === 'transcription') {
+      const transcription = spanData as TranscriptionSpanData
+      if (transcription.input?.format) {
+        properties.audio_input_format = transcription.input.format
+      }
+      // Transcription output is text
+      if (transcription.output) {
+        properties.$ai_output_state = this._withPrivacyMode(transcription.output)
+      }
+    } else if (spanData.type === 'speech') {
+      const speech = spanData as SpeechSpanData
+      if (speech.output?.format) {
+        properties.audio_output_format = speech.output.format
+      }
+      // Text input for TTS
+      if (speech.input) {
+        properties.$ai_input = this._withPrivacyMode(speech.input)
+      }
+    }
+
+    this._captureEvent('$ai_span', properties, distinctId)
+  }
+
+  private _handleMcpSpan(
+    spanData: MCPListToolsSpanData,
+    traceId: string,
+    spanId: string,
+    parentId: string | null,
+    latency: number,
+    distinctId: string,
+    groupId: string | null,
+    errorProperties: Record<string, any>
+  ): void {
+    const properties: Record<string, any> = {
+      ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
+      $ai_span_name: `mcp:${spanData.server}`,
+      $ai_span_type: 'mcp_tools',
+      $ai_mcp_server: spanData.server,
+      $ai_mcp_tools: spanData.result,
+    }
+
+    this._captureEvent('$ai_span', properties, distinctId)
+  }
+
+  private _handleGenericSpan(
+    spanData: SpanData,
+    traceId: string,
+    spanId: string,
+    parentId: string | null,
+    latency: number,
+    distinctId: string,
+    groupId: string | null,
+    errorProperties: Record<string, any>
+  ): void {
+    const spanType = spanData.type || 'unknown'
+
+    const properties: Record<string, any> = {
+      ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
+      $ai_span_name: spanType,
+      $ai_span_type: spanType,
+    }
+
+    this._captureEvent('$ai_span', properties, distinctId)
+  }
+}

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -342,6 +342,28 @@ describe('PostHogTracingProcessor', () => {
       expect(call.properties.$ai_cache_read_input_tokens).toBe(80)
       expect(call.properties.$ai_cache_creation_input_tokens).toBe(20)
     })
+
+    it('truncates oversized generation payloads', async () => {
+      const largeContent = 'x'.repeat(220000)
+      const span = createMockSpan({
+        spanData: {
+          type: 'generation',
+          input: [{ role: 'user', content: largeContent }],
+          output: [{ role: 'assistant', content: largeContent }],
+          model: 'gpt-4o',
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(typeof call.properties.$ai_input).toBe('string')
+      expect(call.properties.$ai_input).toContain('[truncated]')
+      expect(typeof call.properties.$ai_output_choices).toBe('string')
+      expect(call.properties.$ai_output_choices).toContain('[truncated]')
+    })
   })
 
   describe('input role normalization', () => {
@@ -583,6 +605,33 @@ describe('PostHogTracingProcessor', () => {
       expect(call.properties.$ai_total_tokens).toBe(35)
       expect(call.properties.$ai_output_choices).toEqual([{ type: 'message', content: 'Hello!' }])
     })
+
+    it('truncates oversized response span payloads', async () => {
+      const largeContent = 'x'.repeat(220000)
+      const span = createMockSpan({
+        spanData: {
+          type: 'response',
+          response_id: 'resp_oversized',
+          _input: largeContent,
+          _response: {
+            id: 'resp_oversized',
+            model: 'gpt-4o',
+            output: [{ type: 'message', content: largeContent }],
+            usage: { input_tokens: 25, output_tokens: 10 },
+          },
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(typeof call.properties.$ai_input).toBe('string')
+      expect(call.properties.$ai_input).toContain('[truncated]')
+      expect(typeof call.properties.$ai_output_choices).toBe('string')
+      expect(call.properties.$ai_output_choices).toContain('[truncated]')
+    })
   })
 
   describe('audio spans', () => {
@@ -605,8 +654,8 @@ describe('PostHogTracingProcessor', () => {
       expect(call.event).toBe('$ai_span')
       expect(call.properties.$ai_span_type).toBe('transcription')
       expect(call.properties.$ai_model).toBe('whisper-1')
-      expect(call.properties.audio_input_format).toBe('pcm')
-      expect(call.properties.model_config).toEqual({ language: 'en' })
+      expect(call.properties.$ai_audio_input_format).toBe('pcm')
+      expect(call.properties.$ai_model_config).toEqual({ language: 'en' })
       expect(call.properties.$ai_output_state).toBe('This is the transcribed text.')
     })
 
@@ -629,7 +678,7 @@ describe('PostHogTracingProcessor', () => {
       expect(call.event).toBe('$ai_span')
       expect(call.properties.$ai_span_type).toBe('speech')
       expect(call.properties.$ai_model).toBe('tts-1')
-      expect(call.properties.audio_output_format).toBe('pcm')
+      expect(call.properties.$ai_audio_output_format).toBe('pcm')
       expect(call.properties.$ai_input).toBe('Hello, how can I help you?')
     })
 
@@ -648,6 +697,24 @@ describe('PostHogTracingProcessor', () => {
 
       expect(call.event).toBe('$ai_span')
       expect(call.properties.$ai_span_type).toBe('speech_group')
+    })
+
+    it('truncates oversized custom span data', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'custom',
+          name: 'oversized_payload',
+          data: { content: 'x'.repeat(220000) },
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(typeof call.properties.$ai_custom_data).toBe('string')
+      expect(call.properties.$ai_custom_data).toContain('[truncated]')
     })
   })
 

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -1,0 +1,957 @@
+import { PostHogTracingProcessor } from '../src/openai-agents/processor'
+
+// Mock types matching @openai/agents-core interfaces
+interface MockTrace {
+  type: 'trace'
+  traceId: string
+  name: string
+  groupId: string | null
+  metadata?: Record<string, any>
+}
+
+interface MockSpanError {
+  message: string
+  data?: Record<string, any>
+}
+
+interface MockSpan {
+  type: 'trace.span'
+  traceId: string
+  spanId: string
+  parentId: string | null
+  spanData: any
+  startedAt: string | null
+  endedAt: string | null
+  error: MockSpanError | null
+}
+
+function createMockClient() {
+  return {
+    capture: jest.fn(),
+    flush: jest.fn().mockResolvedValue(undefined),
+    privacy_mode: false,
+  } as any
+}
+
+function createMockTrace(overrides: Partial<MockTrace> = {}): MockTrace {
+  return {
+    type: 'trace',
+    traceId: 'trace_123456789',
+    name: 'Test Workflow',
+    groupId: 'group_123',
+    metadata: { key: 'value' },
+    ...overrides,
+  }
+}
+
+function createMockSpan(overrides: Partial<MockSpan> = {}): MockSpan {
+  return {
+    type: 'trace.span',
+    traceId: 'trace_123456789',
+    spanId: 'span_987654321',
+    parentId: null,
+    spanData: { type: 'generation', model: 'gpt-4o' },
+    startedAt: '2024-01-01T00:00:00Z',
+    endedAt: '2024-01-01T00:00:01Z',
+    error: null,
+    ...overrides,
+  }
+}
+
+describe('PostHogTracingProcessor', () => {
+  let mockClient: ReturnType<typeof createMockClient>
+  let processor: PostHogTracingProcessor
+
+  beforeEach(() => {
+    mockClient = createMockClient()
+    processor = new PostHogTracingProcessor({
+      client: mockClient,
+      distinctId: 'test-user',
+      privacyMode: false,
+    })
+  })
+
+  describe('initialization', () => {
+    it('initializes correctly with all options', () => {
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: 'user@example.com',
+        privacyMode: true,
+        groups: { company: 'acme' },
+        properties: { env: 'test' },
+      })
+
+      expect(proc).toBeInstanceOf(PostHogTracingProcessor)
+    })
+
+    it('initializes with minimal options', () => {
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+      })
+
+      expect(proc).toBeInstanceOf(PostHogTracingProcessor)
+    })
+  })
+
+  describe('trace lifecycle', () => {
+    it('on_trace_start stores metadata without capturing event', async () => {
+      const trace = createMockTrace()
+      await processor.onTraceStart(trace as any)
+
+      expect(mockClient.capture).not.toHaveBeenCalled()
+    })
+
+    it('on_trace_end captures $ai_trace event', async () => {
+      const trace = createMockTrace()
+      await processor.onTraceStart(trace as any)
+      await processor.onTraceEnd(trace as any)
+
+      expect(mockClient.capture).toHaveBeenCalledTimes(1)
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_trace')
+      expect(call.distinctId).toBe('test-user')
+      expect(call.properties.$ai_trace_id).toBe('trace_123456789')
+      expect(call.properties.$ai_trace_name).toBe('Test Workflow')
+      expect(call.properties.$ai_provider).toBe('openai')
+      expect(call.properties.$ai_framework).toBe('openai-agents')
+      expect(call.properties.$ai_latency).toBeDefined()
+    })
+
+    it('includes group_id in trace events', async () => {
+      const trace = createMockTrace({ groupId: 'group_abc' })
+      await processor.onTraceStart(trace as any)
+      await processor.onTraceEnd(trace as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_group_id).toBe('group_abc')
+    })
+
+    it('includes trace metadata in trace events', async () => {
+      const trace = createMockTrace({ metadata: { user_id: 'u123', session: 'sess_1' } })
+      await processor.onTraceStart(trace as any)
+      await processor.onTraceEnd(trace as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_trace_metadata).toEqual({ user_id: 'u123', session: 'sess_1' })
+    })
+  })
+
+  describe('personless mode', () => {
+    it('uses personless mode when no distinct_id is provided', async () => {
+      const proc = new PostHogTracingProcessor({ client: mockClient })
+      const trace = createMockTrace()
+
+      await proc.onTraceStart(trace as any)
+      await proc.onTraceEnd(trace as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$process_person_profile).toBe(false)
+      expect(call.distinctId).toBe(trace.traceId)
+    })
+
+    it('uses personless mode for spans when no distinct_id is provided', async () => {
+      const proc = new PostHogTracingProcessor({ client: mockClient })
+      const trace = createMockTrace()
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+      })
+
+      await proc.onTraceStart(trace as any)
+      mockClient.capture.mockClear()
+
+      await proc.onSpanStart(span as any)
+      await proc.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$process_person_profile).toBe(false)
+      expect(call.distinctId).toBe(trace.traceId)
+    })
+
+    it('uses personless mode when callable distinct_id returns null', async () => {
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: () => null,
+      })
+      const trace = createMockTrace()
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+      })
+
+      await proc.onTraceStart(trace as any)
+      mockClient.capture.mockClear()
+
+      await proc.onSpanStart(span as any)
+      await proc.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$process_person_profile).toBe(false)
+      expect(call.distinctId).toBe(trace.traceId)
+    })
+
+    it('does not set $process_person_profile when distinct_id is provided', async () => {
+      const trace = createMockTrace()
+      await processor.onTraceStart(trace as any)
+      await processor.onTraceEnd(trace as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$process_person_profile).toBeUndefined()
+    })
+  })
+
+  describe('distinct_id resolution', () => {
+    it('supports callable distinct_id', async () => {
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: (trace: any) => `user-${trace.name}`,
+      })
+      const trace = createMockTrace()
+
+      await proc.onTraceStart(trace as any)
+      await proc.onTraceEnd(trace as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.distinctId).toBe('user-Test Workflow')
+    })
+
+    it('spans use distinct_id resolved at trace start', async () => {
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: (trace: any) => `user-${trace.name}`,
+      })
+      const trace = createMockTrace()
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+      })
+
+      await proc.onTraceStart(trace as any)
+      mockClient.capture.mockClear()
+
+      await proc.onSpanStart(span as any)
+      await proc.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.distinctId).toBe('user-Test Workflow')
+    })
+  })
+
+  describe('generation spans', () => {
+    it('maps GenerationSpanData to $ai_generation event', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'generation',
+          input: [{ role: 'user', content: 'Hello' }],
+          output: [{ role: 'assistant', content: 'Hi there!' }],
+          model: 'gpt-4o',
+          model_config: { temperature: 0.7, max_tokens: 100 },
+          usage: { input_tokens: 10, output_tokens: 20 },
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_generation')
+      expect(call.properties.$ai_trace_id).toBe('trace_123456789')
+      expect(call.properties.$ai_span_id).toBe('span_987654321')
+      expect(call.properties.$ai_provider).toBe('openai')
+      expect(call.properties.$ai_framework).toBe('openai-agents')
+      expect(call.properties.$ai_model).toBe('gpt-4o')
+      expect(call.properties.$ai_input_tokens).toBe(10)
+      expect(call.properties.$ai_output_tokens).toBe(20)
+      expect(call.properties.$ai_total_tokens).toBe(30)
+      expect(call.properties.$ai_input).toEqual([{ role: 'user', content: 'Hello' }])
+      expect(call.properties.$ai_output_choices).toEqual([{ role: 'assistant', content: 'Hi there!' }])
+      expect(call.properties.$ai_model_parameters).toEqual({ temperature: 0.7, max_tokens: 100 })
+    })
+
+    it('handles no usage data with zero defaults', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_input_tokens).toBe(0)
+      expect(call.properties.$ai_output_tokens).toBe(0)
+      expect(call.properties.$ai_total_tokens).toBe(0)
+    })
+
+    it('handles partial usage data', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'generation',
+          model: 'gpt-4o',
+          usage: { input_tokens: 42 },
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_input_tokens).toBe(42)
+      expect(call.properties.$ai_output_tokens).toBe(0)
+      expect(call.properties.$ai_total_tokens).toBe(42)
+    })
+
+    it('includes reasoning tokens when present', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'generation',
+          model: 'o1-preview',
+          usage: {
+            input_tokens: 100,
+            output_tokens: 500,
+            reasoning_tokens: 400,
+          },
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_reasoning_tokens).toBe(400)
+    })
+
+    it('includes cache tokens from details when present', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'generation',
+          model: 'gpt-4o',
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            details: {
+              cache_read_input_tokens: 80,
+              cache_creation_input_tokens: 20,
+            },
+          },
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_cache_read_input_tokens).toBe(80)
+      expect(call.properties.$ai_cache_creation_input_tokens).toBe(20)
+    })
+  })
+
+  describe('function spans', () => {
+    it('maps FunctionSpanData to $ai_span event with type=tool', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'function',
+          name: 'get_weather',
+          input: '{"city": "San Francisco"}',
+          output: 'Sunny, 72F',
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_span')
+      expect(call.properties.$ai_span_name).toBe('get_weather')
+      expect(call.properties.$ai_span_type).toBe('tool')
+      expect(call.properties.$ai_input_state).toBe('{"city": "San Francisco"}')
+      expect(call.properties.$ai_output_state).toBe('Sunny, 72F')
+    })
+
+    it('includes MCP data when present', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'function',
+          name: 'search',
+          input: 'query',
+          output: 'result',
+          mcp_data: '{"server": "brave-search"}',
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_mcp_data).toBe('{"server": "brave-search"}')
+    })
+  })
+
+  describe('agent spans', () => {
+    it('maps AgentSpanData to $ai_span event with type=agent', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'agent',
+          name: 'CustomerServiceAgent',
+          handoffs: ['TechnicalAgent', 'BillingAgent'],
+          tools: ['search', 'get_order'],
+          output_type: 'str',
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_span')
+      expect(call.properties.$ai_span_name).toBe('CustomerServiceAgent')
+      expect(call.properties.$ai_span_type).toBe('agent')
+      expect(call.properties.$ai_agent_handoffs).toEqual(['TechnicalAgent', 'BillingAgent'])
+      expect(call.properties.$ai_agent_tools).toEqual(['search', 'get_order'])
+      expect(call.properties.$ai_agent_output_type).toBe('str')
+    })
+  })
+
+  describe('handoff spans', () => {
+    it('maps HandoffSpanData to $ai_span event with type=handoff', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'handoff',
+          from_agent: 'TriageAgent',
+          to_agent: 'TechnicalAgent',
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_span')
+      expect(call.properties.$ai_span_type).toBe('handoff')
+      expect(call.properties.$ai_handoff_from_agent).toBe('TriageAgent')
+      expect(call.properties.$ai_handoff_to_agent).toBe('TechnicalAgent')
+      expect(call.properties.$ai_span_name).toBe('TriageAgent -> TechnicalAgent')
+    })
+  })
+
+  describe('guardrail spans', () => {
+    it('maps GuardrailSpanData to $ai_span event with type=guardrail', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'guardrail',
+          name: 'ContentFilter',
+          triggered: true,
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_span')
+      expect(call.properties.$ai_span_name).toBe('ContentFilter')
+      expect(call.properties.$ai_span_type).toBe('guardrail')
+      expect(call.properties.$ai_guardrail_triggered).toBe(true)
+    })
+  })
+
+  describe('custom spans', () => {
+    it('maps CustomSpanData to $ai_span event with type=custom', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'custom',
+          name: 'database_query',
+          data: { query: 'SELECT * FROM users', rows: 100 },
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_span')
+      expect(call.properties.$ai_span_name).toBe('database_query')
+      expect(call.properties.$ai_span_type).toBe('custom')
+      expect(call.properties.$ai_custom_data).toEqual({ query: 'SELECT * FROM users', rows: 100 })
+    })
+  })
+
+  describe('response spans', () => {
+    it('maps ResponseSpanData to $ai_generation event', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'response',
+          response_id: 'resp_123',
+          _input: 'Hello, world!',
+          _response: {
+            id: 'resp_123',
+            model: 'gpt-4o',
+            output: [{ type: 'message', content: 'Hello!' }],
+            usage: { input_tokens: 25, output_tokens: 10 },
+          },
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_generation')
+      expect(call.properties.$ai_response_id).toBe('resp_123')
+      expect(call.properties.$ai_model).toBe('gpt-4o')
+      expect(call.properties.$ai_input_tokens).toBe(25)
+      expect(call.properties.$ai_output_tokens).toBe(10)
+      expect(call.properties.$ai_total_tokens).toBe(35)
+      expect(call.properties.$ai_output_choices).toEqual([{ type: 'message', content: 'Hello!' }])
+    })
+  })
+
+  describe('audio spans', () => {
+    it('maps TranscriptionSpanData to $ai_span with type=transcription', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'transcription',
+          input: { data: 'base64_audio', format: 'pcm' },
+          output: 'This is the transcribed text.',
+          model: 'whisper-1',
+          model_config: { language: 'en' },
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_span')
+      expect(call.properties.$ai_span_type).toBe('transcription')
+      expect(call.properties.$ai_model).toBe('whisper-1')
+      expect(call.properties.audio_input_format).toBe('pcm')
+      expect(call.properties.model_config).toEqual({ language: 'en' })
+      expect(call.properties.$ai_output_state).toBe('This is the transcribed text.')
+    })
+
+    it('maps SpeechSpanData to $ai_span with type=speech', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'speech',
+          input: 'Hello, how can I help you?',
+          output: { data: 'base64_audio_data', format: 'pcm' },
+          model: 'tts-1',
+          model_config: { voice: 'alloy', speed: 1.0 },
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_span')
+      expect(call.properties.$ai_span_type).toBe('speech')
+      expect(call.properties.$ai_model).toBe('tts-1')
+      expect(call.properties.audio_output_format).toBe('pcm')
+      expect(call.properties.$ai_input).toBe('Hello, how can I help you?')
+    })
+
+    it('maps SpeechGroupSpanData to $ai_span with type=speech_group', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'speech_group',
+          input: 'Group input text',
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_span')
+      expect(call.properties.$ai_span_type).toBe('speech_group')
+    })
+  })
+
+  describe('MCP spans', () => {
+    it('maps MCPListToolsSpanData to $ai_span with type=mcp_tools', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'mcp_tools',
+          server: 'brave-search',
+          result: ['web_search', 'image_search'],
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_span')
+      expect(call.properties.$ai_span_type).toBe('mcp_tools')
+      expect(call.properties.$ai_span_name).toBe('mcp:brave-search')
+      expect(call.properties.$ai_mcp_server).toBe('brave-search')
+      expect(call.properties.$ai_mcp_tools).toEqual(['web_search', 'image_search'])
+    })
+  })
+
+  describe('privacy mode', () => {
+    it('redacts input/output content when privacy mode is enabled', async () => {
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: 'test-user',
+        privacyMode: true,
+      })
+
+      const span = createMockSpan({
+        spanData: {
+          type: 'generation',
+          input: [{ role: 'user', content: 'Secret message' }],
+          output: [{ role: 'assistant', content: 'Secret response' }],
+          model: 'gpt-4o',
+          usage: { input_tokens: 10, output_tokens: 20 },
+        },
+      })
+
+      await proc.onSpanStart(span as any)
+      await proc.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.properties.$ai_input).toBeNull()
+      expect(call.properties.$ai_output_choices).toBeNull()
+      // Token counts should still be present
+      expect(call.properties.$ai_input_tokens).toBe(10)
+      expect(call.properties.$ai_output_tokens).toBe(20)
+    })
+
+    it('redacts function span input/output in privacy mode', async () => {
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: 'test-user',
+        privacyMode: true,
+      })
+
+      const span = createMockSpan({
+        spanData: {
+          type: 'function',
+          name: 'get_secret',
+          input: 'sensitive input',
+          output: 'sensitive output',
+        },
+      })
+
+      await proc.onSpanStart(span as any)
+      await proc.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.properties.$ai_input_state).toBeNull()
+      expect(call.properties.$ai_output_state).toBeNull()
+      expect(call.properties.$ai_span_name).toBe('get_secret')
+    })
+
+    it('redacts custom span data in privacy mode', async () => {
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: 'test-user',
+        privacyMode: true,
+      })
+
+      const span = createMockSpan({
+        spanData: {
+          type: 'custom',
+          name: 'sensitive_op',
+          data: { secret: 'should-be-redacted' },
+        },
+      })
+
+      await proc.onSpanStart(span as any)
+      await proc.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_custom_data).toBeNull()
+    })
+  })
+
+  describe('error handling', () => {
+    it('captures span errors correctly', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+        error: { message: 'Rate limit exceeded' },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.properties.$ai_is_error).toBe(true)
+      expect(call.properties.$ai_error).toBe('Rate limit exceeded')
+    })
+
+    it('categorizes ModelBehaviorError', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+        error: { message: 'ModelBehaviorError: Invalid JSON output' },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_error_type).toBe('model_behavior_error')
+    })
+
+    it('categorizes UserError', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+        error: { message: 'UserError: Tool failed' },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_error_type).toBe('user_error')
+    })
+
+    it('categorizes InputGuardrailTripwireTriggered', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+        error: { message: 'InputGuardrailTripwireTriggered: Content blocked' },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_error_type).toBe('input_guardrail_triggered')
+    })
+
+    it('categorizes OutputGuardrailTripwireTriggered', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+        error: { message: 'OutputGuardrailTripwireTriggered: Response blocked' },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_error_type).toBe('output_guardrail_triggered')
+    })
+
+    it('categorizes MaxTurnsExceeded', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+        error: { message: 'MaxTurnsExceeded: Agent exceeded maximum turns' },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_error_type).toBe('max_turns_exceeded')
+    })
+
+    it('categorizes unknown errors', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+        error: { message: 'Some random error occurred' },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_error_type).toBe('unknown')
+    })
+  })
+
+  describe('latency calculation', () => {
+    it('calculates latency from span start/end times', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+      })
+
+      const now = Date.now()
+      jest.spyOn(Date, 'now').mockReturnValueOnce(now).mockReturnValueOnce(now + 1500)
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_latency).toBeCloseTo(1.5, 1)
+
+      jest.restoreAllMocks()
+    })
+
+    it('falls back to ISO timestamp parsing', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o' },
+        startedAt: '2024-01-01T00:00:00.000Z',
+        endedAt: '2024-01-01T00:00:02.000Z',
+      })
+
+      // Don't call onSpanStart to skip recording start time
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.$ai_latency).toBeCloseTo(2.0, 1)
+    })
+  })
+
+  describe('groups and properties', () => {
+    it('includes groups in captured events', async () => {
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: 'test-user',
+        groups: { company: 'acme', team: 'engineering' },
+      })
+      const trace = createMockTrace()
+
+      await proc.onTraceStart(trace as any)
+      await proc.onTraceEnd(trace as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.groups).toEqual({ company: 'acme', team: 'engineering' })
+    })
+
+    it('includes additional properties in events', async () => {
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: 'test-user',
+        properties: { environment: 'production', version: '1.0' },
+      })
+      const trace = createMockTrace()
+
+      await proc.onTraceStart(trace as any)
+      await proc.onTraceEnd(trace as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      expect(call.properties.environment).toBe('production')
+      expect(call.properties.version).toBe('1.0')
+    })
+  })
+
+  describe('shutdown and flush', () => {
+    it('clears internal state on shutdown', async () => {
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: 'test-user',
+      })
+
+      // Add some internal state
+      const trace = createMockTrace()
+      const span = createMockSpan()
+      await proc.onTraceStart(trace as any)
+      await proc.onSpanStart(span as any)
+
+      await proc.shutdown()
+
+      // Verify state is cleared by checking that subsequent operations don't crash
+      // and that flush was called
+      expect(mockClient.flush).toHaveBeenCalled()
+    })
+
+    it('calls client flush on forceFlush', async () => {
+      await processor.forceFlush()
+      expect(mockClient.flush).toHaveBeenCalled()
+    })
+  })
+
+  describe('memory management', () => {
+    it('evicts stale entries when exceeding max tracked entries', async () => {
+      const proc = new PostHogTracingProcessor({
+        client: mockClient,
+        distinctId: 'test-user',
+      })
+      ;(proc as any)._maxTrackedEntries = 10
+
+      // Fill beyond max
+      for (let i = 0; i < 15; i++) {
+        const span = createMockSpan({ spanId: `span_${i}` })
+        await proc.onSpanStart(span as any)
+      }
+
+      // Trigger eviction
+      const span = createMockSpan({ spanId: 'span_trigger' })
+      await proc.onSpanStart(span as any)
+
+      // Should have evicted some entries
+      expect((proc as any)._spanStartTimes.size).toBeLessThanOrEqual(11)
+    })
+  })
+
+  describe('generic spans', () => {
+    it('handles unknown span types as generic spans', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'some_future_type' },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+
+      expect(call.event).toBe('$ai_span')
+      expect(call.properties.$ai_span_type).toBe('some_future_type')
+      expect(call.properties.$ai_span_name).toBe('some_future_type')
+    })
+  })
+})
+
+const mockAddTraceProcessor = jest.fn()
+jest.mock('@openai/agents-core', () => ({
+  addTraceProcessor: mockAddTraceProcessor,
+}))
+
+describe('instrument()', () => {
+  beforeEach(() => {
+    mockAddTraceProcessor.mockClear()
+  })
+
+  it('creates processor and registers it', () => {
+    const { instrument } = require('../src/openai-agents')
+    const mockClient = createMockClient()
+
+    const processor = instrument({
+      client: mockClient,
+      distinctId: 'test-user',
+    })
+
+    expect(processor).toBeInstanceOf(PostHogTracingProcessor)
+    expect(mockAddTraceProcessor).toHaveBeenCalledWith(processor)
+  })
+
+  it('passes privacy mode to processor', () => {
+    const { instrument } = require('../src/openai-agents')
+    const mockClient = createMockClient()
+
+    const processor = instrument({
+      client: mockClient,
+      privacyMode: true,
+    })
+
+    expect((processor as any)._privacyMode).toBe(true)
+  })
+
+  it('passes groups and properties to processor', () => {
+    const { instrument } = require('../src/openai-agents')
+    const mockClient = createMockClient()
+
+    const processor = instrument({
+      client: mockClient,
+      groups: { company: 'acme' },
+      properties: { env: 'test' },
+    })
+
+    expect((processor as any)._groups).toEqual({ company: 'acme' })
+    expect((processor as any)._properties).toEqual({ env: 'test' })
+  })
+})

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -769,82 +769,24 @@ describe('PostHogTracingProcessor', () => {
       expect(call.properties.$ai_error).toBe('Rate limit exceeded')
     })
 
-    it('categorizes ModelBehaviorError', async () => {
+    it.each([
+      ['ModelBehaviorError: Invalid JSON output', 'model_behavior_error'],
+      ['UserError: Tool failed', 'user_error'],
+      ['InputGuardrailTripwireTriggered: Content blocked', 'input_guardrail_triggered'],
+      ['OutputGuardrailTripwireTriggered: Response blocked', 'output_guardrail_triggered'],
+      ['MaxTurnsExceeded: Agent exceeded maximum turns', 'max_turns_exceeded'],
+      ['Some random error occurred', 'unknown'],
+    ])('categorizes "%s" as %s', async (message, expectedType) => {
       const span = createMockSpan({
         spanData: { type: 'generation', model: 'gpt-4o' },
-        error: { message: 'ModelBehaviorError: Invalid JSON output' },
+        error: { message },
       })
 
       await processor.onSpanStart(span as any)
       await processor.onSpanEnd(span as any)
 
       const call = mockClient.capture.mock.calls[0][0]
-      expect(call.properties.$ai_error_type).toBe('model_behavior_error')
-    })
-
-    it('categorizes UserError', async () => {
-      const span = createMockSpan({
-        spanData: { type: 'generation', model: 'gpt-4o' },
-        error: { message: 'UserError: Tool failed' },
-      })
-
-      await processor.onSpanStart(span as any)
-      await processor.onSpanEnd(span as any)
-
-      const call = mockClient.capture.mock.calls[0][0]
-      expect(call.properties.$ai_error_type).toBe('user_error')
-    })
-
-    it('categorizes InputGuardrailTripwireTriggered', async () => {
-      const span = createMockSpan({
-        spanData: { type: 'generation', model: 'gpt-4o' },
-        error: { message: 'InputGuardrailTripwireTriggered: Content blocked' },
-      })
-
-      await processor.onSpanStart(span as any)
-      await processor.onSpanEnd(span as any)
-
-      const call = mockClient.capture.mock.calls[0][0]
-      expect(call.properties.$ai_error_type).toBe('input_guardrail_triggered')
-    })
-
-    it('categorizes OutputGuardrailTripwireTriggered', async () => {
-      const span = createMockSpan({
-        spanData: { type: 'generation', model: 'gpt-4o' },
-        error: { message: 'OutputGuardrailTripwireTriggered: Response blocked' },
-      })
-
-      await processor.onSpanStart(span as any)
-      await processor.onSpanEnd(span as any)
-
-      const call = mockClient.capture.mock.calls[0][0]
-      expect(call.properties.$ai_error_type).toBe('output_guardrail_triggered')
-    })
-
-    it('categorizes MaxTurnsExceeded', async () => {
-      const span = createMockSpan({
-        spanData: { type: 'generation', model: 'gpt-4o' },
-        error: { message: 'MaxTurnsExceeded: Agent exceeded maximum turns' },
-      })
-
-      await processor.onSpanStart(span as any)
-      await processor.onSpanEnd(span as any)
-
-      const call = mockClient.capture.mock.calls[0][0]
-      expect(call.properties.$ai_error_type).toBe('max_turns_exceeded')
-    })
-
-    it('categorizes unknown errors', async () => {
-      const span = createMockSpan({
-        spanData: { type: 'generation', model: 'gpt-4o' },
-        error: { message: 'Some random error occurred' },
-      })
-
-      await processor.onSpanStart(span as any)
-      await processor.onSpanEnd(span as any)
-
-      const call = mockClient.capture.mock.calls[0][0]
-      expect(call.properties.$ai_error_type).toBe('unknown')
+      expect(call.properties.$ai_error_type).toBe(expectedType)
     })
   })
 
@@ -994,12 +936,11 @@ describe('instrument()', () => {
     mockAddTraceProcessor.mockClear()
   })
 
-  it('creates processor and registers it', () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { instrument } = require('../src/openai-agents')
+  it('creates processor and registers it', async () => {
+    const { instrument } = await import('../src/openai-agents')
     const mockClient = createMockClient()
 
-    const processor = instrument({
+    const processor = await instrument({
       client: mockClient,
       distinctId: 'test-user',
     })
@@ -1008,12 +949,11 @@ describe('instrument()', () => {
     expect(mockAddTraceProcessor).toHaveBeenCalledWith(processor)
   })
 
-  it('passes privacy mode to processor', () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { instrument } = require('../src/openai-agents')
+  it('passes privacy mode to processor', async () => {
+    const { instrument } = await import('../src/openai-agents')
     const mockClient = createMockClient()
 
-    const processor = instrument({
+    const processor = await instrument({
       client: mockClient,
       privacyMode: true,
     })
@@ -1021,12 +961,11 @@ describe('instrument()', () => {
     expect((processor as any)._privacyMode).toBe(true)
   })
 
-  it('passes groups and properties to processor', () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { instrument } = require('../src/openai-agents')
+  it('passes groups and properties to processor', async () => {
+    const { instrument } = await import('../src/openai-agents')
     const mockClient = createMockClient()
 
-    const processor = instrument({
+    const processor = await instrument({
       client: mockClient,
       groups: { company: 'acme' },
       properties: { env: 'test' },

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -855,7 +855,10 @@ describe('PostHogTracingProcessor', () => {
       })
 
       const now = Date.now()
-      jest.spyOn(Date, 'now').mockReturnValueOnce(now).mockReturnValueOnce(now + 1500)
+      jest
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(now)
+        .mockReturnValueOnce(now + 1500)
 
       await processor.onSpanStart(span as any)
       await processor.onSpanEnd(span as any)
@@ -992,6 +995,7 @@ describe('instrument()', () => {
   })
 
   it('creates processor and registers it', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { instrument } = require('../src/openai-agents')
     const mockClient = createMockClient()
 
@@ -1005,6 +1009,7 @@ describe('instrument()', () => {
   })
 
   it('passes privacy mode to processor', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { instrument } = require('../src/openai-agents')
     const mockClient = createMockClient()
 
@@ -1017,6 +1022,7 @@ describe('instrument()', () => {
   })
 
   it('passes groups and properties to processor', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { instrument } = require('../src/openai-agents')
     const mockClient = createMockClient()
 

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -344,6 +344,81 @@ describe('PostHogTracingProcessor', () => {
     })
   })
 
+  describe('input role normalization', () => {
+    it('adds role=assistant to function_call items in generation input', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'generation',
+          model: 'gpt-4o',
+          input: [
+            { role: 'user', content: 'What is the weather?', type: 'message' },
+            { type: 'function_call', name: 'get_weather', arguments: '{"city":"Tokyo"}', callId: 'call_1' },
+            { type: 'function_call_result', name: 'get_weather', output: { text: 'Sunny' }, callId: 'call_1' },
+          ],
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      const input = call.properties.$ai_input
+
+      expect(input[0].role).toBe('user')
+      expect(input[1].role).toBe('assistant')
+      expect(input[1].type).toBe('function_call')
+      expect(input[2].role).toBe('tool')
+      expect(input[2].type).toBe('function_call_result')
+    })
+
+    it('adds role=assistant to function_call items in response span input', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'response',
+          response_id: 'resp_123',
+          _input: [
+            { role: 'user', content: 'Hello', type: 'message' },
+            { type: 'function_call', name: 'search', arguments: '{}', callId: 'call_2' },
+            { type: 'function_call_result', name: 'search', output: { text: 'results' }, callId: 'call_2' },
+          ],
+          _response: { id: 'resp_123', model: 'gpt-4o' },
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      const input = call.properties.$ai_input
+
+      expect(input[0].role).toBe('user')
+      expect(input[1].role).toBe('assistant')
+      expect(input[2].role).toBe('tool')
+    })
+
+    it('does not override existing role fields', async () => {
+      const span = createMockSpan({
+        spanData: {
+          type: 'generation',
+          model: 'gpt-4o',
+          input: [
+            { role: 'system', content: 'You are helpful', type: 'message' },
+            { role: 'user', content: 'Hi', type: 'message' },
+          ],
+        },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      const call = mockClient.capture.mock.calls[0][0]
+      const input = call.properties.$ai_input
+
+      expect(input[0].role).toBe('system')
+      expect(input[1].role).toBe('user')
+    })
+  })
+
   describe('function spans', () => {
     it('maps FunctionSpanData to $ai_span event with type=tool', async () => {
       const span = createMockSpan({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       '@babel/preset-typescript':
         specifier: 'catalog:'
         version: 7.28.5(@babel/core@7.28.5)
+      '@openai/agents':
+        specifier: ^0.8.0
+        version: 0.8.3(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@4.1.13)
       '@openai/agents-core':
         specifier: ^0.8.0
         version: 0.8.3(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@4.1.13)
@@ -3495,6 +3498,21 @@ packages:
       zod:
         optional: true
 
+  '@openai/agents-openai@0.8.3':
+    resolution: {integrity: sha512-n5bsRfVDINupkeSh/E/lRoGWUi9xVSRpf6muRjnEckIO0pmCG3NzKO+FQVhiyFA3c8i2vrn28SXF/ZdGcG4+vQ==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@openai/agents-realtime@0.8.3':
+    resolution: {integrity: sha512-no5AdAfYM5V/1u32OEQpP+VOJP/Y/JyTCVOvcgAdSKIV43ZG82f72pxbB0B2aFRdLZwC7C6sDgCJz6pbp+TjRg==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@openai/agents@0.8.3':
+    resolution: {integrity: sha512-VmUywYNVaOuBOOv5hdH6tj3UjU3ZOkvM5WyRyEgRXEVkYbISkZuVWlnzEtiZkQ3lWjp0M8GGtKfSq2Dbr5DaQQ==}
+    peerDependencies:
+      zod: ^4.0.0
+
   '@opentelemetry/api-logs@0.200.0':
     resolution: {integrity: sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==}
     engines: {node: '>=8.0.0'}
@@ -4883,6 +4901,9 @@ packages:
 
   '@types/web@0.0.222':
     resolution: {integrity: sha512-vBvVv2L5ArWQenebQiUCtZNpL4mguLCbrZ8aqzVCundYRvwZZzlqBP7EEpoUszLnztmzWmBxQ4+4nHAMFlfYlA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -17525,6 +17546,45 @@ snapshots:
       - supports-color
       - ws
 
+  '@openai/agents-openai@0.8.3(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@4.1.13)':
+    dependencies:
+      '@openai/agents-core': 0.8.3(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@4.1.13)
+      debug: 4.4.3
+      openai: 6.33.0(ws@8.19.0)(zod@4.1.13)
+      zod: 4.1.13
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-realtime@0.8.3(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
+    dependencies:
+      '@openai/agents-core': 0.8.3(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@4.1.13)
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.19.0
+      zod: 4.1.13
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@openai/agents@0.8.3(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@4.1.13)':
+    dependencies:
+      '@openai/agents-core': 0.8.3(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@4.1.13)
+      '@openai/agents-openai': 0.8.3(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@4.1.13)
+      '@openai/agents-realtime': 0.8.3(@cfworker/json-schema@4.1.1)(zod@4.1.13)
+      debug: 4.4.3
+      openai: 6.33.0(ws@8.19.0)(zod@4.1.13)
+      zod: 4.1.13
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+
   '@opentelemetry/api-logs@0.200.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -19050,6 +19110,10 @@ snapshots:
   '@types/uuid@10.0.0': {}
 
   '@types/web@0.0.222': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.1
 
   '@types/yargs-parser@21.0.3': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,7 @@ importers:
         version: 0.78.0(zod@4.1.13)
       '@google/genai':
         specifier: ^1.43.0
-        version: 1.43.0
+        version: 1.43.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.1.13))
       '@langchain/core':
         specifier: ^1.1.29
         version: 1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13))
@@ -198,7 +198,7 @@ importers:
         version: link:../core
       langchain:
         specifier: ^1.2.28
-        version: 1.2.28(@langchain/core@1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13)))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod-to-json-schema@3.24.6(zod@4.1.13))
+        version: 1.2.28(@langchain/core@1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13)))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod-to-json-schema@3.25.2(zod@4.1.13))
       openai:
         specifier: ^6.25.0
         version: 6.25.0(ws@8.19.0)(zod@4.1.13)
@@ -218,6 +218,9 @@ importers:
       '@babel/preset-typescript':
         specifier: 'catalog:'
         version: 7.28.5(@babel/core@7.28.5)
+      '@openai/agents-core':
+        specifier: ^0.8.0
+        version: 0.8.3(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@4.1.13)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -235,7 +238,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -522,10 +525,10 @@ importers:
         version: 17.3.0
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
       ts-jest:
         specifier: 'catalog:'
-        version: 29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)))(typescript@5.8.2)
+        version: 29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)))(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -546,7 +549,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
 
   packages/next:
     dependencies:
@@ -586,7 +589,7 @@ importers:
         version: 3.4.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -601,7 +604,7 @@ importers:
         version: 19.2.1(react@19.2.1)
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)))(typescript@5.8.2)
+        version: 29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)))(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -641,13 +644,13 @@ importers:
         version: 7.7.0
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       next:
         specifier: ^15.5.7
         version: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       ts-jest:
         specifier: 'catalog:'
-        version: 29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)))(typescript@5.9.3)
+        version: 29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)))(typescript@5.9.3)
 
   packages/node:
     dependencies:
@@ -675,7 +678,7 @@ importers:
         version: 20.19.9
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3))
       rxjs:
         specifier: ^7.8.0
         version: 7.8.2
@@ -743,7 +746,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
 
   packages/react:
     devDependencies:
@@ -785,7 +788,7 @@ importers:
         version: 7.0.3
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
       jest-environment-jsdom:
         specifier: 'catalog:'
         version: 29.7.0
@@ -888,7 +891,7 @@ importers:
         version: 11.0.0
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
       jest-environment-jsdom:
         specifier: 'catalog:'
         version: 29.7.0
@@ -897,7 +900,7 @@ importers:
         version: 29.7.0
       jest-expo:
         specifier: 'catalog:'
-        version: 47.0.1(@babel/core@7.28.5)(jest@29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)))(react@18.2.0)
+        version: 47.0.1(@babel/core@7.28.5)(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)))(react@18.2.0)
       metro:
         specifier: 0.83.1
         version: 0.83.1
@@ -930,7 +933,7 @@ importers:
         version: 15.15.0(react-native@0.69.12(@babel/core@7.28.5)(@babel/preset-env@7.28.5(@babel/core@7.28.5))(react@18.2.0))(react@18.2.0)
       ts-jest:
         specifier: 'catalog:'
-        version: 29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)))(typescript@5.8.2)
+        version: 29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)))(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -955,7 +958,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
       rollup:
         specifier: ~4.53.2
         version: 4.53.3
@@ -973,10 +976,10 @@ importers:
         version: 29.5.14
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
       ts-jest:
         specifier: 'catalog:'
-        version: 29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)))(typescript@5.8.2)
+        version: 29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)))(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -1004,7 +1007,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: 'catalog:'
         version: 29.7.0
@@ -1029,7 +1032,7 @@ importers:
         version: 0.10.6(@microsoft/api-extractor@7.55.1(@types/node@24.10.13))(typescript@5.9.3)
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+        version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
       webpack:
         specifier: ^5
         version: 5.102.1
@@ -2871,6 +2874,12 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
+  '@hono/node-server@1.19.12':
+    resolution: {integrity: sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -3283,6 +3292,16 @@ packages:
     resolution: {integrity: sha512-TaW4jTGVE1/ln2VGFChnheMh589QCAZy1MVnLvjjSzZ4pEAa4WYAWPwFkDVZbSdPQdLfZy7LuTyZjWRkhX9/Gg==}
     engines: {node: '>=6'}
 
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@module-federation/error-codes@0.16.0':
     resolution: {integrity: sha512-TfmA45b8vvISniGudMg8jjIy1q3tLPon0QN/JdFp5f8AJ8/peICN5b+dkEQnWsAVg2fEusYhk9dO7z3nUeJM8A==}
 
@@ -3467,6 +3486,14 @@ packages:
 
   '@open-draft/until@1.0.3':
     resolution: {integrity: sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==}
+
+  '@openai/agents-core@0.8.3':
+    resolution: {integrity: sha512-UWRwtGF4t+MkT2xMWTHuEUI2xgp58bKvMYN0rQu6rB9zWtiP0aY5tCXlWUdPKhpPlM/X68u6eUN7qDitqrf50g==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@opentelemetry/api-logs@0.200.0':
     resolution: {integrity: sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==}
@@ -5333,6 +5360,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-globals@6.0.0:
     resolution: {integrity: sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==}
 
@@ -5429,6 +5460,9 @@ packages:
 
   ajv@8.13.0:
     resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   alien-signals@3.0.0:
     resolution: {integrity: sha512-JHoRJf18Y6HN4/KZALr3iU+0vW9LKG+8FMThQlbn4+gv8utsLIkwpomjElGPccGeNwh0FI2HN6BLnyFLo6OyLQ==}
@@ -5865,6 +5899,10 @@ packages:
   body-parser@1.19.0:
     resolution: {integrity: sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==}
     engines: {node: '>= 0.8'}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -6351,6 +6389,10 @@ packages:
     resolution: {integrity: sha512-dPyZofqggxuvSf7WXvNjuRfnsOk1YazkVP8FdxH4tcH2c37wc79/Yl6Bhr7Lsu00KMgy2ql/qCMuNu8xctZM8g==}
     engines: {node: '> 0.10'}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -6388,8 +6430,16 @@ packages:
   cookie-es@2.0.0:
     resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
   cookie@0.4.2:
     resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
+    engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   cookie@1.0.2:
@@ -6415,6 +6465,10 @@ packages:
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   corser@2.0.1:
     resolution: {integrity: sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==}
@@ -7436,6 +7490,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   exec-async@2.2.0:
     resolution: {integrity: sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==}
 
@@ -7551,6 +7613,16 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  express-rate-limit@8.3.2:
+    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
 
@@ -7601,6 +7673,9 @@ packages:
 
   fast-npm-meta@0.4.7:
     resolution: {integrity: sha512-aZU3i3eRcSb2NCq8i6N6IlyiTyF6vqAqzBGl2NBF6ngNx/GIqfYbkLDIKZ4z4P0o/RmtsFnVqHwdrSm13o4tnQ==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -7684,6 +7759,10 @@ packages:
   finalhandler@1.1.2:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
     engines: {node: '>= 0.8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-babel-config@1.2.2:
     resolution: {integrity: sha512-oK59njMyw2y3yxto1BCfVK7MQp/OYf4FleHu0RgosH3riFJ1aOuo/7naLDLAObfrgn3ueFhw5sAT/cp0QuJI3Q==}
@@ -7779,6 +7858,10 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -8207,6 +8290,10 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  hono@4.12.11:
+    resolution: {integrity: sha512-r4xbIa3mGGGoH9nN4A14DOg2wx7y2oQyJEb5O57C/xzETG/qx4c7CVDQ5WMeKHZ7ORk2W0hZ/sQKXTav3cmYBA==}
+    engines: {node: '>=16.9.0'}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -8234,6 +8321,10 @@ packages:
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
   http-proxy-agent@4.0.1:
@@ -8455,6 +8546,10 @@ packages:
   ioredis@5.8.1:
     resolution: {integrity: sha512-Qho8TgIamqEPdgiMadJwzRMW3TudIg6vpg4YONokGDudy4eqRIJtDbVX72pfLBcWxvbn3qm/40TyGUObdW4tLQ==}
     engines: {node: '>=12.22.0'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
 
   ip-regex@2.1.0:
     resolution: {integrity: sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==}
@@ -8733,6 +8828,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -9156,6 +9254,9 @@ packages:
   join-component@1.1.0:
     resolution: {integrity: sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==}
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
     engines: {node: '>=0.10.0'}
@@ -9261,6 +9362,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -9685,11 +9789,19 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
   memory-cache@0.2.0:
     resolution: {integrity: sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-options@3.0.4:
     resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
@@ -10108,6 +10220,10 @@ packages:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -10406,6 +10522,18 @@ packages:
       zod:
         optional: true
 
+  openai@6.33.0:
+    resolution: {integrity: sha512-xAYN1W3YsDXJWA5F277135YfkEk6H7D3D6vWwRhJ3OEkzRgcyK8z/P5P9Gyi/wB4N8kK9kM5ZjprfvyHagKmpw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
@@ -10661,6 +10789,9 @@ packages:
   path-to-regexp@6.2.1:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -10737,6 +10868,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@3.0.0:
     resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
@@ -11369,6 +11504,10 @@ packages:
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -11403,6 +11542,10 @@ packages:
   qrcode-terminal@0.11.0:
     resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
     hasBin: true
+
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
 
   qs@6.5.3:
     resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
@@ -11444,6 +11587,10 @@ packages:
   raw-body@2.4.0:
     resolution: {integrity: sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
@@ -11883,6 +12030,10 @@ packages:
     resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   rrdom@2.0.0-alpha.17:
     resolution: {integrity: sha512-b6caDiNcFO96Opp7TGdcVd4OLGSXu5dJe+A0IDiAu8mk7OmhqZCSDlgQdTKmdO5wMf4zPsUTgb8H/aNvR3kDHA==}
@@ -12368,6 +12519,10 @@ packages:
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   std-env@3.9.0:
@@ -13022,6 +13177,10 @@ packages:
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
   type-level-regexp@0.1.17:
@@ -13872,10 +14031,10 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
-  zod-to-json-schema@3.24.6:
-    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.24.1
+      zod: ^3.25.28 || ^4
 
   zod@4.1.13:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
@@ -16030,12 +16189,14 @@ snapshots:
 
   '@gar/promisify@1.1.3': {}
 
-  '@google/genai@1.43.0':
+  '@google/genai@1.43.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.1.13))':
     dependencies:
       google-auth-library: 10.6.1
       p-retry: 4.6.2
       protobufjs: 7.5.4
       ws: 8.19.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16050,6 +16211,11 @@ snapshots:
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
+
+  '@hono/node-server@1.19.12(hono@4.12.11)':
+    dependencies:
+      hono: 4.12.11
+    optional: true
 
   '@humanfs/core@0.19.1': {}
 
@@ -16225,6 +16391,80 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
+  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0(node-notifier@8.0.2)
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.19.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0(node-notifier@8.0.2)
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.19.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))':
     dependencies:
       '@jest/console': 29.7.0
@@ -16240,6 +16480,44 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
       jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
+  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0(node-notifier@8.0.2)
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.19.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -16277,6 +16555,80 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
       jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.2))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0(node-notifier@8.0.2)
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.19.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0(node-notifier@8.0.2)
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.19.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -16558,7 +16910,7 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
-  '@langchain/langgraph@1.2.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13)))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod-to-json-schema@3.24.6(zod@4.1.13))(zod@4.1.13)':
+  '@langchain/langgraph@1.2.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13)))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod-to-json-schema@3.25.2(zod@4.1.13))(zod@4.1.13)':
     dependencies:
       '@langchain/core': 1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13))
       '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13)))
@@ -16567,7 +16919,7 @@ snapshots:
       uuid: 10.0.0
       zod: 4.1.13
     optionalDependencies:
-      zod-to-json-schema: 3.24.6(zod@4.1.13)
+      zod-to-json-schema: 3.25.2(zod@4.1.13)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -16729,6 +17081,31 @@ snapshots:
   '@microsoft/tsdoc@0.16.0': {}
 
   '@miherlosev/esm@3.2.26': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
+    dependencies:
+      '@hono/node-server': 1.19.12(hono@4.12.11)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.11
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.1.13
+      zod-to-json-schema: 3.25.2(zod@4.1.13)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@module-federation/error-codes@0.16.0': {}
 
@@ -17135,6 +17512,18 @@ snapshots:
       - yaml
 
   '@open-draft/until@1.0.3': {}
+
+  '@openai/agents-core@0.8.3(@cfworker/json-schema@4.1.1)(ws@8.19.0)(zod@4.1.13)':
+    dependencies:
+      debug: 4.4.3
+      openai: 6.33.0(ws@8.19.0)(zod@4.1.13)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)
+      zod: 4.1.13
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
 
   '@opentelemetry/api-logs@0.200.0':
     dependencies:
@@ -19347,6 +19736,12 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.1
+      negotiator: 1.0.0
+    optional: true
+
   acorn-globals@6.0.0:
     dependencies:
       acorn: 7.4.1
@@ -19410,6 +19805,11 @@ snapshots:
     optionalDependencies:
       ajv: 8.13.0
 
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+    optional: true
+
   ajv-keywords@5.1.0(ajv@8.13.0):
     dependencies:
       ajv: 8.13.0
@@ -19435,6 +19835,14 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+    optional: true
 
   alien-signals@3.0.0: {}
 
@@ -19986,6 +20394,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.0
+      iconv-lite: 0.7.0
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   boolbase@1.0.0: {}
 
   bowser@1.6.0: {}
@@ -20523,6 +20946,9 @@ snapshots:
     dependencies:
       easy-table: 1.1.0
 
+  content-disposition@1.0.1:
+    optional: true
+
   content-type@1.0.5: {}
 
   convert-source-map@1.7.0:
@@ -20546,7 +20972,13 @@ snapshots:
 
   cookie-es@2.0.0: {}
 
+  cookie-signature@1.2.2:
+    optional: true
+
   cookie@0.4.2: {}
+
+  cookie@0.7.2:
+    optional: true
 
   cookie@1.0.2: {}
 
@@ -20565,6 +20997,12 @@ snapshots:
   core-js@3.44.0: {}
 
   core-util-is@1.0.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+    optional: true
 
   corser@2.0.1: {}
 
@@ -20590,13 +21028,13 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.7.0
 
-  create-jest@29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)):
+  create-jest@29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -20605,13 +21043,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)):
+  create-jest@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -20627,6 +21065,22 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
+  create-jest@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -20650,13 +21104,28 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)):
+  create-jest@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  create-jest@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -21917,6 +22386,14 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.6:
+    optional: true
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+    optional: true
+
   exec-async@2.2.0: {}
 
   exec-sh@0.3.4: {}
@@ -22135,6 +22612,46 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
+  express-rate-limit@8.3.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+    optional: true
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.1
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.0
+      serve-static: 2.2.0
+      statuses: 2.0.1
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   exsolve@1.0.7: {}
 
   extend-shallow@2.0.1:
@@ -22192,6 +22709,9 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-npm-meta@0.4.7: {}
+
+  fast-uri@3.1.0:
+    optional: true
 
   fastq@1.19.1:
     dependencies:
@@ -22288,6 +22808,18 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   find-babel-config@1.2.2:
     dependencies:
@@ -22391,6 +22923,9 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  forwarded@0.2.0:
+    optional: true
 
   fraction.js@4.3.7: {}
 
@@ -22878,6 +23413,9 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  hono@4.12.11:
+    optional: true
+
   hookable@5.5.3: {}
 
   hosted-git-info@3.0.8:
@@ -22911,6 +23449,15 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+    optional: true
 
   http-proxy-agent@4.0.1:
     dependencies:
@@ -23154,6 +23701,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ip-address@10.1.0:
+    optional: true
+
   ip-regex@2.1.0: {}
 
   ip@1.1.5: {}
@@ -23381,6 +23931,9 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@4.0.0:
+    optional: true
+
   is-reference@1.2.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -23591,16 +24144,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)):
+  jest-cli@29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      create-jest: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -23612,16 +24165,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)):
+  jest-cli@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      create-jest: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -23643,6 +24196,28 @@ snapshots:
       exit: 0.1.2
       import-local: 3.2.0
       jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
+  jest-cli@29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -23675,16 +24250,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)):
+  jest-cli@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      create-jest: 29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -23696,7 +24271,28 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)):
+  jest-cli@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest-config@29.7.0(@types/node@20.19.9)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
@@ -23722,12 +24318,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.9
-      ts-node: 10.9.2(@types/node@22.19.1)(typescript@5.8.2)
+      ts-node: 10.9.2(@types/node@20.19.9)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)):
+  jest-config@29.7.0(@types/node@22.16.5)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
@@ -23753,7 +24349,69 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.16.5
-      ts-node: 10.9.2(@types/node@22.19.1)(typescript@5.8.2)
+      ts-node: 10.9.2(@types/node@22.16.5)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.1
+      ts-node: 10.9.2(@types/node@20.19.9)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.1
+      ts-node: 10.9.2(@types/node@22.16.5)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -23785,6 +24443,38 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.1
       ts-node: 10.9.2(@types/node@22.19.1)(typescript@5.8.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    optional: true
+
+  jest-config@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.1
+      ts-node: 10.9.2(@types/node@22.19.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -23820,6 +24510,68 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.1
+      ts-node: 10.9.2(@types/node@24.10.13)(typescript@5.8.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.19.1)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.1
+      ts-node: 10.9.2(@types/node@24.10.13)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-config@29.7.0(@types/node@22.5.0)(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.28.5
@@ -23851,7 +24603,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)):
+  jest-config@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
@@ -23877,7 +24629,38 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.10.13
-      ts-node: 10.9.2(@types/node@22.19.1)(typescript@5.8.2)
+      ts-node: 10.9.2(@types/node@24.10.13)(typescript@5.8.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.10.13
+      ts-node: 10.9.2(@types/node@24.10.13)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -23925,14 +24708,14 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@47.0.1(@babel/core@7.28.5)(jest@29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)))(react@18.2.0):
+  jest-expo@47.0.1(@babel/core@7.28.5)(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)))(react@18.2.0):
     dependencies:
       '@expo/config': 7.0.3
       '@jest/create-cache-key-function': 27.5.1
       babel-jest: 26.6.3(@babel/core@7.28.5)
       find-up: 5.0.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 0.6.4(jest@29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)))
+      jest-watch-typeahead: 0.6.4(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)))
       json5: 2.2.3
       lodash: 4.17.21
       react-test-renderer: 18.1.0(react@18.2.0)
@@ -24224,11 +25007,11 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
-  jest-watch-typeahead@0.6.4(jest@29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))):
+  jest-watch-typeahead@0.6.4(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      jest: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
       jest-regex-util: 27.5.1
       jest-watcher: 27.5.1
       slash: 3.0.0
@@ -24275,12 +25058,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)):
+  jest@29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-cli: 29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3))
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -24289,12 +25072,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)):
+  jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-cli: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -24309,6 +25092,21 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
+  jest@29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -24331,12 +25129,26 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)):
+  jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest-cli: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
+    optionalDependencies:
+      node-notifier: 8.0.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -24364,6 +25176,9 @@ snapshots:
       '@sideway/pinpoint': 2.0.0
 
   join-component@1.1.0: {}
+
+  jose@6.2.2:
+    optional: true
 
   js-levenshtein@1.1.6: {}
 
@@ -24526,6 +25341,9 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  json-schema-typed@8.0.2:
+    optional: true
+
   json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -24604,10 +25422,10 @@ snapshots:
 
   knitwork@1.2.0: {}
 
-  langchain@1.2.28(@langchain/core@1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13)))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod-to-json-schema@3.24.6(zod@4.1.13)):
+  langchain@1.2.28(@langchain/core@1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13)))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod-to-json-schema@3.25.2(zod@4.1.13)):
     dependencies:
       '@langchain/core': 1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13))
-      '@langchain/langgraph': 1.2.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13)))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod-to-json-schema@3.24.6(zod@4.1.13))(zod@4.1.13)
+      '@langchain/langgraph': 1.2.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13)))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod-to-json-schema@3.25.2(zod@4.1.13))(zod@4.1.13)
       '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@1.1.29(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13)))
       langsmith: 0.5.7(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(openai@6.25.0(ws@8.19.0)(zod@4.1.13))
       uuid: 11.1.0
@@ -24961,9 +25779,15 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0:
+    optional: true
+
   memoize-one@5.2.1: {}
 
   memory-cache@0.2.0: {}
+
+  merge-descriptors@2.0.0:
+    optional: true
 
   merge-options@3.0.4:
     dependencies:
@@ -25685,6 +26509,9 @@ snapshots:
 
   negotiator@0.6.4: {}
 
+  negotiator@1.0.0:
+    optional: true
+
   neo-async@2.6.2: {}
 
   nested-error-stacks@2.0.1: {}
@@ -26179,6 +27006,11 @@ snapshots:
       ws: 8.19.0
       zod: 4.1.13
 
+  openai@6.33.0(ws@8.19.0)(zod@4.1.13):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 4.1.13
+
   opener@1.5.2: {}
 
   optionator@0.8.3:
@@ -26476,6 +27308,9 @@ snapshots:
 
   path-to-regexp@6.2.1: {}
 
+  path-to-regexp@8.4.2:
+    optional: true
+
   path-type@4.0.0: {}
 
   path-type@6.0.0: {}
@@ -26523,6 +27358,9 @@ snapshots:
   pinkie@2.0.4: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1:
+    optional: true
 
   pkg-dir@3.0.0:
     dependencies:
@@ -27247,6 +28085,12 @@ snapshots:
 
   protocols@2.0.2: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    optional: true
+
   proxy-from-env@1.1.0: {}
 
   ps-tree@1.2.0:
@@ -27274,6 +28118,11 @@ snapshots:
   qrcode-terminal@0.10.0: {}
 
   qrcode-terminal@0.11.0: {}
+
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+    optional: true
 
   qs@6.5.3: {}
 
@@ -27312,6 +28161,14 @@ snapshots:
       http-errors: 1.7.2
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.0
+      unpipe: 1.0.0
+    optional: true
 
   rc9@2.1.2:
     dependencies:
@@ -27836,6 +28693,17 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.53.3
       '@rollup/rollup-win32-x64-msvc': 4.53.3
       fsevents: 2.3.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   rrdom@2.0.0-alpha.17:
     dependencies:
@@ -28450,6 +29318,9 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.1: {}
+
+  statuses@2.0.2:
+    optional: true
 
   std-env@3.9.0: {}
 
@@ -29201,12 +30072,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)))(typescript@5.9.3):
+  ts-jest@29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest: 29.7.0(@types/node@22.16.5)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -29221,12 +30092,12 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.28.5)
       jest-util: 29.7.0
 
-  ts-jest@29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)))(typescript@5.8.2):
+  ts-jest@29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2)))(typescript@5.8.2):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.19.1)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
+      jest: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -29241,25 +30112,43 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.28.5)
       jest-util: 29.7.0
 
-  ts-jest@29.4.0(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2)))(typescript@5.8.2):
+  ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3):
     dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.9
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
       make-error: 1.3.6
-      semver: 7.7.4
-      type-fest: 4.41.0
-      typescript: 5.8.2
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.5
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.5)
-      jest-util: 29.7.0
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@22.16.5)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.16.5
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   ts-node@10.9.2(@types/node@22.19.1)(typescript@5.8.2):
     dependencies:
@@ -29279,6 +30168,25 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.19.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
   ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -29296,6 +30204,44 @@ snapshots:
       typescript: 5.8.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@24.10.13)(typescript@5.8.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.10.13
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.10.13
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
@@ -29374,6 +30320,13 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
+    optional: true
 
   type-level-regexp@0.1.17: {}
 
@@ -30258,7 +31211,7 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
-  zod-to-json-schema@3.24.6(zod@4.1.13):
+  zod-to-json-schema@3.25.2(zod@4.1.13):
     dependencies:
       zod: 4.1.13
     optional: true


### PR DESCRIPTION
## Summary

- Adds `PostHogTracingProcessor` implementing the `TracingProcessor` interface from `@openai/agents-core` to capture OpenAI Agents SDK traces as PostHog LLM analytics events
- New submodule export at `@posthog/ai/openai-agents` with `instrument()` one-liner and `PostHogTracingProcessor` class
- Ports the existing Python SDK implementation ([posthog-python](https://github.com/PostHog/posthog-python/tree/master/posthog/ai/openai_agents)) to JS with matching event schema

### Span type support

All 11 span types mapped to PostHog events:

| Span Type | PostHog Event | Key Properties |
|-----------|--------------|----------------|
| `generation` | `$ai_generation` | model, input/output, tokens, model params |
| `response` | `$ai_generation` | response_id, model, tokens from response object |
| `function` | `$ai_span` (type=tool) | name, input/output state, MCP data |
| `agent` | `$ai_span` (type=agent) | name, handoffs, tools, output_type |
| `handoff` | `$ai_span` (type=handoff) | from_agent, to_agent |
| `guardrail` | `$ai_span` (type=guardrail) | name, triggered |
| `custom` | `$ai_span` (type=custom) | name, custom data |
| `transcription` | `$ai_span` (type=transcription) | model, audio format, text output |
| `speech` | `$ai_span` (type=speech) | model, audio format, text input |
| `speech_group` | `$ai_span` (type=speech_group) | input text |
| `mcp_tools` | `$ai_span` (type=mcp_tools) | server, tool list |

### Features
- Privacy mode (redacts input/output, preserves token counts)
- Personless mode (no distinct_id → uses trace_id, sets `$process_person_profile: false`)
- Callable distinct_id resolver (`(trace) => userId`)
- Error categorization (ModelBehaviorError, UserError, guardrail triggers, MaxTurnsExceeded)
- Groups and custom properties pass-through
- Memory-safe with auto-eviction of stale tracking entries

### Usage

```typescript
import { instrument } from '@posthog/ai/openai-agents'
import { PostHog } from 'posthog-node'
import { Agent, run } from '@openai/agents'

const phClient = new PostHog('<API_KEY>')
instrument({ client: phClient, distinctId: 'user@example.com' })

const agent = new Agent({ name: 'Assistant', model: 'gpt-4o-mini' })
const result = await run(agent, 'Hello!')
// Traces automatically sent to PostHog
```

### Verified

Tested locally — single-agent and multi-agent traces land correctly in PostHog with full span hierarchy, token counts, latency, costs, and tool call details.

## Test plan

- [x] 49 unit tests covering all span types, privacy mode, personless mode, error categorization, latency calculation, groups, properties, memory eviction
- [x] All 286 existing tests pass (no regressions)
- [x] Build succeeds — produces `dist/openai-agents/index.{cjs,mjs,d.ts}`
- [x] Live test: single-agent with tool calling → trace verified in PostHog
- [x] Live test: multi-agent with handoffs → trace verified in PostHog