### PR TITLE
docs: align contributing guides with CI checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,57 +1,47 @@
+# Contributing
+
 ## Tooling
 
-- Install [corepack](https://github.com/nodejs/corepack), if it's not already the case
-- Install [nvm](https://github.com/nvm-sh/nvm), if it's not already the case
+- Install [corepack](https://github.com/nodejs/corepack), if it is not already available
+- Install [nvm](https://github.com/nvm-sh/nvm), if it is not already available
 
-At the root folder, run :
+At the repository root, run:
 
-```
+```sh
 nvm use
+pnpm install --frozen-lockfile
 ```
 
-## Installation
+## CI-aligned checks
 
-At the root of the project, run:
+Run these commands from the repository root before opening a PR:
 
-```shell
-pnpm install
-```
-
-This will install all the workspace dependencies.
-
-## Building
-
-From the root folder, run:
-
-```shell
+```sh
 pnpm build
+pnpm lint
+pnpm lint:playground
+pnpm test:unit
+pnpm test:functional
 ```
 
-This will build all packages, by taking dependencies into account.
+These are the main build, lint, and test commands used by CI for the monorepo.
 
 ## Development
 
-Go to the `packages` directory and run:
+Run watch mode from the repository root:
 
-```shell
+```sh
 pnpm dev
 ```
 
-It will watch for changes and rebuild the packages.
+## Package-specific guides
 
-## Testing
+Some packages have their own contributor guides with extra package-level checks:
 
-To run tests for a specific package, navigate to the package directory and run:
-
-```shell
-pnpm test
-```
-
-or from the root of the project, run:
-
-```shell
-pnpm --filter=<package-name> test
-```
+- [packages/browser/CONTRIBUTING.md](packages/browser/CONTRIBUTING.md)
+- [packages/react-native/CONTRIBUTING.md](packages/react-native/CONTRIBUTING.md)
+- [packages/convex/CONTRIBUTING.md](packages/convex/CONTRIBUTING.md)
+- [packages/nuxt/CONTRIBUTING.md](packages/nuxt/CONTRIBUTING.md)
 
 ## Opening a new PR
 

--- a/packages/react-native/CONTRIBUTING.md
+++ b/packages/react-native/CONTRIBUTING.md
@@ -1,11 +1,19 @@
 # Contributing
 
-## Running sample app with Expo
+This guide covers package-specific development for `posthog-react-native`.
 
-See [Example Expo 53](../examples/example-expo-53/README.md)
+For repository-wide setup, see the root [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
-## Running tests
+## Running the sample app with Expo
+
+See [Example Expo 53](../../examples/example-expo-53/README.md).
+
+## CI-aligned checks
+
+Run these commands from the repository root:
 
 ```sh
-yarn test:rn
+pnpm --filter=posthog-react-native lint
+pnpm --filter=posthog-react-native test
+pnpm --filter=posthog-react-native build
 ```


### PR DESCRIPTION
## Problem

The repo-level and `posthog-react-native` contributing guides had drifted from the commands we actually run in CI.

## Changes

- update the root `CONTRIBUTING.md` to point contributors at the current repo-level build, lint, and test commands
- update `packages/react-native/CONTRIBUTING.md` to use the current pnpm-based package commands instead of the old yarn command
- keep the release process documentation unchanged

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
