### PR TITLE
fix: disable React Native SDK without API key

### DIFF
--- a/.changeset/quiet-ravens-collect.md
+++ b/.changeset/quiet-ravens-collect.md
@@ -1,0 +1,6 @@
+---
+"@posthog/core": patch
+"posthog-react-native": patch
+---
+
+Do not crash when the React Native SDK is initialized without an API key; initialize as disabled and log an error instead. Disabled clients now also skip manual reload/flush/survey/log network calls.

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -54,6 +54,9 @@ export class PostHogLogs {
   }
 
   captureLog(options: CaptureLogOptions): void {
+    if (this._instance.isDisabled) {
+      return
+    }
     if (this._instance.optedOut) {
       return
     }
@@ -172,6 +175,9 @@ export class PostHogLogs {
    * head of the queue can't be sent twice.
    */
   async flush(): Promise<void> {
+    if (this._instance.isDisabled) {
+      return
+    }
     if (this._flushPromise) {
       return this._flushPromise
     }

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -807,6 +807,10 @@ export abstract class PostHogCoreStateless {
   public async getSurveysStateless(): Promise<SurveyResponse['surveys']> {
     await this._initPromise
 
+    if (this.disabled) {
+      return []
+    }
+
     if (this.disableSurveys === true) {
       this._logger.info('Loading surveys is disabled.')
       return []
@@ -1071,6 +1075,10 @@ export abstract class PostHogCoreStateless {
    * @throws Error
    */
   async flush(): Promise<void> {
+    if (this.disabled) {
+      return
+    }
+
     // Wait for the current flush operation to finish (regardless of success or failure), then try to flush again.
     // Use allSettled instead of finally to be defensive around flush throwing errors immediately rather than rejecting.
     // Use a custom allSettled implementation to avoid issues with patching Promise on RN
@@ -1208,6 +1216,10 @@ export abstract class PostHogCoreStateless {
    * shrink `maxBatchRecordsPerPost` and retry the same records.
    */
   async _sendLogsBatch(payload: OtlpLogsPayload): Promise<SendLogsBatchOutcome> {
+    if (this.disabled) {
+      return { kind: 'fatal', error: new Error('The client is disabled') }
+    }
+
     const serialized = JSON.stringify(payload)
     const url = `${this.host}/i/v1/logs?token=${encodeURIComponent(this.apiKey)}`
 
@@ -1304,6 +1316,10 @@ export abstract class PostHogCoreStateless {
     await this._initPromise
     let hasTimedOut = false
     this.clearFlushTimer()
+
+    if (this.disabled) {
+      return
+    }
 
     const doShutdown = async (): Promise<void> => {
       try {

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -566,6 +566,9 @@ export abstract class PostHogCore extends PostHogCoreStateless {
 
   private async remoteConfigAsync(): Promise<PostHogRemoteConfig | undefined> {
     await this._initPromise
+    if (this.disabled) {
+      return undefined
+    }
     if (this._remoteConfigResponsePromise) {
       return this._remoteConfigResponsePromise
     }
@@ -578,6 +581,9 @@ export abstract class PostHogCore extends PostHogCoreStateless {
   protected async flagsAsync(options?: FlagsAsyncOptions): Promise<PostHogFeatureFlagsResponse | undefined> {
     const { sendAnonDistinctId = true, fetchConfig = false, triggerOnRemoteConfig = false } = options ?? {}
     await this._initPromise
+    if (this.disabled) {
+      return undefined
+    }
     if (this._flagsResponsePromise) {
       // Queue the reload request instead of dropping it
       // This ensures that requests with $anon_distinct_id (from identify()) are not lost

--- a/packages/react-native/src/PostHogProvider.tsx
+++ b/packages/react-native/src/PostHogProvider.tsx
@@ -123,12 +123,6 @@ export const PostHogProvider = ({
   style,
   debug = false,
 }: PostHogProviderProps): JSX.Element | null => {
-  if (!client && !apiKey) {
-    throw new Error(
-      'Either a PostHog client or an apiKey is required. If you want to use the PostHogProvider without a client, please provide an apiKey and the options={ disabled: true }.'
-    )
-  }
-
   const captureAll = autocapture === true
   const captureNone = autocapture === false
 

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -240,6 +240,11 @@ export class PostHog extends PostHogCore {
    * @param options - PostHog configuration options
    */
   constructor(apiKey: string, options?: PostHogOptions) {
+    const normalizedApiKey = typeof apiKey === 'string' ? apiKey.trim() : ''
+    if (!normalizedApiKey) {
+      console.error("You must pass your PostHog project's api key. The client will be disabled.")
+    }
+
     super(apiKey, options)
     this._isInitialized = false
     this._persistence = options?.persistence ?? 'file'
@@ -401,6 +406,10 @@ export class PostHog extends PostHogCore {
       }
 
       this._isInitialized = true
+
+      if (this.isDisabled) {
+        return
+      }
 
       // Preload error tracking state from cached remote config.
       // This gates error tracking autocapture before the fresh remote config is fetched.

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -245,7 +245,7 @@ export class PostHog extends PostHogCore {
       console.error("You must pass your PostHog project's api key. The client will be disabled.")
     }
 
-    super(apiKey, options)
+    super(normalizedApiKey, options)
     this._isInitialized = false
     this._persistence = options?.persistence ?? 'file'
     this._disableSurveys = options?.disableSurveys ?? false

--- a/packages/react-native/test/PostHogProvider.spec.ts
+++ b/packages/react-native/test/PostHogProvider.spec.ts
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+import React, { useEffect } from 'react'
+import { render, cleanup } from '@testing-library/react'
+import { AppState, Linking } from 'react-native'
+
+import { PostHogProvider } from '../src/PostHogProvider'
+import { usePostHog } from '../src/hooks/usePostHog'
+import type { PostHog } from '../src/posthog-rn'
+
+Linking.getInitialURL = jest.fn(() => Promise.resolve(null))
+AppState.addEventListener = jest.fn()
+
+const CaptureClient = ({ onClient }: { onClient: (client: PostHog) => void }) => {
+  const posthog = usePostHog()
+
+  useEffect(() => {
+    onClient(posthog)
+  }, [onClient, posthog])
+
+  return null
+}
+
+describe('PostHogProvider', () => {
+  beforeEach(() => {
+    ;(globalThis as any).window.fetch = jest.fn(async () => ({
+      status: 200,
+      json: () => Promise.resolve({ featureFlags: {} }),
+    }))
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it.each([
+    ['missing', undefined],
+    ['empty', ''],
+    ['blank', '   '],
+  ])('should render a disabled client instead of throwing when the api key is %s', (_case, apiKey) => {
+    const onClient = jest.fn()
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      expect(() => {
+        render(
+          React.createElement(
+            PostHogProvider,
+            { apiKey, autocapture: false, options: { persistence: 'memory' } },
+            React.createElement(CaptureClient, { onClient })
+          )
+        )
+      }).not.toThrow()
+
+      const posthog = onClient.mock.calls[0][0] as PostHog
+      expect(posthog.isDisabled).toEqual(true)
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "You must pass your PostHog project's api key. The client will be disabled."
+      )
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+})

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -133,6 +133,44 @@ describe('PostHog React Native', () => {
     expect(posthog.getDistinctId()).toEqual('bar')
   })
 
+  it.each([
+    ['missing', undefined as unknown as string],
+    ['empty', ''],
+    ['blank', '   '],
+  ])('should initialize disabled instead of throwing when the api key is %s', async (_case, apiKey) => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      posthog = new PostHog(apiKey, {
+        persistence: 'memory',
+        flushInterval: 0,
+      })
+
+      await posthog.ready()
+
+      expect(posthog.isDisabled).toEqual(true)
+
+      posthog.reloadFeatureFlags()
+      await posthog.reloadFeatureFlagsAsync()
+      await posthog.reloadRemoteConfigAsync()
+      await posthog.getSurveysStateless()
+
+      posthog.setPersistedProperty(PostHogPersistedProperty.Queue, [{ message: { event: 'queued' } }] as any)
+      posthog.setPersistedProperty(PostHogPersistedProperty.LogsQueue, [{ record: { body: 'queued' } }] as any)
+      posthog.capture('event')
+      posthog.captureLog({ body: 'log' })
+      await posthog.flush()
+      await posthog.flushLogs()
+
+      expect((globalThis as any).window.fetch).not.toHaveBeenCalled()
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "You must pass your PostHog project's api key. The client will be disabled."
+      )
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
   it('should initialize properly with bootstrap using async storage', async () => {
     posthog = new PostHog('test-token', {
       bootstrap: { distinctId: 'bar' },


### PR DESCRIPTION
## Problem

React Native apps can crash during startup if the PostHog API key is missing, empty, or blank (for example due to an ENV misconfiguration in CI). The SDK should fail safe by disabling itself instead of throwing or attempting API calls without a token.

## Changes

- Stop throwing from `PostHogProvider` when no `apiKey` is provided.
- Let the React Native SDK initialize as disabled when the API key is missing/blank and log an error.
- Add disabled-client guards in core reload, survey, flush, shutdown, and logs paths so manual calls do not hit network APIs without a token.
- Add React Native regression tests for missing, empty, and blank API keys via both `PostHogProvider` and direct `PostHog` construction.
- Add changeset entries for `@posthog/core` and `posthog-react-native`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
