### PR TITLE
chore: remove exp from hermes in react-native tooling

### DIFF
--- a/.changeset/rich-rockets-check.md
+++ b/.changeset/rich-rockets-check.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': minor
+---
+
+"exp" flag is no longer needed in tooling to upload or clone with hermes when using posthog-cli

--- a/.changeset/rich-rockets-check.md
+++ b/.changeset/rich-rockets-check.md
@@ -2,4 +2,4 @@
 'posthog-react-native': minor
 ---
 
-"exp" flag is no longer needed in tooling to upload or clone with hermes when using posthog-cli
+"exp" flag is no longer needed in tooling to upload or clone with hermes when using posthog-cli >= 0.7.4

--- a/.changeset/rich-rockets-check.md
+++ b/.changeset/rich-rockets-check.md
@@ -1,5 +1,5 @@
 ---
-'posthog-react-native': minor
+'posthog-react-native': patch
 ---
 
 "exp" flag is no longer needed in tooling to upload or clone with hermes when using posthog-cli >= 0.7.4

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -90,7 +90,7 @@ set -x -e
 
 # Execute posthog cli clone
 set +x +e
-CLI_CLONE_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH exp hermes clone --minified-map-path $SOURCEMAP_PACKAGER_FILE --composed-map-path $SOURCEMAP_FILE" 2>&1)
+CLI_CLONE_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH hermes clone --minified-map-path $SOURCEMAP_PACKAGER_FILE --composed-map-path $SOURCEMAP_FILE" 2>&1)
 CLONE_EXIT_CODE=$?
 if [ $CLONE_EXIT_CODE -eq 0 ]; then
   echo "$CLI_CLONE_OUTPUT" | awk '{print "output: posthog-cli - " $0}'
@@ -102,7 +102,7 @@ set -x -e
 
 # Execute posthog cli upload
 set +x +e
-CLI_UPLOAD_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH exp hermes upload --directory $DERIVED_FILE_DIR" 2>&1)
+CLI_UPLOAD_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH hermes upload --directory $DERIVED_FILE_DIR" 2>&1)
 UPLOAD_EXIT_CODE=$?
 if [ $UPLOAD_EXIT_CODE -eq 0 ]; then
   echo "$CLI_UPLOAD_OUTPUT" | awk '{print "output: posthog-cli - " $0}'

--- a/packages/react-native/tooling/posthog.gradle
+++ b/packages/react-native/tooling/posthog.gradle
@@ -85,7 +85,7 @@ plugins.withId('com.android.application') {
                                 def cliPackage = resolvePostHogCliPackagePath(reactRoot)
                                 def args = [cliPackage]
 
-                                args.addAll(["exp", "hermes", "clone",
+                                args.addAll(["hermes", "clone",
                                     "--minified-map-path", packagerSourcemapOutput, // The path to a sourcemap
                                     "--composed-map-path", sourcemapOutput          // The path of the composed source map
                                 ])
@@ -107,7 +107,7 @@ plugins.withId('com.android.application') {
                                 def args = [cliPackage]
 
                                 def sourcemapDir = sourcemapOutput.getParent()
-                                args.addAll(["exp", "hermes", "upload",
+                                args.addAll(["hermes", "upload",
                                     "--directory", sourcemapDir        // The path to a sourcemap that should be uploaded.
                                 ])
 


### PR DESCRIPTION
## Problem

Update React Native iOS and Android tooling

## Changes

"exp" flag is no longer needed in tooling to upload or clone with hermes when using posthog-cli 0.7.4

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [X] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [X] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [X] Ran `pnpm changeset` to generate a changeset file
- [X] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
