### PR TITLE
chore: run dependabot weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
           - release
       directory: '/'
       schedule:
-          interval: 'daily'
+          interval: 'weekly'
+          day: 'monday'
           time: '10:00'
           timezone: 'UTC'
       groups:


### PR DESCRIPTION
## Problem

Dependabot currently checks the configured AI provider dependencies every day, which can create more frequent dependency PRs than needed.

## Changes

Updated `.github/dependabot.yml` to run the npm Dependabot schedule weekly on Mondays at 10:00 UTC, while keeping the existing explicit dependency grouping patterns.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
