### PR TITLE
fix: disable native async gzip after NotReadableError

### DIFF
--- a/.changeset/silent-gzip-fix.md
+++ b/.changeset/silent-gzip-fix.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Disable native gzip compression after a NotReadableError in the browser SDK

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -560,4 +560,126 @@ describe('request', () => {
             )
         })
     })
+
+    describe('native async gzip retry flow', () => {
+        let isolatedRequestModule: any
+        let isolatedCompression: typeof Compression
+        let mockedIsolatedFetch: jest.Mock
+        let mockedIsolatedGzipCompress: jest.Mock
+
+        beforeEach(async () => {
+            jest.resetModules()
+            jest.clearAllMocks()
+            jest.useFakeTimers()
+            jest.setSystemTime(now)
+
+            mockedIsolatedFetch = jest.fn(() =>
+                Promise.resolve({
+                    status: 200,
+                    text: () => Promise.resolve('{ "a": 1 }'),
+                })
+            )
+            mockedIsolatedGzipCompress = jest.fn()
+
+            jest.doMock('../utils/globals', () => ({
+                ...jest.requireActual('../utils/globals'),
+                fetch: mockedIsolatedFetch,
+                XMLHttpRequest: jest.fn(),
+                navigator: {
+                    sendBeacon: jest.fn(),
+                },
+                CompressionStream: jest.fn(),
+            }))
+
+            jest.doMock('@posthog/core', () => ({
+                ...jest.requireActual('@posthog/core'),
+                gzipCompress: mockedIsolatedGzipCompress,
+            }))
+
+            isolatedRequestModule = await import('../request')
+            isolatedCompression = (await import('../types')).Compression
+            isolatedRequestModule.__resetNativeAsyncGzipDisabledForTests()
+        })
+
+        afterEach(() => {
+            isolatedRequestModule.__resetNativeAsyncGzipDisabledForTests()
+        })
+
+        it('retries uncompressed and disables native async gzip after NotReadableError', async () => {
+            mockedIsolatedGzipCompress.mockRejectedValueOnce({ name: 'NotReadableError' })
+
+            isolatedRequestModule.request({
+                url: 'https://any.posthog-instance.com?ver=1.23.45',
+                data: { foo: 'bar' },
+                headers: {},
+                callback: jest.fn(),
+                transport: 'fetch',
+                method: 'POST',
+                compression: isolatedCompression.GZipJS,
+            })
+
+            await flushPromises()
+
+            expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
+            expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
+            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][1].body).toBe('{"foo":"bar"}')
+
+            mockedIsolatedFetch.mockClear()
+
+            isolatedRequestModule.request({
+                url: 'https://any.posthog-instance.com?ver=1.23.45',
+                data: { foo: 'baz' },
+                headers: {},
+                callback: jest.fn(),
+                transport: 'fetch',
+                method: 'POST',
+                compression: isolatedCompression.GZipJS,
+            })
+
+            await flushPromises()
+
+            expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
+            expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
+            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
+        })
+
+        it('resets native async gzip state between tests', async () => {
+            mockedIsolatedGzipCompress.mockRejectedValueOnce({ name: 'NotReadableError' })
+
+            isolatedRequestModule.request({
+                url: 'https://any.posthog-instance.com?ver=1.23.45',
+                data: { foo: 'bar' },
+                headers: {},
+                callback: jest.fn(),
+                transport: 'fetch',
+                method: 'POST',
+                compression: isolatedCompression.GZipJS,
+            })
+
+            await flushPromises()
+
+            isolatedRequestModule.__resetNativeAsyncGzipDisabledForTests()
+            mockedIsolatedFetch.mockClear()
+            mockedIsolatedGzipCompress.mockResolvedValueOnce(new Blob(['compressed'], { type: 'text/plain' }))
+
+            isolatedRequestModule.request({
+                url: 'https://any.posthog-instance.com?ver=1.23.45',
+                data: { foo: 'baz' },
+                headers: {},
+                callback: jest.fn(),
+                transport: 'fetch',
+                method: 'POST',
+                compression: isolatedCompression.GZipJS,
+            })
+
+            await flushPromises()
+
+            expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(2)
+            expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
+            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
+        })
+    })
 })

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -598,11 +598,6 @@ describe('request', () => {
 
             isolatedRequestModule = await import('../request')
             isolatedCompression = (await import('../types')).Compression
-            isolatedRequestModule.__resetNativeAsyncGzipDisabledForTests()
-        })
-
-        afterEach(() => {
-            isolatedRequestModule.__resetNativeAsyncGzipDisabledForTests()
         })
 
         it('retries uncompressed and disables native async gzip after NotReadableError', async () => {
@@ -645,23 +640,7 @@ describe('request', () => {
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
         })
 
-        it('resets native async gzip state between tests', async () => {
-            mockedIsolatedGzipCompress.mockRejectedValueOnce({ name: 'NotReadableError' })
-
-            isolatedRequestModule.request({
-                url: 'https://any.posthog-instance.com?ver=1.23.45',
-                data: { foo: 'bar' },
-                headers: {},
-                callback: jest.fn(),
-                transport: 'fetch',
-                method: 'POST',
-                compression: isolatedCompression.GZipJS,
-            })
-
-            await flushPromises()
-
-            isolatedRequestModule.__resetNativeAsyncGzipDisabledForTests()
-            mockedIsolatedFetch.mockClear()
+        it('starts with native async gzip enabled in a fresh module instance', async () => {
             mockedIsolatedGzipCompress.mockResolvedValueOnce(new Blob(['compressed'], { type: 'text/plain' }))
 
             isolatedRequestModule.request({
@@ -676,7 +655,7 @@ describe('request', () => {
 
             await flushPromises()
 
-            expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(2)
+            expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
             expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
             expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -617,7 +617,7 @@ describe('request', () => {
 
             expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
             expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
-            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][0]).not.toContain('&compression=gzip-js')
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBe('{"foo":"bar"}')
 
             mockedIsolatedFetch.mockClear()

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -29,6 +29,10 @@ const SIXTY_FOUR_KILOBYTES = 64 * 1024
 const KEEP_ALIVE_THRESHOLD = SIXTY_FOUR_KILOBYTES * 0.8
 let nativeAsyncGzipDisabled = false
 
+export const __resetNativeAsyncGzipDisabledForTests = (): void => {
+    nativeAsyncGzipDisabled = false
+}
+
 type EncodedBody = {
     contentType: string
     body: string | BlobPart | ArrayBuffer
@@ -304,10 +308,6 @@ export const request = (_options: RequestWithOptions) => {
     // Clone the options so we don't modify the original object
     const options: RequestWithEncodedBody = { ..._options }
     options.timeout = options.timeout || 60000
-
-    if (nativeAsyncGzipDisabled && options.compression === Compression.GZipJS) {
-        options.compression = undefined
-    }
 
     options.url = extendURLParams(options.url, {
         _: new Date().getTime().toString(),

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -272,6 +272,14 @@ const _sendBeacon = (options: RequestWithOptions) => {
     }
 }
 
+const buildRequestURL = (url: string, compression?: Compression): string => {
+    return extendURLParams(url, {
+        _: new Date().getTime().toString(),
+        ver: Config.JS_SDK_VERSION,
+        compression,
+    })
+}
+
 const AVAILABLE_TRANSPORTS: {
     transport: RequestWithOptions['transport']
     method: (options: RequestWithOptions) => void
@@ -305,11 +313,7 @@ export const request = (_options: RequestWithOptions) => {
     const options: RequestWithEncodedBody = { ..._options }
     options.timeout = options.timeout || 60000
 
-    options.url = extendURLParams(options.url, {
-        _: new Date().getTime().toString(),
-        ver: Config.JS_SDK_VERSION,
-        compression: options.compression,
-    })
+    options.url = buildRequestURL(options.url, options.compression)
 
     const transport = options.transport ?? 'fetch'
 
@@ -344,6 +348,7 @@ export const request = (_options: RequestWithOptions) => {
                     transportMethod({
                         ...options,
                         compression: undefined,
+                        url: buildRequestURL(_options.url, undefined),
                     })
                     return
                 }

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -27,6 +27,18 @@ const SIXTY_FOUR_KILOBYTES = 64 * 1024
  any overhead doesn't push over the threshold after checking here
 */
 const KEEP_ALIVE_THRESHOLD = SIXTY_FOUR_KILOBYTES * 0.8
+let nativeAsyncGzipDisabled = false
+
+const isNativeAsyncGzipReadError = (error: unknown): boolean => {
+    if (!error || typeof error !== 'object') {
+        return false
+    }
+
+    const name = 'name' in error ? String(error.name) : ''
+
+    return name === 'NotReadableError'
+}
+
 type EncodedBody = {
     contentType: string
     body: string | BlobPart | ArrayBuffer
@@ -118,15 +130,13 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
  * which can take 300ms+ on constrained devices.
  *
  * Callers must check preconditions (data exists, gzip compression, CompressionStream available)
- * before calling this function. Uses `gzipCompress` from @posthog/core.
+ * before calling this function.
  */
 const preEncodeAsync = async (options: RequestWithEncodedBody): Promise<RequestWithEncodedBody> => {
     const jsonData = jsonStringify(options.data)
-    const compressed = await gzipCompress(jsonData, Config.DEBUG)
-    if (!compressed) {
-        return options
-    }
-    const body = await compressed.arrayBuffer()
+    const compressedBlob = await gzipCompress(jsonData, Config.DEBUG, { rethrow: true })
+    const body = await compressedBlob!.arrayBuffer()
+
     return {
         ...options,
         _encodedBody: {
@@ -302,6 +312,10 @@ export const request = (_options: RequestWithOptions) => {
     const options: RequestWithEncodedBody = { ..._options }
     options.timeout = options.timeout || 60000
 
+    if (nativeAsyncGzipDisabled && options.compression === Compression.GZipJS) {
+        options.compression = undefined
+    }
+
     options.url = extendURLParams(options.url, {
         _: new Date().getTime().toString(),
         ver: Config.JS_SDK_VERSION,
@@ -328,14 +342,24 @@ export const request = (_options: RequestWithOptions) => {
         transport !== 'sendBeacon' &&
         options.data &&
         options.compression === Compression.GZipJS &&
-        !!CompressionStream
+        !!CompressionStream &&
+        !nativeAsyncGzipDisabled
     ) {
         preEncodeAsync(options)
             .then((encodedOptions) => {
                 transportMethod(encodedOptions)
             })
-            .catch(() => {
-                // If async compression fails, fall back to the synchronous fflate path
+            .catch((error) => {
+                if (isNativeAsyncGzipReadError(error)) {
+                    nativeAsyncGzipDisabled = true
+                    transportMethod({
+                        ...options,
+                        compression: undefined,
+                    })
+                    return
+                }
+
+                // If async compression fails for another reason, fall back to the synchronous fflate path
                 transportMethod(options)
             })
     } else {

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -272,7 +272,7 @@ const _sendBeacon = (options: RequestWithOptions) => {
     }
 }
 
-const buildRequestURL = (url: string, compression?: Compression): string => {
+const buildRequestURL = (url: string, compression?: RequestWithOptions['compression']): string => {
     return extendURLParams(url, {
         _: new Date().getTime().toString(),
         ver: Config.JS_SDK_VERSION,

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -29,10 +29,6 @@ const SIXTY_FOUR_KILOBYTES = 64 * 1024
 const KEEP_ALIVE_THRESHOLD = SIXTY_FOUR_KILOBYTES * 0.8
 let nativeAsyncGzipDisabled = false
 
-export const __resetNativeAsyncGzipDisabledForTests = (): void => {
-    nativeAsyncGzipDisabled = false
-}
-
 type EncodedBody = {
     contentType: string
     body: string | BlobPart | ArrayBuffer
@@ -128,11 +124,11 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
  */
 const preEncodeAsync = async (options: RequestWithEncodedBody): Promise<RequestWithEncodedBody> => {
     const jsonData = jsonStringify(options.data)
-    const compressedBlob = await gzipCompress(jsonData, Config.DEBUG, { rethrow: true })
-    if (!compressedBlob) {
+    const compressed = await gzipCompress(jsonData, Config.DEBUG, { rethrow: true })
+    if (!compressed) {
         return options
     }
-    const body = await compressedBlob.arrayBuffer()
+    const body = await compressed.arrayBuffer()
 
     return {
         ...options,

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -8,7 +8,7 @@ import { AbortController, CompressionStream, fetch, navigator, XMLHttpRequest } 
 import { gzipSync, strToU8 } from 'fflate'
 
 import { _base64Encode } from './utils/encode-utils'
-import { gzipCompress } from '@posthog/core'
+import { gzipCompress, isNativeAsyncGzipReadError } from '@posthog/core'
 
 interface RequestWithEncodedBody extends RequestWithOptions {
     _encodedBody?: EncodedBody
@@ -28,16 +28,6 @@ const SIXTY_FOUR_KILOBYTES = 64 * 1024
 */
 const KEEP_ALIVE_THRESHOLD = SIXTY_FOUR_KILOBYTES * 0.8
 let nativeAsyncGzipDisabled = false
-
-const isNativeAsyncGzipReadError = (error: unknown): boolean => {
-    if (!error || typeof error !== 'object') {
-        return false
-    }
-
-    const name = 'name' in error ? String(error.name) : ''
-
-    return name === 'NotReadableError'
-}
 
 type EncodedBody = {
     contentType: string
@@ -135,7 +125,10 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
 const preEncodeAsync = async (options: RequestWithEncodedBody): Promise<RequestWithEncodedBody> => {
     const jsonData = jsonStringify(options.data)
     const compressedBlob = await gzipCompress(jsonData, Config.DEBUG, { rethrow: true })
-    const body = await compressedBlob!.arrayBuffer()
+    if (!compressedBlob) {
+        return options
+    }
+    const body = await compressedBlob.arrayBuffer()
 
     return {
         ...options,

--- a/packages/core/src/__tests__/gzip.spec.ts
+++ b/packages/core/src/__tests__/gzip.spec.ts
@@ -1,4 +1,4 @@
-import { isGzipSupported, gzipCompress } from '@/gzip'
+import { isGzipSupported, gzipCompress, isNativeAsyncGzipReadError } from '@/gzip'
 import { gzip } from 'node:zlib'
 import { randomBytes, randomUUID } from 'node:crypto'
 import { promisify } from 'node:util'
@@ -41,6 +41,17 @@ describe('gzip', () => {
       ;(globalThis as any).CompressionStream = CompressionStream
     })
   })
+  describe('isNativeAsyncGzipReadError', () => {
+    it('returns true for NotReadableError', () => {
+      expect(isNativeAsyncGzipReadError({ name: 'NotReadableError' })).toBe(true)
+    })
+
+    it('returns false for other errors', () => {
+      expect(isNativeAsyncGzipReadError({ name: 'TypeError' })).toBe(false)
+      expect(isNativeAsyncGzipReadError(null)).toBe(false)
+    })
+  })
+
   describe('gzipCompress', () => {
     it('rethrows errors when requested', async () => {
       const CompressionStream = globalThis.CompressionStream

--- a/packages/core/src/__tests__/gzip.spec.ts
+++ b/packages/core/src/__tests__/gzip.spec.ts
@@ -51,14 +51,12 @@ describe('gzip', () => {
       expect(isNativeAsyncGzipReadError(null)).toBe(false)
     })
   })
-
   describe('gzipCompress', () => {
     it('rethrows errors when requested', async () => {
       const CompressionStream = globalThis.CompressionStream
       delete (globalThis as any).CompressionStream
 
       await expect(gzipCompress(RANDOM_TEST_INPUT, false, { rethrow: true })).rejects.toThrow()
-
       ;(globalThis as any).CompressionStream = CompressionStream
     })
 

--- a/packages/core/src/__tests__/gzip.spec.ts
+++ b/packages/core/src/__tests__/gzip.spec.ts
@@ -42,6 +42,15 @@ describe('gzip', () => {
     })
   })
   describe('gzipCompress', () => {
+    it('rethrows errors when requested', async () => {
+      const CompressionStream = globalThis.CompressionStream
+      delete (globalThis as any).CompressionStream
+
+      await expect(gzipCompress(RANDOM_TEST_INPUT, false, { rethrow: true })).rejects.toThrow()
+
+      ;(globalThis as any).CompressionStream = CompressionStream
+    })
+
     it('compressed random data should match node', async () => {
       const compressed = await gzipCompress(RANDOM_TEST_INPUT)
       expect(compressed).not.toBe(null)

--- a/packages/core/src/gzip.ts
+++ b/packages/core/src/gzip.ts
@@ -29,11 +29,7 @@ export type GzipCompressOptions = {
 /**
  * Gzip a string using Compression Streams API if it's available
  */
-export async function gzipCompress(
-  input: string,
-  isDebug = true,
-  options?: GzipCompressOptions
-): Promise<Blob | null> {
+export async function gzipCompress(input: string, isDebug = true, options?: GzipCompressOptions): Promise<Blob | null> {
   try {
     // Turn the string into a stream using a Blob, and then compress it
     const dataStream = new Blob([input], {

--- a/packages/core/src/gzip.ts
+++ b/packages/core/src/gzip.ts
@@ -6,6 +6,16 @@ export function isGzipSupported(): boolean {
   return 'CompressionStream' in globalThis
 }
 
+export const isNativeAsyncGzipReadError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const name = 'name' in error ? String(error.name) : ''
+
+  return name === 'NotReadableError'
+}
+
 export type GzipCompressOptions = {
   /**
    * By default this helper swallows compression errors and returns null.

--- a/packages/core/src/gzip.ts
+++ b/packages/core/src/gzip.ts
@@ -7,6 +7,12 @@ export function isGzipSupported(): boolean {
 }
 
 export type GzipCompressOptions = {
+  /**
+   * By default this helper swallows compression errors and returns null.
+   * Some browsers, notably Safari 16, can throw NotReadableError from the
+   * native CompressionStream path. Callers can opt into rethrowing so they
+   * can detect that case and change future compression behavior if needed.
+   */
   rethrow?: boolean
 }
 

--- a/packages/core/src/gzip.ts
+++ b/packages/core/src/gzip.ts
@@ -6,10 +6,18 @@ export function isGzipSupported(): boolean {
   return 'CompressionStream' in globalThis
 }
 
+export type GzipCompressOptions = {
+  rethrow?: boolean
+}
+
 /**
  * Gzip a string using Compression Streams API if it's available
  */
-export async function gzipCompress(input: string, isDebug = true): Promise<Blob | null> {
+export async function gzipCompress(
+  input: string,
+  isDebug = true,
+  options?: GzipCompressOptions
+): Promise<Blob | null> {
   try {
     // Turn the string into a stream using a Blob, and then compress it
     const dataStream = new Blob([input], {
@@ -21,6 +29,10 @@ export async function gzipCompress(input: string, isDebug = true): Promise<Blob 
     // Using a Response to easily extract the readablestream value. Decoding into a string for fetch
     return await new Response(compressedStream).blob()
   } catch (error) {
+    if (options?.rethrow) {
+      throw error
+    }
+
     if (isDebug) {
       console.error('Failed to gzip compress data', error)
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { getFeatureFlagValue } from './featureFlagUtils'
-export { gzipCompress } from './gzip'
+export { gzipCompress, isNativeAsyncGzipReadError } from './gzip'
 export * from './utils'
 export * as ErrorTracking from './error-tracking'
 export { uuidv7 } from './vendor/uuidv7'


### PR DESCRIPTION
## Problem

Some browser SDK users are seeing `NotReadableError` from the native async gzip path when sending compressed requests. When that happens, the request should still go through and we should stop retrying the broken native compression path for the rest of the page lifetime.

## Changes

- add a `rethrow` option to `gzipCompress` in `@posthog/core`, with docs explaining the Safari 16 `NotReadableError` use case
- move native gzip `NotReadableError` detection into `@posthog/core` so browser code can reuse it
- update `packages/browser/src/request.ts` to reuse `gzipCompress(..., { rethrow: true })`
- detect `NotReadableError`, swallow it, retry the current request without compression, and disable native async gzip for subsequent requests in the same page session
- keep the existing synchronous gzip-js fallback for other compression failures
- add a changeset for `posthog-js`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
