### PR TITLE
feat(surveys): render translated survey copy

### DIFF
--- a/.changeset/survey-translations.md
+++ b/.changeset/survey-translations.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Add browser survey translation rendering and language tracking.

--- a/packages/browser/playwright/mocked/surveys/translations.spec.ts
+++ b/packages/browser/playwright/mocked/surveys/translations.spec.ts
@@ -1,0 +1,88 @@
+import { getSurveyResponseKey } from '@/extensions/surveys/surveys-extension-utils'
+import { pollUntilEventCaptured } from '../utils/event-capture-utils'
+import { expect, test } from '../utils/posthog-playwright-test-base'
+import { start } from '../utils/setup'
+
+const startOptions = {
+    options: {
+        override_display_language: 'es',
+    },
+    flagsResponseOverrides: {
+        surveys: true,
+    },
+    url: './playground/cypress/index.html',
+}
+
+test.describe('surveys - translations', () => {
+    test('renders translated copy and captures the applied language', async ({ page, context }) => {
+        const surveysAPICall = page.route('**/surveys/**', async (route) => {
+            await route.fulfill({
+                json: {
+                    surveys: [
+                        {
+                            id: 'translation-test',
+                            name: 'Product feedback',
+                            type: 'popover',
+                            start_date: '2021-01-01T00:00:00Z',
+                            questions: [
+                                {
+                                    type: 'single_choice',
+                                    question: 'How was your experience?',
+                                    choices: ['Good', 'Bad'],
+                                    id: 'experience',
+                                    translations: {
+                                        es: {
+                                            question: '¿Cómo fue tu experiencia?',
+                                            choices: ['Buena', 'Mala'],
+                                        },
+                                    },
+                                },
+                            ],
+                            appearance: {
+                                displayThankYouMessage: true,
+                                thankYouMessageHeader: 'Thank you!',
+                                thankYouMessageDescription: 'We appreciate your feedback.',
+                            },
+                            translations: {
+                                es: {
+                                    name: 'Comentarios del producto',
+                                    thankYouMessageHeader: '¡Gracias!',
+                                    thankYouMessageDescription: 'Agradecemos tus comentarios.',
+                                    thankYouMessageCloseButtonText: 'Cerrar',
+                                },
+                            },
+                        },
+                    ],
+                },
+            })
+        })
+
+        await start(startOptions, page, context)
+        await surveysAPICall
+
+        const survey = page.locator('.PostHogSurvey-translation-test')
+        await expect(survey.locator('.survey-form')).toBeVisible()
+        await expect(survey.locator('.survey-question')).toHaveText('¿Cómo fue tu experiencia?')
+        await expect(survey.locator('label:has-text("Buena")')).toBeVisible()
+
+        await survey.locator('label:has-text("Buena")').click()
+        await survey.locator('.form-submit').click()
+
+        await expect(survey.locator('.thank-you-message-header')).toHaveText('¡Gracias!')
+        await expect(survey.locator('.thank-you-message-body')).toHaveText('Agradecemos tus comentarios.')
+        await expect(survey.locator('.form-submit')).toHaveText('Cerrar')
+
+        await pollUntilEventCaptured(page, 'survey sent')
+        const captures = await page.capturedEvents()
+        const surveySent = captures.find((capture) => capture.event === 'survey sent')
+        expect(surveySent?.properties.$survey_language).toBe('es')
+        expect(surveySent?.properties[getSurveyResponseKey('experience')]).toBe('Buena')
+        expect(surveySent?.properties.$survey_questions).toEqual([
+            {
+                id: 'experience',
+                question: '¿Cómo fue tu experiencia?',
+                response: 'Buena',
+            },
+        ])
+    })
+})

--- a/packages/browser/src/__tests__/utils/survey-translations.test.ts
+++ b/packages/browser/src/__tests__/utils/survey-translations.test.ts
@@ -128,6 +128,22 @@ describe('Survey Translations', () => {
                 }
             }
         )
