### PR TITLE
fix(core): consume fetch response body after flush

### DIFF
--- a/.changeset/fix-consume-fetch-response-body.md
+++ b/.changeset/fix-consume-fetch-response-body.md
@@ -1,5 +1,6 @@
 ---
 '@posthog/core': patch
+'posthog-node': patch
 ---
 
 fix: consume fetch response body to prevent CF Workers runtime warnings

--- a/.changeset/fix-consume-fetch-response-body.md
+++ b/.changeset/fix-consume-fetch-response-body.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+fix: consume fetch response body to prevent CF Workers runtime warnings

--- a/packages/core/src/__tests__/posthog.flush.spec.ts
+++ b/packages/core/src/__tests__/posthog.flush.spec.ts
@@ -49,6 +49,39 @@ describe('PostHog Core', () => {
       ])
     })
 
+    it('calls response.body.cancel() after successful flush to consume body', async () => {
+      const mockCancel = jest.fn().mockResolvedValue(undefined)
+
+      mocks.fetch.mockImplementation(async () => {
+        return Promise.resolve({
+          status: 200,
+          text: () => Promise.resolve('ok'),
+          json: () => Promise.resolve({ status: 'ok' }),
+          body: { cancel: mockCancel },
+        })
+      })
+
+      posthog.capture('test-event-1')
+      jest.useRealTimers()
+      await expect(posthog.flush()).resolves.not.toThrow()
+      expect(mockCancel).toHaveBeenCalledTimes(1)
+    })
+
+    it('handles null response body gracefully after flush', async () => {
+      mocks.fetch.mockImplementation(async () => {
+        return Promise.resolve({
+          status: 200,
+          text: () => Promise.resolve('ok'),
+          json: () => Promise.resolve({ status: 'ok' }),
+          body: null,
+        })
+      })
+
+      posthog.capture('test-event-1')
+      jest.useRealTimers()
+      await expect(posthog.flush()).resolves.not.toThrow()
+    })
+
     it.each([400, 500])('responds with an error after retries with %s error', async (status) => {
       mocks.fetch.mockImplementation(() => {
         return Promise.resolve({
@@ -196,6 +229,23 @@ describe('PostHog Core', () => {
       posthog.capture('test-event-1')
       await expect(posthog.flush()).rejects.toHaveProperty('name', 'PostHogFetchHttpError')
       expect(mocks.fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls response.body.cancel() after a successful flush', async () => {
+      const cancelFn = jest.fn().mockResolvedValue(undefined)
+
+      mocks.fetch.mockImplementation(() => {
+        return Promise.resolve({
+          status: 200,
+          text: () => Promise.resolve('ok'),
+          json: () => Promise.resolve({ status: 'ok' }),
+          body: { cancel: cancelFn },
+        })
+      })
+
+      posthog.capture('test-event-1')
+      await expect(posthog.flush()).resolves.not.toThrow()
+      expect(cancelFn).toHaveBeenCalledTimes(1)
     })
 
     it('should stop at first error', async () => {

--- a/packages/core/src/__tests__/posthog.flush.spec.ts
+++ b/packages/core/src/__tests__/posthog.flush.spec.ts
@@ -49,37 +49,28 @@ describe('PostHog Core', () => {
       ])
     })
 
-    it('calls response.body.cancel() after successful flush to consume body', async () => {
-      const mockCancel = jest.fn().mockResolvedValue(undefined)
+    it.each([
+      ['with ReadableStream body', { cancel: jest.fn().mockResolvedValue(undefined) }, true],
+      ['with null body', null, false],
+    ])('consumes response body after flush (%s)', async (_label, body, expectCancel) => {
+      const cancelFn = body?.cancel
 
       mocks.fetch.mockImplementation(async () => {
         return Promise.resolve({
           status: 200,
           text: () => Promise.resolve('ok'),
           json: () => Promise.resolve({ status: 'ok' }),
-          body: { cancel: mockCancel },
+          body,
         })
       })
 
       posthog.capture('test-event-1')
       jest.useRealTimers()
       await expect(posthog.flush()).resolves.not.toThrow()
-      expect(mockCancel).toHaveBeenCalledTimes(1)
-    })
 
-    it('handles null response body gracefully after flush', async () => {
-      mocks.fetch.mockImplementation(async () => {
-        return Promise.resolve({
-          status: 200,
-          text: () => Promise.resolve('ok'),
-          json: () => Promise.resolve({ status: 'ok' }),
-          body: null,
-        })
-      })
-
-      posthog.capture('test-event-1')
-      jest.useRealTimers()
-      await expect(posthog.flush()).resolves.not.toThrow()
+      if (expectCancel) {
+        expect(cancelFn).toHaveBeenCalledTimes(1)
+      }
     })
 
     it.each([400, 500])('responds with an error after retries with %s error', async (status) => {
@@ -229,23 +220,6 @@ describe('PostHog Core', () => {
       posthog.capture('test-event-1')
       await expect(posthog.flush()).rejects.toHaveProperty('name', 'PostHogFetchHttpError')
       expect(mocks.fetch).toHaveBeenCalledTimes(1)
-    })
-
-    it('calls response.body.cancel() after a successful flush', async () => {
-      const cancelFn = jest.fn().mockResolvedValue(undefined)
-
-      mocks.fetch.mockImplementation(() => {
-        return Promise.resolve({
-          status: 200,
-          text: () => Promise.resolve('ok'),
-          json: () => Promise.resolve({ status: 'ok' }),
-          body: { cancel: cancelFn },
-        })
-      })
-
-      posthog.capture('test-event-1')
-      await expect(posthog.flush()).resolves.not.toThrow()
-      expect(cancelFn).toHaveBeenCalledTimes(1)
     })
 
     it('should stop at first error', async () => {

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -997,7 +997,11 @@ export abstract class PostHogCoreStateless {
     }
 
     try {
-      await this.fetchWithRetry(url, fetchOptions)
+      const response = await this.fetchWithRetry(url, fetchOptions)
+      // Consume the response body to prevent cross-request promise warnings
+      // in runtimes like Cloudflare Workers that enforce body consumption.
+      // See: https://github.com/PostHog/posthog-js/issues/3173
+      await response.body?.cancel()?.catch(() => {})
     } catch (err) {
       this._events.emit('error', err)
     }
@@ -1176,7 +1180,11 @@ export abstract class PostHogCoreStateless {
       }
 
       try {
-        await this.fetchWithRetry(url, fetchOptions, retryOptions)
+        const response = await this.fetchWithRetry(url, fetchOptions, retryOptions)
+        // Consume the response body to prevent cross-request promise warnings
+        // in runtimes like Cloudflare Workers that enforce body consumption.
+        // See: https://github.com/PostHog/posthog-js/issues/3173
+        await response.body?.cancel()?.catch(() => {})
       } catch (err) {
         if (isPostHogFetchContentTooLargeError(err) && batchMessages.length > 1) {
           // if we get a 413 error, we want to reduce the batch size and try again

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -271,6 +271,7 @@ export type PostHogFetchResponse = {
   headers?: {
     get(name: string): string | null
   }
+  body?: ReadableStream<Uint8Array> | null
 }
 
 export type PostHogQueueItem = {


### PR DESCRIPTION
## Problem

Cloudflare Workers can warn when fetch response bodies are left unconsumed after flushing PostHog events.
Closes https://github.com/PostHog/posthog-js/issues/3173

## Changes

- Consume successful fetch response bodies with `response.body?.cancel()` after both regular and batched flushes.
- Add parameterized tests covering body cancellation and null response bodies.
- Add a changeset for `@posthog/core` and `posthog-node`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

`@posthog/core` is affected, but is not listed in the checklist above.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->


