### PR TITLE
chore: update posthog-js release asset buckets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -562,8 +562,8 @@ jobs:
             fail-fast: false
             matrix:
                 region:
-                    - { name: us, bucket: posthog-js-prod-us, aws_region: us-east-1 }
-                    - { name: eu, bucket: posthog-js-prod-eu, aws_region: eu-central-1 }
+                    - { name: us, bucket: us-assets.i.posthog.com, aws_region: us-east-1 }
+                    - { name: eu, bucket: eu-assets.i.posthog.com, aws_region: eu-central-1 }
         steps:
             # Sparse checkout the release tooling plus the root pnpm files so
             # we can do a locked, filtered install for @posthog-tooling/release.

--- a/tooling/release/src/s3.test.ts
+++ b/tooling/release/src/s3.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createS3ClientConfig } from './s3.ts'
+
+test('createS3ClientConfig always enables path-style addressing for dotted bucket names', () => {
+    const originalAwsRegion = process.env.AWS_REGION
+    const originalAwsDefaultRegion = process.env.AWS_DEFAULT_REGION
+    const originalEndpoint = process.env.AWS_ENDPOINT_URL_S3
+
+    try {
+        delete process.env.AWS_REGION
+        delete process.env.AWS_DEFAULT_REGION
+        delete process.env.AWS_ENDPOINT_URL_S3
+
+        assert.deepEqual(createS3ClientConfig(), {
+            region: 'us-east-1',
+            endpoint: undefined,
+            forcePathStyle: true,
+        })
+
+        process.env.AWS_DEFAULT_REGION = 'eu-central-1'
+        process.env.AWS_ENDPOINT_URL_S3 = 'http://localhost:4566'
+
+        assert.deepEqual(createS3ClientConfig(), {
+            region: 'eu-central-1',
+            endpoint: 'http://localhost:4566',
+            forcePathStyle: true,
+        })
+
+        process.env.AWS_REGION = 'ap-southeast-1'
+
+        assert.deepEqual(createS3ClientConfig(), {
+            region: 'ap-southeast-1',
+            endpoint: 'http://localhost:4566',
+            forcePathStyle: true,
+        })
+    } finally {
+        if (originalAwsRegion === undefined) {
+            delete process.env.AWS_REGION
+        } else {
+            process.env.AWS_REGION = originalAwsRegion
+        }
+
+        if (originalAwsDefaultRegion === undefined) {
+            delete process.env.AWS_DEFAULT_REGION
+        } else {
+            process.env.AWS_DEFAULT_REGION = originalAwsDefaultRegion
+        }
+
+        if (originalEndpoint === undefined) {
+            delete process.env.AWS_ENDPOINT_URL_S3
+        } else {
+            process.env.AWS_ENDPOINT_URL_S3 = originalEndpoint
+        }
+    }
+})

--- a/tooling/release/src/s3.ts
+++ b/tooling/release/src/s3.ts
@@ -3,13 +3,19 @@ import { HeadObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s
 
 let cachedClient: S3Client | null = null
 
+export function createS3ClientConfig() {
+    return {
+        region: process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1',
+        endpoint: process.env.AWS_ENDPOINT_URL_S3,
+        // Production bucket names contain dots, so virtual-hosted-style HTTPS
+        // would produce hostnames that fail AWS wildcard certificate matching.
+        forcePathStyle: true,
+    }
+}
+
 function getS3Client(): S3Client {
     if (!cachedClient) {
-        cachedClient = new S3Client({
-            region: process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1',
-            endpoint: process.env.AWS_ENDPOINT_URL_S3,
-            forcePathStyle: !!process.env.AWS_ENDPOINT_URL_S3,
-        })
+        cachedClient = new S3Client(createS3ClientConfig())
     }
 
     return cachedClient


### PR DESCRIPTION
## Problem

posthog-js releases should publish browser assets to the new regional asset buckets so the release workflow uploads to `us-assets.i.posthog.com` and `eu-assets.i.posthog.com` instead of the old bucket names.

## Changes

- update the release workflow S3 upload matrix to target `us-assets.i.posthog.com`
- update the release workflow S3 upload matrix to target `eu-assets.i.posthog.com`
- leave the existing regional AWS role configuration unchanged

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
