### PR TITLE
fix: avoid Blob.stream for native gzip

### DIFF
--- a/.changeset/wise-owls-refuse.md
+++ b/.changeset/wise-owls-refuse.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-js': patch
+---
+
+Avoid using `Blob.stream()` for native async gzip compression to prevent Safari `NotReadableError` stream failures.

--- a/packages/core/src/__tests__/gzip.spec.ts
+++ b/packages/core/src/__tests__/gzip.spec.ts
@@ -40,6 +40,20 @@ describe('gzip', () => {
       expect(isGzipSupported()).toBe(false)
       ;(globalThis as any).CompressionStream = CompressionStream
     })
+
+    it('should return false if TextEncoder not available', () => {
+      const TextEncoder = globalThis.TextEncoder
+      delete (globalThis as any).TextEncoder
+      expect(isGzipSupported()).toBe(false)
+      ;(globalThis as any).TextEncoder = TextEncoder
+    })
+
+    it('should return false if Response.blob not available', () => {
+      const blob = globalThis.Response.prototype.blob
+      delete (globalThis.Response.prototype as any).blob
+      expect(isGzipSupported()).toBe(false)
+      ;(globalThis.Response.prototype as any).blob = blob
+    })
   })
   describe('isNativeAsyncGzipReadError', () => {
     it('returns true for NotReadableError', () => {
@@ -58,6 +72,20 @@ describe('gzip', () => {
 
       await expect(gzipCompress(RANDOM_TEST_INPUT, false, { rethrow: true })).rejects.toThrow()
       ;(globalThis as any).CompressionStream = CompressionStream
+    })
+
+    it('does not read input using Blob.stream', async () => {
+      const blobStream = Blob.prototype.stream
+      Blob.prototype.stream = jest.fn(() => {
+        throw new Error('Blob.stream should not be used')
+      })
+
+      try {
+        const compressed = await gzipCompress(API_TEST_INPUT, false, { rethrow: true })
+        expect(compressed).not.toBe(null)
+      } finally {
+        Blob.prototype.stream = blobStream
+      }
     })
 
     it('compressed random data should match node', async () => {

--- a/packages/core/src/__tests__/gzip.spec.ts
+++ b/packages/core/src/__tests__/gzip.spec.ts
@@ -34,25 +34,39 @@ describe('gzip', () => {
       expect(globalThis.CompressionStream).toBeDefined()
       expect(isGzipSupported()).toBe(true)
     })
-    it('should return false if CompressStream not available', () => {
-      const CompressionStream = globalThis.CompressionStream
-      delete (globalThis as any).CompressionStream
-      expect(isGzipSupported()).toBe(false)
-      ;(globalThis as any).CompressionStream = CompressionStream
-    })
+    it.each([
+      [
+        'CompressionStream',
+        () => {
+          const CompressionStream = globalThis.CompressionStream
+          delete (globalThis as any).CompressionStream
+          return () => ((globalThis as any).CompressionStream = CompressionStream)
+        },
+      ],
+      [
+        'TextEncoder',
+        () => {
+          const TextEncoder = globalThis.TextEncoder
+          delete (globalThis as any).TextEncoder
+          return () => ((globalThis as any).TextEncoder = TextEncoder)
+        },
+      ],
+      [
+        'Response.blob',
+        () => {
+          const blob = globalThis.Response.prototype.blob
+          delete (globalThis.Response.prototype as any).blob
+          return () => ((globalThis.Response.prototype as any).blob = blob)
+        },
+      ],
+    ])('should return false if %s not available', (_name, removeDependency) => {
+      const restoreDependency = removeDependency()
 
-    it('should return false if TextEncoder not available', () => {
-      const TextEncoder = globalThis.TextEncoder
-      delete (globalThis as any).TextEncoder
-      expect(isGzipSupported()).toBe(false)
-      ;(globalThis as any).TextEncoder = TextEncoder
-    })
-
-    it('should return false if Response.blob not available', () => {
-      const blob = globalThis.Response.prototype.blob
-      delete (globalThis.Response.prototype as any).blob
-      expect(isGzipSupported()).toBe(false)
-      ;(globalThis.Response.prototype as any).blob = blob
+      try {
+        expect(isGzipSupported()).toBe(false)
+      } finally {
+        restoreDependency()
+      }
     })
   })
   describe('isNativeAsyncGzipReadError', () => {

--- a/packages/core/src/__tests__/gzip.spec.ts
+++ b/packages/core/src/__tests__/gzip.spec.ts
@@ -102,6 +102,30 @@ describe('gzip', () => {
       }
     })
 
+    it('aborts the compression writer when writing input fails', async () => {
+      const CompressionStream = globalThis.CompressionStream
+      const writeError = new Error('write failed')
+      const abort = jest.fn(() => Promise.resolve())
+
+      ;(globalThis as any).CompressionStream = jest.fn(() => ({
+        writable: {
+          getWriter: () => ({
+            write: () => Promise.reject(writeError),
+            close: jest.fn(),
+            abort,
+          }),
+        },
+        readable: new ReadableStream(),
+      }))
+
+      try {
+        await expect(gzipCompress(API_TEST_INPUT, false, { rethrow: true })).rejects.toBe(writeError)
+        expect(abort).toHaveBeenCalledWith(writeError)
+      } finally {
+        ;(globalThis as any).CompressionStream = CompressionStream
+      }
+    })
+
     it('compressed random data should match node', async () => {
       const compressed = await gzipCompress(RANDOM_TEST_INPUT)
       expect(compressed).not.toBe(null)

--- a/packages/core/src/gzip.ts
+++ b/packages/core/src/gzip.ts
@@ -3,7 +3,12 @@
  * This API (as of 2025-05-07) is not available on React Native.
  */
 export function isGzipSupported(): boolean {
-  return 'CompressionStream' in globalThis
+  return (
+    'CompressionStream' in globalThis &&
+    'TextEncoder' in globalThis &&
+    'Response' in globalThis &&
+    typeof Response.prototype.blob === 'function'
+  )
 }
 
 export const isNativeAsyncGzipReadError = (error: unknown): boolean => {
@@ -31,15 +36,14 @@ export type GzipCompressOptions = {
  */
 export async function gzipCompress(input: string, isDebug = true, options?: GzipCompressOptions): Promise<Blob | null> {
   try {
-    // Turn the string into a stream using a Blob, and then compress it
-    const dataStream = new Blob([input], {
-      type: 'text/plain',
-    }).stream()
+    const compressedStream = new CompressionStream('gzip')
+    const writer = compressedStream.writable.getWriter()
 
-    const compressedStream = dataStream.pipeThrough(new CompressionStream('gzip'))
+    const writePromise = writer.write(new TextEncoder().encode(input)).then(() => writer.close())
+    const responsePromise = new Response(compressedStream.readable).blob()
 
-    // Using a Response to easily extract the readablestream value. Decoding into a string for fetch
-    return await new Response(compressedStream).blob()
+    const [compressed] = await Promise.all([responsePromise, writePromise])
+    return compressed
   } catch (error) {
     if (options?.rethrow) {
       throw error

--- a/packages/core/src/gzip.ts
+++ b/packages/core/src/gzip.ts
@@ -39,7 +39,17 @@ export async function gzipCompress(input: string, isDebug = true, options?: Gzip
     const compressedStream = new CompressionStream('gzip')
     const writer = compressedStream.writable.getWriter()
 
-    const writePromise = writer.write(new TextEncoder().encode(input)).then(() => writer.close())
+    const writePromise = writer
+      .write(new TextEncoder().encode(input))
+      .then(() => writer.close())
+      .catch(async (err) => {
+        try {
+          await writer.abort(err)
+        } catch {
+          // Ignore abort failures and rethrow the original compression error below.
+        }
+        throw err
+      })
     const responsePromise = new Response(compressedStream.readable).blob()
 
     const [compressed] = await Promise.all([responsePromise, writePromise])


### PR DESCRIPTION
## Problem

Safari/WebKit users are still seeing `NotReadableError: The I/O read operation failed` from the native async gzip path. The stack points at `new Blob([input]).stream()` inside `@posthog/core`'s `gzipCompress`, before the browser SDK can recover and retry.

## Changes

- Rework `gzipCompress` to write UTF-8 bytes directly to `CompressionStream.writable` instead of creating a `Blob` and reading it with `Blob.stream()`.
- Keep returning a `Blob` so existing callers continue to convert the compressed result to `ArrayBuffer` before sending requests.
- Tighten `isGzipSupported()` to require the APIs used by this implementation (`CompressionStream`, `TextEncoder`, and `Response.blob`).
- Add tests that verify `Blob.stream()` is not used and gzip output still exactly matches Node's gzip output.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

Also bumps `@posthog/core` via changeset.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
