### PR TITLE
feat(node): use relative file paths in error tracking stack frames

### DIFF
--- a/.changeset/breezy-pumas-build.md
+++ b/.changeset/breezy-pumas-build.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': minor
+---
+
+send relative file paths in frames

--- a/packages/node/src/__tests__/extensions/error-conversion.spec.ts
+++ b/packages/node/src/__tests__/extensions/error-conversion.spec.ts
@@ -1,6 +1,7 @@
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { createModulerModifier } from '@/extensions/error-tracking/modifiers/module.node'
 import { addSourceContext } from '@/extensions/error-tracking/modifiers/context-lines.node'
+import { createRelativePathModifier } from '@/extensions/error-tracking/modifiers/relative-path.node'
 
 describe('error conversion', () => {
   const errorPropertiesBuilder = new CoreErrorTracking.ErrorPropertiesBuilder(
@@ -12,7 +13,7 @@ describe('error conversion', () => {
       new CoreErrorTracking.PrimitiveCoercer(),
     ],
     CoreErrorTracking.createStackParser('node:javascript', CoreErrorTracking.nodeStackLineParser),
-    [createModulerModifier(), addSourceContext]
+    [createModulerModifier(), addSourceContext, createRelativePathModifier()]
   )
 
   async function getExceptionList(error: unknown): Promise<CoreErrorTracking.ErrorProperties['$exception_list']> {

--- a/packages/node/src/__tests__/extensions/exception-autocapture.spec.ts
+++ b/packages/node/src/__tests__/extensions/exception-autocapture.spec.ts
@@ -2,6 +2,7 @@ import ErrorTracking from '@/extensions/error-tracking'
 import { PostHog } from '@/entrypoints/index.node'
 import { addUncaughtExceptionListener, addUnhandledRejectionListener } from '@/extensions/error-tracking/autocapture'
 import { Worker } from 'worker_threads'
+import { relative } from 'path'
 import type { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 
 describe('exception autocapture', () => {
@@ -69,7 +70,7 @@ describe('exception autocapture', () => {
             type: 'onuncaughtexception',
           },
           framesLength: 3,
-          lastFrameFileName: workerFilename,
+          lastFrameFileName: relative(process.cwd(), workerFilename),
           lastFrameHasContext: true,
         })
         res()
@@ -95,7 +96,7 @@ describe('exception autocapture', () => {
             type: 'onunhandledrejection',
           },
           framesLength: 1,
-          lastFrameFileName: workerFilename,
+          lastFrameFileName: relative(process.cwd(), workerFilename),
           lastFrameHasContext: true,
         })
         res()

--- a/packages/node/src/__tests__/extensions/relative-path.spec.ts
+++ b/packages/node/src/__tests__/extensions/relative-path.spec.ts
@@ -14,97 +14,41 @@ describe('relative path modifier', () => {
     }
   }
 
-  it('should convert absolute paths to relative', async () => {
+  it.each([
+    { label: 'converts absolute path to relative', filename: '/app/src/index.js', expected: 'src/index.js' },
+    { label: 'handles nested paths', filename: '/app/src/lib/utils/helpers.js', expected: 'src/lib/utils/helpers.js' },
+    {
+      label: 'handles node_modules paths',
+      filename: '/app/node_modules/express/index.js',
+      expected: 'node_modules/express/index.js',
+    },
+    { label: 'skips node: prefixed paths', filename: 'node:_http_common', expected: 'node:_http_common' },
+    {
+      label: 'skips data: prefixed paths',
+      filename: 'data:text/javascript,console.log(1)',
+      expected: 'data:text/javascript,console.log(1)',
+    },
+    { label: 'skips frames without filename', filename: undefined, expected: undefined },
+    { label: 'leaves already-relative paths unchanged', filename: 'src/index.js', expected: 'src/index.js' },
+    {
+      label: 'handles paths outside the base path',
+      filename: '/other/project/file.js',
+      expected: '../other/project/file.js',
+    },
+  ])('$label', async ({ filename, expected }) => {
     const modifier = createRelativePathModifier('/app')
-    const frames = [makeFrame({ filename: '/app/src/index.js' })]
-
-    const result = await modifier(frames)
-
-    expect(result[0].filename).toBe('src/index.js')
-    expect(result[0].abs_path).toBeUndefined()
-  })
-
-  it('should handle nested paths', async () => {
-    const modifier = createRelativePathModifier('/app')
-    const frames = [makeFrame({ filename: '/app/src/lib/utils/helpers.js' })]
-
-    const result = await modifier(frames)
-
-    expect(result[0].filename).toBe('src/lib/utils/helpers.js')
-    expect(result[0].abs_path).toBeUndefined()
-  })
-
-  it('should handle node_modules paths', async () => {
-    const modifier = createRelativePathModifier('/app')
-    const frames = [makeFrame({ filename: '/app/node_modules/express/index.js', in_app: false })]
-
-    const result = await modifier(frames)
-
-    expect(result[0].filename).toBe('node_modules/express/index.js')
-    expect(result[0].abs_path).toBeUndefined()
-    expect(result[0].in_app).toBe(false)
-  })
-
-  it('should skip node: prefixed paths', async () => {
-    const modifier = createRelativePathModifier('/app')
-    const frames = [makeFrame({ filename: 'node:_http_common' })]
-
-    const result = await modifier(frames)
-
-    expect(result[0].filename).toBe('node:_http_common')
-    expect(result[0].abs_path).toBeUndefined()
-  })
-
-  it('should skip data: prefixed paths', async () => {
-    const modifier = createRelativePathModifier('/app')
-    const frames = [makeFrame({ filename: 'data:text/javascript,console.log(1)' })]
-
-    const result = await modifier(frames)
-
-    expect(result[0].filename).toBe('data:text/javascript,console.log(1)')
-    expect(result[0].abs_path).toBeUndefined()
-  })
-
-  it('should skip frames without filename', async () => {
-    const modifier = createRelativePathModifier('/app')
-    const frames = [makeFrame({ filename: undefined })]
-
-    const result = await modifier(frames)
-
-    expect(result[0].filename).toBeUndefined()
-    expect(result[0].abs_path).toBeUndefined()
-  })
-
-  it('should leave already-relative paths unchanged', async () => {
-    const modifier = createRelativePathModifier('/app')
-    const frames = [makeFrame({ filename: 'src/index.js' })]
-
-    const result = await modifier(frames)
-
-    expect(result[0].filename).toBe('src/index.js')
-    expect(result[0].abs_path).toBeUndefined()
+    const result = await modifier([makeFrame({ filename })])
+    expect(result[0].filename).toBe(expected)
   })
 
   it('should preserve in_app value', async () => {
     const modifier = createRelativePathModifier('/app')
-    const frames = [
+    const result = await modifier([
       makeFrame({ filename: '/app/src/index.js', in_app: true }),
       makeFrame({ filename: '/app/node_modules/lib/index.js', in_app: false }),
-    ]
-
-    const result = await modifier(frames)
+    ])
 
     expect(result[0].in_app).toBe(true)
     expect(result[1].in_app).toBe(false)
-  })
-
-  it('should handle paths outside the base path', async () => {
-    const modifier = createRelativePathModifier('/app')
-    const frames = [makeFrame({ filename: '/other/project/file.js' })]
-
-    const result = await modifier(frames)
-
-    expect(result[0].filename).toBe('../other/project/file.js')
-    expect(result[0].abs_path).toBeUndefined()
   })
 })

--- a/packages/node/src/__tests__/extensions/relative-path.spec.ts
+++ b/packages/node/src/__tests__/extensions/relative-path.spec.ts
@@ -1,0 +1,110 @@
+import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
+import { createRelativePathModifier } from '@/extensions/error-tracking/modifiers/relative-path.node'
+
+describe('relative path modifier', () => {
+  function makeFrame(overrides: Partial<CoreErrorTracking.StackFrame> = {}): CoreErrorTracking.StackFrame {
+    return {
+      platform: 'node:javascript',
+      filename: '/app/src/index.js',
+      function: 'handler',
+      lineno: 10,
+      colno: 5,
+      in_app: true,
+      ...overrides,
+    }
+  }
+
+  it('should convert absolute paths to relative', async () => {
+    const modifier = createRelativePathModifier('/app')
+    const frames = [makeFrame({ filename: '/app/src/index.js' })]
+
+    const result = await modifier(frames)
+
+    expect(result[0].filename).toBe('src/index.js')
+    expect(result[0].abs_path).toBe('/app/src/index.js')
+  })
+
+  it('should handle nested paths', async () => {
+    const modifier = createRelativePathModifier('/app')
+    const frames = [makeFrame({ filename: '/app/src/lib/utils/helpers.js' })]
+
+    const result = await modifier(frames)
+
+    expect(result[0].filename).toBe('src/lib/utils/helpers.js')
+    expect(result[0].abs_path).toBe('/app/src/lib/utils/helpers.js')
+  })
+
+  it('should handle node_modules paths', async () => {
+    const modifier = createRelativePathModifier('/app')
+    const frames = [makeFrame({ filename: '/app/node_modules/express/index.js', in_app: false })]
+
+    const result = await modifier(frames)
+
+    expect(result[0].filename).toBe('node_modules/express/index.js')
+    expect(result[0].abs_path).toBe('/app/node_modules/express/index.js')
+    expect(result[0].in_app).toBe(false)
+  })
+
+  it('should skip node: prefixed paths', async () => {
+    const modifier = createRelativePathModifier('/app')
+    const frames = [makeFrame({ filename: 'node:_http_common' })]
+
+    const result = await modifier(frames)
+
+    expect(result[0].filename).toBe('node:_http_common')
+    expect(result[0].abs_path).toBeUndefined()
+  })
+
+  it('should skip data: prefixed paths', async () => {
+    const modifier = createRelativePathModifier('/app')
+    const frames = [makeFrame({ filename: 'data:text/javascript,console.log(1)' })]
+
+    const result = await modifier(frames)
+
+    expect(result[0].filename).toBe('data:text/javascript,console.log(1)')
+    expect(result[0].abs_path).toBeUndefined()
+  })
+
+  it('should skip frames without filename', async () => {
+    const modifier = createRelativePathModifier('/app')
+    const frames = [makeFrame({ filename: undefined })]
+
+    const result = await modifier(frames)
+
+    expect(result[0].filename).toBeUndefined()
+    expect(result[0].abs_path).toBeUndefined()
+  })
+
+  it('should leave already-relative paths unchanged', async () => {
+    const modifier = createRelativePathModifier('/app')
+    const frames = [makeFrame({ filename: 'src/index.js' })]
+
+    const result = await modifier(frames)
+
+    expect(result[0].filename).toBe('src/index.js')
+    expect(result[0].abs_path).toBeUndefined()
+  })
+
+  it('should preserve in_app value', async () => {
+    const modifier = createRelativePathModifier('/app')
+    const frames = [
+      makeFrame({ filename: '/app/src/index.js', in_app: true }),
+      makeFrame({ filename: '/app/node_modules/lib/index.js', in_app: false }),
+    ]
+
+    const result = await modifier(frames)
+
+    expect(result[0].in_app).toBe(true)
+    expect(result[1].in_app).toBe(false)
+  })
+
+  it('should handle paths outside the base path', async () => {
+    const modifier = createRelativePathModifier('/app')
+    const frames = [makeFrame({ filename: '/other/project/file.js' })]
+
+    const result = await modifier(frames)
+
+    expect(result[0].filename).toBe('../other/project/file.js')
+    expect(result[0].abs_path).toBe('/other/project/file.js')
+  })
+})

--- a/packages/node/src/__tests__/extensions/relative-path.spec.ts
+++ b/packages/node/src/__tests__/extensions/relative-path.spec.ts
@@ -21,7 +21,7 @@ describe('relative path modifier', () => {
     const result = await modifier(frames)
 
     expect(result[0].filename).toBe('src/index.js')
-    expect(result[0].abs_path).toBe('/app/src/index.js')
+    expect(result[0].abs_path).toBeUndefined()
   })
 
   it('should handle nested paths', async () => {
@@ -31,7 +31,7 @@ describe('relative path modifier', () => {
     const result = await modifier(frames)
 
     expect(result[0].filename).toBe('src/lib/utils/helpers.js')
-    expect(result[0].abs_path).toBe('/app/src/lib/utils/helpers.js')
+    expect(result[0].abs_path).toBeUndefined()
   })
 
   it('should handle node_modules paths', async () => {
@@ -41,7 +41,7 @@ describe('relative path modifier', () => {
     const result = await modifier(frames)
 
     expect(result[0].filename).toBe('node_modules/express/index.js')
-    expect(result[0].abs_path).toBe('/app/node_modules/express/index.js')
+    expect(result[0].abs_path).toBeUndefined()
     expect(result[0].in_app).toBe(false)
   })
 
@@ -105,6 +105,6 @@ describe('relative path modifier', () => {
     const result = await modifier(frames)
 
     expect(result[0].filename).toBe('../other/project/file.js')
-    expect(result[0].abs_path).toBe('/other/project/file.js')
+    expect(result[0].abs_path).toBeUndefined()
   })
 })

--- a/packages/node/src/entrypoints/index.node.ts
+++ b/packages/node/src/entrypoints/index.node.ts
@@ -2,6 +2,7 @@ export * from '../exports'
 
 import { createModulerModifier } from '../extensions/error-tracking/modifiers/module.node'
 import { addSourceContext } from '../extensions/error-tracking/modifiers/context-lines.node'
+import { createRelativePathModifier } from '../extensions/error-tracking/modifiers/relative-path.node'
 import ErrorTracking from '../extensions/error-tracking'
 
 import { PostHogBackendClient } from '../client'
@@ -17,7 +18,7 @@ ErrorTracking.errorPropertiesBuilder = new CoreErrorTracking.ErrorPropertiesBuil
     new CoreErrorTracking.PrimitiveCoercer(),
   ],
   CoreErrorTracking.createStackParser('node:javascript', CoreErrorTracking.nodeStackLineParser),
-  [createModulerModifier(), addSourceContext]
+  [createModulerModifier(), addSourceContext, createRelativePathModifier()]
 )
 
 export class PostHog extends PostHogBackendClient {

--- a/packages/node/src/extensions/error-tracking/modifiers/relative-path.node.ts
+++ b/packages/node/src/extensions/error-tracking/modifiers/relative-path.node.ts
@@ -2,7 +2,9 @@ import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { relative, isAbsolute, sep } from 'path'
 
 export function createRelativePathModifier(basePath: string = process.cwd()) {
-  const normalizedBase = sep === '\\' ? basePath.replace(/\\/g, '/') : basePath
+  const isWindows = sep === '\\'
+  const toUnix = (p: string) => (isWindows ? p.replace(/\\/g, '/') : p)
+  const normalizedBase = toUnix(basePath)
 
   return async (frames: CoreErrorTracking.StackFrame[]): Promise<CoreErrorTracking.StackFrame[]> => {
     for (const frame of frames) {
@@ -10,11 +12,7 @@ export function createRelativePathModifier(basePath: string = process.cwd()) {
         continue
       }
       if (isAbsolute(frame.filename)) {
-        const normalizedFilename = sep === '\\' ? frame.filename.replace(/\\/g, '/') : frame.filename
-        frame.filename = relative(normalizedBase, normalizedFilename)
-        if (sep === '\\') {
-          frame.filename = frame.filename.replace(/\\/g, '/')
-        }
+        frame.filename = toUnix(relative(normalizedBase, toUnix(frame.filename)))
       }
     }
     return frames

--- a/packages/node/src/extensions/error-tracking/modifiers/relative-path.node.ts
+++ b/packages/node/src/extensions/error-tracking/modifiers/relative-path.node.ts
@@ -1,0 +1,23 @@
+import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
+import { relative, isAbsolute, sep } from 'path'
+
+export function createRelativePathModifier(basePath: string = process.cwd()) {
+  const normalizedBase = sep === '\\' ? basePath.replace(/\\/g, '/') : basePath
+
+  return async (frames: CoreErrorTracking.StackFrame[]): Promise<CoreErrorTracking.StackFrame[]> => {
+    for (const frame of frames) {
+      if (!frame.filename || frame.filename.startsWith('node:') || frame.filename.startsWith('data:')) {
+        continue
+      }
+      if (isAbsolute(frame.filename)) {
+        frame.abs_path = frame.filename
+        const normalizedFilename = sep === '\\' ? frame.filename.replace(/\\/g, '/') : frame.filename
+        frame.filename = relative(normalizedBase, normalizedFilename)
+        if (sep === '\\') {
+          frame.filename = frame.filename.replace(/\\/g, '/')
+        }
+      }
+    }
+    return frames
+  }
+}

--- a/packages/node/src/extensions/error-tracking/modifiers/relative-path.node.ts
+++ b/packages/node/src/extensions/error-tracking/modifiers/relative-path.node.ts
@@ -10,7 +10,6 @@ export function createRelativePathModifier(basePath: string = process.cwd()) {
         continue
       }
       if (isAbsolute(frame.filename)) {
-        frame.abs_path = frame.filename
         const normalizedFilename = sep === '\\' ? frame.filename.replace(/\\/g, '/') : frame.filename
         frame.filename = relative(normalizedBase, normalizedFilename)
         if (sep === '\\') {


### PR DESCRIPTION
## Problem

The Node.js SDK sends absolute file paths in error tracking stack frames (e.g., `/Users/alice/myapp/src/index.js`). This causes:
- **Poor fingerprinting in Cymbal**: the same error on different machines produces different fingerprints because absolute paths differ
- **Privacy concerns**: absolute paths leak filesystem structure (usernames, deployment paths)

Cymbal does NOT use `filename` for source map resolution (it uses `chunk_id` + `lineno`/`colno`), so making it relative is safe for symbolication.

## Changes

Adds a `createRelativePathModifier()` that runs as the **last** frame modifier, after module and context-lines modifiers have already used the absolute paths they need. For each frame with an absolute `filename`:
- Stores the original in `abs_path`
- Converts `filename` to a relative path using `process.cwd()` as base

Skips `node:`, `data:`, and already-relative paths. No `fs` dependency so it works in edge environments.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages