### PR TITLE
chore: Pin GitHub Actions to SHA digests and bump to latest

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -27,7 +27,7 @@ runs:
       run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node_version }}
         registry-url: https://registry.npmjs.org
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: npm install -g npm@11.6.4
 
-    - uses: actions/cache@v5
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: pnpm-cache
       with:
         path: ${{ steps.pnpm-cache-dir.outputs.PNPM_STORE_PATH }}

--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -16,12 +16,12 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup
 
       - name: Upload bundle size visualization
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         id: viz-upload
         with:
           name: bundle-stats-array.html

--- a/.github/workflows/check-posthog-major-version.yml
+++ b/.github/workflows/check-posthog-major-version.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
         
@@ -78,7 +78,7 @@ jobs:
       
       - name: Remove outdated comments
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           NO_CHANGESETS: ${{ steps.check-major.outputs.no_changesets }}
           MAJOR_BUMP_FOUND: ${{ steps.check-major.outputs.major_bump_found }}
@@ -130,7 +130,7 @@ jobs:
       
       - name: Comment on PR
         if: failure() && steps.check-major.outputs.major_bump_found == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           CHANGESET_FILE: ${{ steps.check-major.outputs.changeset_file }}
         with:
@@ -186,7 +186,7 @@ jobs:
       
       - name: Comment about missing changeset
         if: always() && steps.check-major.outputs.no_changesets == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -60,7 +60,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       with:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
@@ -90,6 +90,6 @@ jobs:
     #     exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -14,7 +14,7 @@ jobs:
           app_id: ${{ secrets.GH_APP_POSTHOG_JS_TESTS_APP_ID }}
           private_key: ${{ secrets.GH_APP_POSTHOG_JS_TESTS_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/es-check.yml
+++ b/.github/workflows/es-check.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and check ES5/ES6 support
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/generate-references.yml
+++ b/.github/workflows/generate-references.yml
@@ -26,7 +26,7 @@ jobs:
           private_key: ${{ secrets.GH_APP_POSTHOG_JS_TESTS_PRIVATE_KEY }}
 
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,7 +39,7 @@ jobs:
             install: "chromium"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/label-alpha-release.yml
+++ b/.github/workflows/label-alpha-release.yml
@@ -39,7 +39,7 @@ jobs:
       id-token: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup environment
         uses: ./.github/actions/setup
@@ -29,7 +29,7 @@ jobs:
     name: Playwright E2E tests
     runs-on: depot-ubuntu-latest-8
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
         run: pnpm exec playwright test --workers=5
         working-directory: packages/browser
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() && steps.is-affected.outputs.is-affected == 'true' }}
         with:
           name: playwright-report
@@ -69,7 +69,7 @@ jobs:
     runs-on: depot-ubuntu-latest-8
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -196,7 +196,7 @@ jobs:
 
       - name: Remove outdated comment
         if: steps.find-passing-comment.outputs.comment-id != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMENT_ID: ${{ steps.find-passing-comment.outputs.comment-id }}
         with:
@@ -207,7 +207,7 @@ jobs:
               comment_id: process.env.COMMENT_ID
             })
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() && steps.is-affected.outputs.is-affected == 'true' }}
         with:
           name: playwright-compat-report
@@ -218,7 +218,7 @@ jobs:
     name: Functional tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup environment
         uses: ./.github/actions/setup
       - run: pnpm test:functional
@@ -227,7 +227,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup environment
         uses: ./.github/actions/setup
         with:
@@ -241,7 +241,7 @@ jobs:
     name: Write mangled property names
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup environment
         uses: ./.github/actions/setup

--- a/.github/workflows/minimum-version-ts-check.yaml
+++ b/.github/workflows/minimum-version-ts-check.yaml
@@ -28,7 +28,7 @@ jobs:
             extra-flags: "--ignoreConfig"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup
         with:

--- a/.github/workflows/posthog-com-upgrade.yml
+++ b/.github/workflows/posthog-com-upgrade.yml
@@ -31,7 +31,7 @@ jobs:
                   private_key: ${{ secrets.GH_APP_POSTHOG_JS_UPGRADER_PRIVATE_KEY }}
 
             - name: Check out PostHog.com repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   repository: 'PostHog/posthog.com'
                   token: ${{ steps.upgrader.outputs.token }}
@@ -39,7 +39,7 @@ jobs:
             - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # pin v5.0.0
 
             - name: Set up Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 22
                   cache: pnpm

--- a/.github/workflows/posthog-upgrade.yml
+++ b/.github/workflows/posthog-upgrade.yml
@@ -31,7 +31,7 @@ jobs:
                   private_key: ${{ secrets.GH_APP_POSTHOG_JS_UPGRADER_PRIVATE_KEY }}
 
             - name: Check out main repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   repository: 'PostHog/posthog'
                   token: ${{ steps.upgrader.outputs.token }}
