### PR TITLE
feat(node): add `getFeatureFlags` for bulk flag evaluation with events

### DIFF
--- a/.changeset/node-bulk-flag-events.md
+++ b/.changeset/node-bulk-flag-events.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': minor
+---
+
+Add `getFeatureFlags(keys, distinctId, options)` for evaluating a known subset of feature flags in one bulk pass while still emitting `$feature_flag_called` events per resolved flag. Also adds a `sendFeatureFlagEvents` option to the existing `getAllFlags` and `getAllFlagsAndPayloads` methods for opt-in per-flag event emission. Locally-evaluated flags reuse the poller's cached definitions; any keys that can't be resolved locally fall through to a single remote `/flags` call with `flag_keys_to_evaluate`. Event dedup uses the existing `distinctIdHasSentFlagCalls` cache so the single-flag and bulk paths share one source of truth.

--- a/packages/node/src/__tests__/feature-flags.bulk-events.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.bulk-events.spec.ts
@@ -173,66 +173,31 @@ describe('getFeatureFlags', () => {
 
   describe('local + remote hybrid', () => {
     it('resolves some keys locally, falls back once for the rest, and emits events for both', async () => {
-      const localFlagDefinitions = {
+      const localFlags = {
         flags: [
           {
             id: 42,
             name: 'Local Flag',
             key: 'local-flag',
             active: true,
-            rollout_percentage: 100,
             filters: {
-              groups: [{ rollout_percentage: 100, variant: null, properties: [] }],
+              groups: [{ properties: [], rollout_percentage: 100 }],
             },
           },
         ],
       }
-      const remoteResponse: PostHogV2FlagsResponse = {
-        flags: {
-          'remote-flag': {
-            key: 'remote-flag',
-            enabled: true,
-            variant: undefined,
-            reason: { code: 'matched', condition_index: 0, description: 'Matched' },
-            metadata: { id: 77, version: 1, payload: undefined, description: undefined },
-          },
-        },
-        errorsWhileComputingFlags: false,
-        requestId: 'req-hybrid',
-        evaluatedAt: 1700000000000,
-      }
-
-      // Custom fetch impl that serves local eval definitions AND the v2 flags endpoint
-      mockedFetch.mockImplementation((url: any): Promise<any> => {
-        if ((url as string).includes('local_evaluation')) {
-          return Promise.resolve({
-            status: 200,
-            text: () => Promise.resolve('ok'),
-            json: () => Promise.resolve(localFlagDefinitions),
-            headers: { get: () => null },
-          }) as any
-        }
-        if ((url as string).includes('/flags/?v=2')) {
-          return Promise.resolve({
-            status: 200,
-            text: () => Promise.resolve('ok'),
-            json: () => Promise.resolve(remoteResponse),
-          }) as any
-        }
-        return Promise.resolve({
-          status: 200,
-          text: () => Promise.resolve('ok'),
-          json: () => Promise.resolve({ status: 'ok' }),
-        }) as any
-      })
+      mockedFetch.mockImplementation(
+        apiImplementation({
+          localFlags,
+          decideFlags: { 'remote-flag': true },
+        })
+      )
 
       posthog = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',
         personalApiKey: 'TEST_PERSONAL_API_KEY',
         ...posthogImmediateResolveOptions,
       })
-      // Wait for local eval to load
-      await posthog.reloadFeatureFlags()
 
       const captured: any[] = []
       posthog.on('capture', (msg) => captured.push(msg))
@@ -243,7 +208,7 @@ describe('getFeatureFlags', () => {
       expect(results['local-flag']?.enabled).toBe(true)
       expect(results['remote-flag']?.enabled).toBe(true)
 
-      // Exactly one remote /flags call happened, and it requested only the unresolved key
+      // Exactly one remote /flags call happened, and it requested only the unresolved key.
       const flagsCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/flags/?v=2'))
       expect(flagsCalls).toHaveLength(1)
       const requestBody = JSON.parse((flagsCalls[0][1] as any).body)
@@ -256,7 +221,6 @@ describe('getFeatureFlags', () => {
       expect(local.properties.locally_evaluated).toBe(true)
       expect(local.properties.$feature_flag_id).toBe(42)
       expect(remote.properties.locally_evaluated).toBe(false)
-      expect(remote.properties.$feature_flag_request_id).toBe('req-hybrid')
     })
   })
 

--- a/packages/node/src/__tests__/feature-flags.bulk-events.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.bulk-events.spec.ts
@@ -1,6 +1,6 @@
 import { PostHog } from '@/entrypoints/index.node'
 import { PostHogOptions } from '@/types'
-import { anyFlagsCall, anyLocalEvalCall, apiImplementation, apiImplementationV4, waitForPromises } from './utils'
+import { apiImplementation, apiImplementationV4, waitForPromises } from './utils'
 import { PostHogV2FlagsResponse } from '@posthog/core'
 
 jest.spyOn(console, 'debug').mockImplementation()
@@ -225,28 +225,40 @@ describe('getFeatureFlags', () => {
   })
 
   describe('getAllFlags sendFeatureFlagEvents option', () => {
-    it('emits $feature_flag_called per flag when explicitly enabled on the bulk method', async () => {
-      const flagsResponse: PostHogV2FlagsResponse = {
-        flags: {
-          'bulk-a': {
-            key: 'bulk-a',
-            enabled: true,
-            variant: undefined,
-            reason: { code: 'matched', condition_index: 0, description: 'Matched' },
-            metadata: { id: 1, version: 1, payload: undefined, description: undefined },
-          },
-          'bulk-b': {
-            key: 'bulk-b',
-            enabled: true,
-            variant: 'b-variant',
-            reason: { code: 'matched', condition_index: 0, description: 'Matched' },
-            metadata: { id: 2, version: 1, payload: undefined, description: undefined },
-          },
+    const flagsResponse: PostHogV2FlagsResponse = {
+      flags: {
+        'bulk-a': {
+          key: 'bulk-a',
+          enabled: true,
+          variant: undefined,
+          reason: { code: 'matched', condition_index: 0, description: 'Matched' },
+          metadata: { id: 1, version: 1, payload: undefined, description: undefined },
         },
-        errorsWhileComputingFlags: false,
-        requestId: 'req-all',
-        evaluatedAt: 1700000000000,
-      }
+        'bulk-b': {
+          key: 'bulk-b',
+          enabled: true,
+          variant: 'b-variant',
+          reason: { code: 'matched', condition_index: 0, description: 'Matched' },
+          metadata: { id: 2, version: 1, payload: undefined, description: undefined },
+        },
+      },
+      errorsWhileComputingFlags: false,
+      requestId: 'req-all',
+      evaluatedAt: 1700000000000,
+    }
+
+    it.each([
+      {
+        name: 'emits $feature_flag_called per flag when explicitly enabled',
+        options: { sendFeatureFlagEvents: true } as const,
+        expectedEventKeys: ['bulk-a', 'bulk-b'],
+      },
+      {
+        name: 'does not emit events by default, preserving existing behavior',
+        options: undefined,
+        expectedEventKeys: [] as string[],
+      },
+    ])('$name', async ({ options, expectedEventKeys }) => {
       mockedFetch.mockImplementation(apiImplementationV4(flagsResponse))
       posthog = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',
@@ -256,42 +268,12 @@ describe('getFeatureFlags', () => {
       const captured: any[] = []
       posthog.on('capture', (msg) => captured.push(msg))
 
-      const all = await posthog.getAllFlags('user-1', { sendFeatureFlagEvents: true })
+      const all = await posthog.getAllFlags('user-1', options)
       await waitForPromises()
 
       expect(all).toEqual({ 'bulk-a': true, 'bulk-b': 'b-variant' })
       const events = captured.filter((m) => m.event === '$feature_flag_called')
-      expect(events).toHaveLength(2)
-      expect(events.map((e) => e.properties.$feature_flag).sort()).toEqual(['bulk-a', 'bulk-b'])
-    })
-
-    it('does not emit events by default, preserving existing behavior', async () => {
-      const flagsResponse: PostHogV2FlagsResponse = {
-        flags: {
-          'bulk-a': {
-            key: 'bulk-a',
-            enabled: true,
-            variant: undefined,
-            reason: { code: 'matched', condition_index: 0, description: 'Matched' },
-            metadata: { id: 1, version: 1, payload: undefined, description: undefined },
-          },
-        },
-        errorsWhileComputingFlags: false,
-        requestId: 'req-all-no-events',
-      }
-      mockedFetch.mockImplementation(apiImplementationV4(flagsResponse))
-      posthog = new PostHog('TEST_API_KEY', {
-        host: 'http://example.com',
-        ...posthogImmediateResolveOptions,
-      })
-
-      const captured: any[] = []
-      posthog.on('capture', (msg) => captured.push(msg))
-
-      await posthog.getAllFlags('user-1')
-      await waitForPromises()
-
-      expect(captured.filter((m) => m.event === '$feature_flag_called')).toHaveLength(0)
+      expect(events.map((e) => e.properties.$feature_flag).sort()).toEqual(expectedEventKeys)
     })
   })
 
@@ -320,7 +302,3 @@ describe('getFeatureFlags', () => {
     })
   })
 })
-
-// Suppress unused import warning when apiImplementation is unused in a describe block variant
-void anyFlagsCall
-void anyLocalEvalCall

--- a/packages/node/src/__tests__/feature-flags.bulk-events.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.bulk-events.spec.ts
@@ -1,0 +1,362 @@
+import { PostHog } from '@/entrypoints/index.node'
+import { PostHogOptions } from '@/types'
+import { anyFlagsCall, anyLocalEvalCall, apiImplementation, apiImplementationV4, waitForPromises } from './utils'
+import { PostHogV2FlagsResponse } from '@posthog/core'
+
+jest.spyOn(console, 'debug').mockImplementation()
+
+const mockedFetch = jest.spyOn(globalThis, 'fetch').mockImplementation()
+
+const posthogImmediateResolveOptions: PostHogOptions = {
+  fetchRetryCount: 0,
+}
+
+describe('getFeatureFlags', () => {
+  let posthog: PostHog
+
+  afterEach(async () => {
+    await posthog.shutdown()
+  })
+
+  describe('remote evaluation', () => {
+    const flagsResponse: PostHogV2FlagsResponse = {
+      flags: {
+        'flag-one': {
+          key: 'flag-one',
+          enabled: true,
+          variant: 'variant-a',
+          reason: { code: 'matched', condition_index: 0, description: 'Matched condition set 1' },
+          metadata: { id: 11, version: 3, payload: '{"feature":"a"}', description: undefined },
+        },
+        'flag-two': {
+          key: 'flag-two',
+          enabled: false,
+          variant: undefined,
+          reason: { code: 'no_match', condition_index: undefined, description: 'Did not match any condition' },
+          metadata: { id: 22, version: 7, payload: undefined, description: undefined },
+        },
+      },
+      errorsWhileComputingFlags: false,
+      requestId: 'req-bulk-1',
+      evaluatedAt: 1700000000000,
+    }
+
+    beforeEach(() => {
+      mockedFetch.mockImplementation(apiImplementationV4(flagsResponse))
+      posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        ...posthogImmediateResolveOptions,
+      })
+    })
+
+    it('returns rich FeatureFlagResult for each requested key from a single remote call', async () => {
+      const results = await posthog.getFeatureFlags(['flag-one', 'flag-two'], 'user-1', {
+        sendFeatureFlagEvents: false,
+      })
+
+      expect(results['flag-one']).toEqual({
+        key: 'flag-one',
+        enabled: true,
+        variant: 'variant-a',
+        payload: { feature: 'a' },
+      })
+      expect(results['flag-two']).toEqual({
+        key: 'flag-two',
+        enabled: false,
+        variant: undefined,
+        payload: undefined,
+      })
+
+      const flagsCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/flags/'))
+      expect(flagsCalls).toHaveLength(1)
+    })
+
+    it('emits $feature_flag_called per resolved flag with metadata parity to getFeatureFlag', async () => {
+      const captured: any[] = []
+      posthog.on('capture', (msg) => captured.push(msg))
+
+      await posthog.getFeatureFlags(['flag-one', 'flag-two'], 'user-1')
+      await waitForPromises()
+
+      const events = captured.filter((m) => m.event === '$feature_flag_called')
+      expect(events).toHaveLength(2)
+
+      const byKey = Object.fromEntries(events.map((e) => [e.properties.$feature_flag, e]))
+      expect(byKey['flag-one'].properties).toMatchObject({
+        $feature_flag: 'flag-one',
+        $feature_flag_response: 'variant-a',
+        $feature_flag_id: 11,
+        $feature_flag_version: 3,
+        $feature_flag_reason: 'Matched condition set 1',
+        $feature_flag_request_id: 'req-bulk-1',
+        $feature_flag_evaluated_at: 1700000000000,
+        locally_evaluated: false,
+        '$feature/flag-one': 'variant-a',
+      })
+      expect(byKey['flag-two'].properties).toMatchObject({
+        $feature_flag: 'flag-two',
+        $feature_flag_response: false,
+        $feature_flag_id: 22,
+        $feature_flag_version: 7,
+        $feature_flag_reason: 'Did not match any condition',
+        $feature_flag_request_id: 'req-bulk-1',
+        locally_evaluated: false,
+        '$feature/flag-two': false,
+      })
+    })
+
+    it('dedupes events across calls using the existing distinctIdHasSentFlagCalls cache', async () => {
+      const captured: any[] = []
+      posthog.on('capture', (msg) => captured.push(msg))
+
+      await posthog.getFeatureFlags(['flag-one'], 'user-1')
+      await posthog.getFeatureFlags(['flag-one'], 'user-1')
+      await waitForPromises()
+
+      const events = captured.filter((m) => m.event === '$feature_flag_called')
+      expect(events).toHaveLength(1)
+    })
+
+    it('does not emit events when sendFeatureFlagEvents is false', async () => {
+      const captured: any[] = []
+      posthog.on('capture', (msg) => captured.push(msg))
+
+      await posthog.getFeatureFlags(['flag-one'], 'user-1', { sendFeatureFlagEvents: false })
+      await waitForPromises()
+
+      expect(captured.filter((m) => m.event === '$feature_flag_called')).toHaveLength(0)
+    })
+
+    it('emits an event with response=undefined when a requested key is missing from the response', async () => {
+      const captured: any[] = []
+      posthog.on('capture', (msg) => captured.push(msg))
+
+      await posthog.getFeatureFlags(['flag-one', 'unknown-flag'], 'user-1')
+      await waitForPromises()
+
+      const events = captured.filter((m) => m.event === '$feature_flag_called')
+      const unknown = events.find((e) => e.properties.$feature_flag === 'unknown-flag')
+      expect(unknown).toBeDefined()
+      expect(unknown!.properties.$feature_flag_response).toBeUndefined()
+      expect(unknown!.properties.$feature_flag_error).toContain('flag_missing')
+    })
+  })
+
+  describe('onlyEvaluateLocally', () => {
+    it('returns undefined for unresolved keys without hitting the network and still emits events', async () => {
+      mockedFetch.mockImplementation(apiImplementation({ localFlags: { flags: [] } }))
+      posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        personalApiKey: 'TEST_PERSONAL_API_KEY',
+        ...posthogImmediateResolveOptions,
+      })
+
+      const captured: any[] = []
+      posthog.on('capture', (msg) => captured.push(msg))
+
+      const results = await posthog.getFeatureFlags(['missing-flag'], 'user-1', { onlyEvaluateLocally: true })
+      expect(results['missing-flag']).toBeUndefined()
+      await waitForPromises()
+
+      const flagsCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/flags/?v=2'))
+      expect(flagsCalls).toHaveLength(0)
+
+      const events = captured.filter((m) => m.event === '$feature_flag_called')
+      expect(events).toHaveLength(1)
+      expect(events[0].properties).toMatchObject({
+        $feature_flag: 'missing-flag',
+        $feature_flag_response: undefined,
+        locally_evaluated: false,
+      })
+    })
+  })
+
+  describe('local + remote hybrid', () => {
+    it('resolves some keys locally, falls back once for the rest, and emits events for both', async () => {
+      const localFlagDefinitions = {
+        flags: [
+          {
+            id: 42,
+            name: 'Local Flag',
+            key: 'local-flag',
+            active: true,
+            rollout_percentage: 100,
+            filters: {
+              groups: [{ rollout_percentage: 100, variant: null, properties: [] }],
+            },
+          },
+        ],
+      }
+      const remoteResponse: PostHogV2FlagsResponse = {
+        flags: {
+          'remote-flag': {
+            key: 'remote-flag',
+            enabled: true,
+            variant: undefined,
+            reason: { code: 'matched', condition_index: 0, description: 'Matched' },
+            metadata: { id: 77, version: 1, payload: undefined, description: undefined },
+          },
+        },
+        errorsWhileComputingFlags: false,
+        requestId: 'req-hybrid',
+        evaluatedAt: 1700000000000,
+      }
+
+      // Custom fetch impl that serves local eval definitions AND the v2 flags endpoint
+      mockedFetch.mockImplementation((url: any): Promise<any> => {
+        if ((url as string).includes('local_evaluation')) {
+          return Promise.resolve({
+            status: 200,
+            text: () => Promise.resolve('ok'),
+            json: () => Promise.resolve(localFlagDefinitions),
+            headers: { get: () => null },
+          }) as any
+        }
+        if ((url as string).includes('/flags/?v=2')) {
+          return Promise.resolve({
+            status: 200,
+            text: () => Promise.resolve('ok'),
+            json: () => Promise.resolve(remoteResponse),
+          }) as any
+        }
+        return Promise.resolve({
+          status: 200,
+          text: () => Promise.resolve('ok'),
+          json: () => Promise.resolve({ status: 'ok' }),
+        }) as any
+      })
+
+      posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        personalApiKey: 'TEST_PERSONAL_API_KEY',
+        ...posthogImmediateResolveOptions,
+      })
+      // Wait for local eval to load
+      await posthog.reloadFeatureFlags()
+
+      const captured: any[] = []
+      posthog.on('capture', (msg) => captured.push(msg))
+
+      const results = await posthog.getFeatureFlags(['local-flag', 'remote-flag'], 'user-1')
+      await waitForPromises()
+
+      expect(results['local-flag']?.enabled).toBe(true)
+      expect(results['remote-flag']?.enabled).toBe(true)
+
+      // Exactly one remote /flags call happened, and it requested only the unresolved key
+      const flagsCalls = mockedFetch.mock.calls.filter((c) => (c[0] as string).includes('/flags/?v=2'))
+      expect(flagsCalls).toHaveLength(1)
+      const requestBody = JSON.parse((flagsCalls[0][1] as any).body)
+      expect(requestBody.flag_keys_to_evaluate).toEqual(['remote-flag'])
+
+      const events = captured.filter((m) => m.event === '$feature_flag_called')
+      expect(events).toHaveLength(2)
+      const local = events.find((e) => e.properties.$feature_flag === 'local-flag')!
+      const remote = events.find((e) => e.properties.$feature_flag === 'remote-flag')!
+      expect(local.properties.locally_evaluated).toBe(true)
+      expect(local.properties.$feature_flag_id).toBe(42)
+      expect(remote.properties.locally_evaluated).toBe(false)
+      expect(remote.properties.$feature_flag_request_id).toBe('req-hybrid')
+    })
+  })
+
+  describe('getAllFlags sendFeatureFlagEvents option', () => {
+    it('emits $feature_flag_called per flag when explicitly enabled on the bulk method', async () => {
+      const flagsResponse: PostHogV2FlagsResponse = {
+        flags: {
+          'bulk-a': {
+            key: 'bulk-a',
+            enabled: true,
+            variant: undefined,
+            reason: { code: 'matched', condition_index: 0, description: 'Matched' },
+            metadata: { id: 1, version: 1, payload: undefined, description: undefined },
+          },
+          'bulk-b': {
+            key: 'bulk-b',
+            enabled: true,
+            variant: 'b-variant',
+            reason: { code: 'matched', condition_index: 0, description: 'Matched' },
+            metadata: { id: 2, version: 1, payload: undefined, description: undefined },
+          },
+        },
+        errorsWhileComputingFlags: false,
+        requestId: 'req-all',
+        evaluatedAt: 1700000000000,
+      }
+      mockedFetch.mockImplementation(apiImplementationV4(flagsResponse))
+      posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        ...posthogImmediateResolveOptions,
+      })
+
+      const captured: any[] = []
+      posthog.on('capture', (msg) => captured.push(msg))
+
+      const all = await posthog.getAllFlags('user-1', { sendFeatureFlagEvents: true })
+      await waitForPromises()
+
+      expect(all).toEqual({ 'bulk-a': true, 'bulk-b': 'b-variant' })
+      const events = captured.filter((m) => m.event === '$feature_flag_called')
+      expect(events).toHaveLength(2)
+      expect(events.map((e) => e.properties.$feature_flag).sort()).toEqual(['bulk-a', 'bulk-b'])
+    })
+
+    it('does not emit events by default, preserving existing behavior', async () => {
+      const flagsResponse: PostHogV2FlagsResponse = {
+        flags: {
+          'bulk-a': {
+            key: 'bulk-a',
+            enabled: true,
+            variant: undefined,
+            reason: { code: 'matched', condition_index: 0, description: 'Matched' },
+            metadata: { id: 1, version: 1, payload: undefined, description: undefined },
+          },
+        },
+        errorsWhileComputingFlags: false,
+        requestId: 'req-all-no-events',
+      }
+      mockedFetch.mockImplementation(apiImplementationV4(flagsResponse))
+      posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        ...posthogImmediateResolveOptions,
+      })
+
+      const captured: any[] = []
+      posthog.on('capture', (msg) => captured.push(msg))
+
+      await posthog.getAllFlags('user-1')
+      await waitForPromises()
+
+      expect(captured.filter((m) => m.event === '$feature_flag_called')).toHaveLength(0)
+    })
+  })
+
+  describe('overrides', () => {
+    it('honors flag overrides without emitting events for overridden flags', async () => {
+      mockedFetch.mockImplementation(apiImplementation({ decideFlags: {} }))
+      posthog = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        ...posthogImmediateResolveOptions,
+      })
+      posthog.overrideFeatureFlags({ 'overridden-flag': 'forced-variant' })
+
+      const captured: any[] = []
+      posthog.on('capture', (msg) => captured.push(msg))
+
+      const results = await posthog.getFeatureFlags(['overridden-flag'], 'user-1')
+      await waitForPromises()
+
+      expect(results['overridden-flag']).toEqual({
+        key: 'overridden-flag',
+        enabled: true,
+        variant: 'forced-variant',
+        payload: undefined,
+      })
+      expect(captured.filter((m) => m.event === '$feature_flag_called')).toHaveLength(0)
+    })
+  })
+})
+
+// Suppress unused import warning when apiImplementation is unused in a describe block variant
+void anyFlagsCall
+void anyLocalEvalCall

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -7,6 +7,7 @@ import {
   JsonType,
   PostHogCaptureOptions,
   PostHogCoreStateless,
+  PostHogFeatureFlagDetails,
   PostHogFetchOptions,
   PostHogFetchResponse,
   PostHogFlagsAndPayloadsResponse,
@@ -1751,9 +1752,16 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       }
     }
 
