### PR TITLE
fix: make react-native-svg require optional

### DIFF
--- a/.changeset/tidy-svg-require.md
+++ b/.changeset/tidy-svg-require.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Fix Metro resolution for optional react-native-svg survey icons.

--- a/packages/react-native/src/optional/OptionalReactNativeSvg.ts
+++ b/packages/react-native/src/optional/OptionalReactNativeSvg.ts
@@ -22,7 +22,8 @@ const hasNativeSvgSupport = (): boolean => {
 export let OptionalReactNativeSvg: typeof ReactNativeSvg | undefined = undefined
 
 try {
+  const ReactNativeSvg = require('react-native-svg')
   if (hasNativeSvgSupport()) {
-    OptionalReactNativeSvg = require('react-native-svg')
+    OptionalReactNativeSvg = ReactNativeSvg
   }
 } catch (e) {}


### PR DESCRIPTION
## Problem

Metro fails to bundle apps without `react-native-svg` because the optional survey icon loader still has a nested static `require('react-native-svg')` that Metro does not classify as optional.

## Changes

- Moves the `react-native-svg` require to the top level of the `try` block so Metro treats it as an optional dependency.
- Keeps native SVG availability checks before using the loaded module.
- Adds a changeset for `posthog-react-native`.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