@@ -39,7 +39,7 @@ jobs:
             - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # pin v5.0.0
 
             - name: Set up Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 22
                   cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
             has-changesets: ${{ steps.check.outputs.has-changesets }}
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: main
                   fetch-depth: 0
@@ -148,7 +148,7 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_JS_RELEASER_PRIVATE_KEY }} # Secrets available only inside the `NPM Release` environment, requires approval from a maintainer
 
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: main
                   fetch-depth: 0
@@ -289,7 +289,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: ${{ needs.version-bump.outputs.commit-hash }}
                   fetch-depth: 0
@@ -433,7 +433,7 @@ jobs:
             committed-version: ${{ steps.check-version.outputs.committed-version }}
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: ${{ needs.version-bump.outputs.commit-hash }}
                   fetch-depth: 1
@@ -450,7 +450,7 @@ jobs:
 
             - name: Upload dist artifact
               if: steps.check-version.outputs.is-new-version == 'true'
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: posthog-js-dist
                   path: packages/browser/dist/*.js
@@ -489,7 +489,7 @@ jobs:
             TOOLBAR_PUBLIC_PATH: https://${{ matrix.region.host }}/static/${{ needs.version-bump.outputs.version }}/
         steps:
             - name: Checkout posthog/posthog
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   repository: PostHog/posthog
                   ref: master
@@ -499,7 +499,7 @@ jobs:
               uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # pin v5.0.0
 
             - name: Setup Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: '24'
                   cache: 'pnpm'
@@ -588,7 +588,7 @@ jobs:
                   echo "  built from:          PostHog/posthog@$(git rev-parse HEAD)"
 
             - name: Upload toolbar artifact
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: toolbar-dist-${{ matrix.region.name }}
                   # Least common ancestor of these paths is `frontend/dist`,
@@ -623,7 +623,7 @@ jobs:
             # Sparse checkout the release tooling plus the root pnpm files so
             # we can do a locked, filtered install for @posthog-tooling/release.
             - name: Checkout release tooling
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: ${{ needs.version-bump.outputs.commit-hash }}
                   sparse-checkout: |
@@ -638,7 +638,7 @@ jobs:
               uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # pin v4.2.0
 
             - name: Setup Node.js
-              uses: actions/setup-node@v5
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: '24'
                   cache: 'pnpm'
@@ -647,7 +647,7 @@ jobs:
               run: pnpm install --filter @posthog-tooling/release... --frozen-lockfile
 
             - name: Download dist artifact
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: posthog-js-dist
                   path: packages/browser/dist
@@ -661,7 +661,7 @@ jobs:
             # region-specific artifact is missing gives us clean per-region
             # fate-sharing.
             - name: Download toolbar artifact
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: toolbar-dist-${{ matrix.region.name }}
                   path: packages/browser/dist
@@ -722,7 +722,7 @@ jobs:
             needs.notify-approval-needed.outputs.slack_ts != ''
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Notify Slack - Released
               continue-on-error: true # Slack failure shouldn't mark release as failed

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -26,7 +26,7 @@ jobs:
                     echo "skip=false" >> $GITHUB_OUTPUT
                   fi
 
-            - uses: actions/stale@v9
+            - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
               if: steps.holiday.outputs.skip != 'true'
               with:
                   days-before-issue-stale: 730

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -30,7 +30,7 @@ jobs:
             name: IE11
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
Pins every third-party `uses:` reference across the workflows and the shared [.github/actions/setup](https://github.com/PostHog/posthog-js/blob/main/.github/actions/setup/action.yaml) composite action to a 40-char commit SHA (with the version as a trailing comment) and bumps the built-in actions to their latest major versions. Many `peter-evans/*`, `pnpm/*`, `getsentry/*`, `planetscale/*`, `amannn/*`, `actions-cool/*`, `aws-actions/*`, `stefanzweifel/*`, `the-guild-org/*`, and `preactjs/*` actions were already SHA-pinned — this PR brings the remaining `actions/*` and `github/*` references in line. Closes the retagging-attack window on PR-triggered workflows (which have `GITHUB_TOKEN` write scopes via `issues: write` / `pull-requests: write`) and on the npm release publishing path in [release.yml](https://github.com/PostHog/posthog-js/blob/main/.github/workflows/release.yml).

PostHog-owned references (`PostHog/.github`, `PostHog/posthog-github-action`, `PostHog/check-package-version`, `PostHog/posthog-sdk-test-harness`) are intentionally left as tag/branch refs.

## Changes made
- `actions/checkout` `v6` → `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
- `actions/setup-node` `v5`/`v6` → `@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0` (unified)
- `actions/upload-artifact` `v7` → `@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`
- `actions/download-artifact` `v8` → `@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1`
- `actions/cache` `v5` → `@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5`
- `actions/github-script` `v7` → `@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0`
- `actions/stale` `v9` → `@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0`
- `github/codeql-action/{init,analyze}` `v4` → `@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2`

Already SHA-pinned and unchanged: `getsentry/action-github-app-token`, `the-guild-org/changesets-dependencies-action`, `peter-evans/{find-comment,create-or-update-comment,create-pull-request}`, `planetscale/ghcommit-action`, `stefanzweifel/git-auto-commit-action`, `pnpm/action-setup`, `aws-actions/configure-aws-credentials`, `actions-cool/check-user-permission`, `amannn/action-semantic-pull-request`, `preactjs/compressed-size-action`, `actions/create-github-app-token`.

<details><summary>Why this matters — real-world GitHub Actions supply-chain incidents</summary>

GitHub Action retagging is an active attack vector: the attacker force-pushes a mutable tag (like `v1`) to a malicious commit, and every consumer that pins by tag picks it up on the next workflow run. Pinning to a 40-char SHA is the only mitigation — tags are advisory, commits are immutable.

Known incidents:

- **`tj-actions/changed-files`** ([CVE-2025-30066](https://nvd.nist.gov/vuln/detail/CVE-2025-30066), March 2025) — existing version tags were retagged to a commit that dumped secrets from the runner process memory to workflow logs. Affected 23,000+ repos.
- **`reviewdog/action-setup`** ([CVE-2025-30154](https://nvd.nist.gov/vuln/detail/CVE-2025-30154), March 2025) — the upstream compromise that enabled the `tj-actions` attack.
- **Trivy, KICS, LiteLLM — `TeamCityPCP` attack** ([CVE-2026-33634](https://nvd.nist.gov/vuln/detail/CVE-2026-33634), 2026) — coordinated retagging of three popular security-scanning actions. See the [Wiz write-up on KICS](https://www.wiz.io/blog/teampcp-attack-kics-github-action) and the [LiteLLM advisory](https://docs.litellm.ai/blog/security-update-march-2026).

In each case, consumers that pinned by SHA were unaffected; consumers that pinned by tag or branch executed the malicious code on their next run.

[release.yml](https://github.com/PostHog/posthog-js/blob/main/.github/workflows/release.yml) in this repo has `contents: write` and publishes packages to npm — an unpinned action there could inject arbitrary code into the published tarball.
</details>

## Follow-up recommendations (not in this PR)

<details><summary>Add Dependabot cooldown</summary>

[.github/dependabot.yml](https://github.com/PostHog/posthog-js/blob/main/.github/dependabot.yml) doesn't set [`cooldown.default-days`](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-). Add `cooldown: { default-days: 7 }` to give time for post-publish compromise detection — incidents like the [axios/OpenAI npm compromise](https://openai.com/index/axios-developer-tool-compromise/) (2026) are typically caught by registry sweeps within days, but only if consumers pause before pulling.
</details>

<details><summary>Pin Docker base images in compliance Dockerfiles</summary>

Use `docker buildx imagetools inspect <image>:<tag>` to resolve `@sha256:<digest>` for:
- [compliance/browser/Dockerfile](https://github.com/PostHog/posthog-js/blob/main/compliance/browser/Dockerfile) line 1: `node:20-alpine`
- [compliance/node/Dockerfile](https://github.com/PostHog/posthog-js/blob/main/compliance/node/Dockerfile) line 1: `node:20-alpine`
</details>

<details><summary>Pin adapter <code>npm install</code> versions in compliance Dockerfiles</summary>

[compliance/browser/Dockerfile](https://github.com/PostHog/posthog-js/blob/main/compliance/browser/Dockerfile) and [compliance/node/Dockerfile](https://github.com/PostHog/posthog-js/blob/main/compliance/node/Dockerfile) run `npm init -y && npm install express` (and `jsdom-global` in browser) in a separate adapter directory — outside the lockfile. Pin to specific versions (e.g. `express@5.x.y`) and consider `--ignore-scripts`.

(The `RUN npm install -g pnpm` lines are fine: pnpm 10 with `manage-package-manager-versions` reads `packageManager` from `package.json` and self-installs the pinned version on first run.)
</details>

<details><summary>Add <code>es-check</code> as a <code>devDependency</code></summary>

[.github/workflows/es-check.yml](https://github.com/PostHog/posthog-js/blob/main/.github/workflows/es-check.yml) invokes `npx es-check@7.2.1`. The tool version is pinned, but transitive deps are resolved fresh each run. Adding `es-check` to root `devDependencies` locks the whole tree via `pnpm-lock.yaml` (which already benefits from `minimumReleaseAge: 10080` and `blockExoticSubdeps: true`).
</details>