### PR TITLE
chore: expo release info version, release name, and parity fix

### DIFF
--- a/.changeset/slick-guests-sing.md
+++ b/.changeset/slick-guests-sing.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Add version and project to expo react native symbols

--- a/.changeset/slick-guests-sing.md
+++ b/.changeset/slick-guests-sing.md
@@ -1,5 +1,5 @@
 ---
-'posthog-react-native': patch
+'posthog-react-native': minor
 ---
 
 Add version and project to expo react native symbols

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -90,6 +90,9 @@ type PostHogPluginProps = {
    * Default: true (disable sandboxing so uploads "just work").
    * Set to false if your org requires sandboxing stays on —
    * you'll lose automatic git metadata on sourcemap uploads on iOS builds only.
+   * 
+   * Note that this setting is recommended in the Expo docs: 
+   * https://docs.expo.dev/brownfield/integrated-approach/#configuring-your-xcode-project
    */
   disableSandboxing?: boolean
 }

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -65,11 +65,11 @@ export function disableUserScriptSandboxing(xcodeProject: any): void {
   // posthog-cli needs to read .git/ for release auto-detection, which the
   // Xcode 14+ user script sandbox blocks.
   //
-  // Scope: withXcodeProject only exposes the main app's .xcodeproj. The Pods
-  // project is a separate .xcodeproj in the workspace with its own sandboxing
-  // settings managed by CocoaPods — we neither see nor touch those here.
-  // This function only flips ENABLE_USER_SCRIPT_SANDBOXING on the user's main
-  // app target configurations (Debug/Release/custom schemes).
+  // Scope: withXcodeProject only exposes the main app's .xcodeproj (the Pods
+  // project is a separate .xcodeproj managed by CocoaPods — not touched here).
+  // Within the main .xcodeproj, this iterates ALL build configurations without
+  // filtering — that includes the app target, test targets, app extensions, and
+  // any other target defined in the project.
   const configurations = xcodeProject.pbxXCBuildConfigurationSection()
   for (const key in configurations) {
     const configuration = configurations[key]
@@ -88,8 +88,8 @@ type PostHogPluginProps = {
    * or fail silently.
    *
    * Default: true (disable sandboxing so uploads "just work").
-   * Set to false if your org requires sandboxing stays on for security/compliance —
-   * you'll lose automatic git metadata on sourcemap uploads.
+   * Set to false if your org requires sandboxing stays on —
+   * you'll lose automatic git metadata on sourcemap uploads on iOS builds only.
    */
   disableSandboxing?: boolean
 }

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -61,7 +61,40 @@ export function addPostHogWithBundledScriptsToBundleShellScript(script: string):
   )
 }
 
