### PR TITLE
feat(node): add request context tracing headers

### DIFF
--- a/.changeset/fuzzy-geese-trace.md
+++ b/.changeset/fuzzy-geese-trace.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': minor
+---
+
+Add Express and NestJS request context support for PostHog tracing headers.

--- a/packages/node/src/__tests__/extensions/express.spec.ts
+++ b/packages/node/src/__tests__/extensions/express.spec.ts
@@ -1,0 +1,214 @@
+import type { IncomingHttpHeaders } from 'node:http'
+import { PostHog } from '@/entrypoints/index.node'
+import { setupExpressErrorHandler, setupExpressRequestContext } from '@/extensions/express'
+
+jest.mock('../../version', () => ({ version: '1.2.3' }))
+
+const mockedFetch = jest.spyOn(globalThis, 'fetch').mockImplementation()
+
+const waitForFlushTimer = async (posthog: PostHog): Promise<void> => {
+  await posthog.shutdown()
+}
+
+const getLastBatchEvents = (): any[] | undefined => {
+  expect(mockedFetch).toHaveBeenCalledWith('http://example.com/batch/', expect.objectContaining({ method: 'POST' }))
+
+  const call = [...mockedFetch.mock.calls].reverse().find((x) => (x[0] as string).includes('/batch/'))
+  if (!call) {
+    return undefined
+  }
+  return JSON.parse((call[1] as any).body as any).batch
+}
+
+const createMockRequest = (overrides?: {
+  headers?: IncomingHttpHeaders
+  originalUrl?: string
+  url?: string
+  method?: string
+  path?: string
+  remoteAddress?: string
+}): any => ({
+  originalUrl: overrides?.originalUrl,
+  url: overrides?.url ?? '/test-path',
+  method: overrides?.method ?? 'GET',
+  path: overrides?.path ?? '/test-path',
+  headers: overrides?.headers ?? {},
+  socket: { remoteAddress: overrides?.remoteAddress ?? '127.0.0.1' },
+})
+
+const createMockResponse = (overrides?: { statusCode?: number }): any => ({
+  statusCode: overrides?.statusCode ?? 500,
+})
+
+const createRequestContextMiddleware = (posthog: PostHog): any => {
+  const app = { use: jest.fn() }
+  setupExpressRequestContext(posthog, app)
+  return app.use.mock.calls[0][0]
+}
+
+const createErrorHandlerMiddleware = (posthog: PostHog): any => {
+  const app = { use: jest.fn() }
+  setupExpressErrorHandler(posthog, app)
+  return app.use.mock.calls[0][0]
+}
+
+describe('Express extension', () => {
+  let posthog: PostHog
+
+  beforeEach(() => {
+    posthog = new PostHog('TEST_API_KEY', {
+      host: 'http://example.com',
+      fetchRetryCount: 0,
+      disableCompression: true,
+      flushAt: 1,
+      flushInterval: 0,
+    })
+
+    mockedFetch.mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve('ok'),
+      json: () => Promise.resolve({ status: 'ok' }),
+    } as any)
+  })
+
+  afterEach(async () => {
+    await posthog.shutdown()
+  })
+
+  describe('request context middleware', () => {
+    it('should register middleware with setupExpressRequestContext', () => {
+      const app = { use: jest.fn() }
+
+      setupExpressRequestContext(posthog, app)
+
+      expect(app.use).toHaveBeenCalledWith(expect.any(Function))
+    })
+
+    it('should set request context for normal captures', async () => {
+      const middleware = createRequestContextMiddleware(posthog)
+      const req = createMockRequest({
+        headers: {
+          'x-posthog-session-id': 'session-123',
+          'x-posthog-distinct-id': 'user-456',
+          'x-posthog-window-id': 'window-789',
+          'user-agent': 'TestAgent/1.0',
+          'x-forwarded-for': '10.0.0.1, 172.16.0.1',
+        },
+        originalUrl: '/api/test?query=1',
+        method: 'POST',
+        path: '/api/test',
+        remoteAddress: '192.168.1.1',
+      })
+      const res = createMockResponse()
+
+      middleware(req, res, () => {
+        posthog.capture({ event: 'handler_event' })
+      })
+      await waitForFlushTimer(posthog)
+
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents).toBeDefined()
+
+      const event = batchEvents!.find((e: any) => e.event === 'handler_event')
+      expect(event).toBeDefined()
+      expect(event.distinct_id).toBe('user-456')
+      expect(event.properties.$session_id).toBe('session-123')
+      expect(event.properties.$window_id).toBe('window-789')
+      expect(event.properties.$current_url).toBe('/api/test?query=1')
+      expect(event.properties.$request_method).toBe('POST')
+      expect(event.properties.$request_path).toBe('/api/test')
+      expect(event.properties.$user_agent).toBe('TestAgent/1.0')
+      expect(event.properties.$ip).toBe('10.0.0.1')
+    })
+
+    it('should sanitize tracing header values and preserve explicit capture properties', async () => {
+      const middleware = createRequestContextMiddleware(posthog)
+      const req = createMockRequest({
+        headers: {
+          'x-posthog-session-id': [' \u0000 session-123\t ', 'ignored'],
+          'x-posthog-distinct-id': ' user-456\u0001 ',
+          'x-posthog-window-id': ` ${'w'.repeat(1105)} `,
+        },
+      })
+      const res = createMockResponse()
+
+      middleware(req, res, () => {
+        posthog.capture({
+          event: 'handler_event',
+          properties: {
+            $session_id: 'explicit-session',
+            $window_id: 'explicit-window',
+          },
+        })
+      })
+      await waitForFlushTimer(posthog)
+
+      const batchEvents = getLastBatchEvents()
+      const event = batchEvents!.find((e: any) => e.event === 'handler_event')
+      expect(event.distinct_id).toBe('user-456')
+      expect(event.properties.$session_id).toBe('explicit-session')
+      expect(event.properties.$window_id).toBe('explicit-window')
+    })
+
+    it('should not swallow errors thrown by downstream middleware', () => {
+      const middleware = createRequestContextMiddleware(posthog)
+      const error = new Error('downstream error')
+
+      expect(() => {
+        middleware(createMockRequest(), createMockResponse(), () => {
+          throw error
+        })
+      }).toThrow(error)
+    })
+  })
+
+  describe('error handler', () => {
+    it('should keep setupExpressErrorHandler backwards compatible', () => {
+      const app = { use: jest.fn() }
+
+      setupExpressErrorHandler(posthog, app)
+
+      expect(app.use).toHaveBeenCalledWith(expect.any(Function))
+    })
+
+    it('should capture exceptions with sanitized session, distinct, and window headers', async () => {
+      const handler = createErrorHandlerMiddleware(posthog)
+      const error = new Error('Express error')
+      const req = createMockRequest({
+        headers: {
+          'x-posthog-session-id': ' session-123\u0000 ',
+          'x-posthog-distinct-id': ' user-456 ',
+          'x-posthog-window-id': ' window-789 ',
+          'user-agent': 'TestAgent/1.0',
+        },
+        url: '/api/error',
+        method: 'POST',
+        path: '/api/error',
+        remoteAddress: '192.168.1.1',
+      })
+      const res = createMockResponse({ statusCode: 503 })
+      const next = jest.fn()
+
+      handler(error, req, res, next)
+      await waitForFlushTimer(posthog)
+
+      expect(next).toHaveBeenCalledWith(error)
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents).toBeDefined()
+      expect(batchEvents!.length).toBe(1)
+
+      const event = batchEvents![0]
+      expect(event.event).toBe('$exception')
+      expect(event.distinct_id).toBe('user-456')
+      expect(event.properties.$session_id).toBe('session-123')
+      expect(event.properties.$window_id).toBe('window-789')
+      expect(event.properties.$current_url).toBe('/api/error')
+      expect(event.properties.$request_method).toBe('POST')
+      expect(event.properties.$request_path).toBe('/api/error')
+      expect(event.properties.$user_agent).toBe('TestAgent/1.0')
+      expect(event.properties.$response_status_code).toBe(503)
+      expect(event.properties.$ip).toBe('192.168.1.1')
+      expect(event.properties.$exception_list).toBeDefined()
+    })
+  })
+})

