### PR TITLE
chore(examples): patch fmt consteval for Xcode 26.4 in example-expo-53

### DIFF
--- a/examples/example-expo-53/ios/Podfile
+++ b/examples/example-expo-53/ios/Podfile
@@ -60,5 +60,24 @@ target 'exampleexpo53' do
         end
       end
     end
+
+    # Xcode 26.4+ Clang rejects fmt's FMT_STRING consteval. fmt's base.h redefines
+    # FMT_USE_CONSTEVAL based on compiler detection, so a -D flag is not enough —
+    # patch the header directly to force it off.
+    # Upstream:
+    #   https://github.com/fmtlib/fmt/issues/4740
+    #   https://github.com/facebook/react-native/issues/55601
+    #   https://github.com/expo/expo/issues/44229
+    # Remove once RN/Expo pull in a fmt release that builds cleanly on Apple clang 21.
+    fmt_base_h = File.join(installer.sandbox.root, 'fmt', 'include', 'fmt', 'base.h')
+    if File.exist?(fmt_base_h)
+      contents = File.read(fmt_base_h)
+      patched = contents.gsub(/^(#\s*define FMT_USE_CONSTEVAL )1$/, '\10')
+      if patched != contents
+        File.chmod(0644, fmt_base_h)
+        File.write(fmt_base_h, patched)
+        Pod::UI.puts "Patched #{fmt_base_h} to disable FMT_USE_CONSTEVAL (Xcode 26.4 fix)"
+      end
+    end
   end
 end


### PR DESCRIPTION
 Ran into this re-installing the latest Xcode on the new Mac.   

Xcode 26.4's Apple Clang 21 is stricter about consteval call sites,
  which rejects fmt's FMT_STRING usages and breaks pod install for the
  Expo 53 example. fmt's base.h redefines FMT_USE_CONSTEVAL based on
  compiler detection, so a -D flag in xcconfig isn't enough — patch the
  header in the post_install hook to force it off.
  

  See:
  - https://github.com/fmtlib/fmt/issues/4740
  - https://github.com/facebook/react-native/issues/55601
  - https://github.com/expo/expo/issues/44229

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [X] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