-const withIosPlugin = (config: any) => {
+export function disableUserScriptSandboxing(xcodeProject: any): void {
+  // posthog-cli needs to read .git/ for release auto-detection, which the
+  // Xcode 14+ user script sandbox blocks.
+  //
+  // Scope: withXcodeProject only exposes the main app's .xcodeproj. The Pods
+  // project is a separate .xcodeproj in the workspace with its own sandboxing
+  // settings managed by CocoaPods — we neither see nor touch those here.
+  // This function only flips ENABLE_USER_SCRIPT_SANDBOXING on the user's main
+  // app target configurations (Debug/Release/custom schemes).
+  const configurations = xcodeProject.pbxXCBuildConfigurationSection()
+  for (const key in configurations) {
+    const configuration = configurations[key]
+    if (configuration && configuration.buildSettings) {
+      configuration.buildSettings.ENABLE_USER_SCRIPT_SANDBOXING = '"NO"'
+    }
+  }
+}
+
+type PostHogPluginProps = {
+  /**
+   * Whether to disable Xcode's user script sandboxing (ENABLE_USER_SCRIPT_SANDBOXING=NO).
+   *
+   * posthog-cli reads .git/ during sourcemap uploads for release auto-detection;
+   * sandboxing (on by default in Xcode 14+) blocks that, so uploads lose git info
+   * or fail silently.
+   *
+   * Default: true (disable sandboxing so uploads "just work").
+   * Set to false if your org requires sandboxing stays on for security/compliance —
+   * you'll lose automatic git metadata on sourcemap uploads.
+   */
+  disableSandboxing?: boolean
+}
+
+const withIosPlugin = (config: any, props: PostHogPluginProps = {}) => {
   return withXcodeProject(config, (config: any) => {
     const xcodeProject = config.modResults
 
@@ -72,15 +105,33 @@ const withIosPlugin = (config: any) => {
 
     modifyExistingXcodeBuildScript(bundleReactNativePhase)
 
+    if (props.disableSandboxing !== false) {
+      disableUserScriptSandboxing(xcodeProject)
+      console.warn(
+        '[posthog-react-native] Setting ENABLE_USER_SCRIPT_SANDBOXING=NO on all Xcode ' +
+          'build configurations so sourcemap uploads can resolve git metadata. ' +
+          "If your org requires sandboxing to stay enabled, set `{ disableSandboxing: false }` " +
+          'on the plugin in app.json — note that stock Expo projects may fail to build under ' +
+          'sandboxing until every script build phase declares its input/output files.'
+      )
+    }
+
     return config
   })
 }
 
-const withPostHogPlugin = (config: any) => {
+const withPostHogPlugin = (config: any, props: PostHogPluginProps = {}) => {
   config = withAndroidPlugin(config)
-  return withIosPlugin(config)
+  return withIosPlugin(config, props)
 }
 
-module.exports = (config: any) => {
-  return withPostHogPlugin(config)
+const postHogPlugin = (config: any, props: PostHogPluginProps = {}): any => {
+  return withPostHogPlugin(config, props)
 }
+
+// Re-export the plugin function as the default export while keeping the
+// named exports above callable from tests.
+module.exports = postHogPlugin
+module.exports.modifyExistingXcodeBuildScript = modifyExistingXcodeBuildScript
+module.exports.addPostHogWithBundledScriptsToBundleShellScript = addPostHogWithBundledScriptsToBundleShellScript
+module.exports.disableUserScriptSandboxing = disableUserScriptSandboxing

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -1,0 +1,95 @@
+import {
+  addPostHogWithBundledScriptsToBundleShellScript,
+  disableUserScriptSandboxing,
+  modifyExistingXcodeBuildScript,
+} from '../src/tooling/expoconfig'
+
+type MockBuildConfig = { buildSettings: Record<string, string> }
+
+const mockXcodeProject = (): {
+  pbxXCBuildConfigurationSection: () => Record<string, MockBuildConfig>
+  configs: Record<string, MockBuildConfig>
+} => {
+  const configs: Record<string, MockBuildConfig> = {
+    '1A:Release': { buildSettings: { PRODUCT_NAME: '"MyApp"' } },
+    '2B:Debug': { buildSettings: { PRODUCT_NAME: '"MyApp"' } },
+    '3C:Pods-Release': { buildSettings: { PRODUCT_NAME: '"Pods-MyApp"' } },
+  }
+  return {
+    pbxXCBuildConfigurationSection: () => configs,
+    configs,
+  }
+}
+
+describe('disableUserScriptSandboxing', () => {
+  it('sets ENABLE_USER_SCRIPT_SANDBOXING="NO" on every build configuration', () => {
+    const xp = mockXcodeProject()
+    disableUserScriptSandboxing(xp)
+    for (const key of Object.keys(xp.configs)) {
+      expect(xp.configs[key].buildSettings.ENABLE_USER_SCRIPT_SANDBOXING).toBe('"NO"')
+    }
+  })
+
+  it('uses the literal quoted "NO" string required by the pbxproj format', () => {
+    // Unquoted NO corrupts the project file in some xcode-npm versions.
+    const xp = mockXcodeProject()
+    disableUserScriptSandboxing(xp)
+    expect(xp.configs['1A:Release'].buildSettings.ENABLE_USER_SCRIPT_SANDBOXING).not.toBe('NO')
+    expect(xp.configs['1A:Release'].buildSettings.ENABLE_USER_SCRIPT_SANDBOXING).not.toBe(false)
+  })
+
+  it('preserves existing build settings', () => {
+    const xp = mockXcodeProject()
+    disableUserScriptSandboxing(xp)
+    expect(xp.configs['1A:Release'].buildSettings.PRODUCT_NAME).toBe('"MyApp"')
+  })
+
+  it('is idempotent — running twice yields the same result', () => {
+    const xp = mockXcodeProject()
+    disableUserScriptSandboxing(xp)
+    disableUserScriptSandboxing(xp)
+    expect(xp.configs['1A:Release'].buildSettings.ENABLE_USER_SCRIPT_SANDBOXING).toBe('"NO"')
+  })
+})
+
+describe('addPostHogWithBundledScriptsToBundleShellScript', () => {
+  it('wraps the react-native-xcode.sh invocation with posthog-xcode.sh', () => {
+    const original = '"../node_modules/react-native/scripts/react-native-xcode.sh"'
+    const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
+    expect(wrapped).toContain('posthog-xcode.sh')
+    expect(wrapped).toContain('react-native-xcode.sh')
+    expect(wrapped.startsWith('/bin/sh ')).toBe(true)
+    expect(wrapped.indexOf('posthog-xcode.sh')).toBeLessThan(wrapped.indexOf('react-native-xcode.sh'))
+  })
+
+  it('supports the alternative packager/ path', () => {
+    const original = '"node_modules/react-native/packager/react-native-xcode.sh"'
+    const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
+    expect(wrapped).toContain('posthog-xcode.sh')
+    expect(wrapped).toContain('packager/react-native-xcode.sh')
+  })
+})
+
+describe('modifyExistingXcodeBuildScript', () => {
+  it('wraps the bundle phase shellScript', () => {
+    const script = { shellScript: JSON.stringify('"../node_modules/react-native/scripts/react-native-xcode.sh"') }
+    modifyExistingXcodeBuildScript(script)
+    const parsed = JSON.parse(script.shellScript)
+    expect(parsed).toContain('posthog-xcode.sh')
+  })
+
+  it('is idempotent — re-running does not double-wrap', () => {
+    const script = { shellScript: JSON.stringify('"../node_modules/react-native/scripts/react-native-xcode.sh"') }
+    modifyExistingXcodeBuildScript(script)
+    const firstPass = script.shellScript
+    modifyExistingXcodeBuildScript(script)
+    expect(script.shellScript).toBe(firstPass)
+  })
+
+  it('skips scripts that do not invoke react-native-xcode.sh', () => {
+    const script = { shellScript: JSON.stringify('echo "hello"') }
+    const original = script.shellScript
+    modifyExistingXcodeBuildScript(script)
+    expect(script.shellScript).toBe(original)
+  })
+})

--- a/packages/react-native/test/posthog-xcode-parse.spec.ts
+++ b/packages/react-native/test/posthog-xcode-parse.spec.ts
@@ -45,6 +45,9 @@ describe('posthog-xcode.sh remote URL parsing', () => {
     ['git@bitbucket.org:foo/bar.git', 'bitbucket.org', 'foo/bar'],
     ['git@git.mycompany.internal:team/repo.git', 'git.mycompany.internal', 'team/repo'],
     ['ssh://git@github.com:22/foo/bar.git', 'github.com', 'foo/bar'],
+    ['https://gitlab.com/org/subgroup/repo.git', 'gitlab.com', 'org/subgroup/repo'],
+    ['git@gitlab.com:org/subgroup/repo.git', 'gitlab.com', 'org/subgroup/repo'],
+    ['https://gitlab.com/org/deep/nested/subgroup/repo.git', 'gitlab.com', 'org/deep/nested/subgroup/repo'],
   ]
 
   it.each(cases)('parses %s → host=%s repo=%s', (url, expectedHost, expectedRepo) => {

--- a/packages/react-native/test/posthog-xcode-parse.spec.ts
+++ b/packages/react-native/test/posthog-xcode-parse.spec.ts
@@ -1,0 +1,65 @@
+import { execSync } from 'child_process'
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * These tests validate the sed expressions used in tooling/posthog-xcode.sh
+ * to parse a git remote URL into {host, owner/repo}. Rather than re-declare
+ * the regexes here (and risk drift), we extract them at test runtime from the
+ * shell script itself — so the tests cannot diverge from the source.
+ */
+
+const SCRIPT_PATH = path.resolve(__dirname, '..', 'tooling', 'posthog-xcode.sh')
+
+const extractSed = (label: 'GIT_HOST' | 'GIT_REPO_PATH'): string => {
+  const contents = fs.readFileSync(SCRIPT_PATH, 'utf8')
+  // Match lines like:   GIT_HOST=$(echo "$GIT_REMOTE_URL" | sed -E '<expr>')
+  const re = new RegExp(`${label}=\\$\\(echo "\\$GIT_REMOTE_URL" \\| sed -E '([^']+)'\\)`)
+  const match = contents.match(re)
+  if (!match) {
+    throw new Error(`Could not find ${label} sed expression in ${SCRIPT_PATH}`)
+  }
+  return match[1]
+}
+
+const runSed = (sedExpr: string, input: string): string => {
+  // Shell-escape the sed expression to pass it through execSync safely.
+  const escaped = sedExpr.replace(/'/g, `'\\''`)
+  return execSync(`printf %s '${input}' | sed -E '${escaped}'`).toString().trim()
+}
+
+describe('posthog-xcode.sh remote URL parsing', () => {
+  const HOST_SED = extractSed('GIT_HOST')
+  const REPO_SED = extractSed('GIT_REPO_PATH')
+
+  const parse = (url: string): { host: string; repo: string } => ({
+    host: runSed(HOST_SED, url),
+    repo: runSed(REPO_SED, url),
+  })
+
+  const cases: Array<[string, string, string]> = [
+    ['git@github.com:PostHog/posthog-js.git', 'github.com', 'PostHog/posthog-js'],
+    ['https://github.com/PostHog/posthog-js.git', 'github.com', 'PostHog/posthog-js'],
+    ['git@gitlab.com:foo/bar.git', 'gitlab.com', 'foo/bar'],
+    ['https://gitlab.com/foo/bar.git', 'gitlab.com', 'foo/bar'],
+    ['git@bitbucket.org:foo/bar.git', 'bitbucket.org', 'foo/bar'],
+    ['git@git.mycompany.internal:team/repo.git', 'git.mycompany.internal', 'team/repo'],
+    ['ssh://git@github.com:22/foo/bar.git', 'github.com', 'foo/bar'],
+  ]
+
+  it.each(cases)('parses %s → host=%s repo=%s', (url, expectedHost, expectedRepo) => {
+    const { host, repo } = parse(url)
+    expect(host).toBe(expectedHost)
+    expect(repo).toBe(expectedRepo)
+  })
+
+  it('constructs the expected remote_url for github', () => {
+    const { host, repo } = parse('git@github.com:PostHog/posthog-js.git')
+    expect(`https://${host}/${repo}.git`).toBe('https://github.com/PostHog/posthog-js.git')
+  })
+
+  it('constructs the expected remote_url for self-hosted', () => {
+    const { host, repo } = parse('git@git.corp.internal:team/repo.git')
+    expect(`https://${host}/${repo}.git`).toBe('https://git.corp.internal/team/repo.git')
+  })
+})

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -1,11 +1,14 @@
-# adapted from https://github.com/getsentry/sentry-react-native/blob/e76d0d388228437e82f235546de00f4e748fcbda/packages/core/scripts/sentry-xcode.sh
-
 #!/bin/bash
+# adapted from https://github.com/getsentry/sentry-react-native/blob/e76d0d388228437e82f235546de00f4e748fcbda/packages/core/scripts/sentry-xcode.sh
 # Bundle React Native code and images
 # PWD=ios
 
 # print commands before executing them and stop on first error
 set -x -e
+
+# Ensure common tool paths are available so posthog-cli can auto-detect git
+# (Xcode runs build phases with a minimal PATH)
+export PATH="/usr/bin:/usr/local/bin:/opt/homebrew/bin:$HOME/.cargo/bin:$HOME/.local/bin:$HOME/.posthog:$PATH"
 
 # WITH_ENVIRONMENT is executed by React Native
 
@@ -45,8 +48,7 @@ else
     if [ -n "$NPM_LOCAL_ROOT" ] && [ -f "$NPM_LOCAL_ROOT/.bin/posthog-cli" ]; then
       PH_CLI_PATH="$NPM_LOCAL_ROOT/.bin/posthog-cli"
     else
-      # Fallback to searching common locations
-      export PATH="/usr/local/bin:/opt/homebrew/bin:$HOME/.cargo/bin:$HOME/.local/bin:$HOME/.posthog:$PATH"
+      # Fallback to searching common locations (PATH was already extended above)
       PH_CLI_PATH=$(command -v posthog-cli 2>/dev/null || true)
     fi
   fi
@@ -100,6 +102,51 @@ if [[ "$SKIP_BUNDLING" ]]; then
   exit 0;
 fi
 set -x -e
+
+# posthog-cli auto-detects git by walking UP from the --directory arg
+# (the sourcemap location). For Xcode, that's ~/Library/Developer/Xcode/DerivedData/
+# which is outside the project tree, so .git is never found.
+#
+# Workaround for local builds: populate GITHUB_* env vars from the local git
+# remote so the CLI's GitHub Actions detection path picks them up. The CLI
+# doesn't validate the host — it builds the remote URL as
+# "{GITHUB_SERVER_URL}/{GITHUB_REPOSITORY}.git", so this works regardless of
+# the user's actual git provider (GitHub, GitLab, Bitbucket, self-hosted, ...).
+#
+# We only do this when not already inside a CI environment the CLI recognizes
+# natively (GitHub Actions, Vercel). Those runners inject the real variables
+# themselves, and we don't want to overwrite them with locally-derived ones.
+#
+if [ -z "$GITHUB_SHA" ] && [ -z "$VERCEL" ]; then
+  GIT_TOPLEVEL=$(git -C "${SRCROOT:-$(pwd)}" rev-parse --show-toplevel 2>/dev/null)
+  if [ -n "$GIT_TOPLEVEL" ]; then
+    GIT_REMOTE_URL=$(git -C "$GIT_TOPLEVEL" config --get remote.origin.url 2>/dev/null)
+    if [ -n "$GIT_REMOTE_URL" ]; then
+      # Parse host and "owner/repo" from either:
+      #   git@host:owner/repo.git           → host=host, repo=owner/repo
+      #   https://host/owner/repo.git       → host=host, repo=owner/repo
+      #   ssh://git@host:port/owner/repo    → host=host, repo=owner/repo
+      # Strip leading scheme + optional user@, then take everything up to the first : or /
+      GIT_HOST=$(echo "$GIT_REMOTE_URL" | sed -E 's#^[a-z]+://##; s#^[^@]*@##; s#[:/].*$##')
+      GIT_REPO_PATH=$(echo "$GIT_REMOTE_URL" | sed -E 's#^.*[:/]([^:/]+/[^/]+)$#\1#; s#\.git$##')
+      if [ -n "$GIT_HOST" ] && [ -n "$GIT_REPO_PATH" ]; then
+        GIT_BRANCH_NAME=$(git -C "$GIT_TOPLEVEL" rev-parse --abbrev-ref HEAD 2>/dev/null)
+        # --abbrev-ref returns the literal string "HEAD" when the working copy
+        # is in a detached-HEAD state (bisect, checking out a tag, CI checkouts
+        # that resolved to a SHA). Fall back to the short SHA so the branch
+        # field is meaningful rather than just "HEAD".
+        if [ "$GIT_BRANCH_NAME" = "HEAD" ]; then
+          GIT_BRANCH_NAME=$(git -C "$GIT_TOPLEVEL" rev-parse --short HEAD 2>/dev/null)
+        fi
+        export GITHUB_ACTIONS="true"
+        export GITHUB_SHA=$(git -C "$GIT_TOPLEVEL" rev-parse HEAD 2>/dev/null)
+        export GITHUB_REF_NAME="$GIT_BRANCH_NAME"
+        export GITHUB_REPOSITORY="$GIT_REPO_PATH"
+        export GITHUB_SERVER_URL="https://${GIT_HOST}"
+      fi
+    fi
+  fi
+fi
 
 # Execute posthog cli clone
 set +x +e

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -60,6 +60,19 @@ fi
 # mimics how the file is defined in node_modules/react-native/scripts/react-native-xcode.sh (PACKAGER_SOURCEMAP_FILE)
 SOURCEMAP_PACKAGER_FILE="$CONFIGURATION_BUILD_DIR/$SOURCEMAP_NAME"
 
+# Pass release info from Xcode build settings when available
+CLI_RELEASE_ARGS=""
+if [ -n "${PRODUCT_BUNDLE_IDENTIFIER}" ]; then
+  CLI_RELEASE_ARGS="$CLI_RELEASE_ARGS --release-name $PRODUCT_BUNDLE_IDENTIFIER"
+fi
+if [ -n "${MARKETING_VERSION}" ]; then
+  RELEASE_VERSION="$MARKETING_VERSION"
+  if [ -n "${CURRENT_PROJECT_VERSION}" ]; then
+    RELEASE_VERSION="${MARKETING_VERSION}+${CURRENT_PROJECT_VERSION}"
+  fi
+  CLI_RELEASE_ARGS="$CLI_RELEASE_ARGS --release-version $RELEASE_VERSION"
+fi
+
 # RN deletes the PACKAGER_SOURCEMAP_FILE file after execution but we need it
 # lets patch the script to comment out this part if not yet
 if grep -q '^[[:space:]]*rm.*PACKAGER_SOURCEMAP_FILE' "$REACT_NATIVE_XCODE"; then
@@ -90,7 +103,7 @@ set -x -e
 
 # Execute posthog cli clone
 set +x +e
-CLI_CLONE_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH hermes clone --minified-map-path $SOURCEMAP_PACKAGER_FILE --composed-map-path $SOURCEMAP_FILE" 2>&1)
+CLI_CLONE_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH hermes clone --minified-map-path $SOURCEMAP_PACKAGER_FILE --composed-map-path $SOURCEMAP_FILE $CLI_RELEASE_ARGS" 2>&1)
 CLONE_EXIT_CODE=$?
 if [ $CLONE_EXIT_CODE -eq 0 ]; then
   echo "$CLI_CLONE_OUTPUT" | awk '{print "output: posthog-cli - " $0}'
@@ -102,7 +115,7 @@ set -x -e
 
 # Execute posthog cli upload
 set +x +e
-CLI_UPLOAD_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH hermes upload --directory $DERIVED_FILE_DIR" 2>&1)
+CLI_UPLOAD_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH hermes upload --directory $DERIVED_FILE_DIR $CLI_RELEASE_ARGS" 2>&1)
 UPLOAD_EXIT_CODE=$?
 if [ $UPLOAD_EXIT_CODE -eq 0 ]; then
   echo "$CLI_UPLOAD_OUTPUT" | awk '{print "output: posthog-cli - " $0}'

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -123,12 +123,14 @@ if [ -z "$GITHUB_SHA" ] && [ -z "$VERCEL" ]; then
     GIT_REMOTE_URL=$(git -C "$GIT_TOPLEVEL" config --get remote.origin.url 2>/dev/null)
     if [ -n "$GIT_REMOTE_URL" ]; then
       # Parse host and "owner/repo" from either:
-      #   git@host:owner/repo.git           → host=host, repo=owner/repo
-      #   https://host/owner/repo.git       → host=host, repo=owner/repo
-      #   ssh://git@host:port/owner/repo    → host=host, repo=owner/repo
+      #   git@host:owner/repo.git                    → host=host, repo=owner/repo
+      #   https://host/owner/repo.git                → host=host, repo=owner/repo
+      #   ssh://git@host:port/owner/repo             → host=host, repo=owner/repo
+      #   git@gitlab.com:org/subgroup/repo.git       → host=gitlab.com, repo=org/subgroup/repo
       # Strip leading scheme + optional user@, then take everything up to the first : or /
       GIT_HOST=$(echo "$GIT_REMOTE_URL" | sed -E 's#^[a-z]+://##; s#^[^@]*@##; s#[:/].*$##')
-      GIT_REPO_PATH=$(echo "$GIT_REMOTE_URL" | sed -E 's#^.*[:/]([^:/]+/[^/]+)$#\1#; s#\.git$##')
+      # Strip scheme + user@host + separator, optional port, and .git suffix
+      GIT_REPO_PATH=$(echo "$GIT_REMOTE_URL" | sed -E 's#^([a-z]+://)?[^:/]*[:/]##; s#^[0-9]+/##; s#\.git$##')
       if [ -n "$GIT_HOST" ] && [ -n "$GIT_REPO_PATH" ]; then
         GIT_BRANCH_NAME=$(git -C "$GIT_TOPLEVEL" rev-parse --abbrev-ref HEAD 2>/dev/null)
         # --abbrev-ref returns the literal string "HEAD" when the working copy

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -59,6 +59,16 @@ if [ -z "$PH_CLI_PATH" ] || [ ! -x "$PH_CLI_PATH" ]; then
   exit 1
 fi
 
+MIN_POSTHOG_CLI_VERSION="0.7.8"
+PH_CLI_VERSION=$("$PH_CLI_PATH" --version 2>/dev/null | awk '{print $NF}' | tr -d 'v')
+if [ -n "$PH_CLI_VERSION" ]; then
+  LOWEST=$(printf '%s\n%s\n' "$MIN_POSTHOG_CLI_VERSION" "$PH_CLI_VERSION" | sort -t. -k1,1n -k2,2n -k3,3n | head -n1)
+  if [ "$LOWEST" != "$MIN_POSTHOG_CLI_VERSION" ]; then
+    echo "error: posthog-cli >= ${MIN_POSTHOG_CLI_VERSION} required (found ${PH_CLI_VERSION}). Upgrade: npm install -g @posthog/cli@latest"
+    exit 1
+  fi
+fi
+
 # mimics how the file is defined in node_modules/react-native/scripts/react-native-xcode.sh (PACKAGER_SOURCEMAP_FILE)
 SOURCEMAP_PACKAGER_FILE="$CONFIGURATION_BUILD_DIR/$SOURCEMAP_NAME"
 
@@ -68,11 +78,10 @@ if [ -n "${PRODUCT_BUNDLE_IDENTIFIER}" ]; then
   CLI_RELEASE_ARGS="$CLI_RELEASE_ARGS --release-name $PRODUCT_BUNDLE_IDENTIFIER"
 fi
 if [ -n "${MARKETING_VERSION}" ]; then
-  RELEASE_VERSION="$MARKETING_VERSION"
-  if [ -n "${CURRENT_PROJECT_VERSION}" ]; then
-    RELEASE_VERSION="${MARKETING_VERSION}+${CURRENT_PROJECT_VERSION}"
-  fi
-  CLI_RELEASE_ARGS="$CLI_RELEASE_ARGS --release-version $RELEASE_VERSION"
+  CLI_RELEASE_ARGS="$CLI_RELEASE_ARGS --release-version $MARKETING_VERSION"
+fi
+if [ -n "${CURRENT_PROJECT_VERSION}" ]; then
+  CLI_RELEASE_ARGS="$CLI_RELEASE_ARGS --build $CURRENT_PROJECT_VERSION"
 fi
 
 # RN deletes the PACKAGER_SOURCEMAP_FILE file after execution but we need it

--- a/packages/react-native/tooling/posthog.gradle
+++ b/packages/react-native/tooling/posthog.gradle
@@ -54,6 +54,8 @@ plugins.withId('com.android.application') {
                     def releaseName = currentVariant[1]
                     def versionCode = currentVariant[2]
                     applicationVariant = currentVariant[3]
+                    def appId = currentVariant[4]
+                    def versionName = currentVariant[5]
 
                     try {
                         if (versionCode instanceof String) {
@@ -76,6 +78,13 @@ plugins.withId('com.android.application') {
                         group = 'posthog.com'
 
                         def extraArgs = []
+                        if (appId != null && !appId.isEmpty()) {
+                            extraArgs.addAll(["--release-name", appId.toString()])
+                        }
+                        if (versionName != null && !versionName.toString().isEmpty()) {
+                            def releaseVersion = versionCode != null ? "${versionName}+${versionCode}" : versionName.toString()
+                            extraArgs.addAll(["--release-version", releaseVersion])
+                        }
 
                         def injected = project.objects.newInstance(InjectedExecOps)
                         doFirst {
@@ -365,7 +374,7 @@ static extractCurrentVariants(bundleTask, variant) {
             def outputName = output.baseName
 
             if (currentVariants[outputName] == null) currentVariants[outputName] = []
-            currentVariants[outputName] = [outputName, releaseName, versionCode, variantName]
+            currentVariants[outputName] = [outputName, releaseName, versionCode, variantName, appId, versionName]
         }
     }
 

--- a/packages/react-native/tooling/posthog.gradle
+++ b/packages/react-native/tooling/posthog.gradle
@@ -82,8 +82,10 @@ plugins.withId('com.android.application') {
                             extraArgs.addAll(["--release-name", appId.toString()])
                         }
                         if (versionName != null && !versionName.toString().isEmpty()) {
-                            def releaseVersion = versionCode != null ? "${versionName}+${versionCode}" : versionName.toString()
-                            extraArgs.addAll(["--release-version", releaseVersion])
+                            extraArgs.addAll(["--release-version", versionName.toString()])
+                        }
+                        if (versionCode != null) {
+                            extraArgs.addAll(["--build", versionCode.toString()])
                         }
 
                         def injected = project.objects.newInstance(InjectedExecOps)


### PR DESCRIPTION
## Problem

Previously, Expo React Native apps uploaded sourcemaps with generic release names derived from git (e.g. posthog-js@9ddbcf35... — the monorepo SHA), which meant every version of a shipped app ended
   up sharing a single release record in PostHog. The first commit on this branch fixes that by having both  
  posthog-xcode.sh (iOS) and posthog.gradle (Android) pass explicit --release-name (the app's bundle identifier) and --release-version (marketing version + build number, packed as 1.0+2) to          
  posthog-cli hermes clone/upload. Each shipped version now gets its own release record, named consistently with native iOS/Android conventions, regardless of the surrounding git history.  
  
Building on that, this branch also closes an Android/iOS parity gap: iOS symbol sets in the Error Tracking UI previously showed only a version chip, while Android showed a full git SHA chip with 
  branch and repo. The root cause was that posthog-cli auto-detects git by walking up from the --directory arg — which works on Android (sourcemaps live inside the project tree) but fails on iOS     
  (Xcode writes sourcemaps to ~/Library/Developer/Xcode/DerivedData/, outside any project). The fix populates GITHUB_* env vars from the local git remote inside posthog-xcode.sh so the CLI's existing
   GitHub Actions detection path picks them up — this works for GitHub, GitLab, Bitbucket, and self-hosted providers since the CLI doesn't validate the host. The plugin now also sets                 
  ENABLE_USER_SCRIPT_SANDBOXING=NO on the main app's Xcode configurations (with a console.warn at prebuild time for visibility) so the script can actually read .git/ and invoke the CLI; a 
  disableSandboxing: false plugin option gives an escape hatch (uploads still succeed, just without git metadata).       
## Changes

- Use --release-name and --release-version for hermes clone/upload
- closes a parity gap to display a full git SHA chip with branch and repo for iOS


- [x] Depends on cli release: https://github.com/PostHog/posthog/pull/54869
- [ ] Docs: https://github.com/PostHog/posthog.com/pull/16394

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [X] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [X] Accounted for the impact of any changes across different platforms
- [X] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [X] Ran `pnpm changeset` to generate a changeset file
- [X] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
