### PR TITLE
docs(ai): drop resource-level distinct_id from vercel-ai examples

### DIFF
--- a/examples/example-ai-convex/generate.ts
+++ b/examples/example-ai-convex/generate.ts
@@ -15,7 +15,6 @@ import { openai } from '@ai-sdk/openai'
 const sdk = new NodeSDK({
     resource: resourceFromAttributes({
         'service.name': 'example-convex-app',
-        'posthog.distinct_id': 'example-user',
         foo: 'bar',
         conversation_id: 'abc-123',
     }),

--- a/examples/example-ai-vercel-ai/anthropic-streaming.ts
+++ b/examples/example-ai-vercel-ai/anthropic-streaming.ts
@@ -10,7 +10,6 @@ import { z } from 'zod'
 const sdk = new NodeSDK({
     resource: resourceFromAttributes({
         'service.name': 'example-vercel-ai-app',
-        'posthog.distinct_id': 'example-user',
         foo: 'bar',
         conversation_id: 'abc-123',
     }),

--- a/examples/example-ai-vercel-ai/anthropic.ts
+++ b/examples/example-ai-vercel-ai/anthropic.ts
@@ -9,7 +9,6 @@ import { createAnthropic } from '@ai-sdk/anthropic'
 const sdk = new NodeSDK({
     resource: resourceFromAttributes({
         'service.name': 'example-vercel-ai-app',
-        'posthog.distinct_id': 'example-user',
         foo: 'bar',
         conversation_id: 'abc-123',
     }),

--- a/examples/example-ai-vercel-ai/generate-object.ts
+++ b/examples/example-ai-vercel-ai/generate-object.ts
@@ -10,7 +10,6 @@ import { z } from 'zod'
 const sdk = new NodeSDK({
     resource: resourceFromAttributes({
         'service.name': 'example-vercel-ai-app',
-        'posthog.distinct_id': 'example-user',
         foo: 'bar',
         conversation_id: 'abc-123',
     }),

--- a/examples/example-ai-vercel-ai/generate-text.ts
+++ b/examples/example-ai-vercel-ai/generate-text.ts
@@ -10,7 +10,6 @@ import { z } from 'zod'
 const sdk = new NodeSDK({
     resource: resourceFromAttributes({
         'service.name': 'example-vercel-ai-app',
-        'posthog.distinct_id': 'example-user',
         foo: 'bar',
         conversation_id: 'abc-123',
     }),

--- a/examples/example-ai-vercel-ai/google-streaming.ts
+++ b/examples/example-ai-vercel-ai/google-streaming.ts
@@ -10,7 +10,6 @@ import { z } from 'zod'
 const sdk = new NodeSDK({
     resource: resourceFromAttributes({
         'service.name': 'example-vercel-ai-app',
-        'posthog.distinct_id': 'example-user',
         foo: 'bar',
         conversation_id: 'abc-123',
     }),

--- a/examples/example-ai-vercel-ai/google.ts
+++ b/examples/example-ai-vercel-ai/google.ts
@@ -9,7 +9,6 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google'
 const sdk = new NodeSDK({
     resource: resourceFromAttributes({
         'service.name': 'example-vercel-ai-app',
-        'posthog.distinct_id': 'example-user',
         foo: 'bar',
         conversation_id: 'abc-123',
     }),

--- a/examples/example-ai-vercel-ai/stream-object.ts
+++ b/examples/example-ai-vercel-ai/stream-object.ts
@@ -10,7 +10,6 @@ import { z } from 'zod'
 const sdk = new NodeSDK({
     resource: resourceFromAttributes({
         'service.name': 'example-vercel-ai-app',
-        'posthog.distinct_id': 'example-user',
         foo: 'bar',
         conversation_id: 'abc-123',
     }),

--- a/examples/example-ai-vercel-ai/stream-text.ts
+++ b/examples/example-ai-vercel-ai/stream-text.ts
@@ -9,7 +9,6 @@ import { createOpenAI } from '@ai-sdk/openai'
 const sdk = new NodeSDK({
     resource: resourceFromAttributes({
         'service.name': 'example-vercel-ai-app',
-        'posthog.distinct_id': 'example-user',
         foo: 'bar',
         conversation_id: 'abc-123',
     }),


### PR DESCRIPTION
## Problem

The Convex OTEL example and the eight `example-ai-vercel-ai/*` scripts each set `posthog.distinct_id` at two levels:

1. As an SDK Resource attribute (hard-coded `'example-user'`)
2. Per-call via `experimental_telemetry.metadata.posthog_distinct_id`

Today, only the Resource-level value reaches PostHog — Rust capture's `extract_distinct_id` only inspects OTEL Resource attributes, and the Node ingestion middleware strips every `ai.telemetry.metadata.*` key without lifting `posthog_distinct_id` onto the event. Showing both forms together teaches the wrong pattern: a reader can't tell which is canonical, and the per-call form they're being shown is silently ignored. For real Convex actions or any server serving many users from one process, hard-coding distinct_id at the Resource level is fundamentally wrong — every event gets the same user.

## Changes

Drop `'posthog.distinct_id': 'example-user'` from the SDK Resource in:

- `examples/example-ai-convex/generate.ts`
- `examples/example-ai-vercel-ai/{anthropic,anthropic-streaming,generate-object,generate-text,google,google-streaming,stream-object,stream-text}.ts`

Each example now demonstrates the canonical per-call form (`experimental_telemetry.metadata.posthog_distinct_id`) only, matching what real Vercel AI SDK / Convex apps need. Non-Vercel-AI examples (anthropic SDK direct, openai, gemini, etc.) are intentionally left alone — they have no per-call metadata path and Resource-level is their only mechanism.

**Companion PR** — PostHog/posthog#56876 fixes the server side so the per-call metadata path actually works end-to-end:

- Rust capture now resolves distinct_id per span (preferring `ai.telemetry.metadata.posthog_distinct_id`), so a mixed-user OTLP batch produces correctly attributed events.
- Node ingestion lifts `ai.telemetry.metadata.posthog_distinct_id` onto `event.distinct_id` as a safety net for non-PostHog OTEL collector chains.

These example changes depend on #56876 landing first; together they make `experimental_telemetry.metadata.posthog_distinct_id` the canonical per-call user-attribution path for Convex / Vercel AI SDK flows.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

(Example files only — no library version bump required.)

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*