+
+        it('calls get_property with the PostHog instance as context', () => {
+            mockPostHog = {
+                config: {},
+                persistence: {
+                    props: {
+                        [STORED_PERSON_PROPERTIES_KEY]: { language: 'it' },
+                    },
+                },
+                get_property(propertyName: string) {
+                    return this.persistence.props[propertyName]
+                },
+            } as unknown as PostHog
+
+            expect(detectUserLanguage(mockPostHog)).toBe('it')
+        })
     })
 
     describe('applySurveyTranslationForUser', () => {

--- a/packages/browser/src/__tests__/utils/survey-translations.test.ts
+++ b/packages/browser/src/__tests__/utils/survey-translations.test.ts
@@ -1,0 +1,544 @@
+/// <reference lib="dom" />
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import { detectUserLanguage, applySurveyTranslationForUser } from '../../utils/survey-translations'
+import { Survey, SurveyType, SurveyQuestionType } from '../../posthog-surveys-types'
+import { PostHog } from '../../posthog-core'
+import { STORED_PERSON_PROPERTIES_KEY } from '../../constants'
+
+describe('Survey Translations', () => {
+    let mockPostHog: PostHog
+    const originalNavigator = global.navigator
+
+    beforeEach(() => {
+        mockPostHog = {
+            get_property: jest.fn(),
+            config: {},
+        } as unknown as PostHog
+
+        // Reset navigator mock
+        Object.defineProperty(global, 'navigator', {
+            value: { language: undefined },
+            writable: true,
+            configurable: true,
+        })
+    })
+
+    afterEach(() => {
+        // Restore original navigator
+        Object.defineProperty(global, 'navigator', {
+            value: originalNavigator,
+            writable: true,
+            configurable: true,
+        })
+    })
+
+    describe('detectUserLanguage', () => {
+        it.each([
+            {
+                name: 'prioritizes config.override_display_language over all other sources',
+                configLanguage: 'de',
+                browserLanguage: 'fr',
+                storedPersonProperties: { language: 'es' },
+                expectedLanguage: 'de',
+                expectsStoredPropertiesLookup: false,
+            },
+            {
+                name: 'uses person property language when config override is not set',
+                configLanguage: null,
+                browserLanguage: 'fr',
+                storedPersonProperties: { language: 'es' },
+                expectedLanguage: 'es',
+                expectsStoredPropertiesLookup: true,
+            },
+            {
+                name: 'falls back to browser language when config and person language are not available',
+                configLanguage: null,
+                browserLanguage: 'fr',
+                storedPersonProperties: { some_other_property: 'value' },
+                expectedLanguage: 'fr',
+                expectsStoredPropertiesLookup: true,
+            },
+            {
+                name: 'returns null when no language source is available',
+                configLanguage: null,
+                browserLanguage: undefined,
+                storedPersonProperties: { some_other_property: 'value' },
+                expectedLanguage: null,
+                expectsStoredPropertiesLookup: true,
+            },
+            {
+                name: 'trims whitespace from person property language value',
+                configLanguage: null,
+                browserLanguage: undefined,
+                storedPersonProperties: { language: '  es  ' },
+                expectedLanguage: 'es',
+                expectsStoredPropertiesLookup: true,
+            },
+            {
+                name: 'returns null for empty string person property language',
+                configLanguage: null,
+                browserLanguage: undefined,
+                storedPersonProperties: { language: '   ' },
+                expectedLanguage: null,
+                expectsStoredPropertiesLookup: true,
+            },
+            {
+                name: 'handles non-string person property language values',
+                configLanguage: null,
+                browserLanguage: undefined,
+                storedPersonProperties: { language: 123 },
+                expectedLanguage: null,
+                expectsStoredPropertiesLookup: true,
+            },
+            {
+                name: 'falls back to browser language when get_property is not available',
+                configLanguage: null,
+                browserLanguage: 'pt-BR',
+                storedPersonProperties: undefined,
+                expectedLanguage: 'pt-BR',
+                expectsStoredPropertiesLookup: false,
+                hasGetProperty: false,
+            },
+        ])(
+            '$name',
+            ({
+                configLanguage,
+                browserLanguage,
+                storedPersonProperties,
+                expectedLanguage,
+                expectsStoredPropertiesLookup,
+                hasGetProperty = true,
+            }) => {
+                mockPostHog.config.override_display_language = configLanguage
+                ;(global.navigator as any).language = browserLanguage
+
+                if (hasGetProperty) {
+                    ;(mockPostHog.get_property as jest.Mock).mockReturnValue(storedPersonProperties)
+                } else {
+                    delete (mockPostHog as Partial<PostHog>).get_property
+                }
+
+                expect(detectUserLanguage(mockPostHog)).toBe(expectedLanguage)
+
+                if (expectsStoredPropertiesLookup) {
+                    expect(mockPostHog.get_property).toHaveBeenCalledWith(STORED_PERSON_PROPERTIES_KEY)
+                } else if (hasGetProperty) {
+                    expect(mockPostHog.get_property).not.toHaveBeenCalled()
+                }
+            }
+        )
+    })
+
+    describe('applySurveyTranslationForUser', () => {
+        const createBaseSurvey = (): Survey => ({
+            id: 'test-survey',
+            name: 'Test Survey',
+            description: 'Test Description',
+            type: SurveyType.Popover,
+            questions: [
+                {
+                    type: SurveyQuestionType.Open,
+                    question: 'What do you think?',
+                    id: 'q1',
+                },
+            ],
+            appearance: {
+                thankYouMessageHeader: 'Thank you!',
+                thankYouMessageDescription: 'We appreciate your feedback',
+                thankYouMessageCloseButtonText: 'Close',
+            },
+            conditions: null,
+            start_date: '2024-01-01',
+            end_date: null,
+            current_iteration: null,
+            current_iteration_start_date: null,
+            feature_flag_keys: null,
+            linked_flag_key: null,
+            targeting_flag_key: null,
+            internal_targeting_flag_key: null,
+        })
+
+        it('should return original survey when no language is detected', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({})
+            const survey = createBaseSurvey()
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey).toEqual(survey)
+            expect(result.language).toBeNull()
+        })
+
+        it('should return original survey when no translations exist', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr' })
+            const survey = createBaseSurvey()
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey).toEqual(survey)
+            expect(result.language).toBeNull()
+        })
+
+        it('should apply exact match translation', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                fr: {
+                    name: 'Enquête Test',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Enquête Test')
+            expect(result.survey.description).toBe('Test Description')
+            expect(result.language).toBe('fr')
+        })
+
+        it('should apply case-insensitive match', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'FR' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                fr: {
+                    name: 'Enquête Test',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Enquête Test')
+            expect(result.language).toBe('fr')
+        })
+
+        it('should fallback to base language for language variants', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr-CA' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                fr: {
+                    name: 'Enquête Française',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Enquête Française')
+            expect(result.language).toBe('fr')
+        })
+
+        it('should prefer exact match over base language', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr-CA' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                fr: {
+                    name: 'Français Standard',
+                },
+                'fr-CA': {
+                    name: 'Français Canadien',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Français Canadien')
+            expect(result.language).toBe('fr-CA')
+        })
+
+        it.each([
+            {
+                name: 'question text',
+                language: 'es',
+                prepareSurvey: (survey: Survey) => {
+                    survey.questions[0].translations = {
+                        es: {
+                            question: '¿Qué piensas?',
+                        },
+                    }
+                },
+                assertTranslatedSurvey: (survey: Survey) => {
+                    expect(survey.questions[0].question).toBe('¿Qué piensas?')
+                },
+            },
+            {
+                name: 'question description',
+                language: 'es',
+                prepareSurvey: (survey: Survey) => {
+                    survey.questions[0].description = 'Please tell us'
+                    survey.questions[0].translations = {
+                        es: {
+                            description: 'Por favor díganos',
+                        },
+                    }
+                },
+                assertTranslatedSurvey: (survey: Survey) => {
+                    expect(survey.questions[0].description).toBe('Por favor díganos')
+                },
+            },
+            {
+                name: 'button text',
+                language: 'es',
+                prepareSurvey: (survey: Survey) => {
+                    survey.questions[0].buttonText = 'Submit'
+                    survey.questions[0].translations = {
+                        es: {
+                            buttonText: 'Enviar',
+                        },
+                    }
+                },
+                assertTranslatedSurvey: (survey: Survey) => {
+                    expect(survey.questions[0].buttonText).toBe('Enviar')
+                },
+            },
+            {
+                name: 'multiple choice options',
+                language: 'de',
+                prepareSurvey: (survey: Survey) => {
+                    survey.questions[0] = {
+                        type: SurveyQuestionType.MultipleChoice,
+                        question: 'Choose options',
+                        choices: ['Option 1', 'Option 2', 'Option 3'],
+                        id: 'q1',
+                        translations: {
+                            de: {
+                                question: 'Wählen Sie Optionen',
+                                choices: ['Option 1', 'Option 2', 'Option 3'],
+                            },
+                        },
+                    }
+                },
+                assertTranslatedSurvey: (survey: Survey) => {
+                    expect(survey.questions[0].question).toBe('Wählen Sie Optionen')
+                    expect((survey.questions[0] as any).choices).toEqual(['Option 1', 'Option 2', 'Option 3'])
+                },
+            },
+            {
+                name: 'rating labels',
+                language: 'ja',
+                prepareSurvey: (survey: Survey) => {
+                    survey.questions[0] = {
+                        type: SurveyQuestionType.Rating,
+                        question: 'Rate us',
+                        scale: 5,
+                        display: 'number',
+                        lowerBoundLabel: 'Poor',
+                        upperBoundLabel: 'Excellent',
+                        id: 'q1',
+                        translations: {
+                            ja: {
+                                question: '評価してください',
+                                lowerBoundLabel: '悪い',
+                                upperBoundLabel: '優秀',
+                            },
+                        },
+                    }
+                },
+                assertTranslatedSurvey: (survey: Survey) => {
+                    expect(survey.questions[0].question).toBe('評価してください')
+                    expect((survey.questions[0] as any).lowerBoundLabel).toBe('悪い')
+                    expect((survey.questions[0] as any).upperBoundLabel).toBe('優秀')
+                },
+            },
+            {
+                name: 'link URL',
+                language: 'es',
+                prepareSurvey: (survey: Survey) => {
+                    survey.questions[0] = {
+                        type: SurveyQuestionType.Link,
+                        question: 'Click here',
+                        link: 'https://example.com/en',
+                        id: 'q1',
+                        translations: {
+                            es: {
+                                question: 'Haga clic aquí',
+                                link: 'https://example.com/es',
+                            },
+                        },
+                    }
+                },
+                assertTranslatedSurvey: (survey: Survey) => {
+                    expect(survey.questions[0].question).toBe('Haga clic aquí')
+                    expect((survey.questions[0] as any).link).toBe('https://example.com/es')
+                },
+            },
+        ])('should translate $name', ({ language, prepareSurvey, assertTranslatedSurvey }) => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language })
+            const survey = createBaseSurvey()
+
+            prepareSurvey(survey)
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            assertTranslatedSurvey(result.survey)
+        })
+
+        it('should translate thank you message', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'pt' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                pt: {
+                    thankYouMessageHeader: 'Obrigado!',
+                    thankYouMessageDescription: 'Agradecemos seu feedback',
+                    thankYouMessageCloseButtonText: 'Fechar',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.appearance?.thankYouMessageHeader).toBe('Obrigado!')
+            expect(result.survey.appearance?.thankYouMessageDescription).toBe('Agradecemos seu feedback')
+            expect(result.survey.appearance?.thankYouMessageCloseButtonText).toBe('Fechar')
+        })
+
+        it('should handle partial translations gracefully', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                fr: {
+                    name: 'Enquête', // Only name translated
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Enquête')
+            expect(result.survey.description).toBe('Test Description') // Original
+        })
+
+        it('should ignore unsupported root translation fields', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                fr: {
+                    description: 'Description traduite',
+                },
+            } as unknown as Survey['translations']
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey).toEqual(survey)
+            expect(result.language).toBeNull()
+        })
+
+        it.each([
+            {
+                name: 'empty question translation',
+                translations: {
+                    es: {},
+                },
+            },
+            {
+                name: 'question translation fields that do not apply to the question type',
+                translations: {
+                    es: {
+                        link: 'https://example.com/es',
+                        lowerBoundLabel: 'Malo',
+                        upperBoundLabel: 'Excelente',
+                        choices: ['Uno', 'Dos'],
+                    },
+                },
+            },
+        ])('should ignore $name', ({ translations }) => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'es' })
+            const survey = createBaseSurvey()
+            survey.questions[0].translations = translations
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey).toEqual(survey)
+            expect(result.survey.questions[0]).toBe(survey.questions[0])
+            expect(result.language).toBeNull()
+        })
+
+        it('should translate multiple questions independently', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'es' })
+            const survey = createBaseSurvey()
+            survey.questions = [
+                {
+                    type: SurveyQuestionType.Open,
+                    question: 'Question 1',
+                    id: 'q1',
+                    translations: {
+                        es: {
+                            question: 'Pregunta 1',
+                        },
+                    },
+                },
+                {
+                    type: SurveyQuestionType.Open,
+                    question: 'Question 2',
+                    id: 'q2',
+                    translations: {
+                        es: {
+                            question: 'Pregunta 2',
+                        },
+                    },
+                },
+            ]
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.questions[0].question).toBe('Pregunta 1')
+            expect(result.survey.questions[1].question).toBe('Pregunta 2')
+        })
+
+        it('should not mutate the original survey object', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr' })
+            const survey = createBaseSurvey()
+            const originalName = survey.name
+            survey.translations = {
+                fr: {
+                    name: 'Nom Traduit',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Nom Traduit')
+            expect(survey.name).toBe(originalName) // Original unchanged
+        })
+
+        it('should handle surveys without appearance object', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr' })
+            const survey = createBaseSurvey()
+            survey.appearance = null
+            survey.translations = {
+                fr: {
+                    name: 'Enquête',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.name).toBe('Enquête')
+            expect(result.survey.appearance).toBeNull()
+        })
+
+        it('should track matched language for thank you translations without appearance', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'fr' })
+            const survey = createBaseSurvey()
+            survey.appearance = null
+            survey.translations = {
+                fr: {
+                    thankYouMessageHeader: 'Merci!',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.survey.appearance).toBeNull()
+            expect(result.language).toBe('fr')
+        })
+
+        it('should return original language code that matched', () => {
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({ language: 'zh-CN' })
+            const survey = createBaseSurvey()
+            survey.translations = {
+                'zh-CN': {
+                    name: '测试调查',
+                },
+            }
+
+            const result = applySurveyTranslationForUser(survey, mockPostHog)
+
+            expect(result.language).toBe('zh-CN')
+        })
+    })
+})

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -69,6 +69,7 @@ import {
     calculatePrefillStartIndex,
 } from '../utils/survey-url-prefill'
 import { getNextSurveyStep } from '../utils/survey-branching'
