### PR TITLE
fix(react-native): honor appearance.position in SurveyModal

### DIFF
--- a/.changeset/survey-modal-position.md
+++ b/.changeset/survey-modal-position.md
@@ -2,4 +2,4 @@
 'posthog-react-native': patch
 ---
 
-Fix `SurveyModal` ignoring `appearance.position`. The modal previously hard-coded a bottom-center layout regardless of the configured position. It now honors all 9 `SurveyPosition` values, mirroring the web SDK semantics: `top_*` anchors to the top edge, `middle_*` to the vertical middle, and `left` / `center` / `right` (no prefix) to the bottom edge. The deafult remains bottom `center`.
+Fix `SurveyModal` ignoring `appearance.position`. The modal previously hard-coded a bottom-center layout regardless of the configured position. It now honors all 9 `SurveyPosition` values, mirroring the web SDK semantics: `top_*` anchors to the top edge, `middle_*` to the vertical middle, and `left` / `center` / `right` (no prefix) to the bottom edge. The default remains bottom `center`.

--- a/.changeset/survey-modal-position.md
+++ b/.changeset/survey-modal-position.md
@@ -2,6 +2,4 @@
 'posthog-react-native': patch
 ---
 
-Fix `SurveyModal` ignoring `appearance.position`. The modal previously hard-coded a bottom-center layout regardless of the configured position. It now honors all 9 `SurveyPosition` values, mirroring the web SDK semantics: `top_*` anchors to the top edge, `middle_*` to the vertical middle, and `left` / `center` / `right` (no prefix) to the bottom edge.
-
-Note: the documented default `SurveyPosition.Right` now actually applies. Surveys without an explicit position will move from bottom-center (the previous accidental default) to bottom-right (the documented default). Set `appearance.position` to `SurveyPosition.Center` to restore the old layout.
+Fix `SurveyModal` ignoring `appearance.position`. The modal previously hard-coded a bottom-center layout regardless of the configured position. It now honors all 9 `SurveyPosition` values, mirroring the web SDK semantics: `top_*` anchors to the top edge, `middle_*` to the vertical middle, and `left` / `center` / `right` (no prefix) to the bottom edge. The deafult remains bottom `center`.

--- a/.changeset/survey-modal-position.md
+++ b/.changeset/survey-modal-position.md
@@ -1,0 +1,7 @@
+---
+'posthog-react-native': patch
+---
+
+Fix `SurveyModal` ignoring `appearance.position`. The modal previously hard-coded a bottom-center layout regardless of the configured position. It now honors all 9 `SurveyPosition` values, mirroring the web SDK semantics: `top_*` anchors to the top edge, `middle_*` to the vertical middle, and `left` / `center` / `right` (no prefix) to the bottom edge.
+
+Note: the documented default `SurveyPosition.Right` now actually applies. Surveys without an explicit position will move from bottom-center (the previous accidental default) to bottom-right (the documented default). Set `appearance.position` to `SurveyPosition.Center` to restore the old layout.

