### PR TITLE
chore: update GitHub Actions for Node 24

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # pin v4.2.0
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # pin v5.0.0
 
     - name: Get pnpm cache directory path
       id: pnpm-cache-dir
@@ -27,7 +27,7 @@ runs:
       run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node_version }}
         registry-url: https://registry.npmjs.org

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Upload bundle size visualization
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         id: viz-upload
         with:
           name: bundle-stats-array.html

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: pnpm exec playwright test --workers=5
         working-directory: packages/browser
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() && steps.is-affected.outputs.is-affected == 'true' }}
         with:
           name: playwright-report
@@ -207,7 +207,7 @@ jobs:
               comment_id: process.env.COMMENT_ID
             })
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() && steps.is-affected.outputs.is-affected == 'true' }}
         with:
           name: playwright-compat-report

--- a/.github/workflows/posthog-com-upgrade.yml
+++ b/.github/workflows/posthog-com-upgrade.yml
@@ -36,10 +36,10 @@ jobs:
                   repository: 'PostHog/posthog.com'
                   token: ${{ steps.upgrader.outputs.token }}
 
-            - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # pin v4.2.0
+            - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # pin v5.0.0
 
             - name: Set up Node.js
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: pnpm

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -36,10 +36,10 @@ jobs:
                   repository: 'PostHog/posthog'
                   token: ${{ steps.upgrader.outputs.token }}
 
-            - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # pin v4.2.0
+            - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # pin v5.0.0
 
             - name: Set up Node.js
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
             - name: Get GitHub App token
               id: releaser
-              uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               with:
                   app-id: ${{ secrets.GH_APP_POSTHOG_JS_RELEASER_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_JS_RELEASER_PRIVATE_KEY }} # Secrets available only inside the `NPM Release` environment, requires approval from a maintainer
@@ -395,7 +395,7 @@ jobs:
 
             - name: Upload dist artifact
               if: steps.check-version.outputs.is-new-version == 'true'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: posthog-js-dist
                   path: packages/browser/dist/*.js
@@ -441,10 +441,10 @@ jobs:
                   fetch-depth: 1
 
             - name: Install pnpm
-              uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # pin v4.2.0
+              uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # pin v5.0.0
 
             - name: Setup Node.js
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@v6
               with:
                   node-version: '24'
                   cache: 'pnpm'
@@ -533,7 +533,7 @@ jobs:
                   echo "  built from:          PostHog/posthog@$(git rev-parse HEAD)"
 
             - name: Upload toolbar artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: toolbar-dist-${{ matrix.region.name }}
                   # Least common ancestor of these paths is `frontend/dist`,
@@ -573,7 +573,7 @@ jobs:
                   sparse-checkout: .github/scripts
 
             - name: Download dist artifact
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: posthog-js-dist
                   path: packages/browser/dist
@@ -587,7 +587,7 @@ jobs:
             # region-specific artifact is missing gives us clean per-region
             # fate-sharing.
             - name: Download toolbar artifact
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: toolbar-dist-${{ matrix.region.name }}
                   path: packages/browser/dist


### PR DESCRIPTION
## Problem

Several workflow files still pin older action releases that run on Node 20 or emit deprecated `set-output` warnings. We want the GitHub Actions surface in this repo on current node-24-capable releases.

## Changes

- bumped the shared setup action and upgrade/release workflows to `pnpm/action-setup@v5`
- updated release token creation to `actions/create-github-app-token@v3.1.1`
- moved remaining `actions/setup-node`, `upload-artifact`, and `download-artifact` usages onto their current majors

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
