### PR TITLE
fix(core): log invalid api keys and disable client

### DIFF
--- a/.changeset/fresh-worms-fix.md
+++ b/.changeset/fresh-worms-fix.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+Log invalid API keys as errors and disable the core client instead of throwing.

--- a/.changeset/fresh-worms-fix.md
+++ b/.changeset/fresh-worms-fix.md
@@ -2,4 +2,4 @@
 '@posthog/core': patch
 ---
 
-Log invalid API keys as errors and disable the core client instead of throwing.
+Disable the core client instead of throwing when the API key is missing, blank, or invalid.

--- a/packages/core/src/__tests__/posthog.init.spec.ts
+++ b/packages/core/src/__tests__/posthog.init.spec.ts
@@ -17,25 +17,15 @@ describe('PostHog Core', () => {
       ['missing', undefined as unknown as string],
       ['empty', '   '],
       ['non string', {} as string],
-    ])('should disable and log if %s api key', (_case, apiKey) => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    ])('should disable if %s api key', (_case, apiKey) => {
+      const [client, clientMocks] = createTestClient(apiKey)
 
-      try {
-        const [client, clientMocks] = createTestClient(apiKey)
+      expect(client.isDisabled).toEqual(true)
+      expect((client as any).apiKey).toEqual('')
 
-        expect(client.isDisabled).toEqual(true)
-        expect((client as any).apiKey).toEqual('')
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-          '[PostHog]',
-          "You must pass your PostHog project's api key. The client will be disabled."
-        )
+      client.capture('test')
 
-        client.capture('test')
-
-        expect(clientMocks.fetch).not.toHaveBeenCalled()
-      } finally {
-        consoleErrorSpy.mockRestore()
-      }
+      expect(clientMocks.fetch).not.toHaveBeenCalled()
     })
 
     it('should initialise default options', () => {

--- a/packages/core/src/__tests__/posthog.init.spec.ts
+++ b/packages/core/src/__tests__/posthog.init.spec.ts
@@ -1,5 +1,28 @@
 import { createTestClient, waitForPromises, PostHogCoreTestClient, PostHogCoreTestClientMocks } from '@/testing'
 
+// Force constructor-time logger calls through so they can be asserted in tests.
+class PostHogCoreLoggingTestClient extends PostHogCoreTestClient {
+  protected logMsgIfDebug(fn: () => void): void {
+    fn()
+  }
+}
+
+const createLoggingTestClient = (apiKey: string): [PostHogCoreTestClient, PostHogCoreTestClientMocks] => {
+  const mocks: PostHogCoreTestClientMocks = {
+    fetch: jest.fn(async () => ({
+      status: 200,
+      text: () => Promise.resolve('ok'),
+      json: () => Promise.resolve({ status: 'ok' }),
+    })),
+    storage: {
+      getItem: jest.fn(),
+      setItem: jest.fn(),
+    },
+  }
+
+  return [new PostHogCoreLoggingTestClient(mocks, apiKey, { disableCompression: true }), mocks]
+}
+
 describe('PostHog Core', () => {
   let posthog: PostHogCoreTestClient
   let mocks: PostHogCoreTestClientMocks
@@ -26,6 +49,25 @@ describe('PostHog Core', () => {
       client.capture('test')
 
       expect(clientMocks.fetch).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      ['missing', undefined as unknown as string],
+      ['empty', '   '],
+      ['non string', {} as string],
+    ])('should log when %s api key disables the client', (_case, apiKey) => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      try {
+        createLoggingTestClient(apiKey)
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          '[PostHog]',
+          "You must pass your PostHog project's api key. The client will be disabled."
+        )
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
     })
 
     it('should initialise default options', () => {

--- a/packages/core/src/__tests__/posthog.init.spec.ts
+++ b/packages/core/src/__tests__/posthog.init.spec.ts
@@ -13,18 +13,29 @@ describe('PostHog Core', () => {
       expect(posthog.optedOut).toEqual(false)
     })
 
-    it('should throw if missing api key', () => {
-      expect(() => createTestClient(undefined as unknown as string)).toThrowError(
-        "You must pass your PostHog project's api key."
-      )
-    })
+    it.each([
+      ['missing', undefined as unknown as string],
+      ['empty', '   '],
+      ['non string', {} as string],
+    ])('should disable and log if %s api key', (_case, apiKey) => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
-    it('should throw if empty api key', () => {
-      expect(() => createTestClient('   ')).toThrowError("You must pass your PostHog project's api key.")
-    })
+      try {
+        const [client, clientMocks] = createTestClient(apiKey)
 
-    it('should throw if non string api key', () => {
-      expect(() => createTestClient({} as string)).toThrowError("You must pass your PostHog project's api key.")
+        expect(client.isDisabled).toEqual(true)
+        expect((client as any).apiKey).toEqual('')
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          '[PostHog]',
+          "You must pass your PostHog project's api key. The client will be disabled."
+        )
+
+        client.capture('test')
+
+        expect(clientMocks.fetch).not.toHaveBeenCalled()
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
     })
 
     it('should initialise default options', () => {

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -24,7 +24,6 @@ import {
 } from './types'
 import {
   allSettled,
-  assert,
   currentISOTime,
   PromiseQueue,
   removeTrailingSlash,
@@ -147,8 +146,12 @@ export abstract class PostHogCoreStateless {
   constructor(apiKey: string, options: PostHogCoreOptions = {}) {
     const normalizedApiKey = typeof apiKey === 'string' ? apiKey.trim() : ''
     const normalizedHost = typeof options.host === 'string' ? options.host.trim() : ''
+    const missingApiKey = !normalizedApiKey
 
-    assert(normalizedApiKey, "You must pass your PostHog project's api key.")
+    this._logger = createLogger('[PostHog]', this.logMsgIfDebug.bind(this))
+    if (missingApiKey) {
+      this._logger.error("You must pass your PostHog project's api key. The client will be disabled.")
+    }
 
     this.apiKey = normalizedApiKey
     this.host = removeTrailingSlash(normalizedHost || 'https://us.i.posthog.com')
@@ -170,12 +173,11 @@ export abstract class PostHogCoreStateless {
     this.featureFlagsRequestTimeoutMs = options.featureFlagsRequestTimeoutMs ?? 3000 // 3 seconds
     this.remoteConfigRequestTimeoutMs = options.remoteConfigRequestTimeoutMs ?? 3000 // 3 seconds
     this.disableGeoip = options.disableGeoip ?? true
-    this.disabled = options.disabled ?? false
+    this.disabled = (options.disabled ?? false) || missingApiKey
     this.historicalMigration = options?.historicalMigration ?? false
     // Init promise allows the derived class to block calls until it is ready
     this._initPromise = Promise.resolve()
     this._isInitialized = true
-    this._logger = createLogger('[PostHog]', this.logMsgIfDebug.bind(this))
     // Support both evaluationContexts (new) and evaluationEnvironments (deprecated)
     this.evaluationContexts = options?.evaluationContexts ?? options?.evaluationEnvironments
     if (options?.evaluationEnvironments && !options?.evaluationContexts) {


### PR DESCRIPTION
## Problem

Invalid or blank API keys in `@posthog/core` currently throw during `PostHogCoreStateless` construction.

Generally, we want to avoid throwing exceptions from within the SDK, so invalid API keys are better logged as an error.

Fixes https://github.com/PostHog/posthog-js/issues/3436

## Changes

- replaced the constructor assertion in `posthog-core-stateless` with a missing-key check that logs an error and disables the client
- kept a single `_logger` instantiation in the constructor
- updated init tests to assert missing/empty/non-string API keys now log and disable the client instead of throwing
- added a changeset for `@posthog/core`

## Release info Sub-libraries affected

### Libraries affected

<!-- `@posthog/core` is the affected package here; it is not listed in the checklist below. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