-    let remoteDetails: Awaited<ReturnType<PostHogBackendClient['_callFeatureFlagDetailsStateless']>> | undefined
+    let remoteDetails: PostHogFeatureFlagDetails | undefined
     if (fallbackToFlags && !onlyEvaluateLocally) {
-      remoteDetails = await this._callFeatureFlagDetailsStateless(evaluationContext, disableGeoip, flagKeys)
+      remoteDetails = await super.getFeatureFlagDetailsStateless(
+        evaluationContext.distinctId,
+        evaluationContext.groups,
+        evaluationContext.personProperties,
+        evaluationContext.groupProperties,
+        disableGeoip,
+        flagKeys
+      )
       if (remoteDetails) {
         if (remoteDetails.featureFlags) {
           featureFlags = { ...featureFlags, ...remoteDetails.featureFlags }
@@ -1793,38 +1801,6 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   }
 
   /**
-   * Thin wrapper around `super.getFeatureFlagDetailsStateless` so
-   * `getAllFlagsAndPayloads` can share its full return shape with the
-   * event-emission path without losing per-flag metadata.
-   */
-  private async _callFeatureFlagDetailsStateless(
-    evaluationContext: FeatureFlagEvaluationContext,
-    disableGeoip?: boolean,
-    flagKeys?: string[]
-  ): Promise<
-    | {
-        featureFlags?: Record<string, FeatureFlagValue>
-        featureFlagPayloads?: Record<string, JsonType>
-        flags?: Record<string, import('@posthog/core').FeatureFlagDetail>
-        requestId?: string
-        evaluatedAt?: number
-        errorsWhileComputingFlags?: boolean
-        quotaLimited?: string[]
-      }
-    | undefined
-  > {
-    const details = await super.getFeatureFlagDetailsStateless(
-      evaluationContext.distinctId,
-      evaluationContext.groups,
-      evaluationContext.personProperties,
-      evaluationContext.groupProperties,
-      disableGeoip,
-      flagKeys
-    )
-    return details
-  }
-
-  /**
    * Emits `$feature_flag_called` events for a bulk evaluation, using whichever
    * source (local poller or remote response) produced each flag.
    */
@@ -1832,13 +1808,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     distinctId: string
     featureFlags: Record<string, FeatureFlagValue>
     locallyEvaluatedKeys: Set<string>
-    remoteDetails?: {
-      flags?: Record<string, import('@posthog/core').FeatureFlagDetail>
-      requestId?: string
-      evaluatedAt?: number
-      errorsWhileComputingFlags?: boolean
-      quotaLimited?: string[]
-    }
+    remoteDetails?: PostHogFeatureFlagDetails
     groups?: Record<string, string>
     disableGeoip?: boolean
   }): void {

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -728,6 +728,90 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   }
 
   /**
+   * Emits a `$feature_flag_called` event for a single flag, reusing the
+   * `distinctIdHasSentFlagCalls` cache so a given (distinctId, key, value)
+   * tuple only produces one event per process.
+   */
+  private _emitFeatureFlagCalled(args: {
+    distinctId: string
+    key: string
+    response: FeatureFlagValue | undefined
+    flagWasLocallyEvaluated: boolean
+    flagId?: number
+    flagVersion?: number
+    flagReason?: string
+    requestId?: string
+    evaluatedAt?: number
+    featureFlagError?: FeatureFlagErrorType
+    groups?: Record<string, string>
+    disableGeoip?: boolean
+  }): void {
+    const {
+      distinctId,
+      key,
+      response,
+      flagWasLocallyEvaluated,
+      flagId,
+      flagVersion,
+      flagReason,
+      requestId,
+      evaluatedAt,
+      featureFlagError,
+      groups,
+      disableGeoip,
+    } = args
+
+    const featureFlagReportedKey = `${key}_${response}`
+
+    if (
+      distinctId in this.distinctIdHasSentFlagCalls &&
+      this.distinctIdHasSentFlagCalls[distinctId].includes(featureFlagReportedKey)
+    ) {
+      return
+    }
+
+    if (Object.keys(this.distinctIdHasSentFlagCalls).length >= this.maxCacheSize) {
+      this.distinctIdHasSentFlagCalls = {}
+    }
+    if (Array.isArray(this.distinctIdHasSentFlagCalls[distinctId])) {
+      this.distinctIdHasSentFlagCalls[distinctId].push(featureFlagReportedKey)
+    } else {
+      this.distinctIdHasSentFlagCalls[distinctId] = [featureFlagReportedKey]
+    }
+
+    const properties: Record<string, any> = {
+      $feature_flag: key,
+      $feature_flag_response: response,
+      $feature_flag_id: flagId,
+      $feature_flag_version: flagVersion,
+      $feature_flag_reason: flagReason,
+      locally_evaluated: flagWasLocallyEvaluated,
+      [`$feature/${key}`]: response,
+      $feature_flag_request_id: requestId,
+      $feature_flag_evaluated_at: flagWasLocallyEvaluated ? Date.now() : evaluatedAt,
+    }
+
+    if (flagWasLocallyEvaluated && this.featureFlagsPoller) {
+      const flagDefinitionsLoadedAt = this.featureFlagsPoller.getFlagDefinitionsLoadedAt()
+      if (flagDefinitionsLoadedAt !== undefined) {
+        properties.$feature_flag_definitions_loaded_at = flagDefinitionsLoadedAt
+      }
+    }
+
+    if (featureFlagError) {
+      properties.$feature_flag_error = featureFlagError
+    }
+
+    this.capture({
+      distinctId,
+      event: '$feature_flag_called',
+      properties,
+      groups,
+      disableGeoip,
+    })
+  }
+
+  /**
    * Internal method that handles feature flag evaluation with full details.
    * Used by getFeatureFlag, getFeatureFlagPayload, and getFeatureFlagResult.
    *
@@ -899,56 +983,21 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
 
     // Send feature flag event if configured
     if (sendFeatureFlagEvents) {
-      // Compute the response value for event tracking
       const response = result === undefined ? undefined : result.enabled === false ? false : (result.variant ?? true)
-      const featureFlagReportedKey = `${key}_${response}`
-
-      if (
-        !(distinctId in this.distinctIdHasSentFlagCalls) ||
-        !this.distinctIdHasSentFlagCalls[distinctId].includes(featureFlagReportedKey)
-      ) {
-        if (Object.keys(this.distinctIdHasSentFlagCalls).length >= this.maxCacheSize) {
-          this.distinctIdHasSentFlagCalls = {}
-        }
-        if (Array.isArray(this.distinctIdHasSentFlagCalls[distinctId])) {
-          this.distinctIdHasSentFlagCalls[distinctId].push(featureFlagReportedKey)
-        } else {
-          this.distinctIdHasSentFlagCalls[distinctId] = [featureFlagReportedKey]
-        }
-
-        const properties: Record<string, any> = {
-          $feature_flag: key,
-          $feature_flag_response: response,
-          $feature_flag_id: flagId,
-          $feature_flag_version: flagVersion,
-          $feature_flag_reason: flagReason,
-          locally_evaluated: flagWasLocallyEvaluated,
-          [`$feature/${key}`]: response,
-          $feature_flag_request_id: requestId,
-          $feature_flag_evaluated_at: flagWasLocallyEvaluated ? Date.now() : evaluatedAt,
-        }
-
-        // Add local evaluation definition load timestamp
-        if (flagWasLocallyEvaluated && this.featureFlagsPoller) {
-          const flagDefinitionsLoadedAt = this.featureFlagsPoller.getFlagDefinitionsLoadedAt()
-
-          if (flagDefinitionsLoadedAt !== undefined) {
-            properties.$feature_flag_definitions_loaded_at = flagDefinitionsLoadedAt
-          }
-        }
-
-        if (featureFlagError) {
-          properties.$feature_flag_error = featureFlagError
-        }
-
-        this.capture({
-          distinctId,
-          event: '$feature_flag_called',
-          properties,
-          groups,
-          disableGeoip,
-        })
-      }
+      this._emitFeatureFlagCalled({
+        distinctId,
+        key,
+        response,
+        flagWasLocallyEvaluated,
+        flagId,
+        flagVersion,
+        flagReason,
+        requestId,
+        evaluatedAt,
+        featureFlagError,
+        groups,
+        disableGeoip,
+      })
     }
 
     // Apply payload override if present (even when there's no flag override)
@@ -961,6 +1010,252 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     }
 
     return result
+  }
+
+  /**
+   * Internal method that evaluates a subset of feature flags in one local pass
+   * plus at most one remote round trip, and optionally emits
+   * `$feature_flag_called` events for every resolved flag.
+   */
+  private async _getFeatureFlagResults(
+    keys: string[],
+    distinctId: string,
+    options: {
+      groups?: Record<string, string>
+      personProperties?: Record<string, string>
+      groupProperties?: Record<string, Record<string, string>>
+      onlyEvaluateLocally?: boolean
+      sendFeatureFlagEvents?: boolean
+      disableGeoip?: boolean
+    } = {}
+  ): Promise<Record<string, FeatureFlagResult | undefined>> {
+    const sendFeatureFlagEvents = options.sendFeatureFlagEvents ?? true
+    const { groups, disableGeoip } = options
+    let { onlyEvaluateLocally, personProperties, groupProperties } = options
+
+    const adjustedProperties = this.addLocalPersonAndGroupProperties(
+      distinctId,
+      groups,
+      personProperties,
+      groupProperties
+    )
+    personProperties = adjustedProperties.allPersonProperties
+    groupProperties = adjustedProperties.allGroupProperties
+    const evaluationContext = this.createFeatureFlagEvaluationContext(
+      distinctId,
+      groups,
+      personProperties,
+      groupProperties
+    )
+
+    if (onlyEvaluateLocally == undefined) {
+      onlyEvaluateLocally = this.options.strictLocalEvaluation ?? false
+    }
+
+    type EventMeta = {
+      key: string
+      response: FeatureFlagValue | undefined
+      flagWasLocallyEvaluated: boolean
+      flagId?: number
+      flagVersion?: number
+      flagReason?: string
+      requestId?: string
+      evaluatedAt?: number
+      featureFlagError?: FeatureFlagErrorType
+    }
+
+    const results: Record<string, FeatureFlagResult | undefined> = {}
+    const eventMetadata: EventMeta[] = []
+    const nonOverriddenKeys: string[] = []
+
+    // Deduplicate requested keys while preserving order.
+    const uniqueKeys = Array.from(new Set(keys))
+
+    // Apply flag overrides up front. Overridden flags short-circuit evaluation
+    // and do not emit `$feature_flag_called` events, matching the single-flag path.
+    for (const key of uniqueKeys) {
+      if (this._flagOverrides !== undefined && key in this._flagOverrides) {
+        const overrideValue = this._flagOverrides[key]
+        if (overrideValue === undefined) {
+          results[key] = undefined
+        } else {
+          const overridePayload = this._payloadOverrides?.[key]
+          results[key] = {
+            key,
+            enabled: overrideValue !== false,
+            variant: typeof overrideValue === 'string' ? overrideValue : undefined,
+            payload: overridePayload,
+          }
+        }
+        continue
+      }
+      nonOverriddenKeys.push(key)
+    }
+
+    const stillUnresolved: string[] = []
+    const localEvaluationEnabled = this.featureFlagsPoller !== undefined
+    if (localEvaluationEnabled && nonOverriddenKeys.length > 0) {
+      await this.featureFlagsPoller?.loadFeatureFlags()
+
+      for (const key of nonOverriddenKeys) {
+        const flag = this.featureFlagsPoller?.featureFlagsByKey[key]
+        if (!flag) {
+          stillUnresolved.push(key)
+          continue
+        }
+        try {
+          const localResult = await this.featureFlagsPoller!.computeFlagAndPayloadLocally(flag, evaluationContext)
+          const value = localResult.value
+          results[key] = {
+            key,
+            enabled: value !== false,
+            variant: typeof value === 'string' ? value : undefined,
+            payload: localResult.payload ?? undefined,
+          }
+          const response: FeatureFlagValue = value === false ? false : typeof value === 'string' ? value : true
+          eventMetadata.push({
+            key,
+            response,
+            flagWasLocallyEvaluated: true,
+            flagId: flag.id,
+            flagReason: 'Evaluated locally',
+          })
+        } catch (e) {
+          if (e instanceof RequiresServerEvaluation || e instanceof InconclusiveMatchError) {
+            this._logger?.info(`${e.name} when computing flag locally: ${key}: ${e.message}`)
+            stillUnresolved.push(key)
+          } else {
+            throw e
+          }
+        }
+      }
+    } else {
+      stillUnresolved.push(...nonOverriddenKeys)
+    }
+
+    if (stillUnresolved.length > 0 && !onlyEvaluateLocally) {
+      const flagsResponse = await super.getFeatureFlagDetailsStateless(
+        evaluationContext.distinctId,
+        evaluationContext.groups,
+        evaluationContext.personProperties,
+        evaluationContext.groupProperties,
+        disableGeoip,
+        stillUnresolved
+      )
+
+      if (flagsResponse === undefined) {
+        for (const key of stillUnresolved) {
+          results[key] = undefined
+          eventMetadata.push({
+            key,
+            response: undefined,
+            flagWasLocallyEvaluated: false,
+            featureFlagError: FeatureFlagError.UNKNOWN_ERROR,
+          })
+        }
+      } else {
+        const requestId = flagsResponse.requestId
+        const evaluatedAt = flagsResponse.evaluatedAt
+        const topLevelErrors: string[] = []
+        if (flagsResponse.errorsWhileComputingFlags) {
+          topLevelErrors.push(FeatureFlagError.ERRORS_WHILE_COMPUTING)
+        }
+        if (flagsResponse.quotaLimited?.includes('feature_flags')) {
+          topLevelErrors.push(FeatureFlagError.QUOTA_LIMITED)
+        }
+
+        for (const key of stillUnresolved) {
+          const flagDetail = flagsResponse.flags[key]
+          const errors = [...topLevelErrors]
+          if (flagDetail === undefined) {
+            errors.push(FeatureFlagError.FLAG_MISSING)
+            results[key] = undefined
+            eventMetadata.push({
+              key,
+              response: undefined,
+              flagWasLocallyEvaluated: false,
+              requestId,
+              evaluatedAt,
+              featureFlagError: errors.length > 0 ? errors.join(',') : undefined,
+            })
+            continue
+          }
+
+          let parsedPayload: JsonType | undefined = undefined
+          if (flagDetail.metadata?.payload !== undefined) {
+            try {
+              parsedPayload = JSON.parse(flagDetail.metadata.payload)
+            } catch {
+              parsedPayload = flagDetail.metadata.payload
+            }
+          }
+
+          const flagResult: FeatureFlagResult = {
+            key,
+            enabled: flagDetail.enabled,
+            variant: flagDetail.variant,
+            payload: parsedPayload,
+          }
+          results[key] = flagResult
+
+          const response: FeatureFlagValue = flagResult.enabled === false ? false : (flagResult.variant ?? true)
+          eventMetadata.push({
+            key,
+            response,
+            flagWasLocallyEvaluated: false,
+            flagId: flagDetail.metadata?.id,
+            flagVersion: flagDetail.metadata?.version,
+            flagReason: flagDetail.reason?.description ?? flagDetail.reason?.code,
+            requestId,
+            evaluatedAt,
+            featureFlagError: errors.length > 0 ? errors.join(',') : undefined,
+          })
+        }
+      }
+    } else if (stillUnresolved.length > 0) {
+      // `onlyEvaluateLocally` is true: record undefined results and emit events
+      // so locally-unresolved keys are still reported, matching the single-flag path.
+      for (const key of stillUnresolved) {
+        results[key] = undefined
+        eventMetadata.push({
+          key,
+          response: undefined,
+          flagWasLocallyEvaluated: false,
+        })
+      }
+    }
+
+    // Payload overrides take precedence over any computed payload, mirroring
+    // the single-flag behavior.
+    if (this._payloadOverrides !== undefined) {
+      for (const key of uniqueKeys) {
+        const current = results[key]
+        if (current !== undefined && key in this._payloadOverrides) {
+          results[key] = { ...current, payload: this._payloadOverrides[key] }
+        }
+      }
+    }
+
+    if (sendFeatureFlagEvents) {
+      for (const meta of eventMetadata) {
+        this._emitFeatureFlagCalled({
+          distinctId,
+          key: meta.key,
+          response: meta.response,
+          flagWasLocallyEvaluated: meta.flagWasLocallyEvaluated,
+          flagId: meta.flagId,
+          flagVersion: meta.flagVersion,
+          flagReason: meta.flagReason,
+          requestId: meta.requestId,
+          evaluatedAt: meta.evaluatedAt,
+          featureFlagError: meta.featureFlagError,
+          groups,
+          disableGeoip,
+        })
+      }
+    }
+
+    return results
   }
 
   /**
@@ -1156,6 +1451,62 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     }
 
     return this._getFeatureFlagResult(key, resolvedDistinctId, {
+      ...resolvedOptions,
+      sendFeatureFlagEvents: resolvedOptions?.sendFeatureFlagEvents ?? this.options.sendFeatureFlagEvent ?? true,
+    })
+  }
+
+  /**
+   * Evaluate a subset of feature flags in one bulk pass while still emitting
+   * `$feature_flag_called` events for each resolved flag.
+   *
+   * Evaluates each key locally first (if local evaluation is enabled) and then
+   * makes at most one remote request for any keys that couldn't be resolved
+   * locally — avoiding the N remote round trips of calling `getFeatureFlag`
+   * per flag while preserving the flag-usage signal that `getAllFlags` loses.
+   *
+   * @example
+   * ```ts
+   * const results = await client.getFeatureFlags(
+   *   ['new-dashboard', 'beta-search'],
+   *   'user_123',
+   *   { personProperties: { plan: 'pro' } }
+   * )
+   * if (results['new-dashboard']?.enabled) { ... }
+   * ```
+   *
+   * {@label Feature flags}
+   *
+   * @param keys - The feature flag keys to evaluate
+   * @param distinctId - The user's distinct ID
+   * @param options - Optional configuration for flag evaluation. `sendFeatureFlagEvents` defaults to `true`.
+   * @returns Promise that resolves to a record of flag keys to their results (undefined if not found)
+   */
+  async getFeatureFlags(
+    keys: string[],
+    options?: FlagEvaluationOptions
+  ): Promise<Record<string, FeatureFlagResult | undefined>>
+  async getFeatureFlags(
+    keys: string[],
+    distinctId: string,
+    options?: FlagEvaluationOptions
+  ): Promise<Record<string, FeatureFlagResult | undefined>>
+  async getFeatureFlags(
+    keys: string[],
+    distinctIdOrOptions?: string | FlagEvaluationOptions,
+    options?: FlagEvaluationOptions
+  ): Promise<Record<string, FeatureFlagResult | undefined>> {
+    const { distinctId: resolvedDistinctId, options: resolvedOptions } = this._resolveDistinctId(
+      distinctIdOrOptions,
+      options
+    )
+
+    if (!resolvedDistinctId) {
+      this._logger.warn('[PostHog] distinctId is required — pass it explicitly or use withContext()')
+      return {}
+    }
+
+    return this._getFeatureFlagResults(keys, resolvedDistinctId, {
       ...resolvedOptions,
       sendFeatureFlagEvents: resolvedOptions?.sendFeatureFlagEvents ?? this.options.sendFeatureFlagEvent ?? true,
     })
@@ -1361,7 +1712,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       return { featureFlags: {}, featureFlagPayloads: {} }
     }
 
