### PR TITLE
feat(flags): switch local evaluation endpoint to /flags/definitions

### DIFF
--- a/.changeset/flags-definitions-endpoint.md
+++ b/.changeset/flags-definitions-endpoint.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': patch
+---
+
+feat(flags): switch local evaluation polling from `/api/feature_flag/local_evaluation` to `/flags/definitions`

--- a/.changeset/flags-definitions-endpoint.md
+++ b/.changeset/flags-definitions-endpoint.md
@@ -2,4 +2,4 @@
 'posthog-node': patch
 ---
 
-feat(flags): switch local evaluation polling from `/api/feature_flag/local_evaluation` to `/flags/definitions`
+fix(flags): switch local evaluation polling from `/api/feature_flag/local_evaluation` to `/flags/definitions`

--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -6020,7 +6020,7 @@ describe('error handling and backoff', () => {
   function createMockFetch(statusCode: number, onFlagFetch?: () => void): jest.Mock & { callCount: number } {
     let callCount = 0
     const mockFetch = jest.fn((url: string) => {
-      if ((url as string).includes('api/feature_flag/local_evaluation')) {
+      if ((url as string).includes('flags/definitions')) {
         callCount++
         onFlagFetch?.()
         return Promise.resolve({
@@ -6130,7 +6130,7 @@ describe('error handling and backoff', () => {
     Date.now = () => mockTime
 
     const mockFetch = jest.fn((url: string) => {
-      if ((url as string).includes('api/feature_flag/local_evaluation')) {
+      if ((url as string).includes('flags/definitions')) {
         fetchCallCount++
         // Always return 401 to keep triggering backoff
         return Promise.resolve({
@@ -6191,7 +6191,7 @@ describe('error handling and backoff', () => {
     Date.now = () => mockTime
 
     const mockFetch = jest.fn((url: string) => {
-      if ((url as string).includes('api/feature_flag/local_evaluation')) {
+      if ((url as string).includes('flags/definitions')) {
         fetchCallCount++
         return Promise.resolve({
           status: 401,
@@ -6246,7 +6246,7 @@ describe('error handling and backoff', () => {
   it('should clear backoff after successful response', async () => {
     let fetchCallCount = 0
     const mockFetch = jest.fn((url: string) => {
-      if ((url as string).includes('api/feature_flag/local_evaluation')) {
+      if ((url as string).includes('flags/definitions')) {
         fetchCallCount++
         if (fetchCallCount === 1) {
           // First fetch: return 401 to trigger backoff
@@ -6310,7 +6310,7 @@ describe('error handling and backoff', () => {
   it('should allow reloadFeatureFlags() to bypass backoff', async () => {
     let fetchCallCount = 0
     const mockFetch = jest.fn((url: string) => {
-      if ((url as string).includes('api/feature_flag/local_evaluation')) {
+      if ((url as string).includes('flags/definitions')) {
         fetchCallCount++
         // Always return 401 to keep backoff active
         return Promise.resolve({

--- a/packages/node/src/__tests__/utils/index.ts
+++ b/packages/node/src/__tests__/utils/index.ts
@@ -112,7 +112,7 @@ export const apiImplementation = ({
 }
 
 export const anyLocalEvalCall = [
-  'http://example.com/api/feature_flag/local_evaluation?token=TEST_API_KEY&send_cohorts',
+  'http://example.com/flags/definitions?token=TEST_API_KEY&send_cohorts',
   expect.any(Object),
 ]
 export const anyFlagsCall = ['http://example.com/flags/?v=2', expect.any(Object)]

--- a/packages/node/src/__tests__/utils/index.ts
+++ b/packages/node/src/__tests__/utils/index.ts
@@ -79,7 +79,7 @@ export const apiImplementation = ({
       }) as any
     }
 
-    if ((url as any).includes('api/feature_flag/local_evaluation?token=TEST_API_KEY&send_cohorts')) {
+    if ((url as any).includes('flags/definitions?token=TEST_API_KEY&send_cohorts')) {
       const headers = localFlagsEtag ? createMockHeaders({ ETag: localFlagsEtag }) : createMockHeaders()
       return Promise.resolve({
         status: localFlagsStatus,

--- a/packages/node/src/__tests__/utils/index.ts
+++ b/packages/node/src/__tests__/utils/index.ts
@@ -59,7 +59,7 @@ export const apiImplementation = ({
   localFlagsEtag?: string
 }) => {
   return (url: any): Promise<any> => {
-    if ((url as any).includes('/flags/')) {
+    if ((url as any).includes('/flags/?')) {
       return Promise.resolve({
         status: flagsStatus,
         text: () => Promise.resolve('ok'),

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -914,7 +914,7 @@ class FeatureFlagsPoller {
   }
 
   _requestFeatureFlagDefinitions(): Promise<PostHogFetchResponse> {
-    const url = `${this.host}/api/feature_flag/local_evaluation?token=${this.projectApiKey}&send_cohorts`
+    const url = `${this.host}/flags/definitions?token=${this.projectApiKey}&send_cohorts`
 
     const options = this.getPersonalApiKeyRequestOptions('GET', this.flagsEtag)
 


### PR DESCRIPTION
## Motivation and Context

The Rust feature flags definitions fleet now serves 100% of `/api/feature_flag/local_evaluation` traffic in all environments. This switches the Node SDK's default polling URL from the legacy Django path to the Rust endpoint's native path (`/flags/definitions`).

The old `/api/feature_flag/local_evaluation` path remains registered as a route alias on the Rust service, so older SDK versions continue to work.

## How did you test it?

- Updated the test utility URL constant in `packages/node/src/__tests__/utils/index.ts`
- The `/flags/definitions` endpoint has been serving production traffic since 2026-04-09