### PR TITLE
chore: remove release label requirement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,6 +37,5 @@
 ### If releasing new changes
 
 - [ ] Ran `pnpm changeset` to generate a changeset file
-- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
 
 <!-- For more details check RELEASING.md -->

--- a/.github/workflows/check-posthog-major-version.yml
+++ b/.github/workflows/check-posthog-major-version.yml
@@ -24,9 +24,6 @@ jobs:
         
       - name: Check for major version bumps
         id: check-major
-        env:
-          # Avoid wrapping labels JSON in shell single quotes; apostrophes in label text break the script.
-          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels) }}
         run: |
           # Get only added changeset files in this PR
           changesets=$(git diff --name-only --diff-filter=A origin/${{ github.base_ref }}...HEAD | grep '^\.changeset/.*\.md$' | grep -v 'README.md' || true)
@@ -34,14 +31,6 @@ jobs:
           if [ -z "$changesets" ]; then
             echo "No new changesets found in this PR"
             echo "no_changesets=true" >> $GITHUB_OUTPUT
-
-            # Check if PR has release label
-            has_release_label=$(echo "$PR_LABELS_JSON" | jq -r '.[] | select(.name == "release") | .name')
-
-            if [ -n "$has_release_label" ]; then
-              echo "❌ Error: PR has 'release' label but no changeset found"
-              exit 1
-            fi
 
             exit 0
           fi
