### PR TITLE
fix(browser): fix session recording in full no-external bundles

### DIFF
--- a/.changeset/bright-replays-work.md
+++ b/.changeset/bright-replays-work.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Fix session recording in the full no-external browser bundles.

--- a/packages/browser/src/__tests__/entrypoints/module.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/module.test.ts
@@ -17,6 +17,11 @@ describe('Array entrypoint', () => {
         expect(arrayNoExternalJs).not.toContain('__PosthogExtensions__.loadExternalDependency=')
         expect(arrayFullNoExternalJs).not.toContain('__PosthogExtensions__.loadExternalDependency=')
     })
+
+    it('full no-external bundle should eagerly bootstrap session recording', () => {
+        expect(arrayFullNoExternalJs).toMatch(/__PosthogExtensions__\.initSessionRecording\s*=/)
+        expect(arrayNoExternalJs).not.toMatch(/__PosthogExtensions__\.initSessionRecording\s*=/)
+    })
 })
 
 describe('Module entrypoint', () => {
@@ -34,5 +39,10 @@ describe('Module entrypoint', () => {
         expect(moduleFullJs).toContain('__PosthogExtensions__.loadExternalDependency=')
         expect(moduleNoExternalJs).not.toContain('__PosthogExtensions__.loadExternalDependency=')
         expect(moduleFullNoExternalJs).not.toContain('__PosthogExtensions__.loadExternalDependency=')
+    })
+
+    it('full no-external bundle should eagerly bootstrap session recording', () => {
+        expect(moduleFullNoExternalJs).toMatch(/__PosthogExtensions__\.initSessionRecording\s*=/)
+        expect(moduleNoExternalJs).not.toMatch(/__PosthogExtensions__\.initSessionRecording\s*=/)
     })
 })

--- a/packages/browser/src/__tests__/entrypoints/module.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/module.test.ts
@@ -2,37 +2,26 @@ import fs from 'fs'
 import path from 'path'
 // Sanity checks to check the built code does not contain any script loaders
 
