### PR TITLE
feat(web-vitals): polyfill `Array.prototype.at()` in web analytics

### DIFF
--- a/packages/browser/src/__tests__/extensions/web-vitals-polyfill.test.ts
+++ b/packages/browser/src/__tests__/extensions/web-vitals-polyfill.test.ts
@@ -1,0 +1,50 @@
+describe('web-vitals Array.prototype.at polyfill', () => {
+    const originalAt = Array.prototype.at
+
+    beforeEach(() => {
+        jest.resetModules()
+    })
+
+    afterEach(() => {
+        if (originalAt) {
+            // eslint-disable-next-line no-extend-native
+            Object.defineProperty(Array.prototype, 'at', {
+                value: originalAt,
+                writable: true,
+                configurable: true,
+            })
+        }
+    })
+
+    it('installs Array.prototype.at when missing', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (Array.prototype as any).at
+        expect(Array.prototype.at).toBeUndefined()
+
+        require('../../extensions/web-vitals/polyfill')
+
+        expect(typeof Array.prototype.at).toBe('function')
+        expect([10, 20, 30].at(0)).toBe(10)
+        expect([10, 20, 30].at(2)).toBe(30)
+        expect([10, 20, 30].at(-1)).toBe(30)
+        expect([10, 20, 30].at(-3)).toBe(10)
+        expect([10, 20, 30].at(5)).toBeUndefined()
+        expect([10, 20, 30].at(-5)).toBeUndefined()
+        expect([].at(0)).toBeUndefined()
+    })
+
+    it('does not overwrite a native Array.prototype.at', () => {
+        const marker = jest.fn().mockReturnValue('native')
+        // eslint-disable-next-line no-extend-native
+        Object.defineProperty(Array.prototype, 'at', {
+            value: marker,
+            writable: true,
+            configurable: true,
+        })
+
+        require('../../extensions/web-vitals/polyfill')
+
+        expect(Array.prototype.at).toBe(marker)
+        expect([1, 2, 3].at(0)).toBe('native')
+    })
+})

--- a/packages/browser/src/entrypoints/web-vitals-with-attribution.ts
+++ b/packages/browser/src/entrypoints/web-vitals-with-attribution.ts
@@ -16,6 +16,7 @@
  *
  * @see web-vitals.ts for the lighter, default bundle
  */
+import '../extensions/web-vitals/polyfill'
 import { assignableWindow } from '../utils/globals'
 
 import {

--- a/packages/browser/src/entrypoints/web-vitals.ts
+++ b/packages/browser/src/entrypoints/web-vitals.ts
@@ -15,6 +15,7 @@
  *
  * @see web-vitals-with-attribution.ts
  */
+import '../extensions/web-vitals/polyfill'
 import { assignableWindow } from '../utils/globals'
 
 import { onINP, onLCP, onCLS, onFCP } from 'web-vitals'

--- a/packages/browser/src/extensions/web-vitals/polyfill.ts
+++ b/packages/browser/src/extensions/web-vitals/polyfill.ts
@@ -1,0 +1,3 @@
+// web-vitals v5 uses Array.prototype.at() (ES2022), absent in Safari < 15.4 and
+// synthetic monitoring browsers (e.g. Pingdom). Only these two bundles pay the cost.
+import 'core-js/stable/array/at'

--- a/packages/browser/src/extensions/web-vitals/polyfill.ts
+++ b/packages/browser/src/extensions/web-vitals/polyfill.ts
@@ -1,3 +1,2 @@
-// web-vitals v5 uses Array.prototype.at() (ES2022), absent in Safari < 15.4 and
-// synthetic monitoring browsers (e.g. Pingdom). Only these two bundles pay the cost.
+// web-vitals uses Array.prototype.at() (ES2022)
 import 'core-js/stable/array/at'


### PR DESCRIPTION
## Problem

web-vitals uses `Array.prototype.at()` (ES2022). Customer reported issues when running with Pingdom synthetic monitoring.

## Changes

Polyfill the `Array.prototype.at` method on the web-vitals script from `core-js`

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
