### PR TITLE
fix(browser): merge partial /flags response with bootstrapped flags

### DIFF
--- a/.changeset/fix-partial-flags-overwrite-bootstrap.md
+++ b/.changeset/fix-partial-flags-overwrite-bootstrap.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix bootstrapped feature flags being overwritten by partial /flags response when `advanced_only_evaluate_survey_feature_flags` is enabled

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -2888,124 +2888,84 @@ describe('parseFlagsResponse', () => {
     })
 
     describe('partialResponse option', () => {
-        it('merges partial response with existing flags instead of overwriting', () => {
-            const existingFlags = {
-                'bootstrapped-flag': true,
-                'session-recording': true,
-            }
-            const existingPayloads = {
-                'bootstrapped-flag': 'bootstrap-payload',
-            }
-            const existingDetails = {
-                'bootstrapped-flag': {
-                    key: 'bootstrapped-flag',
-                    enabled: true,
-                    variant: undefined,
-                    reason: { code: 'condition_match', condition_index: 0, description: undefined },
-                    metadata: { id: 10, version: 1, payload: 'bootstrap-payload', description: undefined },
-                },
-            }
+        const surveyFlagDetail = {
+            key: 'survey-flag',
+            enabled: true,
+            variant: undefined,
+            reason: { code: 'condition_match', condition_index: 0, description: undefined },
+            metadata: { id: 1, version: 1, payload: undefined, description: undefined },
+        }
 
-            const flagsResponse = {
-                flags: {
-                    'survey-flag': {
-                        key: 'survey-flag',
-                        enabled: true,
-                        variant: undefined,
-                        reason: { code: 'condition_match', condition_index: 0, description: undefined },
-                        metadata: { id: 1, version: 1, payload: undefined, description: undefined },
-                    },
-                },
-            }
+        const bootstrapDetail = {
+            key: 'bootstrapped-flag',
+            enabled: true,
+            variant: undefined,
+            reason: { code: 'condition_match', condition_index: 0, description: undefined },
+            metadata: { id: 10, version: 1, payload: 'bootstrap-payload', description: undefined },
+        }
 
-            parseFlagsResponse(flagsResponse, persistence, existingFlags, existingPayloads, existingDetails, {
-                partialResponse: true,
-            })
-
-            expect(persistence.register).toHaveBeenCalledWith({
-                $active_feature_flags: ['bootstrapped-flag', 'session-recording', 'survey-flag'],
-                $enabled_feature_flags: {
-                    'bootstrapped-flag': true,
-                    'session-recording': true,
-                    'survey-flag': true,
-                },
-                $feature_flag_payloads: {
-                    'bootstrapped-flag': 'bootstrap-payload',
-                },
-                $feature_flag_details: {
-                    'bootstrapped-flag': existingDetails['bootstrapped-flag'],
-                    'survey-flag': flagsResponse.flags['survey-flag'],
-                },
-            })
-        })
-
-        it('partial response overwrites values for overlapping flag keys', () => {
-            const existingFlags = {
-                'survey-flag': false,
-                'other-flag': true,
-            }
-
-            const flagsResponse = {
-                flags: {
-                    'survey-flag': {
-                        key: 'survey-flag',
-                        enabled: true,
-                        variant: undefined,
-                        reason: { code: 'condition_match', condition_index: 0, description: undefined },
-                        metadata: { id: 1, version: 2, payload: undefined, description: undefined },
-                    },
-                },
-            }
-
-            parseFlagsResponse(
-                flagsResponse,
-                persistence,
+        it.each([
+            {
+                name: 'merges partial response with existing flags',
+                existingFlags: { 'bootstrapped-flag': true, 'session-recording': true },
+                existingPayloads: { 'bootstrapped-flag': 'bootstrap-payload' },
+                existingDetails: { 'bootstrapped-flag': bootstrapDetail },
+                options: { partialResponse: true },
+                expectedFlags: { 'bootstrapped-flag': true, 'session-recording': true, 'survey-flag': true },
+                expectedPayloads: { 'bootstrapped-flag': 'bootstrap-payload' },
+                expectedDetails: { 'bootstrapped-flag': bootstrapDetail, 'survey-flag': surveyFlagDetail },
+            },
+            {
+                name: 'partial response overwrites values for overlapping flag keys',
+                existingFlags: { 'survey-flag': false, 'other-flag': true },
+                existingPayloads: {},
+                existingDetails: {},
+                options: { partialResponse: true },
+                expectedFlags: { 'survey-flag': true, 'other-flag': true },
+                expectedPayloads: {},
+                expectedDetails: { 'survey-flag': surveyFlagDetail },
+            },
+            {
+                name: 'without partialResponse, response overwrites existing flags entirely',
+                existingFlags: { 'bootstrapped-flag': true, 'session-recording': true },
+                existingPayloads: {},
+                existingDetails: {},
+                options: undefined,
+                expectedFlags: { 'survey-flag': true },
+                expectedPayloads: {},
+                expectedDetails: { 'survey-flag': surveyFlagDetail },
+            },
+        ])(
+            '$name',
+            ({
                 existingFlags,
-                {},
-                {},
-                {
-                    partialResponse: true,
-                }
-            )
+                existingPayloads,
+                existingDetails,
+                options,
+                expectedFlags,
+                expectedPayloads,
+                expectedDetails,
+            }) => {
+                const flagsResponse = { flags: { 'survey-flag': surveyFlagDetail } }
 
-            expect(persistence.register).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    $enabled_feature_flags: {
-                        'survey-flag': true,
-                        'other-flag': true,
-                    },
-                })
-            )
-        })
+                parseFlagsResponse(
+                    flagsResponse,
+                    persistence,
+                    existingFlags,
+                    existingPayloads,
+                    existingDetails,
+                    options
+                )
 
-        it('without partialResponse, response overwrites existing flags entirely', () => {
-            const existingFlags = {
-                'bootstrapped-flag': true,
-                'session-recording': true,
+                expect(persistence.register).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        $enabled_feature_flags: expectedFlags,
+                        $feature_flag_payloads: expectedPayloads,
+                        $feature_flag_details: expectedDetails,
+                    })
+                )
             }
