### PR TITLE
chore: use engineering@posthog.com in package metadata

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -3,7 +3,7 @@
     "version": "1.369.0",
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
-    "author": "hey@posthog.com",
+    "author": "engineering@posthog.com",
     "license": "SEE LICENSE IN LICENSE",
     "homepage": "https://posthog.com/docs/libraries/js",
     "packageManager": "pnpm@10.12.4",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -9,7 +9,7 @@
     },
     "author": {
         "name": "PostHog",
-        "email": "hey@posthog.com",
+        "email": "engineering@posthog.com",
         "url": "https://posthog.com"
     },
     "type": "module",

--- a/packages/nextjs-config/package.json
+++ b/packages/nextjs-config/package.json
@@ -9,7 +9,7 @@
   },
   "author": {
     "name": "PostHog",
-    "email": "hey@posthog.com",
+    "email": "engineering@posthog.com",
     "url": "https://posthog.com"
   },
   "main": "./dist/index.js",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "author": {
     "name": "PostHog",
-    "email": "hey@posthog.com",
+    "email": "engineering@posthog.com",
     "url": "https://posthog.com"
   },
   "main": "dist/entrypoints/index.node.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,7 +7,7 @@
         "url": "git+https://github.com/PostHog/posthog-js.git",
         "directory": "packages/react"
     },
-    "author": "hey@posthog.com",
+    "author": "engineering@posthog.com",
     "license": "MIT",
     "homepage": "https://posthog.com/docs/libraries/react",
     "packageManager": "pnpm@10.12.4",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -9,7 +9,7 @@
     },
     "author": {
         "name": "PostHog",
-        "email": "hey@posthog.com",
+        "email": "engineering@posthog.com",
         "url": "https://posthog.com"
     },
     "main": "./dist/index.js",


### PR DESCRIPTION
## Problem

Some published package metadata in this repo still points to `hey@posthog.com`. We want package contact metadata to consistently use `engineering@posthog.com`.

## Changes

- Updated package metadata emails in `posthog-js (web)`, `posthog-node`, `@posthog/react`, `@posthog/next`, `@posthog/nextjs-config`, and `@posthog/webpack-plugin`
- Replaced `hey@posthog.com` with `engineering@posthog.com`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [x] @posthog/next
- [x] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [x] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
