### PR TITLE
fix(ai): read tool-call input field in vercel non-streaming output

### DIFF
--- a/.changeset/fix-vercel-tool-call-input.md
+++ b/.changeset/fix-vercel-tool-call-input.md
@@ -1,0 +1,5 @@
+---
+"@posthog/ai": patch
+---
+
+fix(ai): read tool-call input field in vercel non-streaming output

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -200,7 +200,8 @@ const mapVercelOutput = (result: LanguageModelContent[]): PostHogInput[] => {
       return { type: 'text', text: truncate(item.text) }
     }
     if (item.type === 'tool-call') {
-      const rawArgs = (item as any).input ?? (item as any).args ?? (item as any).arguments ?? {}
+      const toolCall = item as { input?: unknown; args?: unknown; arguments?: unknown }
+      const rawArgs = toolCall.input ?? toolCall.args ?? toolCall.arguments ?? {}
       return {
         type: 'tool-call',
         id: item.toolCallId,

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -200,12 +200,13 @@ const mapVercelOutput = (result: LanguageModelContent[]): PostHogInput[] => {
       return { type: 'text', text: truncate(item.text) }
     }
     if (item.type === 'tool-call') {
+      const rawArgs = (item as any).input ?? (item as any).args ?? (item as any).arguments ?? {}
       return {
         type: 'tool-call',
         id: item.toolCallId,
         function: {
           name: item.toolName,
-          arguments: (item as any).args || JSON.stringify((item as any).arguments || {}),
+          arguments: typeof rawArgs === 'string' ? rawArgs : JSON.stringify(rawArgs),
         },
       }
     }

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -373,6 +373,59 @@ describe('Vercel AI SDK - Dual Version Support', () => {
         },
       ])
     })
+
+    it.each([
+      ['string input (per spec)', '{"message":"hello world"}'],
+      ['object input (defensive)', { message: 'hello world' }],
+    ])('should handle non-streaming tool calls with %s (AI SDK v6)', async (_label, input) => {
+      const baseModel: LanguageModelV3 = {
+        specificationVersion: 'v3' as const,
+        provider: 'openai',
+        modelId: 'gpt-4o',
+        supportedUrls: {},
+        doGenerate: jest.fn().mockResolvedValue({
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call_123',
+              toolName: 'myTool',
+              input,
+            },
+          ],
+          usage: v3TokenUsage(10, 5),
+          response: { modelId: 'gpt-4o' },
+          providerMetadata: {},
+          finishReason: { unified: 'tool-calls' as const, raw: undefined },
+          warnings: [],
+        }),
+        doStream: jest.fn(),
+      }
+
+      const model = withTracing(baseModel, mockPostHogClient, {
+        posthogDistinctId: 'test-user',
+        posthogTraceId: 'test-v3-tool-input',
+      })
+
+      await model.doGenerate({
+        prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Call myTool' }] }],
+      } as any)
+
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+
+      expect(captureCall[0].properties.$ai_output_choices).toEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              id: 'call_123',
+              function: { name: 'myTool', arguments: '{"message":"hello world"}' },
+            },
+          ],
+        },
+      ])
+    })
   })
 
   describe('V2 Model (AI SDK 5)', () => {

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -374,10 +374,12 @@ describe('Vercel AI SDK - Dual Version Support', () => {
       ])
     })
 
-    it.each([
-      ['string input (per spec)', '{"message":"hello world"}'],
-      ['object input (defensive)', { message: 'hello world' }],
-    ])('should handle non-streaming tool calls with %s (AI SDK v6)', async (_label, input) => {
+    it.each<[string, { input?: unknown; args?: unknown; arguments?: unknown }]>([
+      ['input as string (AI SDK v6 spec)', { input: '{"message":"hello world"}' }],
+      ['input as object (defensive)', { input: { message: 'hello world' } }],
+      ['args fallback (legacy SDK)', { args: '{"message":"hello world"}' }],
+      ['arguments fallback (legacy SDK)', { arguments: { message: 'hello world' } }],
+    ])('should handle non-streaming tool calls with %s', async (_label, extraFields) => {
       const baseModel: LanguageModelV3 = {
         specificationVersion: 'v3' as const,
         provider: 'openai',
@@ -389,7 +391,7 @@ describe('Vercel AI SDK - Dual Version Support', () => {
               type: 'tool-call',
               toolCallId: 'call_123',
               toolName: 'myTool',
-              input,
+              ...extraFields,
             },
           ],
           usage: v3TokenUsage(10, 5),
@@ -406,9 +408,10 @@ describe('Vercel AI SDK - Dual Version Support', () => {
         posthogTraceId: 'test-v3-tool-input',
       })
 
-      await model.doGenerate({
+      const callOptions: LanguageModelV3CallOptions = {
         prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Call myTool' }] }],
-      } as any)
+      }
+      await model.doGenerate(callOptions)
 
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
       const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls


### PR DESCRIPTION
## Problem

When using `withTracing` with Vercel AI SDK v6 and `generateText` (non-streaming), tool call arguments were logged as empty `"{}"` in `$ai_output_choices` instead of the actual arguments. Affects anyone tracking tool-calling agents with `@posthog/ai` + `ai@^6`.

Root cause: `mapVercelOutput` in `packages/ai/src/vercel/middleware.ts` looked for `item.args` / `item.arguments`, but AI SDK v5+ emits tool-call content parts with `item.input` (a stringified JSON, per `LanguageModelV{2,3}ToolCall` in `@ai-sdk/provider`). The streaming path and `mapVercelPrompt` already read `input` correctly — only the non-streaming output mapping was wrong.

Fixes #3011.

## Changes

- `mapVercelOutput` now reads `item.input` first, falling back to `item.args` / `item.arguments` for older AI SDK versions. When `input` is an object (non-conforming providers), it is `JSON.stringify`d to produce the string shape `$ai_output_choices` expects.
- Added a parameterised test covering both string-input (per spec) and object-input (defensive) cases for V3 non-streaming tool calls.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*