-describe('Array entrypoint', () => {
-    const arrayJs = fs.readFileSync(path.join(__dirname, '../../../dist/array.js'), 'utf-8')
-    const arrayFullJs = fs.readFileSync(path.join(__dirname, '../../../dist/array.full.js'), 'utf-8')
-    const arrayNoExternalJs = fs.readFileSync(path.join(__dirname, '../../../dist/array.no-external.js'), 'utf-8')
-    const arrayFullNoExternalJs = fs.readFileSync(
-        path.join(__dirname, '../../../dist/array.full.no-external.js'),
-        'utf-8'
-    )
+const arrayJs = fs.readFileSync(path.join(__dirname, '../../../dist/array.js'), 'utf-8')
+const arrayFullJs = fs.readFileSync(path.join(__dirname, '../../../dist/array.full.js'), 'utf-8')
+const arrayNoExternalJs = fs.readFileSync(path.join(__dirname, '../../../dist/array.no-external.js'), 'utf-8')
+const arrayFullNoExternalJs = fs.readFileSync(path.join(__dirname, '../../../dist/array.full.no-external.js'), 'utf-8')
 
+const moduleJs = fs.readFileSync(path.join(__dirname, '../../../dist/module.js'), 'utf-8')
+const moduleFullJs = fs.readFileSync(path.join(__dirname, '../../../dist/module.full.js'), 'utf-8')
+const moduleNoExternalJs = fs.readFileSync(path.join(__dirname, '../../../dist/module.no-external.js'), 'utf-8')
+const moduleFullNoExternalJs = fs.readFileSync(path.join(__dirname, '../../../dist/module.full.no-external.js'), 'utf-8')
+
+describe('Array entrypoint', () => {
     it('should not contain any script loaders', () => {
         expect(arrayJs).toContain('__PosthogExtensions__.loadExternalDependency=')
         expect(arrayFullJs).toContain('__PosthogExtensions__.loadExternalDependency=')
         expect(arrayNoExternalJs).not.toContain('__PosthogExtensions__.loadExternalDependency=')
         expect(arrayFullNoExternalJs).not.toContain('__PosthogExtensions__.loadExternalDependency=')
     })
-
-    it('full no-external bundle should eagerly bootstrap session recording', () => {
-        expect(arrayFullNoExternalJs).toMatch(/__PosthogExtensions__\.initSessionRecording\s*=/)
-        expect(arrayNoExternalJs).not.toMatch(/__PosthogExtensions__\.initSessionRecording\s*=/)
-    })
 })
 
 describe('Module entrypoint', () => {
-    const moduleJs = fs.readFileSync(path.join(__dirname, '../../../dist/module.js'), 'utf-8')
-    const moduleFullJs = fs.readFileSync(path.join(__dirname, '../../../dist/module.full.js'), 'utf-8')
-    const moduleNoExternalJs = fs.readFileSync(path.join(__dirname, '../../../dist/module.no-external.js'), 'utf-8')
-    const moduleFullNoExternalJs = fs.readFileSync(
-        path.join(__dirname, '../../../dist/module.full.no-external.js'),
-        'utf-8'
-    )
-
     it('should not contain any script loaders', () => {
         // For the module loader, the code isn't minified
         expect(moduleJs).toContain('__PosthogExtensions__.loadExternalDependency=')
@@ -40,9 +29,17 @@ describe('Module entrypoint', () => {
         expect(moduleNoExternalJs).not.toContain('__PosthogExtensions__.loadExternalDependency=')
         expect(moduleFullNoExternalJs).not.toContain('__PosthogExtensions__.loadExternalDependency=')
     })
+})
 
-    it('full no-external bundle should eagerly bootstrap session recording', () => {
-        expect(moduleFullNoExternalJs).toMatch(/__PosthogExtensions__\.initSessionRecording\s*=/)
-        expect(moduleNoExternalJs).not.toMatch(/__PosthogExtensions__\.initSessionRecording\s*=/)
-    })
+describe('Full no-external bundles', () => {
+    it.each([
+        ['array', arrayFullNoExternalJs, arrayNoExternalJs],
+        ['module', moduleFullNoExternalJs, moduleNoExternalJs],
+    ])(
+        '%s full no-external bundle should eagerly bootstrap session recording',
+        (_name, fullNoExternalBundle, noExternalBundle) => {
+            expect(fullNoExternalBundle).toMatch(/__PosthogExtensions__\.initSessionRecording\s*=/)
+            expect(noExternalBundle).not.toMatch(/__PosthogExtensions__\.initSessionRecording\s*=/)
+        }
+    )
 })

--- a/packages/browser/src/__tests__/entrypoints/module.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/module.test.ts
@@ -10,7 +10,10 @@ const arrayFullNoExternalJs = fs.readFileSync(path.join(__dirname, '../../../dis
 const moduleJs = fs.readFileSync(path.join(__dirname, '../../../dist/module.js'), 'utf-8')
 const moduleFullJs = fs.readFileSync(path.join(__dirname, '../../../dist/module.full.js'), 'utf-8')
 const moduleNoExternalJs = fs.readFileSync(path.join(__dirname, '../../../dist/module.no-external.js'), 'utf-8')
-const moduleFullNoExternalJs = fs.readFileSync(path.join(__dirname, '../../../dist/module.full.no-external.js'), 'utf-8')
+const moduleFullNoExternalJs = fs.readFileSync(
+    path.join(__dirname, '../../../dist/module.full.no-external.js'),
+    'utf-8'
+)
 
 describe('Array entrypoint', () => {
     it('should not contain any script loaders', () => {

--- a/packages/browser/src/entrypoints/array.full.no-external.ts
+++ b/packages/browser/src/entrypoints/array.full.no-external.ts
@@ -1,3 +1,4 @@
 // Same as loader-globals.ts except includes all additional extension loaders
 import './all-external-dependencies'
+import './lazy-recorder'
 import './array.no-external'

--- a/packages/browser/src/entrypoints/module.full.no-external.es.ts
+++ b/packages/browser/src/entrypoints/module.full.no-external.es.ts
@@ -1,4 +1,5 @@
 import './all-external-dependencies'
+import './lazy-recorder'
 import posthog from './module.no-external.es'
 export * from './module.no-external.es'
 export default posthog


### PR DESCRIPTION
## Problem

Customers using the documented `posthog-js/dist/module.full.no-external` / `array.full.no-external` workaround for  replay bundling can still end up with session recording failing to start. Those bundles pre-bundle the standard extensions, but they were missing the replay bootstrap needed to initialize session recording without loading another script at runtime.

## Changes

- add `lazy-recorder` to the `module.full.no-external` and `array.full.no-external` entrypoints only
- keep the fix scoped to the two broken no-external full bundles rather than changing `full`, `recorder`, or other replay entrypoints
- add regression tests asserting that:
  - `array.full.no-external.js` and `module.full.no-external.js` eagerly register `__PosthogExtensions__.initSessionRecording`
  - `array.no-external.js` and `module.no-external.js` do not
  - the no-external loader checks still hold

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
