### PR TITLE
fix(ai): adjust V3 cache tokens for Claude on any host

### DIFF
--- a/.changeset/fix-bedrock-claude-cache-cost.md
+++ b/.changeset/fix-bedrock-claude-cache-cost.md
@@ -1,0 +1,5 @@
+---
+"@posthog/ai": patch
+---
+
+fix(ai): adjust V3 cache tokens for Claude on any host (including Bedrock)

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -301,41 +301,6 @@ const extractWebSearchCount = (providerMetadata: unknown, usage: any): number =>
   })
 }
 
-// Extract additional token values from provider metadata
-const extractAdditionalTokenValues = (providerMetadata: unknown): Record<string, any> => {
-  if (
-    providerMetadata &&
-    typeof providerMetadata === 'object' &&
-    'anthropic' in providerMetadata &&
-    providerMetadata.anthropic &&
-    typeof providerMetadata.anthropic === 'object' &&
-    'cacheCreationInputTokens' in providerMetadata.anthropic
-  ) {
-    return {
-      cacheCreationInputTokens: providerMetadata.anthropic.cacheCreationInputTokens,
-    }
-  }
-  return {}
-}
-
-// For Anthropic providers in V3, inputTokens.total is the sum of all tokens (uncached + cache read + cache write).
-// Our cost calculation expects inputTokens to be only the uncached portion for Anthropic.
-// This helper subtracts cache tokens from inputTokens for Anthropic V3 models.
-const adjustAnthropicV3CacheTokens = (
-  model: LanguageModel,
-  provider: string,
-  usage: { inputTokens?: number; cacheReadInputTokens?: unknown; cacheCreationInputTokens?: unknown }
-): void => {
-  if (isV3Model(model) && provider.toLowerCase().includes('anthropic')) {
-    const cacheReadTokens = (usage.cacheReadInputTokens as number) || 0
-    const cacheWriteTokens = (usage.cacheCreationInputTokens as number) || 0
-    const cacheTokens = cacheReadTokens + cacheWriteTokens
-    if (usage.inputTokens && cacheTokens > 0) {
-      usage.inputTokens = Math.max(usage.inputTokens - cacheTokens, 0)
-    }
-  }
-}
-
 // Helper to extract numeric token value from V2 (number) or V3 (object with .total) usage formats
 const extractTokenCount = (value: unknown): number | undefined => {
   if (typeof value === 'number') {
@@ -388,6 +353,75 @@ const extractCacheReadTokens = (usage: Record<string, unknown>): unknown => {
   return undefined
 }
 
+// Helper to extract cache write tokens from V3 (usage.inputTokens.cacheWrite). Providers like
+// Amazon Bedrock populate this standardized field instead of providerMetadata.anthropic.
+const extractCacheWriteTokens = (usage: Record<string, unknown>): unknown => {
+  if (
+    'inputTokens' in usage &&
+    usage.inputTokens &&
+    typeof usage.inputTokens === 'object' &&
+    'cacheWrite' in usage.inputTokens
+  ) {
+    return (usage.inputTokens as { cacheWrite: unknown }).cacheWrite
+  }
+  return undefined
+}
+
+// Extract additional token values from provider metadata, with a V3 standardized fallback
+// (e.g. Amazon Bedrock exposes cache write tokens via usage.inputTokens.cacheWrite rather
+// than providerMetadata.anthropic.cacheCreationInputTokens).
+const extractAdditionalTokenValues = (providerMetadata: unknown, usage?: unknown): Record<string, any> => {
+  if (
+    providerMetadata &&
+    typeof providerMetadata === 'object' &&
+    'anthropic' in providerMetadata &&
+    providerMetadata.anthropic &&
+    typeof providerMetadata.anthropic === 'object' &&
+    'cacheCreationInputTokens' in providerMetadata.anthropic
+  ) {
+    return {
+      cacheCreationInputTokens: providerMetadata.anthropic.cacheCreationInputTokens,
+    }
+  }
+  if (usage && typeof usage === 'object') {
+    const cacheWrite = extractCacheWriteTokens(usage as Record<string, unknown>)
+    if (cacheWrite !== undefined) {
+      return { cacheCreationInputTokens: cacheWrite }
+    }
+  }
+  return {}
+}
+
+// Detects Anthropic Claude regardless of host (direct Anthropic, Amazon Bedrock, Google Vertex, etc.).
+// The server applies exclusive cache token accounting based on the model name, so any Claude model
+// needs its V3 input tokens adjusted to exclude cache tokens — not just those routed through a
+// provider whose name contains "anthropic".
+const isAnthropicClaudeModel = (model: LanguageModel, provider: string): boolean => {
+  if (provider.toLowerCase().includes('anthropic')) {
+    return true
+  }
+  const modelId = (model.modelId ?? '').toLowerCase()
+  return /claude|anthropic/.test(modelId)
+}
+
+// For Anthropic providers in V3, inputTokens.total is the sum of all tokens (uncached + cache read + cache write).
+// Our cost calculation expects inputTokens to be only the uncached portion for Anthropic.
+// This helper subtracts cache tokens from inputTokens for Anthropic V3 models.
+const adjustAnthropicV3CacheTokens = (
+  model: LanguageModel,
+  provider: string,
+  usage: { inputTokens?: number; cacheReadInputTokens?: unknown; cacheCreationInputTokens?: unknown }
+): void => {
+  if (isV3Model(model) && isAnthropicClaudeModel(model, provider)) {
+    const cacheReadTokens = (usage.cacheReadInputTokens as number) || 0
+    const cacheWriteTokens = (usage.cacheCreationInputTokens as number) || 0
+    const cacheTokens = cacheReadTokens + cacheWriteTokens
+    if (usage.inputTokens && cacheTokens > 0) {
+      usage.inputTokens = Math.max(usage.inputTokens - cacheTokens, 0)
+    }
+  }
+}
+
 /**
  * Wraps a Vercel AI SDK language model (V2 or V3) with PostHog tracing.
  * Automatically detects the model version and applies appropriate instrumentation.
@@ -431,7 +465,7 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
           const content = mapVercelOutput((result.content ?? []) as LanguageModelContent[])
           const latency = (Date.now() - startTime) / 1000
           const providerMetadata = result.providerMetadata
-          const additionalTokenValues = extractAdditionalTokenValues(providerMetadata)
+          const additionalTokenValues = extractAdditionalTokenValues(providerMetadata, result.usage)
 
           const webSearchCount = extractWebSearchCount(providerMetadata, result.usage)
 
@@ -612,8 +646,8 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
 
               if (chunk.type === 'finish') {
                 providerMetadata = chunk.providerMetadata
-                const additionalTokenValues = extractAdditionalTokenValues(providerMetadata)
                 const chunkUsage = (chunk.usage as Record<string, unknown>) || {}
+                const additionalTokenValues = extractAdditionalTokenValues(providerMetadata, chunkUsage)
                 usage = {
                   inputTokens: extractTokenCount(chunk.usage?.inputTokens),
                   outputTokens: extractTokenCount(chunk.usage?.outputTokens),

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -369,8 +369,10 @@ const extractCacheWriteTokens = (usage: Record<string, unknown>): unknown => {
 
 // Extract additional token values from provider metadata, with a V3 standardized fallback
 // (e.g. Amazon Bedrock exposes cache write tokens via usage.inputTokens.cacheWrite rather
-// than providerMetadata.anthropic.cacheCreationInputTokens).
-const extractAdditionalTokenValues = (providerMetadata: unknown, usage?: unknown): Record<string, any> => {
+// than providerMetadata.anthropic.cacheCreationInputTokens). A cacheWrite of 0 is treated
+// as absent so we preserve the pre-fallback event shape on providers that simply omit the
+// field — consumers downstream saw `$ai_cache_creation_input_tokens` missing, not 0.
+const extractAdditionalTokenValues = (providerMetadata: unknown, usage: unknown): Record<string, any> => {
   if (
     providerMetadata &&
     typeof providerMetadata === 'object' &&
@@ -385,7 +387,7 @@ const extractAdditionalTokenValues = (providerMetadata: unknown, usage?: unknown
   }
   if (usage && typeof usage === 'object') {
     const cacheWrite = extractCacheWriteTokens(usage as Record<string, unknown>)
-    if (cacheWrite !== undefined) {
+    if (typeof cacheWrite === 'number' && cacheWrite > 0) {
       return { cacheCreationInputTokens: cacheWrite }
     }
   }
@@ -395,13 +397,13 @@ const extractAdditionalTokenValues = (providerMetadata: unknown, usage?: unknown
 // Detects Anthropic Claude regardless of host (direct Anthropic, Amazon Bedrock, Google Vertex, etc.).
 // The server applies exclusive cache token accounting based on the model name, so any Claude model
 // needs its V3 input tokens adjusted to exclude cache tokens — not just those routed through a
-// provider whose name contains "anthropic".
-const isAnthropicClaudeModel = (model: LanguageModel, provider: string): boolean => {
+// provider whose name contains "anthropic". Accepts the resolved modelId string (not the raw model)
+// so it sees the same id the server does after posthogModelOverride / response.modelId fallbacks.
+const isAnthropicClaudeModel = (modelId: string, provider: string): boolean => {
   if (provider.toLowerCase().includes('anthropic')) {
     return true
   }
-  const modelId = (model.modelId ?? '').toLowerCase()
-  return /claude|anthropic/.test(modelId)
+  return /claude|anthropic/i.test(modelId)
 }
 
 // For Anthropic providers in V3, inputTokens.total is the sum of all tokens (uncached + cache read + cache write).
@@ -409,10 +411,11 @@ const isAnthropicClaudeModel = (model: LanguageModel, provider: string): boolean
 // This helper subtracts cache tokens from inputTokens for Anthropic V3 models.
 const adjustAnthropicV3CacheTokens = (
   model: LanguageModel,
+  modelId: string,
   provider: string,
   usage: { inputTokens?: number; cacheReadInputTokens?: unknown; cacheCreationInputTokens?: unknown }
 ): void => {
-  if (isV3Model(model) && isAnthropicClaudeModel(model, provider)) {
+  if (isV3Model(model) && isAnthropicClaudeModel(modelId, provider)) {
     const cacheReadTokens = (usage.cacheReadInputTokens as number) || 0
     const cacheWriteTokens = (usage.cacheCreationInputTokens as number) || 0
     const cacheTokens = cacheReadTokens + cacheWriteTokens
@@ -499,7 +502,7 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
             rawUsage: rawUsageData,
           }
 
-          adjustAnthropicV3CacheTokens(model, provider, usage)
+          adjustAnthropicV3CacheTokens(model, modelId, provider, usage)
 
           // Extract finish reason - V2 returns a string, V3 returns an object with .unified
           const rawFinishReason = result.finishReason
@@ -713,7 +716,7 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
                 rawUsage: { usage, providerMetadata },
               }
 
-              adjustAnthropicV3CacheTokens(model, provider, finalUsage)
+              adjustAnthropicV3CacheTokens(model, modelId, provider, finalUsage)
 
               await sendEventToPosthog({
                 client: phClient,

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -797,6 +797,153 @@ describe('Vercel AI SDK - Dual Version Support', () => {
       expect(captureCall[0].properties['$ai_cache_read_input_tokens']).toBe(1000)
       expect(captureCall[0].properties['$ai_cache_creation_input_tokens']).toBe(20)
     })
+
+    it('should adjust cache tokens and read cacheWrite from V3 usage for Bedrock Claude', async () => {
+      // Simulates @ai-sdk/amazon-bedrock hosting Claude: provider is "amazon-bedrock",
+      // no providerMetadata.anthropic is set, and cacheWrite is exposed via usage.inputTokens.cacheWrite.
+      // Previously this path was skipped, causing cacheRead/cacheWrite tokens to be double-counted
+      // by the server's exclusive cache accounting (triggered by the "claude" model name).
+      const baseModel: LanguageModelV3 = {
+        specificationVersion: 'v3' as const,
+        provider: 'amazon-bedrock',
+        modelId: 'global.anthropic.claude-opus-4-6-v1',
+        supportedUrls: {},
+        doGenerate: jest.fn().mockImplementation(async () => ({
+          text: 'Cached response',
+          usage: {
+            inputTokens: { total: 22145, noCache: 740, cacheRead: 21405, cacheWrite: 0 },
+            outputTokens: { total: 50, text: 50, reasoning: undefined },
+          },
+          content: [{ type: 'text', text: 'Cached response' }],
+          response: { modelId: 'global.anthropic.claude-opus-4-6-v1' },
+          providerMetadata: {},
+          finishReason: { unified: 'stop' as const, raw: undefined },
+          warnings: [],
+        })),
+        doStream: jest.fn(),
+      }
+
+      const model = withTracing(baseModel, mockPostHogClient, {
+        posthogDistinctId: 'test-user',
+        posthogTraceId: 'test-bedrock-claude-cache-read',
+      })
+
+      await simulateGenerateText({
+        model: model,
+        prompt: 'Test Bedrock Claude cache read',
+      })
+
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+
+      // 22145 - 21405 - 0 = 740
+      expect(captureCall[0].properties['$ai_input_tokens']).toBe(740)
+      expect(captureCall[0].properties['$ai_cache_read_input_tokens']).toBe(21405)
+    })
+
+    it('should extract cacheCreationInputTokens from V3 usage.inputTokens.cacheWrite when providerMetadata is absent', async () => {
+      // Bedrock doesn't populate providerMetadata.anthropic.cacheCreationInputTokens,
+      // so we must fall back to the V3 standardized usage.inputTokens.cacheWrite field.
+      const baseModel: LanguageModelV3 = {
+        specificationVersion: 'v3' as const,
+        provider: 'amazon-bedrock',
+        modelId: 'anthropic.claude-sonnet-4-5-v1',
+        supportedUrls: {},
+        doGenerate: jest.fn().mockImplementation(async () => ({
+          text: 'Cached response',
+          usage: {
+            inputTokens: { total: 21561, noCache: 5, cacheRead: 17399, cacheWrite: 4157 },
+            outputTokens: { total: 139, text: 139, reasoning: undefined },
+          },
+          content: [{ type: 'text', text: 'Cached response' }],
+          response: { modelId: 'anthropic.claude-sonnet-4-5-v1' },
+          providerMetadata: {},
+          finishReason: { unified: 'stop' as const, raw: undefined },
+          warnings: [],
+        })),
+        doStream: jest.fn(),
+      }
+
+      const model = withTracing(baseModel, mockPostHogClient, {
+        posthogDistinctId: 'test-user',
+        posthogTraceId: 'test-bedrock-claude-cache-write',
+      })
+
+      await simulateGenerateText({
+        model: model,
+        prompt: 'Test Bedrock Claude cache write',
+      })
+
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+
+      // 21561 - 17399 - 4157 = 5
+      expect(captureCall[0].properties['$ai_input_tokens']).toBe(5)
+      expect(captureCall[0].properties['$ai_cache_read_input_tokens']).toBe(17399)
+      expect(captureCall[0].properties['$ai_cache_creation_input_tokens']).toBe(4157)
+      expect(captureCall[0].properties['$ai_output_tokens']).toBe(139)
+    })
+
+    it('should handle Bedrock Claude V3 streaming with cache tokens', async () => {
+      const streamParts: LanguageModelV3StreamPart[] = [
+        { type: 'text-delta', id: 'text-1', delta: 'Cached streaming response' },
+        {
+          type: 'finish',
+          usage: {
+            inputTokens: { total: 1120, noCache: 100, cacheRead: 1000, cacheWrite: 20 },
+            outputTokens: { total: 50, text: 50, reasoning: undefined },
+          },
+          finishReason: { unified: 'stop' as const, raw: undefined },
+          providerMetadata: {},
+        },
+      ]
+
+      const baseModel: LanguageModelV3 = {
+        specificationVersion: 'v3' as const,
+        provider: 'amazon-bedrock',
+        modelId: 'global.anthropic.claude-opus-4-6-v1',
+        supportedUrls: {},
+        doGenerate: jest.fn(),
+        doStream: jest.fn().mockImplementation(async () => {
+          const stream = new ReadableStream({
+            async start(controller) {
+              for (const part of streamParts) {
+                controller.enqueue(part)
+              }
+              controller.close()
+            },
+          })
+          return {
+            stream,
+            response: { modelId: 'global.anthropic.claude-opus-4-6-v1' },
+          }
+        }),
+      }
+
+      const model = withTracing(baseModel, mockPostHogClient, {
+        posthogDistinctId: 'test-user',
+        posthogTraceId: 'test-bedrock-claude-v3-stream-cache',
+      })
+
+      const result = await model.doStream({
+        prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Cached?' }] }],
+      })
+
+      const reader = result.stream.getReader()
+      while (!(await reader.read()).done) {
+        // Consume stream
+      }
+
+      await flushPromises()
+
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+
+      // 1120 - 1000 - 20 = 100
+      expect(captureCall[0].properties['$ai_input_tokens']).toBe(100)
+      expect(captureCall[0].properties['$ai_cache_read_input_tokens']).toBe(1000)
+      expect(captureCall[0].properties['$ai_cache_creation_input_tokens']).toBe(20)
+    })
   })
 
   describe('Mixed reasoning and text content', () => {

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -798,91 +798,96 @@ describe('Vercel AI SDK - Dual Version Support', () => {
       expect(captureCall[0].properties['$ai_cache_creation_input_tokens']).toBe(20)
     })
 
-    it('should adjust cache tokens and read cacheWrite from V3 usage for Bedrock Claude', async () => {
-      // Simulates @ai-sdk/amazon-bedrock hosting Claude: provider is "amazon-bedrock",
-      // no providerMetadata.anthropic is set, and cacheWrite is exposed via usage.inputTokens.cacheWrite.
-      // Previously this path was skipped, causing cacheRead/cacheWrite tokens to be double-counted
-      // by the server's exclusive cache accounting (triggered by the "claude" model name).
-      const baseModel: LanguageModelV3 = {
-        specificationVersion: 'v3' as const,
+    // Covers Claude hosted by providers whose name doesn't contain "anthropic". Server-side
+    // exclusive cache accounting triggers on "claude" in the model id, so the client must
+    // recognise the same signal and subtract cache tokens from inputTokens before sending.
+    //
+    // Vertex row exercises the `|anthropic` arm of the regex: `claude-sonnet-4-5@20250929`
+    // has no "anthropic" substring.
+    it.each([
+      {
+        name: 'Bedrock Claude, cacheRead only — omits $ai_cache_creation_input_tokens when cacheWrite is 0',
         provider: 'amazon-bedrock',
         modelId: 'global.anthropic.claude-opus-4-6-v1',
-        supportedUrls: {},
-        doGenerate: jest.fn().mockImplementation(async () => ({
-          text: 'Cached response',
-          usage: {
-            inputTokens: { total: 22145, noCache: 740, cacheRead: 21405, cacheWrite: 0 },
-            outputTokens: { total: 50, text: 50, reasoning: undefined },
-          },
-          content: [{ type: 'text', text: 'Cached response' }],
-          response: { modelId: 'global.anthropic.claude-opus-4-6-v1' },
-          providerMetadata: {},
-          finishReason: { unified: 'stop' as const, raw: undefined },
-          warnings: [],
-        })),
-        doStream: jest.fn(),
-      }
-
-      const model = withTracing(baseModel, mockPostHogClient, {
-        posthogDistinctId: 'test-user',
-        posthogTraceId: 'test-bedrock-claude-cache-read',
-      })
-
-      await simulateGenerateText({
-        model: model,
-        prompt: 'Test Bedrock Claude cache read',
-      })
-
-      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
-      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
-
-      // 22145 - 21405 - 0 = 740
-      expect(captureCall[0].properties['$ai_input_tokens']).toBe(740)
-      expect(captureCall[0].properties['$ai_cache_read_input_tokens']).toBe(21405)
-    })
-
-    it('should extract cacheCreationInputTokens from V3 usage.inputTokens.cacheWrite when providerMetadata is absent', async () => {
-      // Bedrock doesn't populate providerMetadata.anthropic.cacheCreationInputTokens,
-      // so we must fall back to the V3 standardized usage.inputTokens.cacheWrite field.
-      const baseModel: LanguageModelV3 = {
-        specificationVersion: 'v3' as const,
+        inputTokens: { total: 22145, noCache: 740, cacheRead: 21405, cacheWrite: 0 },
+        outputTokens: { total: 50, text: 50, reasoning: undefined },
+        expectedInputTokens: 740,
+        expectedCacheRead: 21405,
+        expectedCacheCreation: undefined,
+        expectedOutputTokens: 50,
+      },
+      {
+        name: 'Bedrock Claude, cacheRead + cacheWrite via V3 standardized location',
         provider: 'amazon-bedrock',
         modelId: 'anthropic.claude-sonnet-4-5-v1',
-        supportedUrls: {},
-        doGenerate: jest.fn().mockImplementation(async () => ({
-          text: 'Cached response',
-          usage: {
-            inputTokens: { total: 21561, noCache: 5, cacheRead: 17399, cacheWrite: 4157 },
-            outputTokens: { total: 139, text: 139, reasoning: undefined },
-          },
-          content: [{ type: 'text', text: 'Cached response' }],
-          response: { modelId: 'anthropic.claude-sonnet-4-5-v1' },
-          providerMetadata: {},
-          finishReason: { unified: 'stop' as const, raw: undefined },
-          warnings: [],
-        })),
-        doStream: jest.fn(),
+        inputTokens: { total: 21561, noCache: 5, cacheRead: 17399, cacheWrite: 4157 },
+        outputTokens: { total: 139, text: 139, reasoning: undefined },
+        expectedInputTokens: 5,
+        expectedCacheRead: 17399,
+        expectedCacheCreation: 4157,
+        expectedOutputTokens: 139,
+      },
+      {
+        name: 'Vertex Claude (modelId carries "claude" without "anthropic")',
+        provider: 'google-vertex',
+        modelId: 'claude-sonnet-4-5@20250929',
+        inputTokens: { total: 1000, noCache: 100, cacheRead: 800, cacheWrite: 100 },
+        outputTokens: { total: 50, text: 50, reasoning: undefined },
+        expectedInputTokens: 100,
+        expectedCacheRead: 800,
+        expectedCacheCreation: 100,
+        expectedOutputTokens: 50,
+      },
+    ])(
+      'adjusts V3 cache tokens for $name',
+      async ({
+        provider,
+        modelId,
+        inputTokens,
+        outputTokens,
+        expectedInputTokens,
+        expectedCacheRead,
+        expectedCacheCreation,
+        expectedOutputTokens,
+      }) => {
+        const baseModel: LanguageModelV3 = {
+          specificationVersion: 'v3' as const,
+          provider,
+          modelId,
+          supportedUrls: {},
+          doGenerate: jest.fn().mockImplementation(async () => ({
+            text: 'Cached response',
+            usage: { inputTokens, outputTokens },
+            content: [{ type: 'text', text: 'Cached response' }],
+            response: { modelId },
+            providerMetadata: {},
+            finishReason: { unified: 'stop' as const, raw: undefined },
+            warnings: [],
+          })),
+          doStream: jest.fn(),
+        }
+
+        const model = withTracing(baseModel, mockPostHogClient, {
+          posthogDistinctId: 'test-user',
+          posthogTraceId: `test-${provider}-${modelId}`,
+        })
+
+        await simulateGenerateText({ model, prompt: 'Test non-anthropic-provider Claude cache' })
+
+        expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+        const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+        const properties = captureCall[0].properties
+
+        expect(properties['$ai_input_tokens']).toBe(expectedInputTokens)
+        expect(properties['$ai_cache_read_input_tokens']).toBe(expectedCacheRead)
+        expect(properties['$ai_output_tokens']).toBe(expectedOutputTokens)
+        if (expectedCacheCreation === undefined) {
+          expect(properties['$ai_cache_creation_input_tokens']).toBeUndefined()
+        } else {
+          expect(properties['$ai_cache_creation_input_tokens']).toBe(expectedCacheCreation)
+        }
       }
-
-      const model = withTracing(baseModel, mockPostHogClient, {
-        posthogDistinctId: 'test-user',
-        posthogTraceId: 'test-bedrock-claude-cache-write',
-      })
-
-      await simulateGenerateText({
-        model: model,
-        prompt: 'Test Bedrock Claude cache write',
-      })
-
-      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
-      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
-
-      // 21561 - 17399 - 4157 = 5
-      expect(captureCall[0].properties['$ai_input_tokens']).toBe(5)
-      expect(captureCall[0].properties['$ai_cache_read_input_tokens']).toBe(17399)
-      expect(captureCall[0].properties['$ai_cache_creation_input_tokens']).toBe(4157)
-      expect(captureCall[0].properties['$ai_output_tokens']).toBe(139)
-    })
+    )
 
     it('should handle Bedrock Claude V3 streaming with cache tokens', async () => {
       const streamParts: LanguageModelV3StreamPart[] = [


### PR DESCRIPTION
## Problem

Closes #3022.

For Vercel AI SDK LanguageModel V3, `adjustAnthropicV3CacheTokens` only fired when `model.provider` contained `"anthropic"`. With `@ai-sdk/amazon-bedrock`, the provider is `"amazon-bedrock"`, so Bedrock-hosted Claude skipped the adjustment entirely. The server's exclusive cache accounting (auto-detected from `claude` in the model name) then double-charged cache tokens — @gauravp-cubic reported 5-10x cost overstatement at typical cache hit rates, up to 9.6x at 95%+ hit ratios.

Second bug: `extractAdditionalTokenValues` only read `providerMetadata.anthropic.cacheCreationInputTokens`. Bedrock populates cache-write via the V3-standardized `usage.inputTokens.cacheWrite` instead, so `$ai_cache_creation_input_tokens` was silently dropped on every Bedrock-Claude event.

## Changes

- Broaden Anthropic detection: match on `provider.includes("anthropic")` OR `modelId` containing `claude`/`anthropic`. This covers direct Anthropic, Amazon Bedrock, Google Vertex, OpenRouter, and any other Claude host — mirroring the server's own `claude`-based heuristic for `$ai_cache_reporting_exclusive`.
- Add `extractCacheWriteTokens` helper that reads V3's standardized `usage.inputTokens.cacheWrite`, and fall back to it in `extractAdditionalTokenValues` when `providerMetadata.anthropic` is absent. Wired through both `doGenerate` and `doStream`.

Verified against the exact numbers in the issue:
- OP's 21561/17399/4157 → `$ai_input_tokens = 5`, `$ai_cache_creation_input_tokens = 4157`.
- @gauravp-cubic's row 1 (22145/21405) → `$ai_input_tokens = 740`, cost `$0.01440` (matches their "Correct" column exactly, down from the reported `$0.12143`).

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran \`pnpm changeset\` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*