--- a/examples/example-expo-53/app/(tabs)/index.tsx
+++ b/examples/example-expo-53/app/(tabs)/index.tsx
@@ -60,7 +60,6 @@ const DEMO_APPEARANCE: any = {
     submitButtonText: 'Submit',
     autoDisappear: false,
     surveyPopupDelaySeconds: 0,
-    position: 'right',
 }
 
 export default function HomeScreen() {

--- a/examples/example-expo-53/app/(tabs)/index.tsx
+++ b/examples/example-expo-53/app/(tabs)/index.tsx
@@ -7,115 +7,183 @@ import { ThemedText } from '@/components/ThemedText'
 import { ThemedView } from '@/components/ThemedView'
 import { posthog } from '../posthog'
 import { useState } from 'react'
+import { SurveyModal } from 'posthog-react-native'
+
+// Demo survey for local dogfooding. Real apps get Survey objects from
+// PostHogSurveyProvider, so consumers don't usually construct these by hand.
+const DEMO_SURVEY: any = {
+    id: 'demo-survey',
+    name: 'Demo survey',
+    type: 'popover',
+    questions: [
+        {
+            type: 'rating',
+            question: 'How would you rate this example app?',
+            id: 'q1',
+            display: 'number',
+            scale: 5,
+            lowerBoundLabel: 'Bad',
+            upperBoundLabel: 'Great',
+            originalQuestionIndex: 0,
+        },
+        {
+            type: 'single_choice',
+            question: 'What would make it better?',
+            id: 'q2',
+            choices: ['More examples', 'Better docs', 'Nothing, it’s great'],
+            originalQuestionIndex: 1,
+        },
+        {
+            type: 'open',
+            question: 'Anything else?',
+            id: 'q3',
+            optional: true,
+            originalQuestionIndex: 2,
+        },
+    ],
+}
+
+const DEMO_APPEARANCE: any = {
+    backgroundColor: '#eeeded',
+    submitButtonColor: 'black',
+    submitButtonTextColor: 'white',
+    ratingButtonColor: 'white',
+    ratingButtonActiveColor: 'black',
+    inputBackground: 'white',
+    borderColor: '#c9c6c6',
+    placeholder: 'Start typing...',
+    displayThankYouMessage: true,
+    thankYouMessageHeader: 'Thank you!',
+    thankYouMessageDescription: 'Your feedback helps us improve.',
+    thankYouMessageDescriptionContentType: 'text',
+    thankYouMessageCloseButtonText: 'Close',
+    submitButtonText: 'Submit',
+    autoDisappear: false,
+    surveyPopupDelaySeconds: 0,
+    position: 'right',
+}
 
 export default function HomeScreen() {
-  const [buttonText, setButtonText] = useState(
-    `Tap the Explore tab to learn more about what's included in this starter app.`
-  )
-  const [replayStatus, setReplayStatus] = useState('Unknown')
+    const [buttonText, setButtonText] = useState(
+        `Tap the Explore tab to learn more about what's included in this starter app.`
+    )
+    const [replayStatus, setReplayStatus] = useState('Unknown')
+    const [showSurvey, setShowSurvey] = useState(false)
 
-  const handleClick = () => {
-    posthog.capture('button_clicked', { name: 'example' })
-    setButtonText('button_clicked' + new Date().toISOString())
-  }
-
-  const handleStartRecording = async (resumeCurrent: boolean) => {
-    try {
-      await posthog.startSessionRecording(resumeCurrent)
-      setReplayStatus(`Started (resume=${resumeCurrent})`)
-    } catch (e) {
-      setReplayStatus(`Error: ${e}`)
+    const handleClick = () => {
+        posthog.capture('button_clicked', { name: 'example' })
+        setButtonText('button_clicked' + new Date().toISOString())
     }
-  }
 
-  const handleStopRecording = async () => {
-    try {
-      await posthog.stopSessionRecording()
-      setReplayStatus('Stopped')
-    } catch (e) {
-      setReplayStatus(`Error: ${e}`)
+    const handleStartRecording = async (resumeCurrent: boolean) => {
+        try {
+            await posthog.startSessionRecording(resumeCurrent)
+            setReplayStatus(`Started (resume=${resumeCurrent})`)
+        } catch (e) {
+            setReplayStatus(`Error: ${e}`)
+        }
     }
-  }
 
-  const handleCheckStatus = async () => {
-    try {
-      const isActive = await posthog.isSessionReplayActive()
-      setReplayStatus(`Active: ${isActive}`)
-    } catch (e) {
-      setReplayStatus(`Error: ${e}`)
+    const handleStopRecording = async () => {
+        try {
+            await posthog.stopSessionRecording()
+            setReplayStatus('Stopped')
+        } catch (e) {
+            setReplayStatus(`Error: ${e}`)
+        }
     }
-  }
 
-  return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
-      headerImage={<Image source={require('@/assets/images/partial-react-logo.png')} style={styles.reactLogo} />}
-    >
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
-        <HelloWave />
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes. Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-        <ThemedText onPress={handleClick}>{buttonText}</ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Session Replay Controls</ThemedText>
-        <ThemedText>Status: {replayStatus}</ThemedText>
-        <View style={styles.buttonContainer}>
-          <Button title="Start (Resume)" onPress={() => handleStartRecording(true)} />
-          <Button title="Start (New)" onPress={() => handleStartRecording(false)} />
-          <Button title="Stop" onPress={handleStopRecording} />
-          <Button title="Check Status" onPress={handleCheckStatus} />
-        </View>
-      </ThemedView>
-    </ParallaxScrollView>
-  )
+    const handleCheckStatus = async () => {
+        try {
+            const isActive = await posthog.isSessionReplayActive()
+            setReplayStatus(`Active: ${isActive}`)
+        } catch (e) {
+            setReplayStatus(`Error: ${e}`)
+        }
+    }
+
+    return (
+        <ParallaxScrollView
+            headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
+            headerImage={<Image source={require('@/assets/images/partial-react-logo.png')} style={styles.reactLogo} />}
+        >
+            <ThemedView style={styles.titleContainer}>
+                <ThemedText type="title">Welcome!</ThemedText>
+                <HelloWave />
+            </ThemedView>
+            <ThemedView style={styles.stepContainer}>
+                <ThemedText type="subtitle">Step 1: Try it</ThemedText>
+                <ThemedText>
+                    Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes. Press{' '}
+                    <ThemedText type="defaultSemiBold">
+                        {Platform.select({
+                            ios: 'cmd + d',
+                            android: 'cmd + m',
+                            web: 'F12',
+                        })}
+                    </ThemedText>{' '}
+                    to open developer tools.
+                </ThemedText>
+            </ThemedView>
+            <ThemedView style={styles.stepContainer}>
+                <ThemedText type="subtitle">Step 2: Explore</ThemedText>
+                <ThemedText onPress={handleClick}>{buttonText}</ThemedText>
+            </ThemedView>
+            <ThemedView style={styles.stepContainer}>
+                <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
+                <ThemedText>
+                    {`When you're ready, run `}
+                    <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
+                    <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
+                    <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
+                    <ThemedText type="defaultSemiBold">app-example</ThemedText>.
+                </ThemedText>
+            </ThemedView>
+            <ThemedView style={styles.stepContainer}>
+                <ThemedText type="subtitle">Surveys</ThemedText>
+                <Button title="Show survey" onPress={() => setShowSurvey(true)} />
+            </ThemedView>
+            {showSurvey && (
+                <SurveyModal
+                    survey={DEMO_SURVEY}
+                    appearance={DEMO_APPEARANCE}
+                    onShow={() => {}}
+                    onClose={() => setShowSurvey(false)}
+                />
+            )}
+            <ThemedView style={styles.stepContainer}>
+                <ThemedText type="subtitle">Session Replay Controls</ThemedText>
+                <ThemedText>Status: {replayStatus}</ThemedText>
+                <View style={styles.buttonContainer}>
+                    <Button title="Start (Resume)" onPress={() => handleStartRecording(true)} />
+                    <Button title="Start (New)" onPress={() => handleStartRecording(false)} />
+                    <Button title="Stop" onPress={handleStopRecording} />
+                    <Button title="Check Status" onPress={handleCheckStatus} />
+                </View>
+            </ThemedView>
+        </ParallaxScrollView>
+    )
 }
 
 const styles = StyleSheet.create({
-  titleContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  stepContainer: {
-    gap: 8,
-    marginBottom: 8,
-  },
-  buttonContainer: {
-    gap: 8,
-    marginTop: 8,
-  },
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-  },
+    titleContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+    },
+    stepContainer: {
+        gap: 8,
+        marginBottom: 8,
+    },
+    buttonContainer: {
+        gap: 8,
+        marginTop: 8,
+    },
+    reactLogo: {
+        height: 178,
+        width: 290,
+        bottom: 0,
+        left: 0,
+        position: 'absolute',
+    },
 })

--- a/examples/example-expo-53/app/(tabs)/index.tsx
+++ b/examples/example-expo-53/app/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import { Image } from 'expo-image'
 import { Platform, StyleSheet, Button, View } from 'react-native'
+import { Link } from 'expo-router'
 
 import { HelloWave } from '@/components/HelloWave'
 import ParallaxScrollView from '@/components/ParallaxScrollView'
@@ -7,67 +8,12 @@ import { ThemedText } from '@/components/ThemedText'
 import { ThemedView } from '@/components/ThemedView'
 import { posthog } from '../posthog'
 import { useState } from 'react'
-import { SurveyModal } from 'posthog-react-native'
-
-// Demo survey for local dogfooding. Real apps get Survey objects from
-// PostHogSurveyProvider, so consumers don't usually construct these by hand.
-const DEMO_SURVEY: any = {
-    id: 'demo-survey',
-    name: 'Demo survey',
-    type: 'popover',
-    questions: [
-        {
-            type: 'rating',
-            question: 'How would you rate this example app?',
-            id: 'q1',
-            display: 'number',
-            scale: 5,
-            lowerBoundLabel: 'Bad',
-            upperBoundLabel: 'Great',
-            originalQuestionIndex: 0,
-        },
-        {
-            type: 'single_choice',
-            question: 'What would make it better?',
-            id: 'q2',
-            choices: ['More examples', 'Better docs', 'Nothing, it’s great'],
-            originalQuestionIndex: 1,
-        },
-        {
-            type: 'open',
-            question: 'Anything else?',
-            id: 'q3',
-            optional: true,
-            originalQuestionIndex: 2,
-        },
-    ],
-}
-
-const DEMO_APPEARANCE: any = {
-    backgroundColor: '#eeeded',
-    submitButtonColor: 'black',
-    submitButtonTextColor: 'white',
-    ratingButtonColor: 'white',
-    ratingButtonActiveColor: 'black',
-    inputBackground: 'white',
-    borderColor: '#c9c6c6',
-    placeholder: 'Start typing...',
-    displayThankYouMessage: true,
-    thankYouMessageHeader: 'Thank you!',
-    thankYouMessageDescription: 'Your feedback helps us improve.',
-    thankYouMessageDescriptionContentType: 'text',
-    thankYouMessageCloseButtonText: 'Close',
-    submitButtonText: 'Submit',
-    autoDisappear: false,
-    surveyPopupDelaySeconds: 0,
-}
 
 export default function HomeScreen() {
     const [buttonText, setButtonText] = useState(
         `Tap the Explore tab to learn more about what's included in this starter app.`
     )
     const [replayStatus, setReplayStatus] = useState('Unknown')
-    const [showSurvey, setShowSurvey] = useState(false)
 
     const handleClick = () => {
         posthog.capture('button_clicked', { name: 'example' })
@@ -140,16 +86,10 @@ export default function HomeScreen() {
             </ThemedView>
             <ThemedView style={styles.stepContainer}>
                 <ThemedText type="subtitle">Surveys</ThemedText>
-                <Button title="Show survey" onPress={() => setShowSurvey(true)} />
+                <Link href="/surveys" asChild>
+                    <Button title="Open survey demo" />
+                </Link>
             </ThemedView>
-            {showSurvey && (
-                <SurveyModal
-                    survey={DEMO_SURVEY}
-                    appearance={DEMO_APPEARANCE}
-                    onShow={() => {}}
-                    onClose={() => setShowSurvey(false)}
-                />
-            )}
             <ThemedView style={styles.stepContainer}>
                 <ThemedText type="subtitle">Session Replay Controls</ThemedText>
                 <ThemedText>Status: {replayStatus}</ThemedText>

--- a/examples/example-expo-53/app/_layout.tsx
+++ b/examples/example-expo-53/app/_layout.tsx
@@ -12,7 +12,7 @@ import { posthog } from './posthog'
 export default function RootLayout() {
     const colorScheme = useColorScheme()
     const [loaded] = useFonts({
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
+         
         SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
     })
 

--- a/examples/example-expo-53/app/_layout.tsx
+++ b/examples/example-expo-53/app/_layout.tsx
@@ -35,6 +35,7 @@ export default function RootLayout() {
                 <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
                     <Stack>
                         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+                        <Stack.Screen name="surveys" options={{ title: 'Surveys' }} />
                         <Stack.Screen name="+not-found" />
                     </Stack>
                     <StatusBar style="auto" />

--- a/examples/example-expo-53/app/surveys.tsx
+++ b/examples/example-expo-53/app/surveys.tsx
@@ -1,0 +1,150 @@
+import { Stack } from 'expo-router'
+import { Button, ScrollView, StyleSheet, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useState } from 'react'
+import { SurveyModal } from 'posthog-react-native'
+
+import { ThemedText } from '@/components/ThemedText'
+import { ThemedView } from '@/components/ThemedView'
+
+const POSITIONS: { label: string; value: string | undefined }[] = [
+    { label: '(default)', value: undefined },
+    { label: 'top_left', value: 'top_left' },
+    { label: 'top_center', value: 'top_center' },
+    { label: 'top_right', value: 'top_right' },
+    { label: 'middle_left', value: 'middle_left' },
+    { label: 'middle_center', value: 'middle_center' },
+    { label: 'middle_right', value: 'middle_right' },
+    { label: 'left', value: 'left' },
+    { label: 'center', value: 'center' },
+    { label: 'right', value: 'right' },
+]
+
+// Demo survey for local dogfooding. Real apps get Survey objects from
+// PostHogSurveyProvider, so consumers don't usually construct these by hand.
+const DEMO_SURVEY: any = {
+    id: 'demo-survey',
+    name: 'Demo survey',
+    type: 'popover',
+    questions: [
+        {
+            type: 'open',
+            question:
+                'We genuinely want to hear what you think — the longer and more honest, the better. ' +
+                'What worked well, what got in the way, what surprised you, what would you change first if it were up to you? ' +
+                'Anything you can share helps us prioritize. Take your time, no character limit.',
+            description:
+                'This question is intentionally verbose so the survey body is tall enough to push the text input down into the keyboard zone on smaller devices.',
+            id: 'q1',
+            optional: true,
+            originalQuestionIndex: 0,
+        },
+        {
+            type: 'rating',
+            question: 'How would you rate this example app?',
+            id: 'q2',
+            display: 'number',
+            scale: 5,
+            lowerBoundLabel: 'Bad',
+            upperBoundLabel: 'Great',
+            originalQuestionIndex: 1,
+        },
+        {
+            type: 'single_choice',
+            question: 'What would make it better?',
+            id: 'q3',
+            choices: ['More examples', 'Better docs', 'Nothing, it’s great'],
+            originalQuestionIndex: 2,
+        },
+    ],
+}
+
+const DEMO_APPEARANCE: any = {
+    backgroundColor: '#eeeded',
+    submitButtonColor: 'black',
+    submitButtonTextColor: 'white',
+    ratingButtonColor: 'white',
+    ratingButtonActiveColor: 'black',
+    inputBackground: 'white',
+    borderColor: '#c9c6c6',
+    placeholder: 'Start typing...',
+    displayThankYouMessage: true,
+    thankYouMessageHeader: 'Thank you!',
+    thankYouMessageDescription: 'Your feedback helps us improve.',
+    thankYouMessageDescriptionContentType: 'text',
+    thankYouMessageCloseButtonText: 'Close',
+    submitButtonText: 'Submit',
+    autoDisappear: false,
+    surveyPopupDelaySeconds: 0,
+}
+
+export default function SurveysScreen() {
+    const [showSurvey, setShowSurvey] = useState(false)
+    const [positionIdx, setPositionIdx] = useState(0)
+    const currentPosition = POSITIONS[positionIdx]
+    const surveyAppearance = {
+        ...DEMO_APPEARANCE,
+        ...(currentPosition.value ? { position: currentPosition.value } : {}),
+    }
+
+    return (
+        <SafeAreaView style={styles.safeArea} edges={['top', 'bottom']}>
+            <Stack.Screen options={{ title: 'Surveys' }} />
+            <ScrollView contentContainerStyle={styles.container}>
+                <ThemedView style={styles.section}>
+                    <ThemedText type="title">Surveys</ThemedText>
+                    <ThemedText>
+                        Cycle through every <ThemedText type="defaultSemiBold">SurveyPosition</ThemedText> value and
+                        verify the modal lands in the expected quadrant. Use the open-text question to test keyboard
+                        interaction.
+                    </ThemedText>
+                </ThemedView>
+
+                <ThemedView style={styles.section}>
+                    <ThemedText type="subtitle">Position</ThemedText>
+                    <ThemedText>
+                        Active: <ThemedText type="defaultSemiBold">{currentPosition.label}</ThemedText>
+                    </ThemedText>
+                    <View style={styles.row}>
+                        <Button
+                            title="◀ prev"
+                            onPress={() => setPositionIdx((i) => (i - 1 + POSITIONS.length) % POSITIONS.length)}
+                        />
+                        <Button title="next ▶" onPress={() => setPositionIdx((i) => (i + 1) % POSITIONS.length)} />
+                    </View>
+                </ThemedView>
+
+                <ThemedView style={styles.section}>
+                    <Button title="Show survey" onPress={() => setShowSurvey(true)} />
+                </ThemedView>
+            </ScrollView>
+
+            {showSurvey && (
+                <SurveyModal
+                    survey={DEMO_SURVEY}
+                    appearance={surveyAppearance}
+                    onShow={() => {}}
+                    onClose={() => setShowSurvey(false)}
+                />
+            )}
+        </SafeAreaView>
+    )
+}
+
+const styles = StyleSheet.create({
+    safeArea: {
+        flex: 1,
+    },
+    container: {
+        padding: 16,
+        gap: 16,
+    },
+    section: {
+        gap: 8,
+    },
+    row: {
+        flexDirection: 'row',
+        gap: 8,
+        marginTop: 8,
+    },
+})

--- a/examples/example-expo-53/components/ui/IconSymbol.tsx
+++ b/examples/example-expo-53/components/ui/IconSymbol.tsx
@@ -20,6 +20,7 @@ const MAPPING = {
   'chevron.right': 'chevron-right',
   'exclamationmark.warninglight': 'warning',
   'link': 'link',
+  'list.bullet.rectangle': 'assignment',
 } as IconMapping
 
 /**

--- a/packages/react-native/src/surveys/components/QuestionTypes.tsx
+++ b/packages/react-native/src/surveys/components/QuestionTypes.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from 'react'
-import { Pressable, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native'
+import React, { ReactNode, useMemo, useState } from 'react'
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native'
 
 import {
   CheckSVG,
@@ -37,6 +37,34 @@ interface QuestionCommonProps {
   appearance: SurveyAppearanceTheme
 }
 
+// Wraps question content in a scrollable region with a sticky BottomSection
+// (Submit button) at the bottom. The ScrollView has flexShrink: 1 so it
+// shrinks to fit when the parent modal is capped at its keyboard-aware
+// maxHeight, keeping Submit visible regardless of survey length.
+function QuestionLayout({ children, footer }: { children: ReactNode; footer: ReactNode }): JSX.Element {
+  return (
+    <View style={questionLayoutStyles.container}>
+      <ScrollView
+        style={questionLayoutStyles.scroll}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        {children}
+      </ScrollView>
+      {footer}
+    </View>
+  )
+}
+
+const questionLayoutStyles = StyleSheet.create({
+  container: {
+    flexShrink: 1,
+  },
+  scroll: {
+    flexShrink: 1,
+  },
+})
+
 export function OpenTextQuestion({
   question,
   appearance,
@@ -65,7 +93,16 @@ export function OpenTextQuestion({
   }
 
   return (
-    <View>
+    <QuestionLayout
+      footer={
+        <BottomSection
+          text={question.buttonText ?? appearance.submitButtonText}
+          submitDisabled={!!validationError}
+          appearance={appearance}
+          onSubmit={handleSubmit}
+        />
+      }
+    >
       <QuestionHeader
         question={question.question}
         description={question.description}
@@ -106,13 +143,7 @@ export function OpenTextQuestion({
           </Text>
         )}
       </View>
-      <BottomSection
-        text={question.buttonText ?? appearance.submitButtonText}
-        submitDisabled={!!validationError}
-        appearance={appearance}
-        onSubmit={handleSubmit}
-      />
-    </View>
+    </QuestionLayout>
   )
 }
 
@@ -126,21 +157,24 @@ export function LinkQuestion({
   question = question as LinkSurveyQuestion
 
   return (
-    <>
+    <QuestionLayout
+      footer={
+        <BottomSection
+          text={question.buttonText ?? appearance.submitButtonText ?? 'Submit'}
+          submitDisabled={false}
+          link={question.link}
+          appearance={appearance}
+          onSubmit={() => onSubmit('link clicked')}
+        />
+      }
+    >
       <QuestionHeader
         question={question.question}
         description={question.description}
         descriptionContentType={question.descriptionContentType}
         appearance={appearance}
       />
-      <BottomSection
-        text={question.buttonText ?? appearance.submitButtonText ?? 'Submit'}
-        submitDisabled={false}
-        link={question.link}
-        appearance={appearance}
-        onSubmit={() => onSubmit('link clicked')}
-      />
-    </>
+    </QuestionLayout>
   )
 }
 
@@ -156,7 +190,17 @@ export function RatingQuestion({
   question = question as RatingSurveyQuestion
 
   return (
-    <>
+    <QuestionLayout
+      footer={
+        <BottomSection
+          text={question.buttonText ?? appearance.submitButtonText}
+          submitDisabled={rating === null && !question.optional}
+          appearance={appearance}
+          onSubmit={() => onSubmit(rating)}
+          skipSubmitButton={question.skipSubmitButton}
+        />
+      }
+    >
       <QuestionHeader
         question={question.question}
         description={question.description}
@@ -229,14 +273,7 @@ export function RatingQuestion({
           </Text>
         </View>
       </View>
-      <BottomSection
-        text={question.buttonText ?? appearance.submitButtonText}
-        submitDisabled={rating === null && !question.optional}
-        appearance={appearance}
-        onSubmit={() => onSubmit(rating)}
-        skipSubmitButton={question.skipSubmitButton}
-      />
-    </>
+    </QuestionLayout>
   )
 }
 
@@ -292,7 +329,24 @@ export function MultipleChoiceQuestion({
   const shouldSkipSubmit = question.skipSubmitButton && isSingleChoice && !question.hasOpenChoice
 
   return (
-    <View>
+    <QuestionLayout
+      footer={
+        <BottomSection
+          text={question.buttonText ?? appearance.submitButtonText}
+          submitDisabled={
+            !question.optional &&
+            (selectedChoices.length === 0 ||
+              (openChoice !== null && selectedChoices.includes(openChoice) && openEndedInput.length === 0))
+          }
+          appearance={appearance}
+          onSubmit={() => {
+            const result = selectedChoices.map((c) => (c === openChoice ? openEndedInput : c))
+            onSubmit(allowMultiple ? result : result[0])
+          }}
+          skipSubmitButton={shouldSkipSubmit}
+        />
+      }
+    >
       <QuestionHeader
         question={question.question}
         description={question.description}
@@ -349,24 +403,7 @@ export function MultipleChoiceQuestion({
           )
         })}
       </View>
-      <BottomSection
-        text={question.buttonText ?? appearance.submitButtonText}
-        submitDisabled={
-          !question.optional &&
-          (selectedChoices.length === 0 ||
-            (openChoice !== null && selectedChoices.includes(openChoice) && openEndedInput.length === 0))
-        }
-        appearance={appearance}
-        onSubmit={() => {
-          // If open choice is selected, replace the choice name with the actual value entered
-          const result = selectedChoices.map((c) => (c === openChoice ? openEndedInput : c))
-          // For single choice questions, return the first element
-          // For multiple choice questions, always return an array
-          onSubmit(allowMultiple ? result : result[0])
-        }}
-        skipSubmitButton={shouldSkipSubmit}
-      />
-    </View>
+    </QuestionLayout>
   )
 }
 
@@ -402,6 +439,10 @@ const styles = StyleSheet.create({
     padding: 10,
     marginVertical: 10,
     fontSize: 16,
+    // Fixed height keeps the surrounding layout stable as the user types —
+    // the TextInput scrolls its own content internally
+    height: 80,
+    textAlignVertical: 'top',
   },
   ratingSection: {
     marginVertical: 10,

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -1,13 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import {
-  Keyboard,
-  KeyboardAvoidingView,
-  Modal,
-  Platform,
-  StyleSheet,
-  View,
-  useWindowDimensions,
-} from 'react-native'
+import { Keyboard, KeyboardAvoidingView, Modal, Platform, StyleSheet, View, useWindowDimensions } from 'react-native'
 
 import { Cancel } from './Cancel'
 import { ConfirmationMessage } from './ConfirmationMessage'
@@ -68,10 +60,7 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
     return null
   }
 
-  const maxModalHeight = Math.max(
-    windowHeight - keyboardHeight - insets.top - insets.bottom - VIEWPORT_BUFFER,
-    200
-  )
+  const maxModalHeight = Math.max(windowHeight - keyboardHeight - insets.top - insets.bottom - VIEWPORT_BUFFER, 200)
 
   const keyboardBehavior = Platform.OS === 'ios' ? 'padding' : androidKeyboardBehavior
 

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Keyboard, KeyboardAvoidingView, Modal, Platform, Pressable, StyleSheet, View } from 'react-native'
+import { Keyboard, KeyboardAvoidingView, Modal, Platform, StyleSheet, View } from 'react-native'
 
 import { Cancel } from './Cancel'
 import { ConfirmationMessage } from './ConfirmationMessage'
 import { Questions } from './Surveys'
 
-import { SurveyAppearanceTheme } from '../surveys-utils'
-import { Survey, SurveyQuestionDescriptionContentType } from '@posthog/core'
+import { SurveyAppearanceTheme, resolveSurveyAlignment } from '../surveys-utils'
+import { Survey } from '@posthog/core'
 import { useOptionalSafeAreaInsets } from '../../optional/OptionalReactNativeSafeArea'
 
 export type SurveyModalProps = {
@@ -23,6 +23,8 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
   const [responses, setResponses] = useState<Record<string, string | number | string[] | null>>({})
   const onClose = useCallback(() => props.onClose(isSurveySent, responses), [isSurveySent, props, responses])
   const insets = useOptionalSafeAreaInsets()
+  const { vertical, horizontal } = resolveSurveyAlignment(appearance.position)
+  const isBottom = vertical === 'flex-end'
 
   const [isVisible] = useState(true)
 
@@ -38,15 +40,21 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
     return null
   }
 
+  // KeyboardAvoidingView lifts content above the keyboard. That only matters
+  // for bottom-anchored modals; for top/middle the content is already above
+  // the keyboard, and `padding` would just shrink the visible area and jank
+  // the centering animation. Skip the avoid behavior in those cases.
+  const keyboardBehavior = isBottom ? (Platform.OS === 'ios' ? 'padding' : androidKeyboardBehavior) : undefined
+
   return (
     <Modal animationType="fade" transparent onRequestClose={onClose} statusBarTranslucent={true}>
       <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : androidKeyboardBehavior}
-        style={{ flex: 1, justifyContent: 'flex-end' }}
+        behavior={keyboardBehavior}
+        style={styles.fill}
         keyboardVerticalOffset={Platform.OS === 'ios' ? 10 : 0}
       >
-        <View style={styles.modalBackdrop} onTouchStart={Keyboard.dismiss}>
-          <View style={styles.modalRow}>
+        <View style={[styles.fill, { justifyContent: vertical }]} onTouchStart={Keyboard.dismiss}>
+          <View style={[styles.modalRow, { justifyContent: horizontal }]}>
             <View style={styles.modalContent} pointerEvents="box-none">
               <View
                 style={[
@@ -54,7 +62,8 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
                   {
                     borderColor: appearance.borderColor,
                     backgroundColor: appearance.backgroundColor,
-                    marginBottom: insets.bottom + 10,
+                    marginTop: vertical === 'flex-start' ? insets.top + 10 : 0,
+                    marginBottom: isBottom ? insets.bottom + 10 : 0,
                     marginHorizontal: 10,
                   },
                 ]}
@@ -90,13 +99,11 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
 }
 
 const styles = StyleSheet.create({
-  modalBackdrop: {
+  fill: {
     flex: 1,
-    justifyContent: 'flex-end',
   },
   modalRow: {
     flexDirection: 'row',
-    justifyContent: 'center',
   },
   modalContent: {
     width: '90%',

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -1,5 +1,13 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Keyboard, KeyboardAvoidingView, Modal, Platform, StyleSheet, View } from 'react-native'
+import {
+  Keyboard,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  StyleSheet,
+  View,
+  useWindowDimensions,
+} from 'react-native'
 
 import { Cancel } from './Cancel'
 import { ConfirmationMessage } from './ConfirmationMessage'
@@ -17,12 +25,18 @@ export type SurveyModalProps = {
   androidKeyboardBehavior?: 'padding' | 'height'
 }
 
+// No extra buffer — let the modal extend right up to the safe-area / keyboard
+// edges. Insets already keep it clear of the status bar and home indicator.
+const VIEWPORT_BUFFER = 0
+
 export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
   const { survey, appearance, onShow, androidKeyboardBehavior = 'height' } = props
   const [isSurveySent, setIsSurveySent] = useState(false)
   const [responses, setResponses] = useState<Record<string, string | number | string[] | null>>({})
   const onClose = useCallback(() => props.onClose(isSurveySent, responses), [isSurveySent, props, responses])
   const insets = useOptionalSafeAreaInsets()
+  const { height: windowHeight } = useWindowDimensions()
+  const [keyboardHeight, setKeyboardHeight] = useState(0)
   const { vertical, horizontal } = resolveSurveyAlignment(appearance.position)
   const isBottom = vertical === 'flex-end'
 
@@ -36,23 +50,34 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
     }
   }, [isVisible, onShow])
 
+  // Track keyboard height so we can cap the modal to the visible viewport.
+  // KAV alone lifts the modal but doesn't shrink it — a tall modal would
+  // still bleed past the screen top.
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow'
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide'
+    const showSub = Keyboard.addListener(showEvent, (e) => setKeyboardHeight(e.endCoordinates.height))
+    const hideSub = Keyboard.addListener(hideEvent, () => setKeyboardHeight(0))
+    return () => {
+      showSub.remove()
+      hideSub.remove()
+    }
+  }, [])
+
   if (!isVisible) {
     return null
   }
 
-  // KeyboardAvoidingView lifts content above the keyboard. That only matters
-  // for bottom-anchored modals; for top/middle the content is already above
-  // the keyboard, and `padding` would just shrink the visible area and jank
-  // the centering animation. Skip the avoid behavior in those cases.
-  const keyboardBehavior = isBottom ? (Platform.OS === 'ios' ? 'padding' : androidKeyboardBehavior) : undefined
+  const maxModalHeight = Math.max(
+    windowHeight - keyboardHeight - insets.top - insets.bottom - VIEWPORT_BUFFER,
+    200
+  )
+
+  const keyboardBehavior = Platform.OS === 'ios' ? 'padding' : androidKeyboardBehavior
 
   return (
     <Modal animationType="fade" transparent onRequestClose={onClose} statusBarTranslucent={true}>
-      <KeyboardAvoidingView
-        behavior={keyboardBehavior}
-        style={styles.fill}
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 10 : 0}
-      >
+      <KeyboardAvoidingView behavior={keyboardBehavior} style={styles.fill}>
         <View style={[styles.fill, { justifyContent: vertical }]} onTouchStart={Keyboard.dismiss}>
           <View style={[styles.modalRow, { justifyContent: horizontal }]}>
             <View style={styles.modalContent} pointerEvents="box-none">
@@ -63,11 +88,17 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
                     borderColor: appearance.borderColor,
                     backgroundColor: appearance.backgroundColor,
                     marginTop: vertical === 'flex-start' ? insets.top + 10 : 0,
-                    marginBottom: isBottom ? insets.bottom + 10 : 0,
+                    // When keyboard is up, sit flush against it (no extra gap).
+                    // When keyboard is down, leave room for the home indicator.
+                    marginBottom: isBottom ? (keyboardHeight > 0 ? 0 : insets.bottom + 10) : 0,
                     marginHorizontal: 10,
+                    maxHeight: maxModalHeight,
                   },
                 ]}
               >
+                <View style={styles.topIconContainer}>
+                  <Cancel onPress={onClose} appearance={appearance} />
+                </View>
                 {!shouldShowConfirmation ? (
                   <Questions
                     survey={survey}
@@ -86,9 +117,6 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
                     isModal={true}
                   />
                 )}
-                <View style={styles.topIconContainer}>
-                  <Cancel onPress={onClose} appearance={appearance} />
-                </View>
               </View>
             </View>
           </View>
@@ -115,8 +143,11 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   topIconContainer: {
+    // Keep the close button inside the modal so it can never bleed off-screen
+    // when the modal lifts above the keyboard.
     position: 'absolute',
-    right: -20,
-    top: -20,
+    right: 8,
+    top: 8,
+    zIndex: 1,
   },
 })

--- a/packages/react-native/src/surveys/components/Surveys.tsx
+++ b/packages/react-native/src/surveys/components/Surveys.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react'
-import { ScrollView, StyleProp, ViewStyle } from 'react-native'
+import { StyleProp, ViewStyle } from 'react-native'
 
 import { getDisplayOrderQuestions, getNextSurveyStep, SurveyAppearanceTheme } from '../surveys-utils'
 import {
@@ -172,29 +172,23 @@ export function Questions({
 
   const question = surveyQuestions[currentQuestionIndex]
 
-  return (
-    <ScrollView
-      style={[styleOverrides, { flexGrow: 0 }]}
-      keyboardShouldPersistTaps="handled" // do not dismiss keyboard on submit button tap
-    >
-      {getQuestionComponent({
-        question,
-        appearance,
-        onSubmit: (res) =>
-          onNextButtonClick({
-            res,
-            originalQuestionIndex: question.originalQuestionIndex,
-            questionId: question.id,
-            // displayQuestionIndex: currentQuestionIndex,
-          }),
-      })}
-    </ScrollView>
-  )
+  return getQuestionComponent({
+    question,
+    appearance,
+    styleOverrides,
+    onSubmit: (res) =>
+      onNextButtonClick({
+        res,
+        originalQuestionIndex: question.originalQuestionIndex,
+        questionId: question.id,
+      }),
+  })
 }
 
 type GetQuestionComponentProps = {
   question: SurveyQuestion
   appearance: SurveyAppearance
+  styleOverrides?: StyleProp<ViewStyle>
   onSubmit: (res: string | string[] | number | null) => void
 }
 

--- a/packages/react-native/src/surveys/surveys-utils.ts
+++ b/packages/react-native/src/surveys/surveys-utils.ts
@@ -140,7 +140,7 @@ export const defaultSurveyAppearance: SurveyAppearanceTheme = {
   placeholder: 'Start typing...',
   displayThankYouMessage: true,
   thankYouMessageHeader: 'Thank you for your feedback!',
-  position: SurveyPosition.Right,
+  position: SurveyPosition.Center,
   submitButtonText: 'Submit',
   autoDisappear: false,
   thankYouMessageDescription: '',
@@ -162,7 +162,7 @@ export function resolveSurveyAlignment(position: string | undefined): {
   vertical: SurveyFlexAlign
   horizontal: SurveyFlexAlign
 } {
-  let resolvedPosition: SurveyPosition = SurveyPosition.Right
+  let resolvedPosition: SurveyPosition = defaultSurveyAppearance.position
   if (position) {
     if (KNOWN_SURVEY_POSITIONS.has(position)) {
       resolvedPosition = position as SurveyPosition
@@ -170,7 +170,7 @@ export function resolveSurveyAlignment(position: string | undefined): {
       warnedUnknownPositions.add(position)
       // eslint-disable-next-line no-console
       console.warn(
-        `[PostHog.surveys] Unknown survey position ${JSON.stringify(position)} — falling back to ${SurveyPosition.Right}. Expected one of: ${Object.values(SurveyPosition).join(', ')}.`
+        `[PostHog.surveys] Unknown survey position ${JSON.stringify(position)} — falling back to ${defaultSurveyAppearance.position}. Expected one of: ${Object.values(SurveyPosition).join(', ')}.`
       )
     }
   }

--- a/packages/react-native/src/surveys/surveys-utils.ts
+++ b/packages/react-native/src/surveys/surveys-utils.ts
@@ -149,6 +149,53 @@ export const defaultSurveyAppearance: SurveyAppearanceTheme = {
   surveyPopupDelaySeconds: 0,
 }
 
+export type SurveyFlexAlign = 'flex-start' | 'center' | 'flex-end'
+
+const KNOWN_SURVEY_POSITIONS: ReadonlySet<string> = new Set(Object.values(SurveyPosition))
+const warnedUnknownPositions = new Set<string>()
+
+// Mirrors web SDK semantics: `.ph-survey` is bottom-anchored by default and
+// getPopoverPosition only overrides `top` for top_* / middle_* variants. So
+// `left` / `right` / `center` (no prefix) anchor to the bottom edge — they
+// are NOT shorthand for middle.
+export function resolveSurveyAlignment(position: string | undefined): {
+  vertical: SurveyFlexAlign
+  horizontal: SurveyFlexAlign
+} {
+  let resolvedPosition: SurveyPosition = SurveyPosition.Right
+  if (position) {
+    if (KNOWN_SURVEY_POSITIONS.has(position)) {
+      resolvedPosition = position as SurveyPosition
+    } else if (!warnedUnknownPositions.has(position)) {
+      warnedUnknownPositions.add(position)
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[PostHog.surveys] Unknown survey position ${JSON.stringify(position)} — falling back to ${SurveyPosition.Right}. Expected one of: ${Object.values(SurveyPosition).join(', ')}.`
+      )
+    }
+  }
+  const isTop =
+    resolvedPosition === SurveyPosition.TopLeft ||
+    resolvedPosition === SurveyPosition.TopCenter ||
+    resolvedPosition === SurveyPosition.TopRight
+  const isMiddle =
+    resolvedPosition === SurveyPosition.MiddleLeft ||
+    resolvedPosition === SurveyPosition.MiddleCenter ||
+    resolvedPosition === SurveyPosition.MiddleRight
+  const isLeft =
+    resolvedPosition === SurveyPosition.TopLeft ||
+    resolvedPosition === SurveyPosition.MiddleLeft ||
+    resolvedPosition === SurveyPosition.Left
+  const isRight =
+    resolvedPosition === SurveyPosition.TopRight ||
+    resolvedPosition === SurveyPosition.MiddleRight ||
+    resolvedPosition === SurveyPosition.Right
+  return {
+    vertical: isTop ? 'flex-start' : isMiddle ? 'center' : 'flex-end',
+    horizontal: isLeft ? 'flex-start' : isRight ? 'flex-end' : 'center',
+  }
+}
+
 export const getDisplayOrderQuestions = (survey: Survey): SurveyQuestion[] => {
   // retain the original questionIndex so we can correlate values in the webapp
   survey.questions.forEach((question: SurveyQuestion, idx: number) => {

--- a/packages/react-native/test/resolveSurveyAlignment.spec.ts
+++ b/packages/react-native/test/resolveSurveyAlignment.spec.ts
@@ -1,0 +1,40 @@
+import { SurveyPosition } from '@posthog/core'
+import { resolveSurveyAlignment } from '../src/surveys/surveys-utils'
+
+describe('resolveSurveyAlignment', () => {
+  it.each([
+    [SurveyPosition.TopLeft, 'flex-start', 'flex-start'],
+    [SurveyPosition.TopCenter, 'flex-start', 'center'],
+    [SurveyPosition.TopRight, 'flex-start', 'flex-end'],
+    [SurveyPosition.MiddleLeft, 'center', 'flex-start'],
+    [SurveyPosition.MiddleCenter, 'center', 'center'],
+    [SurveyPosition.MiddleRight, 'center', 'flex-end'],
+    [SurveyPosition.Left, 'flex-end', 'flex-start'],
+    [SurveyPosition.Center, 'flex-end', 'center'],
+    [SurveyPosition.Right, 'flex-end', 'flex-end'],
+  ])('maps %s to vertical=%s, horizontal=%s', (position, vertical, horizontal) => {
+    expect(resolveSurveyAlignment(position)).toEqual({ vertical, horizontal })
+  })
+
+  it('falls back to the documented Right default when position is undefined', () => {
+    expect(resolveSurveyAlignment(undefined)).toEqual({ vertical: 'flex-end', horizontal: 'flex-end' })
+  })
+
+  it('warns once and falls back to the default for unknown position strings', () => {
+    // Module-scope dedup of warned positions persists across tests, so use a
+    // unique unknown string per run to avoid coupling to other tests' state.
+    const unknown = `unknown-${Math.random().toString(36).slice(2)}`
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const result = resolveSurveyAlignment(unknown)
+      expect(result).toEqual({ vertical: 'flex-end', horizontal: 'flex-end' })
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0][0]).toContain(unknown)
+      // Calling again with the same unknown string does not re-warn.
+      resolveSurveyAlignment(unknown)
+      expect(warn).toHaveBeenCalledTimes(1)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})

--- a/packages/react-native/test/resolveSurveyAlignment.spec.ts
+++ b/packages/react-native/test/resolveSurveyAlignment.spec.ts
@@ -16,8 +16,8 @@ describe('resolveSurveyAlignment', () => {
     expect(resolveSurveyAlignment(position)).toEqual({ vertical, horizontal })
   })
 
-  it('falls back to the documented Right default when position is undefined', () => {
-    expect(resolveSurveyAlignment(undefined)).toEqual({ vertical: 'flex-end', horizontal: 'flex-end' })
+  it('falls back to the Center default when position is undefined', () => {
+    expect(resolveSurveyAlignment(undefined)).toEqual({ vertical: 'flex-end', horizontal: 'center' })
   })
 
   it('warns once and falls back to the default for unknown position strings', () => {
@@ -27,7 +27,7 @@ describe('resolveSurveyAlignment', () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
     try {
       const result = resolveSurveyAlignment(unknown)
-      expect(result).toEqual({ vertical: 'flex-end', horizontal: 'flex-end' })
+      expect(result).toEqual({ vertical: 'flex-end', horizontal: 'center' })
       expect(warn).toHaveBeenCalledTimes(1)
       expect(warn.mock.calls[0][0]).toContain(unknown)
       // Calling again with the same unknown string does not re-warn.


### PR DESCRIPTION
## Problem

`SurveyModal` was hard-coded to a bottom-center layout, ignoring `appearance.position` entirely. Consumers who set `appearance.position = SurveyPosition.TopRight` (or any of the other 8 values) saw no effect — every survey rendered bottom-center on React Native regardless of configuration. This diverged from the web SDK behavior and broke the documented `SurveyPosition` API.

Closes #3497

## Changes

- **`SurveyModal` honors `appearance.position`.** New `resolveSurveyAlignment` helper in `surveys-utils.ts` maps all 9 `SurveyPosition` values to flex alignment, mirroring web SDK semantics: `top_*` anchors to the top edge, `middle_*` to the vertical middle, and `left` / `center` / `right` (no prefix) to the bottom edge. Default is `Center` (matching the previous visible behavior on RN, so existing surveys without an explicit `position` do not shift on upgrade).
- **Single source of truth for the default.** `resolveSurveyAlignment` reads its fallback from `defaultSurveyAppearance.position`, so changing the default only requires editing one line.
- **Sticky-footer Submit.** New `QuestionLayout` helper component wraps each of the 4 question types (`OpenText`, `Link`, `Rating`, `MultipleChoice`) so the Submit button stays anchored at the bottom of the modal regardless of survey length. Removed the redundant outer `ScrollView` in `Surveys.tsx`.
- **Keyboard-aware modal sizing.** `SurveyModal` tracks `keyboardHeight` via a `Keyboard` listener and applies `maxHeight = window − keyboard − safe-area insets` to `modalContentInner`, so the modal can never bleed past the visible viewport when `KeyboardAvoidingView` lifts it. Bottom margin collapses to 0 when keyboard is up so the modal sits flush against it.
- **Multiline open-text TextInput is now capped at 80px** with `textAlignVertical: 'top'`, so typing scrolls the input own content instead of growing the modal and pushing Submit off-screen.
- **Cancel (X) button moved inside the modal** (`top: 8, right: 8, zIndex: 1`, was `top: -20, right: -20` floating outside) so it can never bleed off-screen when the modal sits flush at the viewport edge.
- **Tests.** New `resolveSurveyAlignment.spec.ts` covers all 9 position mappings + undefined fallback + unknown-string warning dedup.
- **Manual test harness.** New `examples/example-expo-53/app/surveys.tsx` screen (separate route, accessible from Home) with a position picker that cycles through every `SurveyPosition` value.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## Test plan

- [x] iOS simulator (iPhone 17 Pro): cycled through all 10 picker values (default + 9 positions) — modal lands in the expected quadrant for each.
- [x] iOS simulator: open-text input + keyboard up — modal lifts above keyboard, sticky Submit visible, X visible, input scrolls internally as user types past 80px height.
- [x] iOS simulator: long question content + capped modal — content scrollable inside modal, Submit pinned at bottom.
- [x] Pixel 4 (Android 13, real device): app builds and installs, position rendering verified.
- [x] All 295 RN unit tests pass; new `resolveSurveyAlignment.spec.ts` (11 cases) green.
- [ ] Android keyboard-with-modal layout precision: blocked by emulator floating-keyboard quirk; needs full real-device verification.