@@ -190,24 +179,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const hasReleaseLabel = context.payload.pull_request.labels.some(label => label.name === 'release');
+            const comment = `## 📝 No Changeset Found
 
-            const comment = hasReleaseLabel
-              ? `## ❌ No Changeset Found (Build Failed)
-
-            This PR has the \`release\` label but doesn't include a changeset. A changeset is **required** when the release label is present.
-
-            ### How to add a changeset
-
-            Run this command and follow the prompts:
-            \`\`\`bash
-            pnpm changeset
-            \`\`\`
-
-            **Remember:** Never use \`major\` version bumps for \`posthog-js\` as it's autoloaded by clients.`
-              : `## 📝 No Changeset Found
-
-            This PR doesn't include a changeset. A changeset (and the release label) is required to release a new version.
+            This PR doesn't include a changeset. A changeset is required to release a new version.
 
             ### How to add a changeset
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,74 +11,14 @@ on:
     workflow_dispatch:
 
 # Concurrency control: only one release process can run at a time
-# This prevents race conditions if multiple PRs with 'release' label merge simultaneously
+# This prevents race conditions if multiple releasable PRs merge simultaneously
 concurrency:
     group: release
     cancel-in-progress: false
 
 jobs:
-    resolve-release-context:
-        name: Resolve release context
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            pull-requests: read
-        outputs:
-            should-release: ${{ steps.resolve.outputs.should-release }}
-        steps:
-            - name: Resolve release request
-              id: resolve
-              env:
-                  GH_TOKEN: ${{ github.token }}
-                  EVENT_NAME: ${{ github.event_name }}
-                  CURRENT_REF: ${{ github.ref }}
-                  PUSH_SHA: ${{ github.sha }}
-                  PUSH_HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-              run: |
-                  set -euo pipefail
-
-                  SHOULD_RELEASE=false
-
-                  if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-                      if [ "$CURRENT_REF" != "refs/heads/main" ]; then
-                          echo "::notice::Skipping release because workflow_dispatch must be run on main, got $CURRENT_REF."
-                      else
-                          SHOULD_RELEASE=true
-                          echo "✓ Manual release requested on main"
-                      fi
-
-                      echo "should-release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
-                      exit 0
-                  fi
-
-                  if [[ "${PUSH_HEAD_COMMIT_MESSAGE:-}" == *"[version bump]"* ]]; then
-                      echo "::notice::Skipping release for the automated version bump commit."
-                      echo "should-release=false" >> "$GITHUB_OUTPUT"
-                      exit 0
-                  fi
-
-                  PRS_JSON=$(gh api repos/${{ github.repository }}/commits/$PUSH_SHA/pulls)
-                  MATCHING_PR_COUNT=$(echo "$PRS_JSON" | jq '[.[] | select(.merged_at != null and .base.ref == "main" and (.labels | map(.name) | index("release")))] | length')
-
-                  if [ "$MATCHING_PR_COUNT" -eq 0 ]; then
-                      ASSOCIATED_PRS=$(echo "$PRS_JSON" | jq -r '[.[].number | tostring] | join(", ")')
-                      if [ -n "$ASSOCIATED_PRS" ]; then
-                          echo "::notice::Skipping release because push $PUSH_SHA is associated with PR(s) [$ASSOCIATED_PRS], but none currently have the 'release' label."
-                      else
-                          echo "::notice::Skipping release because push $PUSH_SHA is not associated with a merged PR to main that has the 'release' label."
-                      fi
-                      echo "should-release=false" >> "$GITHUB_OUTPUT"
-                      exit 0
-                  fi
-
-                  RELEASE_PRS=$(echo "$PRS_JSON" | jq -r '[.[] | select(.merged_at != null and .base.ref == "main" and (.labels | map(.name) | index("release"))) | "#\(.number)"] | join(", ")')
-                  echo "✓ Release requested by push $PUSH_SHA via $RELEASE_PRS"
-                  echo "should-release=true" >> "$GITHUB_OUTPUT"
-
     check-changesets:
         name: Check for changesets
-        needs: resolve-release-context
-        if: needs.resolve-release-context.outputs.should-release == 'true'
         runs-on: ubuntu-latest
         outputs:
             has-changesets: ${{ steps.check.outputs.has-changesets }}
@@ -115,11 +55,11 @@ jobs:
 
     version-bump:
         name: Bump versions and commit to main
-        needs: [resolve-release-context, check-changesets, notify-approval-needed]
+        needs: [check-changesets, notify-approval-needed]
         runs-on: ubuntu-latest
         # Use `always()` to ensure the job runs even if the notify-approval-needed job fails
         # but still depend on it to be able to use `needs.notify-approval-needed.outputs.slack_ts`
-        if: always() && needs.resolve-release-context.outputs.should-release == 'true' && needs.check-changesets.outputs.has-changesets == 'true'
+        if: always() && needs.check-changesets.outputs.has-changesets == 'true'
         environment: 'NPM Release' # This will require an approval from a maintainer, they are notified in Slack above
         permissions:
             contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,12 +189,12 @@ This will:
 
 ### Publishing
 
-1. Add the `release` label to your PR
-2. When the PR is merged to `main`, the `release.yml` GitHub Action will:
-    - Update package versions
-    - Update CHANGELOG files
-    - Publish to npm
-    - Create GitHub releases
+When a PR containing a changeset is merged to `main`, the `release.yml` GitHub Action will:
+
+- Update package versions
+- Update CHANGELOG files
+- Publish to npm
+- Create GitHub releases
 
 ## CI/CD
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,14 +10,12 @@ pnpm changeset
 
 CLI will prompt questions about the changes you've made and will generate a changeset file for you.
 
-Add a `release` label to your PR to automatically:
+When a PR containing a changeset is merged to `main`, the release workflow will automatically:
 
 1. Bump versions based on changesets
 2. Commit version updates directly to main
 3. Publish packages to npm
 4. Create GitHub releases
-
-All of this happens automatically when the PR is merged - no intermediate PRs needed!
 
 # for posthog-js browser sdk
 


### PR DESCRIPTION
## Problem

The release workflow still required PRs to carry a `release` label before processing changesets. Post-merge review on #3461 pointed out that changesets already encode release intent, so the label gate adds unnecessary workflow/API complexity.

## Changes

- Removed the `resolve-release-context` job and the release-label lookup from `.github/workflows/release.yml`.
- Let `check-changesets` be the release gate for both `push` and manual dispatch runs.
- Updated release documentation and agent guidance to describe changeset-triggered releases.
- Updated missing-changeset bot messaging and the PR template to stop referring to a required `release` label.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