-    const { groups, disableGeoip, flagKeys } = resolvedOptions || {}
+    const { groups, disableGeoip, flagKeys, sendFeatureFlagEvents } = resolvedOptions || {}
     let { onlyEvaluateLocally, personProperties, groupProperties } = resolvedOptions || {}
 
     const adjustedProperties = this.addLocalPersonAndGroupProperties(
@@ -1387,31 +1738,29 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
 
     const localEvaluationResult = await this.featureFlagsPoller?.getAllFlagsAndPayloads(evaluationContext, flagKeys)
 
-    let featureFlags = {}
-    let featureFlagPayloads = {}
+    let featureFlags: Record<string, FeatureFlagValue> = {}
+    let featureFlagPayloads: Record<string, JsonType> = {}
     let fallbackToFlags = true
+    const locallyEvaluatedKeys = new Set<string>()
     if (localEvaluationResult) {
       featureFlags = localEvaluationResult.response
       featureFlagPayloads = localEvaluationResult.payloads
       fallbackToFlags = localEvaluationResult.fallbackToFlags
+      for (const key of Object.keys(localEvaluationResult.response)) {
+        locallyEvaluatedKeys.add(key)
+      }
     }
 
+    let remoteDetails: Awaited<ReturnType<PostHogBackendClient['_callFeatureFlagDetailsStateless']>> | undefined
     if (fallbackToFlags && !onlyEvaluateLocally) {
-      const remoteEvaluationResult = await super.getFeatureFlagsAndPayloadsStateless(
-        evaluationContext.distinctId,
-        evaluationContext.groups,
-        evaluationContext.personProperties,
-        evaluationContext.groupProperties,
-        disableGeoip,
-        flagKeys
-      )
-      featureFlags = {
-        ...featureFlags,
-        ...(remoteEvaluationResult.flags || {}),
-      }
-      featureFlagPayloads = {
-        ...featureFlagPayloads,
-        ...(remoteEvaluationResult.payloads || {}),
+      remoteDetails = await this._callFeatureFlagDetailsStateless(evaluationContext, disableGeoip, flagKeys)
+      if (remoteDetails) {
+        if (remoteDetails.featureFlags) {
+          featureFlags = { ...featureFlags, ...remoteDetails.featureFlags }
+        }
+        if (remoteDetails.featureFlagPayloads) {
+          featureFlagPayloads = { ...featureFlagPayloads, ...remoteDetails.featureFlagPayloads }
+        }
       }
     }
 
@@ -1429,7 +1778,120 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       }
     }
 
