### PR TITLE
fix: gate survey translation logs behind debug

### DIFF
--- a/.changeset/silent-survey-translations.md
+++ b/.changeset/silent-survey-translations.md
@@ -1,0 +1,7 @@
+---
+"@posthog/core": patch
+"posthog-js": patch
+"posthog-react-native": patch
+---
+
+Gate survey translation logs behind SDK debug logging to avoid production console spam.

--- a/packages/browser/src/__tests__/utils/survey-translations.test.ts
+++ b/packages/browser/src/__tests__/utils/survey-translations.test.ts
@@ -5,6 +5,7 @@ import { detectUserLanguage, applySurveyTranslationForUser } from '../../utils/s
 import { Survey, SurveyType, SurveyQuestionType } from '../../posthog-surveys-types'
 import { PostHog } from '../../posthog-core'
 import { STORED_PERSON_PROPERTIES_KEY } from '../../constants'
+import Config from '../../config'
 
 describe('Survey Translations', () => {
     let mockPostHog: PostHog
@@ -25,6 +26,8 @@ describe('Survey Translations', () => {
     })
 
     afterEach(() => {
+        Config.DEBUG = false
+
         // Restore original navigator
         Object.defineProperty(global, 'navigator', {
             value: originalNavigator,
@@ -143,6 +146,24 @@ describe('Survey Translations', () => {
             } as unknown as PostHog
 
             expect(detectUserLanguage(mockPostHog)).toBe('it')
+        })
+
+        it('only logs language detection when browser debug logging is enabled', () => {
+            const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+            ;(global.navigator as any).language = 'en-US'
+            ;(mockPostHog.get_property as jest.Mock).mockReturnValue({})
+
+            try {
+                expect(detectUserLanguage(mockPostHog)).toBe('en-US')
+                expect(logSpy).not.toHaveBeenCalled()
+
+                Config.DEBUG = true
+
+                expect(detectUserLanguage(mockPostHog)).toBe('en-US')
+                expect(logSpy).toHaveBeenCalledWith('[PostHog.js] [SurveyTranslations]', 'Using detected locale: en-US')
+            } finally {
+                logSpy.mockRestore()
+            }
         })
     })
 

--- a/packages/browser/src/utils/survey-translations.ts
+++ b/packages/browser/src/utils/survey-translations.ts
@@ -23,13 +23,16 @@ const logger = createLogger('[SurveyTranslations]')
  * @returns The detected language code (e.g., 'fr', 'es', 'en-US') or null if not found
  */
 export function detectUserLanguage(instance: PostHog): string | null {
-    return detectSurveyLanguage({
-        overrideLanguage: instance.config.override_display_language,
-        storedPersonProperties: isFunction(instance.get_property)
-            ? instance.get_property(STORED_PERSON_PROPERTIES_KEY)
-            : undefined,
-        locale: getBrowserLanguage(),
-    })
+    return detectSurveyLanguage(
+        {
+            overrideLanguage: instance.config.override_display_language,
+            storedPersonProperties: isFunction(instance.get_property)
+                ? instance.get_property(STORED_PERSON_PROPERTIES_KEY)
+                : undefined,
+            locale: getBrowserLanguage(),
+        },
+        logger
+    )
 }
 
 /**
@@ -49,7 +52,7 @@ export function applySurveyTranslationForUser(
         return { survey, language: null }
     }
 
-    const result = applySurveyTranslation(survey, userLanguage)
+    const result = applySurveyTranslation(survey, userLanguage, logger)
 
     return {
         survey: result.survey,

--- a/packages/core/src/surveys/translations.spec.ts
+++ b/packages/core/src/surveys/translations.spec.ts
@@ -1,11 +1,12 @@
-import { describe, expect, it } from '@jest/globals'
+import { describe, expect, it, jest } from '@jest/globals'
 import {
   applySurveyTranslation,
   detectSurveyLanguage,
   findBestTranslationMatch,
   getLanguageFromStoredPersonProperties,
 } from './translations'
-import { Survey, SurveyQuestionType, SurveyType } from '../types'
+import { SurveyQuestionType, SurveyType } from '../types'
+import type { Logger, Survey } from '../types'
 
 const createBaseSurvey = (): Survey => ({
   id: 'test-survey',
@@ -77,6 +78,31 @@ describe('survey translations', () => {
       expect(getLanguageFromStoredPersonProperties({ language: 'it' })).toBe('it')
       expect(getLanguageFromStoredPersonProperties({ language: '   ' })).toBeNull()
       expect(getLanguageFromStoredPersonProperties({})).toBeNull()
+    })
+
+    it('does not log language detection by default', () => {
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+      try {
+        expect(detectSurveyLanguage({ locale: 'en-US' })).toBe('en-US')
+        expect(logSpy).not.toHaveBeenCalled()
+      } finally {
+        logSpy.mockRestore()
+      }
+    })
+
+    it('logs language detection through a provided logger', () => {
+      const logger: Logger = {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        critical: jest.fn(),
+        createLogger: jest.fn(),
+      }
+
+      expect(detectSurveyLanguage({ locale: 'en-US' }, logger)).toBe('en-US')
+      expect(logger.info).toHaveBeenCalledWith('Using detected locale: en-US')
     })
   })
 

--- a/packages/core/src/surveys/translations.ts
+++ b/packages/core/src/surveys/translations.ts
@@ -1,7 +1,5 @@
-import { SurveyQuestionTranslation, SurveyTranslation } from '../types'
-import { createLogger, isArray, isUndefined } from '../utils'
-
-const logger = createLogger('[SurveyTranslations]')
+import type { Logger, SurveyQuestionTranslation, SurveyTranslation } from '../types'
+import { isArray, isUndefined } from '../utils'
 
 export type DetectSurveyLanguageOptions = {
   overrideLanguage?: unknown
@@ -25,30 +23,29 @@ export function getLanguageFromStoredPersonProperties(storedPersonProperties: un
   return getTrimmedLanguage(storedPersonProperties.language)
 }
 
-export function detectSurveyLanguage({
-  overrideLanguage,
-  storedPersonProperties,
-  locale,
-}: DetectSurveyLanguageOptions): string | null {
+export function detectSurveyLanguage(
+  { overrideLanguage, storedPersonProperties, locale }: DetectSurveyLanguageOptions,
+  logger?: Logger
+): string | null {
   const explicitLanguage = getTrimmedLanguage(overrideLanguage)
   if (explicitLanguage) {
-    logger.info(`Using override display language: ${explicitLanguage}`)
+    logger?.info(`Using override display language: ${explicitLanguage}`)
     return explicitLanguage
   }
 
   const personLanguage = getLanguageFromStoredPersonProperties(storedPersonProperties)
   if (personLanguage) {
-    logger.info(`Using person property language: ${personLanguage}`)
+    logger?.info(`Using person property language: ${personLanguage}`)
     return personLanguage
   }
 
   const detectedLocale = getTrimmedLanguage(locale)
   if (detectedLocale) {
-    logger.info(`Using detected locale: ${detectedLocale}`)
+    logger?.info(`Using detected locale: ${detectedLocale}`)
     return detectedLocale
   }
 
-  logger.info('No user language detected')
+  logger?.info('No user language detected')
   return null
 }
 
@@ -62,7 +59,8 @@ export function getBaseLanguage(languageCode: string): string {
 
 export function findBestTranslationMatch(
   translations: Record<string, unknown> | undefined,
-  targetLanguage: string
+  targetLanguage: string,
+  logger?: Logger
 ): string | null {
   if (!translations || !targetLanguage) {
     return null
@@ -72,7 +70,7 @@ export function findBestTranslationMatch(
 
   const exactMatch = Object.keys(translations).find((key) => normalizeLanguageCode(key) === normalizedTarget)
   if (exactMatch) {
-    logger.debug(`Found exact translation match: ${exactMatch}`)
+    logger?.debug(`Found exact translation match: ${exactMatch}`)
     return exactMatch
   }
 
@@ -80,7 +78,7 @@ export function findBestTranslationMatch(
     const baseLanguage = getBaseLanguage(normalizedTarget)
     const baseMatch = Object.keys(translations).find((key) => normalizeLanguageCode(key) === baseLanguage)
     if (baseMatch) {
-      logger.debug(`Found base language translation match: ${baseMatch} (from ${targetLanguage})`)
+      logger?.debug(`Found base language translation match: ${baseMatch} (from ${targetLanguage})`)
       return baseMatch
     }
   }
@@ -128,9 +126,10 @@ type TranslatableSurvey<TQuestion extends TranslatableSurveyQuestion = Translata
 
 function mergeQuestionTranslation<TQuestion extends TranslatableSurveyQuestion>(
   question: TQuestion,
-  targetLanguage: string
+  targetLanguage: string,
+  logger?: Logger
 ): { question: TQuestion; matchedKey: string | null; hasChanges: boolean } {
-  const translationKey = findBestTranslationMatch(question.translations, targetLanguage)
+  const translationKey = findBestTranslationMatch(question.translations, targetLanguage, logger)
   if (!translationKey) {
     return { question, matchedKey: null, hasChanges: false }
   }
@@ -185,8 +184,8 @@ function mergeQuestionTranslation<TQuestion extends TranslatableSurveyQuestion>(
 export function applySurveyTranslation<
   TQuestion extends TranslatableSurveyQuestion,
   TSurvey extends TranslatableSurvey<TQuestion>,
->(survey: TSurvey, targetLanguage: string): { survey: TSurvey; matchedKey: string | null } {
-  const translationKey = findBestTranslationMatch(survey.translations, targetLanguage)
+>(survey: TSurvey, targetLanguage: string, logger?: Logger): { survey: TSurvey; matchedKey: string | null } {
+  const translationKey = findBestTranslationMatch(survey.translations, targetLanguage, logger)
 
   const translated: TSurvey = { ...survey }
   let hasTranslation = false
@@ -194,7 +193,7 @@ export function applySurveyTranslation<
   if (translationKey) {
     const translation = survey.translations?.[translationKey]
     if (translation) {
-      logger.info(`Applying survey-level translation for language: ${translationKey}`)
+      logger?.info(`Applying survey-level translation for language: ${translationKey}`)
 
       if (!isUndefined(translation.name)) {
         translated.name = translation.name
@@ -222,7 +221,9 @@ export function applySurveyTranslation<
     }
   }
 
-  const translatedResults = survey.questions.map((question) => mergeQuestionTranslation(question, targetLanguage))
+  const translatedResults = survey.questions.map((question) =>
+    mergeQuestionTranslation(question, targetLanguage, logger)
+  )
   const translatedQuestions = translatedResults.map((result) => result.question)
   const anyQuestionTranslated = translatedResults.some((result) => result.hasChanges)
 
@@ -234,7 +235,7 @@ export function applySurveyTranslation<
   if (anyQuestionTranslated) {
     translated.questions = translatedQuestions
     hasTranslation = true
-    logger.info(`Applied question-level translations for language: ${targetLanguage}`)
+    logger?.info(`Applied question-level translations for language: ${targetLanguage}`)
   }
 
   return {

--- a/packages/react-native/src/surveys/survey-translations.ts
+++ b/packages/react-native/src/surveys/survey-translations.ts
@@ -1,28 +1,21 @@
-import { createLogger, PostHogPersistedProperty, Survey } from '@posthog/core'
+import { createLogger, Logger, PostHogPersistedProperty, Survey } from '@posthog/core'
 import { applySurveyTranslation, detectSurveyLanguage } from '@posthog/core/surveys'
 import { PostHog } from '../posthog-rn'
 
-let isDebugEnabled = false
-const logger = createLogger('[SurveyTranslations]', (fn) => {
-  if (isDebugEnabled) {
-    fn()
-  }
-})
+const logger = createLogger('[SurveyTranslations]')
 
-function syncLoggerDebugState(instance: PostHog): void {
-  isDebugEnabled = instance.isDebug
+function getLogger(instance: PostHog): Logger | undefined {
+  return instance.isDebug ? logger : undefined
 }
 
 export function detectUserLanguage(instance: PostHog): string | null {
-  syncLoggerDebugState(instance)
-
   return detectSurveyLanguage(
     {
       overrideLanguage: instance.getSurveyDisplayLanguageOverride(),
       storedPersonProperties: instance.getPersistedProperty(PostHogPersistedProperty.PersonProperties),
       locale: instance.getCommonEventProperties().$locale,
     },
-    logger
+    getLogger(instance)
   )
 }
 
@@ -31,9 +24,10 @@ export function applySurveyTranslationForUser(
   instance: PostHog
 ): { survey: Survey; language: string | null } {
   const userLanguage = detectUserLanguage(instance)
+  const logger = getLogger(instance)
 
   if (!userLanguage) {
-    logger.info('No user language detected')
+    logger?.info('No user language detected')
     return { survey, language: null }
   }
 

--- a/packages/react-native/src/surveys/survey-translations.ts
+++ b/packages/react-native/src/surveys/survey-translations.ts
@@ -2,14 +2,28 @@ import { createLogger, PostHogPersistedProperty, Survey } from '@posthog/core'
 import { applySurveyTranslation, detectSurveyLanguage } from '@posthog/core/surveys'
 import { PostHog } from '../posthog-rn'
 
-const logger = createLogger('[SurveyTranslations]')
+let isDebugEnabled = false
+const logger = createLogger('[SurveyTranslations]', (fn) => {
+  if (isDebugEnabled) {
+    fn()
+  }
+})
+
+function syncLoggerDebugState(instance: PostHog): void {
+  isDebugEnabled = instance.isDebug
+}
 
 export function detectUserLanguage(instance: PostHog): string | null {
-  return detectSurveyLanguage({
-    overrideLanguage: instance.getSurveyDisplayLanguageOverride(),
-    storedPersonProperties: instance.getPersistedProperty(PostHogPersistedProperty.PersonProperties),
-    locale: instance.getCommonEventProperties().$locale,
-  })
+  syncLoggerDebugState(instance)
+
+  return detectSurveyLanguage(
+    {
+      overrideLanguage: instance.getSurveyDisplayLanguageOverride(),
+      storedPersonProperties: instance.getPersistedProperty(PostHogPersistedProperty.PersonProperties),
+      locale: instance.getCommonEventProperties().$locale,
+    },
+    logger
+  )
 }
 
 export function applySurveyTranslationForUser(
@@ -23,7 +37,7 @@ export function applySurveyTranslationForUser(
     return { survey, language: null }
   }
 
-  const result = applySurveyTranslation(survey, userLanguage)
+  const result = applySurveyTranslation(survey, userLanguage, logger)
 
   return {
     survey: result.survey,


### PR DESCRIPTION
## Problem

Survey translation logging moved into `@posthog/core`, where the default logger logs immediately. This caused `[SurveyTranslations]` info/debug messages to appear in production consoles on every survey render or language detection path, even when SDK debug logging was disabled.

## Changes

- Keep core survey translation helpers silent unless a platform logger is explicitly provided.
- Pass the browser survey translations logger through to core so survey translation logs are gated by the existing browser debug flags.
- Reuse one React Native survey translations logger and pass it only when the current PostHog instance has debug enabled, avoiding shared mutable debug state across instances.
- Add regression coverage for core default silence and browser debug-gated survey translation logging.
- Add a changeset for affected packages.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
