### PR TITLE
fix(react-native): include survey responses on dismiss

### DIFF
--- a/.changeset/wise-dryers-sip.md
+++ b/.changeset/wise-dryers-sip.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Include survey response properties and partial completion state on survey dismissal events.

--- a/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
+++ b/packages/react-native/src/surveys/PostHogSurveyProvider.tsx
@@ -12,7 +12,13 @@ import { usePostHog } from '../hooks/usePostHog'
 import { useFeatureFlags } from '../hooks/useFeatureFlags'
 import { PostHog } from '../posthog-rn'
 
-type ActiveSurveyContextType = { survey: Survey; onShow: () => void; onClose: (submitted: boolean) => void } | undefined
+type ActiveSurveyContextType =
+  | {
+      survey: Survey
+      onShow: () => void
+      onClose: (submitted: boolean, responses: Record<string, string | number | string[] | null>) => void
+    }
+  | undefined
 const ActiveSurveyContext = React.createContext<ActiveSurveyContextType>(undefined)
 // export const useActiveSurvey = (): ActiveSurveyContextType => React.useContext(ActiveSurveyContext)
 
@@ -155,11 +161,11 @@ export function PostHogSurveyProvider(props: PostHogSurveyProviderProps): JSX.El
         sendSurveyShownEvent(activeSurvey, posthog)
         setLastSeenSurveyDate(new Date())
       },
-      onClose: (submitted: boolean) => {
+      onClose: (submitted: boolean, responses: Record<string, string | number | string[] | null>) => {
         setSeenSurvey(activeSurvey.id)
         setActiveSurvey(undefined)
         if (!submitted) {
-          dismissedSurveyEvent(activeSurvey, posthog)
+          dismissedSurveyEvent(activeSurvey, responses, posthog)
         }
       },
     }

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -13,14 +13,15 @@ export type SurveyModalProps = {
   survey: Survey
   appearance: SurveyAppearanceTheme
   onShow: () => void
-  onClose: (submitted: boolean) => void
+  onClose: (submitted: boolean, responses: Record<string, string | number | string[] | null>) => void
   androidKeyboardBehavior?: 'padding' | 'height'
 }
 
 export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
   const { survey, appearance, onShow, androidKeyboardBehavior = 'height' } = props
   const [isSurveySent, setIsSurveySent] = useState(false)
-  const onClose = useCallback(() => props.onClose(isSurveySent), [isSurveySent, props])
+  const [responses, setResponses] = useState<Record<string, string | number | string[] | null>>({})
+  const onClose = useCallback(() => props.onClose(isSurveySent, responses), [isSurveySent, props, responses])
   const insets = useOptionalSafeAreaInsets()
 
   const [isVisible] = useState(true)
