### PR TITLE
fix(posthog-js): use SPDX expression for license field

### DIFF
--- a/.changeset/spdx-license-expression.md
+++ b/.changeset/spdx-license-expression.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Use SPDX license expression `(Apache-2.0 AND MIT)` in `package.json` so automated license-compliance tools can parse the field. The expression matches the LICENSE file, which combines Apache-2.0 (PostHog/Mixpanel code) with MIT (derived Sentry/Meta/Expo code).

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -4,7 +4,7 @@
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "engineering@posthog.com",
-    "license": "SEE LICENSE IN LICENSE",
+    "license": "(Apache-2.0 AND MIT)",
     "homepage": "https://posthog.com/docs/libraries/js",
     "packageManager": "pnpm@10.12.4",
     "scripts": {


### PR DESCRIPTION
Fixes #2627.

Replace `"license": "SEE LICENSE IN LICENSE"` in `packages/browser/package.json` with the SPDX expression `"(Apache-2.0 AND MIT)"`. This unblocks automated license-compliance tools (e.g. [`license-checker-rseidelsohn`](https://github.com/RSeidelsohn/license-checker-rseidelsohn)) that first try to parse the `license` field as an SPDX expression and only fall back to LICENSE-file scanning when that fails – and the fallback can't reliably resolve a multi-license LICENSE file.

The expression uses `AND` because the LICENSE file applied to this package combines:
- **Apache-2.0** – PostHog / Mixpanel original code
- **MIT** – code derived from Sentry, rrweb (and via vendored modules: Meta Metro, Expo)

`AND` (rather than `OR`) is the correct operator: a consumer of the published package must comply with **both** licenses simultaneously.

The expression validates against [`spdx-expression-parse`](https://www.npmjs.com/package/spdx-expression-parse) (the same parser npm and most license-checker tools use).

### Out of scope for this PR (worth a follow-up)
- `@posthog/rollup-plugin` and `@posthog/webpack-plugin` are missing the `license` field entirely.
- The other publishable sub-packages currently declare `"MIT"`. Some of them (notably `posthog-react-native`, `@posthog/core`, `posthog-node`) also include MIT-licensed third-party derivatives sitting alongside PostHog's own code, so it's worth confirming whether `"MIT"` is accurate for each or whether they should also use a `(Apache-2.0 AND MIT)` expression.