+import { applySurveyTranslationForUser } from '../utils/survey-translations'
 
 // Re-export for surveys-preview entrypoint
 export { getNextSurveyStep }
@@ -180,25 +181,27 @@ export class SurveyManager {
     }
 
     public handlePopoverSurvey = (surveyParam: Survey, options?: DisplaySurveyPopoverOptions): void => {
+        const { survey: translatedSurvey, language: surveyLanguage } = this._translateSurveyForRendering(surveyParam)
+
         // apply overrides for position / selector (needed for thumb surveys)
         const survey =
             options?.position || options?.selector
                 ? {
-                      ...surveyParam,
+                      ...translatedSurvey,
                       appearance: {
-                          ...surveyParam.appearance,
+                          ...translatedSurvey.appearance,
                           ...(options.position && { position: options.position }),
                           ...(options.selector && { widgetSelector: options.selector }),
                       },
                   }
-                : surveyParam
+                : translatedSurvey
 
         this._clearSurveyTimeout(survey.id)
 
         const { properties, initialResponses } = options ?? {}
         const hasPrefillData = initialResponses && Object.keys(initialResponses).length > 0
         const isSurveyCompleted = hasPrefillData
-            ? this._handleInitialResponses(survey, initialResponses, properties)
+            ? this._handleInitialResponses(survey, initialResponses, properties, surveyLanguage)
             : false
 
         // if the survey is done (from prefill) and there is no thank-you, we can break early
@@ -232,6 +235,7 @@ export class SurveyManager {
             style: positionStyle,
             isSurveyCompleted: isSurveyCompleted,
             skipShownEvent: options?.skipShownEvent,
+            surveyLanguage,
         }
 
         if (delaySeconds <= 0) {
@@ -263,15 +267,24 @@ export class SurveyManager {
     }
 
     private _handleWidget = (survey: Survey): void => {
+        const { survey: translatedSurvey, language: surveyLanguage } = this._translateSurveyForRendering(survey)
         // Ensure widget container exists if it doesn't
-        const { shadow, isNewlyCreated } = retrieveSurveyShadow(survey, this._posthog)
+        const { shadow, isNewlyCreated } = retrieveSurveyShadow(translatedSurvey, this._posthog)
 
         // If the widget is already rendered, do nothing. Otherwise the widget will be re-rendered every second
         if (!isNewlyCreated) {
             return
         }
 
-        render(<FeedbackWidget posthog={this._posthog} survey={survey} key={survey.id} />, shadow)
+        render(
+            <FeedbackWidget
+                posthog={this._posthog}
+                survey={translatedSurvey}
+                surveyLanguage={surveyLanguage}
+                key={survey.id}
+            />,
+            shadow
+        )
     }
 
     private _removeWidgetSelectorListener = (survey: Pick<Survey, 'id' | 'type' | 'appearance'>): void => {
@@ -368,33 +381,47 @@ export class SurveyManager {
     }
 
     public renderPopover = (survey: Survey): void => {
-        const { shadow } = retrieveSurveyShadow(survey, this._posthog)
+        const { survey: translatedSurvey, language: surveyLanguage } = this._translateSurveyForRendering(survey)
+        const { shadow } = retrieveSurveyShadow(translatedSurvey, this._posthog)
         render(
-            <SurveyPopup posthog={this._posthog} survey={survey} removeSurveyFromFocus={this._removeSurveyFromFocus} />,
+            <SurveyPopup
+                posthog={this._posthog}
+                survey={translatedSurvey}
+                removeSurveyFromFocus={this._removeSurveyFromFocus}
+                surveyLanguage={surveyLanguage}
+            />,
             shadow
         )
     }
 
     public renderSurvey = (survey: Survey, selector: Element, properties?: Properties): void => {
+        const { survey: translatedSurvey, language: surveyLanguage } = this._translateSurveyForRendering(survey)
         let isSurveyCompleted = false
         if (this._posthog.config?.surveys?.prefillFromUrl) {
-            isSurveyCompleted = this._handleUrlPrefill(survey)
+            isSurveyCompleted = this._handleUrlPrefill(translatedSurvey, surveyLanguage)
         }
 
         render(
             <SurveyPopup
                 posthog={this._posthog}
-                survey={survey}
+                survey={translatedSurvey}
                 removeSurveyFromFocus={this._removeSurveyFromFocus}
                 isPopup={false}
                 properties={properties}
                 isSurveyCompleted={isSurveyCompleted}
+                surveyLanguage={surveyLanguage}
             />,
             selector
         )
     }
 
-    private _handleUrlPrefill(survey: Survey): boolean {
+    private _translateSurveyForRendering(survey: Survey): { survey: Survey; language: string | null } {
+        // Rendering entry points accept the raw API survey. The translation helper is idempotent,
+        // but keeping this central avoids each entry point growing its own language rules.
+        return applySurveyTranslationForUser(survey, this._posthog)
+    }
+
+    private _handleUrlPrefill(survey: Survey, surveyLanguage?: string | null): boolean {
         // Only handle prefill once per survey session to avoid overwriting in-progress responses
         if (this._prefillHandledSurveys.has(survey.id)) {
             return false
@@ -408,7 +435,7 @@ export class SurveyManager {
 
         logger.info('[Survey Prefill] Detected URL prefill parameters')
 
-        const result = this._processPrefillData(survey, params)
+        const result = this._processPrefillData(survey, params, surveyLanguage)
         if (!result) {
             return false
         }
@@ -428,6 +455,7 @@ export class SurveyManager {
                 surveySubmissionId: submissionId,
                 posthog: this._posthog,
                 isSurveyCompleted,
+                surveyLanguage,
             })
         }
 
@@ -445,7 +473,8 @@ export class SurveyManager {
     private _handleInitialResponses(
         survey: Survey,
         initialResponses: Record<number, SurveyResponseValue>,
-        properties?: Properties
+        properties?: Properties,
+        surveyLanguage?: string | null
     ): boolean {
         const prefillParams: { [key: number]: string[] } = {}
         for (const [indexStr, value] of Object.entries(initialResponses)) {
@@ -455,7 +484,7 @@ export class SurveyManager {
 
         logger.info('[Survey] Processing initial responses')
 
-        const result = this._processPrefillData(survey, prefillParams)
+        const result = this._processPrefillData(survey, prefillParams, surveyLanguage)
         if (!result) {
             return false
         }
@@ -470,6 +499,7 @@ export class SurveyManager {
             posthog: this._posthog,
             isSurveyCompleted,
             properties,
+            surveyLanguage,
         })
 
         return isSurveyCompleted
@@ -477,7 +507,8 @@ export class SurveyManager {
 
     private _processPrefillData(
         survey: Survey,
-        prefillParams: Record<number, string[]>
+        prefillParams: Record<number, string[]>,
+        surveyLanguage?: string | null
     ): {
         responses: Record<string, any>
         submissionId: string
@@ -508,6 +539,7 @@ export class SurveyManager {
                 surveySubmissionId: submissionId,
                 responses: responses,
                 lastQuestionIndex: startQuestionIndex,
+                surveyLanguage,
             })
 
             logger.info('[Survey Prefill] Stored prefilled responses in localStorage')
@@ -940,7 +972,8 @@ export function usePopupVisibility(
     removeSurveyFromFocus: (survey: SurveyWithTypeAndAppearance) => void,
     isPopup: boolean,
     surveyContainerRef?: RefObject<HTMLDivElement>,
-    skipShownEvent?: boolean
+    skipShownEvent?: boolean,
+    surveyLanguage?: string | null
 ) {
     const [isPopupVisible, setIsPopupVisible] = useState(
         isPreviewMode || millisecondDelay === 0 || survey.type === SurveyType.ExternalSurvey
@@ -1015,6 +1048,7 @@ export function usePopupVisibility(
                     [SurveyEventProperties.SURVEY_ID]: survey.id,
                     [SurveyEventProperties.SURVEY_ITERATION]: survey.current_iteration,
                     [SurveyEventProperties.SURVEY_ITERATION_START_DATE]: survey.current_iteration_start_date,
+                    ...(surveyLanguage && { [SurveyEventProperties.SURVEY_LANGUAGE]: surveyLanguage }),
                     sessionRecordingUrl: posthog.get_session_replay_url?.(),
                 })
             }
@@ -1070,6 +1104,8 @@ interface SurveyPopupProps {
     isSurveyCompleted?: boolean
     /** When true, `survey shown` events will not be emitted automatically */
     skipShownEvent?: boolean
+    /** The language that was applied to the survey. */
+    surveyLanguage?: string | null
 }
 
 function getTabPositionStyles(position: SurveyTabPosition = SurveyTabPosition.Right): JSX.CSSProperties {
@@ -1106,6 +1142,7 @@ export function SurveyPopup({
     properties,
     isSurveyCompleted,
     skipShownEvent,
+    surveyLanguage,
 }: SurveyPopupProps) {
     const surveyContainerRef = useRef<HTMLDivElement>(null)
     const isPreviewMode = Number.isInteger(previewPageIndex)
@@ -1121,7 +1158,8 @@ export function SurveyPopup({
         removeSurveyFromFocus,
         isPopup,
         surveyContainerRef,
-        skipShownEvent
+        skipShownEvent,
+        surveyLanguage
     )
 
     /**
@@ -1135,20 +1173,36 @@ export function SurveyPopup({
 
     const surveyContextValue = useMemo(() => {
         const getInProgressSurvey = getInProgressSurveyState(survey)
+        const surveySubmissionId = getInProgressSurvey?.surveySubmissionId || uuidv7()
         return {
             isPreviewMode,
             previewPageIndex: previewPageIndex,
             onPopupSurveyDismissed: () => {
-                dismissedSurveyEvent(survey, posthog, isPreviewMode)
+                if (surveyLanguage) {
+                    dismissedSurveyEvent(survey, posthog, isPreviewMode, surveyLanguage)
+                } else {
+                    dismissedSurveyEvent(survey, posthog, isPreviewMode)
+                }
                 onPopupSurveyDismissed()
             },
             isPopup: isPopup || false,
-            surveySubmissionId: getInProgressSurvey?.surveySubmissionId || uuidv7(),
+            surveySubmissionId,
             onPreviewSubmit,
             posthog,
             properties,
+            surveyLanguage,
         }
-    }, [isPreviewMode, previewPageIndex, isPopup, posthog, survey, onPopupSurveyDismissed, onPreviewSubmit, properties])
+    }, [
+        isPreviewMode,
+        previewPageIndex,
+        isPopup,
+        posthog,
+        survey,
+        onPopupSurveyDismissed,
+        onPreviewSubmit,
+        properties,
+        surveyLanguage,
+    ])
 
     if (!isPopupVisible) {
         return null
@@ -1209,6 +1263,7 @@ export function Questions({
         surveySubmissionId,
         isPreviewMode,
         properties,
+        surveyLanguage,
     } = useContext(SurveyContext)
     const [currentQuestionIndex, setCurrentQuestionIndex] = useState(() => {
         const inProgressSurveyData = getInProgressSurveyState(survey)
@@ -1256,6 +1311,7 @@ export function Questions({
                 surveySubmissionId: surveySubmissionId,
                 responses: newResponses,
                 lastQuestionIndex: nextStep,
+                surveyLanguage,
             })
         }
 
@@ -1269,6 +1325,7 @@ export function Questions({
                 isSurveyCompleted,
                 posthog,
                 properties,
+                surveyLanguage,
             })
         }
     }
@@ -1317,11 +1374,13 @@ export function FeedbackWidget({
     forceDisableHtml,
     posthog,
     readOnly,
+    surveyLanguage,
 }: {
     survey: Survey
     forceDisableHtml?: boolean
     posthog?: PostHog
     readOnly?: boolean
+    surveyLanguage?: string | null
 }): JSX.Element | null {
     const [isFeedbackButtonVisible, setIsFeedbackButtonVisible] = useState(true)
     const [showSurvey, setShowSurvey] = useState(false)
@@ -1411,6 +1470,7 @@ export function FeedbackWidget({
                     style={styleOverrides}
                     onPopupSurveyDismissed={resetShowSurvey}
                     onCloseConfirmationMessage={resetShowSurvey}
+                    surveyLanguage={surveyLanguage}
                 />
             )}
         </Fragment>

--- a/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
+++ b/packages/browser/src/extensions/surveys/surveys-extension-utils.tsx
@@ -409,6 +409,8 @@ interface SendSurveyEventArgs {
     posthog?: PostHog
     /** Additional properties to include in the survey event */
     properties?: Properties
+    /** The language that was applied to the survey. */
+    surveyLanguage?: string | null
 }
 
 const getSurveyResponseValue = (responses: Record<string, string | number | string[] | null>, questionId?: string) => {
@@ -429,6 +431,7 @@ export const sendSurveyEvent = ({
     posthog,
     isSurveyCompleted,
     properties,
+    surveyLanguage,
 }: SendSurveyEventArgs) => {
     if (!posthog) {
         logger.error('[survey sent] event not captured, PostHog instance not found.')
@@ -447,6 +450,7 @@ export const sendSurveyEvent = ({
         })),
         [SurveyEventProperties.SURVEY_SUBMISSION_ID]: surveySubmissionId,
         [SurveyEventProperties.SURVEY_COMPLETED]: isSurveyCompleted,
+        ...(surveyLanguage && { [SurveyEventProperties.SURVEY_LANGUAGE]: surveyLanguage }),
         sessionRecordingUrl: posthog.get_session_replay_url?.(),
         ...responses,
         ...properties,
@@ -475,6 +479,9 @@ const _buildSurveyEventProperties = (
     [SurveyEventProperties.SURVEY_ITERATION]: survey.current_iteration,
     [SurveyEventProperties.SURVEY_ITERATION_START_DATE]: survey.current_iteration_start_date,
     [SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED]: _surveyHasResponses(inProgressSurvey),
+    ...(inProgressSurvey?.surveyLanguage && {
+        [SurveyEventProperties.SURVEY_LANGUAGE]: inProgressSurvey.surveyLanguage,
+    }),
     sessionRecordingUrl: posthog.get_session_replay_url?.(),
     ...inProgressSurvey?.responses,
     [SurveyEventProperties.SURVEY_SUBMISSION_ID]: inProgressSurvey?.surveySubmissionId,
@@ -485,7 +492,12 @@ const _buildSurveyEventProperties = (
     })),
 })
 
-export const dismissedSurveyEvent = (survey: Survey, posthog?: PostHog, readOnly?: boolean) => {
+export const dismissedSurveyEvent = (
+    survey: Survey,
+    posthog?: PostHog,
+    readOnly?: boolean,
+    surveyLanguage?: string | null
+) => {
     if (!posthog) {
         logger.error('[survey dismissed] event not captured, PostHog instance not found.')
         return
@@ -497,6 +509,7 @@ export const dismissedSurveyEvent = (survey: Survey, posthog?: PostHog, readOnly
     const inProgressSurvey = getInProgressSurveyState(survey)
     posthog.capture(SurveyEventName.DISMISSED, {
         ..._buildSurveyEventProperties(survey, inProgressSurvey, posthog),
+        ...(surveyLanguage && { [SurveyEventProperties.SURVEY_LANGUAGE]: surveyLanguage }),
         $set: {
             [getSurveyInteractionProperty(survey, 'dismissed')]: true,
         },
@@ -631,6 +644,8 @@ interface SurveyContextProps {
     surveySubmissionId: string
     /** Additional properties to include in all survey events */
     properties?: Properties
+    /** The language that was applied to the survey. */
+    surveyLanguage?: string | null
 }
 
 export const SurveyContext = createContext<SurveyContextProps>({
@@ -641,6 +656,7 @@ export const SurveyContext = createContext<SurveyContextProps>({
     onPreviewSubmit: () => {},
     surveySubmissionId: '',
     properties: undefined,
+    surveyLanguage: null,
 })
 
 export const useSurveyContext = () => {
@@ -700,6 +716,7 @@ interface InProgressSurveyState {
     surveySubmissionId: string
     lastQuestionIndex: number
     responses: Record<string, string | number | string[] | null>
+    surveyLanguage?: string | null
 }
 
 const getInProgressSurveyStateKey = (survey: Pick<Survey, 'id' | 'current_iteration'>): string => {

--- a/packages/browser/src/posthog-surveys-types.ts
+++ b/packages/browser/src/posthog-surveys-types.ts
@@ -58,6 +58,7 @@ interface SurveyQuestionBase {
     buttonText?: string
     branching?: NextQuestionBranching | EndBranching | ResponseBasedBranching | SpecificQuestionBranching
     validation?: SurveyValidationRule[]
+    translations?: Record<string, SurveyQuestionTranslation>
 }
 
 export interface BasicSurveyQuestion extends SurveyQuestionBase {
@@ -128,8 +129,9 @@ export interface Survey {
     // Sync this with the backend's SurveyAPISerializer!
     id: string
     name: string
-    description: string
+    description?: string
     type: SurveyType
+    translations?: Record<string, SurveyTranslation>
     feature_flag_keys:
         | {
               key: string
@@ -327,6 +329,23 @@ export const SurveySchedule = {
 } as const
 export type SurveySchedule = (typeof SurveySchedule)[keyof typeof SurveySchedule]
 
+export interface SurveyTranslation {
+    name?: string
+    thankYouMessageHeader?: string
+    thankYouMessageDescription?: string
+    thankYouMessageCloseButtonText?: string
+}
+
+export interface SurveyQuestionTranslation {
+    question?: string
+    description?: string | null
+    buttonText?: string
+    link?: string | null
+    lowerBoundLabel?: string
+    upperBoundLabel?: string
+    choices?: string[]
+}
+
 export const SurveyEventName = {
     SHOWN: 'survey shown',
     DISMISSED: 'survey dismissed',
@@ -347,6 +366,7 @@ export const SurveyEventProperties = {
     SURVEY_COMPLETED: '$survey_completed',
     PRODUCT_TOUR_ID: '$product_tour_id',
     SURVEY_LAST_SEEN_DATE: '$survey_last_seen_date',
+    SURVEY_LANGUAGE: '$survey_language',
 } as const
 export type SurveyEventProperties = (typeof SurveyEventProperties)[keyof typeof SurveyEventProperties]
 

--- a/packages/browser/src/utils/language-utils.ts
+++ b/packages/browser/src/utils/language-utils.ts
@@ -1,0 +1,58 @@
+import { createLogger } from './logger'
+
+const logger = createLogger('[LanguageUtils]')
+
+/**
+ * Normalizes a language code to lowercase for consistent matching
+ * @param languageCode - The language code to normalize (e.g., 'FR', 'en-US')
+ * @returns Normalized language code (e.g., 'fr', 'en-us')
+ */
+export function normalizeLanguageCode(languageCode: string): string {
+    return languageCode.toLowerCase()
+}
+
+/**
+ * Extracts the base language from a language variant
+ * @param languageCode - The full language code (e.g., 'en-US', 'fr-CA')
+ * @returns The base language code (e.g., 'en', 'fr')
+ */
+export function getBaseLanguage(languageCode: string): string {
+    return languageCode.split('-')[0]
+}
+
+/**
+ * Finds the best matching translation for a given language code
+ * Tries: exact match -> base language fallback -> null
+ * @param translations - Available translations object
+ * @param targetLanguage - The target language code
+ * @returns The best matching language key or null
+ */
+export function findBestTranslationMatch(
+    translations: Record<string, unknown> | undefined,
+    targetLanguage: string
+): string | null {
+    if (!translations || !targetLanguage) {
+        return null
+    }
+
+    const normalizedTarget = normalizeLanguageCode(targetLanguage)
+
+    // Try exact match first (case-insensitive)
+    const exactMatch = Object.keys(translations).find((key) => normalizeLanguageCode(key) === normalizedTarget)
+    if (exactMatch) {
+        logger.info(`Found exact translation match: ${exactMatch}`)
+        return exactMatch
+    }
+
+    // Try base language fallback (e.g., fr-CA -> fr)
+    if (normalizedTarget.includes('-')) {
+        const baseLanguage = getBaseLanguage(normalizedTarget)
+        const baseMatch = Object.keys(translations).find((key) => normalizeLanguageCode(key) === baseLanguage)
+        if (baseMatch) {
+            logger.info(`Found base language translation match: ${baseMatch} (from ${targetLanguage})`)
+            return baseMatch
+        }
+    }
+
+    return null
+}

--- a/packages/browser/src/utils/survey-translations.ts
+++ b/packages/browser/src/utils/survey-translations.ts
@@ -8,6 +8,19 @@ import { isArray, isFunction, isUndefined } from '@posthog/core'
 
 const logger = createLogger('[SurveyTranslations]')
 
+function getLanguageFromStoredPersonProperties(storedPersonProperties: unknown): string | null {
+    if (
+        !storedPersonProperties ||
+        typeof storedPersonProperties !== 'object' ||
+        !('language' in storedPersonProperties)
+    ) {
+        return null
+    }
+
+    const personLanguage = storedPersonProperties.language
+    return typeof personLanguage === 'string' && personLanguage.trim() ? personLanguage.trim() : null
+}
+
 /**
  * Detects the user's language using priority order:
  * 1. config.override_display_language (explicit override)
@@ -29,15 +42,12 @@ export function detectUserLanguage(instance: PostHog): string | null {
         return configLanguage
     }
 
-    const getProperty = (instance as Partial<PostHog>).get_property
-    const personProperties = isFunction(getProperty)
-        ? ((getProperty(STORED_PERSON_PROPERTIES_KEY) || {}) as Record<string, unknown>)
-        : {}
-    const personLanguage = personProperties.language
-
-    if (typeof personLanguage === 'string' && personLanguage.trim()) {
+    const personLanguage = getLanguageFromStoredPersonProperties(
+        isFunction(instance.get_property) ? instance.get_property(STORED_PERSON_PROPERTIES_KEY) : undefined
+    )
+    if (personLanguage) {
         logger.info(`Using person property language: ${personLanguage}`)
-        return personLanguage.trim()
+        return personLanguage
     }
 
     const browserLanguage = getBrowserLanguage()

--- a/packages/browser/src/utils/survey-translations.ts
+++ b/packages/browser/src/utils/survey-translations.ts
@@ -1,0 +1,223 @@
+import { PostHog } from '../posthog-core'
+import { Survey, SurveyQuestion, SurveyQuestionTranslation, SurveyTranslation } from '../posthog-surveys-types'
+import { STORED_PERSON_PROPERTIES_KEY } from '../constants'
+import { createLogger } from './logger'
+import { getBrowserLanguage } from './event-utils'
+import { findBestTranslationMatch } from './language-utils'
+import { isArray, isFunction, isUndefined } from '@posthog/core'
+
+const logger = createLogger('[SurveyTranslations]')
+
+/**
+ * Detects the user's language using priority order:
+ * 1. config.override_display_language (explicit override)
+ * 2. person properties 'language' (allows programmatic control via posthog.identify())
+ * 3. navigator.language (browser language)
+ *
+ * TODO: Consider adding dynamic language change detection in the future:
+ * - Listen to 'languagechange' event on window (https://developer.mozilla.org/en-US/docs/Web/API/Window/languagechange_event)
+ * - Listen to config changes (once we add config change events to PostHog core)
+ * - Re-render survey when language changes mid-session
+ *
+ * @param instance - PostHog instance to retrieve config and person properties
+ * @returns The detected language code (e.g., 'fr', 'es', 'en-US') or null if not found
+ */
+export function detectUserLanguage(instance: PostHog): string | null {
+    const configLanguage = instance.config.override_display_language
+    if (configLanguage) {
+        logger.info(`Using config.override_display_language: ${configLanguage}`)
+        return configLanguage
+    }
+
+    const getProperty = (instance as Partial<PostHog>).get_property
+    const personProperties = isFunction(getProperty)
+        ? ((getProperty(STORED_PERSON_PROPERTIES_KEY) || {}) as Record<string, unknown>)
+        : {}
+    const personLanguage = personProperties.language
+
+    if (typeof personLanguage === 'string' && personLanguage.trim()) {
+        logger.info(`Using person property language: ${personLanguage}`)
+        return personLanguage.trim()
+    }
+
+    const browserLanguage = getBrowserLanguage()
+    if (browserLanguage) {
+        logger.info(`Using browser language: ${browserLanguage}`)
+        return browserLanguage
+    }
+
+    logger.info('No user language detected')
+    return null
+}
+
+/**
+ * Merges translated question fields on top of default question fields
+ * @param question - The original question object
+ * @param targetLanguage - The target language code
+ * @returns An object with the translated question and the matched language key
+ */
+function mergeQuestionTranslation(
+    question: SurveyQuestion,
+    targetLanguage: string
+): { question: SurveyQuestion; matchedKey: string | null; hasChanges: boolean } {
+    const translationKey = findBestTranslationMatch(question.translations, targetLanguage)
+    if (!translationKey) {
+        return { question, matchedKey: null, hasChanges: false }
+    }
+
+    const questionTranslation = question.translations?.[translationKey]
+    if (!questionTranslation) {
+        return { question, matchedKey: null, hasChanges: false }
+    }
+
+    const translated: SurveyQuestion = { ...question }
+    let hasChanges = false
+
+    if (!isUndefined(questionTranslation.question)) {
+        translated.question = questionTranslation.question
+        hasChanges = true
+    }
+    if (!isUndefined(questionTranslation.description)) {
+        translated.description = questionTranslation.description
+        hasChanges = true
+    }
+    if (!isUndefined(questionTranslation.buttonText)) {
+        translated.buttonText = questionTranslation.buttonText
+        hasChanges = true
+    }
+
+    if ('link' in translated && !isUndefined(questionTranslation.link)) {
+        translated.link = questionTranslation.link
+        hasChanges = true
+    }
+
+    if ('lowerBoundLabel' in translated && !isUndefined(questionTranslation.lowerBoundLabel)) {
+        translated.lowerBoundLabel = questionTranslation.lowerBoundLabel
+        hasChanges = true
+    }
+    if ('upperBoundLabel' in translated && !isUndefined(questionTranslation.upperBoundLabel)) {
+        translated.upperBoundLabel = questionTranslation.upperBoundLabel
+        hasChanges = true
+    }
+
+    if ('choices' in translated && isTranslatedChoices(questionTranslation)) {
+        translated.choices = questionTranslation.choices
+        hasChanges = true
+    }
+
+    return {
+        question: hasChanges ? translated : question,
+        matchedKey: hasChanges ? translationKey : null,
+        hasChanges,
+    }
+}
+
+function isTranslatedChoices(
+    questionTranslation: SurveyQuestionTranslation
+): questionTranslation is SurveyQuestionTranslation & { choices: string[] } {
+    return isArray(questionTranslation.choices)
+}
+
+function hasThankYouTranslation(translation: SurveyTranslation): boolean {
+    return (
+        !isUndefined(translation.thankYouMessageHeader) ||
+        !isUndefined(translation.thankYouMessageDescription) ||
+        !isUndefined(translation.thankYouMessageCloseButtonText)
+    )
+}
+
+/**
+ * Applies translations to a survey based on the target language
+ * @param survey - The original survey object
+ * @param targetLanguage - The target language code
+ * @returns An object with the translated survey and the matched language key (or null if no match)
+ */
+export function applySurveyTranslation(
+    survey: Survey,
+    targetLanguage: string
+): { survey: Survey; matchedKey: string | null } {
+    const translationKey = findBestTranslationMatch(survey.translations, targetLanguage)
+
+    const translated = { ...survey }
+    let hasTranslation = false
+
+    if (translationKey) {
+        const translation = survey.translations?.[translationKey]
+        if (translation) {
+            logger.info(`Applying survey-level translation for language: ${translationKey}`)
+
+            if (!isUndefined(translation.name)) {
+                translated.name = translation.name
+                hasTranslation = true
+            }
+
+            if (translated.appearance) {
+                translated.appearance = { ...translated.appearance }
+
+                if (!isUndefined(translation.thankYouMessageHeader)) {
+                    translated.appearance.thankYouMessageHeader = translation.thankYouMessageHeader
+                    hasTranslation = true
+                }
+                if (!isUndefined(translation.thankYouMessageDescription)) {
+                    translated.appearance.thankYouMessageDescription = translation.thankYouMessageDescription
+                    hasTranslation = true
+                }
+                if (!isUndefined(translation.thankYouMessageCloseButtonText)) {
+                    translated.appearance.thankYouMessageCloseButtonText = translation.thankYouMessageCloseButtonText
+                    hasTranslation = true
+                }
+            } else if (hasThankYouTranslation(translation)) {
+                // Nothing renders without appearance, but the locale did match a valid runtime translation.
+                hasTranslation = true
+            }
+        }
+    }
+
+    // Always try to apply question-level translations (each question has its own translations field)
+    const translatedResults = survey.questions.map((question) => mergeQuestionTranslation(question, targetLanguage))
+    const translatedQuestions = translatedResults.map((r) => r.question)
+    const anyQuestionTranslated = translatedResults.some((r) => r.hasChanges)
+
+    // Track the first matched key from question translations if we don't have a survey-level match
+    let questionMatchedKey: string | null = null
+    if (!translationKey) {
+        const firstMatch = translatedResults.find((r) => r.matchedKey)
+        questionMatchedKey = firstMatch?.matchedKey || null
+    }
+
+    if (anyQuestionTranslated) {
+        translated.questions = translatedQuestions
+        hasTranslation = true
+        logger.info(`Applied question-level translations for language: ${targetLanguage}`)
+    }
+
+    return {
+        survey: translated,
+        matchedKey: hasTranslation ? translationKey || questionMatchedKey : null,
+    }
+}
+
+/**
+ * Applies translations to a survey based on the user's language from person properties
+ * @param survey - The original survey object
+ * @param instance - PostHog instance to retrieve person properties
+ * @returns An object containing the translated survey and the language used (or null if no translation applied)
+ */
+export function applySurveyTranslationForUser(
+    survey: Survey,
+    instance: PostHog
+): { survey: Survey; language: string | null } {
+    const userLanguage = detectUserLanguage(instance)
+
+    if (!userLanguage) {
+        logger.info('No user language detected')
+        return { survey, language: null }
+    }
+
+    const result = applySurveyTranslation(survey, userLanguage)
+
+    return {
+        survey: result.survey,
+        language: result.matchedKey,
+    }
+}

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -575,6 +575,7 @@
         "_timer",
         "_timestamp",
         "_totalBytes",
+        "_translateSurveyForRendering",
         "_transport",
         "_triggerGroupMatchers",
         "_triggerGroupSamplingResults",


### PR DESCRIPTION
## Problem

Surveys can now include runtime-safe translations from the app API, but the browser SDK still renders the default survey copy. Customers need survey questions, choices, and thank-you messages to render in the user's language without breaking existing no-translation surveys.

Depends on the app API contract from PostHog/posthog#56407.

SDK web part for https://github.com/PostHog/posthog/issues/42154.

Most credits to https://github.com/PostHog/posthog-js/pull/3004 which kickstarted this. Thank you @Basit-Balogun10

## Changes

- Add survey translation helpers with language matching, case-insensitive lookup, and base-language fallback.
- Detect survey language from `override_display_language`, stored person `language`, then browser locale.
- Apply translated question fields, choices, link/rating labels, and safe thank-you message fields before rendering.
- Track the applied language on survey events via `$survey_language`.
- Add unit coverage for translation behavior and a browser Playwright flow covering rendered copy plus event payloads.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file