--- a/packages/node/src/__tests__/extensions/express.spec.ts
+++ b/packages/node/src/__tests__/extensions/express.spec.ts
@@ -90,7 +90,6 @@ describe('Express extension', () => {
         headers: {
           'x-posthog-session-id': 'session-123',
           'x-posthog-distinct-id': 'user-456',
-          'x-posthog-window-id': 'window-789',
           'user-agent': 'TestAgent/1.0',
           'x-forwarded-for': '10.0.0.1, 172.16.0.1',
         },
@@ -113,7 +112,6 @@ describe('Express extension', () => {
       expect(event).toBeDefined()
       expect(event.distinct_id).toBe('user-456')
       expect(event.properties.$session_id).toBe('session-123')
-      expect(event.properties.$window_id).toBe('window-789')
       expect(event.properties.$current_url).toBe('/api/test?query=1')
       expect(event.properties.$request_method).toBe('POST')
       expect(event.properties.$request_path).toBe('/api/test')
@@ -127,7 +125,6 @@ describe('Express extension', () => {
         headers: {
           'x-posthog-session-id': [' \u0000 session-123\t ', 'ignored'],
           'x-posthog-distinct-id': ' user-456\u0001 ',
-          'x-posthog-window-id': ` ${'w'.repeat(1105)} `,
         },
       })
       const res = createMockResponse()
@@ -137,7 +134,6 @@ describe('Express extension', () => {
           event: 'handler_event',
           properties: {
             $session_id: 'explicit-session',
-            $window_id: 'explicit-window',
           },
         })
       })
@@ -147,7 +143,6 @@ describe('Express extension', () => {
       const event = batchEvents!.find((e: any) => e.event === 'handler_event')
       expect(event.distinct_id).toBe('user-456')
       expect(event.properties.$session_id).toBe('explicit-session')
-      expect(event.properties.$window_id).toBe('explicit-window')
     })
 
     it('should not swallow errors thrown by downstream middleware', () => {
@@ -171,14 +166,13 @@ describe('Express extension', () => {
       expect(app.use).toHaveBeenCalledWith(expect.any(Function))
     })
 
-    it('should capture exceptions with sanitized session, distinct, and window headers', async () => {
+    it('should capture exceptions with sanitized session and distinct headers', async () => {
       const handler = createErrorHandlerMiddleware(posthog)
       const error = new Error('Express error')
       const req = createMockRequest({
         headers: {
           'x-posthog-session-id': ' session-123\u0000 ',
           'x-posthog-distinct-id': ' user-456 ',
-          'x-posthog-window-id': ' window-789 ',
           'user-agent': 'TestAgent/1.0',
         },
         url: '/api/error',
@@ -201,7 +195,6 @@ describe('Express extension', () => {
       expect(event.event).toBe('$exception')
       expect(event.distinct_id).toBe('user-456')
       expect(event.properties.$session_id).toBe('session-123')
-      expect(event.properties.$window_id).toBe('window-789')
       expect(event.properties.$current_url).toBe('/api/error')
       expect(event.properties.$request_method).toBe('POST')
       expect(event.properties.$request_path).toBe('/api/error')

--- a/packages/node/src/__tests__/extensions/nestjs.spec.ts
+++ b/packages/node/src/__tests__/extensions/nestjs.spec.ts
@@ -86,7 +86,6 @@ describe('PostHogInterceptor', () => {
         headers: {
           'x-posthog-session-id': 'session-123',
           'x-posthog-distinct-id': 'user-456',
-          'x-posthog-window-id': 'window-789',
           'user-agent': 'TestAgent/1.0',
         },
         url: '/api/test',
@@ -111,7 +110,6 @@ describe('PostHogInterceptor', () => {
       expect(capturedContext.properties.$current_url).toBe('/api/test')
       expect(capturedContext.properties.$request_method).toBe('POST')
       expect(capturedContext.properties.$request_path).toBe('/api/test')
-      expect(capturedContext.properties.$window_id).toBe('window-789')
       expect(capturedContext.properties.$user_agent).toBe('TestAgent/1.0')
       expect(capturedContext.properties.$ip).toBe('192.168.1.1')
     })
@@ -122,7 +120,6 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext({
         headers: {
           'x-posthog-session-id': [' \u0000 session-123\t ', 'ignored'],
-          'x-posthog-window-id': ' win\u0001dow-789 ',
           'x-posthog-distinct-id': longDistinctId,
           'user-agent': ['Test\u0000Agent/1.0'],
         },
@@ -140,7 +137,6 @@ describe('PostHogInterceptor', () => {
 
       expect(capturedContext.sessionId).toBe('session-123')
       expect(capturedContext.distinctId).toBe('u'.repeat(1000))
-      expect(capturedContext.properties.$window_id).toBe('window-789')
       expect(capturedContext.properties.$user_agent).toBe('Test\u0000Agent/1.0')
     })
 
@@ -149,7 +145,6 @@ describe('PostHogInterceptor', () => {
       const context = createMockContext({
         headers: {
           'x-posthog-session-id': ' \u0000\t ',
-          'x-posthog-window-id': ' \u0001 ',
           'x-posthog-distinct-id': [],
         },
       })
@@ -166,7 +161,6 @@ describe('PostHogInterceptor', () => {
 
       expect(capturedContext.sessionId).toBeUndefined()
       expect(capturedContext.distinctId).toBeUndefined()
-      expect(capturedContext.properties).not.toHaveProperty('$window_id')
     })
 
     it('should propagate context to capture calls in handler', async () => {
@@ -250,7 +244,6 @@ describe('PostHogInterceptor', () => {
         headers: {
           'x-posthog-session-id': 'session-123',
           'x-posthog-distinct-id': 'user-456',
-          'x-posthog-window-id': 'window-789',
           'user-agent': 'TestAgent/1.0',
         },
         url: '/api/test',
@@ -274,7 +267,6 @@ describe('PostHogInterceptor', () => {
       expect(event.properties.$current_url).toBe('/api/test')
       expect(event.properties.$request_method).toBe('POST')
       expect(event.properties.$request_path).toBe('/api/test')
-      expect(event.properties.$window_id).toBe('window-789')
       expect(event.properties.$user_agent).toBe('TestAgent/1.0')
       expect(event.properties.$response_status_code).toBe(500)
       expect(event.properties.$ip).toBe('192.168.1.1')

--- a/packages/node/src/__tests__/extensions/nestjs.spec.ts
+++ b/packages/node/src/__tests__/extensions/nestjs.spec.ts
@@ -1,3 +1,4 @@
+import type { IncomingHttpHeaders } from 'node:http'
 import { of, throwError, lastValueFrom } from 'rxjs'
 
 import { PostHog } from '@/entrypoints/index.node'
@@ -26,7 +27,7 @@ const getLastBatchEvents = (): any[] | undefined => {
 }
 
 const createMockContext = (overrides?: {
-  headers?: Record<string, string>
+  headers?: IncomingHttpHeaders
   url?: string
   method?: string
   path?: string
@@ -85,6 +86,7 @@ describe('PostHogInterceptor', () => {
         headers: {
           'x-posthog-session-id': 'session-123',
           'x-posthog-distinct-id': 'user-456',
+          'x-posthog-window-id': 'window-789',
           'user-agent': 'TestAgent/1.0',
         },
         url: '/api/test',
@@ -109,8 +111,62 @@ describe('PostHogInterceptor', () => {
       expect(capturedContext.properties.$current_url).toBe('/api/test')
       expect(capturedContext.properties.$request_method).toBe('POST')
       expect(capturedContext.properties.$request_path).toBe('/api/test')
+      expect(capturedContext.properties.$window_id).toBe('window-789')
       expect(capturedContext.properties.$user_agent).toBe('TestAgent/1.0')
       expect(capturedContext.properties.$ip).toBe('192.168.1.1')
+    })
+
+    it('should sanitize tracing headers and only include present values', async () => {
+      const interceptor = new PostHogInterceptor(posthog)
+      const longDistinctId = ` ${'u'.repeat(1105)} `
+      const context = createMockContext({
+        headers: {
+          'x-posthog-session-id': [' \u0000 session-123\t ', 'ignored'],
+          'x-posthog-window-id': ' win\u0001dow-789 ',
+          'x-posthog-distinct-id': longDistinctId,
+          'user-agent': ['Test\u0000Agent/1.0'],
+        },
+      })
+
+      let capturedContext: any
+      const handler = {
+        handle: () => {
+          capturedContext = posthog.getContext()
+          return of({ success: true })
+        },
+      }
+
+      await lastValueFrom(interceptor.intercept(context, handler))
+
+      expect(capturedContext.sessionId).toBe('session-123')
+      expect(capturedContext.distinctId).toBe('u'.repeat(1000))
+      expect(capturedContext.properties.$window_id).toBe('window-789')
+      expect(capturedContext.properties.$user_agent).toBe('Test\u0000Agent/1.0')
+    })
+
+    it('should omit invalid tracing header values', async () => {
+      const interceptor = new PostHogInterceptor(posthog)
+      const context = createMockContext({
+        headers: {
+          'x-posthog-session-id': ' \u0000\t ',
+          'x-posthog-window-id': ' \u0001 ',
+          'x-posthog-distinct-id': [],
+        },
+      })
+
+      let capturedContext: any
+      const handler = {
+        handle: () => {
+          capturedContext = posthog.getContext()
+          return of({ success: true })
+        },
+      }
+
+      await lastValueFrom(interceptor.intercept(context, handler))
+
+      expect(capturedContext.sessionId).toBeUndefined()
+      expect(capturedContext.distinctId).toBeUndefined()
+      expect(capturedContext.properties).not.toHaveProperty('$window_id')
     })
 
     it('should propagate context to capture calls in handler', async () => {
@@ -194,6 +250,7 @@ describe('PostHogInterceptor', () => {
         headers: {
           'x-posthog-session-id': 'session-123',
           'x-posthog-distinct-id': 'user-456',
+          'x-posthog-window-id': 'window-789',
           'user-agent': 'TestAgent/1.0',
         },
         url: '/api/test',
@@ -217,6 +274,7 @@ describe('PostHogInterceptor', () => {
       expect(event.properties.$current_url).toBe('/api/test')
       expect(event.properties.$request_method).toBe('POST')
       expect(event.properties.$request_path).toBe('/api/test')
+      expect(event.properties.$window_id).toBe('window-789')
       expect(event.properties.$user_agent).toBe('TestAgent/1.0')
       expect(event.properties.$response_status_code).toBe(500)
       expect(event.properties.$ip).toBe('192.168.1.1')

--- a/packages/node/src/__tests__/extensions/tracing-headers.spec.ts
+++ b/packages/node/src/__tests__/extensions/tracing-headers.spec.ts
@@ -19,28 +19,25 @@ describe('tracing headers', () => {
   describe('getPostHogTracingHeaderValues', () => {
     it.each([
       [
-        'extracts all lowercase tracing headers',
+        'extracts supported lowercase tracing headers',
         {
           'x-posthog-session-id': 'session-123',
-          'x-posthog-window-id': 'window-789',
           'x-posthog-distinct-id': 'user-456',
         },
-        { sessionId: 'session-123', windowId: 'window-789', distinctId: 'user-456' },
+        { sessionId: 'session-123', distinctId: 'user-456' },
       ],
       [
         'sanitizes extracted tracing headers',
         {
           'x-posthog-session-id': ' session\n-123 ',
-          'x-posthog-window-id': ' win\x00dow\x85-789 ',
           'x-posthog-distinct-id': ` ${'u'.repeat(1105)} `,
         },
-        { sessionId: 'session-123', windowId: 'window-789', distinctId: 'u'.repeat(1000) },
+        { sessionId: 'session-123', distinctId: 'u'.repeat(1000) },
       ],
       [
         'omits invalid tracing headers',
         {
           'x-posthog-session-id': ' \x00\t ',
-          'x-posthog-window-id': ' \x00\t ',
           'x-posthog-distinct-id': [],
         },
         {},

--- a/packages/node/src/__tests__/extensions/tracing-headers.spec.ts
+++ b/packages/node/src/__tests__/extensions/tracing-headers.spec.ts
@@ -1,0 +1,61 @@
+import { getPostHogTracingHeaderValues, sanitizeTracingHeaderValue } from '@/extensions/tracing-headers'
+
+describe('tracing headers', () => {
+  describe('sanitizeTracingHeaderValue', () => {
+    it.each([
+      ['plain string', 'session-123', 'session-123'],
+      ['trims surrounding whitespace', '  user-456  ', 'user-456'],
+      ['removes ASCII control chars', 'win\x00dow\n-\t789\x7f', 'window-789'],
+      ['returns undefined for empty string', '', undefined],
+      ['returns undefined when only whitespace/control chars remain', ' \n\t\x00 ', undefined],
+      ['uses the first valid array item', [' \x00 session-123\t ', 'ignored'], 'session-123'],
+      ['returns undefined when array has no valid string item', [' \x00\t '], undefined],
+      ['caps values at 1000 chars', ` ${'x'.repeat(1105)} `, 'x'.repeat(1000)],
+    ])('%s', (_name, value, expected) => {
+      expect(sanitizeTracingHeaderValue(value)).toBe(expected)
+    })
+  })
+
+  describe('getPostHogTracingHeaderValues', () => {
+    it.each([
+      [
+        'extracts all lowercase tracing headers',
+        {
+          'x-posthog-session-id': 'session-123',
+          'x-posthog-window-id': 'window-789',
+          'x-posthog-distinct-id': 'user-456',
+        },
+        { sessionId: 'session-123', windowId: 'window-789', distinctId: 'user-456' },
+      ],
+      [
+        'sanitizes extracted tracing headers',
+        {
+          'x-posthog-session-id': ' session\n-123 ',
+          'x-posthog-window-id': ' win\x00dow-789 ',
+          'x-posthog-distinct-id': ` ${'u'.repeat(1105)} `,
+        },
+        { sessionId: 'session-123', windowId: 'window-789', distinctId: 'u'.repeat(1000) },
+      ],
+      [
+        'omits invalid tracing headers',
+        {
+          'x-posthog-session-id': ' \x00\t ',
+          'x-posthog-window-id': ' \x00\t ',
+          'x-posthog-distinct-id': [],
+        },
+        {},
+      ],
+      [
+        'includes only present valid tracing headers',
+        {
+          'x-posthog-session-id': 'session-only',
+          'x-forwarded-for': '10.0.0.1',
+        },
+        { sessionId: 'session-only' },
+      ],
+      ['returns empty object for missing headers', undefined, {}],
+    ])('%s', (_name, headers, expected) => {
+      expect(getPostHogTracingHeaderValues(headers)).toEqual(expected)
+    })
+  })
+})

--- a/packages/node/src/__tests__/extensions/tracing-headers.spec.ts
+++ b/packages/node/src/__tests__/extensions/tracing-headers.spec.ts
@@ -5,7 +5,7 @@ describe('tracing headers', () => {
     it.each([
       ['plain string', 'session-123', 'session-123'],
       ['trims surrounding whitespace', '  user-456  ', 'user-456'],
-      ['removes ASCII control chars', 'win\x00dow\n-\t789\x7f', 'window-789'],
+      ['removes C0 and C1 control chars', 'win\x00dow\n-\t789\x7f\x80\x9f', 'window-789'],
       ['returns undefined for empty string', '', undefined],
       ['returns undefined when only whitespace/control chars remain', ' \n\t\x00 ', undefined],
       ['uses the first valid array item', [' \x00 session-123\t ', 'ignored'], 'session-123'],
@@ -31,7 +31,7 @@ describe('tracing headers', () => {
         'sanitizes extracted tracing headers',
         {
           'x-posthog-session-id': ' session\n-123 ',
-          'x-posthog-window-id': ' win\x00dow-789 ',
+          'x-posthog-window-id': ' win\x00dow\x85-789 ',
           'x-posthog-distinct-id': ` ${'u'.repeat(1105)} `,
         },
         { sessionId: 'session-123', windowId: 'window-789', distinctId: 'u'.repeat(1000) },

--- a/packages/node/src/extensions/express.ts
+++ b/packages/node/src/extensions/express.ts
@@ -1,7 +1,7 @@
 import ErrorTracking from './error-tracking'
 import { PostHogBackendClient } from '../client'
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
-import { getPostHogTracingHeaderValues } from './tracing-headers'
+import { addProperty, getFirstHeaderValue, getPostHogTracingHeaderValues } from './tracing-headers'
 import type { Request, Response } from 'express'
 import type { ContextData } from './context/types'
 
@@ -21,16 +21,6 @@ interface MiddlewareError extends Error {
   output?: {
     statusCode?: number | string
   }
-}
-
-function addProperty(properties: Record<string, any>, key: string, value: unknown): void {
-  if (value !== undefined && value !== null && value !== '') {
-    properties[key] = value
-  }
-}
-
-function getFirstHeaderValue(value: string | string[] | undefined): string | undefined {
-  return Array.isArray(value) ? value[0] : value
 }
 
 function getClientIp(req: Request): string | undefined {

--- a/packages/node/src/extensions/express.ts
+++ b/packages/node/src/extensions/express.ts
@@ -33,7 +33,7 @@ function getClientIp(req: Request): string | undefined {
 }
 
 function buildRequestContextData(req: Request): Partial<ContextData> {
-  const { sessionId, windowId, distinctId } = getPostHogTracingHeaderValues(req.headers)
+  const { sessionId, distinctId } = getPostHogTracingHeaderValues(req.headers)
   const properties: Record<string, any> = {}
 
   addProperty(properties, '$current_url', req.originalUrl || req.url)
@@ -41,7 +41,6 @@ function buildRequestContextData(req: Request): Partial<ContextData> {
   addProperty(properties, '$request_path', req.path)
   addProperty(properties, '$user_agent', getFirstHeaderValue(req.headers['user-agent']))
   addProperty(properties, '$ip', getClientIp(req))
-  addProperty(properties, '$window_id', windowId)
 
   return {
     ...(sessionId !== undefined ? { sessionId } : {}),

--- a/packages/node/src/extensions/express.ts
+++ b/packages/node/src/extensions/express.ts
@@ -1,7 +1,9 @@
 import ErrorTracking from './error-tracking'
 import { PostHogBackendClient } from '../client'
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
+import { getPostHogTracingHeaderValues } from './tracing-headers'
 import type { Request, Response } from 'express'
+import type { ContextData } from './context/types'
 
 type ExpressMiddleware = (req: Request, res: Response, next: () => void) => void
 
@@ -21,6 +23,58 @@ interface MiddlewareError extends Error {
   }
 }
 
+function addProperty(properties: Record<string, any>, key: string, value: unknown): void {
+  if (value !== undefined && value !== null && value !== '') {
+    properties[key] = value
+  }
+}
+
+function getFirstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function getClientIp(req: Request): string | undefined {
+  const forwarded = getFirstHeaderValue(req.headers['x-forwarded-for'])
+  if (forwarded) {
+    const ip = forwarded.split(',')[0].trim()
+    if (ip) return ip
+  }
+  return req.socket?.remoteAddress
+}
+
+function buildRequestContextData(req: Request): Partial<ContextData> {
+  const { sessionId, windowId, distinctId } = getPostHogTracingHeaderValues(req.headers)
+  const properties: Record<string, any> = {}
+
+  addProperty(properties, '$current_url', req.originalUrl || req.url)
+  addProperty(properties, '$request_method', req.method)
+  addProperty(properties, '$request_path', req.path)
+  addProperty(properties, '$user_agent', getFirstHeaderValue(req.headers['user-agent']))
+  addProperty(properties, '$ip', getClientIp(req))
+  addProperty(properties, '$window_id', windowId)
+
+  return {
+    ...(sessionId !== undefined ? { sessionId } : {}),
+    ...(distinctId !== undefined ? { distinctId } : {}),
+    properties,
+  }
+}
+
+export function setupExpressRequestContext(
+  _posthog: PostHogBackendClient,
+  app: {
+    use: (middleware: ExpressMiddleware) => unknown
+  }
+): void {
+  app.use(posthogRequestContext(_posthog))
+}
+
+function posthogRequestContext(posthog: PostHogBackendClient): ExpressMiddleware {
+  return (req, _res, next): void => {
+    posthog.withContext(buildRequestContextData(req), () => next())
+  }
+}
+
 export function setupExpressErrorHandler(
   _posthog: PostHogBackendClient,
   app: {
@@ -37,21 +91,17 @@ function posthogErrorHandler(posthog: PostHogBackendClient): ExpressErrorMiddlew
       return
     }
 
-    const sessionId: string | undefined = req.headers['x-posthog-session-id'] as string | undefined
-    const distinctId: string | undefined = req.headers['x-posthog-distinct-id'] as string | undefined
+    const contextData = buildRequestContextData(req)
     const syntheticException = new Error('Synthetic exception')
     const hint: CoreErrorTracking.EventHint = { mechanism: { type: 'middleware', handled: false }, syntheticException }
+    const additionalProperties: Record<string, any> = {
+      ...(contextData.sessionId !== undefined ? { $session_id: contextData.sessionId } : {}),
+      ...(contextData.properties || {}),
+      $response_status_code: res.statusCode,
+    }
 
     posthog.addPendingPromise(
-      ErrorTracking.buildEventMessage(error, hint, distinctId, {
-        $session_id: sessionId,
-        $current_url: req.url,
-        $request_method: req.method,
-        $request_path: req.path,
-        $user_agent: req.headers['user-agent'],
-        $response_status_code: res.statusCode,
-        $ip: req.headers['x-forwarded-for'] || req?.socket?.remoteAddress,
-      }).then((msg) => {
+      ErrorTracking.buildEventMessage(error, hint, contextData.distinctId, additionalProperties).then((msg) => {
         posthog.capture(msg)
       })
     )

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -3,7 +3,7 @@ import { Observable, throwError } from 'rxjs'
 import { catchError } from 'rxjs/operators'
 
 import ErrorTracking from './error-tracking'
-import { getPostHogTracingHeaderValues } from './tracing-headers'
+import { addProperty, getFirstHeaderValue, getPostHogTracingHeaderValues } from './tracing-headers'
 import { PostHogBackendClient } from '../client'
 
 // Local interfaces to avoid runtime dependency on @nestjs/common
@@ -34,10 +34,6 @@ export interface PostHogInterceptorOptions {
   captureExceptions?: boolean | ExceptionCaptureOptions
 }
 
-function getFirstHeaderValue(value: string | string[] | undefined): string | undefined {
-  return Array.isArray(value) ? value[0] : value
-}
-
 function getClientIp(headers: IncomingHttpHeaders, request: any): string | undefined {
   const forwarded = getFirstHeaderValue(headers['x-forwarded-for'])
   if (forwarded) {
@@ -45,12 +41,6 @@ function getClientIp(headers: IncomingHttpHeaders, request: any): string | undef
     if (ip) return ip
   }
   return request?.socket?.remoteAddress
-}
-
-function addProperty(properties: Record<string, any>, key: string, value: unknown): void {
-  if (value !== undefined && value !== null && value !== '') {
-    properties[key] = value
-  }
 }
 
 function getExceptionStatus(exception: unknown): number | undefined {

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -1,7 +1,9 @@
+import type { IncomingHttpHeaders } from 'node:http'
 import { Observable, throwError } from 'rxjs'
 import { catchError } from 'rxjs/operators'
 
 import ErrorTracking from './error-tracking'
+import { getPostHogTracingHeaderValues } from './tracing-headers'
 import { PostHogBackendClient } from '../client'
 
 // Local interfaces to avoid runtime dependency on @nestjs/common
@@ -32,13 +34,23 @@ export interface PostHogInterceptorOptions {
   captureExceptions?: boolean | ExceptionCaptureOptions
 }
 
-function getClientIp(headers: Record<string, any>, request: any): string | undefined {
-  const forwarded = headers['x-forwarded-for']
+function getFirstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function getClientIp(headers: IncomingHttpHeaders, request: any): string | undefined {
+  const forwarded = getFirstHeaderValue(headers['x-forwarded-for'])
   if (forwarded) {
-    const ip = String(forwarded).split(',')[0].trim()
+    const ip = forwarded.split(',')[0].trim()
     if (ip) return ip
   }
   return request?.socket?.remoteAddress
+}
+
+function addProperty(properties: Record<string, any>, key: string, value: unknown): void {
+  if (value !== undefined && value !== null && value !== '') {
+    properties[key] = value
+  }
 }
 
 function getExceptionStatus(exception: unknown): number | undefined {
@@ -71,22 +83,21 @@ export class PostHogInterceptor implements NestInterceptor {
     const request = httpHost.getRequest()
     const response = httpHost.getResponse()
 
-    const headers = request?.headers ?? {}
-    const sessionId: string | undefined = headers['x-posthog-session-id']
-    const windowId: string | undefined = headers['x-posthog-window-id']
-    const distinctId: string | undefined = headers['x-posthog-distinct-id']
+    const headers = (request?.headers ?? {}) as IncomingHttpHeaders
+    const { sessionId, windowId, distinctId } = getPostHogTracingHeaderValues(headers)
+
+    const properties: Record<string, any> = {}
+    addProperty(properties, '$current_url', request?.url)
+    addProperty(properties, '$request_method', request?.method)
+    addProperty(properties, '$request_path', request?.path ?? request?.url)
+    addProperty(properties, '$window_id', windowId)
+    addProperty(properties, '$user_agent', getFirstHeaderValue(headers['user-agent']))
+    addProperty(properties, '$ip', getClientIp(headers, request))
 
     const contextData = {
-      sessionId,
-      distinctId,
-      properties: {
-        $current_url: request?.url,
-        $request_method: request?.method,
-        $request_path: request?.path ?? request?.url,
-        $window_id: windowId,
-        $user_agent: headers['user-agent'],
-        $ip: getClientIp(headers, request),
-      },
+      ...(sessionId !== undefined ? { sessionId } : {}),
+      ...(distinctId !== undefined ? { distinctId } : {}),
+      properties,
     }
 
     // Use enterContext so the context propagates through RxJS Observable

--- a/packages/node/src/extensions/nestjs.ts
+++ b/packages/node/src/extensions/nestjs.ts
@@ -74,13 +74,12 @@ export class PostHogInterceptor implements NestInterceptor {
     const response = httpHost.getResponse()
 
     const headers = (request?.headers ?? {}) as IncomingHttpHeaders
-    const { sessionId, windowId, distinctId } = getPostHogTracingHeaderValues(headers)
+    const { sessionId, distinctId } = getPostHogTracingHeaderValues(headers)
 
     const properties: Record<string, any> = {}
     addProperty(properties, '$current_url', request?.url)
     addProperty(properties, '$request_method', request?.method)
     addProperty(properties, '$request_path', request?.path ?? request?.url)
-    addProperty(properties, '$window_id', windowId)
     addProperty(properties, '$user_agent', getFirstHeaderValue(headers['user-agent']))
     addProperty(properties, '$ip', getClientIp(headers, request))
 

--- a/packages/node/src/extensions/tracing-headers.ts
+++ b/packages/node/src/extensions/tracing-headers.ts
@@ -9,13 +9,11 @@ type HeaderValue = IncomingHttpHeaders[string]
 
 export const POSTHOG_TRACING_HEADERS = {
   sessionId: 'x-posthog-session-id',
-  windowId: 'x-posthog-window-id',
   distinctId: 'x-posthog-distinct-id',
 } as const
 
 export interface PostHogTracingHeaderValues {
   sessionId?: string
-  windowId?: string
   distinctId?: string
 }
 
@@ -58,12 +56,10 @@ export function getPostHogTracingHeaderValues(headers?: IncomingHttpHeaders): Po
   }
 
   const sessionId = sanitizeTracingHeaderValue(headers[POSTHOG_TRACING_HEADERS.sessionId])
-  const windowId = sanitizeTracingHeaderValue(headers[POSTHOG_TRACING_HEADERS.windowId])
   const distinctId = sanitizeTracingHeaderValue(headers[POSTHOG_TRACING_HEADERS.distinctId])
 
   return {
     ...(sessionId !== undefined ? { sessionId } : {}),
-    ...(windowId !== undefined ? { windowId } : {}),
     ...(distinctId !== undefined ? { distinctId } : {}),
   }
 }

--- a/packages/node/src/extensions/tracing-headers.ts
+++ b/packages/node/src/extensions/tracing-headers.ts
@@ -1,8 +1,9 @@
 import type { IncomingHttpHeaders } from 'node:http'
 
 const TRACING_HEADER_MAX_LENGTH = 1000
+// Remove C0 controls, DEL, and C1 controls from PostHog tracing IDs only.
 // eslint-disable-next-line no-control-regex
-const TRACING_HEADER_CONTROL_CHARS_REGEX = /[\x00-\x1f\x7f]/g
+const TRACING_HEADER_CONTROL_CHARS_REGEX = /[\x00-\x1f\x7f-\x9f]/g
 
 type HeaderValue = IncomingHttpHeaders[string]
 

--- a/packages/node/src/extensions/tracing-headers.ts
+++ b/packages/node/src/extensions/tracing-headers.ts
@@ -1,0 +1,58 @@
+import type { IncomingHttpHeaders } from 'node:http'
+
+const TRACING_HEADER_MAX_LENGTH = 1000
+// eslint-disable-next-line no-control-regex
+const TRACING_HEADER_CONTROL_CHARS_REGEX = /[\x00-\x1f\x7f]/g
+
+type HeaderValue = IncomingHttpHeaders[string]
+
+export const POSTHOG_TRACING_HEADERS = {
+  sessionId: 'x-posthog-session-id',
+  windowId: 'x-posthog-window-id',
+  distinctId: 'x-posthog-distinct-id',
+} as const
+
+export interface PostHogTracingHeaderValues {
+  sessionId?: string
+  windowId?: string
+  distinctId?: string
+}
+
+export function sanitizeTracingHeaderValue(value: HeaderValue): string | undefined {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const sanitized = sanitizeTracingHeaderValue(item)
+      if (sanitized !== undefined) {
+        return sanitized
+      }
+    }
+    return undefined
+  }
+
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const sanitized = value.replace(TRACING_HEADER_CONTROL_CHARS_REGEX, '').trim()
+  if (!sanitized) {
+    return undefined
+  }
+
+  return sanitized.length > TRACING_HEADER_MAX_LENGTH ? sanitized.slice(0, TRACING_HEADER_MAX_LENGTH) : sanitized
+}
+
+export function getPostHogTracingHeaderValues(headers?: IncomingHttpHeaders): PostHogTracingHeaderValues {
+  if (!headers) {
+    return {}
+  }
+
+  const sessionId = sanitizeTracingHeaderValue(headers[POSTHOG_TRACING_HEADERS.sessionId])
+  const windowId = sanitizeTracingHeaderValue(headers[POSTHOG_TRACING_HEADERS.windowId])
+  const distinctId = sanitizeTracingHeaderValue(headers[POSTHOG_TRACING_HEADERS.distinctId])
+
+  return {
+    ...(sessionId !== undefined ? { sessionId } : {}),
+    ...(windowId !== undefined ? { windowId } : {}),
+    ...(distinctId !== undefined ? { distinctId } : {}),
+  }
+}

--- a/packages/node/src/extensions/tracing-headers.ts
+++ b/packages/node/src/extensions/tracing-headers.ts
@@ -18,6 +18,16 @@ export interface PostHogTracingHeaderValues {
   distinctId?: string
 }
 
+export function addProperty(properties: Record<string, any>, key: string, value: unknown): void {
+  if (value !== undefined && value !== null && value !== '') {
+    properties[key] = value
+  }
+}
+
+export function getFirstHeaderValue(value: HeaderValue): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
 export function sanitizeTracingHeaderValue(value: HeaderValue): string | undefined {
   if (Array.isArray(value)) {
     for (const item of value) {


### PR DESCRIPTION
## Problem

Node apps using Express or NestJS should be able to preserve PostHog frontend tracing context on server-side captures and exception events by reading supported PostHog tracing headers from incoming requests.

## Changes

- Added shared tracing header extraction for `x-posthog-session-id` and `x-posthog-distinct-id`.
- Added Express request context middleware via `setupExpressRequestContext()` / `posthogRequestContext()`.
- Updated Express error handling to use sanitized tracing headers.
- Updated the NestJS interceptor to sanitize PostHog tracing headers for request context and exception capture.
- Added unit coverage for tracing header sanitization, Express middleware/error handling, and NestJS propagation.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