@@ -59,7 +60,13 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
                 ]}
               >
                 {!shouldShowConfirmation ? (
-                  <Questions survey={survey} appearance={appearance} onSubmit={() => setIsSurveySent(true)} />
+                  <Questions
+                    survey={survey}
+                    appearance={appearance}
+                    responses={responses}
+                    onResponsesChange={setResponses}
+                    onSubmit={() => setIsSurveySent(true)}
+                  />
                 ) : (
                   <ConfirmationMessage
                     appearance={appearance}

--- a/packages/react-native/src/surveys/components/Surveys.tsx
+++ b/packages/react-native/src/surveys/components/Surveys.tsx
@@ -123,15 +123,15 @@ export function Questions({
   survey,
   appearance,
   styleOverrides,
-  responses,
-  onResponsesChange,
+  responses = {},
+  onResponsesChange = () => {},
   onSubmit,
 }: {
   survey: Survey
   appearance: SurveyAppearanceTheme
   styleOverrides?: StyleProp<ViewStyle>
-  responses: Record<string, string | number | string[] | null>
-  onResponsesChange: (responses: Record<string, string | number | string[] | null>) => void
+  responses?: Record<string, string | number | string[] | null>
+  onResponsesChange?: (responses: Record<string, string | number | string[] | null>) => void
   onSubmit: () => void
 }): JSX.Element {
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0)

--- a/packages/react-native/src/surveys/components/Surveys.tsx
+++ b/packages/react-native/src/surveys/components/Surveys.tsx
@@ -9,6 +9,7 @@ import {
   maybeAdd,
   SurveyQuestionBranchingType,
   isUndefined,
+  isNullish,
 } from '@posthog/core'
 import { LinkQuestion, MultipleChoiceQuestion, OpenTextQuestion, RatingQuestion } from './QuestionTypes'
 import { PostHog } from '../../posthog-rn'
@@ -51,11 +52,10 @@ const getSurveyResponseValue = (responses: Record<string, string | number | stri
   return response
 }
 
-export const sendSurveyEvent = (
+function buildSurveyResponseProperties(
   responses: Record<string, string | number | string[] | null> = {},
-  survey: Survey,
-  posthog: PostHog
-): void => {
+  survey: Survey
+): Record<string, unknown> {
   // map question ids also to the old format for back compatibility
   const oldFormatResponses: Record<string, string | number | string[] | null> = {}
   survey.questions.forEach((question: SurveyQuestion) => {
@@ -70,29 +70,49 @@ export const sendSurveyEvent = (
     ...oldFormatResponses,
   }
 
-  posthog.capture('survey sent', {
-    $survey_name: survey.name,
-    $survey_id: survey.id,
-    ...maybeAdd('$survey_iteration', survey.current_iteration),
-    ...maybeAdd('$survey_iteration_start_date', survey.current_iteration_start_date),
+  return {
     $survey_questions: survey.questions.map((question: SurveyQuestion) => ({
       id: question.id,
       question: question.question,
       response: getSurveyResponseValue(responses, question.id),
     })),
     ...allResponses,
+  }
+}
+
+function surveyHasResponses(responses: Record<string, string | number | string[] | null> = {}): boolean {
+  return Object.values(responses).some((response) => !isNullish(response))
+}
+
+export const sendSurveyEvent = (
+  responses: Record<string, string | number | string[] | null> = {},
+  survey: Survey,
+  posthog: PostHog
+): void => {
+  posthog.capture('survey sent', {
+    $survey_name: survey.name,
+    $survey_id: survey.id,
+    ...maybeAdd('$survey_iteration', survey.current_iteration),
+    ...maybeAdd('$survey_iteration_start_date', survey.current_iteration_start_date),
+    ...buildSurveyResponseProperties(responses, survey),
     $set: {
       [getSurveyInteractionProperty(survey, 'responded')]: true,
     },
   })
 }
 
-export const dismissedSurveyEvent = (survey: Survey, posthog: PostHog): void => {
+export const dismissedSurveyEvent = (
+  survey: Survey,
+  responses: Record<string, string | number | string[] | null> = {},
+  posthog: PostHog
+): void => {
   posthog.capture('survey dismissed', {
     $survey_name: survey.name,
     $survey_id: survey.id,
     ...maybeAdd('$survey_iteration', survey.current_iteration),
     ...maybeAdd('$survey_iteration_start_date', survey.current_iteration_start_date),
+    $survey_partially_completed: surveyHasResponses(responses),
+    ...buildSurveyResponseProperties(responses, survey),
     $set: {
       [getSurveyInteractionProperty(survey, 'dismissed')]: true,
     },
@@ -103,14 +123,17 @@ export function Questions({
   survey,
   appearance,
   styleOverrides,
+  responses,
+  onResponsesChange,
   onSubmit,
 }: {
   survey: Survey
   appearance: SurveyAppearanceTheme
   styleOverrides?: StyleProp<ViewStyle>
+  responses: Record<string, string | number | string[] | null>
+  onResponsesChange: (responses: Record<string, string | number | string[] | null>) => void
   onSubmit: () => void
 }): JSX.Element {
-  const [questionsResponses, setQuestionsResponses] = useState({})
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0)
   const surveyQuestions = useMemo(() => getDisplayOrderQuestions(survey), [survey])
   const posthog = usePostHog()
@@ -129,10 +152,10 @@ export function Questions({
     const responseKey = getSurveyNewResponseKey(questionId)
 
     const allResponses = {
-      ...questionsResponses,
+      ...responses,
       [responseKey]: res,
     }
-    setQuestionsResponses(allResponses)
+    onResponsesChange(allResponses)
 
     // Get the next question index based on conditional logic
     const nextStep = getNextSurveyStep(survey, originalQuestionIndex, res)

--- a/packages/react-native/test/sendSurveyEvent.spec.ts
+++ b/packages/react-native/test/sendSurveyEvent.spec.ts
@@ -1,6 +1,27 @@
 import { dismissedSurveyEvent, sendSurveyEvent } from '../src/surveys/components/Surveys'
 import { Survey, SurveyQuestion } from '@posthog/core'
 
+const createMockSurvey = (overrides: Partial<Survey> = {}): Survey => ({
+  id: 'test-survey-id',
+  name: 'Test Survey',
+  questions: [
+    {
+      id: 'question-1',
+      question: 'How satisfied are you?',
+      type: 'rating',
+      scale: 5,
+      originalQuestionIndex: 0,
+    } as SurveyQuestion,
+    {
+      id: 'question-2',
+      question: 'Any additional comments?',
+      type: 'open',
+      originalQuestionIndex: 1,
+    } as SurveyQuestion,
+  ],
+  ...overrides,
+})
+
 describe('sendSurveyEvent', () => {
   let mockPostHog: any
 
@@ -8,27 +29,6 @@ describe('sendSurveyEvent', () => {
     mockPostHog = {
       capture: jest.fn(),
     }
-  })
-
-  const createMockSurvey = (overrides: Partial<Survey> = {}): Survey => ({
-    id: 'test-survey-id',
-    name: 'Test Survey',
-    questions: [
-      {
-        id: 'question-1',
-        question: 'How satisfied are you?',
-        type: 'rating',
-        scale: 5,
-        originalQuestionIndex: 0,
-      } as SurveyQuestion,
-      {
-        id: 'question-2',
-        question: 'Any additional comments?',
-        type: 'open',
-        originalQuestionIndex: 1,
-      } as SurveyQuestion,
-    ],
-    ...overrides,
   })
 
   describe('basic functionality', () => {
@@ -290,27 +290,6 @@ describe('dismissedSurveyEvent', () => {
     mockPostHog = {
       capture: jest.fn(),
     }
-  })
-
-  const createMockSurvey = (overrides: Partial<Survey> = {}): Survey => ({
-    id: 'test-survey-id',
-    name: 'Test Survey',
-    questions: [
-      {
-        id: 'question-1',
-        question: 'How satisfied are you?',
-        type: 'rating',
-        scale: 5,
-        originalQuestionIndex: 0,
-      } as SurveyQuestion,
-      {
-        id: 'question-2',
-        question: 'Any additional comments?',
-        type: 'open',
-        originalQuestionIndex: 1,
-      } as SurveyQuestion,
-    ],
-    ...overrides,
   })
 
   it('captures dismissal responses and marks partial completion when there are answers', () => {

--- a/packages/react-native/test/sendSurveyEvent.spec.ts
+++ b/packages/react-native/test/sendSurveyEvent.spec.ts
@@ -292,65 +292,67 @@ describe('dismissedSurveyEvent', () => {
     }
   })
 
-  it('captures dismissal responses and marks partial completion when there are answers', () => {
+  it.each([
+    {
+      label: 'captures dismissal responses and marks partial completion when there are answers',
+      responses: {
+        '$survey_response_question-1': 4,
+        '$survey_response_question-2': 'Great service!',
+      },
+      expectedPayload: {
+        $survey_name: 'Test Survey',
+        $survey_id: 'test-survey-id',
+        $survey_partially_completed: true,
+        $survey_questions: [
+          {
+            id: 'question-1',
+            question: 'How satisfied are you?',
+            response: 4,
+          },
+          {
+            id: 'question-2',
+            question: 'Any additional comments?',
+            response: 'Great service!',
+          },
+        ],
+        '$survey_response_question-1': 4,
+        '$survey_response_question-2': 'Great service!',
+        $survey_response: 4,
+        $survey_response_1: 'Great service!',
+        $set: {
+          '$survey_dismissed/test-survey-id': true,
+        },
+      },
+    },
+    {
+      label: 'marks dismissal as not partially completed when no answers exist',
+      responses: {},
+      expectedPayload: {
+        $survey_name: 'Test Survey',
+        $survey_id: 'test-survey-id',
+        $survey_partially_completed: false,
+        $survey_questions: [
+          {
+            id: 'question-1',
+            question: 'How satisfied are you?',
+            response: undefined,
+          },
+          {
+            id: 'question-2',
+            question: 'Any additional comments?',
+            response: undefined,
+          },
+        ],
+        $set: {
+          '$survey_dismissed/test-survey-id': true,
+        },
+      },
+    },
+  ])('$label', ({ responses, expectedPayload }) => {
     const survey = createMockSurvey()
-    const responses = {
-      '$survey_response_question-1': 4,
-      '$survey_response_question-2': 'Great service!',
-    }
 
     dismissedSurveyEvent(survey, responses, mockPostHog)
 
-    expect(mockPostHog.capture).toHaveBeenCalledWith('survey dismissed', {
-      $survey_name: 'Test Survey',
-      $survey_id: 'test-survey-id',
-      $survey_partially_completed: true,
-      $survey_questions: [
-        {
-          id: 'question-1',
-          question: 'How satisfied are you?',
-          response: 4,
-        },
-        {
-          id: 'question-2',
-          question: 'Any additional comments?',
-          response: 'Great service!',
-        },
-      ],
-      '$survey_response_question-1': 4,
-      '$survey_response_question-2': 'Great service!',
-      $survey_response: 4,
-      $survey_response_1: 'Great service!',
-      $set: {
-        '$survey_dismissed/test-survey-id': true,
-      },
-    })
-  })
-
-  it('marks dismissal as not partially completed when no answers exist', () => {
-    const survey = createMockSurvey()
-
-    dismissedSurveyEvent(survey, {}, mockPostHog)
-
-    expect(mockPostHog.capture).toHaveBeenCalledWith('survey dismissed', {
-      $survey_name: 'Test Survey',
-      $survey_id: 'test-survey-id',
-      $survey_partially_completed: false,
-      $survey_questions: [
-        {
-          id: 'question-1',
-          question: 'How satisfied are you?',
-          response: undefined,
-        },
-        {
-          id: 'question-2',
-          question: 'Any additional comments?',
-          response: undefined,
-        },
-      ],
-      $set: {
-        '$survey_dismissed/test-survey-id': true,
-      },
-    })
+    expect(mockPostHog.capture).toHaveBeenCalledWith('survey dismissed', expectedPayload)
   })
 })

--- a/packages/react-native/test/sendSurveyEvent.spec.ts
+++ b/packages/react-native/test/sendSurveyEvent.spec.ts
@@ -1,4 +1,4 @@
-import { sendSurveyEvent } from '../src/surveys/components/Surveys'
+import { dismissedSurveyEvent, sendSurveyEvent } from '../src/surveys/components/Surveys'
 import { Survey, SurveyQuestion } from '@posthog/core'
 
 describe('sendSurveyEvent', () => {
@@ -279,6 +279,99 @@ describe('sendSurveyEvent', () => {
           response: 'Good job!',
         },
       ])
+    })
+  })
+})
+
+describe('dismissedSurveyEvent', () => {
+  let mockPostHog: any
+
+  beforeEach(() => {
+    mockPostHog = {
+      capture: jest.fn(),
+    }
+  })
+
+  const createMockSurvey = (overrides: Partial<Survey> = {}): Survey => ({
+    id: 'test-survey-id',
+    name: 'Test Survey',
+    questions: [
+      {
+        id: 'question-1',
+        question: 'How satisfied are you?',
+        type: 'rating',
+        scale: 5,
+        originalQuestionIndex: 0,
+      } as SurveyQuestion,
+      {
+        id: 'question-2',
+        question: 'Any additional comments?',
+        type: 'open',
+        originalQuestionIndex: 1,
+      } as SurveyQuestion,
+    ],
+    ...overrides,
+  })
+
+  it('captures dismissal responses and marks partial completion when there are answers', () => {
+    const survey = createMockSurvey()
+    const responses = {
+      '$survey_response_question-1': 4,
+      '$survey_response_question-2': 'Great service!',
+    }
+
+    dismissedSurveyEvent(survey, responses, mockPostHog)
+
+    expect(mockPostHog.capture).toHaveBeenCalledWith('survey dismissed', {
+      $survey_name: 'Test Survey',
+      $survey_id: 'test-survey-id',
+      $survey_partially_completed: true,
+      $survey_questions: [
+        {
+          id: 'question-1',
+          question: 'How satisfied are you?',
+          response: 4,
+        },
+        {
+          id: 'question-2',
+          question: 'Any additional comments?',
+          response: 'Great service!',
+        },
+      ],
+      '$survey_response_question-1': 4,
+      '$survey_response_question-2': 'Great service!',
+      $survey_response: 4,
+      $survey_response_1: 'Great service!',
+      $set: {
+        '$survey_dismissed/test-survey-id': true,
+      },
+    })
+  })
+
+  it('marks dismissal as not partially completed when no answers exist', () => {
+    const survey = createMockSurvey()
+
+    dismissedSurveyEvent(survey, {}, mockPostHog)
+
+    expect(mockPostHog.capture).toHaveBeenCalledWith('survey dismissed', {
+      $survey_name: 'Test Survey',
+      $survey_id: 'test-survey-id',
+      $survey_partially_completed: false,
+      $survey_questions: [
+        {
+          id: 'question-1',
+          question: 'How satisfied are you?',
+          response: undefined,
+        },
+        {
+          id: 'question-2',
+          question: 'Any additional comments?',
+          response: undefined,
+        },
+      ],
+      $set: {
+        '$survey_dismissed/test-survey-id': true,
+      },
     })
   })
 })


### PR DESCRIPTION
## Summary

- include survey response properties on React Native `survey dismissed` events
- add `$survey_partially_completed` based on whether any in-progress response exists
- pass in-progress responses through the modal close path so dismissals and submissions share the same survey context

## Why

- partial-answer dismissals are still meaningful survey outcomes for downstream notifications
- browser already sends this richer dismissal context; React Native did not
- this brings React Native dismissal events in line with browser semantics and avoids guessing from a single response key
- we’ll follow up shortly with the iOS and Android app-side changes needed to adopt this SDK update

## How did you validate this change?

- ran `pnpm --dir /Users/lucasfaria/src/posthog-js/packages/react-native test:unit -- sendSurveyEvent.spec.ts`
- added coverage for dismissal with answers
- added coverage for dismissal without answers
- verified existing `survey sent` tests still pass