+    if (sendFeatureFlagEvents) {
+      this._emitBulkFeatureFlagCalledEvents({
+        distinctId: resolvedDistinctId,
+        featureFlags,
+        locallyEvaluatedKeys,
+        remoteDetails,
+        groups,
+        disableGeoip,
+      })
+    }
+
     return { featureFlags, featureFlagPayloads }
+  }
+
+  /**
+   * Thin wrapper around `super.getFeatureFlagDetailsStateless` so
+   * `getAllFlagsAndPayloads` can share its full return shape with the
+   * event-emission path without losing per-flag metadata.
+   */
+  private async _callFeatureFlagDetailsStateless(
+    evaluationContext: FeatureFlagEvaluationContext,
+    disableGeoip?: boolean,
+    flagKeys?: string[]
+  ): Promise<
+    | {
+        featureFlags?: Record<string, FeatureFlagValue>
+        featureFlagPayloads?: Record<string, JsonType>
+        flags?: Record<string, import('@posthog/core').FeatureFlagDetail>
+        requestId?: string
+        evaluatedAt?: number
+        errorsWhileComputingFlags?: boolean
+        quotaLimited?: string[]
+      }
+    | undefined
+  > {
+    const details = await super.getFeatureFlagDetailsStateless(
+      evaluationContext.distinctId,
+      evaluationContext.groups,
+      evaluationContext.personProperties,
+      evaluationContext.groupProperties,
+      disableGeoip,
+      flagKeys
+    )
+    return details
+  }
+
+  /**
+   * Emits `$feature_flag_called` events for a bulk evaluation, using whichever
+   * source (local poller or remote response) produced each flag.
+   */
+  private _emitBulkFeatureFlagCalledEvents(args: {
+    distinctId: string
+    featureFlags: Record<string, FeatureFlagValue>
+    locallyEvaluatedKeys: Set<string>
+    remoteDetails?: {
+      flags?: Record<string, import('@posthog/core').FeatureFlagDetail>
+      requestId?: string
+      evaluatedAt?: number
+      errorsWhileComputingFlags?: boolean
+      quotaLimited?: string[]
+    }
+    groups?: Record<string, string>
+    disableGeoip?: boolean
+  }): void {
+    const { distinctId, featureFlags, locallyEvaluatedKeys, remoteDetails, groups, disableGeoip } = args
+
+    const topLevelErrors: string[] = []
+    if (remoteDetails?.errorsWhileComputingFlags) {
+      topLevelErrors.push(FeatureFlagError.ERRORS_WHILE_COMPUTING)
+    }
+    if (remoteDetails?.quotaLimited?.includes('feature_flags')) {
+      topLevelErrors.push(FeatureFlagError.QUOTA_LIMITED)
+    }
+
+    for (const [key, value] of Object.entries(featureFlags)) {
+      // Overridden flags short-circuit evaluation in the single-flag path and
+      // do not emit events; preserve that behavior here.
+      if (this._flagOverrides !== undefined && key in this._flagOverrides) {
+        continue
+      }
+
+      const response: FeatureFlagValue = value === false ? false : typeof value === 'string' ? value : true
+
+      if (locallyEvaluatedKeys.has(key)) {
+        const flag = this.featureFlagsPoller?.featureFlagsByKey[key]
+        this._emitFeatureFlagCalled({
+          distinctId,
+          key,
+          response,
+          flagWasLocallyEvaluated: true,
+          flagId: flag?.id,
+          flagReason: 'Evaluated locally',
+          groups,
+          disableGeoip,
+        })
+        continue
+      }
+
+      const flagDetail = remoteDetails?.flags?.[key]
+      this._emitFeatureFlagCalled({
+        distinctId,
+        key,
+        response,
+        flagWasLocallyEvaluated: false,
+        flagId: flagDetail?.metadata?.id,
+        flagVersion: flagDetail?.metadata?.version,
+        flagReason: flagDetail?.reason?.description ?? flagDetail?.reason?.code,
+        requestId: remoteDetails?.requestId,
+        evaluatedAt: remoteDetails?.evaluatedAt,
+        featureFlagError: topLevelErrors.length > 0 ? topLevelErrors.join(',') : undefined,
+        groups,
+        disableGeoip,
+      })
+    }
   }
 
   /**

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -90,6 +90,12 @@ export type FlagEvaluationOptions = BaseFlagEvaluationOptions & {
 
 export type AllFlagsOptions = BaseFlagEvaluationOptions & {
   flagKeys?: string[]
+  /**
+   * When true, emits a `$feature_flag_called` event for each resolved flag,
+   * matching the behavior of `getFeatureFlag`. Defaults to `false` for
+   * backwards compatibility with the existing bulk methods.
+   */
+  sendFeatureFlagEvents?: boolean
 }
 
 export type FeatureFlagOverrideOptions = {
@@ -481,6 +487,30 @@ export interface IPostHog {
    * @returns Promise that resolves to flags and payloads
    */
   getAllFlagsAndPayloads(distinctId: string, options?: AllFlagsOptions): Promise<PostHogFlagsAndPayloadsResponse>
+
+  /**
+   * @description Evaluate a subset of feature flags in one bulk pass using distinctId from withContext().
+   */
+  getFeatureFlags(
+    keys: string[],
+    options?: FlagEvaluationOptions
+  ): Promise<Record<string, FeatureFlagResult | undefined>>
+
+  /**
+   * @description Evaluate a subset of feature flags in a single local + remote pass while still
+   * emitting `$feature_flag_called` events per resolved flag. Useful when you know up front
+   * which flags you need and want usage signal without N separate `getFeatureFlag` calls.
+   *
+   * @param keys - The feature flag keys to evaluate
+   * @param distinctId - The user's distinct ID
+   * @param options - Optional configuration for flag evaluation. `sendFeatureFlagEvents` defaults to `true`.
+   * @returns Promise that resolves to a record of flag keys to their results (undefined if not found)
+   */
+  getFeatureFlags(
+    keys: string[],
+    distinctId: string,
+    options?: FlagEvaluationOptions
+  ): Promise<Record<string, FeatureFlagResult | undefined>>
 
   /**
    * @description Get a feature flag result using distinctId from withContext().


### PR DESCRIPTION
## TL;DR

Add a new `getFeatureFlags(keys, distinctId, options)` method to the Node SDK for evaluating a known subset of feature flags in one bulk pass while emitting `$feature_flag_called` events. Also adds a `sendFeatureFlagEvents` option to `getAllFlags` and `getAllFlagsAndPayloads` for opt-in per-flag event emission.

The idea here is that we have some customers who want to evaluate a bunch of flags on the server side as part of like an initial page load for their app, but they (a) don't want to call `getAllFlags` because they only want to evaluate _some_ of them (plus `getAllFlags` doesn't emit `$feature_flag_called` events for all flags, which I'm patching here too), and (b) they don't want to do like 10 individual `getFeatureFlag` calls (10 network requests! dumb!) as part of loading one page. Honestly this is so reasonable I can't believe we didn't have something like it already.

I'm gonna add this to the rest of the server-side SDKs too, I think people will really like this. Prioritizing Node first as a proving ground + the specific customer who asked about this is using Node.

## Changes

- **New `getFeatureFlags` method**: Evaluates a subset of feature flags in bulk while still emitting `$feature_flag_called` events per resolved flag
- **Stuck with the hybrid evaluation strategy**: Locally-evaluated flags reuse the poller's cached definitions; keys that can't be resolved locally fall through to a single remote `/flags` call with `flag_keys_to_evaluate`
- **Stuck with event deduplication**: Uses the existing `distinctIdHasSentFlagCalls` cache so the single-flag and bulk paths share one source of truth
- **New `sendFeatureFlagEvents` option**: Added to both `getAllFlags` and `getAllFlagsAndPayloads` methods for opt-in per-flag event emission. Defaults to off, obvi, but people may like this.
- **Buncha tests**: Added 362 lines of tests covering remote evaluation, local-only evaluation, hybrid scenarios, event deduplication, and edge cases

## Release info

### Libraries affected

- [x] posthog-node

## Checklist

- [x] Tests for new code
- [x] Accounted for backwards compatibility (new method and optional parameter, no breaking changes)
- [x] Changeset generated

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*