### PR TITLE
feat(sourcemaps): add build config option to attach --build to uploads

### DIFF
--- a/.changeset/add-build-to-sourcemaps-config.md
+++ b/.changeset/add-build-to-sourcemaps-config.md
@@ -1,0 +1,6 @@
+---
+'@posthog/plugin-utils': minor
+'@posthog/nuxt': minor
+---
+
+Add `build` to sourcemaps config, forwarded to posthog-cli as `--build`. Lets consumers of the bundler plugins (webpack, rollup, nextjs-config, nuxt) attach a build number as release metadata. Requires posthog-cli >= 0.7.8.

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -23,6 +23,7 @@ interface SourcemapsConfig {
   /** @deprecated Use releaseName instead */
   project?: string
   releaseName?: string
+  build?: string | number
   logLevel?: LogLevel
   deleteAfterUpload?: boolean
   batchSize?: number
@@ -180,6 +181,10 @@ function getInjectArgs(directory: string, sourcemapsConfig: SourcemapsConfig) {
   const releaseVersion = sourcemapsConfig.releaseVersion ?? sourcemapsConfig.version
   if (releaseVersion) {
     processOptions.push('--release-version', releaseVersion)
+  }
+
+  if (sourcemapsConfig.build !== undefined && sourcemapsConfig.build !== '') {
+    processOptions.push('--build', String(sourcemapsConfig.build))
   }
 
   return processOptions

--- a/packages/plugin-utils/src/cli.ts
+++ b/packages/plugin-utils/src/cli.ts
@@ -24,6 +24,10 @@ export function buildSourcemapCliArgs(
         args.push('--release-version', config.sourcemaps.releaseVersion)
     }
 
+    if (config.sourcemaps.build !== undefined && config.sourcemaps.build !== '') {
+        args.push('--build', config.sourcemaps.build)
+    }
+
     if (config.sourcemaps.deleteAfterUpload) {
         args.push('--delete-after')
     }

--- a/packages/plugin-utils/src/config.ts
+++ b/packages/plugin-utils/src/config.ts
@@ -18,6 +18,7 @@ export interface PluginConfig {
         /** @deprecated Use releaseVersion instead */
         version?: string
         releaseVersion?: string
+        build?: string | number
         deleteAfterUpload?: boolean
         batchSize?: number
     }
@@ -32,6 +33,7 @@ export interface ResolvedPluginConfig extends Omit<PluginConfig, 'envId' | 'proj
         enabled: boolean
         releaseName?: string
         releaseVersion?: string
+        build?: string
         deleteAfterUpload: boolean
         batchSize?: number
     }
@@ -79,6 +81,7 @@ export function resolveConfig(options: PluginConfig, resolveOptions?: ResolveCon
             enabled,
             releaseName: userSourcemaps.releaseName ?? userSourcemaps.project,
             releaseVersion: userSourcemaps.releaseVersion ?? userSourcemaps.version,
+            build: userSourcemaps.build !== undefined ? String(userSourcemaps.build) : undefined,
             deleteAfterUpload: userSourcemaps.deleteAfterUpload ?? true,
             batchSize: userSourcemaps.batchSize,
         },


### PR DESCRIPTION
Adds `build` to `@posthog/plugin-utils` and `@posthog/nuxt` sourcemaps config, plumbed through to posthog-cli as `--build`. Consumers of the bundler plugins can now attach a build number (CI build id, CFBundleVersion, versionCode, etc.) as release metadata, matching what the iOS, Android, and React Native SDKs already do.

Requires posthog-cli >= 0.7.8 where `--build` landed in shared ReleaseArgs for sourcemap upload.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [X] @posthog/nextjs-config (auto-patch via `@posthog/plugin-utils` workspace dep)
- [X] @posthog/nuxt
- [X] @posthog/rollup-plugin (auto-patch via `@posthog/plugin-utils` workspace dep)
- [X] @posthog/webpack-plugin (auto-patch via `@posthog/plugin-utils` workspace dep)
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [X] Ran `pnpm changeset` to generate a changeset file
- [X] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
