### PR TITLE
fix: PostHogMaskView not being detected on iOS

### DIFF
--- a/.changeset/true-pigs-win.md
+++ b/.changeset/true-pigs-win.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+fix: `PostHogMaskView` not being detected on iOS

--- a/packages/react-native/src/PostHogMaskView.tsx
+++ b/packages/react-native/src/PostHogMaskView.tsx
@@ -19,8 +19,8 @@ export interface PostHogMaskViewProps extends ViewProps {
  * - Setting `accessibilityLabel` to `"ph-no-capture"` to hide the content from session recordings
  * - Setting `importantForAccessibility` to `"no"` to prevent the wrapper View from hiding
  *   accessible content on Android (since `accessibilityLabel` would otherwise interfere)
- * - Setting `collapsable={false}` so React Native keeps this wrapper in the native iOS view hierarchy
- *   (otherwise layout-only view flattening can remove it and masking is not detected)
+ * - Setting `collapsable={false}` so React Native keeps this wrapper in the native view hierarchy
+ *   (otherwise layout-only view flattening can remove it and masking is not detected on iOS/Android)
  *
  * @example
  * ```jsx

--- a/packages/react-native/src/PostHogMaskView.tsx
+++ b/packages/react-native/src/PostHogMaskView.tsx
@@ -19,6 +19,8 @@ export interface PostHogMaskViewProps extends ViewProps {
  * - Setting `accessibilityLabel` to `"ph-no-capture"` to hide the content from session recordings
  * - Setting `importantForAccessibility` to `"no"` to prevent the wrapper View from hiding
  *   accessible content on Android (since `accessibilityLabel` would otherwise interfere)
+ * - Setting `collapsable={false}` so React Native keeps this wrapper in the native iOS view hierarchy
+ *   (otherwise layout-only view flattening can remove it and masking is not detected)
  *
  * @example
  * ```jsx
@@ -37,7 +39,7 @@ export interface PostHogMaskViewProps extends ViewProps {
  * @public
  */
 export const PostHogMaskView = ({ children, ...viewProps }: PostHogMaskViewProps): JSX.Element => (
-  <View {...viewProps} accessibilityLabel="ph-no-capture" importantForAccessibility="no">
+  <View {...viewProps} accessibilityLabel="ph-no-capture" importantForAccessibility="no" collapsable={false}>
     {children}
   </View>
 )


### PR DESCRIPTION
## Problem

Issue: https://posthog.com/questions/masking-reliably-on-both-android-and-i-os

`PostHogMaskView` was unreliable on iOS because React Native can flatten/remove layout-only wrapper views for optimization reasons. When that happens, the `ph-no-capture` label was not consistently detectable in native view traversal, which means masking would fail.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

Set [collapsable: { false }](https://reactnative.dev/docs/view#collapsable) prop, which ensures that PostHogMaskView will survive the native view hierarchy

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
