### PR TITLE
chore: upload browser source maps to S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,7 +393,9 @@ jobs:
               uses: actions/upload-artifact@v7
               with:
                   name: posthog-js-dist
-                  path: packages/browser/dist/*.js
+                  path: |
+                      packages/browser/dist/*.js
+                      packages/browser/dist/*.js.map
                   retention-days: 1
                   if-no-files-found: error
 
@@ -471,7 +473,7 @@ jobs:
             # upload step has stable filenames. The runtime CSS loader in the
             # JS bundle expects the literal `toolbar.css`.
             #
-            # Source maps are discarded (we don't ship them to end users).
+            # Toolbar source maps are discarded (we don't ship them to end users).
             - name: Normalize toolbar output filenames
               run: |
                   set -euo pipefail

--- a/tooling/release/src/upload-posthog-js-s3.test.ts
+++ b/tooling/release/src/upload-posthog-js-s3.test.ts
@@ -1,8 +1,12 @@
 import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 import test from 'node:test'
 import {
     assertNoCompatibilityVersionNamespaceCollisions,
     buildAssetUploadPlans,
+    collectReleaseAssets,
     inferContentType,
     type ReleaseAsset,
 } from './upload-posthog-js-s3.ts'
@@ -13,6 +17,11 @@ test('buildAssetUploadPlans publishes immutable semver assets, major-version ali
             relativeKey: 'array.js',
             filePath: '/tmp/array.js',
             contentType: 'application/javascript',
+        },
+        {
+            relativeKey: 'array.js.map',
+            filePath: '/tmp/array.js.map',
+            contentType: 'application/json',
         },
         {
             relativeKey: 'toolbar.css',
@@ -37,6 +46,11 @@ test('buildAssetUploadPlans publishes immutable semver assets, major-version ali
                 contentType: 'application/javascript',
             },
             {
+                key: 'static/1.370.0/array.js.map',
+                cacheControl: 'public, max-age=31536000, immutable',
+                contentType: 'application/json',
+            },
+            {
                 key: 'static/1.370.0/toolbar.css',
                 cacheControl: 'public, max-age=31536000, immutable',
                 contentType: 'text/css',
@@ -56,6 +70,11 @@ test('buildAssetUploadPlans publishes immutable semver assets, major-version ali
                 key: 'static/1/array.js',
                 cacheControl: 'public, max-age=300',
                 contentType: 'application/javascript',
+            },
+            {
+                key: 'static/1/array.js.map',
+                cacheControl: 'public, max-age=300',
+                contentType: 'application/json',
             },
             {
                 key: 'static/1/toolbar.css',
@@ -79,6 +98,11 @@ test('buildAssetUploadPlans publishes immutable semver assets, major-version ali
                 contentType: 'application/javascript',
             },
             {
+                key: 'static/array.js.map',
+                cacheControl: 'public, max-age=300',
+                contentType: 'application/json',
+            },
+            {
                 key: 'static/toolbar.css',
                 cacheControl: 'public, max-age=300',
                 contentType: 'text/css',
@@ -95,7 +119,35 @@ test('buildAssetUploadPlans publishes immutable semver assets, major-version ali
 test('inferContentType restores aws-cli style MIME inference for release assets', () => {
     assert.equal(inferContentType('/tmp/assets/logo.svg'), 'image/svg+xml')
     assert.equal(inferContentType('/tmp/assets/font.woff2'), 'font/woff2')
+    assert.equal(inferContentType('/tmp/array.js.map'), 'application/json')
     assert.equal(inferContentType('/tmp/assets/unknown.custom-extension'), undefined)
+})
+
+test('collectReleaseAssets includes browser source maps from the dist root', async () => {
+    const distDir = await fs.mkdtemp(path.join(os.tmpdir(), 'posthog-js-dist-'))
+
+    try {
+        await fs.writeFile(path.join(distDir, 'array.js'), '')
+        await fs.writeFile(path.join(distDir, 'array.js.map'), '{}')
+        await fs.writeFile(path.join(distDir, 'module.d.ts'), '')
+        await fs.writeFile(path.join(distDir, 'toolbar.css'), '')
+        await fs.mkdir(path.join(distDir, 'assets'))
+        await fs.writeFile(path.join(distDir, 'assets', 'logo.svg'), '<svg />')
+
+        const assets = await collectReleaseAssets(distDir)
+
+        assert.deepEqual(
+            assets.map(({ relativeKey, contentType }) => ({ relativeKey, contentType })),
+            [
+                { relativeKey: 'array.js', contentType: 'application/javascript' },
+                { relativeKey: 'array.js.map', contentType: 'application/json' },
+                { relativeKey: 'toolbar.css', contentType: 'text/css' },
+                { relativeKey: 'assets/logo.svg', contentType: 'image/svg+xml' },
+            ]
+        )
+    } finally {
+        await fs.rm(distDir, { recursive: true, force: true })
+    }
 })
 
 test('assertNoCompatibilityVersionNamespaceCollisions rejects compatibility keys that would shadow reserved version namespaces', () => {

--- a/tooling/release/src/upload-posthog-js-s3.ts
+++ b/tooling/release/src/upload-posthog-js-s3.ts
@@ -56,17 +56,17 @@ async function listFilesRecursively(root: string): Promise<string[]> {
     return files.flat()
 }
 
-async function collectReleaseAssets(): Promise<ReleaseAsset[]> {
-    const distEntries = await fs.readdir(DIST_DIR)
+export async function collectReleaseAssets(distDir = DIST_DIR): Promise<ReleaseAsset[]> {
+    const distEntries = (await fs.readdir(distDir)).sort()
     const assets: ReleaseAsset[] = distEntries
-        .filter((name) => name.endsWith('.js'))
+        .filter((name) => name.endsWith('.js') || name.endsWith('.js.map'))
         .map((entry) => ({
             relativeKey: entry,
-            filePath: path.join(DIST_DIR, entry),
-            contentType: 'application/javascript',
+            filePath: path.join(distDir, entry),
+            contentType: entry.endsWith('.js.map') ? 'application/json' : 'application/javascript',
         }))
 
-    const toolbarCssPath = path.join(DIST_DIR, 'toolbar.css')
+    const toolbarCssPath = path.join(distDir, 'toolbar.css')
     if (await fileExists(toolbarCssPath)) {
         assets.push({
             relativeKey: 'toolbar.css',
@@ -75,7 +75,7 @@ async function collectReleaseAssets(): Promise<ReleaseAsset[]> {
         })
     }
 
-    const assetsDir = path.join(DIST_DIR, 'assets')
+    const assetsDir = path.join(distDir, 'assets')
     if (await fileExists(assetsDir)) {
         const files = await listFilesRecursively(assetsDir)
         assets.push(


### PR DESCRIPTION
## Problem

Browser release builds generate `.js.map` files, but the S3 release artifact handoff only included `.js` files. That meant the S3 upload job did not publish browser source maps.

## Changes

- Include `packages/browser/dist/*.js.map` in the temporary GitHub Actions artifact consumed by the S3 upload job.
- S3 release tooling now collects `.js.map` files from the dist root and upload them as `application/json`.
- Add release tooling tests covering source map collection and upload planning.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
