### PR TITLE
ci: avoid shell injection from github.base_ref in changeset check

### DIFF
--- a/.github/workflows/check-posthog-major-version.yml
+++ b/.github/workflows/check-posthog-major-version.yml
@@ -24,9 +24,11 @@ jobs:
         
       - name: Check for major version bumps
         id: check-major
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           # Get only added changeset files in this PR
-          changesets=$(git diff --name-only --diff-filter=A origin/${{ github.base_ref }}...HEAD | grep '^\.changeset/.*\.md$' | grep -v 'README.md' || true)
+          changesets=$(git diff --name-only --diff-filter=A "origin/${BASE_REF}...HEAD" | grep '^\.changeset/.*\.md$' | grep -v 'README.md' || true)
 
           if [ -z "$changesets" ]; then
             echo "No new changesets found in this PR"


### PR DESCRIPTION
## Summary

- Resolves the `yaml.github-actions.security.run-shell-injection` Semgrep finding that's been failing on every PR (e.g. #3489, #3490, #3492).
- `${{ github.base_ref }}` was interpolated directly into a shell command in `.github/workflows/check-posthog-major-version.yml`. Routes it through `env:` and double-quotes the expansion — the standard mitigation pattern.
- `github.base_ref` is generally trusted (validated branch name), so this isn't an exploitable injection in practice. But the env-var pattern silences the rule repo-wide.

## Test plan

- [x] Semgrep check passes on this PR.
- [x] Workflow continues to detect new changesets correctly (verified by the existing branch-targeting logic — `BASE_REF` substitutes for `github.base_ref` 1:1).