### PR TITLE
fix(rollup-plugin): set Vite sourcemap config before transform plugins

### DIFF
--- a/.changeset/fix-rollup-vite-sourcemaps.md
+++ b/.changeset/fix-rollup-vite-sourcemaps.md
@@ -1,0 +1,5 @@
+---
+'@posthog/rollup-plugin': patch
+---
+
+Set Vite build sourcemap config before transform plugins run so uploaded source maps include original sources. The plugin also no longer overrides the `sourcemap` setting when `sourcemaps.enabled` is `false`.

--- a/packages/rollup-plugin/babel.config.mjs
+++ b/packages/rollup-plugin/babel.config.mjs
@@ -1,0 +1,3 @@
+export default {
+    presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
+}

--- a/packages/rollup-plugin/jest.config.mjs
+++ b/packages/rollup-plugin/jest.config.mjs
@@ -1,0 +1,12 @@
+export default {
+    collectCoverage: true,
+    clearMocks: true,
+    coverageDirectory: 'coverage',
+    moduleNameMapper: {
+        '^@posthog/plugin-utils$': '<rootDir>/../plugin-utils/src',
+        '^(\\.{1,2}/.*)\\.js$': '$1',
+    },
+    silent: true,
+    verbose: false,
+    watchman: false,
+}

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -21,7 +21,8 @@
     },
     "files": [
         "src",
-        "dist"
+        "dist",
+        "!src/**/*.spec.ts"
     ],
     "dependencies": {
         "@posthog/cli": "catalog:",

--- a/packages/rollup-plugin/rslib.config.mjs
+++ b/packages/rollup-plugin/rslib.config.mjs
@@ -5,4 +5,10 @@ export default defineConfig({
     bundle: false,
     syntax: 'es6',
     lib: [{ format: 'esm' }],
+    source: {
+        entry: {
+            index: 'src/index.ts',
+        },
+        tsconfigPath: './tsconfig.build.json',
+    },
 })

--- a/packages/rollup-plugin/src/index.spec.ts
+++ b/packages/rollup-plugin/src/index.spec.ts
@@ -1,0 +1,47 @@
+import type { OutputOptions } from 'rollup'
+import posthogRollupPlugin from './index.js'
+
+const options = {
+    personalApiKey: 'phx_test',
+    projectId: '1',
+}
+
+type TestPlugin = {
+    config: () => { build: { sourcemap: 'hidden' | true } } | undefined
+    outputOptions: {
+        handler: (options: OutputOptions) => OutputOptions
+    }
+}
+
+const testPlugin = (...args: Parameters<typeof posthogRollupPlugin>): TestPlugin =>
+    posthogRollupPlugin(...args) as unknown as TestPlugin
+
+describe('posthogRollupPlugin', () => {
+    it('enables hidden sourcemaps in Vite and Rollup when maps are deleted after upload', () => {
+        const plugin = testPlugin(options)
+
+        expect(plugin.config()).toEqual({ build: { sourcemap: 'hidden' } })
+        expect(plugin.outputOptions.handler({} as OutputOptions)).toEqual({ sourcemap: 'hidden' })
+    })
+
+    it('enables visible sourcemaps when maps are kept after upload', () => {
+        const plugin = testPlugin({
+            ...options,
+            sourcemaps: { deleteAfterUpload: false },
+        })
+
+        expect(plugin.config()).toEqual({ build: { sourcemap: true } })
+        expect(plugin.outputOptions.handler({} as OutputOptions)).toEqual({ sourcemap: true })
+    })
+
+    it('leaves sourcemap settings alone when disabled', () => {
+        const plugin = testPlugin({
+            personalApiKey: '',
+            sourcemaps: { enabled: false },
+        })
+        const outputOptions = { sourcemap: false } as OutputOptions
+
+        expect(plugin.config()).toBeUndefined()
+        expect(plugin.outputOptions.handler(outputOptions)).toBe(outputOptions)
+    })
+})

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import type { Plugin, OutputOptions, OutputAsset, OutputChunk } from 'rollup'
-import { PluginConfig, ResolvedPluginConfig, resolveConfig, runSourcemapCli } from '@posthog/plugin-utils'
+import { PluginConfig, resolveConfig, runSourcemapCli } from '@posthog/plugin-utils'
 import path from 'node:path'
 import fs from 'node:fs/promises'
 
@@ -11,9 +11,21 @@ export default function posthogRollupPlugin(userOptions: PostHogRollupPluginOpti
     return {
         name: 'posthog-rollup-plugin',
 
+        config() {
+            if (!posthogOptions.sourcemaps.enabled) return
+
+            return {
+                build: {
+                    sourcemap: posthogOptions.sourcemaps.deleteAfterUpload ? 'hidden' : true,
+                },
+            }
+        },
+
         outputOptions: {
             order: 'post',
             handler(options: OutputOptions) {
+                if (!posthogOptions.sourcemaps.enabled) return options
+
                 return {
                     ...options,
                     sourcemap: posthogOptions.sourcemaps.deleteAfterUpload ? 'hidden' : true,

--- a/packages/rollup-plugin/tsconfig.build.json
+++ b/packages/rollup-plugin/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["src/**/*"],
+    "exclude": ["src/**/*.spec.ts"]
+}


### PR DESCRIPTION
## Summary

- Add a Vite `config()` hook that sets `build.sourcemap` during config resolution. The previous `outputOptions` hook is Rollup-only and runs after transform plugins have already emitted maps, so uploaded source maps were missing the `sources` content under Vite.
- Stop overriding the user's `sourcemap` setting when `sourcemaps.enabled` is `false` — previously `outputOptions` would force `sourcemap` regardless of the disable flag.
- Add unit tests for the enabled (hidden + visible) and disabled paths; mirror plugin-utils' jest/babel/tsconfig.build setup so specs are excluded from the build and the published tarball.

## Test plan

- [x] \`pnpm --filter @posthog/rollup-plugin test:unit\` — 3/3 pass
- [x] \`pnpm --filter @posthog/rollup-plugin lint\` — clean
- [x] \`pnpm --filter @posthog/rollup-plugin build\` — \`dist/\` contains \`index.{js,d.ts,d.ts.map}\` only
- [x] \`tsc --noEmit\` against both \`tsconfig.json\` and \`tsconfig.build.json\` — clean
- [x] \`pnpm pack\` — tarball excludes \`src/index.spec.ts\`
- [x] Manual: build a Vite app with the plugin, confirm uploaded source maps include original sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)