-
-            const flagsResponse = {
-                flags: {
-                    'survey-flag': {
-                        key: 'survey-flag',
-                        enabled: true,
-                        variant: undefined,
-                        reason: { code: 'condition_match', condition_index: 0, description: undefined },
-                        metadata: { id: 1, version: 1, payload: undefined, description: undefined },
-                    },
-                },
-            }
-
-            parseFlagsResponse(flagsResponse, persistence, existingFlags, {}, {})
-
-            expect(persistence.register).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    $enabled_feature_flags: {
-                        'survey-flag': true,
-                    },
-                })
-            )
-        })
+        )
     })
 })
 

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -2886,6 +2886,127 @@ describe('parseFlagsResponse', () => {
             $feature_flag_request_id: 'test-request-id-123',
         })
     })
+
+    describe('partialResponse option', () => {
+        it('merges partial response with existing flags instead of overwriting', () => {
+            const existingFlags = {
+                'bootstrapped-flag': true,
+                'session-recording': true,
+            }
+            const existingPayloads = {
+                'bootstrapped-flag': 'bootstrap-payload',
+            }
+            const existingDetails = {
+                'bootstrapped-flag': {
+                    key: 'bootstrapped-flag',
+                    enabled: true,
+                    variant: undefined,
+                    reason: { code: 'condition_match', condition_index: 0, description: undefined },
+                    metadata: { id: 10, version: 1, payload: 'bootstrap-payload', description: undefined },
+                },
+            }
+
+            const flagsResponse = {
+                flags: {
+                    'survey-flag': {
+                        key: 'survey-flag',
+                        enabled: true,
+                        variant: undefined,
+                        reason: { code: 'condition_match', condition_index: 0, description: undefined },
+                        metadata: { id: 1, version: 1, payload: undefined, description: undefined },
+                    },
+                },
+            }
+
+            parseFlagsResponse(flagsResponse, persistence, existingFlags, existingPayloads, existingDetails, {
+                partialResponse: true,
+            })
+
+            expect(persistence.register).toHaveBeenCalledWith({
+                $active_feature_flags: ['bootstrapped-flag', 'session-recording', 'survey-flag'],
+                $enabled_feature_flags: {
+                    'bootstrapped-flag': true,
+                    'session-recording': true,
+                    'survey-flag': true,
+                },
+                $feature_flag_payloads: {
+                    'bootstrapped-flag': 'bootstrap-payload',
+                },
+                $feature_flag_details: {
+                    'bootstrapped-flag': existingDetails['bootstrapped-flag'],
+                    'survey-flag': flagsResponse.flags['survey-flag'],
+                },
+            })
+        })
+
+        it('partial response overwrites values for overlapping flag keys', () => {
+            const existingFlags = {
+                'survey-flag': false,
+                'other-flag': true,
+            }
+
+            const flagsResponse = {
+                flags: {
+                    'survey-flag': {
+                        key: 'survey-flag',
+                        enabled: true,
+                        variant: undefined,
+                        reason: { code: 'condition_match', condition_index: 0, description: undefined },
+                        metadata: { id: 1, version: 2, payload: undefined, description: undefined },
+                    },
+                },
+            }
+
+            parseFlagsResponse(
+                flagsResponse,
+                persistence,
+                existingFlags,
+                {},
+                {},
+                {
+                    partialResponse: true,
+                }
+            )
+
+            expect(persistence.register).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    $enabled_feature_flags: {
+                        'survey-flag': true,
+                        'other-flag': true,
+                    },
+                })
+            )
+        })
+
+        it('without partialResponse, response overwrites existing flags entirely', () => {
+            const existingFlags = {
+                'bootstrapped-flag': true,
+                'session-recording': true,
+            }
+
+            const flagsResponse = {
+                flags: {
+                    'survey-flag': {
+                        key: 'survey-flag',
+                        enabled: true,
+                        variant: undefined,
+                        reason: { code: 'condition_match', condition_index: 0, description: undefined },
+                        metadata: { id: 1, version: 1, payload: undefined, description: undefined },
+                    },
+                },
+            }
+
+            parseFlagsResponse(flagsResponse, persistence, existingFlags, {}, {})
+
+            expect(persistence.register).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    $enabled_feature_flags: {
+                        'survey-flag': true,
+                    },
+                })
+            )
+        })
+    })
 })
 
 describe('filterActiveFeatureFlags', () => {

--- a/packages/browser/src/__tests__/posthog-core.loaded.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.loaded.test.ts
@@ -199,7 +199,9 @@ describe('loaded() with flags', () => {
             jest.advanceTimersByTime(10)
 
             if (expectedCall) {
-                expect(receivedFeatureFlagsSpy).toHaveBeenCalledWith(expectedArgs, false)
+                expect(receivedFeatureFlagsSpy).toHaveBeenCalledWith(expectedArgs, false, {
+                    partialResponse: false,
+                })
             } else {
                 expect(receivedFeatureFlagsSpy).not.toHaveBeenCalled()
             }

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -87,7 +87,8 @@ export const parseFlagsResponse = (
     persistence: PostHogPersistence,
     currentFlags: Record<string, string | boolean> = {},
     currentFlagPayloads: Record<string, JsonType> = {},
-    currentFlagDetails: Record<string, FeatureFlagDetail> = {}
+    currentFlagDetails: Record<string, FeatureFlagDetail> = {},
+    options?: { partialResponse?: boolean }
 ) => {
     const normalizedResponse = normalizeFlagsResponse(response)
     const flagDetails = normalizedResponse.flags
@@ -122,7 +123,14 @@ export const parseFlagsResponse = (
     let newFeatureFlags = featureFlags
     let newFeatureFlagPayloads = flagPayloads
     let newFeatureFlagDetails = flagDetails
-    if (response.errorsWhileComputingFlags) {
+    if (options?.partialResponse) {
+        // The response is intentionally partial (e.g., only survey flags were requested via
+        // advanced_only_evaluate_survey_feature_flags). Merge with existing flags so that
+        // bootstrapped or previously loaded non-survey flags are preserved.
+        newFeatureFlags = { ...currentFlags, ...newFeatureFlags }
+        newFeatureFlagPayloads = { ...currentFlagPayloads, ...newFeatureFlagPayloads }
+        newFeatureFlagDetails = { ...currentFlagDetails, ...newFeatureFlagDetails }
+    } else if (response.errorsWhileComputingFlags) {
         // if not all flags were computed, we upsert flags instead of replacing them
         // but filter out flags that failed to evaluate so they don't overwrite cached values
         if (flagDetails) {
@@ -626,7 +634,9 @@ export class PostHogFeatureFlags implements Extension {
                 }
 
                 if (!data.disable_flags) {
-                    this.receivedFeatureFlags(response.json ?? {}, errorsLoading)
+                    this.receivedFeatureFlags(response.json ?? {}, errorsLoading, {
+                        partialResponse: !!this._config.advanced_only_evaluate_survey_feature_flags,
+                    })
                 }
 
                 if (this._additionalReloadRequested) {
@@ -927,7 +937,11 @@ export class PostHogFeatureFlags implements Extension {
         this.featureFlagEventHandlers = this.featureFlagEventHandlers.filter((h) => h !== handler)
     }
 
-    receivedFeatureFlags(response: Partial<FlagsResponse>, errorsLoading?: boolean): void {
+    receivedFeatureFlags(
+        response: Partial<FlagsResponse>,
+        errorsLoading?: boolean,
+        options?: { partialResponse?: boolean }
+    ): void {
         if (!this._persistence) {
             return
         }
@@ -936,7 +950,7 @@ export class PostHogFeatureFlags implements Extension {
         const currentFlags = this.getFlagVariants()
         const currentFlagPayloads = this.getFlagPayloads()
         const currentFlagDetails = this.getFlagsWithDetails()
-        parseFlagsResponse(response, this._persistence, currentFlags, currentFlagPayloads, currentFlagDetails)
+        parseFlagsResponse(response, this._persistence, currentFlags, currentFlagPayloads, currentFlagDetails, options)
 
         // Reset stale refresh flag when we successfully receive fresh flags
         if (!errorsLoading) {


### PR DESCRIPTION
## Summary

- When `advanced_only_evaluate_survey_feature_flags: true` is set, the `/flags` response now **merges** with existing flags instead of overwriting them
- Bootstrapped non-survey flags (e.g., session recording linked flags) are preserved after the survey-only `/flags` response arrives

## Root Cause

`parseFlagsResponse` has two code paths: a **merge** path (when `errorsWhileComputingFlags` is true) and an **overwrite** path (default). When `advanced_only_evaluate_survey_feature_flags` is enabled, the server intentionally returns only survey-related flags — but since this isn't an error condition, `errorsWhileComputingFlags` is false. The SDK treats this intentionally-partial response as a complete flag set and overwrites everything in persistence, wiping all bootstrapped non-survey flags.

This means any customer using `bootstrap.featureFlags` together with `advanced_only_evaluate_survey_feature_flags: true` loses their bootstrapped flags as soon as the `/flags` response lands — breaking session recording linked flags, custom feature flags, and anything else that was bootstrapped.

## Fix

Added a `partialResponse` option that threads from `_callFlagsEndpoint` → `receivedFeatureFlags` → `parseFlagsResponse`. When `advanced_only_evaluate_survey_feature_flags` is true, the response is treated as partial and merged with existing flags (new values take precedence for overlapping keys, but non-survey flags are preserved).

## Test plan

- [x] New unit tests: partial response merges with existing flags
- [x] New unit tests: overlapping keys in partial response update correctly
- [x] New unit tests: without `partialResponse`, overwrite behavior is unchanged

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*