### PR TITLE
fix(surveys): guard eligibility checks against storage access errors

### DIFF
--- a/.changeset/tall-coats-pretend.md
+++ b/.changeset/tall-coats-pretend.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(surveys): guard survey seen localStorage access

--- a/packages/browser/src/__tests__/extensions/surveys-utils.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys-utils.test.ts
@@ -87,6 +87,16 @@ describe('hasWaitPeriodPassed', () => {
         localStorage.setItem('lastSeenSurveyDate', '2025-01-08T11:59:59Z') // 7 days and 1 second ago
         expect(hasWaitPeriodPassed(7)).toBe(true)
     })
+
+    it('should not throw when localStorage.getItem is unavailable', () => {
+        const getItemSpy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+            throw new Error('storage unavailable')
+        })
+
+        expect(hasWaitPeriodPassed(7)).toBe(true)
+
+        getItemSpy.mockRestore()
+    })
 })
 
 describe('getSurveySeen', () => {
@@ -121,6 +131,16 @@ describe('getSurveySeen', () => {
     describe('when survey has not been seen', () => {
         it('should return false when no localStorage entry exists', () => {
             expect(getSurveySeen(baseSurvey)).toBe(false)
+        })
+
+        it('should return false when localStorage access throws', () => {
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+                throw new Error('storage unavailable')
+            })
+
+            expect(getSurveySeen(baseSurvey)).toBe(false)
+
+            getItemSpy.mockRestore()
         })
     })
 

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -24,6 +24,7 @@ import {
 import { isArray, isNullish } from '@posthog/core'
 
 import { propertyComparisons } from '../../utils/property-utils'
+import { localStore } from '../../storage'
 import { Properties, PropertyMatchType } from '../../types'
 import { Z_INDEX_SURVEYS } from '../../constants'
 import { prepareStylesheet } from '../utils/stylesheet-loader'
@@ -604,7 +605,7 @@ export const canActivateRepeatedly = (
  * @param survey
  */
 export const getSurveySeen = (survey: Survey): boolean => {
-    const surveySeen = localStorage.getItem(getSurveySeenKey(survey))
+    const surveySeen = localStore._get(getSurveySeenKey(survey))
     if (surveySeen) {
         // if a survey has already been seen,
         // we will override it with the event repeated activation value.
@@ -617,7 +618,7 @@ export const getSurveySeen = (survey: Survey): boolean => {
 const LAST_SEEN_SURVEY_DATE_KEY = 'lastSeenSurveyDate'
 
 export const hasWaitPeriodPassed = (waitPeriodInDays: number | undefined): boolean => {
-    const lastSeenSurveyDate = localStorage.getItem(LAST_SEEN_SURVEY_DATE_KEY)
+    const lastSeenSurveyDate = localStore._get(LAST_SEEN_SURVEY_DATE_KEY)
     return hasPeriodPassed(waitPeriodInDays, lastSeenSurveyDate)
 }
 

--- a/packages/browser/src/utils/survey-utils.ts
+++ b/packages/browser/src/utils/survey-utils.ts
@@ -48,13 +48,18 @@ export const getSurveyAbandonedKey = (survey: Pick<Survey, 'id' | 'current_itera
 }
 
 export const setSurveySeenOnLocalStorage = (survey: Pick<Survey, 'id' | 'current_iteration'>) => {
-    const isSurveySeen = localStorage.getItem(getSurveySeenKey(survey))
-    // if survey is already seen, no need to set it again
-    if (isSurveySeen) {
-        return
-    }
+    try {
+        const surveySeenKey = getSurveySeenKey(survey)
+        const isSurveySeen = localStorage.getItem(surveySeenKey)
+        // if survey is already seen, no need to set it again
+        if (isSurveySeen) {
+            return
+        }
 
-    localStorage.setItem(getSurveySeenKey(survey), 'true')
+        localStorage.setItem(surveySeenKey, 'true')
+    } catch (error) {
+        SURVEY_LOGGER.error('Failed to persist survey seen state', error)
+    }
 }
 
 // These surveys are relevant for the getActiveMatchingSurveys method. They are used to


### PR DESCRIPTION
## Problem

Survey eligibility checks currently read directly from `localStorage`, which can throw in some browser/storage-restricted environments. When that happens, survey wait-period and seen-state checks can fail instead of safely treating the survey as unseen.

Closes https://github.com/PostHog/posthog-js/issues/3324

## Changes

- switched survey seen/wait-period reads in `surveys-extension-utils.tsx` to use `localStore._get(...)` so storage access failures are handled safely
- wrapped `setSurveySeenOnLocalStorage` in a `try/catch` and log persistence failures instead of throwing
- added regression tests covering `localStorage.getItem` throwing for both `hasWaitPeriodPassed` and `getSurveySeen`
- included a patch changeset for `posthog-js`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
