### PR TITLE
feat(posthog-ai): Support generic AI generation tracing beyond Vercel…

### DIFF
--- a/packages/ai/src/capture.ts
+++ b/packages/ai/src/capture.ts
@@ -1,0 +1,116 @@
+import { PostHog } from 'posthog-node'
+import { v4 as uuidv4 } from 'uuid'
+import { sendEventToPosthog, sendEventWithErrorToPosthog, AIEvent } from './utils'
+import type { TokenUsage } from './types'
+
+export interface CaptureAiGenerationOptions {
+  /** Distinct ID of the user */
+  distinctId?: string
+  /** Trace ID for the generation. Automatically generated if not provided */
+  traceId?: string
+  /** The AI provider (e.g. 'cloudflare-workers-ai', 'openai') */
+  provider?: string
+  /** The model used (e.g. '@cf/zai-org/glm-4.7-flash') */
+  model?: string
+  /** The input/prompt passed to the model */
+  input?: any
+  /** The output/response from the model */
+  output?: any
+  /** Token usage statistics */
+  usage?: TokenUsage
+  /** Request latency in seconds */
+  latency?: number
+  /** Time to first token in seconds (for streaming) */
+  timeToFirstToken?: number
+  /** The base URL of the API */
+  baseURL?: string
+  /** HTTP status code of the response */
+  httpStatus?: number
+  /** Any error that occurred during the generation */
+  error?: unknown
+  /** Reason why the generation stopped */
+  stopReason?: string
+  /** Tools available to the model */
+  tools?: any[]
+  /** Any additional PostHog properties to attach to the event */
+  properties?: Record<string, unknown>
+  /** Any PostHog groups to attach to the event */
+  groups?: Record<string, string>
+  /** Wait for the event to be sent immediately */
+  captureImmediate?: boolean
+  /** Whether to redact the input and output */
+  privacyMode?: boolean
+}
+
+export const captureAiGeneration = async (
+  client: PostHog,
+  options: CaptureAiGenerationOptions
+): Promise<void> => {
+  const {
+    distinctId,
+    traceId = uuidv4(),
+    provider = 'unknown',
+    model,
+    input,
+    output,
+    usage = {},
+    latency = 0,
+    timeToFirstToken,
+    baseURL = '',
+    httpStatus = 200,
+    error,
+    stopReason,
+    tools,
+    properties,
+    groups,
+    captureImmediate = false,
+    privacyMode = false,
+  } = options
+
+  const params: any = {
+    posthogProperties: properties,
+    posthogGroups: groups,
+    posthogPrivacyMode: privacyMode,
+  }
+
+  if (error) {
+    await sendEventWithErrorToPosthog({
+      client,
+      distinctId,
+      traceId,
+      provider,
+      model,
+      input,
+      output: output || [],
+      usage,
+      latency,
+      timeToFirstToken,
+      baseURL,
+      stopReason,
+      tools,
+      params,
+      captureImmediate,
+      error,
+    })
+  } else {
+    await sendEventToPosthog({
+      client,
+      eventType: AIEvent.Generation,
+      distinctId,
+      traceId,
+      provider,
+      model,
+      input,
+      output,
+      usage,
+      latency,
+      timeToFirstToken,
+      baseURL,
+      httpStatus,
+      stopReason,
+      tools,
+      params,
+      captureImmediate,
+    })
+  }
+}

--- a/packages/ai/src/capture.ts
+++ b/packages/ai/src/capture.ts
@@ -2,6 +2,7 @@ import { PostHog } from 'posthog-node'
 import { v4 as uuidv4 } from 'uuid'
 import { sendEventToPosthog, sendEventWithErrorToPosthog, AIEvent } from './utils'
 import type { TokenUsage } from './types'
