### PR TITLE
feat: add toolbar state helpers

### DIFF
--- a/.changeset/clean-schools-hunt.md
+++ b/.changeset/clean-schools-hunt.md
@@ -1,0 +1,7 @@
+---
+'@posthog/core': minor
+'@posthog/types': minor
+'posthog-js': minor
+---
+
+Add public toolbar helpers to the browser SDK: `isToolbarLoaded()` and `hideToolbar()`.

--- a/packages/browser/src/__tests__/extensions/toolbar.test.ts
+++ b/packages/browser/src/__tests__/extensions/toolbar.test.ts
@@ -192,6 +192,25 @@ describe('Toolbar', () => {
 
             expect(toolbar.loadToolbar(toolbarParams)).toBe(true)
         })
+
+        it('should report when the toolbar is loaded', () => {
+            expect(toolbar.isToolbarLoaded()).toBe(false)
+
+            expect(toolbar.loadToolbar(toolbarParams)).toBe(true)
+
+            expect(toolbar.isToolbarLoaded()).toBe(true)
+        })
+
+        it('should hide the toolbar and clear the persisted params', () => {
+            expect(toolbar.loadToolbar(toolbarParams)).toBe(true)
+            expect(toolbar.hideToolbar()).toBe(true)
+            expect(toolbar.isToolbarLoaded()).toBe(false)
+            expect(window.localStorage.getItem('_postHogToolbarParams')).toBeNull()
+        })
+
+        it('should return false when hiding an unloaded toolbar', () => {
+            expect(toolbar.hideToolbar()).toBe(false)
+        })
     })
 
     describe('load and close toolbar with minimal params', () => {

--- a/packages/browser/src/extensions/toolbar.ts
+++ b/packages/browser/src/extensions/toolbar.ts
@@ -37,6 +37,25 @@ export class Toolbar implements Extension {
         return assignableWindow['ph_toolbar_state'] ?? ToolbarState.UNINITIALIZED
     }
 
+    isToolbarLoaded(): boolean {
+        return !!document?.getElementById(TOOLBAR_ID)
+    }
+
+    hideToolbar(): boolean {
+        const toolbar = document?.getElementById(TOOLBAR_ID)
+        const container = toolbar?.closest('.toolbar-global-fade-container')
+
+        if (!toolbar) {
+            return false
+        }
+
+        container?.remove()
+        toolbar.remove()
+        window.localStorage.removeItem(LOCALSTORAGE_KEY)
+
+        return true
+    }
+
     initialize(): boolean {
         return this.maybeLoadToolbar()
     }

--- a/packages/browser/src/extensions/toolbar.ts
+++ b/packages/browser/src/extensions/toolbar.ts
@@ -4,7 +4,7 @@ import { ToolbarParams } from '../types'
 import { _getHashParam } from '../utils/request-utils'
 import { createLogger } from '../utils/logger'
 import { window, document, assignableWindow } from '../utils/globals'
-import { TOOLBAR_ID } from '../constants'
+import { TOOLBAR_CONTAINER_CLASS, TOOLBAR_ID } from '../constants'
 import { isFunction, isNullish } from '@posthog/core'
 import { Extension } from './types'
 
@@ -43,7 +43,7 @@ export class Toolbar implements Extension {
 
     hideToolbar(): boolean {
         const toolbar = document?.getElementById(TOOLBAR_ID)
-        const container = toolbar?.closest('.toolbar-global-fade-container')
+        const container = toolbar?.closest?.(`.${TOOLBAR_CONTAINER_CLASS}`)
 
         if (!toolbar) {
             return false

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -3339,6 +3339,32 @@ export class PostHog implements PostHogInterface {
     }
 
     /**
+     * Returns whether the [toolbar](/docs/toolbar) is currently loaded.
+     *
+     * {@label Toolbar}
+     *
+     * @public
+     *
+     * @returns {boolean} Whether the toolbar is loaded
+     */
+    isToolbarLoaded(): boolean {
+        return this.toolbar?.isToolbarLoaded() ?? false
+    }
+
+    /**
+     * Hides the [toolbar](/docs/toolbar) if it is currently loaded.
+     *
+     * {@label Toolbar}
+     *
+     * @public
+     *
+     * @returns {boolean} Whether the toolbar was hidden
+     */
+    hideToolbar(): boolean {
+        return this.toolbar?.hideToolbar() ?? false
+    }
+
+    /**
      * Returns the value of a super property. Returns undefined if the property doesn't exist.
      *
      * {@label Identification}

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -665,6 +665,20 @@ export interface PostHog {
      */
     loadToolbar(params: ToolbarParams): boolean
 
+    /**
+     * Returns whether the PostHog toolbar is currently loaded.
+     *
+     * @returns Whether the toolbar is loaded
+     */
+    isToolbarLoaded(): boolean
+
+    /**
+     * Hide the PostHog toolbar if it is currently loaded.
+     *
+     * @returns Whether the toolbar was hidden
+     */
+    hideToolbar(): boolean
+
     // ============================================================================
     // Page View
     // ============================================================================


### PR DESCRIPTION
## Why

We wanted to add a simple toolbar toggle in our app, but the SDK only exposed `loadToolbar()`. That made us reach into DOM state and clear toolbar storage manually to figure out whether the toolbar was open and how to hide it again.

## What changed

- add `posthog.isToolbarLoaded()`
- add `posthog.hideToolbar()`
- expose both on the public `PostHog` type
- add unit coverage for the toolbar extension
- include a changeset
