### PR TITLE
fix(ai): widen @opentelemetry/exporter-trace-otlp-http peer dep range

### DIFF
--- a/.changeset/widen-otel-exporter-peer-dep.md
+++ b/.changeset/widen-otel-exporter-peer-dep.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Widen the `@opentelemetry/exporter-trace-otlp-http` peer dependency range from `^0.200.0` (which only matched `0.200.x`) to `>=0.200.0 <1.0.0`, so newer 0.x releases brought in by other OpenTelemetry-aware packages no longer trigger ERESOLVE failures or require `--legacy-peer-deps`.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
+    "@opentelemetry/exporter-trace-otlp-http": ">=0.200.0 <1.0.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@ai-sdk/provider": "^2.0.0 || ^3.0.0",
     "@openai/agents": "^0.8.0",


### PR DESCRIPTION
## Problem

`@posthog/ai` declares its peer dependency on `@opentelemetry/exporter-trace-otlp-http` as `^0.200.0`. Under npm's caret rules for versions with a leading-zero major, that range only matches `0.200.x`. Since the exporter has shipped through `0.215.x`, any consumer that also pulls in another OpenTelemetry-aware package (e.g. `langsmith`, `@opentelemetry/auto-instrumentations-node`, `inngest`) hits an `ERESOLVE` and is forced onto `npm install --legacy-peer-deps`.

Closes #3472.

## Changes

- Widen the `@opentelemetry/exporter-trace-otlp-http` peer-dependency range in `packages/ai/package.json` from `^0.200.0` to `>=0.200.0 <1.0.0`.
- Add a patch changeset (`.changeset/widen-otel-exporter-peer-dep.md`).

The `OTLPTraceExporter` API surface used in `packages/ai/src/otel/exporter.ts` and `packages/ai/src/otel/processor.ts` is limited to the constructor (`{ url, headers }`) and `super.export(spans, callback)`, both of which have been stable across the 0.x line, so the wider range is safe.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code (n/a — peer-dep range change only)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file