### PR TITLE
feat(ai): return prompt metadata from Prompts.get()

### DIFF
--- a/.changeset/prompt-metadata.md
+++ b/.changeset/prompt-metadata.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': minor
+---
+
+`Prompts.get()` now accepts `{ withMetadata: true }` and returns a `PromptResult` object containing `source` (`api`, `cache`, `stale_cache`, or `code_fallback`), `name`, and `version` alongside the prompt text. The previous plain-string return is deprecated and will be removed in a future major version.

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -13,3 +13,4 @@ export { PostHogGoogleGenAI as GoogleGenAI }
 export { wrapVercelLanguageModel as withTracing }
 export { LangChainCallbackHandler }
 export { Prompts }
+export type { PromptResult, PromptRemoteResult, PromptCodeFallbackResult } from './types'

--- a/packages/ai/src/prompts.ts
+++ b/packages/ai/src/prompts.ts
@@ -179,9 +179,9 @@ export class Prompts {
 
     if (cached) {
       const isFresh = now - cached.fetchedAt < cacheTtlSeconds * 1000
-      const { fetchedAt: _, ...cachedResult } = cached
 
       if (isFresh) {
+        const { fetchedAt: _, ...cachedResult } = cached
         return { source: 'cache', ...cachedResult }
       }
     }

--- a/packages/ai/src/prompts.ts
+++ b/packages/ai/src/prompts.ts
@@ -1,18 +1,26 @@
 /// <reference lib="dom" />
 
 import type { PostHog } from 'posthog-node'
-import type { CachedPrompt, GetPromptOptions, PromptApiResponse, PromptVariables, PromptsDirectOptions } from './types'
+import type {
+  CachedPrompt,
+  GetPromptOptions,
+  PromptApiResponse,
+  PromptCodeFallbackResult,
+  PromptRemoteResult,
+  PromptResult,
+  PromptVariables,
+  PromptsDirectOptions,
+} from './types'
 
 const DEFAULT_CACHE_TTL_SECONDS = 300 // 5 minutes
 type PromptVersionCache = Map<number | undefined, CachedPrompt>
 
 function isPromptApiResponse(data: unknown): data is PromptApiResponse {
-  return (
-    typeof data === 'object' &&
-    data !== null &&
-    'prompt' in data &&
-    typeof (data as PromptApiResponse).prompt === 'string'
-  )
+  if (typeof data !== 'object' || data === null) {
+    return false
+  }
+  const record = data as Record<string, unknown>
+  return typeof record.prompt === 'string' && typeof record.name === 'string' && typeof record.version === 'number'
 }
 
 export interface PromptsWithPostHogOptions {
@@ -65,6 +73,7 @@ export class Prompts {
   private host: string
   private defaultCacheTtlSeconds: number
   private cache: Map<string, PromptVersionCache> = new Map()
+  private hasWarnedDeprecation = false
 
   constructor(options: PromptsOptions) {
     this.defaultCacheTtlSeconds = options.defaultCacheTtlSeconds ?? DEFAULT_CACHE_TTL_SECONDS
@@ -101,16 +110,66 @@ export class Prompts {
   }
 
   /**
-   * Fetch a prompt by name from the PostHog API
+   * Fetch a prompt by name from the PostHog API.
    *
-   * @param name - The name of the prompt to fetch
-   * @param options - Optional settings for caching, fallback, and exact version selection
-   * @returns The prompt string
-   * @throws Error if the prompt cannot be fetched and no fallback is provided
+   * When `withMetadata` is `true`, returns a `PromptResult` object with `source`,
+   * `name`, and `version` metadata. When omitted or `false`, returns a plain string
+   * (deprecated — will be removed in a future major version).
    */
-  async get(name: string, options?: GetPromptOptions): Promise<string> {
+  async get(name: string, options: GetPromptOptions & { withMetadata: true }): Promise<PromptResult>
+  /** @deprecated Omitting `withMetadata` is deprecated. Pass `{ withMetadata: true }` to receive a `PromptResult`. */
+  async get(name: string, options?: GetPromptOptions): Promise<string>
+  async get(name: string, options?: GetPromptOptions): Promise<string | PromptResult> {
+    const withMetadata = options?.withMetadata
+
+    if (withMetadata === undefined && !this.hasWarnedDeprecation) {
+      this.hasWarnedDeprecation = true
+      console.warn(
+        '[PostHog Prompts] Calling get() without { withMetadata: true } is deprecated and will be ' +
+          'removed in a future major version. Pass { withMetadata: true } to receive a PromptResult ' +
+          'object with source, name, and version metadata. ' +
+          'You can pass { withMetadata: false } to silence this warning, but the plain-string return ' +
+          'will still be removed in the next major version.'
+      )
+    }
+
+    try {
+      const result = await this.getInternal(name, options)
+
+      if (withMetadata) {
+        return result
+      }
+
+      return result.prompt
+    } catch (error) {
+      const fallback = options?.fallback
+
+      if (fallback !== undefined) {
+        const promptLabel = this.getPromptLabel(name, options?.version)
+        console.warn(`[PostHog Prompts] Failed to fetch prompt ${promptLabel}, using fallback:`, error)
+
+        if (withMetadata) {
+          return {
+            source: 'code_fallback',
+            prompt: fallback,
+            name: undefined,
+            version: undefined,
+          } satisfies PromptCodeFallbackResult
+        }
+
+        return fallback
+      }
+
+      throw error
+    }
+  }
+
+  /**
+   * Internal method that handles cache + fetch logic, returning full metadata.
+   * Does NOT handle the string `fallback` option — callers handle that.
+   */
+  private async getInternal(name: string, options?: GetPromptOptions): Promise<PromptRemoteResult> {
     const cacheTtlSeconds = options?.cacheTtlSeconds ?? this.defaultCacheTtlSeconds
-    const fallback = options?.fallback
     const version = options?.version
     const promptLabel = this.getPromptLabel(name, version)
 
@@ -120,39 +179,29 @@ export class Prompts {
 
     if (cached) {
       const isFresh = now - cached.fetchedAt < cacheTtlSeconds * 1000
+      const { fetchedAt: _, ...cachedResult } = cached
 
       if (isFresh) {
-        return cached.prompt
+        return { source: 'cache', ...cachedResult }
       }
     }
 
     // Try to fetch from API
     try {
-      const prompt = await this.fetchPromptFromApi(name, version)
-      const fetchedAt = Date.now()
+      const fetched = await this.fetchPromptFromApi(name, version)
 
       // Update cache
-      this.getOrCreatePromptCache(name).set(version, {
-        prompt,
-        fetchedAt,
-      })
+      this.getOrCreatePromptCache(name).set(version, { ...fetched, fetchedAt: Date.now() })
 
-      return prompt
+      return { source: 'api', ...fetched }
     } catch (error) {
-      // Fallback order:
-      // 1. Return stale cache (with warning)
+      // Return stale cache (with warning)
       if (cached) {
+        const { fetchedAt: _, ...cachedResult } = cached
         console.warn(`[PostHog Prompts] Failed to fetch prompt ${promptLabel}, using stale cache:`, error)
-        return cached.prompt
+        return { source: 'stale_cache', ...cachedResult }
       }
 
-      // 2. Return fallback (with warning)
-      if (fallback !== undefined) {
-        console.warn(`[PostHog Prompts] Failed to fetch prompt ${promptLabel}, using fallback:`, error)
-        return fallback
-      }
-
-      // 3. Throw error
       throw error
     }
   }
@@ -206,7 +255,7 @@ export class Prompts {
     }
   }
 
-  private async fetchPromptFromApi(name: string, version?: number): Promise<string> {
+  private async fetchPromptFromApi(name: string, version?: number): Promise<Omit<PromptRemoteResult, 'source'>> {
     if (!this.personalApiKey) {
       throw new Error(
         '[PostHog Prompts] personalApiKey is required to fetch prompts. ' +
@@ -254,6 +303,6 @@ export class Prompts {
       throw new Error(`[PostHog Prompts] Invalid response format for prompt ${promptLabel}`)
     }
 
-    return data.prompt
+    return { prompt: data.prompt, name: data.name, version: data.version }
   }
 }

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -102,6 +102,14 @@ export interface GetPromptOptions {
   cacheTtlSeconds?: number
   fallback?: string
   version?: number
+  /**
+   * When true, returns a `PromptResult` object with metadata (source, name, version)
+   * instead of a plain string.
+   *
+   * Omitting this option or setting it to false is deprecated and will be removed
+   * in a future major version.
+   */
+  withMetadata?: boolean
 }
 
 /**
@@ -109,6 +117,8 @@ export interface GetPromptOptions {
  */
 export interface CachedPrompt {
   prompt: string
+  name: string
+  version: number
   fetchedAt: number
 }
 
@@ -125,6 +135,36 @@ export interface PromptApiResponse {
   updated_at: string
   deleted: boolean
 }
+
+/**
+ * Result from the Prompts API or local cache — carries real metadata.
+ */
+export interface PromptRemoteResult {
+  source: 'api' | 'cache' | 'stale_cache'
+  prompt: string
+  name: string
+  version: number
+}
+
+/**
+ * Result when the fetch failed and no cache was available — fell back to the
+ * hardcoded fallback string. name and version are undefined so they remain
+ * accessible on the PromptResult union without a type guard.
+ */
+export interface PromptCodeFallbackResult {
+  source: 'code_fallback'
+  prompt: string
+  name: undefined
+  version: undefined
+}
+
+/**
+ * Discriminated union returned by `Prompts.get()` when `withMetadata: true`.
+ *
+ * Narrow on `source` to guarantee metadata, or access `result.name` /
+ * `result.version` directly as `string | undefined` / `number | undefined`.
+ */
+export type PromptResult = PromptRemoteResult | PromptCodeFallbackResult
 
 /**
  * Variables for prompt compilation

--- a/packages/ai/tests/prompts.test.ts
+++ b/packages/ai/tests/prompts.test.ts
@@ -485,6 +485,222 @@ describe('Prompts', () => {
     })
   })
 
+  describe('get() with withMetadata: true', () => {
+    it('should return a PromptRemoteResult with source "api" on fresh fetch', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockPromptResponse),
+      })
+
+      const posthog = createMockPostHog()
+      const prompts = new Prompts({ posthog })
+
+      const result = await prompts.get('test-prompt', { withMetadata: true })
+
+      expect(result).toEqual({
+        source: 'api',
+        prompt: mockPromptResponse.prompt,
+        name: 'test-prompt',
+        version: 1,
+      })
+    })
+
+    it('should return source "cache" on fresh cache hit', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockPromptResponse),
+      })
+
+      const posthog = createMockPostHog()
+      const prompts = new Prompts({ posthog })
+
+      // First call populates cache
+      await prompts.get('test-prompt', { withMetadata: true })
+
+      // Second call should hit cache
+      const result = await prompts.get('test-prompt', { withMetadata: true, cacheTtlSeconds: 300 })
+
+      expect(result).toEqual({
+        source: 'cache',
+        prompt: mockPromptResponse.prompt,
+        name: 'test-prompt',
+        version: 1,
+      })
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return source "stale_cache" on fetch failure with stale cache', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(mockPromptResponse),
+        })
+        .mockRejectedValueOnce(new Error('Network error'))
+
+      const posthog = createMockPostHog()
+      const prompts = new Prompts({ posthog })
+
+      // First call populates cache
+      await prompts.get('test-prompt', { withMetadata: true, cacheTtlSeconds: 60 })
+
+      // Advance past TTL
+      jest.advanceTimersByTime(61 * 1000)
+
+      // Second call should use stale cache
+      const result = await prompts.get('test-prompt', { withMetadata: true, cacheTtlSeconds: 60 })
+
+      expect(result).toEqual({
+        source: 'stale_cache',
+        prompt: mockPromptResponse.prompt,
+        name: 'test-prompt',
+        version: 1,
+      })
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('using stale cache'),
+        expect.any(Error)
+      )
+    })
+
+    it('should return source "code_fallback" with undefined name/version when fallback is used', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      const posthog = createMockPostHog()
+      const prompts = new Prompts({ posthog })
+
+      const result = await prompts.get('test-prompt', {
+        withMetadata: true,
+        fallback: 'Default system prompt.',
+      })
+
+      expect(result).toEqual({
+        source: 'code_fallback',
+        prompt: 'Default system prompt.',
+        name: undefined,
+        version: undefined,
+      })
+    })
+
+    it('should throw when no cache and no fallback', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      const posthog = createMockPostHog()
+      const prompts = new Prompts({ posthog })
+
+      await expect(prompts.get('test-prompt', { withMetadata: true })).rejects.toThrow('Network error')
+    })
+
+    it('should return correct version metadata for versioned fetches', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ ...mockPromptResponse, version: 3, prompt: 'Version 3 prompt' }),
+      })
+
+      const posthog = createMockPostHog()
+      const prompts = new Prompts({ posthog })
+
+      const result = await prompts.get('test-prompt', { withMetadata: true, version: 3 })
+
+      expect(result).toEqual({
+        source: 'api',
+        prompt: 'Version 3 prompt',
+        name: 'test-prompt',
+        version: 3,
+      })
+    })
+
+    it('should share cache with non-metadata get() calls', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockPromptResponse),
+      })
+
+      const posthog = createMockPostHog()
+      const prompts = new Prompts({ posthog })
+
+      // First call without metadata populates cache
+      const stringResult = await prompts.get('test-prompt', { withMetadata: false })
+      expect(stringResult).toBe(mockPromptResponse.prompt)
+
+      // Second call with metadata should use cache — no additional fetch
+      const metadataResult = await prompts.get('test-prompt', { withMetadata: true })
+      expect(metadataResult).toEqual({
+        source: 'cache',
+        prompt: mockPromptResponse.prompt,
+        name: 'test-prompt',
+        version: 1,
+      })
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('get() deprecation warning', () => {
+    it('should emit a deprecation warning once when withMetadata is not provided', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(mockPromptResponse),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ ...mockPromptResponse, name: 'other-prompt' }),
+        })
+
+      const posthog = createMockPostHog()
+      const prompts = new Prompts({ posthog })
+
+      await prompts.get('test-prompt')
+      await prompts.get('other-prompt')
+
+      const deprecationWarnings = consoleWarnSpy.mock.calls.filter(
+        (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('deprecated')
+      )
+      expect(deprecationWarnings).toHaveLength(1)
+    })
+
+    it('should not emit a deprecation warning when withMetadata is false', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockPromptResponse),
+      })
+
+      const posthog = createMockPostHog()
+      const prompts = new Prompts({ posthog })
+
+      await prompts.get('test-prompt', { withMetadata: false })
+
+      const deprecationWarnings = consoleWarnSpy.mock.calls.filter(
+        (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('deprecated')
+      )
+      expect(deprecationWarnings).toHaveLength(0)
+    })
+
+    it('should not emit a deprecation warning when withMetadata is true', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockPromptResponse),
+      })
+
+      const posthog = createMockPostHog()
+      const prompts = new Prompts({ posthog })
+
+      await prompts.get('test-prompt', { withMetadata: true })
+
+      const deprecationWarnings = consoleWarnSpy.mock.calls.filter(
+        (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('deprecated')
+      )
+      expect(deprecationWarnings).toHaveLength(0)
+    })
+  })
+
   describe('compile()', () => {
     it('should replace a single variable', () => {
       const posthog = createMockPostHog()

--- a/packages/ai/tests/prompts.test.ts
+++ b/packages/ai/tests/prompts.test.ts
@@ -558,10 +558,7 @@ describe('Prompts', () => {
         name: 'test-prompt',
         version: 1,
       })
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('using stale cache'),
-        expect.any(Error)
-      )
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('using stale cache'), expect.any(Error))
     })
 
     it('should return source "code_fallback" with undefined name/version when fallback is used', async () => {
@@ -639,7 +636,11 @@ describe('Prompts', () => {
   })
 
   describe('get() deprecation warning', () => {
-    it('should emit a deprecation warning once when withMetadata is not provided', async () => {
+    it.each([
+      [undefined, 1],
+      [false, 0],
+      [true, 0],
+    ] as const)('deprecation warning count when withMetadata=%s', async (withMetadata, expectedWarnings) => {
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
@@ -655,49 +656,13 @@ describe('Prompts', () => {
       const posthog = createMockPostHog()
       const prompts = new Prompts({ posthog })
 
-      await prompts.get('test-prompt')
-      await prompts.get('other-prompt')
+      await prompts.get('test-prompt', withMetadata !== undefined ? { withMetadata } : undefined)
+      await prompts.get('other-prompt', withMetadata !== undefined ? { withMetadata } : undefined)
 
       const deprecationWarnings = consoleWarnSpy.mock.calls.filter(
         (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('deprecated')
       )
-      expect(deprecationWarnings).toHaveLength(1)
-    })
-
-    it('should not emit a deprecation warning when withMetadata is false', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(mockPromptResponse),
-      })
-
-      const posthog = createMockPostHog()
-      const prompts = new Prompts({ posthog })
-
-      await prompts.get('test-prompt', { withMetadata: false })
-
-      const deprecationWarnings = consoleWarnSpy.mock.calls.filter(
-        (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('deprecated')
-      )
-      expect(deprecationWarnings).toHaveLength(0)
-    })
-
-    it('should not emit a deprecation warning when withMetadata is true', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve(mockPromptResponse),
-      })
-
-      const posthog = createMockPostHog()
-      const prompts = new Prompts({ posthog })
-
-      await prompts.get('test-prompt', { withMetadata: true })
-
-      const deprecationWarnings = consoleWarnSpy.mock.calls.filter(
-        (call: unknown[]) => typeof call[0] === 'string' && call[0].includes('deprecated')
-      )
-      expect(deprecationWarnings).toHaveLength(0)
+      expect(deprecationWarnings).toHaveLength(expectedWarnings)
     })
   })
 


### PR DESCRIPTION
## Problem

`Prompts.get()` returns only the prompt string, discarding `name` and `version` from the API response. Users want to track `$ai_prompt_name` / `$ai_prompt_version` on AI generation events without a separate HTTP call.

## Changes

- Add `withMetadata` option to `get()`. When `true`, returns a `PromptResult` discriminated union with `source` (`api` | `cache` | `stale_cache` | `code_fallback`), `name`, and `version`.
- Deprecate calling `get()` without `withMetadata` (warns once per instance). Plain-string return will be removed in next major.
- Internal cache now stores metadata alongside the prompt text.
- Validate `name` and `version` fields in API response.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/ai

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size