### PR TITLE
fix: Exclude feature flag payloads from event properties

### DIFF
--- a/.changeset/cozy-cameras-yawn.md
+++ b/.changeset/cozy-cameras-yawn.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Stop sending all active flags payloads in events

--- a/.changeset/cozy-cameras-yawn.md
+++ b/.changeset/cozy-cameras-yawn.md
@@ -2,4 +2,4 @@
 'posthog-js': patch
 ---
 
-Stop sending all active flags payloads in events
+Exclude active feature flag payloads from event properties

--- a/packages/browser/src/__tests__/posthog-persistence.test.ts
+++ b/packages/browser/src/__tests__/posthog-persistence.test.ts
@@ -3,6 +3,8 @@ import { PostHogPersistence } from '../posthog-persistence'
 import {
     DEVICE_ID,
     INITIAL_PERSON_INFO,
+    PERSISTENCE_FEATURE_FLAG_PAYLOADS,
+    PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS,
     PERSISTENCE_RESERVED_PROPERTIES,
     PRODUCT_TOURS,
     PRODUCT_TOURS_ACTIVATED,
@@ -261,6 +263,8 @@ describe('persistence', () => {
             [PRODUCT_TOURS_ACTIVATED, ['tour-1']],
             [SURVEYS_ACTIVATED, ['survey-1']],
             [SESSION_RECORDING_REMOTE_CONFIG, { endpoint: '/s/' }],
+            [PERSISTENCE_FEATURE_FLAG_PAYLOADS, { 'flag-a': '{"key":"value"}' }],
+            [PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS, { 'flag-a': '{"key":"value"}' }],
         ])('should not include reserved property %s in event properties', (key, value) => {
             library.register({ [key]: value })
             expect(library.props[key]).toEqual(value)

--- a/packages/browser/src/constants.ts
+++ b/packages/browser/src/constants.ts
@@ -54,6 +54,8 @@ export const SESSION_RECORDING_FIRST_FULL_SNAPSHOT_TIMESTAMP = '$debug_first_ful
 export const ENABLED_FEATURE_FLAGS = '$enabled_feature_flags'
 export const PERSISTENCE_EARLY_ACCESS_FEATURES = '$early_access_features'
 export const PERSISTENCE_FEATURE_FLAG_DETAILS = '$feature_flag_details'
+export const PERSISTENCE_FEATURE_FLAG_PAYLOADS = '$feature_flag_payloads'
+export const PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS = '$override_feature_flag_payloads'
 export const STORED_PERSON_PROPERTIES_KEY = '$stored_person_properties'
 export const STORED_GROUP_PROPERTIES_KEY = '$stored_group_properties'
 export const SURVEYS = '$surveys'
@@ -119,6 +121,8 @@ export const PERSISTENCE_RESERVED_PROPERTIES = [
     PRODUCT_TOURS_ENABLED_SERVER_SIDE,
     SURVEYS_ACTIVATED,
     SESSION_RECORDING_REMOTE_CONFIG,
+    PERSISTENCE_FEATURE_FLAG_PAYLOADS,
+    PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS,
 ]
 
 export const SURVEYS_REQUEST_TIMEOUT_MS = 10000

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -30,6 +30,8 @@ import {
     STORED_PERSON_PROPERTIES_KEY,
     FLAG_CALL_REPORTED,
     FLAG_CALL_REPORTED_SESSION_ID,
+    PERSISTENCE_FEATURE_FLAG_PAYLOADS,
+    PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS,
 } from './constants'
 
 import { isUndefined, isArray, isNull } from '@posthog/core'
@@ -59,8 +61,6 @@ export const FeatureFlagError = {
 
 const PERSISTENCE_ACTIVE_FEATURE_FLAGS = '$active_feature_flags'
 const PERSISTENCE_OVERRIDE_FEATURE_FLAGS = '$override_feature_flags'
-const PERSISTENCE_FEATURE_FLAG_PAYLOADS = '$feature_flag_payloads'
-const PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS = '$override_feature_flag_payloads'
 const PERSISTENCE_FEATURE_FLAG_REQUEST_ID = '$feature_flag_request_id'
 
 /** Converts an array of flag names to a Record where each flag is set to true. */


### PR DESCRIPTION
## Problem

Feature flag payloads (`$feature_flag_payloads` and `$override_feature_flag_payloads`) stored in persistence were leaking into captured event properties, inflating event payloads with internal SDK cache data.

## Changes

Move `PERSISTENCE_FEATURE_FLAG_PAYLOADS` and `PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS` from local definitions in `posthog-featureflags.ts` to the shared `constants.ts` module and add them to `PERSISTENCE_RESERVED_PROPERTIES` so they are stripped from event properties. This follows the same pattern as #3392.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages