### PR TITLE
feat(logs): flush RN logs queue to /i/v1/logs with batching

### DIFF
--- a/.changeset/rn-manual-log-capture.md
+++ b/.changeset/rn-manual-log-capture.md
@@ -1,0 +1,8 @@
+---
+'posthog-react-native': minor
+'@posthog/core': minor
+---
+
+Add manual log capture API for React Native: `posthog.captureLog()`, `posthog.logger.{trace,debug,info,warn,error,fatal}()`, `posthog.flushLogs()`, and a `logs` config option on the constructor. Records ship to PostHog's logs product (`/i/v1/logs`) in OTLP format, batched on a timer / AppState change / buffer fill, persisted to a dedicated logs-storage file, and tagged with `service.name`, `os.*`, `telemetry.sdk.*`, plus per-record `posthogDistinctId`, `sessionId`, `screen.name`, `app.state`, `feature_flags`. AppState backgrounding races against an iOS-budget; `shutdown()` drains both events and logs.
+
+Manual capture is unconditional — calling the API ships records, matching the browser SDK's manual path. The server can remotely block capture by returning `response.logs.captureConsoleLogs: false`; an explicit `true` and an absent key both leave it allowed.

--- a/.changeset/rn-manual-log-capture.md
+++ b/.changeset/rn-manual-log-capture.md
@@ -3,6 +3,6 @@
 '@posthog/core': minor
 ---
 
-Add manual log capture API for React Native: `posthog.captureLog()`, `posthog.logger.{trace,debug,info,warn,error,fatal}()`, `posthog.flushLogs()`, and a `logs` config option on the constructor. Records ship to PostHog's logs product (`/i/v1/logs`) in OTLP format, batched on a timer / AppState change / buffer fill, persisted to a dedicated logs-storage file, and tagged with `service.name`, `os.*`, `telemetry.sdk.*`, plus per-record `posthogDistinctId`, `sessionId`, `screen.name`, `app.state`, `feature_flags`. AppState backgrounding races against an iOS-budget; `shutdown()` drains both events and logs.
+Add manual log capture API for React Native: `posthog.captureLog()`, `posthog.logger.{trace,debug,info,warn,error,fatal}()`, `posthog.flushLogs()`, and a `logs` config option on the constructor. Records ship to PostHog's logs product (`/i/v1/logs`) in OTLP format, batched on a timer / AppState change / buffer fill, and persisted to a dedicated logs-storage file.
 
-Manual capture is unconditional — calling the API ships records, matching the browser SDK's manual path. The server can remotely block capture by returning `response.logs.captureConsoleLogs: false`; an explicit `true` and an absent key both leave it allowed.
+Manual capture is unconditional — calling the API ships records, matching the events pipeline's manual `capture()` shape. Only blockers: `optedOut`, missing/empty `body`, and missing API key. The wire field `response.logs.captureConsoleLogs` is browser-only (it gates the JS SDK's `console.*` autocapture extension) and is not read by RN. When console autocapture lands on RN as a follow-up, that PR will introduce a local opt-in for the autocapture path specifically; manual capture will remain unconditional.

--- a/examples/example-expo-53/app/(tabs)/_layout.tsx
+++ b/examples/example-expo-53/app/(tabs)/_layout.tsx
@@ -57,6 +57,13 @@ export default function TabLayout() {
                     tabBarIcon: ({ color }) => <IconSymbol size={28} name="link" color={color} />,
                 }}
             />
+            <Tabs.Screen
+                name="logs"
+                options={{
+                    title: 'Logs',
+                    tabBarIcon: ({ color }) => <IconSymbol size={28} name="text.bubble.fill" color={color} />,
+                }}
+            />
         </Tabs>
     )
 }

--- a/examples/example-expo-53/app/(tabs)/logs.tsx
+++ b/examples/example-expo-53/app/(tabs)/logs.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Button, ScrollView, StyleSheet, View } from 'react-native'
+import { useEffect, useState } from 'react'
+import { AppState, Button, ScrollView, StyleSheet, View } from 'react-native'
 
 import ParallaxScrollView from '@/components/ParallaxScrollView'
 import { ThemedText } from '@/components/ThemedText'
@@ -12,6 +12,20 @@ type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
 export default function LogsScreen() {
     const [status, setStatus] = useState('Idle')
     const [counter, setCounter] = useState(0)
+
+    // Emit a log on every AppState transition so the SDK's `app.state`
+    // tagging path can be exercised without manual taps. The PostHog
+    // constructor registers its own AppState listener first, which updates
+    // `_currentAppState` synchronously *before* this hook's body runs, so
+    // the captured record reads the new state.
+    useEffect(() => {
+        let prev: string = AppState.currentState
+        const sub = AppState.addEventListener('change', (next) => {
+            posthog.logger.info(`AppState ${prev} → ${next}`, { from: prev, to: next })
+            prev = next
+        })
+        return () => sub.remove()
+    }, [])
 
     const bump = (message: string) => {
         const next = counter + 1

--- a/examples/example-expo-53/app/(tabs)/logs.tsx
+++ b/examples/example-expo-53/app/(tabs)/logs.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { AppState, Button, ScrollView, StyleSheet, View } from 'react-native'
+import { PostHogPersistedProperty } from 'posthog-react-native'
 
 import ParallaxScrollView from '@/components/ParallaxScrollView'
 import { ThemedText } from '@/components/ThemedText'
@@ -8,10 +9,35 @@ import { IconSymbol } from '@/components/ui/IconSymbol'
 import { posthog } from '../posthog'
 
 type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
+type BeforeSendMode = 'pass' | 'drop' | 'throw'
+
+interface DevStatus {
+    distinctId: string | null
+    sessionId: string | null
+    appState: 'foreground' | 'background' | null
+}
 
 export default function LogsScreen() {
     const [status, setStatus] = useState('Idle')
     const [counter, setCounter] = useState(0)
+    const [devStatus, setDevStatus] = useState<DevStatus>({
+        distinctId: null,
+        sessionId: null,
+        appState: null,
+    })
+    const [beforeSendMode, setBeforeSendMode] = useState<BeforeSendMode>('pass')
+    const [queueDump, setQueueDump] = useState<string>('')
+    // Snapshot any user-supplied beforeSend at first render so the "pass"
+    // button can restore it instead of overwriting with `undefined`.
+    const [originalBeforeSend] = useState<unknown>(() => (posthog as any)._logs?._config?.beforeSend)
+
+    const refresh = (): void => {
+        setDevStatus({
+            distinctId: posthog.getDistinctId() || null,
+            sessionId: posthog.getSessionId() || null,
+            appState: ((posthog as any)._currentAppState ?? null) as DevStatus['appState'],
+        })
+    }
 
     // Emit a log on every AppState transition so the SDK's `app.state`
     // tagging path can be exercised without manual taps. The PostHog
@@ -23,17 +49,21 @@ export default function LogsScreen() {
         const sub = AppState.addEventListener('change', (next) => {
             posthog.logger.info(`AppState ${prev} → ${next}`, { from: prev, to: next })
             prev = next
+            refresh()
         })
+        refresh()
         return () => sub.remove()
     }, [])
 
-    const bump = (message: string) => {
+    const bump = (message: string): void => {
         const next = counter + 1
         setCounter(next)
         setStatus(`${message} (#${next} @ ${new Date().toISOString().slice(11, 19)})`)
     }
 
-    const sendOne = (level: LogLevel) => {
+    // ===== Existing capture buttons =====
+
+    const sendOne = (level: LogLevel): void => {
         posthog.logger[level](`${level} log from example-expo-53`, {
             source: 'logs-tab',
             level,
@@ -42,7 +72,7 @@ export default function LogsScreen() {
         bump(`Sent ${level}`)
     }
 
-    const sendAllLevels = () => {
+    const sendAllLevels = (): void => {
         const levels: LogLevel[] = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
         levels.forEach((level, i) => {
             posthog.logger[level](`Level-sweep message (${level}) #${i}`, { sweep: true, index: i })
@@ -50,7 +80,7 @@ export default function LogsScreen() {
         bump(`Sent all 6 levels`)
     }
 
-    const sendStructured = () => {
+    const sendStructured = (): void => {
         posthog.captureLog({
             body: 'Structured attributes payload',
             level: 'info',
@@ -65,14 +95,14 @@ export default function LogsScreen() {
         bump('Sent structured attrs')
     }
 
-    const sendBurst = () => {
+    const sendBurst = (): void => {
         for (let i = 0; i < 20; i++) {
             posthog.logger[i % 2 === 0 ? 'info' : 'debug'](`Burst log #${i}`, { i })
         }
         bump('Sent 20-burst')
     }
 
-    const sendFlood = () => {
+    const sendFlood = (): void => {
         // Hit the rate-cap window (default 500/10s on RN). Should emit
         // 500-ish and then warn + drop.
         for (let i = 0; i < 600; i++) {
@@ -81,7 +111,7 @@ export default function LogsScreen() {
         bump('Sent 600-flood (expect rate cap)')
     }
 
-    const sendError = () => {
+    const sendError = (): void => {
         posthog.logger.error('Simulated error with stack', {
             errorName: 'SimulatedError',
             errorMessage: 'Something bad happened',
@@ -90,7 +120,7 @@ export default function LogsScreen() {
         bump('Sent error+stack')
     }
 
-    const flushNow = async () => {
+    const flushNow = async (): Promise<void> => {
         try {
             // Drain BOTH pipelines — events on `flush()`, logs on `flushLogs()`.
             // Run in parallel so a slow events flush doesn't delay logs and
@@ -100,6 +130,84 @@ export default function LogsScreen() {
         } catch (e) {
             setStatus(`Flush error: ${e}`)
         }
+    }
+
+    // ===== Dev tools =====
+    //
+    // The buttons below reach into private SDK internals (`_logs`, `_config`,
+    // `_currentAppState`) so we can exercise edge cases from the example app
+    // without re-building or running adb. Reach-ins are ONLY appropriate in
+    // dogfood-style examples; production wrappers should stick to the public
+    // surface (`captureLog`, `logger.*`, `flushLogs`).
+
+    const setBefore = (mode: BeforeSendMode): void => {
+        const config = (posthog as any)._logs?._config
+        if (!config) return
+        if (mode === 'pass') {
+            config.beforeSend = originalBeforeSend
+        } else if (mode === 'drop') {
+            config.beforeSend = (): null => null
+        } else {
+            config.beforeSend = (): never => {
+                throw new Error('beforeSend boom')
+            }
+        }
+        setBeforeSendMode(mode)
+        bump(`beforeSend = ${mode}`)
+    }
+
+    const captureNoLevel = (): void => {
+        // Verifies default-level INFO behaviour without a `level` arg.
+        posthog.captureLog({ body: 'no-level test (defaults to INFO)' })
+        bump('Sent no-level (default INFO)')
+    }
+
+    const captureEmptyBody = (): void => {
+        posthog.captureLog({ body: '' })
+        bump('Sent empty body (should be silently dropped)')
+    }
+
+    const captureNoBody = (): void => {
+        posthog.captureLog({} as any)
+        bump('Sent no body (should be silently dropped)')
+    }
+
+    const dumpQueue = (): void => {
+        const queue = posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue) as unknown[] | undefined
+        const text = queue
+            ? `length=${queue.length}\n${JSON.stringify(queue, null, 2).slice(0, 4000)}`
+            : '(empty/undefined)'
+        setQueueDump(text)
+    }
+
+    const screenAndCapture = async (name: string): Promise<void> => {
+        await posthog.screen(name)
+        posthog.logger.info(`captured on ${name}`, { screenTagTest: true })
+        bump(`screen('${name}') + capture`)
+    }
+
+    const callIdentify = (id: string): void => {
+        posthog.identify(id, { source: 'logs-tab' })
+        refresh()
+        bump(`identify('${id}')`)
+    }
+
+    const callReset = (): void => {
+        posthog.reset()
+        refresh()
+        bump('reset()')
+    }
+
+    const callOptOut = async (): Promise<void> => {
+        await posthog.optOut()
+        refresh()
+        bump('optOut()')
+    }
+
+    const callOptIn = async (): Promise<void> => {
+        await posthog.optIn()
+        refresh()
+        bump('optIn()')
     }
 
     return (
@@ -140,6 +248,61 @@ export default function LogsScreen() {
                     <ThemedText type="subtitle">Control</ThemedText>
                     <Button title="Flush now" onPress={flushNow} />
                 </View>
+
+                <View style={styles.divider} />
+                <ThemedText type="subtitle">Dev tools</ThemedText>
+
+                <View style={styles.section}>
+                    <ThemedText type="defaultSemiBold">Status</ThemedText>
+                    <ThemedText>distinctId: {devStatus.distinctId ?? '<none>'}</ThemedText>
+                    <ThemedText>sessionId: {devStatus.sessionId ?? '<none>'}</ThemedText>
+                    <ThemedText>app.state: {devStatus.appState ?? '<unknown>'}</ThemedText>
+                    <ThemedText>beforeSend mode: {beforeSendMode}</ThemedText>
+                    <Button title="Refresh status" onPress={refresh} />
+                </View>
+
+                <View style={styles.section}>
+                    <ThemedText type="defaultSemiBold">Identity</ThemedText>
+                    <View style={styles.row}>
+                        <Button title="identify(alice)" onPress={() => callIdentify('alice')} />
+                        <Button title="identify(bob)" onPress={() => callIdentify('bob')} />
+                    </View>
+                    <View style={styles.row}>
+                        <Button title="reset()" onPress={callReset} />
+                        <Button title="optOut()" onPress={callOptOut} />
+                        <Button title="optIn()" onPress={callOptIn} />
+                    </View>
+                </View>
+
+                <View style={styles.section}>
+                    <ThemedText type="defaultSemiBold">Screen tagging</ThemedText>
+                    <Button title="screen('Checkout') + capture" onPress={() => screenAndCapture('Checkout')} />
+                    <Button title="screen('Profile') + capture" onPress={() => screenAndCapture('Profile')} />
+                </View>
+
+                <View style={styles.section}>
+                    <ThemedText type="defaultSemiBold">Edge captures</ThemedText>
+                    <Button title="captureLog (no level → INFO)" onPress={captureNoLevel} />
+                    <Button title="captureLog (empty body)" onPress={captureEmptyBody} />
+                    <Button title="captureLog (no body)" onPress={captureNoBody} />
+                </View>
+
+                <View style={styles.section}>
+                    <ThemedText type="defaultSemiBold">beforeSend hook</ThemedText>
+                    <View style={styles.row}>
+                        <Button title="pass-through" onPress={() => setBefore('pass')} />
+                        <Button title="drop (return null)" onPress={() => setBefore('drop')} />
+                        <Button title="throw" onPress={() => setBefore('throw')} />
+                    </View>
+                </View>
+
+                <View style={styles.section}>
+                    <ThemedText type="defaultSemiBold">Storage</ThemedText>
+                    <Button title="Dump LogsQueue" onPress={dumpQueue} />
+                    <ScrollView style={styles.dump}>
+                        <ThemedText>{queueDump || '(tap Dump to inspect)'}</ThemedText>
+                    </ScrollView>
+                </View>
             </ScrollView>
         </ParallaxScrollView>
     )
@@ -167,5 +330,17 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         gap: 8,
         marginBottom: 6,
+        flexWrap: 'wrap',
+    },
+    divider: {
+        height: 1,
+        backgroundColor: 'rgba(128,128,128,0.4)',
+        marginVertical: 8,
+    },
+    dump: {
+        marginTop: 6,
+        maxHeight: 220,
+        backgroundColor: 'rgba(0,0,0,0.05)',
+        padding: 8,
     },
 })

--- a/examples/example-expo-53/app/(tabs)/logs.tsx
+++ b/examples/example-expo-53/app/(tabs)/logs.tsx
@@ -6,7 +6,7 @@ import ParallaxScrollView from '@/components/ParallaxScrollView'
 import { ThemedText } from '@/components/ThemedText'
 import { ThemedView } from '@/components/ThemedView'
 import { IconSymbol } from '@/components/ui/IconSymbol'
-import { posthog } from '../posthog'
+import { beforeSendMode, posthog } from '../posthog'
 
 type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
 type BeforeSendMode = 'pass' | 'drop' | 'throw'
@@ -25,11 +25,10 @@ export default function LogsScreen() {
         sessionId: null,
         appState: null,
     })
-    const [beforeSendMode, setBeforeSendMode] = useState<BeforeSendMode>('pass')
+    // Mirror of `beforeSendMode.current` for UI display. The actual filter
+    // reads from the module-level ref in posthog.tsx.
+    const [beforeSendModeUI, setBeforeSendModeUI] = useState<BeforeSendMode>(beforeSendMode.current)
     const [queueDump, setQueueDump] = useState<string>('')
-    // Snapshot any user-supplied beforeSend at first render so the "pass"
-    // button can restore it instead of overwriting with `undefined`.
-    const [originalBeforeSend] = useState<unknown>(() => (posthog as any)._logs?._config?.beforeSend)
 
     const refresh = (): void => {
         setDevStatus({
@@ -134,25 +133,19 @@ export default function LogsScreen() {
 
     // ===== Dev tools =====
     //
-    // The buttons below reach into private SDK internals (`_logs`, `_config`,
-    // `_currentAppState`) so we can exercise edge cases from the example app
-    // without re-building or running adb. Reach-ins are ONLY appropriate in
-    // dogfood-style examples; production wrappers should stick to the public
-    // surface (`captureLog`, `logger.*`, `flushLogs`).
+    // Status reads `_currentAppState` via a reach-in because there's no
+    // public getter for the SDK's cached AppState. Reach-ins like this are
+    // ONLY appropriate in dogfood-style examples; production wrappers
+    // should stick to the public surface (`captureLog`, `logger.*`,
+    // `flushLogs`).
 
     const setBefore = (mode: BeforeSendMode): void => {
-        const config = (posthog as any)._logs?._config
-        if (!config) return
-        if (mode === 'pass') {
-            config.beforeSend = originalBeforeSend
-        } else if (mode === 'drop') {
-            config.beforeSend = (): null => null
-        } else {
-            config.beforeSend = (): never => {
-                throw new Error('beforeSend boom')
-            }
-        }
-        setBeforeSendMode(mode)
+        // Update the shared ref in posthog.tsx — the `beforeSend` closure
+        // reads it on every capture, so behavior switches at runtime
+        // without touching SDK internals. This is the public-API-only
+        // pattern customers should follow for runtime-tunable filters.
+        beforeSendMode.current = mode
+        setBeforeSendModeUI(mode)
         bump(`beforeSend = ${mode}`)
     }
 
@@ -257,7 +250,7 @@ export default function LogsScreen() {
                     <ThemedText>distinctId: {devStatus.distinctId ?? '<none>'}</ThemedText>
                     <ThemedText>sessionId: {devStatus.sessionId ?? '<none>'}</ThemedText>
                     <ThemedText>app.state: {devStatus.appState ?? '<unknown>'}</ThemedText>
-                    <ThemedText>beforeSend mode: {beforeSendMode}</ThemedText>
+                    <ThemedText>beforeSend mode: {beforeSendModeUI}</ThemedText>
                     <Button title="Refresh status" onPress={refresh} />
                 </View>
 

--- a/examples/example-expo-53/app/(tabs)/logs.tsx
+++ b/examples/example-expo-53/app/(tabs)/logs.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+import { Button, ScrollView, StyleSheet, View } from 'react-native'
+
+import ParallaxScrollView from '@/components/ParallaxScrollView'
+import { ThemedText } from '@/components/ThemedText'
+import { ThemedView } from '@/components/ThemedView'
+import { IconSymbol } from '@/components/ui/IconSymbol'
+import { posthog } from '../posthog'
+
+type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
+
+export default function LogsScreen() {
+    const [status, setStatus] = useState('Idle')
+    const [counter, setCounter] = useState(0)
+
+    const bump = (message: string) => {
+        const next = counter + 1
+        setCounter(next)
+        setStatus(`${message} (#${next} @ ${new Date().toISOString().slice(11, 19)})`)
+    }
+
+    const sendOne = (level: LogLevel) => {
+        posthog.logger[level](`${level} log from example-expo-53`, {
+            source: 'logs-tab',
+            level,
+            tsClient: Date.now(),
+        })
+        bump(`Sent ${level}`)
+    }
+
+    const sendAllLevels = () => {
+        const levels: LogLevel[] = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
+        levels.forEach((level, i) => {
+            posthog.logger[level](`Level-sweep message (${level}) #${i}`, { sweep: true, index: i })
+        })
+        bump(`Sent all 6 levels`)
+    }
+
+    const sendStructured = () => {
+        posthog.captureLog({
+            body: 'Structured attributes payload',
+            level: 'info',
+            attributes: {
+                userId: 'user-42',
+                feature: 'checkout',
+                durationMs: 123,
+                tags: ['beta', 'ios'],
+                nested: { foo: 'bar', count: 3 },
+            },
+        })
+        bump('Sent structured attrs')
+    }
+
+    const sendBurst = () => {
+        for (let i = 0; i < 20; i++) {
+            posthog.logger[i % 2 === 0 ? 'info' : 'debug'](`Burst log #${i}`, { i })
+        }
+        bump('Sent 20-burst')
+    }
+
+    const sendFlood = () => {
+        // Hit the rate-cap window (default 500/10s on RN). Should emit
+        // 500-ish and then warn + drop.
+        for (let i = 0; i < 600; i++) {
+            posthog.logger.info(`Flood #${i}`, { i, flood: true })
+        }
+        bump('Sent 600-flood (expect rate cap)')
+    }
+
+    const sendError = () => {
+        posthog.logger.error('Simulated error with stack', {
+            errorName: 'SimulatedError',
+            errorMessage: 'Something bad happened',
+            stack: new Error('Simulated').stack ?? '',
+        })
+        bump('Sent error+stack')
+    }
+
+    const flushNow = async () => {
+        try {
+            // Drain BOTH pipelines — events on `flush()`, logs on `flushLogs()`.
+            // Run in parallel so a slow events flush doesn't delay logs and
+            // vice-versa.
+            await Promise.all([posthog.flush(), posthog.flushLogs()])
+            bump('Manual flush ok')
+        } catch (e) {
+            setStatus(`Flush error: ${e}`)
+        }
+    }
+
+    return (
+        <ParallaxScrollView
+            headerBackgroundColor={{ light: '#FFE6B3', dark: '#3D2E1D' }}
+            headerImage={<IconSymbol size={310} color="#808080" name="text.bubble.fill" style={styles.headerImage} />}
+        >
+            <ThemedView style={styles.titleContainer}>
+                <ThemedText type="title">Logs</ThemedText>
+            </ThemedView>
+            <ThemedText>Status: {status}</ThemedText>
+            <ScrollView style={styles.scroll}>
+                <View style={styles.section}>
+                    <ThemedText type="subtitle">Single level</ThemedText>
+                    <View style={styles.row}>
+                        <Button title="trace" onPress={() => sendOne('trace')} />
+                        <Button title="debug" onPress={() => sendOne('debug')} />
+                        <Button title="info" onPress={() => sendOne('info')} />
+                    </View>
+                    <View style={styles.row}>
+                        <Button title="warn" onPress={() => sendOne('warn')} />
+                        <Button title="error" onPress={() => sendOne('error')} />
+                        <Button title="fatal" onPress={() => sendOne('fatal')} />
+                    </View>
+                </View>
+                <View style={styles.section}>
+                    <ThemedText type="subtitle">Mixed</ThemedText>
+                    <Button title="All 6 levels" onPress={sendAllLevels} />
+                    <Button title="Structured attributes" onPress={sendStructured} />
+                    <Button title="Error + stack" onPress={sendError} />
+                </View>
+                <View style={styles.section}>
+                    <ThemedText type="subtitle">Volume</ThemedText>
+                    <Button title="Burst 20" onPress={sendBurst} />
+                    <Button title="Flood 600 (rate cap)" onPress={sendFlood} />
+                </View>
+                <View style={styles.section}>
+                    <ThemedText type="subtitle">Control</ThemedText>
+                    <Button title="Flush now" onPress={flushNow} />
+                </View>
+            </ScrollView>
+        </ParallaxScrollView>
+    )
+}
+
+const styles = StyleSheet.create({
+    headerImage: {
+        color: '#808080',
+        bottom: -90,
+        left: -35,
+        position: 'absolute',
+    },
+    titleContainer: {
+        flexDirection: 'row',
+        gap: 8,
+    },
+    scroll: {
+        marginTop: 12,
+    },
+    section: {
+        marginBottom: 16,
+        gap: 6,
+    },
+    row: {
+        flexDirection: 'row',
+        gap: 8,
+        marginBottom: 6,
+    },
+})

--- a/examples/example-expo-53/app/posthog.tsx
+++ b/examples/example-expo-53/app/posthog.tsx
@@ -28,14 +28,17 @@ export const posthog = new PostHog(process.env.EXPO_PUBLIC_POSTHOG_PROJECT_API_K
     // requests to these hostnames. Used by the Tracing Headers screen to verify
     // the patch works end-to-end; see https://posthog.com/docs/llm-analytics/link-session-replay
     addTracingHeaders: ['httpbin.org'],
-    // Logs feature config. Defaults are reasonable; the values below mainly
-    // make local dogfooding nicer:
+    // Logs feature config. Off by default — `captureConsoleLogs: true`
+    // Server can also enable via remote config, or kill-switch with an explicit `false`.
+    //
+    // The remaining values are mainly for local dogfooding:
     //   - serviceName / environment / serviceVersion show up as OTLP resource
     //     attrs on every batch, so you can group/filter in the Logs UI and
     //     spot example traffic vs your real apps.
     //   - Try uncommenting `beforeSend` to redact bodies, or
     //     `maxLogsPerInterval` to exercise the rate cap from the Logs tab.
     logs: {
+        captureConsoleLogs: true,
         serviceName: 'expo-example',
         environment: 'dev',
         serviceVersion: '0.0.1',

--- a/examples/example-expo-53/app/posthog.tsx
+++ b/examples/example-expo-53/app/posthog.tsx
@@ -28,6 +28,21 @@ export const posthog = new PostHog(process.env.EXPO_PUBLIC_POSTHOG_PROJECT_API_K
     // requests to these hostnames. Used by the Tracing Headers screen to verify
     // the patch works end-to-end; see https://posthog.com/docs/llm-analytics/link-session-replay
     addTracingHeaders: ['httpbin.org'],
+    // Logs feature config. Defaults are reasonable; the values below mainly
+    // make local dogfooding nicer:
+    //   - serviceName / environment / serviceVersion show up as OTLP resource
+    //     attrs on every batch, so you can group/filter in the Logs UI and
+    //     spot example traffic vs your real apps.
+    //   - Try uncommenting `beforeSend` to redact bodies, or
+    //     `maxLogsPerInterval` to exercise the rate cap from the Logs tab.
+    logs: {
+        serviceName: 'expo-example',
+        environment: 'dev',
+        serviceVersion: '0.0.1',
+        // beforeSend: (r) => (r.body.includes('skip') ? null : r),
+        // maxLogsPerInterval: 5,
+        // rateCapWindowMs: 10000,
+    },
     // persistence: 'memory',
     // if using WebView, you have to disable masking for text inputs and images
     // sessionReplayConfig: {

--- a/examples/example-expo-53/app/posthog.tsx
+++ b/examples/example-expo-53/app/posthog.tsx
@@ -1,5 +1,14 @@
 import PostHog from 'posthog-react-native'
 
+/**
+ * Module-level beforeSend mode for the dev-tools panel in /logs. The
+ * `beforeSend` filter below reads this on every capture, so flipping
+ * `beforeSendMode.current` from another file changes filter behavior at
+ * runtime without reaching into SDK internals. Demonstrates the closure
+ * pattern customers should use for any runtime-tunable filter.
+ */
+export const beforeSendMode: { current: 'pass' | 'drop' | 'throw' } = { current: 'pass' }
+
 // If you want to use Session relay on React Native web, use the posthog-js SDK instead.
 // Example:
 //
@@ -28,24 +37,20 @@ export const posthog = new PostHog(process.env.EXPO_PUBLIC_POSTHOG_PROJECT_API_K
     // requests to these hostnames. Used by the Tracing Headers screen to verify
     // the patch works end-to-end; see https://posthog.com/docs/llm-analytics/link-session-replay
     addTracingHeaders: ['httpbin.org'],
-    // Logs feature config. Manual capture (`posthog.captureLog`,
-    // `posthog.logger.*`) is unconditional — these settings only customize
-    // resource attributes, rate cap, and filtering for local dogfooding.
-    // The server can kill-switch the pipeline via remote config
-    // (`response.logs.captureConsoleLogs: false`).
-    //
-    //   - serviceName / environment / serviceVersion show up as OTLP resource
-    //     attrs on every batch, so you can group/filter in the Logs UI and
-    //     spot example traffic vs your real apps.
-    //   - Uncomment `beforeSend` to redact bodies, or `maxLogsPerInterval`
-    //     to exercise the rate cap from the Logs tab.
     logs: {
         serviceName: 'expo-example',
         environment: 'dev',
         serviceVersion: '0.0.1',
-        // beforeSend: (r) => (r.body.includes('skip') ? null : r),
-        // maxLogsPerInterval: 5,
-        // rateCapWindowMs: 10000,
+        // The /logs dev-tools panel toggles `beforeSendMode.current` at
+        // runtime. The closure here reads it on every capture, so the
+        // behavior switches without re-constructing the SDK or touching
+        // private internals. Customers wiring runtime-tunable filters
+        // should follow this pattern.
+        beforeSend: (record) => {
+            if (beforeSendMode.current === 'drop') return null
+            if (beforeSendMode.current === 'throw') throw new Error('beforeSend boom')
+            return record
+        },
     },
     // persistence: 'memory',
     // if using WebView, you have to disable masking for text inputs and images

--- a/examples/example-expo-53/app/posthog.tsx
+++ b/examples/example-expo-53/app/posthog.tsx
@@ -28,17 +28,18 @@ export const posthog = new PostHog(process.env.EXPO_PUBLIC_POSTHOG_PROJECT_API_K
     // requests to these hostnames. Used by the Tracing Headers screen to verify
     // the patch works end-to-end; see https://posthog.com/docs/llm-analytics/link-session-replay
     addTracingHeaders: ['httpbin.org'],
-    // Logs feature config. Off by default — `captureConsoleLogs: true`
-    // Server can also enable via remote config, or kill-switch with an explicit `false`.
+    // Logs feature config. Manual capture (`posthog.captureLog`,
+    // `posthog.logger.*`) is unconditional — these settings only customize
+    // resource attributes, rate cap, and filtering for local dogfooding.
+    // The server can kill-switch the pipeline via remote config
+    // (`response.logs.captureConsoleLogs: false`).
     //
-    // The remaining values are mainly for local dogfooding:
     //   - serviceName / environment / serviceVersion show up as OTLP resource
     //     attrs on every batch, so you can group/filter in the Logs UI and
     //     spot example traffic vs your real apps.
-    //   - Try uncommenting `beforeSend` to redact bodies, or
-    //     `maxLogsPerInterval` to exercise the rate cap from the Logs tab.
+    //   - Uncomment `beforeSend` to redact bodies, or `maxLogsPerInterval`
+    //     to exercise the rate cap from the Logs tab.
     logs: {
-        captureConsoleLogs: true,
         serviceName: 'expo-example',
         environment: 'dev',
         serviceVersion: '0.0.1',

--- a/examples/example-expo-53/pnpm-lock.yaml
+++ b/examples/example-expo-53/pnpm-lock.yaml
@@ -867,8 +867,12 @@ packages:
     engines: {node: '>=14'}
 
   '@posthog/core@file:../../target/posthog-core.tgz':
-    resolution: {integrity: sha512-bjfrkkzz2VIlAgZ3brGn/tR8v+rNqONscPh0QZcyu/chY6BtmT5rCQZGZUCTh1uale9jajMDlju6FVBdNQKqgA==, tarball: file:../../target/posthog-core.tgz}
-    version: 1.23.4
+    resolution: {integrity: sha512-XeeSqo/UNA8itbVs9qlseZMA/Z3MWtkQZ7nb+N/fTeeltNtBZCfL0Tt7tgnZ9+932nh/+cT7J205mPyCn/JC7g==, tarball: file:../../target/posthog-core.tgz}
+    version: 1.27.7
+
+  '@posthog/types@file:../../target/posthog-types.tgz':
+    resolution: {integrity: sha512-67d/J6sJY2YFuM57v61jrvwk31nea//DR4scLzu5f1GdJuBafCoRx4DcMNF+wgO5+95g8vDGA/DNcZdLELBCvQ==, tarball: file:../../target/posthog-types.tgz}
+    version: 1.372.3
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -1225,6 +1229,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -3135,8 +3140,8 @@ packages:
       react-native: '*'
 
   posthog-react-native@file:../../target/posthog-react-native.tgz:
-    resolution: {integrity: sha512-+nqFZywVNk4kgGHRrVivoReJTuC+an7Ka5ButL4nsTDso72IaRqnve7FHu4DhpNFQ3lq5N84N1nzlOUEMV7Jmw==, tarball: file:../../target/posthog-react-native.tgz}
-    version: 4.37.3
+    resolution: {integrity: sha512-XvkNZkDbnsz/hzV2emgIdMsWATiazRBGC4MjEVgpcYXY3dTRT91Oh2OChZpwSE7gnPEMssHiQbnjhUW9qIBRBQ==, tarball: file:../../target/posthog-react-native.tgz}
+    version: 4.43.10
     peerDependencies:
       '@react-native-async-storage/async-storage': '>=1.0.0'
       '@react-navigation/native': '>= 5.0.0'
@@ -3144,7 +3149,7 @@ packages:
       expo-device: '>= 4.0.0'
       expo-file-system: '>= 13.0.0'
       expo-localization: '>= 11.0.0'
-      posthog-react-native-session-replay: '>= 1.5.0'
+      posthog-react-native-session-replay: '>= 1.5.6'
       react-native-device-info: '>= 10.0.0'
       react-native-localize: '>= 3.0.0'
       react-native-navigation: '>= 6.0.0'
@@ -3172,6 +3177,8 @@ packages:
       react-native-navigation:
         optional: true
       react-native-safe-area-context:
+        optional: true
+      react-native-svg:
         optional: true
 
   prelude-ls@1.2.1:
@@ -5085,7 +5092,9 @@ snapshots:
 
   '@posthog/core@file:../../target/posthog-core.tgz':
     dependencies:
-      cross-spawn: 7.0.6
+      '@posthog/types': file:../../target/posthog-types.tgz
+
+  '@posthog/types@file:../../target/posthog-types.tgz': {}
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.0.14)(react@19.0.0)':
     dependencies:
@@ -7768,7 +7777,7 @@ snapshots:
   posthog-react-native@file:../../target/posthog-react-native.tgz(60444f062407d5e43e33bacdf6e729df):
     dependencies:
       '@posthog/core': file:../../target/posthog-core.tgz
-      react-native-svg: 15.11.2(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      '@posthog/types': file:../../target/posthog-types.tgz
     optionalDependencies:
       '@react-navigation/native': 7.1.31(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       expo-application: 6.1.5(expo@53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.0.14)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))
@@ -7777,6 +7786,7 @@ snapshots:
       expo-localization: 16.1.6(expo@53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.0.14)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react@19.0.0)
       posthog-react-native-session-replay: 1.5.6(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-safe-area-context: 5.4.0(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native-svg: 15.11.2(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
 
   prelude-ls@1.2.1: {}
 

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -107,8 +107,8 @@ export type {
     OtlpKeyValue,
     OtlpLogRecord,
     OtlpLogsPayload,
-    LogSdkContext,
 } from '@posthog/types'
+export type { LogSdkContext } from '@posthog/core'
 
 // Re-export KnownUnsafeEditableEvent from @posthog/core for backwards compatibility
 export type { KnownUnsafeEditableEvent } from '@posthog/core'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,17 @@ export {
   toOtlpKeyValueList,
 } from './logs/logs-utils'
 export { PostHogLogs } from './logs'
-export type { BufferedLogEntry, PostHogLogsConfig, ResolvedPostHogLogsConfig } from './logs/types'
+export type {
+  BeforeSendLogFn,
+  BufferedLogEntry,
+  CaptureLogger,
+  PostHogLogsConfig,
+  ResolvedPostHogLogsConfig,
+} from './logs/types'
+// Re-export the user-facing OTLP log types straight from `@posthog/types`
+// via the `logs/types` barrel so consumers don't have to import from two
+// packages to type their `captureLog` calls.
+export type { CaptureLogOptions, LogAttributeValue, LogAttributes, LogSeverityLevel } from './logs/types'
 export { uuidv7 } from './vendor/uuidv7'
 export * from './posthog-core'
 export * from './posthog-core-stateless'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export type {
   BeforeSendLogFn,
   BufferedLogEntry,
   CaptureLogger,
+  LogSdkContext,
   PostHogLogsConfig,
   ResolvedPostHogLogsConfig,
 } from './logs/types'

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -7,9 +7,18 @@ import type { BufferedLogEntry, PostHogLogsConfig, ResolvedPostHogLogsConfig } f
 // merging user config onto its own defaults. Test-only fixture; the real
 // defaults live per-SDK.
 const DEFAULT_MAX_BUFFER_SIZE = 100
+const DEFAULT_FLUSH_INTERVAL_MS = 10000
+const DEFAULT_MAX_BATCH_RECORDS_PER_POST = 50
+const DEFAULT_RATE_CAP_WINDOW_MS = 10000
 const resolveForTest = (partial?: PostHogLogsConfig): ResolvedPostHogLogsConfig => ({
   ...partial,
   maxBufferSize: partial?.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE,
+  flushIntervalMs: partial?.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS,
+  maxBatchRecordsPerPost: partial?.maxBatchRecordsPerPost ?? DEFAULT_MAX_BATCH_RECORDS_PER_POST,
+  rateCapWindowMs: partial?.rateCapWindowMs ?? DEFAULT_RATE_CAP_WINDOW_MS,
+  // Uncapped by default so existing tests aren't affected. The rate-limit
+  // describe block opts in explicitly via { maxLogsPerInterval: N }.
+  maxLogsPerInterval: partial?.maxLogsPerInterval,
 })
 
 // Mock PostHog instance exposing the `PostHogCoreStateless` surface PostHogLogs
@@ -20,6 +29,8 @@ const createMockInstance = (overrides: Record<string, any> = {}): any => {
     optedOut: false,
     getDistinctId: jest.fn(() => 'user-123'),
     getSessionId: jest.fn(() => 'sess-456'),
+    getLibraryId: jest.fn(() => 'posthog-core-tests'),
+    getLibraryVersion: jest.fn(() => '0.0.0-test'),
     getPersistedProperty: jest.fn((key: string) => store[key]),
     setPersistedProperty: jest.fn((key: string, value: any) => {
       if (value === null || value === undefined) {
@@ -28,6 +39,7 @@ const createMockInstance = (overrides: Record<string, any> = {}): any => {
         store[key] = value
       }
     }),
+    _sendLogsBatch: jest.fn(() => Promise.resolve({ kind: 'ok' })),
     addPendingPromise: jest.fn(<T>(promise: Promise<T>) => promise),
     _store: store,
     ...overrides,
@@ -355,6 +367,706 @@ describe('PostHogLogs', () => {
 
       expect(() => logs.captureLog({ body: 'after-reject-1' })).not.toThrow()
       expect(() => logs.captureLog({ body: 'after-reject-2' })).not.toThrow()
+    })
+  })
+
+  describe('flush', () => {
+    it('is a no-op when the queue is empty', async () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      await logs.flush()
+      expect(mockInstance._sendLogsBatch).not.toHaveBeenCalled()
+    })
+
+    it('drains the queue and sends an OTLP payload with resource + scope attrs', async () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ serviceName: 'my-service', environment: 'prod', serviceVersion: '1.2.3' }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'one' })
+      logs.captureLog({ body: 'two' })
+
+      await logs.flush()
+
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+      const payload = mockInstance._sendLogsBatch.mock.calls[0][0]
+      const resourceAttrs = Object.fromEntries(
+        payload.resourceLogs[0].resource.attributes.map((a: any) => [a.key, a.value])
+      )
+      expect(resourceAttrs['service.name']).toEqual({ stringValue: 'my-service' })
+      expect(resourceAttrs['deployment.environment']).toEqual({ stringValue: 'prod' })
+      expect(resourceAttrs['service.version']).toEqual({ stringValue: '1.2.3' })
+
+      const scope = payload.resourceLogs[0].scopeLogs[0].scope
+      expect(scope).toEqual({ name: 'posthog-core-tests', version: '0.0.0-test' })
+
+      const bodies = payload.resourceLogs[0].scopeLogs[0].logRecords.map((r: any) => r.body.stringValue)
+      expect(bodies).toEqual(['one', 'two'])
+
+      expect(readQueue(mockInstance)).toHaveLength(0)
+    })
+
+    it('defaults service.name to "unknown_service" when not configured', async () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'hi' })
+      await logs.flush()
+
+      const attrs = Object.fromEntries(
+        mockInstance._sendLogsBatch.mock.calls[0][0].resourceLogs[0].resource.attributes.map((a: any) => [
+          a.key,
+          a.value,
+        ])
+      )
+      expect(attrs['service.name']).toEqual({ stringValue: 'unknown_service' })
+    })
+
+    it('splits a large queue into multiple batches of maxBatchRecordsPerPost and persists after each', async () => {
+      const sendOrder: number[] = []
+      let persistCallsBeforeSecondSend = 0
+      mockInstance._sendLogsBatch = jest.fn(async (payload: any) => {
+        // Record the persist count *at the start of* send #2. The first send
+        // must have already persisted its queue advance by then — otherwise a
+        // crash between sends could double-send the first batch.
+        if (sendOrder.length === 1) {
+          persistCallsBeforeSecondSend = mockInstance.setPersistedProperty.mock.calls.length
+        }
+        sendOrder.push(payload.resourceLogs[0].scopeLogs[0].logRecords.length)
+        return { kind: 'ok' }
+      })
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxBatchRecordsPerPost: 2, maxBufferSize: 10 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      for (let i = 0; i < 5; i++) {
+        logs.captureLog({ body: `msg-${i}` })
+      }
+
+      await logs.flush()
+
+      // 2 + 2 + 1 = 5 records across 3 POSTs
+      expect(sendOrder).toEqual([2, 2, 1])
+      // After the first send, the queue must have been persisted before the second send —
+      // otherwise a crash between sends could double-send the first batch.
+      expect(persistCallsBeforeSecondSend).toBeGreaterThan(5 /* enqueue writes */)
+      expect(readQueue(mockInstance)).toHaveLength(0)
+    })
+
+    it('halves maxBatchRecordsPerPost and retries the same records on too-large outcome', async () => {
+      const sendSizes: number[] = []
+      mockInstance._sendLogsBatch = jest.fn(async (payload: any) => {
+        const size = payload.resourceLogs[0].scopeLogs[0].logRecords.length
+        sendSizes.push(size)
+        if (sendSizes.length === 1) {
+          return { kind: 'too-large' }
+        }
+        return { kind: 'ok' }
+      })
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxBatchRecordsPerPost: 4, maxBufferSize: 10 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      for (let i = 0; i < 4; i++) {
+        logs.captureLog({ body: `msg-${i}` })
+      }
+
+      await logs.flush()
+
+      // First POST: 4 records → too-large. Retry with halved cap = 2, so: 2 + 2.
+      expect(sendSizes).toEqual([4, 2, 2])
+      expect(readQueue(mockInstance)).toHaveLength(0)
+    })
+
+    it('drops the only record when too-large arrives on a batch of size 1', async () => {
+      mockInstance._sendLogsBatch = jest.fn(() => Promise.resolve({ kind: 'too-large' }))
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxBatchRecordsPerPost: 1 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'too-big' })
+
+      await logs.flush()
+
+      // Batch of 1 that's rejected as too-large is permanent — drop it rather
+      // than spin on the same record forever.
+      expect(readQueue(mockInstance)).toHaveLength(0)
+    })
+
+    it('keeps records in the queue on retry-later outcome and re-throws the carried error', async () => {
+      const netErr = new Error('offline')
+      mockInstance._sendLogsBatch = jest.fn(() => Promise.resolve({ kind: 'retry-later', error: netErr }))
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'queued' })
+
+      await expect(logs.flush()).rejects.toBe(netErr)
+
+      expect(readQueue(mockInstance)).toHaveLength(1)
+    })
+
+    it('drops the batch on fatal outcome and re-throws the carried error', async () => {
+      const bogus = new Error('malformed')
+      mockInstance._sendLogsBatch = jest.fn(() => Promise.resolve({ kind: 'fatal', error: bogus }))
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'doomed' })
+
+      await expect(logs.flush()).rejects.toBe(bogus)
+
+      expect(readQueue(mockInstance)).toHaveLength(0)
+    })
+
+    it('awaits _waitForStoragePersist between batches so a crash can’t replay records', async () => {
+      const sequence: string[] = []
+      mockInstance._sendLogsBatch = jest.fn(async (payload: any) => {
+        sequence.push(`send:${payload.resourceLogs[0].scopeLogs[0].logRecords.length}`)
+        return { kind: 'ok' }
+      })
+      const waitForStoragePersist = jest.fn(async () => {
+        sequence.push('waitForPersist')
+      })
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxBatchRecordsPerPost: 2, maxBufferSize: 10 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady,
+        waitForStoragePersist
+      )
+      for (let i = 0; i < 3; i++) {
+        logs.captureLog({ body: `msg-${i}` })
+      }
+
+      await logs.flush()
+
+      // Send 2 → waitForPersist → send 1 → waitForPersist. If the wait
+      // landed out-of-order (e.g. before send), a crash mid-batch could
+      // replay records on the next startup.
+      expect(sequence).toEqual(['send:2', 'waitForPersist', 'send:1', 'waitForPersist'])
+      expect(waitForStoragePersist).toHaveBeenCalledTimes(2)
+    })
+
+    it('serializes concurrent flush calls rather than racing them', async () => {
+      let resolveFirst: (v: any) => void = () => {}
+      mockInstance._sendLogsBatch = jest.fn(
+        () =>
+          new Promise((r) => {
+            resolveFirst = r
+          })
+      )
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'a' })
+
+      const first = logs.flush()
+      const second = logs.flush()
+
+      // Both callers observe the same in-flight promise, so only one POST happens.
+      resolveFirst({ kind: 'ok' })
+      await Promise.all([first, second])
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('flush triggers', () => {
+    beforeEach(() => jest.useFakeTimers())
+    afterEach(() => jest.useRealTimers())
+
+    it('fires a flush when the buffer hits maxBufferSize', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxBufferSize: 3 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'a' })
+      logs.captureLog({ body: 'b' })
+      expect(mockInstance._sendLogsBatch).not.toHaveBeenCalled()
+
+      logs.captureLog({ body: 'c' })
+      // Threshold trigger fires `flush()` fire-and-forget; the call happens
+      // synchronously on the hot path.
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+    })
+
+    it('schedules one timer per idle window and fires flush on expiry', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ flushIntervalMs: 5000 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'first' })
+      logs.captureLog({ body: 'second' })
+      logs.captureLog({ body: 'third' })
+
+      // Only one timer armed, not three — subsequent enqueues inside the
+      // window must not push the flush out.
+      expect(mockInstance._sendLogsBatch).not.toHaveBeenCalled()
+      jest.advanceTimersByTime(4999)
+      expect(mockInstance._sendLogsBatch).not.toHaveBeenCalled()
+      jest.advanceTimersByTime(1)
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not schedule a timer for the threshold-triggered path', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxBufferSize: 2, flushIntervalMs: 5000 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'a' })
+      logs.captureLog({ body: 'b' })
+      // Threshold path flushed already; advancing time must not trigger a second send.
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+      jest.advanceTimersByTime(5000)
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('shutdown', () => {
+    beforeEach(() => jest.useFakeTimers())
+    afterEach(() => jest.useRealTimers())
+
+    it('drains the queue and clears any armed flush timer', async () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ flushIntervalMs: 5000 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'a' })
+      // A timer is now armed — shutdown must cancel it so the process can
+      // exit cleanly even if the final flush triggers a duplicate send.
+
+      await logs.shutdown()
+
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+      // Advancing past the original interval must not produce a second flush.
+      jest.advanceTimersByTime(10000)
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+    })
+
+    it('swallows flush errors so shutdown can complete', async () => {
+      mockInstance._sendLogsBatch = jest.fn(() => Promise.resolve({ kind: 'fatal', error: new Error('boom') }))
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'doomed' })
+
+      await expect(logs.shutdown()).resolves.toBeUndefined()
+    })
+
+    it('is a no-op when the queue is empty and no timer is armed', async () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      await logs.shutdown()
+      expect(mockInstance._sendLogsBatch).not.toHaveBeenCalled()
+    })
+
+    it('called twice is idempotent (second call is a no-op once queue drains)', async () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'x' })
+      await logs.shutdown()
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+
+      // Queue is empty now — a second shutdown shouldn't re-send.
+      await logs.shutdown()
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+    })
+
+    it('while a flush is in flight, the shared promise coordinates a single drain', async () => {
+      let resolveFirst: (v: any) => void = () => {}
+      mockInstance._sendLogsBatch = jest.fn(
+        () =>
+          new Promise((r) => {
+            resolveFirst = r
+          })
+      )
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'a' })
+
+      // Real timers only here — shutdown(timeoutMs) path uses safeSetTimeout,
+      // which is incompatible with the default `jest.useFakeTimers()`.
+      jest.useRealTimers()
+
+      const flushP = logs.flush()
+      const shutdownP = logs.shutdown()
+
+      resolveFirst({ kind: 'ok' })
+      await Promise.all([flushP, shutdownP])
+
+      // Both callers joined the same in-flight flush — no double-send.
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+    })
+
+    it('races the final flush against timeoutMs so a stalled send does not hang shutdown', async () => {
+      jest.useRealTimers()
+      // _sendLogsBatch never resolves — the budget must force shutdown to return.
+      mockInstance._sendLogsBatch = jest.fn(() => new Promise(() => {}))
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'stuck' })
+
+      const start = Date.now()
+      await logs.shutdown(30)
+      const elapsed = Date.now() - start
+
+      // Loose upper bound — just prove we didn't wait forever.
+      expect(elapsed).toBeLessThan(500)
+    })
+
+    it('propagates a _waitForStoragePersist rejection out of flush (so callers can react)', async () => {
+      const persistErr = new Error('disk is gone')
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady,
+        // Persist fails AFTER the HTTP send succeeds — records were sent but
+        // the queue-advance didn't reach disk. Surface the error so the
+        // caller knows a retry on restart may re-send.
+        () => Promise.reject(persistErr)
+      )
+      logs.captureLog({ body: 'sent-but-not-persisted' })
+
+      await expect(logs.flush()).rejects.toBe(persistErr)
+    })
+  })
+
+  describe('beforeSend hook', () => {
+    it('mutates the record when the fn returns a transformed value', () => {
+      const beforeSend = jest.fn((r: any) => ({ ...r, body: r.body.toUpperCase() }))
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ beforeSend }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'hello' })
+
+      const queue = readQueue(mockInstance)
+      expect(queue).toHaveLength(1)
+      expect(queue[0].record.body.stringValue).toBe('HELLO')
+      expect(beforeSend).toHaveBeenCalledTimes(1)
+    })
+
+    it('drops the record when the fn returns null (no budget consumed downstream)', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ beforeSend: () => null }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'silent' })
+      expect(readQueue(mockInstance)).toHaveLength(0)
+      expect(logger.info).toHaveBeenCalledWith('Log was rejected in beforeSend function')
+    })
+
+    it('chains an array of fns left-to-right (each fn sees the previous result)', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({
+          beforeSend: [
+            (r) => ({ ...r, body: `${r.body}-1` }),
+            (r) => ({ ...r, body: `${r.body}-2` }),
+            (r) => ({ ...r, body: `${r.body}-3` }),
+          ],
+        }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'x' })
+      expect(readQueue(mockInstance)[0].record.body.stringValue).toBe('x-1-2-3')
+    })
+
+    it('short-circuits the chain when any fn returns null', () => {
+      const after = jest.fn((r) => r)
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({
+          beforeSend: [(r) => r, () => null, after],
+        }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'dropped' })
+      expect(readQueue(mockInstance)).toHaveLength(0)
+      expect(after).not.toHaveBeenCalled()
+    })
+
+    it('never crashes the caller when a fn throws — the chain continues with the prior result', () => {
+      const thrower = jest.fn(() => {
+        throw new Error('bad filter')
+      })
+      const after = jest.fn((r: any) => ({ ...r, body: `${r.body}!` }))
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ beforeSend: [thrower, after] }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+
+      expect(() => logs.captureLog({ body: 'hi' })).not.toThrow()
+      // After the thrower, the chain continues with the original options.
+      // `after` sees `body: 'hi'`, appends '!', so final body is 'hi!'.
+      expect(readQueue(mockInstance)[0].record.body.stringValue).toBe('hi!')
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error in beforeSend function for log:'),
+        expect.any(Error)
+      )
+    })
+
+    it('treats an empty body returned by beforeSend as a drop', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ beforeSend: (r) => ({ ...r, body: '' }) }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'will-be-emptied' })
+      expect(readQueue(mockInstance)).toHaveLength(0)
+    })
+  })
+
+  describe('rate limiting', () => {
+    beforeEach(() => jest.useFakeTimers({ now: 0 }))
+    afterEach(() => jest.useRealTimers())
+
+    it('is uncapped when maxLogsPerInterval is undefined (default)', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      for (let i = 0; i < 50; i++) {
+        logs.captureLog({ body: `msg-${i}` })
+      }
+      expect(readQueue(mockInstance)).toHaveLength(50)
+    })
+
+    it('drops captures beyond maxLogsPerInterval within the window', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxLogsPerInterval: 3, rateCapWindowMs: 1000 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      for (let i = 0; i < 5; i++) {
+        logs.captureLog({ body: `msg-${i}` })
+      }
+      expect(readQueue(mockInstance)).toHaveLength(3)
+    })
+
+    it('warns exactly once per window when dropping, regardless of how many drops', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxLogsPerInterval: 2, rateCapWindowMs: 1000 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      for (let i = 0; i < 10; i++) {
+        logs.captureLog({ body: `msg-${i}` })
+      }
+      expect(logger.warn).toHaveBeenCalledTimes(1)
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('captureLog dropping logs'))
+    })
+
+    it('resets the counter when the window rolls (and warns again on next overflow)', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxLogsPerInterval: 1, rateCapWindowMs: 1000 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'window-1-kept' })
+      logs.captureLog({ body: 'window-1-dropped' })
+      expect(readQueue(mockInstance)).toHaveLength(1)
+      expect(logger.warn).toHaveBeenCalledTimes(1)
+
+      jest.setSystemTime(1001)
+      logs.captureLog({ body: 'window-2-kept' })
+      logs.captureLog({ body: 'window-2-dropped' })
+      expect(readQueue(mockInstance)).toHaveLength(2)
+      expect(logger.warn).toHaveBeenCalledTimes(2)
+    })
+
+    it('resets the window when the clock jumps backward (NTP correction / manual clock change)', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxLogsPerInterval: 2, rateCapWindowMs: 1000 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      // Seed the window at t=5000, fill the budget.
+      jest.setSystemTime(5000)
+      logs.captureLog({ body: 'a' })
+      logs.captureLog({ body: 'b' })
+      logs.captureLog({ body: 'dropped-pre-jump' })
+      expect(readQueue(mockInstance)).toHaveLength(2)
+
+      // Clock jumps backward by 1 hour (e.g. user reset device time).
+      // Without the `elapsed < 0` guard, the rate cap would stay "stuck"
+      // until `now` exceeds the old window-start again — potentially
+      // dropping every log for the duration of the backward jump.
+      jest.setSystemTime(5000 - 60 * 60 * 1000)
+      logs.captureLog({ body: 'accepted-post-jump' })
+
+      expect(readQueue(mockInstance)).toHaveLength(3)
+      expect(readQueue(mockInstance)[2].record.body.stringValue).toBe('accepted-post-jump')
+    })
+
+    it('beforeSend-rejected records do not consume the per-interval budget', () => {
+      // beforeSend drops the first record; rate cap is 1 per window. The
+      // SECOND capture should still succeed — if beforeSend consumed the
+      // budget, it'd be dropped.
+      const beforeSend = jest
+        .fn()
+        .mockReturnValueOnce(null)
+        .mockImplementation((r: any) => r)
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxLogsPerInterval: 1, rateCapWindowMs: 1000, beforeSend }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'pre-filtered-out' })
+      logs.captureLog({ body: 'should-still-fit' })
+
+      expect(readQueue(mockInstance)).toHaveLength(1)
+      expect(readQueue(mockInstance)[0].record.body.stringValue).toBe('should-still-fit')
+    })
+  })
+
+  describe('concurrent capture during flush', () => {
+    it('mid-flush captures land in the queue for the next cycle — not lost, not double-sent', async () => {
+      let resolveSend: (v: any) => void = () => {}
+      let captureDuringSend: (() => void) | null = null
+
+      mockInstance._sendLogsBatch = jest.fn(
+        () =>
+          new Promise((r) => {
+            if (captureDuringSend) {
+              captureDuringSend()
+              captureDuringSend = null
+            }
+            resolveSend = (v) => r(v)
+          })
+      )
+
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxBatchRecordsPerPost: 1, maxBufferSize: 10 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'first' })
+      captureDuringSend = (): void => {
+        logs.captureLog({ body: 'mid-flight' })
+      }
+
+      const flushP = logs.flush()
+      await new Promise((r) => setImmediate(r))
+      resolveSend({ kind: 'ok' })
+      await flushP
+
+      // flush() uses `originalQueueLength` at entry, so a mid-flight capture
+      // is intentionally left for the NEXT flush (matches events semantics).
+      // The invariant we care about: not lost, not double-sent.
+      expect(readQueue(mockInstance)).toHaveLength(1)
+      expect(readQueue(mockInstance)[0].record.body.stringValue).toBe('mid-flight')
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(1)
+
+      // A subsequent flush picks it up — no data lost.
+      const flushP2 = logs.flush()
+      await new Promise((r) => setImmediate(r))
+      resolveSend({ kind: 'ok' })
+      await flushP2
+      expect(readQueue(mockInstance)).toHaveLength(0)
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -583,6 +583,81 @@ describe('PostHogLogs', () => {
       expect(readQueue(mockInstance)).toHaveLength(0)
     })
 
+    it('warns explicitly when dropping a size-1 413 (visibility for the lost record)', async () => {
+      mockInstance._sendLogsBatch = jest.fn(() => Promise.resolve({ kind: 'too-large' }))
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxBatchRecordsPerPost: 1 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'oversized' })
+      await logs.flush()
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Dropping a single log record after 413 with batch size 1')
+      )
+    })
+
+    it('keeps draining the queue after a size-1 413 drop (one bad record does not stall the pipeline)', async () => {
+      // First record returns too-large with size 1 (drops and warns), then
+      // the rest of the queue should continue flushing normally.
+      let callCount = 0
+      mockInstance._sendLogsBatch = jest.fn(() => {
+        callCount++
+        return Promise.resolve(callCount === 1 ? { kind: 'too-large' } : { kind: 'ok' })
+      })
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxBatchRecordsPerPost: 1, maxBufferSize: 10 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'oversized' })
+      logs.captureLog({ body: 'ok-1' })
+      logs.captureLog({ body: 'ok-2' })
+
+      await logs.flush()
+
+      // Three sends: oversized (dropped), ok-1, ok-2. Queue is empty.
+      expect(mockInstance._sendLogsBatch).toHaveBeenCalledTimes(3)
+      expect(readQueue(mockInstance)).toHaveLength(0)
+    })
+
+    it('size-1 413 retry-shrink path: starts at maxBatchRecordsPerPost, halves to 1, drops at 1', async () => {
+      // Realistic flow: batch=N gets too-large, halves to N/2, halves to 1,
+      // then 413 on size 1 is the permanent drop. Verifies the cap actually
+      // shrinks all the way down before the size-1 drop fires.
+      const sendSizes: number[] = []
+      mockInstance._sendLogsBatch = jest.fn(async (payload: any) => {
+        const size = payload.resourceLogs[0].scopeLogs[0].logRecords.length
+        sendSizes.push(size)
+        return { kind: 'too-large' }
+      })
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxBatchRecordsPerPost: 4, maxBufferSize: 10 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      // Single oversized record. With maxBatchRecordsPerPost=4 but only 1 record
+      // in the queue, the first send is size 1 — going straight to the drop path.
+      logs.captureLog({ body: 'huge' })
+
+      await logs.flush()
+
+      // Single send of size 1, dropped immediately (no halving rounds because
+      // batch was already at 1).
+      expect(sendSizes).toEqual([1])
+      expect(readQueue(mockInstance)).toHaveLength(0)
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Dropping a single log record after 413 with batch size 1')
+      )
+    })
+
     it('keeps records in the queue on retry-later outcome and re-throws the carried error', async () => {
       const netErr = new Error('offline')
       mockInstance._sendLogsBatch = jest.fn(() => Promise.resolve({ kind: 'retry-later', error: netErr }))

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -10,12 +10,20 @@ const DEFAULT_MAX_BUFFER_SIZE = 100
 const DEFAULT_FLUSH_INTERVAL_MS = 10000
 const DEFAULT_MAX_BATCH_RECORDS_PER_POST = 50
 const DEFAULT_RATE_CAP_WINDOW_MS = 10000
+const DEFAULT_BACKGROUND_FLUSH_BUDGET_MS = 25000
+const DEFAULT_TERMINATION_FLUSH_BUDGET_MS = 2000
 const resolveForTest = (partial?: PostHogLogsConfig): ResolvedPostHogLogsConfig => ({
+  // Default the gate to ON in tests so each spec doesn't have to repeat the
+  // opt-in. The gating-specific tests pass `captureConsoleLogs: false` (or
+  // `undefined`) explicitly to exercise the off paths.
+  captureConsoleLogs: true,
   ...partial,
   maxBufferSize: partial?.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE,
   flushIntervalMs: partial?.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS,
   maxBatchRecordsPerPost: partial?.maxBatchRecordsPerPost ?? DEFAULT_MAX_BATCH_RECORDS_PER_POST,
   rateCapWindowMs: partial?.rateCapWindowMs ?? DEFAULT_RATE_CAP_WINDOW_MS,
+  backgroundFlushBudgetMs: partial?.backgroundFlushBudgetMs ?? DEFAULT_BACKGROUND_FLUSH_BUDGET_MS,
+  terminationFlushBudgetMs: partial?.terminationFlushBudgetMs ?? DEFAULT_TERMINATION_FLUSH_BUDGET_MS,
   // Uncapped by default so existing tests aren't affected. The rate-limit
   // describe block opts in explicitly via { maxLogsPerInterval: N }.
   maxLogsPerInterval: partial?.maxLogsPerInterval,
@@ -199,10 +207,10 @@ describe('PostHogLogs', () => {
       expect(readQueue(instance)).toHaveLength(0)
     })
 
-    it('is a no-op when config.enabled is false', () => {
+    it('is a no-op when captureConsoleLogs is false', () => {
       const logs = new PostHogLogs(
         mockInstance,
-        resolveForTest({ enabled: false }),
+        resolveForTest({ captureConsoleLogs: false }),
         logger,
         getContextFor(mockInstance),
         immediateOnReady
@@ -211,15 +219,75 @@ describe('PostHogLogs', () => {
       expect(readQueue(mockInstance)).toHaveLength(0)
     })
 
-    it('captures when config is provided with enabled undefined (defaults to true)', () => {
+    it('is a no-op when captureConsoleLogs is undefined (default off)', () => {
+      // Mirrors the JS SDK: the logs feature is opt-in, so an absent flag
+      // leaves it disabled until either local sets `true` or remote config
+      // turns it on via `setRemoteEnabled(true)`.
       const logs = new PostHogLogs(
         mockInstance,
-        resolveForTest({}),
+        resolveForTest({ captureConsoleLogs: undefined }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'should be dropped' })
+      expect(readQueue(mockInstance)).toHaveLength(0)
+    })
+
+    it('captures when captureConsoleLogs is true', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ captureConsoleLogs: true }),
         logger,
         getContextFor(mockInstance),
         immediateOnReady
       )
       logs.captureLog({ body: 'kept' })
+      expect(readQueue(mockInstance)).toHaveLength(1)
+    })
+
+    it('remote setRemoteEnabled(true) flips a local-off instance on', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ captureConsoleLogs: false }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'pre-remote-drop' })
+      expect(readQueue(mockInstance)).toHaveLength(0)
+
+      logs.setRemoteEnabled(true)
+      logs.captureLog({ body: 'post-remote-keep' })
+      expect(readQueue(mockInstance)).toHaveLength(1)
+    })
+
+    it('remote setRemoteEnabled(false) acts as a kill-switch even when local is on', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ captureConsoleLogs: true }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.setRemoteEnabled(false)
+      logs.captureLog({ body: 'killed' })
+      expect(readQueue(mockInstance)).toHaveLength(0)
+    })
+
+    it('setRemoteEnabled(undefined) leaves the existing decision unchanged', () => {
+      // Mirrors the JS SDK: a remote response that omits the flag must not
+      // overwrite a previous explicit decision.
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ captureConsoleLogs: false }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.setRemoteEnabled(true)
+      logs.setRemoteEnabled(undefined)
+      logs.captureLog({ body: 'still-on' })
       expect(readQueue(mockInstance)).toHaveLength(1)
     })
 
@@ -438,13 +506,20 @@ describe('PostHogLogs', () => {
       expect(attrs['service.name']).toEqual({ stringValue: 'unknown_service' })
     })
 
-    it('user-supplied resourceAttributes win over auto-populated telemetry.sdk.*', async () => {
+    it('SDK-controlled telemetry.sdk.* and service.name win over user resourceAttributes', async () => {
+      // Most logs backends index on these keys for routing, SDK-version
+      // dashboards, and bug-correlation. Letting a stray user key clobber
+      // them silently breaks ingestion attribution, so the layout puts
+      // user attrs first and SDK identity attrs on top.
       const logs = new PostHogLogs(
         mockInstance,
         resolveForTest({
-          // Edge case: user pinning a specific telemetry.sdk.name (e.g. via
-          // a wrapper SDK that needs to identify as itself, not the core).
-          resourceAttributes: { 'telemetry.sdk.name': 'my-wrapper' },
+          resourceAttributes: {
+            'telemetry.sdk.name': 'my-wrapper',
+            'service.name': 'user-supplied-service',
+            // Non-protected user keys still pass through.
+            'host.name': 'my-host',
+          },
         }),
         logger,
         getContextFor(mockInstance),
@@ -459,10 +534,10 @@ describe('PostHogLogs', () => {
           a.value,
         ])
       )
-      expect(attrs['telemetry.sdk.name']).toEqual({ stringValue: 'my-wrapper' })
-      // The version still falls through from the instance — only the
-      // explicitly-overridden key is replaced.
+      expect(attrs['telemetry.sdk.name']).toEqual({ stringValue: 'posthog-core-tests' })
       expect(attrs['telemetry.sdk.version']).toEqual({ stringValue: '0.0.0-test' })
+      expect(attrs['service.name']).toEqual({ stringValue: 'unknown_service' })
+      expect(attrs['host.name']).toEqual({ stringValue: 'my-host' })
     })
 
     it('splits a large queue into multiple batches of maxBatchRecordsPerPost and persists after each', async () => {
@@ -524,6 +599,43 @@ describe('PostHogLogs', () => {
 
       // First POST: 4 records → too-large. Retry with halved cap = 2, so: 2 + 2.
       expect(sendSizes).toEqual([4, 2, 2])
+      expect(readQueue(mockInstance)).toHaveLength(0)
+    })
+
+    it('ramps maxBatchRecordsPerPost back toward the configured cap after a healthy streak', async () => {
+      // Reproduces the Greptile P1 concern: a one-off oversized payload
+      // should not permanently degrade throughput. After a 413 halves the
+      // cap, each healthy send grows it back by 1 until the configured
+      // maximum is reached.
+      const sendSizes: number[] = []
+      mockInstance._sendLogsBatch = jest.fn(async (payload: any) => {
+        const size = payload.resourceLogs[0].scopeLogs[0].logRecords.length
+        sendSizes.push(size)
+        // First POST is rejected as too-large; everything else succeeds.
+        if (sendSizes.length === 1) {
+          return { kind: 'too-large' }
+        }
+        return { kind: 'ok' }
+      })
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ maxBatchRecordsPerPost: 4, maxBufferSize: 100 }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      // Enqueue plenty so the recovery has room to ramp.
+      for (let i = 0; i < 16; i++) {
+        logs.captureLog({ body: `msg-${i}` })
+      }
+
+      await logs.flush()
+
+      // First POST: 4 records → too-large. Cap halves to 2. From there each
+      // healthy send grows the cap by 1 toward the configured 4:
+      //   sizes: [4 (413), 2, 3, 4, 4, ...] (the trailing 3 drains the
+      //   remainder of the 16-record queue).
+      expect(sendSizes).toEqual([4, 2, 3, 4, 4, 3])
       expect(readQueue(mockInstance)).toHaveLength(0)
     })
 
@@ -835,71 +947,91 @@ describe('PostHogLogs', () => {
   })
 
   describe('beforeSend hook', () => {
-    it('mutates the record when the fn returns a transformed value', () => {
-      const beforeSend = jest.fn((r: any) => ({ ...r, body: r.body.toUpperCase() }))
-      const logs = new PostHogLogs(
+    // Helper that hides the constructor boilerplate so the table-driven
+    // cases below can be a single line of setup each.
+    const makeLogs = (beforeSend: PostHogLogsConfig['beforeSend']): PostHogLogs =>
+      new PostHogLogs(
         mockInstance,
         resolveForTest({ beforeSend }),
         logger,
         getContextFor(mockInstance),
         immediateOnReady
       )
-      logs.captureLog({ body: 'hello' })
+
+    // Cases that share a "captureLog → assert queue body" shape. Bespoke
+    // assertions (logger expectations, throw-doesn't-crash, post-chain
+    // continuation after throw) live in their own `it` blocks below — those
+    // were warping the table when forced into it.
+    type Case = {
+      name: string
+      beforeSend: PostHogLogsConfig['beforeSend']
+      input: string
+      expectedQueueLen: number
+      expectedBody?: string
+    }
+    const cases: Case[] = [
+      {
+        name: 'transforms body when fn returns mutated value',
+        beforeSend: (r) => ({ ...r, body: r.body.toUpperCase() }),
+        input: 'hello',
+        expectedQueueLen: 1,
+        expectedBody: 'HELLO',
+      },
+      {
+        name: 'drops the record when fn returns null',
+        beforeSend: () => null,
+        input: 'silent',
+        expectedQueueLen: 0,
+      },
+      {
+        name: 'chains an array left-to-right (each fn sees previous result)',
+        beforeSend: [
+          (r) => ({ ...r, body: `${r.body}-1` }),
+          (r) => ({ ...r, body: `${r.body}-2` }),
+          (r) => ({ ...r, body: `${r.body}-3` }),
+        ],
+        input: 'x',
+        expectedQueueLen: 1,
+        expectedBody: 'x-1-2-3',
+      },
+      {
+        name: 'short-circuits the chain when any fn returns null',
+        beforeSend: [(r) => r, () => null, (r) => r],
+        input: 'dropped',
+        expectedQueueLen: 0,
+      },
+      {
+        name: 'treats an empty body returned by beforeSend as a drop',
+        beforeSend: (r) => ({ ...r, body: '' }),
+        input: 'will-be-emptied',
+        expectedQueueLen: 0,
+      },
+    ]
+
+    it.each(cases)('$name', ({ beforeSend, input, expectedQueueLen, expectedBody }) => {
+      const logs = makeLogs(beforeSend)
+      logs.captureLog({ body: input })
 
       const queue = readQueue(mockInstance)
-      expect(queue).toHaveLength(1)
-      expect(queue[0].record.body.stringValue).toBe('HELLO')
-      expect(beforeSend).toHaveBeenCalledTimes(1)
+      expect(queue).toHaveLength(expectedQueueLen)
+      if (expectedBody !== undefined) {
+        expect(queue[0].record.body.stringValue).toBe(expectedBody)
+      }
     })
 
-    it('drops the record when the fn returns null (no budget consumed downstream)', () => {
-      const logs = new PostHogLogs(
-        mockInstance,
-        resolveForTest({ beforeSend: () => null }),
-        logger,
-        getContextFor(mockInstance),
-        immediateOnReady
-      )
+    it('logs an info line when a fn returns null', () => {
+      // Carved out because the table only asserts queue shape; this
+      // verifies the diagnostic path that warns the user a record was
+      // dropped by their filter (no other knob to surface that).
+      const logs = makeLogs(() => null)
       logs.captureLog({ body: 'silent' })
-      expect(readQueue(mockInstance)).toHaveLength(0)
       expect(logger.info).toHaveBeenCalledWith('Log was rejected in beforeSend function')
     })
 
-    it('chains an array of fns left-to-right (each fn sees the previous result)', () => {
-      const logs = new PostHogLogs(
-        mockInstance,
-        resolveForTest({
-          beforeSend: [
-            (r) => ({ ...r, body: `${r.body}-1` }),
-            (r) => ({ ...r, body: `${r.body}-2` }),
-            (r) => ({ ...r, body: `${r.body}-3` }),
-          ],
-        }),
-        logger,
-        getContextFor(mockInstance),
-        immediateOnReady
-      )
-      logs.captureLog({ body: 'x' })
-      expect(readQueue(mockInstance)[0].record.body.stringValue).toBe('x-1-2-3')
-    })
-
-    it('short-circuits the chain when any fn returns null', () => {
-      const after = jest.fn((r) => r)
-      const logs = new PostHogLogs(
-        mockInstance,
-        resolveForTest({
-          beforeSend: [(r) => r, () => null, after],
-        }),
-        logger,
-        getContextFor(mockInstance),
-        immediateOnReady
-      )
-      logs.captureLog({ body: 'dropped' })
-      expect(readQueue(mockInstance)).toHaveLength(0)
-      expect(after).not.toHaveBeenCalled()
-    })
-
     it('never crashes the caller when a fn throws — the chain continues with the prior result', () => {
+      // Bespoke: needs to verify (a) no throw escapes captureLog, (b) the
+      // chain continues with the previous result so a buggy filter degrades
+      // to a no-op, and (c) the failure is logged. Doesn't fit the table.
       const thrower = jest.fn(() => {
         throw new Error('bad filter')
       })
@@ -913,25 +1045,11 @@ describe('PostHogLogs', () => {
       )
 
       expect(() => logs.captureLog({ body: 'hi' })).not.toThrow()
-      // After the thrower, the chain continues with the original options.
-      // `after` sees `body: 'hi'`, appends '!', so final body is 'hi!'.
       expect(readQueue(mockInstance)[0].record.body.stringValue).toBe('hi!')
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining('Error in beforeSend function for log:'),
         expect.any(Error)
       )
-    })
-
-    it('treats an empty body returned by beforeSend as a drop', () => {
-      const logs = new PostHogLogs(
-        mockInstance,
-        resolveForTest({ beforeSend: (r) => ({ ...r, body: '' }) }),
-        logger,
-        getContextFor(mockInstance),
-        immediateOnReady
-      )
-      logs.captureLog({ body: 'will-be-emptied' })
-      expect(readQueue(mockInstance)).toHaveLength(0)
     })
   })
 
@@ -939,32 +1057,43 @@ describe('PostHogLogs', () => {
     beforeEach(() => jest.useFakeTimers({ now: 0 }))
     afterEach(() => jest.useRealTimers())
 
-    it('is uncapped when maxLogsPerInterval is undefined (default)', () => {
-      const logs = new PostHogLogs(
-        mockInstance,
-        resolveForTest(),
-        logger,
-        getContextFor(mockInstance),
-        immediateOnReady
-      )
-      for (let i = 0; i < 50; i++) {
-        logs.captureLog({ body: `msg-${i}` })
-      }
-      expect(readQueue(mockInstance)).toHaveLength(50)
-    })
+    // Tabular form for the simple in-window cap cases. Bespoke ones
+    // (warn-once, window-roll reset, clock-jump backward, beforeSend
+    // accounting) keep their own `it` blocks because they assert
+    // multi-window or interleaving behavior.
+    type CapCase = {
+      name: string
+      maxLogsPerInterval: number | undefined
+      capturesInWindow: number
+      expectedQueueLen: number
+    }
+    const capCases: CapCase[] = [
+      {
+        name: 'is uncapped when maxLogsPerInterval is undefined (default)',
+        maxLogsPerInterval: undefined,
+        capturesInWindow: 50,
+        expectedQueueLen: 50,
+      },
+      {
+        name: 'drops captures beyond maxLogsPerInterval within the window',
+        maxLogsPerInterval: 3,
+        capturesInWindow: 5,
+        expectedQueueLen: 3,
+      },
+    ]
 
-    it('drops captures beyond maxLogsPerInterval within the window', () => {
+    it.each(capCases)('$name', ({ maxLogsPerInterval, capturesInWindow, expectedQueueLen }) => {
       const logs = new PostHogLogs(
         mockInstance,
-        resolveForTest({ maxLogsPerInterval: 3, rateCapWindowMs: 1000 }),
+        resolveForTest({ maxLogsPerInterval, rateCapWindowMs: 1000 }),
         logger,
         getContextFor(mockInstance),
         immediateOnReady
       )
-      for (let i = 0; i < 5; i++) {
+      for (let i = 0; i < capturesInWindow; i++) {
         logs.captureLog({ body: `msg-${i}` })
       }
-      expect(readQueue(mockInstance)).toHaveLength(3)
+      expect(readQueue(mockInstance)).toHaveLength(expectedQueueLen)
     })
 
     it('warns exactly once per window when dropping, regardless of how many drops', () => {

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -203,9 +203,12 @@ describe('PostHogLogs', () => {
       expect(readQueue(instance)).toHaveLength(0)
     })
 
-    it('captures unconditionally without any local opt-in', () => {
-      // Manual capture has no local gate (matches the browser SDK's manual
-      // path). Only optedOut, missing body, and the remote kill switch block.
+    it('captures unconditionally — only optedOut, missing body, and beforeSend can drop', () => {
+      // Manual capture has no SDK gate beyond opt-out and body validation.
+      // Matches the events pipeline's `capture()` shape: server cannot
+      // remotely block. The wire field `response.logs.captureConsoleLogs` is
+      // browser-only (controls console autocapture there) and is not read
+      // by RN until console autocapture lands as a follow-up.
       const logs = new PostHogLogs(
         mockInstance,
         resolveForTest(),
@@ -215,54 +218,6 @@ describe('PostHogLogs', () => {
       )
       logs.captureLog({ body: 'kept' })
       expect(readQueue(mockInstance)).toHaveLength(1)
-    })
-
-    it('setRemoteEnabled(false) acts as a server-side kill switch', () => {
-      const logs = new PostHogLogs(
-        mockInstance,
-        resolveForTest(),
-        logger,
-        getContextFor(mockInstance),
-        immediateOnReady
-      )
-      logs.captureLog({ body: 'pre-kill-keep' })
-      expect(readQueue(mockInstance)).toHaveLength(1)
-
-      logs.setRemoteEnabled(false)
-      logs.captureLog({ body: 'killed' })
-      expect(readQueue(mockInstance)).toHaveLength(1)
-    })
-
-    it('setRemoteEnabled(true) and undefined both leave capture allowed', () => {
-      // Functionally identical: the gate only blocks on an explicit `false`.
-      const logs = new PostHogLogs(
-        mockInstance,
-        resolveForTest(),
-        logger,
-        getContextFor(mockInstance),
-        immediateOnReady
-      )
-      logs.setRemoteEnabled(true)
-      logs.captureLog({ body: 'remote-true' })
-      logs.setRemoteEnabled(undefined)
-      logs.captureLog({ body: 'remote-undefined-after-true' })
-      expect(readQueue(mockInstance)).toHaveLength(2)
-    })
-
-    it('setRemoteEnabled(undefined) does not overwrite a previous kill-switch', () => {
-      // A response that omits the key must not silently re-enable a feature
-      // the server explicitly disabled.
-      const logs = new PostHogLogs(
-        mockInstance,
-        resolveForTest(),
-        logger,
-        getContextFor(mockInstance),
-        immediateOnReady
-      )
-      logs.setRemoteEnabled(false)
-      logs.setRemoteEnabled(undefined)
-      logs.captureLog({ body: 'still-killed' })
-      expect(readQueue(mockInstance)).toHaveLength(0)
     })
 
     it('appends subsequent captures to the existing queue', () => {

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -1,25 +1,27 @@
 import { PostHogPersistedProperty } from '../types'
 import type { Logger } from '../types'
 import { PostHogLogs } from './index'
-import type { BufferedLogEntry, PostHogLogsConfig, ResolvedPostHogLogsConfig } from './types'
+import type { BufferedLogEntry, ResolvedPostHogLogsConfig } from './types'
 
 // Default resolved config for tests — mirrors what each SDK would build by
 // merging user config onto its own defaults. Test-only fixture; the real
-// defaults live per-SDK.
+// defaults live per-SDK. Takes the resolved (flat) shape directly so tests
+// can override `maxLogsPerInterval` / `rateCapWindowMs` without going through
+// the public `rateCap: { maxLogs, windowMs }` wrapper.
 const DEFAULT_MAX_BUFFER_SIZE = 100
 const DEFAULT_FLUSH_INTERVAL_MS = 10000
 const DEFAULT_MAX_BATCH_RECORDS_PER_POST = 50
 const DEFAULT_RATE_CAP_WINDOW_MS = 10000
 const DEFAULT_BACKGROUND_FLUSH_BUDGET_MS = 25000
 const DEFAULT_TERMINATION_FLUSH_BUDGET_MS = 2000
-const resolveForTest = (partial?: PostHogLogsConfig): ResolvedPostHogLogsConfig => ({
+const resolveForTest = (partial?: Partial<ResolvedPostHogLogsConfig>): ResolvedPostHogLogsConfig => ({
   ...partial,
   maxBufferSize: partial?.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE,
   flushIntervalMs: partial?.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS,
   maxBatchRecordsPerPost: partial?.maxBatchRecordsPerPost ?? DEFAULT_MAX_BATCH_RECORDS_PER_POST,
   rateCapWindowMs: partial?.rateCapWindowMs ?? DEFAULT_RATE_CAP_WINDOW_MS,
-  backgroundFlushBudgetMs: partial?.backgroundFlushBudgetMs ?? DEFAULT_BACKGROUND_FLUSH_BUDGET_MS,
-  terminationFlushBudgetMs: partial?.terminationFlushBudgetMs ?? DEFAULT_TERMINATION_FLUSH_BUDGET_MS,
+  backgroundFlushBudgetMs: DEFAULT_BACKGROUND_FLUSH_BUDGET_MS,
+  terminationFlushBudgetMs: DEFAULT_TERMINATION_FLUSH_BUDGET_MS,
   // Uncapped by default so existing tests aren't affected. The rate-limit
   // describe block opts in explicitly via { maxLogsPerInterval: N }.
   maxLogsPerInterval: partial?.maxLogsPerInterval,

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -204,11 +204,6 @@ describe('PostHogLogs', () => {
     })
 
     it('captures unconditionally — only optedOut, missing body, and beforeSend can drop', () => {
-      // Manual capture has no SDK gate beyond opt-out and body validation.
-      // Matches the events pipeline's `capture()` shape: server cannot
-      // remotely block. The wire field `response.logs.captureConsoleLogs` is
-      // browser-only (controls console autocapture there) and is not read
-      // by RN until console autocapture lands as a follow-up.
       const logs = new PostHogLogs(
         mockInstance,
         resolveForTest(),

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -404,6 +404,10 @@ describe('PostHogLogs', () => {
       expect(resourceAttrs['service.name']).toEqual({ stringValue: 'my-service' })
       expect(resourceAttrs['deployment.environment']).toEqual({ stringValue: 'prod' })
       expect(resourceAttrs['service.version']).toEqual({ stringValue: '1.2.3' })
+      // OTLP-standard SDK identification — pulled from the instance's
+      // getLibraryId/Version so every SDK self-identifies.
+      expect(resourceAttrs['telemetry.sdk.name']).toEqual({ stringValue: 'posthog-core-tests' })
+      expect(resourceAttrs['telemetry.sdk.version']).toEqual({ stringValue: '0.0.0-test' })
 
       const scope = payload.resourceLogs[0].scopeLogs[0].scope
       expect(scope).toEqual({ name: 'posthog-core-tests', version: '0.0.0-test' })
@@ -432,6 +436,33 @@ describe('PostHogLogs', () => {
         ])
       )
       expect(attrs['service.name']).toEqual({ stringValue: 'unknown_service' })
+    })
+
+    it('user-supplied resourceAttributes win over auto-populated telemetry.sdk.*', async () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({
+          // Edge case: user pinning a specific telemetry.sdk.name (e.g. via
+          // a wrapper SDK that needs to identify as itself, not the core).
+          resourceAttributes: { 'telemetry.sdk.name': 'my-wrapper' },
+        }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'hi' })
+      await logs.flush()
+
+      const attrs = Object.fromEntries(
+        mockInstance._sendLogsBatch.mock.calls[0][0].resourceLogs[0].resource.attributes.map((a: any) => [
+          a.key,
+          a.value,
+        ])
+      )
+      expect(attrs['telemetry.sdk.name']).toEqual({ stringValue: 'my-wrapper' })
+      // The version still falls through from the instance — only the
+      // explicitly-overridden key is replaced.
+      expect(attrs['telemetry.sdk.version']).toEqual({ stringValue: '0.0.0-test' })
     })
 
     it('splits a large queue into multiple batches of maxBatchRecordsPerPost and persists after each', async () => {

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -246,7 +246,10 @@ describe('PostHogLogs', () => {
       expect(readQueue(mockInstance)).toHaveLength(1)
     })
 
-    it('remote setRemoteEnabled(true) flips a local-off instance on', () => {
+    it('setRemoteEnabled(true) does NOT flip a local-off instance on (AND semantics)', () => {
+      // Diverges from the JS SDK: server cannot start capture for a user
+      // who has not opted in locally. Mirrors the RN session-replay
+      // `consoleLogRecordingEnabled` gate.
       const logs = new PostHogLogs(
         mockInstance,
         resolveForTest({ captureConsoleLogs: false }),
@@ -258,11 +261,29 @@ describe('PostHogLogs', () => {
       expect(readQueue(mockInstance)).toHaveLength(0)
 
       logs.setRemoteEnabled(true)
-      logs.captureLog({ body: 'post-remote-keep' })
+      logs.captureLog({ body: 'still-dropped-no-local-optin' })
+      expect(readQueue(mockInstance)).toHaveLength(0)
+    })
+
+    it('setRemoteEnabled(false) acts as a kill-switch when local is on', () => {
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest({ captureConsoleLogs: true }),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.captureLog({ body: 'pre-kill-keep' })
+      expect(readQueue(mockInstance)).toHaveLength(1)
+
+      logs.setRemoteEnabled(false)
+      logs.captureLog({ body: 'killed' })
       expect(readQueue(mockInstance)).toHaveLength(1)
     })
 
-    it('remote setRemoteEnabled(false) acts as a kill-switch even when local is on', () => {
+    it('setRemoteEnabled(undefined) leaves the existing decision unchanged', () => {
+      // A remote response that omits the flag must not overwrite a
+      // previous explicit decision.
       const logs = new PostHogLogs(
         mockInstance,
         resolveForTest({ captureConsoleLogs: true }),
@@ -271,24 +292,9 @@ describe('PostHogLogs', () => {
         immediateOnReady
       )
       logs.setRemoteEnabled(false)
-      logs.captureLog({ body: 'killed' })
-      expect(readQueue(mockInstance)).toHaveLength(0)
-    })
-
-    it('setRemoteEnabled(undefined) leaves the existing decision unchanged', () => {
-      // Mirrors the JS SDK: a remote response that omits the flag must not
-      // overwrite a previous explicit decision.
-      const logs = new PostHogLogs(
-        mockInstance,
-        resolveForTest({ captureConsoleLogs: false }),
-        logger,
-        getContextFor(mockInstance),
-        immediateOnReady
-      )
-      logs.setRemoteEnabled(true)
       logs.setRemoteEnabled(undefined)
-      logs.captureLog({ body: 'still-on' })
-      expect(readQueue(mockInstance)).toHaveLength(1)
+      logs.captureLog({ body: 'still-killed' })
+      expect(readQueue(mockInstance)).toHaveLength(0)
     })
 
     it('appends subsequent captures to the existing queue', () => {

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -13,10 +13,6 @@ const DEFAULT_RATE_CAP_WINDOW_MS = 10000
 const DEFAULT_BACKGROUND_FLUSH_BUDGET_MS = 25000
 const DEFAULT_TERMINATION_FLUSH_BUDGET_MS = 2000
 const resolveForTest = (partial?: PostHogLogsConfig): ResolvedPostHogLogsConfig => ({
-  // Default the gate to ON in tests so each spec doesn't have to repeat the
-  // opt-in. The gating-specific tests pass `captureConsoleLogs: false` (or
-  // `undefined`) explicitly to exercise the off paths.
-  captureConsoleLogs: true,
   ...partial,
   maxBufferSize: partial?.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE,
   flushIntervalMs: partial?.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS,
@@ -207,37 +203,12 @@ describe('PostHogLogs', () => {
       expect(readQueue(instance)).toHaveLength(0)
     })
 
-    it('is a no-op when captureConsoleLogs is false', () => {
+    it('captures unconditionally without any local opt-in', () => {
+      // Manual capture has no local gate (matches the browser SDK's manual
+      // path). Only optedOut, missing body, and the remote kill switch block.
       const logs = new PostHogLogs(
         mockInstance,
-        resolveForTest({ captureConsoleLogs: false }),
-        logger,
-        getContextFor(mockInstance),
-        immediateOnReady
-      )
-      logs.captureLog({ body: 'should be dropped' })
-      expect(readQueue(mockInstance)).toHaveLength(0)
-    })
-
-    it('is a no-op when captureConsoleLogs is undefined (default off)', () => {
-      // Mirrors the JS SDK: the logs feature is opt-in, so an absent flag
-      // leaves it disabled until either local sets `true` or remote config
-      // turns it on via `setRemoteEnabled(true)`.
-      const logs = new PostHogLogs(
-        mockInstance,
-        resolveForTest({ captureConsoleLogs: undefined }),
-        logger,
-        getContextFor(mockInstance),
-        immediateOnReady
-      )
-      logs.captureLog({ body: 'should be dropped' })
-      expect(readQueue(mockInstance)).toHaveLength(0)
-    })
-
-    it('captures when captureConsoleLogs is true', () => {
-      const logs = new PostHogLogs(
-        mockInstance,
-        resolveForTest({ captureConsoleLogs: true }),
+        resolveForTest(),
         logger,
         getContextFor(mockInstance),
         immediateOnReady
@@ -246,29 +217,10 @@ describe('PostHogLogs', () => {
       expect(readQueue(mockInstance)).toHaveLength(1)
     })
 
-    it('setRemoteEnabled(true) does NOT flip a local-off instance on (AND semantics)', () => {
-      // Diverges from the JS SDK: server cannot start capture for a user
-      // who has not opted in locally. Mirrors the RN session-replay
-      // `consoleLogRecordingEnabled` gate.
+    it('setRemoteEnabled(false) acts as a server-side kill switch', () => {
       const logs = new PostHogLogs(
         mockInstance,
-        resolveForTest({ captureConsoleLogs: false }),
-        logger,
-        getContextFor(mockInstance),
-        immediateOnReady
-      )
-      logs.captureLog({ body: 'pre-remote-drop' })
-      expect(readQueue(mockInstance)).toHaveLength(0)
-
-      logs.setRemoteEnabled(true)
-      logs.captureLog({ body: 'still-dropped-no-local-optin' })
-      expect(readQueue(mockInstance)).toHaveLength(0)
-    })
-
-    it('setRemoteEnabled(false) acts as a kill-switch when local is on', () => {
-      const logs = new PostHogLogs(
-        mockInstance,
-        resolveForTest({ captureConsoleLogs: true }),
+        resolveForTest(),
         logger,
         getContextFor(mockInstance),
         immediateOnReady
@@ -281,12 +233,28 @@ describe('PostHogLogs', () => {
       expect(readQueue(mockInstance)).toHaveLength(1)
     })
 
-    it('setRemoteEnabled(undefined) leaves the existing decision unchanged', () => {
-      // A remote response that omits the flag must not overwrite a
-      // previous explicit decision.
+    it('setRemoteEnabled(true) and undefined both leave capture allowed', () => {
+      // Functionally identical: the gate only blocks on an explicit `false`.
       const logs = new PostHogLogs(
         mockInstance,
-        resolveForTest({ captureConsoleLogs: true }),
+        resolveForTest(),
+        logger,
+        getContextFor(mockInstance),
+        immediateOnReady
+      )
+      logs.setRemoteEnabled(true)
+      logs.captureLog({ body: 'remote-true' })
+      logs.setRemoteEnabled(undefined)
+      logs.captureLog({ body: 'remote-undefined-after-true' })
+      expect(readQueue(mockInstance)).toHaveLength(2)
+    })
+
+    it('setRemoteEnabled(undefined) does not overwrite a previous kill-switch', () => {
+      // A response that omits the key must not silently re-enable a feature
+      // the server explicitly disabled.
+      const logs = new PostHogLogs(
+        mockInstance,
+        resolveForTest(),
         logger,
         getContextFor(mockInstance),
         immediateOnReady

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -248,13 +248,18 @@ export class PostHogLogs {
    * Mirrors the web SDK's resource attribute layout
    * (`packages/browser/src/posthog-logs.ts:163`). `service.name` is always
    * present; `environment` / `serviceVersion` only appear when configured;
-   * `resourceAttributes` spreads last so user keys win.
+   * `telemetry.sdk.*` is OTLP-standard and identifies which client emitted
+   * the batch (most logs backends index on it for SDK-version dashboards
+   * and bug-correlation). `resourceAttributes` spreads last so user keys
+   * win on any conflict.
    */
   private _buildResourceAttributes(): Record<string, LogAttributeValue> {
     return {
       'service.name': this._config.serviceName || 'unknown_service',
       ...(this._config.environment && { 'deployment.environment': this._config.environment }),
       ...(this._config.serviceVersion && { 'service.version': this._config.serviceVersion }),
+      'telemetry.sdk.name': this._instance.getLibraryId(),
+      'telemetry.sdk.version': this._instance.getLibraryVersion(),
       ...this._config.resourceAttributes,
     }
   }

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -63,9 +63,23 @@ export class PostHogLogs {
    * Manual `captureLog` and `logger.*` are otherwise unconditional (matching
    * the browser SDK's manual path). The kill switch is the one mobile-only
    * lever — useful for shutting down a runaway log flood remotely without
-   * shipping an app update. An undefined value never overwrites a previous
-   * explicit decision so a remote response that omits the key can't silently
-   * re-enable a feature the server explicitly disabled.
+   * shipping an app update.
+   *
+   * Best-effort, eventually consistent: between SDK init and the first
+   * remote-config response, `_remoteEnabled` is `undefined` and capture is
+   * allowed. Records emitted in that window will enqueue and flush even if
+   * the customer's project has the switch on. Hosts that cache the previous
+   * remote-config response (RN does, see `posthog-rn.ts`) cover second-and-
+   * later launches; the very first launch and any post-`reset()` of the
+   * cached response are uncovered.
+   *
+   * Monotonically biased toward "allow": `setRemoteEnabled(undefined)` is a
+   * no-op and never overwrites a previous explicit decision. If the server
+   * has flipped the kill switch on (`false`) and later wants to release it,
+   * it must respond with an explicit `true` — removing the key from the
+   * response leaves the kill switch in place. This prevents a flaky or
+   * partially-populated response from silently re-enabling a feature the
+   * server explicitly disabled.
    */
   setRemoteEnabled(enabled: boolean | undefined): void {
     if (enabled !== undefined) {
@@ -322,10 +336,15 @@ export class PostHogLogs {
   }
 
   private _enqueue(entry: BufferedLogEntry): void {
-    // Re-check: optedOut can flip between captureLog and here — preload may
-    // have hydrated the real persisted value, or optIn/optOut may have fired
-    // while this fn was deferred.
+    // Re-check both gates: state can flip between captureLog and here.
+    // optedOut: preload may have hydrated the real persisted value, or
+    //   optIn/optOut may have fired while this fn was deferred.
+    // _isCaptureEnabled: a remote-config response that flipped the kill
+    //   switch may have landed during the same init-promise tick window.
     if (this._instance.optedOut) {
+      return
+    }
+    if (!this._isCaptureEnabled()) {
       return
     }
 

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -7,9 +7,17 @@ import type { BeforeSendLogFn, BufferedLogEntry, CaptureLogOptions, ResolvedPost
 
 export class PostHogLogs {
   private _localEnabled: boolean
+  // Tri-state remote flag:
+  //   - undefined → remote hasn't spoken yet; local config decides.
+  //   - true      → remote opt-in; capture allowed even if local is off.
+  //   - false     → remote kill-switch; capture forbidden even if local is on.
+  // Updated via `setRemoteEnabled()` from the host SDK's `onRemoteConfig`.
+  private _remoteEnabled?: boolean
   private _maxBufferSize: number
   private _flushIntervalMs: number
-  // Mutable — halved on 413 to shrink the next POST.
+  // Mutable — halved on 413 to shrink the next POST, and ramped back up by
+  // one record after each successful send so a one-off oversized payload
+  // (e.g. a giant stack trace) doesn't permanently degrade throughput.
   private _maxBatchRecordsPerPost: number
   private _flushTimer?: ReturnType<typeof safeSetTimeout>
   // Serializes concurrent flushes — the second caller awaits the first rather
@@ -39,7 +47,7 @@ export class PostHogLogs {
     // wires this to its dedicated `_logsStorage.waitForPersist()`.
     private readonly _waitForStoragePersist: () => Promise<void> = () => Promise.resolve()
   ) {
-    this._localEnabled = _config.enabled !== false
+    this._localEnabled = _config.captureConsoleLogs === true
     this._maxBufferSize = _config.maxBufferSize
     this._flushIntervalMs = _config.flushIntervalMs
     this._maxBatchRecordsPerPost = _config.maxBatchRecordsPerPost
@@ -47,8 +55,35 @@ export class PostHogLogs {
     this._maxLogsPerInterval = _config.maxLogsPerInterval
   }
 
+  /**
+   * The host SDK calls this from its `onRemoteConfig` handler with whatever
+   * `response.logs.captureConsoleLogs` resolves to:
+   *   - `true`  — server-side opt-in; capture allowed even if local is off.
+   *   - `false` — server-side kill-switch; capture forbidden even if local
+   *               is on.
+   *   - `undefined` — no opinion; local config decides.
+   */
+  setRemoteEnabled(enabled: boolean | undefined): void {
+    if (enabled !== undefined) {
+      this._remoteEnabled = enabled
+    }
+  }
+
+  /**
+   * Effective enabled state for the hot path. Either side can opt in; remote
+   * `false` is a hard kill-switch that overrides local. This matches the JS
+   * SDK except for the explicit kill-switch — browser only treats remote as
+   * an additional on-switch, not an off-switch.
+   */
+  private _isCaptureEnabled(): boolean {
+    if (this._remoteEnabled === false) {
+      return false
+    }
+    return this._localEnabled || this._remoteEnabled === true
+  }
+
   captureLog(options: CaptureLogOptions): void {
-    if (!this._localEnabled) {
+    if (!this._isCaptureEnabled()) {
       return
     }
     if (this._instance.optedOut) {
@@ -136,6 +171,13 @@ export class PostHogLogs {
    * dropping logs for hours. Browser's current impl has the same quirk
    * (`packages/browser/src/posthog-logs.ts:105`); when browser migrates to
    * this class, it inherits the fix for free.
+   *
+   * Pre-init note: the counter increments here, before `_onReady` defers
+   * `_enqueue` to the init promise. If init resolves slowly and the user
+   * is later opted out (or remote config disables logs), the counter has
+   * already consumed budget for records that won't enqueue. Cosmetic — no
+   * record is "lost" beyond what's already gated, and the window rolls on
+   * its own.
    */
   private _checkRateLimit(): boolean {
     if (this._maxLogsPerInterval === undefined) {
@@ -223,7 +265,19 @@ export class PostHogLogs {
 
       // ok | fatal | too-large-with-batch-of-1 → records are leaving the
       // queue. 'fatal' and size-1 413s are dropped so we don't spin on the
-      // same record forever.
+      // same record forever. Surface the size-1 413 explicitly so a single
+      // oversized record (e.g. a giant body field) is visible in logs
+      // instead of silently disappearing.
+      if (outcome.kind === 'too-large') {
+        this._logger.warn(
+          'Dropping a single log record after 413 with batch size 1 — the record is larger than the server cap and cannot be split further.'
+        )
+      } else if (outcome.kind === 'ok' && this._maxBatchRecordsPerPost < this._config.maxBatchRecordsPerPost) {
+        // Linear recovery: each healthy send pushes the cap back up by 1
+        // toward the configured maximum. Linear (not doubling) so we don't
+        // immediately retrigger a 413 if the previous shrink was justified.
+        this._maxBatchRecordsPerPost = Math.min(this._config.maxBatchRecordsPerPost, this._maxBatchRecordsPerPost + 1)
+      }
       await this._persistQueueAdvance(batch.length)
       queue = this._instance.getPersistedProperty<BufferedLogEntry[]>(PostHogPersistedProperty.LogsQueue) ?? []
       sentCount += batch.length
@@ -245,22 +299,25 @@ export class PostHogLogs {
   }
 
   /**
-   * Mirrors the web SDK's resource attribute layout
-   * (`packages/browser/src/posthog-logs.ts:163`). `service.name` is always
-   * present; `environment` / `serviceVersion` only appear when configured;
-   * `telemetry.sdk.*` is OTLP-standard and identifies which client emitted
-   * the batch (most logs backends index on it for SDK-version dashboards
-   * and bug-correlation). `resourceAttributes` spreads last so user keys
-   * win on any conflict.
+   * OTLP resource attributes for every batch.
+   *
+   * Layout: user `resourceAttributes` spread first, then SDK-controlled
+   * keys layered on top so users cannot accidentally clobber them. Most logs
+   * backends index on `service.name` and `telemetry.sdk.*` for routing,
+   * SDK-version dashboards, and bug-correlation; letting a stray user key
+   * overwrite them silently breaks ingestion attribution. The dedicated
+   * `serviceName` / `environment` / `serviceVersion` config fields are the
+   * supported way to override `service.name` / `deployment.environment` /
+   * `service.version`.
    */
   private _buildResourceAttributes(): Record<string, LogAttributeValue> {
     return {
+      ...this._config.resourceAttributes,
       'service.name': this._config.serviceName || 'unknown_service',
       ...(this._config.environment && { 'deployment.environment': this._config.environment }),
       ...(this._config.serviceVersion && { 'service.version': this._config.serviceVersion }),
       'telemetry.sdk.name': this._instance.getLibraryId(),
       'telemetry.sdk.version': this._instance.getLibraryVersion(),
-      ...this._config.resourceAttributes,
     }
   }
 
@@ -320,6 +377,38 @@ export class PostHogLogs {
       return
     }
     await Promise.race([flushPromise, new Promise<void>((resolve) => safeSetTimeout(resolve, timeoutMs))])
+  }
+
+  /**
+   * Time-bounded flush for transient lifecycle events (e.g. RN
+   * foreground→background) that must complete inside an OS-imposed window.
+   * Unlike `shutdown`, this leaves the periodic flush timer in place so the
+   * pipeline keeps draining if the process is resumed instead of suspended.
+   *
+   * Errors propagate so the host SDK can route them through its standard
+   * lifecycle error handler (e.g. RN's `logFlushError`). If the timer wins
+   * the race, a late rejection from the in-flight flush is silenced via a
+   * no-op handler attached after the race settles, to avoid noisy
+   * unhandled-rejection logs — the next regular flush cycle will retry.
+   */
+  async flushWithTimeout(timeoutMs: number): Promise<void> {
+    let timedOut = false
+    const flushPromise = this.flush()
+    const timerPromise = new Promise<void>((resolve) =>
+      safeSetTimeout(() => {
+        timedOut = true
+        resolve()
+      }, timeoutMs)
+    )
+    try {
+      await Promise.race([flushPromise, timerPromise])
+    } finally {
+      if (timedOut) {
+        // Race lost — flush is still in flight. Attach a no-op rejection
+        // handler so a late failure isn't logged as unhandled.
+        void flushPromise.catch(() => {})
+      }
+    }
   }
 
   private _flushInBackground(): void {

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -1,9 +1,15 @@
-import type { LogAttributeValue, LogSdkContext } from '@posthog/types'
+import type { LogAttributeValue } from '@posthog/types'
 import { buildOtlpLogRecord, buildOtlpLogsPayload } from './logs-utils'
 import { Logger, PostHogPersistedProperty } from '../types'
 import type { PostHogCoreStateless } from '../posthog-core-stateless'
 import { isArray, safeSetTimeout } from '../utils'
-import type { BeforeSendLogFn, BufferedLogEntry, CaptureLogOptions, ResolvedPostHogLogsConfig } from './types'
+import type {
+  BeforeSendLogFn,
+  BufferedLogEntry,
+  CaptureLogOptions,
+  LogSdkContext,
+  ResolvedPostHogLogsConfig,
+} from './types'
 
 export class PostHogLogs {
   private _maxBufferSize: number

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -56,9 +56,7 @@ export class PostHogLogs {
     }
 
     // Ordering: beforeSend → rate cap → OTLP build. beforeSend runs first so
-    // user-dropped records don't consume the per-interval budget (documented
-    // in `PostHogLogsConfig.beforeSend`). Matches the events pipeline's
-    // `before_send` semantics in `PostHogCore._runBeforeSend`.
+    // user-dropped records don't consume the per-interval budget.
     const filtered = this._runBeforeSend(options)
     if (filtered === null) {
       return
@@ -82,16 +80,12 @@ export class PostHogLogs {
   }
 
   /**
-   * Runs the configured `beforeSend` hook(s) on a capture record. Mirrors the
-   * events pipeline's `PostHogCore._runBeforeSend`:
+   * Runs the configured `beforeSend` hook(s) on a capture record:
    *   - single fn OR array of fns (chain, left-to-right)
    *   - returning `null` drops the record (logged at info)
    *   - a thrown error is logged and the chain *continues* with the previous
    *     result — a buggy user filter must never crash the caller's
    *     `captureLog()` call
-   *
-   * Kept private to match events' `_runBeforeSend`; exposed behaviour is
-   * whatever `captureLog` chooses to do with the return value.
    */
   private _runBeforeSend(options: CaptureLogOptions): CaptureLogOptions | null {
     const beforeSend = this._config.beforeSend
@@ -119,28 +113,23 @@ export class PostHogLogs {
 
   /**
    * Returns `true` if this capture fits within the current rate-cap window,
-   * `false` if it should be dropped. Mirrors the rate-cap branch in the
-   * browser SDK's `PostHogLogs.captureLog`.
+   * `false` if it should be dropped.
    *
-   * Fixed (tumbling) window: the counter resets the first time
-   * `captureLog` fires after `rateCapWindowMs` has elapsed — no timer
-   * needed. `maxLogsPerInterval === undefined` means unbounded (useful for
-   * node-style SDKs where bandwidth isn't the concern).
+   * Fixed (tumbling) window: the counter resets the first time `captureLog`
+   * fires after `rateCapWindowMs` has elapsed — no timer needed.
+   * `maxLogsPerInterval === undefined` means unbounded.
    *
    * Wall-clock safety: if `Date.now()` jumps backward (manual device-clock
    * change, big NTP correction), `elapsed` goes negative. We treat that the
    * same as "window expired" and reset — otherwise the rate cap would be
    * stuck until the clock caught up to the old window start, potentially
-   * dropping logs for hours. The browser SDK's window-roll check has the
-   * same quirk; when browser migrates to this class, it inherits the fix
-   * for free.
+   * dropping logs for hours.
    *
    * Pre-init note: the counter increments here, before `_onReady` defers
-   * `_enqueue` to the init promise. If init resolves slowly and the user
-   * is later opted out (or remote config disables logs), the counter has
-   * already consumed budget for records that won't enqueue. Cosmetic — no
-   * record is "lost" beyond what's already gated, and the window rolls on
-   * its own.
+   * `_enqueue` to the init promise. If init resolves slowly and the user is
+   * later opted out, the counter has already consumed budget for records
+   * that won't enqueue. Cosmetic — no record is "lost" beyond what's
+   * already gated, and the window rolls on its own.
    */
   private _checkRateLimit(): boolean {
     if (this._maxLogsPerInterval === undefined) {
@@ -168,7 +157,7 @@ export class PostHogLogs {
 
   /**
    * Drains `LogsQueue` in `maxBatchRecordsPerPost` slices, POSTing each as an
-   * OTLP payload. Mirrors `PostHogCoreStateless._flush()` semantics:
+   * OTLP payload.
    *   - Network error   → keep items in queue, re-throw (caller retries later)
    *   - 413             → halve batch size, retry same records (do not advance)
    *   - Any other error → drop the batch (avoid infinite loop on malformed data),
@@ -300,8 +289,7 @@ export class PostHogLogs {
     this._instance.setPersistedProperty(PostHogPersistedProperty.LogsQueue, queue)
 
     // Threshold trigger: at-capacity means flushing now reclaims space before
-    // the next capture has to shift something out. Matches the threshold-flush
-    // branch in the browser SDK's `PostHogLogs.captureLog`.
+    // the next capture has to shift something out.
     if (queue.length >= this._maxBufferSize) {
       this._flushInBackground()
       return

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -6,12 +6,11 @@ import { isArray, safeSetTimeout } from '../utils'
 import type { BeforeSendLogFn, BufferedLogEntry, CaptureLogOptions, ResolvedPostHogLogsConfig } from './types'
 
 export class PostHogLogs {
-  private _localEnabled: boolean
-  // Tri-state remote flag:
-  //   - undefined → remote hasn't spoken yet; local config decides.
-  //   - true      → remote opt-in; capture allowed even if local is off.
-  //   - false     → remote kill-switch; capture forbidden even if local is on.
-  // Updated via `setRemoteEnabled()` from the host SDK's `onRemoteConfig`.
+  // Server-side kill switch. Tri-state:
+  //   - undefined → remote hasn't spoken (or host SDK ignores remote); allow.
+  //   - true      → remote explicitly allowed; allow.
+  //   - false     → remote explicitly disabled; block all capture.
+  // Set via `setRemoteEnabled()` from the host SDK's `onRemoteConfig`.
   private _remoteEnabled?: boolean
   private _maxBufferSize: number
   private _flushIntervalMs: number
@@ -47,7 +46,6 @@ export class PostHogLogs {
     // wires this to its dedicated `_logsStorage.waitForPersist()`.
     private readonly _waitForStoragePersist: () => Promise<void> = () => Promise.resolve()
   ) {
-    this._localEnabled = _config.captureConsoleLogs === true
     this._maxBufferSize = _config.maxBufferSize
     this._flushIntervalMs = _config.flushIntervalMs
     this._maxBatchRecordsPerPost = _config.maxBatchRecordsPerPost
@@ -56,18 +54,18 @@ export class PostHogLogs {
   }
 
   /**
-   * The host SDK calls this from its `onRemoteConfig` handler with whatever
-   * `response.logs.captureConsoleLogs` resolves to:
-   *   - `false` — server-side kill-switch; capture forbidden even if local
-   *               opted in.
-   *   - `true`  — server has no objection; effective state still requires a
-   *               local opt-in.
-   *   - `undefined` — no opinion; local config decides.
+   * Server-side kill switch. The host SDK calls this from its
+   * `onRemoteConfig` handler with whatever `response.logs.captureConsoleLogs`
+   * resolves to:
+   *   - `false` — block all capture going forward.
+   *   - `true` / `undefined` — allow (default state).
    *
-   * AND semantics with local: this mirrors the RN session-replay
-   * `consoleLogRecordingEnabled` gate (in `PostHog.startSessionReplay`) and
-   * other mobile-config patterns. Server can disable a locally-on feature,
-   * but cannot turn the feature on for a user who hasn't opted in locally.
+   * Manual `captureLog` and `logger.*` are otherwise unconditional (matching
+   * the browser SDK's manual path). The kill switch is the one mobile-only
+   * lever — useful for shutting down a runaway log flood remotely without
+   * shipping an app update. An undefined value never overwrites a previous
+   * explicit decision so a remote response that omits the key can't silently
+   * re-enable a feature the server explicitly disabled.
    */
   setRemoteEnabled(enabled: boolean | undefined): void {
     if (enabled !== undefined) {
@@ -76,21 +74,11 @@ export class PostHogLogs {
   }
 
   /**
-   * Effective enabled state for the hot path:
-   *   `enabled = localOptIn AND remote !== false`.
-   *
-   * The local opt-in is the source of truth for whether the user wants logs;
-   * remote acts purely as a server-side off-switch. Diverges from the
-   * browser SDK's `PostHogLogs.onRemoteConfig`, which lets remote `true` flip
-   * a locally-off instance on. RN matches the session-replay precedent
-   * because mobile users rarely expect the server to silently start
-   * collecting data they didn't ask for locally.
+   * Effective enabled state for the hot path: `remote !== false`.
+   * `undefined` and `true` both pass — only an explicit server `false` blocks.
    */
   private _isCaptureEnabled(): boolean {
-    if (this._remoteEnabled === false) {
-      return false
-    }
-    return this._localEnabled
+    return this._remoteEnabled !== false
   }
 
   captureLog(options: CaptureLogOptions): void {

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -65,10 +65,9 @@ export class PostHogLogs {
    *   - `undefined` — no opinion; local config decides.
    *
    * AND semantics with local: this mirrors the RN session-replay
-   * `consoleLogRecordingEnabled` gate (`packages/react-native/src/posthog-rn.ts:1813-1825`)
-   * and other mobile-config patterns. Server can disable a locally-on
-   * feature, but cannot turn the feature on for a user who hasn't opted
-   * in locally.
+   * `consoleLogRecordingEnabled` gate (in `PostHog.startSessionReplay`) and
+   * other mobile-config patterns. Server can disable a locally-on feature,
+   * but cannot turn the feature on for a user who hasn't opted in locally.
    */
   setRemoteEnabled(enabled: boolean | undefined): void {
     if (enabled !== undefined) {
@@ -81,9 +80,9 @@ export class PostHogLogs {
    *   `enabled = localOptIn AND remote !== false`.
    *
    * The local opt-in is the source of truth for whether the user wants logs;
-   * remote acts purely as a server-side off-switch. Diverges from the JS SDK
-   * (`packages/browser/src/posthog-logs.ts:41-49`), which lets remote `true`
-   * flip a locally-off instance on. RN matches the session-replay precedent
+   * remote acts purely as a server-side off-switch. Diverges from the
+   * browser SDK's `PostHogLogs.onRemoteConfig`, which lets remote `true` flip
+   * a locally-off instance on. RN matches the session-replay precedent
    * because mobile users rarely expect the server to silently start
    * collecting data they didn't ask for locally.
    */
@@ -107,8 +106,8 @@ export class PostHogLogs {
 
     // Ordering: beforeSend → rate cap → OTLP build. beforeSend runs first so
     // user-dropped records don't consume the per-interval budget (documented
-    // in `logs/types.ts`). Matches the events pipeline's `before_send`
-    // semantics in `packages/core/src/posthog-core.ts:1478-1499`.
+    // in `PostHogLogsConfig.beforeSend`). Matches the events pipeline's
+    // `before_send` semantics in `PostHogCore._runBeforeSend`.
     const filtered = this._runBeforeSend(options)
     if (filtered === null) {
       return
@@ -133,7 +132,7 @@ export class PostHogLogs {
 
   /**
    * Runs the configured `beforeSend` hook(s) on a capture record. Mirrors the
-   * events pipeline at `packages/core/src/posthog-core.ts:1478-1499`:
+   * events pipeline's `PostHogCore._runBeforeSend`:
    *   - single fn OR array of fns (chain, left-to-right)
    *   - returning `null` drops the record (logged at info)
    *   - a thrown error is logged and the chain *continues* with the previous
@@ -169,7 +168,8 @@ export class PostHogLogs {
 
   /**
    * Returns `true` if this capture fits within the current rate-cap window,
-   * `false` if it should be dropped. Mirrors `packages/browser/src/posthog-logs.ts:103-120`.
+   * `false` if it should be dropped. Mirrors the rate-cap branch in the
+   * browser SDK's `PostHogLogs.captureLog`.
    *
    * Fixed (tumbling) window: the counter resets the first time
    * `captureLog` fires after `rateCapWindowMs` has elapsed — no timer
@@ -180,9 +180,9 @@ export class PostHogLogs {
    * change, big NTP correction), `elapsed` goes negative. We treat that the
    * same as "window expired" and reset — otherwise the rate cap would be
    * stuck until the clock caught up to the old window start, potentially
-   * dropping logs for hours. Browser's current impl has the same quirk
-   * (`packages/browser/src/posthog-logs.ts:105`); when browser migrates to
-   * this class, it inherits the fix for free.
+   * dropping logs for hours. The browser SDK's window-roll check has the
+   * same quirk; when browser migrates to this class, it inherits the fix
+   * for free.
    *
    * Pre-init note: the counter increments here, before `_onReady` defers
    * `_enqueue` to the init promise. If init resolves slowly and the user
@@ -350,8 +350,8 @@ export class PostHogLogs {
     this._instance.setPersistedProperty(PostHogPersistedProperty.LogsQueue, queue)
 
     // Threshold trigger: at-capacity means flushing now reclaims space before
-    // the next capture has to shift something out. Matches the web SDK at
-    // `packages/browser/src/posthog-logs.ts:128`.
+    // the next capture has to shift something out. Matches the threshold-flush
+    // branch in the browser SDK's `PostHogLogs.captureLog`.
     if (queue.length >= this._maxBufferSize) {
       this._flushInBackground()
       return

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -6,12 +6,6 @@ import { isArray, safeSetTimeout } from '../utils'
 import type { BeforeSendLogFn, BufferedLogEntry, CaptureLogOptions, ResolvedPostHogLogsConfig } from './types'
 
 export class PostHogLogs {
-  // Server-side kill switch. Tri-state:
-  //   - undefined → remote hasn't spoken (or host SDK ignores remote); allow.
-  //   - true      → remote explicitly allowed; allow.
-  //   - false     → remote explicitly disabled; block all capture.
-  // Set via `setRemoteEnabled()` from the host SDK's `onRemoteConfig`.
-  private _remoteEnabled?: boolean
   private _maxBufferSize: number
   private _flushIntervalMs: number
   // Mutable — halved on 413 to shrink the next POST, and ramped back up by
@@ -53,52 +47,7 @@ export class PostHogLogs {
     this._maxLogsPerInterval = _config.maxLogsPerInterval
   }
 
-  /**
-   * Server-side kill switch. The host SDK calls this from its
-   * `onRemoteConfig` handler with whatever `response.logs.captureConsoleLogs`
-   * resolves to:
-   *   - `false` — block all capture going forward.
-   *   - `true` / `undefined` — allow (default state).
-   *
-   * Manual `captureLog` and `logger.*` are otherwise unconditional (matching
-   * the browser SDK's manual path). The kill switch is the one mobile-only
-   * lever — useful for shutting down a runaway log flood remotely without
-   * shipping an app update.
-   *
-   * Best-effort, eventually consistent: between SDK init and the first
-   * remote-config response, `_remoteEnabled` is `undefined` and capture is
-   * allowed. Records emitted in that window will enqueue and flush even if
-   * the customer's project has the switch on. Hosts that cache the previous
-   * remote-config response (RN does, see `posthog-rn.ts`) cover second-and-
-   * later launches; the very first launch and any post-`reset()` of the
-   * cached response are uncovered.
-   *
-   * Monotonically biased toward "allow": `setRemoteEnabled(undefined)` is a
-   * no-op and never overwrites a previous explicit decision. If the server
-   * has flipped the kill switch on (`false`) and later wants to release it,
-   * it must respond with an explicit `true` — removing the key from the
-   * response leaves the kill switch in place. This prevents a flaky or
-   * partially-populated response from silently re-enabling a feature the
-   * server explicitly disabled.
-   */
-  setRemoteEnabled(enabled: boolean | undefined): void {
-    if (enabled !== undefined) {
-      this._remoteEnabled = enabled
-    }
-  }
-
-  /**
-   * Effective enabled state for the hot path: `remote !== false`.
-   * `undefined` and `true` both pass — only an explicit server `false` blocks.
-   */
-  private _isCaptureEnabled(): boolean {
-    return this._remoteEnabled !== false
-  }
-
   captureLog(options: CaptureLogOptions): void {
-    if (!this._isCaptureEnabled()) {
-      return
-    }
     if (this._instance.optedOut) {
       return
     }
@@ -336,15 +285,9 @@ export class PostHogLogs {
   }
 
   private _enqueue(entry: BufferedLogEntry): void {
-    // Re-check both gates: state can flip between captureLog and here.
-    // optedOut: preload may have hydrated the real persisted value, or
-    //   optIn/optOut may have fired while this fn was deferred.
-    // _isCaptureEnabled: a remote-config response that flipped the kill
-    //   switch may have landed during the same init-promise tick window.
+    // Re-check optedOut: preload may have hydrated the real persisted value,
+    // or optIn/optOut may have fired while this fn was deferred.
     if (this._instance.optedOut) {
-      return
-    }
-    if (!this._isCaptureEnabled()) {
       return
     }
 

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -1,22 +1,50 @@
-import type { LogSdkContext } from '@posthog/types'
-import { buildOtlpLogRecord } from './logs-utils'
+import type { LogAttributeValue, LogSdkContext } from '@posthog/types'
+import { buildOtlpLogRecord, buildOtlpLogsPayload } from './logs-utils'
 import { Logger, PostHogPersistedProperty } from '../types'
 import type { PostHogCoreStateless } from '../posthog-core-stateless'
-import type { BufferedLogEntry, CaptureLogOptions, ResolvedPostHogLogsConfig } from './types'
+import { isArray, safeSetTimeout } from '../utils'
+import type { BeforeSendLogFn, BufferedLogEntry, CaptureLogOptions, ResolvedPostHogLogsConfig } from './types'
 
 export class PostHogLogs {
   private _localEnabled: boolean
   private _maxBufferSize: number
+  private _flushIntervalMs: number
+  // Mutable — halved on 413 to shrink the next POST.
+  private _maxBatchRecordsPerPost: number
+  private _flushTimer?: ReturnType<typeof safeSetTimeout>
+  // Serializes concurrent flushes — the second caller awaits the first rather
+  // than racing it and double-sending the same head-of-queue records.
+  private _flushPromise: Promise<void> | null = null
+
+  // Fixed-window rate cap. Tumbling (not sliding) for cheap arithmetic on the
+  // hot path. Window rolls the first time `captureLog` fires after the window
+  // expires — no background timer needed. `_droppedWarned` keeps the log noise
+  // to one line per window regardless of how many records got dropped.
+  private _rateCapWindowMs: number
+  private _maxLogsPerInterval?: number
+  private _intervalWindowStart = 0
+  private _intervalLogCount = 0
+  private _droppedWarned = false
 
   constructor(
     private readonly _instance: PostHogCoreStateless,
     private readonly _config: ResolvedPostHogLogsConfig,
     private readonly _logger: Logger,
     private readonly _getContext: () => LogSdkContext,
-    private readonly _onReady: (fn: () => void) => void
+    private readonly _onReady: (fn: () => void) => void,
+    // Waits for the logs-storage persist to hit disk. Called between batches
+    // so a crash after a successful HTTP send but before the queue-advance
+    // reaches disk can't cause duplicate records on next startup. SDKs with
+    // synchronous storage (or no async persist layer) can pass a no-op. RN
+    // wires this to its dedicated `_logsStorage.waitForPersist()`.
+    private readonly _waitForStoragePersist: () => Promise<void> = () => Promise.resolve()
   ) {
     this._localEnabled = _config.enabled !== false
     this._maxBufferSize = _config.maxBufferSize
+    this._flushIntervalMs = _config.flushIntervalMs
+    this._maxBatchRecordsPerPost = _config.maxBatchRecordsPerPost
+    this._rateCapWindowMs = _config.rateCapWindowMs
+    this._maxLogsPerInterval = _config.maxLogsPerInterval
   }
 
   captureLog(options: CaptureLogOptions): void {
@@ -30,13 +58,205 @@ export class PostHogLogs {
       return
     }
 
+    // Ordering: beforeSend → rate cap → OTLP build. beforeSend runs first so
+    // user-dropped records don't consume the per-interval budget (documented
+    // in `logs/types.ts`). Matches the events pipeline's `before_send`
+    // semantics in `packages/core/src/posthog-core.ts:1478-1499`.
+    const filtered = this._runBeforeSend(options)
+    if (filtered === null) {
+      return
+    }
+    // beforeSend could return a record with empty body — treat as drop.
+    if (!filtered.body) {
+      return
+    }
+
+    if (!this._checkRateLimit()) {
+      return
+    }
+
     // Build before deferring so attributes reflect state at capture time, not
     // at drain time (identity/session changes between capture and drain must
     // not corrupt recorded attributes).
-    const record = buildOtlpLogRecord(options, this._getContext())
+    const record = buildOtlpLogRecord(filtered, this._getContext())
     const entry: BufferedLogEntry = { record }
 
     this._onReady(() => this._enqueue(entry))
+  }
+
+  /**
+   * Runs the configured `beforeSend` hook(s) on a capture record. Mirrors the
+   * events pipeline at `packages/core/src/posthog-core.ts:1478-1499`:
+   *   - single fn OR array of fns (chain, left-to-right)
+   *   - returning `null` drops the record (logged at info)
+   *   - a thrown error is logged and the chain *continues* with the previous
+   *     result — a buggy user filter must never crash the caller's
+   *     `captureLog()` call
+   *
+   * Kept private to match events' `_runBeforeSend`; exposed behaviour is
+   * whatever `captureLog` chooses to do with the return value.
+   */
+  private _runBeforeSend(options: CaptureLogOptions): CaptureLogOptions | null {
+    const beforeSend = this._config.beforeSend
+    if (!beforeSend) {
+      return options
+    }
+    const fns = isArray(beforeSend) ? beforeSend : [beforeSend]
+    let result: CaptureLogOptions = options
+    for (const fn of fns) {
+      try {
+        const next = fn(result)
+        if (!next) {
+          this._logger.info(`Log was rejected in beforeSend function`)
+          return null
+        }
+        result = next
+      } catch (e) {
+        // Swallow the throw — the chain continues with `result` unchanged so
+        // a buggy filter degrades to a no-op rather than crashing the app.
+        this._logger.error(`Error in beforeSend function for log:`, e)
+      }
+    }
+    return result
+  }
+
+  /**
+   * Returns `true` if this capture fits within the current rate-cap window,
+   * `false` if it should be dropped. Mirrors `packages/browser/src/posthog-logs.ts:103-120`.
+   *
+   * Fixed (tumbling) window: the counter resets the first time
+   * `captureLog` fires after `rateCapWindowMs` has elapsed — no timer
+   * needed. `maxLogsPerInterval === undefined` means unbounded (useful for
+   * node-style SDKs where bandwidth isn't the concern).
+   *
+   * Wall-clock safety: if `Date.now()` jumps backward (manual device-clock
+   * change, big NTP correction), `elapsed` goes negative. We treat that the
+   * same as "window expired" and reset — otherwise the rate cap would be
+   * stuck until the clock caught up to the old window start, potentially
+   * dropping logs for hours. Browser's current impl has the same quirk
+   * (`packages/browser/src/posthog-logs.ts:105`); when browser migrates to
+   * this class, it inherits the fix for free.
+   */
+  private _checkRateLimit(): boolean {
+    if (this._maxLogsPerInterval === undefined) {
+      return true
+    }
+    const now = Date.now()
+    const elapsed = now - this._intervalWindowStart
+    if (elapsed >= this._rateCapWindowMs || elapsed < 0) {
+      this._intervalWindowStart = now
+      this._intervalLogCount = 0
+      this._droppedWarned = false
+    }
+    if (this._intervalLogCount >= this._maxLogsPerInterval) {
+      if (!this._droppedWarned) {
+        this._logger.warn(
+          `captureLog dropping logs: exceeded ${this._maxLogsPerInterval} logs per ${this._rateCapWindowMs}ms`
+        )
+        this._droppedWarned = true
+      }
+      return false
+    }
+    this._intervalLogCount++
+    return true
+  }
+
+  /**
+   * Drains `LogsQueue` in `maxBatchRecordsPerPost` slices, POSTing each as an
+   * OTLP payload. Mirrors `PostHogCoreStateless._flush()` semantics:
+   *   - Network error   → keep items in queue, re-throw (caller retries later)
+   *   - 413             → halve batch size, retry same records (do not advance)
+   *   - Any other error → drop the batch (avoid infinite loop on malformed data),
+   *                       re-throw so callers can log/report
+   * Concurrent calls are serialized through `_flushPromise` so records at the
+   * head of the queue can't be sent twice.
+   */
+  async flush(): Promise<void> {
+    if (this._flushPromise) {
+      return this._flushPromise
+    }
+    this._flushPromise = this._flushInner().finally(() => {
+      this._flushPromise = null
+    })
+    return this._flushPromise
+  }
+
+  private async _flushInner(): Promise<void> {
+    this._clearFlushTimer()
+
+    let queue = this._instance.getPersistedProperty<BufferedLogEntry[]>(PostHogPersistedProperty.LogsQueue) ?? []
+    if (queue.length === 0) {
+      return
+    }
+
+    const originalQueueLength = queue.length
+    let sentCount = 0
+
+    while (queue.length > 0 && sentCount < originalQueueLength) {
+      const batchSize = Math.min(queue.length, this._maxBatchRecordsPerPost)
+      const batch = queue.slice(0, batchSize)
+      const records = batch.map((e) => e.record)
+
+      const payload = buildOtlpLogsPayload(
+        records,
+        this._buildResourceAttributes(),
+        this._instance.getLibraryId(),
+        this._instance.getLibraryVersion()
+      )
+
+      const outcome = await this._instance._sendLogsBatch(payload)
+
+      if (outcome.kind === 'too-large' && batch.length > 1) {
+        this._maxBatchRecordsPerPost = Math.max(1, Math.floor(batch.length / 2))
+        this._logger.warn(
+          `Received 413 when sending logs batch of size ${batch.length}, reducing batch size to ${this._maxBatchRecordsPerPost}`
+        )
+        // Don't advance the queue — retry the same records with the smaller cap.
+        continue
+      }
+
+      if (outcome.kind === 'retry-later') {
+        // Network error: keep records in the queue for the next flush cycle
+        // and surface the error so the caller can log/react.
+        throw outcome.error
+      }
+
+      // ok | fatal | too-large-with-batch-of-1 → records are leaving the
+      // queue. 'fatal' and size-1 413s are dropped so we don't spin on the
+      // same record forever.
+      await this._persistQueueAdvance(batch.length)
+      queue = this._instance.getPersistedProperty<BufferedLogEntry[]>(PostHogPersistedProperty.LogsQueue) ?? []
+      sentCount += batch.length
+
+      if (outcome.kind === 'fatal') {
+        throw outcome.error
+      }
+    }
+  }
+
+  private async _persistQueueAdvance(consumed: number): Promise<void> {
+    // Re-read the queue in case captures landed mid-flush, then drop the head.
+    const refreshed = this._instance.getPersistedProperty<BufferedLogEntry[]>(PostHogPersistedProperty.LogsQueue) ?? []
+    this._instance.setPersistedProperty(PostHogPersistedProperty.LogsQueue, refreshed.slice(consumed))
+    // Wait for the advance to hit disk before the next batch sends, matching
+    // events' `flushStorage()` contract. Prevents duplicates if the app crashes
+    // after the HTTP success but before the queue-advance persists.
+    await this._waitForStoragePersist()
+  }
+
+  /**
+   * Mirrors the web SDK's resource attribute layout
+   * (`packages/browser/src/posthog-logs.ts:163`). `service.name` is always
+   * present; `environment` / `serviceVersion` only appear when configured;
+   * `resourceAttributes` spreads last so user keys win.
+   */
+  private _buildResourceAttributes(): Record<string, LogAttributeValue> {
+    return {
+      'service.name': this._config.serviceName || 'unknown_service',
+      ...(this._config.environment && { 'deployment.environment': this._config.environment }),
+      ...(this._config.serviceVersion && { 'service.version': this._config.serviceVersion }),
+      ...this._config.resourceAttributes,
+    }
   }
 
   private _enqueue(entry: BufferedLogEntry): void {
@@ -54,5 +274,59 @@ export class PostHogLogs {
     }
     queue.push(entry)
     this._instance.setPersistedProperty(PostHogPersistedProperty.LogsQueue, queue)
+
+    // Threshold trigger: at-capacity means flushing now reclaims space before
+    // the next capture has to shift something out. Matches the web SDK at
+    // `packages/browser/src/posthog-logs.ts:128`.
+    if (queue.length >= this._maxBufferSize) {
+      this._flushInBackground()
+      return
+    }
+
+    // Timer trigger: only arm one timer at a time. A subsequent enqueue within
+    // the window shouldn't reschedule — that would keep pushing the flush out.
+    if (!this._flushTimer) {
+      this._flushTimer = safeSetTimeout(() => {
+        this._flushTimer = undefined
+        this._flushInBackground()
+      }, this._flushIntervalMs)
+    }
+  }
+
+  /**
+   * Stops the timer-based flush and sends anything still in the queue.
+   * Intended for process-teardown paths (RN `_shutdown` override). Swallows
+   * errors so a failing final flush can't block the broader shutdown.
+   *
+   * If `timeoutMs` is provided, the final flush races against that budget so
+   * a slow network/storage can't hold up shutdown indefinitely. Without it,
+   * flush time is bounded only by `fetchRetryCount * (requestTimeout +
+   * fetchRetryDelay)`, which can exceed the caller's shutdown SLA.
+   */
+  async shutdown(timeoutMs?: number): Promise<void> {
+    this._clearFlushTimer()
+    const flushPromise = this.flush().catch(() => {
+      // Best-effort: a logs-flush failure during shutdown is not actionable
+      // and must not prevent the rest of shutdown from running. Errors are
+      // still surfaced from the regular `flush()` path in normal operation.
+    })
+    if (timeoutMs === undefined) {
+      await flushPromise
+      return
+    }
+    await Promise.race([flushPromise, new Promise<void>((resolve) => safeSetTimeout(resolve, timeoutMs))])
+  }
+
+  private _flushInBackground(): void {
+    void this.flush().catch((err) => {
+      this._logger.error('PostHog logs flush failed:', err)
+    })
+  }
+
+  private _clearFlushTimer(): void {
+    if (this._flushTimer) {
+      clearTimeout(this._flushTimer)
+      this._flushTimer = undefined
+    }
   }
 }

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -58,10 +58,17 @@ export class PostHogLogs {
   /**
    * The host SDK calls this from its `onRemoteConfig` handler with whatever
    * `response.logs.captureConsoleLogs` resolves to:
-   *   - `true`  — server-side opt-in; capture allowed even if local is off.
    *   - `false` — server-side kill-switch; capture forbidden even if local
-   *               is on.
+   *               opted in.
+   *   - `true`  — server has no objection; effective state still requires a
+   *               local opt-in.
    *   - `undefined` — no opinion; local config decides.
+   *
+   * AND semantics with local: this mirrors the RN session-replay
+   * `consoleLogRecordingEnabled` gate (`packages/react-native/src/posthog-rn.ts:1813-1825`)
+   * and other mobile-config patterns. Server can disable a locally-on
+   * feature, but cannot turn the feature on for a user who hasn't opted
+   * in locally.
    */
   setRemoteEnabled(enabled: boolean | undefined): void {
     if (enabled !== undefined) {
@@ -70,16 +77,21 @@ export class PostHogLogs {
   }
 
   /**
-   * Effective enabled state for the hot path. Either side can opt in; remote
-   * `false` is a hard kill-switch that overrides local. This matches the JS
-   * SDK except for the explicit kill-switch — browser only treats remote as
-   * an additional on-switch, not an off-switch.
+   * Effective enabled state for the hot path:
+   *   `enabled = localOptIn AND remote !== false`.
+   *
+   * The local opt-in is the source of truth for whether the user wants logs;
+   * remote acts purely as a server-side off-switch. Diverges from the JS SDK
+   * (`packages/browser/src/posthog-logs.ts:41-49`), which lets remote `true`
+   * flip a locally-off instance on. RN matches the session-replay precedent
+   * because mobile users rarely expect the server to silently start
+   * collecting data they didn't ask for locally.
    */
   private _isCaptureEnabled(): boolean {
     if (this._remoteEnabled === false) {
       return false
     }
-    return this._localEnabled || this._remoteEnabled === true
+    return this._localEnabled
   }
 
   captureLog(options: CaptureLogOptions): void {

--- a/packages/core/src/logs/logs-utils.spec.ts
+++ b/packages/core/src/logs/logs-utils.spec.ts
@@ -1,4 +1,5 @@
-import type { CaptureLogOptions, LogSdkContext, LogSeverityLevel } from '@posthog/types'
+import type { CaptureLogOptions, LogSeverityLevel } from '@posthog/types'
+import type { LogSdkContext } from './types'
 import {
   buildOtlpLogRecord,
   buildOtlpLogsPayload,

--- a/packages/core/src/logs/logs-utils.ts
+++ b/packages/core/src/logs/logs-utils.ts
@@ -1,7 +1,6 @@
 import type {
   CaptureLogOptions,
   LogAttributeValue,
-  LogSdkContext,
   LogSeverityLevel,
   OtlpAnyValue,
   OtlpKeyValue,
@@ -10,6 +9,7 @@ import type {
   OtlpSeverityEntry,
   OtlpSeverityText,
 } from '@posthog/types'
+import type { LogSdkContext } from './types'
 import { isArray, isBoolean, isNull, isUndefined } from '../utils'
 
 // ============================================================================

--- a/packages/core/src/logs/types.ts
+++ b/packages/core/src/logs/types.ts
@@ -39,17 +39,13 @@ export type BeforeSendLogFn = (record: CaptureLogOptions) => CaptureLogOptions |
 
 // Public configuration for the logs module. Per-SDK defaults diverge (mobile
 // cellular radio cost, browser tab suspension, node process lifecycle).
+//
+// Manual capture (`captureLog`, `logger.*`) has no local opt-in — calling the
+// API ships records, matching the browser SDK's manual path. The host SDK can
+// still wire a server-side kill switch via `PostHogLogs.setRemoteEnabled` if
+// it wants the server to be able to remotely block capture (RN does this by
+// reading `response.logs.captureConsoleLogs: false`).
 export interface PostHogLogsConfig {
-  // Master switch. Default: false. The logs feature is opt-in — pass `true`
-  // explicitly to enable, mirroring the browser SDK's `PostHogLogs`
-  // extension. Server-side remote config (`response.logs.captureConsoleLogs`)
-  // can also flip this on, and an explicit remote `false` acts as a
-  // kill-switch even when local is `true`. The name matches the browser SDK
-  // so cross-SDK config mental models stay in sync; the field gates the
-  // entire logs pipeline (manual `captureLog` included), not only `console.*`
-  // interception.
-  captureConsoleLogs?: boolean
-
   // Resource attributes
   serviceName?: string
   serviceVersion?: string

--- a/packages/core/src/logs/types.ts
+++ b/packages/core/src/logs/types.ts
@@ -41,8 +41,15 @@ export type BeforeSendLogFn = (record: CaptureLogOptions) => CaptureLogOptions |
 // Public configuration for the logs module. Per-SDK defaults diverge (mobile
 // cellular radio cost, browser tab suspension, node process lifecycle).
 export interface PostHogLogsConfig {
-  // Master switch. Default: true when a config object is provided.
-  enabled?: boolean
+  // Master switch. Default: false. The logs feature is opt-in — pass `true`
+  // explicitly to enable, mirroring the JS SDK at
+  // `packages/browser/src/posthog-logs.ts:31-49`. Server-side remote config
+  // (`response.logs.captureConsoleLogs`) can also flip this on, and an
+  // explicit remote `false` acts as a kill-switch even when local is `true`.
+  // The name matches the JS SDK so cross-SDK config mental models stay in
+  // sync; the field gates the entire logs pipeline (manual `captureLog`
+  // included), not only `console.*` interception.
+  captureConsoleLogs?: boolean
 
   // Resource attributes
   serviceName?: string
@@ -84,4 +91,6 @@ export interface ResolvedPostHogLogsConfig extends PostHogLogsConfig {
   flushIntervalMs: number
   maxBatchRecordsPerPost: number
   rateCapWindowMs: number
+  backgroundFlushBudgetMs: number
+  terminationFlushBudgetMs: number
 }

--- a/packages/core/src/logs/types.ts
+++ b/packages/core/src/logs/types.ts
@@ -46,38 +46,134 @@ export interface BufferedLogEntry {
 }
 
 /**
- * `beforeSend` hook signature. Return the (possibly transformed) record to
- * keep it, or `null` to drop it. Configure as a single function or an array
- * (chain of filters, evaluated left-to-right).
+ * Pre-send filter. Inspect, mutate, or drop a captured record before it
+ * enters the rate-cap or the queue. Return the (possibly transformed) record
+ * to keep it; return `null` to drop it.
+ *
+ * Configure as a single fn or an array. Arrays form a left-to-right chain:
+ * each fn receives the previous fn's return value. A `null` from any link
+ * short-circuits the chain and drops the record.
+ *
+ * Runs *before* the rate cap so dropped records don't consume the
+ * per-interval budget. Throwing fns are logged and skipped — the chain
+ * continues with the previous return value, so a buggy filter degrades to a
+ * no-op rather than crashing `captureLog()`.
+ *
+ * @example Redact secrets from log bodies
+ * ```ts
+ * logs: {
+ *   beforeSend: (record) => ({
+ *     ...record,
+ *     body: record.body.replace(/api_key=\S+/g, 'api_key=[REDACTED]'),
+ *   }),
+ * }
+ * ```
+ *
+ * @example Drop noisy debug logs in production
+ * ```ts
+ * logs: {
+ *   beforeSend: (record) => (record.level === 'debug' ? null : record),
+ * }
+ * ```
  */
 export type BeforeSendLogFn = (record: CaptureLogOptions) => CaptureLogOptions | null
 
-// Public configuration for the logs module.
+/**
+ * Configuration for the logs feature on `new PostHog(key, { logs: ... })`.
+ * All fields are optional; per-SDK defaults apply (mobile vs browser tune
+ * differently for cellular cost vs tab-suspension behavior).
+ */
 export interface PostHogLogsConfig {
-  // Resource attributes
+  /**
+   * Service name attached to every record as the OTLP `service.name`
+   * resource attribute. Used by the Logs UI for filtering / grouping.
+   * Default: `'unknown_service'`.
+   */
   serviceName?: string
-  serviceVersion?: string
-  environment?: string
-  resourceAttributes?: Record<string, LogAttributeValue>
-
-  // Buffering
-  flushIntervalMs?: number
-  maxBufferSize?: number
-  maxBatchRecordsPerPost?: number // keeps each POST under the 2 MB server cap
 
   /**
-   * Tumbling-window rate cap. Both fields default per-SDK; pass either to
-   * tune. `maxLogs` undefined means unbounded.
+   * Service version attached as OTLP `service.version`. Useful for
+   * correlating regressions to specific app releases.
+   */
+  serviceVersion?: string
+
+  /**
+   * Deployment environment attached as OTLP `deployment.environment`
+   * (e.g. `'production'`, `'staging'`, `'dev'`).
+   */
+  environment?: string
+
+  /**
+   * Extra OTLP resource attributes attached to every record. Spread first;
+   * SDK-controlled keys (`service.name`, `telemetry.sdk.*`, RN's `os.*`)
+   * are layered on top so users cannot accidentally clobber them. Use the
+   * dedicated `serviceName` / `environment` / `serviceVersion` fields to
+   * override those keys.
+   */
+  resourceAttributes?: Record<string, LogAttributeValue>
+
+  /**
+   * How often the periodic background flush fires (ms). Records also flush
+   * eagerly when the buffer fills, on AppState changes (RN), and on
+   * `shutdown()`. Lower values trade battery/bandwidth for fresher data.
+   * Default: 10000 (RN) / 3000 (browser).
+   */
+  flushIntervalMs?: number
+
+  /**
+   * Max records held in memory before the queue evicts the oldest on push
+   * (FIFO). Bounds memory footprint and on-disk-queue size. When the buffer
+   * hits this size, an immediate flush is triggered to reclaim space; if
+   * the flush hasn't completed before the next capture, the oldest record
+   * is shifted out. Default: 100.
+   */
+  maxBufferSize?: number
+
+  /**
+   * Max records per outbound POST. Keeps each request under the server's
+   * 2 MB cap. On a 413 response, the SDK halves this value, retries the
+   * same records, then ramps back up by 1 per healthy send. A 413 on a
+   * single-record batch drops the record (it's larger than the server can
+   * accept regardless of batch size). Default: 50 (RN) / 100 (browser).
+   */
+  maxBatchRecordsPerPost?: number
+
+  /**
+   * Tumbling-window rate cap. Bounds how many records can be captured
+   * within a sliding (technically tumbling) time window. Records exceeding
+   * the cap are dropped synchronously at `captureLog()` (they never enter
+   * the buffer or consume bandwidth). A single warn line is logged per
+   * window when the cap is hit.
+   *
+   * Defaults are per-SDK; on RN the default is `{ maxLogs: 500, windowMs:
+   * 10000 }` (≈50 logs/sec ceiling, tuned for cellular bandwidth).
+   *
+   * @example Allow brief bursts up to 1000/min
+   * ```ts
+   * logs: { rateCap: { maxLogs: 1000, windowMs: 60000 } }
+   * ```
+   *
+   * @example Disable the cap entirely (unbounded)
+   * ```ts
+   * logs: { rateCap: { maxLogs: undefined } }
+   * ```
    */
   rateCap?: {
+    /**
+     * Max records accepted per `windowMs` window. `undefined` = unbounded.
+     */
     maxLogs?: number
+    /**
+     * Window length in ms. Tumbling, not sliding — the counter resets the
+     * first time a capture fires after the window expires.
+     */
     windowMs?: number
   }
 
-  // Filtering. Runs synchronously before the rate cap so beforeSend-dropped
-  // records do not consume the per-interval budget. Accepts a single fn or
-  // an array (chain). Throwing fns are logged and skipped — they must never
-  // crash the caller's `captureLog()`.
+  /**
+   * Pre-send filter. See {@link BeforeSendLogFn} for shape and examples.
+   * Configure as a single function or a chain.
+   */
   beforeSend?: BeforeSendLogFn | BeforeSendLogFn[]
 }
 

--- a/packages/core/src/logs/types.ts
+++ b/packages/core/src/logs/types.ts
@@ -29,6 +29,15 @@ export interface BufferedLogEntry {
   record: OtlpLogRecord
 }
 
+/**
+ * `beforeSend` hook signature. Matches the events pipeline's `BeforeSendFn`
+ * shape (`packages/core/src/types.ts:848`) so users get a consistent mental
+ * model: return the (possibly transformed) record to keep it, or `null` to
+ * drop it. Configure as a single function or an array (chain of filters,
+ * evaluated left-to-right).
+ */
+export type BeforeSendLogFn = (record: CaptureLogOptions) => CaptureLogOptions | null
+
 // Public configuration for the logs module. Per-SDK defaults diverge (mobile
 // cellular radio cost, browser tab suspension, node process lifecycle).
 export interface PostHogLogsConfig {
@@ -54,13 +63,25 @@ export interface PostHogLogsConfig {
   terminationFlushBudgetMs?: number
 
   // Filtering. Runs synchronously before the rate cap so beforeSend-dropped
-  // records do not consume the per-interval budget.
-  beforeSend?: (record: CaptureLogOptions) => CaptureLogOptions | null
+  // records do not consume the per-interval budget. Accepts a single fn or
+  // an array (chain); mirrors the events-pipeline `before_send` contract in
+  // `packages/core/src/types.ts:193`. Throwing fns are logged and skipped —
+  // they must never crash the caller's `captureLog()`.
+  beforeSend?: BeforeSendLogFn | BeforeSendLogFn[]
 }
 
 // Fields PostHogLogs needs resolved at runtime. Each SDK supplies its own
 // defaults (mobile, browser, node have different right answers) and hands the
 // filled-in config to the PostHogLogs constructor.
+//
+// `rateCapWindowMs` is always resolved (falls back to `flushIntervalMs` if
+// unset) so the rate-cap arithmetic doesn't branch at the hot path. The cap
+// itself (`maxLogsPerInterval`) stays optional — `undefined` means unbounded,
+// which is the right default for node-style SDKs where bandwidth isn't the
+// concern.
 export interface ResolvedPostHogLogsConfig extends PostHogLogsConfig {
   maxBufferSize: number
+  flushIntervalMs: number
+  maxBatchRecordsPerPost: number
+  rateCapWindowMs: number
 }

--- a/packages/core/src/logs/types.ts
+++ b/packages/core/src/logs/types.ts
@@ -22,29 +22,18 @@ export type CaptureLogger = CaptureLoggerType
 
 import type { LogAttributeValue, CaptureLogOptions, OtlpLogRecord } from '@posthog/types'
 
-// Wrapper around OtlpLogRecord for queue entries. Parallels events' queue
-// item shape (`{ message }`) — future additions like `retryCount` or
-// `enqueuedAt` can be added without migrating the queue format.
 export interface BufferedLogEntry {
   record: OtlpLogRecord
 }
 
 /**
- * `beforeSend` hook signature. Matches the events pipeline's `BeforeSendFn`
- * shape so users get a consistent mental model: return the (possibly
- * transformed) record to keep it, or `null` to drop it. Configure as a single
- * function or an array (chain of filters, evaluated left-to-right).
+ * `beforeSend` hook signature. Return the (possibly transformed) record to
+ * keep it, or `null` to drop it. Configure as a single function or an array
+ * (chain of filters, evaluated left-to-right).
  */
 export type BeforeSendLogFn = (record: CaptureLogOptions) => CaptureLogOptions | null
 
-// Public configuration for the logs module. Per-SDK defaults diverge (mobile
-// cellular radio cost, browser tab suspension, node process lifecycle).
-//
-// Manual capture (`captureLog`, `logger.*`) has no local opt-in — calling the
-// API ships records. Matches the events pipeline's manual `capture()` shape
-// across SDKs. Console autocapture, when added (browser today, RN later),
-// has its own local-opt-in flag (`response.logs.captureConsoleLogs` for the
-// browser; same field name on RN once that path lands).
+// Public configuration for the logs module.
 export interface PostHogLogsConfig {
   // Resource attributes
   serviceName?: string
@@ -66,21 +55,17 @@ export interface PostHogLogsConfig {
 
   // Filtering. Runs synchronously before the rate cap so beforeSend-dropped
   // records do not consume the per-interval budget. Accepts a single fn or
-  // an array (chain); mirrors the events-pipeline `before_send` contract on
-  // `PostHogCoreOptions`. Throwing fns are logged and skipped — they must
-  // never crash the caller's `captureLog()`.
+  // an array (chain). Throwing fns are logged and skipped — they must never
+  // crash the caller's `captureLog()`.
   beforeSend?: BeforeSendLogFn | BeforeSendLogFn[]
 }
 
-// Fields PostHogLogs needs resolved at runtime. Each SDK supplies its own
-// defaults (mobile, browser, node have different right answers) and hands the
-// filled-in config to the PostHogLogs constructor.
+// Fields PostHogLogs needs resolved at runtime. The host SDK fills in its
+// defaults and hands the resolved config to the PostHogLogs constructor.
 //
-// `rateCapWindowMs` is always resolved (falls back to `flushIntervalMs` if
-// unset) so the rate-cap arithmetic doesn't branch at the hot path. The cap
-// itself (`maxLogsPerInterval`) stays optional — `undefined` means unbounded,
-// which is the right default for node-style SDKs where bandwidth isn't the
-// concern.
+// `rateCapWindowMs` is always resolved so the rate-cap arithmetic doesn't
+// branch at the hot path. `maxLogsPerInterval` stays optional — `undefined`
+// means unbounded.
 export interface ResolvedPostHogLogsConfig extends PostHogLogsConfig {
   maxBufferSize: number
   flushIntervalMs: number

--- a/packages/core/src/logs/types.ts
+++ b/packages/core/src/logs/types.ts
@@ -41,10 +41,10 @@ export type BeforeSendLogFn = (record: CaptureLogOptions) => CaptureLogOptions |
 // cellular radio cost, browser tab suspension, node process lifecycle).
 //
 // Manual capture (`captureLog`, `logger.*`) has no local opt-in — calling the
-// API ships records, matching the browser SDK's manual path. The host SDK can
-// still wire a server-side kill switch via `PostHogLogs.setRemoteEnabled` if
-// it wants the server to be able to remotely block capture (RN does this by
-// reading `response.logs.captureConsoleLogs: false`).
+// API ships records. Matches the events pipeline's manual `capture()` shape
+// across SDKs. Console autocapture, when added (browser today, RN later),
+// has its own local-opt-in flag (`response.logs.captureConsoleLogs` for the
+// browser; same field name on RN once that path lands).
 export interface PostHogLogsConfig {
   // Resource attributes
   serviceName?: string

--- a/packages/core/src/logs/types.ts
+++ b/packages/core/src/logs/types.ts
@@ -43,15 +43,17 @@ export interface PostHogLogsConfig {
 
   // Buffering
   flushIntervalMs?: number
-  rateCapWindowMs?: number // separate from flushIntervalMs so flush cadence does not move the rate-cap window
   maxBufferSize?: number
-  maxLogsPerInterval?: number
   maxBatchRecordsPerPost?: number // keeps each POST under the 2 MB server cap
 
-  // Shutdown — separate budgets because foreground→background and app-terminate
-  // have different OS-imposed windows.
-  backgroundFlushBudgetMs?: number
-  terminationFlushBudgetMs?: number
+  /**
+   * Tumbling-window rate cap. Both fields default per-SDK; pass either to
+   * tune. `maxLogs` undefined means unbounded.
+   */
+  rateCap?: {
+    maxLogs?: number
+    windowMs?: number
+  }
 
   // Filtering. Runs synchronously before the rate cap so beforeSend-dropped
   // records do not consume the per-interval budget. Accepts a single fn or
@@ -62,15 +64,13 @@ export interface PostHogLogsConfig {
 
 // Fields PostHogLogs needs resolved at runtime. The host SDK fills in its
 // defaults and hands the resolved config to the PostHogLogs constructor.
-//
-// `rateCapWindowMs` is always resolved so the rate-cap arithmetic doesn't
-// branch at the hot path. `maxLogsPerInterval` stays optional — `undefined`
-// means unbounded.
-export interface ResolvedPostHogLogsConfig extends PostHogLogsConfig {
+// Flat names internally — public API uses `rateCap: { maxLogs, windowMs }`.
+export interface ResolvedPostHogLogsConfig extends Omit<PostHogLogsConfig, 'rateCap'> {
   maxBufferSize: number
   flushIntervalMs: number
   maxBatchRecordsPerPost: number
   rateCapWindowMs: number
+  maxLogsPerInterval?: number
   backgroundFlushBudgetMs: number
   terminationFlushBudgetMs: number
 }

--- a/packages/core/src/logs/types.ts
+++ b/packages/core/src/logs/types.ts
@@ -31,10 +31,9 @@ export interface BufferedLogEntry {
 
 /**
  * `beforeSend` hook signature. Matches the events pipeline's `BeforeSendFn`
- * shape (`packages/core/src/types.ts:848`) so users get a consistent mental
- * model: return the (possibly transformed) record to keep it, or `null` to
- * drop it. Configure as a single function or an array (chain of filters,
- * evaluated left-to-right).
+ * shape so users get a consistent mental model: return the (possibly
+ * transformed) record to keep it, or `null` to drop it. Configure as a single
+ * function or an array (chain of filters, evaluated left-to-right).
  */
 export type BeforeSendLogFn = (record: CaptureLogOptions) => CaptureLogOptions | null
 
@@ -42,13 +41,13 @@ export type BeforeSendLogFn = (record: CaptureLogOptions) => CaptureLogOptions |
 // cellular radio cost, browser tab suspension, node process lifecycle).
 export interface PostHogLogsConfig {
   // Master switch. Default: false. The logs feature is opt-in — pass `true`
-  // explicitly to enable, mirroring the JS SDK at
-  // `packages/browser/src/posthog-logs.ts:31-49`. Server-side remote config
-  // (`response.logs.captureConsoleLogs`) can also flip this on, and an
-  // explicit remote `false` acts as a kill-switch even when local is `true`.
-  // The name matches the JS SDK so cross-SDK config mental models stay in
-  // sync; the field gates the entire logs pipeline (manual `captureLog`
-  // included), not only `console.*` interception.
+  // explicitly to enable, mirroring the browser SDK's `PostHogLogs`
+  // extension. Server-side remote config (`response.logs.captureConsoleLogs`)
+  // can also flip this on, and an explicit remote `false` acts as a
+  // kill-switch even when local is `true`. The name matches the browser SDK
+  // so cross-SDK config mental models stay in sync; the field gates the
+  // entire logs pipeline (manual `captureLog` included), not only `console.*`
+  // interception.
   captureConsoleLogs?: boolean
 
   // Resource attributes
@@ -71,9 +70,9 @@ export interface PostHogLogsConfig {
 
   // Filtering. Runs synchronously before the rate cap so beforeSend-dropped
   // records do not consume the per-interval budget. Accepts a single fn or
-  // an array (chain); mirrors the events-pipeline `before_send` contract in
-  // `packages/core/src/types.ts:193`. Throwing fns are logged and skipped —
-  // they must never crash the caller's `captureLog()`.
+  // an array (chain); mirrors the events-pipeline `before_send` contract on
+  // `PostHogCoreOptions`. Throwing fns are logged and skipped — they must
+  // never crash the caller's `captureLog()`.
   beforeSend?: BeforeSendLogFn | BeforeSendLogFn[]
 }
 

--- a/packages/core/src/logs/types.ts
+++ b/packages/core/src/logs/types.ts
@@ -11,8 +11,27 @@ export type {
   OtlpKeyValue,
   OtlpLogRecord,
   OtlpLogsPayload,
-  LogSdkContext,
 } from '@posthog/types'
+
+/**
+ * SDK-internal context the host SDK passes to `buildOtlpLogRecord` at capture
+ * time. Each SDK populates the fields that apply to it: browser fills
+ * `currentUrl`, mobile fills `screenName` / `appState`. Missing fields are
+ * omitted from the OTLP record (no stray attributes).
+ *
+ * Internal to `@posthog/core` — customers don't see this in autocomplete.
+ */
+export interface LogSdkContext {
+  distinctId?: string
+  sessionId?: string
+  /** Web-only — current page URL */
+  currentUrl?: string
+  /** Mobile-only — current screen / view name */
+  screenName?: string
+  /** Mobile-only — app foreground/background state at capture time */
+  appState?: 'foreground' | 'background'
+  activeFeatureFlags?: string[]
+}
 
 // The public capture-logger interface lives in @posthog/types as `Logger`. Core
 // also exports a `Logger` (the SDK's internal warn/info/error logger). Alias the

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -1201,8 +1201,8 @@ export abstract class PostHogCoreStateless {
    * Sends a pre-built OTLP logs payload to `/i/v1/logs`. Returns a tagged
    * outcome instead of throwing so PostHogLogs doesn't have to know about the
    * core's error class hierarchy. Error classification lives here (single
-   * source of truth, same policy events use in `_flush()` at
-   * `posthog-core-stateless.ts:1155`).
+   * source of truth, same policy the events `_flush()` uses for its own
+   * 413 / network / fatal handling).
    *
    * 413 is passed through as `too-large` (not auto-retried) so the caller can
    * shrink `maxBatchRecordsPerPost` and retry the same records.

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -1,3 +1,4 @@
+import type { OtlpLogsPayload } from '@posthog/types'
 import { SimpleEventEmitter } from './eventemitter'
 import { getFeatureFlagValue, normalizeFlagsResponse } from './featureFlagUtils'
 import { gzipCompress, isGzipSupported } from './gzip'
@@ -93,6 +94,23 @@ function isPostHogFetchError(err: unknown): err is PostHogFetchHttpError | PostH
 function isPostHogFetchContentTooLargeError(err: unknown): err is PostHogFetchHttpError & { status: 413 } {
   return typeof err === 'object' && err instanceof PostHogFetchHttpError && err.status === 413
 }
+
+/**
+ * Outcome of a logs batch send. Keeps HTTP error classification inside core
+ * (single source of truth — same policy events already use in `_flush()`) so
+ * PostHogLogs doesn't need to know about specific error types.
+ *
+ *   - ok            → records are accepted; drop them from the queue
+ *   - too-large     → 413; caller should halve batch size and retry same records
+ *   - retry-later   → network error; caller keeps records and retries next cycle
+ *   - fatal         → anything else (auth, malformed, etc.); caller drops the
+ *                     batch and surfaces the error
+ */
+export type SendLogsBatchOutcome =
+  | { kind: 'ok' }
+  | { kind: 'too-large' }
+  | { kind: 'retry-later'; error: unknown }
+  | { kind: 'fatal'; error: unknown }
 
 export enum QuotaLimitedFeature {
   FeatureFlags = 'feature_flags',
@@ -1177,6 +1195,52 @@ export abstract class PostHogCoreStateless {
       sentMessages.push(...batchMessages)
     }
     this._events.emit('flush', sentMessages)
+  }
+
+  /**
+   * Sends a pre-built OTLP logs payload to `/i/v1/logs`. Returns a tagged
+   * outcome instead of throwing so PostHogLogs doesn't have to know about the
+   * core's error class hierarchy. Error classification lives here (single
+   * source of truth, same policy events use in `_flush()` at
+   * `posthog-core-stateless.ts:1155`).
+   *
+   * 413 is passed through as `too-large` (not auto-retried) so the caller can
+   * shrink `maxBatchRecordsPerPost` and retry the same records.
+   */
+  async _sendLogsBatch(payload: OtlpLogsPayload): Promise<SendLogsBatchOutcome> {
+    const serialized = JSON.stringify(payload)
+    const url = `${this.host}/i/v1/logs?token=${encodeURIComponent(this.apiKey)}`
+
+    const gzippedPayload = !this.disableCompression ? await gzipCompress(serialized, this.isDebug) : null
+    const fetchOptions: PostHogFetchOptions = {
+      method: 'POST',
+      headers: {
+        ...this.getCustomHeaders(),
+        'Content-Type': 'application/json',
+        ...(gzippedPayload !== null && { 'Content-Encoding': 'gzip' }),
+      },
+      body: gzippedPayload || serialized,
+    }
+
+    try {
+      await this.fetchWithRetry(url, fetchOptions, {
+        retryCheck: (err) => {
+          if (isPostHogFetchContentTooLargeError(err)) {
+            return false
+          }
+          return isPostHogFetchError(err)
+        },
+      })
+      return { kind: 'ok' }
+    } catch (err) {
+      if (isPostHogFetchContentTooLargeError(err)) {
+        return { kind: 'too-large' }
+      }
+      if (err instanceof PostHogFetchNetworkError) {
+        return { kind: 'retry-later', error: err }
+      }
+      return { kind: 'fatal', error: err }
+    }
   }
 
   private async fetchWithRetry(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -347,10 +347,10 @@ export type PostHogRemoteConfig = {
 
   /**
    * Logs feature remote config.
-   * When a map, `captureConsoleLogs` (boolean) is the server-side kill-switch
-   * for the logs pipeline. `false` disables capture even if local config has
-   * it on; missing/`true` leaves the local config in charge. Mirrors the
-   * browser SDK's `response.logs?.captureConsoleLogs` gate.
+   * When a map, `captureConsoleLogs` (boolean) is the server-side kill switch
+   * for the logs pipeline. `false` blocks all capture going forward; `true`
+   * and absent both leave it allowed. Same wire field name as the browser
+   * SDK's `response.logs?.captureConsoleLogs`.
    */
   logs?:
     | boolean

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -347,10 +347,13 @@ export type PostHogRemoteConfig = {
 
   /**
    * Logs feature remote config.
-   * When a map, `captureConsoleLogs` (boolean) is the server-side kill switch
-   * for the logs pipeline. `false` blocks all capture going forward; `true`
-   * and absent both leave it allowed. Same wire field name as the browser
-   * SDK's `response.logs?.captureConsoleLogs`.
+   * When a map, `captureConsoleLogs` (boolean) gates browser-side `console.*`
+   * autocapture (the JS SDK's `PostHogLogs` extension reads it to decide
+   * whether to load the autocapture bundle). RN does not read this field
+   * today; manual `captureLog` / `logger.*` is unconditional, matching the
+   * events pipeline. When console autocapture lands on RN as a follow-up,
+   * that field will gate the RN autocapture path too — manual capture
+   * remains unconditional regardless.
    */
   logs?:
     | boolean

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -344,6 +344,19 @@ export type PostHogRemoteConfig = {
     | {
         [key: string]: JsonType
       }
+
+  /**
+   * Logs feature remote config.
+   * When a map, `captureConsoleLogs` (boolean) is the server-side kill-switch
+   * for the logs pipeline. `false` disables capture even if local config has
+   * it on; missing/`true` leaves the local config in charge. Mirrors the
+   * browser SDK's `response.logs?.captureConsoleLogs` gate.
+   */
+  logs?:
+    | boolean
+    | {
+        [key: string]: JsonType
+      }
 }
 
 export type FeatureFlagValue = string | boolean

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -346,14 +346,10 @@ export type PostHogRemoteConfig = {
       }
 
   /**
-   * Logs feature remote config.
-   * When a map, `captureConsoleLogs` (boolean) gates browser-side `console.*`
-   * autocapture (the JS SDK's `PostHogLogs` extension reads it to decide
-   * whether to load the autocapture bundle). RN does not read this field
-   * today; manual `captureLog` / `logger.*` is unconditional, matching the
-   * events pipeline. When console autocapture lands on RN as a follow-up,
-   * that field will gate the RN autocapture path too — manual capture
-   * remains unconditional regardless.
+   * Logs feature remote config. When a map, `captureConsoleLogs` (boolean)
+   * is the local opt-in flag for `console.*` autocapture (read by the JS
+   * SDK's `PostHogLogs` extension to decide whether to load the autocapture
+   * bundle).
    */
   logs?:
     | boolean

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -12,3 +12,15 @@ export * from './PostHogProvider'
 export * from './PostHogErrorBoundary'
 export * from './types'
 export * from './surveys'
+
+// Re-export logs public types so consumers can type their own wrappers
+// (e.g. hooks, HOCs, custom loggers) without pulling in @posthog/core.
+export type {
+  BeforeSendLogFn,
+  CaptureLogOptions,
+  CaptureLogger,
+  LogAttributes,
+  LogAttributeValue,
+  LogSeverityLevel,
+  PostHogLogsConfig,
+} from '@posthog/core'

--- a/packages/react-native/src/logs-defaults.ts
+++ b/packages/react-native/src/logs-defaults.ts
@@ -29,20 +29,20 @@ function defaultResourceAttributes(): Record<string, string> {
 }
 
 export function resolveLogsConfig(config: PostHogLogsConfig | undefined): ResolvedPostHogLogsConfig {
-  const flushIntervalMs = config?.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS
   return {
     ...config,
     maxBufferSize: config?.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE,
-    flushIntervalMs,
+    flushIntervalMs: config?.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS,
     maxBatchRecordsPerPost: config?.maxBatchRecordsPerPost ?? DEFAULT_MAX_BATCH_RECORDS_PER_POST,
     // Rate-cap window defaults independently of flush cadence: changing flush
-    // frequency shouldn't implicitly re-shape the rate budget. Fall back to
-    // `flushIntervalMs` only if no explicit window is set.
-    rateCapWindowMs: config?.rateCapWindowMs ?? DEFAULT_RATE_CAP_WINDOW_MS ?? flushIntervalMs,
+    // frequency shouldn't implicitly re-shape the rate budget.
+    rateCapWindowMs: config?.rateCapWindowMs ?? DEFAULT_RATE_CAP_WINDOW_MS,
     // `maxLogsPerInterval` stays optional in the resolved config. RN defaults
     // to 500/window to bound cellular data cost; pass `maxLogsPerInterval:
     // undefined` in user config to opt out.
     maxLogsPerInterval: config?.maxLogsPerInterval ?? DEFAULT_MAX_LOGS_PER_INTERVAL,
+    backgroundFlushBudgetMs: config?.backgroundFlushBudgetMs ?? DEFAULT_BACKGROUND_FLUSH_BUDGET_MS,
+    terminationFlushBudgetMs: config?.terminationFlushBudgetMs ?? DEFAULT_TERMINATION_FLUSH_BUDGET_MS,
     // Merge platform-detected attrs first so user-provided `resourceAttributes`
     // wins on any conflict. Never throw if `Platform` is unavailable in
     // unusual envs (web bundle, jest without RN preset) — fall back silently.

--- a/packages/react-native/src/logs-defaults.ts
+++ b/packages/react-native/src/logs-defaults.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native'
 import type { PostHogLogsConfig, ResolvedPostHogLogsConfig } from '@posthog/core'
 
 // Mobile defaults. Tuned for cellular radio tail (longer flush interval keeps
@@ -10,6 +11,22 @@ export const DEFAULT_MAX_BATCH_RECORDS_PER_POST = 50
 // iOS beginBackgroundTask budget is ~30s; stay comfortably under.
 export const DEFAULT_BACKGROUND_FLUSH_BUDGET_MS = 25000
 export const DEFAULT_TERMINATION_FLUSH_BUDGET_MS = 2000
+
+/**
+ * RN-specific resource attribute defaults. Identifies the device's OS so
+ * logs can be filtered by platform (e.g. "all errors on Android 13" or
+ * "iOS 17 only" in the PostHog UI). User-supplied `resourceAttributes`
+ * spreads last in `_buildResourceAttributes` so these are overridable.
+ *
+ * `Platform.Version` is `string` on iOS and `number` on Android — coerce
+ * to string so the OTLP `os.version` attribute has a stable type.
+ */
+function defaultResourceAttributes(): Record<string, string> {
+  return {
+    'os.name': Platform.OS,
+    'os.version': String(Platform.Version),
+  }
+}
 
 export function resolveLogsConfig(config: PostHogLogsConfig | undefined): ResolvedPostHogLogsConfig {
   const flushIntervalMs = config?.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS
@@ -26,5 +43,12 @@ export function resolveLogsConfig(config: PostHogLogsConfig | undefined): Resolv
     // to 500/window to bound cellular data cost; pass `maxLogsPerInterval:
     // undefined` in user config to opt out.
     maxLogsPerInterval: config?.maxLogsPerInterval ?? DEFAULT_MAX_LOGS_PER_INTERVAL,
+    // Merge platform-detected attrs first so user-provided `resourceAttributes`
+    // wins on any conflict. Never throw if `Platform` is unavailable in
+    // unusual envs (web bundle, jest without RN preset) — fall back silently.
+    resourceAttributes: {
+      ...defaultResourceAttributes(),
+      ...config?.resourceAttributes,
+    },
   }
 }

--- a/packages/react-native/src/logs-defaults.ts
+++ b/packages/react-native/src/logs-defaults.ts
@@ -12,8 +12,19 @@ export const DEFAULT_BACKGROUND_FLUSH_BUDGET_MS = 25000
 export const DEFAULT_TERMINATION_FLUSH_BUDGET_MS = 2000
 
 export function resolveLogsConfig(config: PostHogLogsConfig | undefined): ResolvedPostHogLogsConfig {
+  const flushIntervalMs = config?.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS
   return {
     ...config,
     maxBufferSize: config?.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE,
+    flushIntervalMs,
+    maxBatchRecordsPerPost: config?.maxBatchRecordsPerPost ?? DEFAULT_MAX_BATCH_RECORDS_PER_POST,
+    // Rate-cap window defaults independently of flush cadence: changing flush
+    // frequency shouldn't implicitly re-shape the rate budget. Fall back to
+    // `flushIntervalMs` only if no explicit window is set.
+    rateCapWindowMs: config?.rateCapWindowMs ?? DEFAULT_RATE_CAP_WINDOW_MS ?? flushIntervalMs,
+    // `maxLogsPerInterval` stays optional in the resolved config. RN defaults
+    // to 500/window to bound cellular data cost; pass `maxLogsPerInterval:
+    // undefined` in user config to opt out.
+    maxLogsPerInterval: config?.maxLogsPerInterval ?? DEFAULT_MAX_LOGS_PER_INTERVAL,
   }
 }

--- a/packages/react-native/src/logs-defaults.ts
+++ b/packages/react-native/src/logs-defaults.ts
@@ -29,20 +29,21 @@ function defaultResourceAttributes(): Record<string, string> {
 }
 
 export function resolveLogsConfig(config: PostHogLogsConfig | undefined): ResolvedPostHogLogsConfig {
+  // `rateCap` is dropped from the spread so the resolved (flat) names below
+  // are the only authoritative form on the resolved config.
+  const { rateCap: _rateCap, ...rest } = config ?? {}
   return {
-    ...config,
+    ...rest,
     maxBufferSize: config?.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE,
     flushIntervalMs: config?.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS,
     maxBatchRecordsPerPost: config?.maxBatchRecordsPerPost ?? DEFAULT_MAX_BATCH_RECORDS_PER_POST,
     // Rate-cap window defaults independently of flush cadence: changing flush
     // frequency shouldn't implicitly re-shape the rate budget.
-    rateCapWindowMs: config?.rateCapWindowMs ?? DEFAULT_RATE_CAP_WINDOW_MS,
-    // `maxLogsPerInterval` stays optional in the resolved config. RN defaults
-    // to 500/window to bound cellular data cost; pass `maxLogsPerInterval:
-    // undefined` in user config to opt out.
-    maxLogsPerInterval: config?.maxLogsPerInterval ?? DEFAULT_MAX_LOGS_PER_INTERVAL,
-    backgroundFlushBudgetMs: config?.backgroundFlushBudgetMs ?? DEFAULT_BACKGROUND_FLUSH_BUDGET_MS,
-    terminationFlushBudgetMs: config?.terminationFlushBudgetMs ?? DEFAULT_TERMINATION_FLUSH_BUDGET_MS,
+    rateCapWindowMs: config?.rateCap?.windowMs ?? DEFAULT_RATE_CAP_WINDOW_MS,
+    // RN defaults to 500/window to bound cellular data cost.
+    maxLogsPerInterval: config?.rateCap?.maxLogs ?? DEFAULT_MAX_LOGS_PER_INTERVAL,
+    backgroundFlushBudgetMs: DEFAULT_BACKGROUND_FLUSH_BUDGET_MS,
+    terminationFlushBudgetMs: DEFAULT_TERMINATION_FLUSH_BUDGET_MS,
     // Merge platform-detected attrs first so user-provided `resourceAttributes`
     // wins on any conflict. Never throw if `Platform` is unavailable in
     // unusual envs (web bundle, jest without RN preset) — fall back silently.

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -1,4 +1,4 @@
-import { AppState, Dimensions, Linking, Platform } from 'react-native'
+import { AppState, type AppStateStatus, Dimensions, Linking, Platform } from 'react-native'
 
 import {
   CaptureLogOptions,
@@ -44,6 +44,23 @@ import { OptionalReactNativeSessionReplay } from './optional/OptionalSessionRepl
 import { ErrorTracking, ErrorTrackingOptions } from './error-tracking'
 
 export { PostHogPersistedProperty }
+
+/**
+ * Collapses RN's broader AppState status set into the OTLP `app.state`
+ * enum (foreground|background). 'inactive' (iOS transition) and 'extension'
+ * are treated as foreground — the app is still running JS, just not the
+ * primary scene. 'unknown' returns undefined so the attribute is omitted
+ * rather than guessed.
+ */
+function mapAppStateForLogs(state: AppStateStatus | undefined): 'foreground' | 'background' | undefined {
+  if (state === 'background') {
+    return 'background'
+  }
+  if (!state || state === 'unknown') {
+    return undefined
+  }
+  return 'foreground'
+}
 
 export interface PostHogOptions extends PostHogCoreOptions {
   /**
@@ -150,6 +167,11 @@ export class PostHog extends PostHogCore {
   private _disableRemoteConfig: boolean
   private _errorTracking: ErrorTracking
   private _logs: PostHogLogs
+  // Cached, foreground/background view of the app's lifecycle. Read on the
+  // log-capture hot path (per record) so we tag every log with whether it
+  // happened in foreground or background. Updated by the AppState listener
+  // and seeded from `AppState.currentState` at construction.
+  private _currentAppState?: 'foreground' | 'background'
   private _surveysReadyPromise: Promise<void> | null = null
   private _surveysReady: boolean = false
   private _setDefaultPersonProperties: boolean
@@ -241,14 +263,29 @@ export class PostHog extends PostHogCore {
       this._logsStorage = createLogsMemoryStorage()
     }
 
+    // Seed from sync `AppState.currentState` so the very first capture (which
+    // can happen before any 'change' event fires) is already tagged. Maps
+    // RN's broader status set into the OTLP `app.state` enum's
+    // foreground/background dichotomy.
+    this._currentAppState = mapAppStateForLogs(AppState.currentState)
+
     this._logs = new PostHogLogs(
       this,
       resolveLogsConfig(options?.logs),
       this._logger,
-      () => ({
-        distinctId: this.getDistinctId() || undefined,
-        sessionId: this.getSessionId() || undefined,
-      }),
+      () => {
+        // Pulled at capture time so each tag reflects state at the moment
+        // the log was fired, not at flush.
+        const flags = this.getFeatureFlags()
+        const flagKeys = flags ? Object.keys(flags) : undefined
+        return {
+          distinctId: this.getDistinctId() || undefined,
+          sessionId: this.getSessionId() || undefined,
+          screenName: (this.sessionProps?.$screen_name as string | undefined) || undefined,
+          appState: this._currentAppState,
+          activeFeatureFlags: flagKeys && flagKeys.length > 0 ? flagKeys : undefined,
+        }
+      },
       (fn) => this.wrap(fn),
       // Block between batches on the logs-storage disk write so a crash can't
       // replay an already-sent batch. Events do the equivalent via
@@ -261,6 +298,14 @@ export class PostHog extends PostHogCore {
       // ignore unknown state (usually initial state, the app might not be ready yet)
       if (state === 'unknown') {
         return
+      }
+
+      // Update before kicking off the flush — captures that race the flush
+      // (e.g. fired in a `componentWillUnmount` triggered by backgrounding)
+      // should already see the new state.
+      const mapped = mapAppStateForLogs(state)
+      if (mapped) {
+        this._currentAppState = mapped
       }
 
       void this.flush().catch(async (err) => {

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -1,6 +1,8 @@
 import { AppState, Dimensions, Linking, Platform } from 'react-native'
 
 import {
+  CaptureLogOptions,
+  CaptureLogger,
   JsonType,
   PostHogCaptureOptions,
   PostHogCore,
@@ -9,6 +11,7 @@ import {
   PostHogFetchOptions,
   PostHogFetchResponse,
   PostHogLogs,
+  PostHogLogsConfig,
   PostHogPersistedProperty,
   PostHogRemoteConfig,
   Survey,
@@ -115,6 +118,23 @@ export interface PostHogOptions extends PostHogCoreOptions {
    * @default true
    */
   setDefaultPersonProperties?: boolean
+
+  /**
+   * Logs feature configuration. Lets you send structured log records to
+   * PostHog via `posthog.captureLog(...)` or `posthog.logger.info(...)`.
+   *
+   * Not passing a `logs` key still enables the feature with mobile-tuned
+   * defaults (10s flush cadence, 500 logs/window rate cap, 50 records per
+   * POST). Pass `{ enabled: false }` to fully opt out.
+   *
+   * Common overrides:
+   * - `beforeSend` — filter / transform / redact records before they're
+   *   queued. Returning `null` drops the record.
+   * - `maxLogsPerInterval` / `rateCapWindowMs` — throttle capture rate.
+   * - `serviceName` / `environment` / `serviceVersion` — OTLP resource
+   *   attributes attached to every batch.
+   */
+  logs?: PostHogLogsConfig
 }
 
 export class PostHog extends PostHogCore {
@@ -221,11 +241,9 @@ export class PostHog extends PostHogCore {
       this._logsStorage = createLogsMemoryStorage()
     }
 
-    // TODO: wire user-supplied `options.logs` once the public captureLog API
-    // lands. Hardcoded to defaults while PostHogLogs is SDK-internal.
     this._logs = new PostHogLogs(
       this,
-      resolveLogsConfig(undefined),
+      resolveLogsConfig(options?.logs),
       this._logger,
       () => ({
         distinctId: this.getDistinctId() || undefined,
@@ -625,6 +643,70 @@ export class PostHog extends PostHogCore {
    */
   flush(): Promise<void> {
     return super.flush()
+  }
+
+  /**
+   * Captures a structured log record and sends it to PostHog's logs product
+   * (`/i/v1/logs`). Low-level primitive — most callers will prefer
+   * `posthog.logger.info(...)` / `.warn(...)` / `.error(...)` etc., which
+   * wrap this with a level pre-set.
+   *
+   * Records are buffered per-session, rate-limited, batched into OTLP
+   * payloads, and flushed on a timer, on AppState change, or when the
+   * buffer reaches capacity. Configure flush cadence, rate cap, and a
+   * `beforeSend` filter via the `logs` option on `new PostHog(...)`.
+   *
+   * {@label Capture}
+   *
+   * @example
+   * ```ts
+   * posthog.captureLog({
+   *   body: 'checkout completed',
+   *   level: 'info',
+   *   attributes: { order_id: 'ord_789', amount_cents: 4999 },
+   * })
+   * ```
+   *
+   * @public
+   *
+   * @param options Log record. `body` is required; `level` defaults to
+   *   `'info'`. `attributes` are attached as OTLP key-value attributes
+   *   and will override auto-populated ones (distinctId, sessionId) on
+   *   key conflict.
+   */
+  captureLog(options: CaptureLogOptions): void {
+    this._logs.captureLog(options)
+  }
+
+  private _captureLogger?: CaptureLogger
+
+  /**
+   * Convenience per-level logger. Each method is shorthand for
+   * `posthog.captureLog({ body, level, attributes })`. Lazily constructed
+   * on first access, then reused.
+   *
+   * {@label Capture}
+   *
+   * @example
+   * ```ts
+   * posthog.logger.info('checkout completed', { order_id: 'ord_789' })
+   * posthog.logger.error('payment failed', { code: 'E001' })
+   * ```
+   *
+   * @public
+   */
+  get logger(): CaptureLogger {
+    if (!this._captureLogger) {
+      this._captureLogger = {
+        trace: (body, attributes) => this.captureLog({ body, level: 'trace', attributes }),
+        debug: (body, attributes) => this.captureLog({ body, level: 'debug', attributes }),
+        info: (body, attributes) => this.captureLog({ body, level: 'info', attributes }),
+        warn: (body, attributes) => this.captureLog({ body, level: 'warn', attributes }),
+        error: (body, attributes) => this.captureLog({ body, level: 'error', attributes }),
+        fatal: (body, attributes) => this.captureLog({ body, level: 'fatal', attributes }),
+      }
+    }
+    return this._captureLogger
   }
 
   /**

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -137,10 +137,36 @@ export interface PostHogOptions extends PostHogCoreOptions {
   setDefaultPersonProperties?: boolean
 
   /**
-   * Logs feature configuration. Lets you send structured log records to
-   * PostHog via `posthog.captureLog(...)` or `posthog.logger.info(...)`.
-   * Manual capture ships records whenever the API is called; the only
-   * blockers are `optedOut`, missing/empty `body`, and missing API key.
+   * Logs feature configuration. Enables structured log capture via
+   * `posthog.captureLog(...)` or `posthog.logger.info(...)`. Records ship to
+   * PostHog's logs product (`/i/v1/logs`) in OTLP format, batched on a timer,
+   * AppState change, buffer fill, or manual `flushLogs()`.
+   *
+   * Capture is **unconditional** — calling the API ships records as long as
+   * the SDK is initialized and the user hasn't opted out. The only blockers
+   * are `optedOut`, missing/empty `body`, and missing API key.
+   *
+   * All fields below are optional; per-SDK defaults apply (mobile defaults
+   * are tuned for cellular bandwidth and battery, ~50 logs/sec ceiling).
+   *
+   * @example Minimal — just service tagging, defaults for everything else
+   * ```ts
+   * new PostHog(key, {
+   *   logs: { serviceName: 'my-app', environment: 'production' }
+   * })
+   * ```
+   *
+   * @example Tune for higher-volume logging
+   * ```ts
+   * new PostHog(key, {
+   *   logs: {
+   *     serviceName: 'my-app',
+   *     rateCap: { maxLogs: 5000, windowMs: 60000 },
+   *     maxBufferSize: 500,
+   *     beforeSend: (r) => r.body.includes('secret') ? null : r,
+   *   }
+   * })
+   * ```
    */
   logs?: PostHogLogsConfig
 }

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -154,10 +154,10 @@ export interface PostHogOptions extends PostHogCoreOptions {
    * Logs feature configuration. Lets you send structured log records to
    * PostHog via `posthog.captureLog(...)` or `posthog.logger.info(...)`.
    *
-   * **Off by default** (matches the browser SDK's `PostHogLogs` extension).
-   * Opt in either locally (`logs: { captureConsoleLogs: true }`) or via
-   * remote config (`response.logs.captureConsoleLogs: true`); a remote
-   * `false` acts as a kill-switch even when local is `true`.
+   * Manual capture is unconditional — call the API and records ship,
+   * matching the browser SDK's manual path. The server can remotely block
+   * capture by returning `response.logs.captureConsoleLogs: false`; an
+   * explicit `true` and an absent key both leave it allowed.
    */
   logs?: PostHogLogsConfig
 }
@@ -481,10 +481,9 @@ export class PostHog extends PostHogCore {
    */
   protected onRemoteConfig(response: PostHogRemoteConfig): void {
     this._errorTracking.onRemoteConfig(response.errorTracking)
-    // Logs remote kill-switch. Mirrors the browser SDK's `PostHogLogs.onRemoteConfig`
-    // which reads `response.logs?.captureConsoleLogs`. RN treats absent/true
-    // as "leave the decision to local config" — only an explicit `false`
-    // disables.
+    // Logs remote kill switch. Reads `response.logs?.captureConsoleLogs`:
+    // explicit `false` blocks manual capture going forward; `true` or absent
+    // leaves it allowed.
     this._logs.setRemoteEnabled(extractLogsCaptureFlag(response.logs))
   }
 

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -52,16 +52,7 @@ export { PostHogPersistedProperty }
  * primary scene. 'unknown' returns undefined so the attribute is omitted
  * rather than guessed.
  */
-/**
- * Extracts the logs gate from a remote config response. Accepts the same
- * `boolean | { captureConsoleLogs?: boolean }` shape the server may return,
- * and surfaces the tri-state expected by `PostHogLogs.setRemoteEnabled`:
- *   - `undefined`              → no opinion; leave local in charge
- *   - `true`                   → server-side opt-in (forces on)
- *   - `false`                  → server-side kill-switch (forces off)
- *   - `{ captureConsoleLogs }` → tri-state by the inner key; missing key
- *                                 means no opinion.
- */
+// Flatten the server's `logs` field into the tri-state PostHogLogs.setRemoteEnabled consumes.
 function extractLogsCaptureFlag(logs: PostHogRemoteConfig['logs']): boolean | undefined {
   if (logs === undefined) {
     return undefined
@@ -167,14 +158,6 @@ export interface PostHogOptions extends PostHogCoreOptions {
    * Opt in either locally (`logs: { captureConsoleLogs: true }`) or via
    * remote config (`response.logs.captureConsoleLogs: true`); a remote
    * `false` acts as a kill-switch even when local is `true`.
-   *
-   * Common overrides:
-   * - `captureConsoleLogs: true` — enable the feature.
-   * - `beforeSend` — filter / transform / redact records before they're
-   *   queued. Returning `null` drops the record.
-   * - `maxLogsPerInterval` / `rateCapWindowMs` — throttle capture rate.
-   * - `serviceName` / `environment` / `serviceVersion` — OTLP resource
-   *   attributes attached to every batch.
    */
   logs?: PostHogLogsConfig
 }
@@ -369,7 +352,6 @@ export class PostHog extends PostHogCore {
       void this._logsStorage.waitForPersist()
 
       if (state === 'active') {
-        // rotate session id if needed (expired either 30 minutes inactive or max duration 24 hours)
         this.getSessionId()
       }
     })
@@ -385,9 +367,9 @@ export class PostHog extends PostHogCore {
 
       this.setupBootstrap(options)
 
-      // Initialize device_id if not already set. This provides a stable identifier
-      // for device-level feature flag bucketing that survives identify() and reset().
-      // We seed it from the anonymous ID at init time; once set, it's independent.
+      // Seed device_id from the anonymous id at init time so existing installs
+      // get a stable device-level identifier; once set, it survives identify()
+      // and reset() independently of anonymous_id.
       if (!this.getPersistedProperty(PostHogPersistedProperty.DeviceId)) {
         const anonId = this.getAnonymousId()
         if (anonId) {

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -52,20 +52,6 @@ export { PostHogPersistedProperty }
  * primary scene. 'unknown' returns undefined so the attribute is omitted
  * rather than guessed.
  */
-// Flatten the server's `logs` field into the tri-state PostHogLogs.setRemoteEnabled consumes.
-function extractLogsCaptureFlag(logs: PostHogRemoteConfig['logs']): boolean | undefined {
-  if (logs === undefined) {
-    return undefined
-  }
-  if (typeof logs === 'boolean') {
-    return logs
-  }
-  if (typeof logs === 'object' && typeof logs.captureConsoleLogs === 'boolean') {
-    return logs.captureConsoleLogs
-  }
-  return undefined
-}
-
 function mapAppStateForLogs(state: AppStateStatus | undefined): 'foreground' | 'background' | undefined {
   if (state === 'background') {
     return 'background'
@@ -154,10 +140,17 @@ export interface PostHogOptions extends PostHogCoreOptions {
    * Logs feature configuration. Lets you send structured log records to
    * PostHog via `posthog.captureLog(...)` or `posthog.logger.info(...)`.
    *
-   * Manual capture is unconditional — call the API and records ship,
-   * matching the browser SDK's manual path. The server can remotely block
-   * capture by returning `response.logs.captureConsoleLogs: false`; an
-   * explicit `true` and an absent key both leave it allowed.
+   * Manual capture is unconditional — call the API and records ship.
+   * Matches the events pipeline's manual `capture()` shape. Only blockers:
+   * `optedOut`, missing/empty `body`, and missing API key.
+   *
+   * The wire field `response.logs.captureConsoleLogs` is browser-only — it
+   * controls whether the JS SDK loads its `console.*` autocapture extension.
+   * RN does not read this field today. When console autocapture lands as a
+   * follow-up, the RN SDK will read it as a local-opt-in flag for that
+   * autocapture path specifically (matching the events pattern of
+   * `<PostHogProvider autocapture>` and `captureAppLifecycleEvents`); manual
+   * capture will remain unconditional regardless.
    */
   logs?: PostHogLogsConfig
 }
@@ -391,10 +384,6 @@ export class PostHog extends PostHogCore {
       )
       if (cachedRemoteConfig) {
         this._errorTracking.onRemoteConfig(cachedRemoteConfig.errorTracking)
-        // Hydrate the logs kill-switch from the last response so the very
-        // first capture after launch already honours a server-side disable
-        // (the fresh remote config call may not return for several seconds).
-        this._logs.setRemoteEnabled(extractLogsCaptureFlag(cachedRemoteConfig.logs))
       }
 
       if (this._disableRemoteConfig === false) {
@@ -481,10 +470,6 @@ export class PostHog extends PostHogCore {
    */
   protected onRemoteConfig(response: PostHogRemoteConfig): void {
     this._errorTracking.onRemoteConfig(response.errorTracking)
-    // Logs remote kill switch. Reads `response.logs?.captureConsoleLogs`:
-    // explicit `false` blocks manual capture going forward; `true` or absent
-    // leaves it allowed.
-    this._logs.setRemoteEnabled(extractLogsCaptureFlag(response.logs))
   }
 
   /**

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -139,18 +139,8 @@ export interface PostHogOptions extends PostHogCoreOptions {
   /**
    * Logs feature configuration. Lets you send structured log records to
    * PostHog via `posthog.captureLog(...)` or `posthog.logger.info(...)`.
-   *
-   * Manual capture is unconditional — call the API and records ship.
-   * Matches the events pipeline's manual `capture()` shape. Only blockers:
-   * `optedOut`, missing/empty `body`, and missing API key.
-   *
-   * The wire field `response.logs.captureConsoleLogs` is browser-only — it
-   * controls whether the JS SDK loads its `console.*` autocapture extension.
-   * RN does not read this field today. When console autocapture lands as a
-   * follow-up, the RN SDK will read it as a local-opt-in flag for that
-   * autocapture path specifically (matching the events pattern of
-   * `<PostHogProvider autocapture>` and `captureAppLifecycleEvents`); manual
-   * capture will remain unconditional regardless.
+   * Manual capture ships records whenever the API is called; the only
+   * blockers are `optedOut`, missing/empty `body`, and missing API key.
    */
   logs?: PostHogLogsConfig
 }

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -163,11 +163,10 @@ export interface PostHogOptions extends PostHogCoreOptions {
    * Logs feature configuration. Lets you send structured log records to
    * PostHog via `posthog.captureLog(...)` or `posthog.logger.info(...)`.
    *
-   * **Off by default** (matches the JS SDK at
-   * `packages/browser/src/posthog-logs.ts:31-49`). Opt in either locally
-   * (`logs: { captureConsoleLogs: true }`) or via remote config
-   * (`response.logs.captureConsoleLogs: true`); a remote `false` acts as a
-   * kill-switch even when local is `true`.
+   * **Off by default** (matches the browser SDK's `PostHogLogs` extension).
+   * Opt in either locally (`logs: { captureConsoleLogs: true }`) or via
+   * remote config (`response.logs.captureConsoleLogs: true`); a remote
+   * `false` acts as a kill-switch even when local is `true`.
    *
    * Common overrides:
    * - `captureConsoleLogs: true` — enable the feature.
@@ -500,10 +499,10 @@ export class PostHog extends PostHogCore {
    */
   protected onRemoteConfig(response: PostHogRemoteConfig): void {
     this._errorTracking.onRemoteConfig(response.errorTracking)
-    // Logs remote kill-switch. Mirrors the browser SDK
-    // (`packages/browser/src/posthog-logs.ts:42-49`) which reads
-    // `response.logs?.captureConsoleLogs`. RN treats absent/true as "leave
-    // the decision to local config" — only an explicit `false` disables.
+    // Logs remote kill-switch. Mirrors the browser SDK's `PostHogLogs.onRemoteConfig`
+    // which reads `response.logs?.captureConsoleLogs`. RN treats absent/true
+    // as "leave the decision to local config" — only an explicit `false`
+    // disables.
     this._logs.setRemoteEnabled(extractLogsCaptureFlag(response.logs))
   }
 

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -629,6 +629,9 @@ export class PostHog extends PostHogCore {
    * Setting this to 1 will send events immediately and will use more battery. This is set to 20 by default.
    * You can also manually flush the queue. If a flush is already in progress it returns a promise for the existing flush.
    *
+   * Note: this drains the **events** pipeline only. Logs are flushed via
+   * {@link flushLogs}, and {@link shutdown} drains both before terminating.
+   *
    * {@label Capture}
    *
    * @example
@@ -637,6 +640,7 @@ export class PostHog extends PostHogCore {
    * await posthog.flush()
    * ```
    *
+   * @see flushLogs
    * @public
    *
    * @returns Promise that resolves when the flush is complete
@@ -689,6 +693,9 @@ export class PostHog extends PostHogCore {
    * If a flush is already in progress, both callers join the same in-flight
    * promise — no double-send.
    *
+   * Note: this drains the **logs** pipeline only. Events are flushed via
+   * {@link flush}, and {@link shutdown} drains both before terminating.
+   *
    * {@label Capture}
    *
    * @example
@@ -696,6 +703,7 @@ export class PostHog extends PostHogCore {
    * await posthog.flushLogs()
    * ```
    *
+   * @see flush
    * @public
    *
    * @returns Promise that resolves when the flush is complete.

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -678,6 +678,32 @@ export class PostHog extends PostHogCore {
     this._logs.captureLog(options)
   }
 
+  /**
+   * Manually flushes the logs queue.
+   *
+   * Logs flush automatically on a timer, when the buffer fills, or on
+   * AppState change — most apps never need to call this. Use it when you
+   * want a synchronous-style hand-off (e.g. before navigating away from a
+   * critical screen, in a custom crash handler, or while testing locally).
+   *
+   * If a flush is already in progress, both callers join the same in-flight
+   * promise — no double-send.
+   *
+   * {@label Capture}
+   *
+   * @example
+   * ```ts
+   * await posthog.flushLogs()
+   * ```
+   *
+   * @public
+   *
+   * @returns Promise that resolves when the flush is complete.
+   */
+  flushLogs(): Promise<void> {
+    return this._logs.flush()
+  }
+
   private _captureLogger?: CaptureLogger
 
   /**

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -231,7 +231,12 @@ export class PostHog extends PostHogCore {
         distinctId: this.getDistinctId() || undefined,
         sessionId: this.getSessionId() || undefined,
       }),
-      (fn) => this.wrap(fn)
+      (fn) => this.wrap(fn),
+      // Block between batches on the logs-storage disk write so a crash can't
+      // replay an already-sent batch. Events do the equivalent via
+      // `flushStorage()` (events-storage side). Mirror per-pipeline so one
+      // pipeline's slow disk doesn't stall the other.
+      () => this._logsStorage.waitForPersist()
     )
 
     AppState.addEventListener('change', (state) => {
@@ -241,6 +246,14 @@ export class PostHog extends PostHogCore {
       }
 
       void this.flush().catch(async (err) => {
+        await logFlushError(err)
+      })
+      // Flush buffered logs alongside events — OS may suspend or terminate the
+      // process next, and anything left in the queue won't get a second chance
+      // until the app is next foregrounded. Same diagnostic path as events
+      // (`logFlushError`) so a silent transport failure still reaches
+      // `console.error` even when no custom logger is configured.
+      void this._logs.flush().catch(async (err) => {
         await logFlushError(err)
       })
       // Drain pending logs-storage writes to disk before the OS may suspend
@@ -403,6 +416,17 @@ export class PostHog extends PostHogCore {
    */
   protected async flushStorage(): Promise<void> {
     await this._eventsStorage.waitForPersist()
+  }
+
+  /**
+   * Drain both pipelines on shutdown. Run in parallel so the logs final
+   * flush + timer teardown doesn't serialize behind events (and vice-versa).
+   * `_logs.shutdown()` swallows its own errors — a transient logs failure
+   * must not break events shutdown. Both sides share the same timeout budget
+   * so neither can outlive the caller's shutdown SLA.
+   */
+  async _shutdown(shutdownTimeoutMs: number = 30000): Promise<void> {
+    await Promise.all([this._logs.shutdown(shutdownTimeoutMs), super._shutdown(shutdownTimeoutMs)])
   }
 
   fetch(url: string, options: PostHogFetchOptions): Promise<PostHogFetchResponse> {

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -52,6 +52,29 @@ export { PostHogPersistedProperty }
  * primary scene. 'unknown' returns undefined so the attribute is omitted
  * rather than guessed.
  */
+/**
+ * Extracts the logs gate from a remote config response. Accepts the same
+ * `boolean | { captureConsoleLogs?: boolean }` shape the server may return,
+ * and surfaces the tri-state expected by `PostHogLogs.setRemoteEnabled`:
+ *   - `undefined`              → no opinion; leave local in charge
+ *   - `true`                   → server-side opt-in (forces on)
+ *   - `false`                  → server-side kill-switch (forces off)
+ *   - `{ captureConsoleLogs }` → tri-state by the inner key; missing key
+ *                                 means no opinion.
+ */
+function extractLogsCaptureFlag(logs: PostHogRemoteConfig['logs']): boolean | undefined {
+  if (logs === undefined) {
+    return undefined
+  }
+  if (typeof logs === 'boolean') {
+    return logs
+  }
+  if (typeof logs === 'object' && typeof logs.captureConsoleLogs === 'boolean') {
+    return logs.captureConsoleLogs
+  }
+  return undefined
+}
+
 function mapAppStateForLogs(state: AppStateStatus | undefined): 'foreground' | 'background' | undefined {
   if (state === 'background') {
     return 'background'
@@ -140,11 +163,14 @@ export interface PostHogOptions extends PostHogCoreOptions {
    * Logs feature configuration. Lets you send structured log records to
    * PostHog via `posthog.captureLog(...)` or `posthog.logger.info(...)`.
    *
-   * Not passing a `logs` key still enables the feature with mobile-tuned
-   * defaults (10s flush cadence, 500 logs/window rate cap, 50 records per
-   * POST). Pass `{ enabled: false }` to fully opt out.
+   * **Off by default** (matches the JS SDK at
+   * `packages/browser/src/posthog-logs.ts:31-49`). Opt in either locally
+   * (`logs: { captureConsoleLogs: true }`) or via remote config
+   * (`response.logs.captureConsoleLogs: true`); a remote `false` acts as a
+   * kill-switch even when local is `true`.
    *
    * Common overrides:
+   * - `captureConsoleLogs: true` — enable the feature.
    * - `beforeSend` — filter / transform / redact records before they're
    *   queued. Returning `null` drops the record.
    * - `maxLogsPerInterval` / `rateCapWindowMs` — throttle capture rate.
@@ -167,6 +193,10 @@ export class PostHog extends PostHogCore {
   private _disableRemoteConfig: boolean
   private _errorTracking: ErrorTracking
   private _logs: PostHogLogs
+  // Resolved logs config — kept around so lifecycle handlers (AppState
+  // background, _shutdown) can read the configured flush-time budgets without
+  // reaching back into the user's options object.
+  private _resolvedLogsConfig: ReturnType<typeof resolveLogsConfig>
   // Cached, foreground/background view of the app's lifecycle. Read on the
   // log-capture hot path (per record) so we tag every log with whether it
   // happened in foreground or background. Updated by the AppState listener
@@ -269,9 +299,10 @@ export class PostHog extends PostHogCore {
     // foreground/background dichotomy.
     this._currentAppState = mapAppStateForLogs(AppState.currentState)
 
+    this._resolvedLogsConfig = resolveLogsConfig(options?.logs)
     this._logs = new PostHogLogs(
       this,
-      resolveLogsConfig(options?.logs),
+      this._resolvedLogsConfig,
       this._logger,
       () => {
         // Pulled at capture time so each tag reflects state at the moment
@@ -294,6 +325,12 @@ export class PostHog extends PostHogCore {
       () => this._logsStorage.waitForPersist()
     )
 
+    // NOTE: this listener is registered for the lifetime of the PostHog
+    // instance and is never explicitly removed. RN apps typically construct
+    // a single long-lived PostHog and keep it until process exit, so a leak
+    // doesn't matter in practice; just be aware that constructing many
+    // instances (e.g. in tests without an explicit teardown) would
+    // accumulate listeners.
     AppState.addEventListener('change', (state) => {
       // ignore unknown state (usually initial state, the app might not be ready yet)
       if (state === 'unknown') {
@@ -308,15 +345,24 @@ export class PostHog extends PostHogCore {
         this._currentAppState = mapped
       }
 
+      // Flush on every transition, including foreground→active. Foreground
+      // flush is technically redundant (the timer would catch up shortly),
+      // but it's cheap and keeps the lifecycle handler symmetric — no
+      // special-casing of which transitions should drain.
       void this.flush().catch(async (err) => {
         await logFlushError(err)
       })
       // Flush buffered logs alongside events — OS may suspend or terminate the
       // process next, and anything left in the queue won't get a second chance
-      // until the app is next foregrounded. Same diagnostic path as events
-      // (`logFlushError`) so a silent transport failure still reaches
-      // `console.error` even when no custom logger is configured.
-      void this._logs.flush().catch(async (err) => {
+      // until the app is next foregrounded. On background, race the flush
+      // against `backgroundFlushBudgetMs` so a slow network can't run past
+      // the OS-imposed background window (~30s on iOS). Foreground/active
+      // transitions don't need a budget — the app is staying alive.
+      const isBackgrounding = mapped === 'background'
+      const logsFlushPromise = isBackgrounding
+        ? this._logs.flushWithTimeout(this._resolvedLogsConfig.backgroundFlushBudgetMs)
+        : this._logs.flush()
+      void logsFlushPromise.catch(async (err) => {
         await logFlushError(err)
       })
       // Drain pending logs-storage writes to disk before the OS may suspend
@@ -364,6 +410,10 @@ export class PostHog extends PostHogCore {
       )
       if (cachedRemoteConfig) {
         this._errorTracking.onRemoteConfig(cachedRemoteConfig.errorTracking)
+        // Hydrate the logs kill-switch from the last response so the very
+        // first capture after launch already honours a server-side disable
+        // (the fresh remote config call may not return for several seconds).
+        this._logs.setRemoteEnabled(extractLogsCaptureFlag(cachedRemoteConfig.logs))
       }
 
       if (this._disableRemoteConfig === false) {
@@ -450,6 +500,11 @@ export class PostHog extends PostHogCore {
    */
   protected onRemoteConfig(response: PostHogRemoteConfig): void {
     this._errorTracking.onRemoteConfig(response.errorTracking)
+    // Logs remote kill-switch. Mirrors the browser SDK
+    // (`packages/browser/src/posthog-logs.ts:42-49`) which reads
+    // `response.logs?.captureConsoleLogs`. RN treats absent/true as "leave
+    // the decision to local config" — only an explicit `false` disables.
+    this._logs.setRemoteEnabled(extractLogsCaptureFlag(response.logs))
   }
 
   /**
@@ -485,11 +540,16 @@ export class PostHog extends PostHogCore {
    * Drain both pipelines on shutdown. Run in parallel so the logs final
    * flush + timer teardown doesn't serialize behind events (and vice-versa).
    * `_logs.shutdown()` swallows its own errors — a transient logs failure
-   * must not break events shutdown. Both sides share the same timeout budget
-   * so neither can outlive the caller's shutdown SLA.
+   * must not break events shutdown.
+   *
+   * Logs use the smaller of `terminationFlushBudgetMs` and the caller's
+   * `shutdownTimeoutMs` so a final flush can never run past the caller's
+   * shutdown SLA, while still respecting the configured logs-specific
+   * termination budget when it's tighter.
    */
   async _shutdown(shutdownTimeoutMs: number = 30000): Promise<void> {
-    await Promise.all([this._logs.shutdown(shutdownTimeoutMs), super._shutdown(shutdownTimeoutMs)])
+    const logsBudgetMs = Math.min(shutdownTimeoutMs, this._resolvedLogsConfig.terminationFlushBudgetMs)
+    await Promise.all([this._logs.shutdown(logsBudgetMs), super._shutdown(shutdownTimeoutMs)])
   }
 
   fetch(url: string, options: PostHogFetchOptions): Promise<PostHogFetchResponse> {
@@ -704,6 +764,13 @@ export class PostHog extends PostHogCore {
    * payloads, and flushed on a timer, on AppState change, or when the
    * buffer reaches capacity. Configure flush cadence, rate cap, and a
    * `beforeSend` filter via the `logs` option on `new PostHog(...)`.
+   *
+   * Note — naming collision: `posthog.captureLog()` (this method) is the
+   * **logs product** API. There is also a separate, pre-existing
+   * `sessionReplayConfig.captureLog` boolean that controls whether
+   * **session replay** records the device's `console.*` output. The two
+   * are unrelated: this method emits structured records to the logs
+   * pipeline regardless of whether session replay is on.
    *
    * {@label Capture}
    *

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1707,6 +1707,30 @@ describe('PostHog React Native', () => {
       expect(queue).toHaveLength(3)
     })
 
+    it('posthog.flushLogs() drains the logs queue (and only the logs queue)', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      const sendLogsSpy = jest.spyOn(posthog as any, '_sendLogsBatch').mockResolvedValue({ kind: 'ok' } as never)
+
+      posthog.captureLog({ body: 'manual-flush-target' })
+      await posthog.flushLogs()
+
+      expect(sendLogsSpy).toHaveBeenCalledTimes(1)
+      const bodies = (sendLogsSpy.mock.calls[0][0] as any).resourceLogs[0].scopeLogs[0].logRecords.map(
+        (r: any) => r.body.stringValue
+      )
+      expect(bodies).toEqual(['manual-flush-target'])
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue)).toEqual([])
+
+      sendLogsSpy.mockRestore()
+    })
+
     it('options.logs.enabled=false keeps captures from reaching the queue', async () => {
       posthog = new PostHog('test-token', {
         customStorage: mockStorage,

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1731,6 +1731,220 @@ describe('PostHog React Native', () => {
       sendLogsSpy.mockRestore()
     })
 
+    it('flush emits os.* and telemetry.sdk.* resource attrs', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      const sendSpy = jest.spyOn(posthog as any, '_sendLogsBatch').mockResolvedValue({ kind: 'ok' } as never)
+
+      posthog.captureLog({ body: 'platform-tagged' })
+      await posthog.flushLogs()
+
+      const resourceAttrs = Object.fromEntries(
+        (sendSpy.mock.calls[0][0] as any).resourceLogs[0].resource.attributes.map((a: any) => [a.key, a.value])
+      )
+      // The RN test harness reports a real Platform.OS — assert presence
+      // and shape rather than a specific platform value.
+      expect(resourceAttrs['os.name']).toBeDefined()
+      expect(typeof resourceAttrs['os.name'].stringValue).toBe('string')
+      expect(resourceAttrs['os.version']).toBeDefined()
+      expect(typeof resourceAttrs['os.version'].stringValue).toBe('string')
+      expect(resourceAttrs['telemetry.sdk.name']).toEqual({ stringValue: 'posthog-react-native' })
+      expect(resourceAttrs['telemetry.sdk.version']).toBeDefined()
+
+      sendSpy.mockRestore()
+    })
+
+    it('user-supplied options.logs.resourceAttributes overrides os.* defaults', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+        logs: { resourceAttributes: { 'os.name': 'overridden-os' } },
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      const sendSpy = jest.spyOn(posthog as any, '_sendLogsBatch').mockResolvedValue({ kind: 'ok' } as never)
+
+      posthog.captureLog({ body: 'overridden' })
+      await posthog.flushLogs()
+
+      const resourceAttrs = Object.fromEntries(
+        (sendSpy.mock.calls[0][0] as any).resourceLogs[0].resource.attributes.map((a: any) => [a.key, a.value])
+      )
+      expect(resourceAttrs['os.name']).toEqual({ stringValue: 'overridden-os' })
+      // os.version still falls through from Platform — only the overridden
+      // key is replaced.
+      expect(resourceAttrs['os.version']).toBeDefined()
+
+      sendSpy.mockRestore()
+    })
+
+    it('captureLog tags records with screen.name from posthog.screen()', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      // posthog.screen() registers $screen_name as a session-scoped property;
+      // the logs context-builder reads it at capture time.
+      await posthog.screen('checkout')
+      posthog.captureLog({ body: 'on-checkout-screen' })
+
+      const queue = posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue) as any[]
+      // posthog.screen() emits a $screen event which goes to events queue.
+      // The captureLog goes to logs queue. Find ours by body.
+      const target = queue.find((e) => e.record.body.stringValue === 'on-checkout-screen')
+      expect(target).toBeDefined()
+      const attrs = Object.fromEntries(target!.record.attributes.map((a: any) => [a.key, a.value]))
+      expect(attrs['screen.name']).toEqual({ stringValue: 'checkout' })
+    })
+
+    it('captureLog tags records with feature_flags from getFeatureFlags()', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      // Stub the flag store directly — `getFeatureFlags()` is the same
+      // primitive logs reads at capture time.
+      jest.spyOn(posthog, 'getFeatureFlags').mockReturnValue({
+        'new-checkout': true,
+        'experiment-ab': 'variant-a',
+      } as any)
+
+      posthog.captureLog({ body: 'flagged-capture' })
+
+      const queue = posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue) as any[]
+      const target = queue.find((e) => e.record.body.stringValue === 'flagged-capture')
+      const attrs = Object.fromEntries(target!.record.attributes.map((a: any) => [a.key, a.value]))
+      // OTLP serializes a string[] as arrayValue with stringValue children.
+      expect(attrs['feature_flags']).toEqual({
+        arrayValue: {
+          values: [{ stringValue: 'new-checkout' }, { stringValue: 'experiment-ab' }],
+        },
+      })
+    })
+
+    it('captureLog omits feature_flags when flags have not loaded yet (undefined state)', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      jest.spyOn(posthog, 'getFeatureFlags').mockReturnValue(undefined)
+
+      posthog.captureLog({ body: 'no-flags' })
+
+      const queue = posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue) as any[]
+      const target = queue.find((e) => e.record.body.stringValue === 'no-flags')
+      const attrs = Object.fromEntries(target!.record.attributes.map((a: any) => [a.key, a.value]))
+      // `undefined` flags → "we don't know yet" → attribute omitted.
+      expect(attrs['feature_flags']).toBeUndefined()
+    })
+
+    it('captureLog omits feature_flags when flags loaded but none are active (empty state)', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      // Logs gates `[]` to save bytes — same as browser logs. Distinct from
+      // events, which emit `$active_feature_flags: []` for back-compat (the
+      // shared helper preserves the empty array; only the caller's gate
+      // differs).
+      jest.spyOn(posthog, 'getFeatureFlags').mockReturnValue({} as any)
+
+      posthog.captureLog({ body: 'empty-flags' })
+
+      const queue = posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue) as any[]
+      const target = queue.find((e) => e.record.body.stringValue === 'empty-flags')
+      const attrs = Object.fromEntries(target!.record.attributes.map((a: any) => [a.key, a.value]))
+      expect(attrs['feature_flags']).toBeUndefined()
+    })
+
+    it('captureLog tags records with app.state, flipping with AppState changes', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      // The harness mocks `AppState.addEventListener` but not
+      // `AppState.currentState`, so the constructor's seed is undefined and
+      // the first capture omits `app.state` (correct — we don't guess). Drive
+      // explicit 'active' then 'background' transitions through the listener
+      // to verify the foreground/background mapping end-to-end.
+      const calls = (AppState.addEventListener as jest.Mock).mock.calls
+      const callback = calls.find((c) => c[0] === 'change')![1]
+
+      callback('active' as AppStateStatus)
+      posthog.captureLog({ body: 'fg' })
+
+      callback('background' as AppStateStatus)
+      posthog.captureLog({ body: 'bg' })
+
+      const queue = posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue) as any[]
+      const fg = queue.find((e) => e.record.body.stringValue === 'fg')
+      const bg = queue.find((e) => e.record.body.stringValue === 'bg')
+      const fgAttrs = Object.fromEntries(fg!.record.attributes.map((a: any) => [a.key, a.value]))
+      const bgAttrs = Object.fromEntries(bg!.record.attributes.map((a: any) => [a.key, a.value]))
+      expect(fgAttrs['app.state']).toEqual({ stringValue: 'foreground' })
+      expect(bgAttrs['app.state']).toEqual({ stringValue: 'background' })
+    })
+
+    it('captures across identify/reset boundaries keep their capture-time identity', async () => {
+      // PostHogLogs builds the OTLP record at capture time, so distinctId/sessionId are
+      // baked into `attributes` synchronously. reset() preserves the LogsQueue
+      // so a record captured by alice keeps alice's identity even after reset() 
+      // and a subsequent identify(bob).
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      posthog.identify('alice')
+      posthog.captureLog({ body: 'A-as-alice' })
+
+      posthog.reset()
+      posthog.identify('bob')
+      posthog.captureLog({ body: 'B-as-bob' })
+
+      const queue = posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue) as any[]
+      const recordA = queue.find((e) => e.record.body.stringValue === 'A-as-alice')!
+      const recordB = queue.find((e) => e.record.body.stringValue === 'B-as-bob')!
+      const attrsA = Object.fromEntries(recordA.record.attributes.map((a: any) => [a.key, a.value]))
+      const attrsB = Object.fromEntries(recordB.record.attributes.map((a: any) => [a.key, a.value]))
+
+      expect(attrsA['posthogDistinctId']).toEqual({ stringValue: 'alice' })
+      expect(attrsB['posthogDistinctId']).toEqual({ stringValue: 'bob' })
+      // Both records should still be present — reset() must NOT drop the queue.
+      expect(queue).toHaveLength(2)
+    })
+
     it('options.logs.enabled=false keeps captures from reaching the queue', async () => {
       posthog = new PostHog('test-token', {
         customStorage: mockStorage,

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1521,9 +1521,7 @@ describe('PostHog React Native', () => {
       // records the call for verification.
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
       jest.spyOn(posthog, 'flush').mockResolvedValue(undefined)
-      jest
-        .spyOn((posthog as any)._logs, 'flush')
-        .mockRejectedValue(new Error('logs transport down'))
+      jest.spyOn((posthog as any)._logs, 'flush').mockRejectedValue(new Error('logs transport down'))
 
       const calls = (AppState.addEventListener as jest.Mock).mock.calls
       const callback = calls.find((c) => c[0] === 'change')![1]
@@ -1573,9 +1571,7 @@ describe('PostHog React Native', () => {
       await (posthog as any)._logsStorage.preloadPromise
 
       const logsShutdownSpy = jest.spyOn((posthog as any)._logs, 'shutdown')
-      const sendLogsSpy = jest
-        .spyOn(posthog as any, '_sendLogsBatch')
-        .mockResolvedValue({ kind: 'ok' } as never)
+      const sendLogsSpy = jest.spyOn(posthog as any, '_sendLogsBatch').mockResolvedValue({ kind: 'ok' } as never)
 
       // Queue a log and fire a single capture so both pipelines have work.
       ;(posthog as any)._logs.captureLog({ body: 'terminal' })
@@ -1616,6 +1612,115 @@ describe('PostHog React Native', () => {
       expect(bodies).toEqual(['pre-init'])
 
       sendSpy.mockRestore()
+    })
+
+    // Public API — user-facing surface on PostHog: `captureLog` + `logger` +
+    // `options.logs`. These tests verify the seam that replaced the internal
+    // `_logs.captureLog` reach-ins above.
+    it('posthog.captureLog() delegates to the internal logs module', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      posthog.captureLog({ body: 'public-api', level: 'warn', attributes: { foo: 'bar' } })
+
+      const queue = posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue) as any[]
+      expect(queue).toHaveLength(1)
+      expect(queue[0].record.body.stringValue).toBe('public-api')
+      expect(queue[0].record.severityText).toBe('WARN')
+      const attrs = Object.fromEntries(queue[0].record.attributes.map((a: any) => [a.key, a.value]))
+      expect(attrs['foo']).toEqual({ stringValue: 'bar' })
+    })
+
+    it('posthog.logger maps each method to the correct severity level', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      posthog.logger.trace('t')
+      posthog.logger.debug('d')
+      posthog.logger.info('i')
+      posthog.logger.warn('w')
+      posthog.logger.error('e')
+      posthog.logger.fatal('f')
+
+      const queue = posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue) as any[]
+      expect(queue).toHaveLength(6)
+      expect(queue.map((e) => e.record.severityText)).toEqual(['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'])
+    })
+
+    it('posthog.logger returns the same instance on repeated access (lazy + memoized)', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+
+      expect(posthog.logger).toBe(posthog.logger)
+    })
+
+    it('options.logs.beforeSend is honored through the public captureLog path', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+        logs: {
+          beforeSend: (r) => (r.body.includes('secret') ? null : { ...r, body: `${r.body}!` }),
+        },
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      posthog.captureLog({ body: 'hello' })
+      posthog.captureLog({ body: 'this has secret info' }) // dropped
+      posthog.captureLog({ body: 'world' })
+
+      const queue = posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue) as any[]
+      expect(queue).toHaveLength(2)
+      expect(queue.map((e) => e.record.body.stringValue)).toEqual(['hello!', 'world!'])
+    })
+
+    it('options.logs.maxLogsPerInterval enforces the rate cap end-to-end', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+        logs: { maxLogsPerInterval: 3, rateCapWindowMs: 10000 },
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      for (let i = 0; i < 10; i++) {
+        posthog.captureLog({ body: `msg-${i}` })
+      }
+
+      const queue = posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue) as any[]
+      expect(queue).toHaveLength(3)
+    })
+
+    it('options.logs.enabled=false keeps captures from reaching the queue', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+        logs: { enabled: false },
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      posthog.captureLog({ body: 'should-not-land' })
+      posthog.logger.error('also-should-not-land')
+
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue)).toBeUndefined()
     })
   })
 })

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1948,9 +1948,6 @@ describe('PostHog React Native', () => {
     })
 
     it('manual capture is unconditional — remote config cannot block it', async () => {
-      // Matches the events pipeline shape. The wire field
-      // `response.logs.captureConsoleLogs` is browser-only (gates JS console
-      // autocapture there). RN ignores it for manual capture.
       posthog = new PostHog('test-token', {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1696,7 +1696,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { maxLogsPerInterval: 3, rateCapWindowMs: 10000 },
+        logs: { rateCap: { maxLogs: 3, windowMs: 10000 } },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1337,7 +1337,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1365,7 +1364,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1389,7 +1387,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1419,7 +1416,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1442,7 +1438,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1464,7 +1459,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       // Ensure logs storage preload completes before calling captureLog so
@@ -1488,7 +1482,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1521,7 +1514,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1550,7 +1542,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1575,7 +1566,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1604,7 +1594,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
 
       // Capture BEFORE ready() resolves — this exercises the wrap()/onReady
@@ -1635,7 +1624,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1655,7 +1643,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1677,7 +1664,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1690,7 +1676,6 @@ describe('PostHog React Native', () => {
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
         logs: {
-          captureConsoleLogs: true,
           beforeSend: (r) => (r.body.includes('secret') ? null : { ...r, body: `${r.body}!` }),
         },
       })
@@ -1711,7 +1696,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true, maxLogsPerInterval: 3, rateCapWindowMs: 10000 },
+        logs: { maxLogsPerInterval: 3, rateCapWindowMs: 10000 },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1729,7 +1714,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1754,7 +1738,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1784,7 +1767,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true, resourceAttributes: { 'os.name': 'overridden-os' } },
+        logs: { resourceAttributes: { 'os.name': 'overridden-os' } },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1810,7 +1793,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1834,7 +1816,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1864,7 +1845,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1885,7 +1865,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1909,7 +1888,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1946,7 +1924,6 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1970,15 +1947,17 @@ describe('PostHog React Native', () => {
       expect(queue).toHaveLength(2)
     })
 
-    it('options.logs.enabled=false keeps captures from reaching the queue', async () => {
+    it('remote kill switch (response.logs.captureConsoleLogs: false) blocks captures', async () => {
       posthog = new PostHog('test-token', {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { captureConsoleLogs: false },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
+
+      // Simulate a remote-config response that explicitly disables logs.
+      ;(posthog as any)._logs.setRemoteEnabled(false)
 
       posthog.captureLog({ body: 'should-not-land' })
       posthog.logger.error('also-should-not-land')

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1337,6 +1337,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1364,6 +1365,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1387,6 +1389,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1416,6 +1419,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1438,6 +1442,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1459,6 +1464,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       // Ensure logs storage preload completes before calling captureLog so
@@ -1482,6 +1488,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1514,6 +1521,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1542,6 +1550,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1566,6 +1575,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1579,8 +1589,10 @@ describe('PostHog React Native', () => {
 
       await posthog.shutdown(5000)
 
-      // Both pipelines drained through the shared shutdown path.
-      expect(logsShutdownSpy).toHaveBeenCalledWith(5000)
+      // Both pipelines drained through the shared shutdown path. Logs use
+      // the smaller of the caller's shutdown budget and the configured
+      // `terminationFlushBudgetMs` (default 2000ms) — see _shutdown.
+      expect(logsShutdownSpy).toHaveBeenCalledWith(2000)
       expect(sendLogsSpy).toHaveBeenCalled()
 
       logsShutdownSpy.mockRestore()
@@ -1592,6 +1604,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
 
       // Capture BEFORE ready() resolves — this exercises the wrap()/onReady
@@ -1622,6 +1635,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1641,6 +1655,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1662,6 +1677,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
 
@@ -1674,6 +1690,7 @@ describe('PostHog React Native', () => {
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
         logs: {
+          captureConsoleLogs: true,
           beforeSend: (r) => (r.body.includes('secret') ? null : { ...r, body: `${r.body}!` }),
         },
       })
@@ -1694,7 +1711,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { maxLogsPerInterval: 3, rateCapWindowMs: 10000 },
+        logs: { captureConsoleLogs: true, maxLogsPerInterval: 3, rateCapWindowMs: 10000 },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1712,6 +1729,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1736,6 +1754,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1765,7 +1784,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { resourceAttributes: { 'os.name': 'overridden-os' } },
+        logs: { captureConsoleLogs: true, resourceAttributes: { 'os.name': 'overridden-os' } },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1791,6 +1810,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1814,6 +1834,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1843,6 +1864,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1863,6 +1885,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1886,6 +1909,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1916,12 +1940,13 @@ describe('PostHog React Native', () => {
     it('captures across identify/reset boundaries keep their capture-time identity', async () => {
       // PostHogLogs builds the OTLP record at capture time, so distinctId/sessionId are
       // baked into `attributes` synchronously. reset() preserves the LogsQueue
-      // so a record captured by alice keeps alice's identity even after reset() 
+      // so a record captured by alice keeps alice's identity even after reset()
       // and a subsequent identify(bob).
       posthog = new PostHog('test-token', {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
+        logs: { captureConsoleLogs: true },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
@@ -1950,7 +1975,7 @@ describe('PostHog React Native', () => {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
         preloadFeatureFlags: false,
-        logs: { enabled: false },
+        logs: { captureConsoleLogs: false },
       })
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1947,7 +1947,10 @@ describe('PostHog React Native', () => {
       expect(queue).toHaveLength(2)
     })
 
-    it('remote kill switch (response.logs.captureConsoleLogs: false) blocks captures', async () => {
+    it('manual capture is unconditional — remote config cannot block it', async () => {
+      // Matches the events pipeline shape. The wire field
+      // `response.logs.captureConsoleLogs` is browser-only (gates JS console
+      // autocapture there). RN ignores it for manual capture.
       posthog = new PostHog('test-token', {
         customStorage: mockStorage,
         captureAppLifecycleEvents: false,
@@ -1956,13 +1959,11 @@ describe('PostHog React Native', () => {
       await posthog.ready()
       await (posthog as any)._logsStorage.preloadPromise
 
-      // Simulate a remote-config response that explicitly disables logs.
-      ;(posthog as any)._logs.setRemoteEnabled(false)
+      posthog.captureLog({ body: 'manual-1' })
+      posthog.logger.error('manual-2')
 
-      posthog.captureLog({ body: 'should-not-land' })
-      posthog.logger.error('also-should-not-land')
-
-      expect(posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue)).toBeUndefined()
+      const queue = posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue) as any[]
+      expect(queue).toHaveLength(2)
     })
   })
 })

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1486,6 +1486,7 @@ describe('PostHog React Native', () => {
       await posthog.ready()
 
       const flushSpy = jest.spyOn(posthog, 'flush').mockResolvedValue(undefined)
+      const logsFlushSpy = jest.spyOn((posthog as any)._logs, 'flush').mockResolvedValue(undefined)
       const waitForPersistSpy = jest
         .spyOn((posthog as any)._logsStorage, 'waitForPersist')
         .mockResolvedValue(undefined as never)
@@ -1500,10 +1501,121 @@ describe('PostHog React Native', () => {
       callback('background' as AppStateStatus)
 
       expect(flushSpy).toHaveBeenCalled()
+      expect(logsFlushSpy).toHaveBeenCalled()
       expect(waitForPersistSpy).toHaveBeenCalled()
 
       flushSpy.mockRestore()
+      logsFlushSpy.mockRestore()
       waitForPersistSpy.mockRestore()
+    })
+
+    it('AppState surfaces a failing logs flush via logFlushError (console visibility)', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+
+      // Suppress console.error noise from the assertion itself; the spy still
+      // records the call for verification.
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+      jest.spyOn(posthog, 'flush').mockResolvedValue(undefined)
+      jest
+        .spyOn((posthog as any)._logs, 'flush')
+        .mockRejectedValue(new Error('logs transport down'))
+
+      const calls = (AppState.addEventListener as jest.Mock).mock.calls
+      const callback = calls.find((c) => c[0] === 'change')![1]
+      callback('background' as AppStateStatus)
+
+      // Let the catch + awaited logFlushError microtask resolve.
+      await new Promise((r) => setImmediate(r))
+
+      // logFlushError writes to console.error — matches the events pipeline
+      // so a silent transport failure is still visible in the app's logs.
+      expect(consoleErrorSpy).toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('captureLog → flush() posts OTLP payload to /i/v1/logs via _sendLogsBatch', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      const sendSpy = jest.spyOn(posthog as any, '_sendLogsBatch').mockResolvedValue({ kind: 'ok' } as never)
+
+      ;(posthog as any)._logs.captureLog({ body: 'integration-test' })
+      await (posthog as any)._logs.flush()
+
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      const payload = sendSpy.mock.calls[0][0] as any
+      const bodies = payload.resourceLogs[0].scopeLogs[0].logRecords.map((r: any) => r.body.stringValue)
+      expect(bodies).toEqual(['integration-test'])
+      // Successful send should drain the queue.
+      expect(posthog.getPersistedProperty(PostHogPersistedProperty.LogsQueue)).toEqual([])
+
+      sendSpy.mockRestore()
+    })
+
+    it('shutdown() drains both events and logs and clears the logs flush timer', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      const logsShutdownSpy = jest.spyOn((posthog as any)._logs, 'shutdown')
+      const sendLogsSpy = jest
+        .spyOn(posthog as any, '_sendLogsBatch')
+        .mockResolvedValue({ kind: 'ok' } as never)
+
+      // Queue a log and fire a single capture so both pipelines have work.
+      ;(posthog as any)._logs.captureLog({ body: 'terminal' })
+      posthog.capture('terminal-event', {})
+
+      await posthog.shutdown(5000)
+
+      // Both pipelines drained through the shared shutdown path.
+      expect(logsShutdownSpy).toHaveBeenCalledWith(5000)
+      expect(sendLogsSpy).toHaveBeenCalled()
+
+      logsShutdownSpy.mockRestore()
+      sendLogsSpy.mockRestore()
+    })
+
+    it('pre-init captureLog is drained on flush once init completes', async () => {
+      posthog = new PostHog('test-token', {
+        customStorage: mockStorage,
+        captureAppLifecycleEvents: false,
+        preloadFeatureFlags: false,
+      })
+
+      // Capture BEFORE ready() resolves — this exercises the wrap()/onReady
+      // init-gating path: the enqueue defers until _initPromise resolves.
+      ;(posthog as any)._logs.captureLog({ body: 'pre-init' })
+
+      await posthog.ready()
+      await (posthog as any)._logsStorage.preloadPromise
+
+      const sendSpy = jest.spyOn(posthog as any, '_sendLogsBatch').mockResolvedValue({ kind: 'ok' } as never)
+
+      await (posthog as any)._logs.flush()
+
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      const bodies = (sendSpy.mock.calls[0][0] as any).resourceLogs[0].scopeLogs[0].logRecords.map(
+        (r: any) => r.body.stringValue
+      )
+      expect(bodies).toEqual(['pre-init'])
+
+      sendSpy.mockRestore()
     })
   })
 })

--- a/packages/types/src/capture-log.ts
+++ b/packages/types/src/capture-log.ts
@@ -30,12 +30,29 @@ export interface CaptureLogOptions {
     attributes?: LogAttributes
 }
 
+/**
+ * Per-level convenience logger. Each method captures a structured log record
+ * at the corresponding severity, equivalent to
+ * `posthog.captureLog({ body, level, attributes })`.
+ *
+ * @example
+ * ```ts
+ * posthog.logger.info('checkout completed', { order_id: 'ord_789' })
+ * posthog.logger.error('payment failed', { code: 'E001' })
+ * ```
+ */
 export interface Logger {
+    /** Lowest severity. Trace-level diagnostic detail. */
     trace(body: string, attributes?: LogAttributes): void
+    /** Debug-level detail. Verbose, only useful while diagnosing. */
     debug(body: string, attributes?: LogAttributes): void
+    /** Informational. Normal app events worth recording. */
     info(body: string, attributes?: LogAttributes): void
+    /** Warning. Something unexpected but non-fatal. */
     warn(body: string, attributes?: LogAttributes): void
+    /** Error. Operation failed; the app may continue. */
     error(body: string, attributes?: LogAttributes): void
+    /** Fatal. Operation failed; the app likely cannot continue. */
     fatal(body: string, attributes?: LogAttributes): void
 }
 

--- a/packages/types/src/capture-log.ts
+++ b/packages/types/src/capture-log.ts
@@ -77,15 +77,3 @@ export interface OtlpLogsPayload {
         }>
     }>
 }
-
-export interface LogSdkContext {
-    distinctId?: string
-    sessionId?: string
-    /** Web-only — current page URL */
-    currentUrl?: string
-    /** Mobile-only — current screen / view name */
-    screenName?: string
-    /** Mobile-only — app foreground/background state at capture time */
-    appState?: 'foreground' | 'background'
-    activeFeatureFlags?: string[]
-}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -103,5 +103,4 @@ export type {
     OtlpKeyValue,
     OtlpLogRecord,
     OtlpLogsPayload,
-    LogSdkContext,
 } from './capture-log'


### PR DESCRIPTION
## Problem

`posthog-react-native` has no first-party way to ship records to PostHog's logs product (`/i/v1/logs`). Customers who want structured logs have to roll their own OTLP exporter, storage, lifecycle handling, and rate cap. Storage scaffold landed in #3462; this PR adds the public API and the flush pipeline.

## Changes

Adds manual log capture for React Native. Pipeline lives in a shared `PostHogLogs` class in `@posthog/core` (so the JS SDK can later reuse it); RN-specific behavior (mobile flush cadence, AppState transitions, OS-imposed shutdown windows, dedicated logs storage file, `os.*` resource attrs) is wired in `posthog-react-native`.

### Public API (RN)

- `posthog.captureLog({ body, level?, attributes?, trace_id?, span_id?, trace_flags? })`
- `posthog.logger.{trace,debug,info,warn,error,fatal}(body, attributes?)` — lazy + memoized
- `posthog.flushLogs(): Promise<void>` — events still flush via `posthog.flush()`; `shutdown()` drains both
- `new PostHog(key, { logs: PostHogLogsConfig })` — `serviceName` / `serviceVersion` / `environment` / `resourceAttributes`, buffering knobs (`flushIntervalMs`, `rateCapWindowMs`, `maxBufferSize`, `maxLogsPerInterval`, `maxBatchRecordsPerPost`), lifecycle budgets (`backgroundFlushBudgetMs`, `terminationFlushBudgetMs`), `beforeSend`
- Re-exports from `@posthog/core`: `BeforeSendLogFn`, `CaptureLogOptions`, `CaptureLogger`, `LogAttributes`, `LogAttributeValue`, `LogSeverityLevel`, `PostHogLogsConfig`

### Pipeline

`captureLog` → `beforeSend` → tumbling-window rate cap → OTLP record build → persisted queue (dedicated `.posthog-rn-logs.json`) → batched gzipped POST to `/i/v1/logs`.

- **413** halves `maxBatchRecordsPerPost` and retries the same records; ramps back up by 1 per healthy send. Drops a single oversized record at size 1 with an explicit warn.
- **Concurrent `flush()`** serialized via a single in-flight promise — head of queue cannot be sent twice.
- **Flush triggers**: timer, buffer-at-capacity, AppState change, manual `flushLogs()`, `shutdown()`. Background and termination flushes are time-bounded so a slow network cannot outlive the OS-imposed window.
- **Per-record context** tagged at capture time, not flush: `distinctId`, `sessionId`, `screenName`, `appState`, `activeFeatureFlags`.
- **Storage**: `LogsQueue` routes to a dedicated `_logsStorage` file, separate from the events queue. Preserved across `reset()`. `waitForPersist()` runs between batches so a crash after a successful HTTP send but before the queue-advance hits disk cannot replay records.

### Gating — important to note

**Manual capture is unconditional.** Calling `captureLog` / `logger.*` ships records, matching the events pipeline's manual `capture()` shape. Only blockers: `optedOut`, missing/empty `body`, and missing API key. The server cannot remotely block manual capture — same as events.

**The wire field `response.logs.captureConsoleLogs` is browser-only.** It gates the JS SDK's `console.*` autocapture extension (per the project setting copy: *"Automatically capture browser console logs"*). RN does not read this field today. When console autocapture lands on RN as a follow-up, that PR will introduce a local opt-in via the same field for the autocapture path specifically — matching `<PostHogProvider autocapture>` and `captureAppLifecycleEvents` for events. Manual capture will remain unconditional.

Earlier iterations of this PR had a local `logs.captureConsoleLogs: true` opt-in flag plus a tri-state remote kill switch. Both removed:
- The local flag was misleading — the name promised console interception but autocapture isn't part of this PR.
- The remote kill switch conflated two concerns. The UI toggle is named for browser autocapture; using it as a kill switch for RN manual capture meant a customer flipping off web autocapture would also silently kill their RN manual logs, with no UI path to opt out of that side effect.
- Both can be re-introduced cleanly in the autocapture follow-up where they actually fit the wire-field semantic.

> Naming: `posthog.captureLog()` (this PR) is unrelated to the pre-existing `sessionReplayConfig.captureLog` boolean which controls session replay's `console.*` recording.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

Plus `@posthog/core` (minor bump in the same changeset).

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file (`.changeset/rn-manual-log-capture.md`)

### Test plan

**Automated**
- `@posthog/core` `src/logs/index.spec.ts` — 54/54 passing.
- `posthog-react-native` `posthog.spec.ts` — 94/94 passing.

**Manual — Android, example-expo-53, Project 381971** (HogQL + logcat + on-disk file inspection)

<details>
<summary>Phase-by-phase breakdown — 9 phases ✅, 1 skipped (kill switch removed)</summary>

| # | What | Result |
|---|---|---|
| 1 | Per-level taps + Mixed + manual `Flush now`; default-INFO when no level provided | ✅ |
| 2 | OTLP resource attrs (`service.*`, `os.*`, `telemetry.sdk.*`); user `resourceAttributes` overrides defaults | ✅ |
| 3 | `screen.name` via `posthog.screen()`, `app.state=foreground`, `posthogDistinctId`, `sessionId` tagged at capture time (`feature_flags` covered by unit tests; project has no flags) | ✅ |
| 4 | `identify('alice')` / `reset()` / `optOut()` / `optIn()` — verified via distinctId tagging across captures | ✅ |
| 5 | `Flood 600`: rate cap held (max_idx=499, single warn line), 400 buffer evictions logged, records spanning full rate-cap window arrived | ✅ |
| 6 | Tap 3 → home button → records arrive before the 10s timer would fire (`flushWithTimeout(backgroundFlushBudgetMs)` drained inside the bg-task window); AppState log itself tags `app.state=background` correctly | ✅ |
| 7 | _Kill switch removed from this PR — skipped_ | n/a |
| 8 | Airplane mode → 5 captures → `length=5` on disk → network back → `Flush now` → all 5 land with original capture timestamps; network failure classified as `retry-later` (records retained) | ✅ |
| 9 | Empty/no body silently dropped; `beforeSend → null` logs and drops; `beforeSend → throw` logs error but record still arrives (chain continues with original input) | ✅ |
| 10 | 10 captures → `am force-stop` → relaunch → records replay (durability ✅). Reveals **at-least-once delivery**: kill timing between server ACK and `_persistQueueAdvance` disk-write produces duplicates on relaunch — same trade-off as events pipeline | ✅ with caveat |

</details>

Crash-safety: at-least-once delivery, matching events. Records durable across hard kills. Specific kill window (server ACK → disk-advance) can produce duplicates on next flush. Acceptable trade — tombstone-first / at-most-once would lose records on crash.

Earlier iOS sim dogfood (same project) verified the same paths plus 413 retry/ramp-up: temporary `_sendLogsBatch` wrapper forced `too-large` on first call → `Received 413 when sending logs batch of size 20, reducing batch size to 10` → two HTTP 200s with halved batch + linear ramp-up → 20 records delivered, no duplicates.