+import type { MonitoringParams } from './utils'
 
 export interface CaptureAiGenerationOptions {
   /** Distinct ID of the user */
@@ -24,7 +25,7 @@ export interface CaptureAiGenerationOptions {
   timeToFirstToken?: number
   /** The base URL of the API */
   baseURL?: string
-  /** HTTP status code of the response */
+  /** HTTP status code of the response. Ignored if an error is provided. */
   httpStatus?: number
   /** Any error that occurred during the generation */
   error?: unknown
@@ -67,7 +68,7 @@ export const captureAiGeneration = async (
     privacyMode = false,
   } = options
 
-  const params: any = {
+  const params: MonitoringParams = {
     posthogProperties: properties,
     posthogGroups: groups,
     posthogPrivacyMode: privacyMode,
@@ -88,7 +89,7 @@ export const captureAiGeneration = async (
       baseURL,
       stopReason,
       tools,
-      params,
+      params: params as any,
       captureImmediate,
       error,
     })
@@ -109,7 +110,7 @@ export const captureAiGeneration = async (
       httpStatus,
       stopReason,
       tools,
-      params,
+      params: params as any,
       captureImmediate,
     })
   }

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -5,6 +5,7 @@ import PostHogAnthropic from './anthropic'
 import PostHogGoogleGenAI from './gemini'
 import { LangChainCallbackHandler } from './langchain/callbacks'
 import { Prompts } from './prompts'
+import { captureAiGeneration, type CaptureAiGenerationOptions } from './capture'
 
 export { PostHogOpenAI as OpenAI }
 export { PostHogAzureOpenAI as AzureOpenAI }
@@ -13,4 +14,6 @@ export { PostHogGoogleGenAI as GoogleGenAI }
 export { wrapVercelLanguageModel as withTracing }
 export { LangChainCallbackHandler }
 export { Prompts }
+export { captureAiGeneration }
+export type { CaptureAiGenerationOptions }
 export type { PromptResult, PromptRemoteResult, PromptCodeFallbackResult } from './types'

--- a/packages/ai/tests/capture.test.ts
+++ b/packages/ai/tests/capture.test.ts
@@ -1,0 +1,131 @@
+import { captureAiGeneration } from '../src/capture'
+import { PostHog } from 'posthog-node'
+
+jest.mock('posthog-node')
+
+describe('captureAiGeneration', () => {
+  let mockClient: jest.Mocked<PostHog>
+
+  beforeEach(() => {
+    mockClient = {
+      capture: jest.fn(),
+      captureImmediate: jest.fn(),
+      options: {
+        enableExceptionAutocapture: false,
+      },
+      captureException: jest.fn(),
+    } as unknown as jest.Mocked<PostHog>
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should capture a standard ai generation event', async () => {
+    await captureAiGeneration(mockClient, {
+      distinctId: 'user-123',
+      traceId: 'trace-abc',
+      provider: 'cloudflare-workers-ai',
+      model: '@cf/zai-org/glm-4.7-flash',
+      input: 'tell me a joke',
+      output: 'why did the chicken cross the road? to get to the other side.',
+      usage: { inputTokens: 10, outputTokens: 15 },
+      latency: 1.5,
+      properties: { feature: 'test-feature' },
+    })
+
+    expect(mockClient.capture).toHaveBeenCalledTimes(1)
+    expect(mockClient.capture).toHaveBeenCalledWith({
+      distinctId: 'user-123',
+      event: '$ai_generation',
+      properties: expect.objectContaining({
+        $ai_provider: 'cloudflare-workers-ai',
+        $ai_model: '@cf/zai-org/glm-4.7-flash',
+        $ai_input: 'tell me a joke',
+        $ai_output_choices: 'why did the chicken cross the road? to get to the other side.',
+        $ai_input_tokens: 10,
+        $ai_output_tokens: 15,
+        $ai_latency: 1.5,
+        $ai_trace_id: 'trace-abc',
+        feature: 'test-feature',
+        $ai_tokens_source: 'sdk',
+      }),
+      groups: undefined,
+    })
+  })
+
+  it('should generate a traceId if not provided', async () => {
+    await captureAiGeneration(mockClient, {
+      distinctId: 'user-123',
+    })
+
+    expect(mockClient.capture).toHaveBeenCalledTimes(1)
+    expect(mockClient.capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          $ai_trace_id: expect.any(String),
+        }),
+      })
+    )
+  })
+
+  it('should fallback to distinctId as traceId for distinctId param if traceId is missing', async () => {
+     await captureAiGeneration(mockClient, {
+      traceId: 'trace-123',
+    })
+
+    expect(mockClient.capture).toHaveBeenCalledTimes(1)
+    expect(mockClient.capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        distinctId: 'trace-123',
+      })
+    )
+  })
+
+  it('should capture immediate when captureImmediate is true', async () => {
+    await captureAiGeneration(mockClient, {
+      distinctId: 'user-123',
+      captureImmediate: true,
+    })
+
+    expect(mockClient.captureImmediate).toHaveBeenCalledTimes(1)
+    expect(mockClient.capture).not.toHaveBeenCalled()
+  })
+
+  it('should capture an error event correctly', async () => {
+    const error = new Error('Test error')
+    await captureAiGeneration(mockClient, {
+      distinctId: 'user-123',
+      error,
+    })
+
+    expect(mockClient.capture).toHaveBeenCalledTimes(1)
+    expect(mockClient.capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          $ai_is_error: true,
+          $ai_error: JSON.stringify(error),
+        }),
+      })
+    )
+  })
+
+  it('should redact input and output when privacyMode is true', async () => {
+    await captureAiGeneration(mockClient, {
+      distinctId: 'user-123',
+      input: 'secret input',
+      output: 'secret output',
+      privacyMode: true,
+    })
+
+    expect(mockClient.capture).toHaveBeenCalledTimes(1)
+    expect(mockClient.capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          $ai_input: null,
+          $ai_output_choices: null,
+        }),
+      })
+    )
+  })
+})

