### PR TITLE
fix(replay): detect session rotation while _isIdle is unknown

### DIFF
--- a/.changeset/fine-pears-care.md
+++ b/.changeset/fine-pears-care.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+detect session rotation while \_isIdle is unknown

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1240,6 +1240,35 @@ describe('Lazy SessionRecording', () => {
                 const recorderSessionId = sessionRecording['_lazyLoadedSessionRecording']['_sessionId']
                 expect(recorderSessionId).toEqual(rotatedSessionId)
             })
+
+            it('restarts recorder when session rotates while _isIdle is unknown', () => {
+                // _isIdle stays 'unknown' until an rrweb-interactive event fires. Without that, an
+                // external rotation must still be picked up by _updateWindowAndSessionIds rather
+                // than be silently dropped by the idle bail-out.
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_isIdle']).toEqual('unknown')
+                const firstSessionId = sessionRecording['_lazyLoadedSessionRecording']['_sessionId']
+
+                sessionIdGeneratorMock.mockClear()
+                const rotatedSessionId = 'externally-rotated-session-id'
+                sessionIdGeneratorMock.mockImplementation(() => rotatedSessionId)
+
+                const rotationTimestamp = sessionManager['_sessionTimeoutMs'] + startingTimestamp + 1000
+                jest.useFakeTimers().setSystemTime(new Date(rotationTimestamp))
+
+                // Force the session manager to rotate. _onSessionIdCallback fires sync but its
+                // idle-branch only restarts when _isIdle === true, so the recorder's sessionId
+                // is still the old one at this point.
+                sessionManager.checkAndGetSessionAndWindowId(false, rotationTimestamp)
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_sessionId']).toEqual(firstSessionId)
+
+                // The next event through onRRwebEmit should trigger the restart via
+                // _updateWindowAndSessionIds, which previously bailed on 'unknown'.
+                emitInactiveEvent(rotationTimestamp, 'unknown')
+
+                const recorderSessionId = sessionRecording['_lazyLoadedSessionRecording']['_sessionId']
+                expect(recorderSessionId).toEqual(rotatedSessionId)
+                expect(recorderSessionId).not.toEqual(firstSessionId)
+            })
         })
 
         describe('scheduled full snapshots', () => {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1511,7 +1511,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             }
         }
 
-        if (this._isIdle) {
+        if (this._isIdle === true) {
             return
         }
 


### PR DESCRIPTION
## Problem

When a session rotates before any rrweb-interactive event fires, the recorder misses the rotation. The new session's initial Meta + FullSnapshot end up written to the prior session's blob, leaving the new session with orphan incrementals and no renderable base frame, the player sits on "Buffering..." until the next periodic snapshot (~5 minutes later).

`_updateWindowAndSessionIds` bailed early on truthy `_isIdle`, which catches both `true` (confirmed idle) and the initial `'unknown'` state. Sessions whose `_isIdle` never flips from `'unknown'` to `false` (no rrweb-interactive event yet) silently miss session-change detection.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->
Change the predicate from `if (this._isIdle)` to `if (this._isIdle === true)`. This mirrors the existing `=== true` predicate in `onRRwebEmit`, whose comment already calls out: _"we don't want to return early if idle is 'unknown'"_. The confirmed-idle path is unchanged, the `'unknown'` state now correctly proceeds to the session-change check.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