--- a/packages/ai/tests/capture.test.ts
+++ b/packages/ai/tests/capture.test.ts
@@ -21,111 +21,127 @@ describe('captureAiGeneration', () => {
     jest.clearAllMocks()
   })
 
-  it('should capture a standard ai generation event', async () => {
-    await captureAiGeneration(mockClient, {
-      distinctId: 'user-123',
-      traceId: 'trace-abc',
-      provider: 'cloudflare-workers-ai',
-      model: '@cf/zai-org/glm-4.7-flash',
-      input: 'tell me a joke',
-      output: 'why did the chicken cross the road? to get to the other side.',
-      usage: { inputTokens: 10, outputTokens: 15 },
-      latency: 1.5,
-      properties: { feature: 'test-feature' },
-    })
+  const testError = new Error('Test error')
 
-    expect(mockClient.capture).toHaveBeenCalledTimes(1)
-    expect(mockClient.capture).toHaveBeenCalledWith({
-      distinctId: 'user-123',
-      event: '$ai_generation',
-      properties: expect.objectContaining({
-        $ai_provider: 'cloudflare-workers-ai',
-        $ai_model: '@cf/zai-org/glm-4.7-flash',
-        $ai_input: 'tell me a joke',
-        $ai_output_choices: 'why did the chicken cross the road? to get to the other side.',
-        $ai_input_tokens: 10,
-        $ai_output_tokens: 15,
-        $ai_latency: 1.5,
-        $ai_trace_id: 'trace-abc',
-        feature: 'test-feature',
-        $ai_tokens_source: 'sdk',
-      }),
-      groups: undefined,
-    })
-  })
-
-  it('should generate a traceId if not provided', async () => {
-    await captureAiGeneration(mockClient, {
-      distinctId: 'user-123',
-    })
-
-    expect(mockClient.capture).toHaveBeenCalledTimes(1)
-    expect(mockClient.capture).toHaveBeenCalledWith(
-      expect.objectContaining({
-        properties: expect.objectContaining({
-          $ai_trace_id: expect.any(String),
+  it.each([
+    [
+      'should capture a standard ai generation event',
+      {
+        distinctId: 'user-123',
+        traceId: 'trace-abc',
+        provider: 'cloudflare-workers-ai',
+        model: '@cf/zai-org/glm-4.7-flash',
+        input: 'tell me a joke',
+        output: 'why did the chicken cross the road? to get to the other side.',
+        usage: { inputTokens: 10, outputTokens: 15 },
+        latency: 1.5,
+        properties: { feature: 'test-feature' },
+      },
+      {
+        captureTimes: 1,
+        captureImmediateTimes: 0,
+        expectedArgs: {
+          distinctId: 'user-123',
+          event: '$ai_generation',
+          properties: expect.objectContaining({
+            $ai_provider: 'cloudflare-workers-ai',
+            $ai_model: '@cf/zai-org/glm-4.7-flash',
+            $ai_input: 'tell me a joke',
+            $ai_output_choices: 'why did the chicken cross the road? to get to the other side.',
+            $ai_input_tokens: 10,
+            $ai_output_tokens: 15,
+            $ai_latency: 1.5,
+            $ai_trace_id: 'trace-abc',
+            feature: 'test-feature',
+            $ai_tokens_source: 'sdk',
+          }),
+          groups: undefined,
+        },
+      },
+    ],
+    [
+      'should generate a traceId if not provided',
+      {
+        distinctId: 'user-123',
+      },
+      {
+        captureTimes: 1,
+        captureImmediateTimes: 0,
+        expectedArgs: expect.objectContaining({
+          properties: expect.objectContaining({
+            $ai_trace_id: expect.any(String),
+          }),
         }),
-      })
-    )
-  })
-
-  it('should fallback to distinctId as traceId for distinctId param if traceId is missing', async () => {
-     await captureAiGeneration(mockClient, {
-      traceId: 'trace-123',
-    })
-
-    expect(mockClient.capture).toHaveBeenCalledTimes(1)
-    expect(mockClient.capture).toHaveBeenCalledWith(
-      expect.objectContaining({
-        distinctId: 'trace-123',
-      })
-    )
-  })
-
-  it('should capture immediate when captureImmediate is true', async () => {
-    await captureAiGeneration(mockClient, {
-      distinctId: 'user-123',
-      captureImmediate: true,
-    })
-
-    expect(mockClient.captureImmediate).toHaveBeenCalledTimes(1)
-    expect(mockClient.capture).not.toHaveBeenCalled()
-  })
-
-  it('should capture an error event correctly', async () => {
-    const error = new Error('Test error')
-    await captureAiGeneration(mockClient, {
-      distinctId: 'user-123',
-      error,
-    })
-
-    expect(mockClient.capture).toHaveBeenCalledTimes(1)
-    expect(mockClient.capture).toHaveBeenCalledWith(
-      expect.objectContaining({
-        properties: expect.objectContaining({
-          $ai_is_error: true,
-          $ai_error: JSON.stringify(error),
+      },
+    ],
+    [
+      'should use traceId as distinctId when distinctId is not provided',
+      {
+        traceId: 'trace-123',
+      },
+      {
+        captureTimes: 1,
+        captureImmediateTimes: 0,
+        expectedArgs: expect.objectContaining({
+          distinctId: 'trace-123',
         }),
-      })
-    )
-  })
-
-  it('should redact input and output when privacyMode is true', async () => {
-    await captureAiGeneration(mockClient, {
-      distinctId: 'user-123',
-      input: 'secret input',
-      output: 'secret output',
-      privacyMode: true,
-    })
-
-    expect(mockClient.capture).toHaveBeenCalledTimes(1)
-    expect(mockClient.capture).toHaveBeenCalledWith(
-      expect.objectContaining({
-        properties: expect.objectContaining({
-          $ai_input: null,
-          $ai_output_choices: null,
+      },
+    ],
+    [
+      'should capture immediate when captureImmediate is true',
+      {
+        distinctId: 'user-123',
+        captureImmediate: true,
+      },
+      {
+        captureTimes: 0,
+        captureImmediateTimes: 1,
+      },
+    ],
+    [
+      'should capture an error event correctly',
+      {
+        distinctId: 'user-123',
+        error: testError,
+      },
+      {
+        captureTimes: 1,
+        captureImmediateTimes: 0,
+        expectedArgs: expect.objectContaining({
+          properties: expect.objectContaining({
+            $ai_is_error: true,
+            $ai_error: JSON.stringify(testError),
+          }),
         }),
-      })
-    )
+      },
+    ],
+    [
+      'should redact input and output when privacyMode is true',
+      {
+        distinctId: 'user-123',
+        input: 'secret input',
+        output: 'secret output',
+        privacyMode: true,
+      },
+      {
+        captureTimes: 1,
+        captureImmediateTimes: 0,
+        expectedArgs: expect.objectContaining({
+          properties: expect.objectContaining({
+            $ai_input: null,
+            $ai_output_choices: null,
+          }),
+        }),
+      },
+    ],
+  ])('%s', async (description, options, expected) => {
+    await captureAiGeneration(mockClient, options)
+
+    expect(mockClient.capture).toHaveBeenCalledTimes(expected.captureTimes)
+    expect(mockClient.captureImmediate).toHaveBeenCalledTimes(expected.captureImmediateTimes)
+
+    if (expected.captureTimes > 0 && expected.expectedArgs) {
+      expect(mockClient.capture).toHaveBeenCalledWith(expected.expectedArgs)
+    }
   })
 })


### PR DESCRIPTION
## Description

This PR introduces `captureAiGeneration` to the `@posthog/ai` package, exposing a lower-level generic tracking function that bypasses the need for the Vercel AI SDK wrapper (`withTracing`). 

This allows capturing `$ai_generation` tracing events natively when using alternative AI calling mechanisms, such as:
- Direct `env.AI.run()` calls (e.g., Cloudflare Workers AI bindings)
- TanStack AI adapters (`@cloudflare/tanstack-ai`)
- Any non-Vercel AI SDK provider

The newly exposed function seamlessly delegates to the internal event senders (`sendEventToPosthog` and `sendEventWithErrorToPosthog`), ensuring the exact same `$ai_generation` event schema, properties, and analytical behavior as `withTracing`, but completely decoupled from a specific AI SDK.

Fixes #3444 

## Changes Made
- Added `captureAiGeneration` in `packages/ai/src/capture.ts`.
- Exported `captureAiGeneration` and its options interface (`CaptureAiGenerationOptions`) in `packages/ai/src/index.ts`.
- Added comprehensive unit tests in `packages/ai/tests/capture.test.ts` to ensure payload formatting, error handling, auto-generated trace IDs, and privacy mode work flawlessly.

## Usage

Consumers can now trace generations easily:

```typescript
import { captureAiGeneration } from '@posthog/ai'

await captureAiGeneration(posthogClient, {
  distinctId: 'user-123',
  traceId: 'trace-abc', // automatically generated if omitted
  provider: 'cloudflare-workers-ai',
  model: '@cf/zai-org/glm-4.7-flash',
  input: messages,
  output: responseText,
  usage: { inputTokens: 1200, outputTokens: 450 },
  latency: 2.3, // seconds
  properties: { feature: 'transcript-toc', jobId: '...' },
})
