### PR TITLE
ci: test shared changeset-hygiene workflow [SIMULATION]

### DIFF
--- a/.changeset/hygiene-test-major-bump.md
+++ b/.changeset/hygiene-test-major-bump.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': major
+---
+
+[SIMULATION — DO NOT MERGE] Verifying the shared changeset-hygiene workflow's `forbidden-major-packages` input. The major bump on `posthog-js` should trigger a non-blocking warning comment.

--- a/.github/workflows/changeset-hygiene.yml
+++ b/.github/workflows/changeset-hygiene.yml
@@ -1,0 +1,21 @@
+name: 'Changeset hygiene'
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+concurrency:
+    group: changeset-hygiene-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    check:
+        # NOTE: pinned to feat/changeset-hygiene for testing — change to @main once merged.
+        uses: PostHog/.github/.github/workflows/changeset-hygiene.yml@feat/changeset-hygiene
+        with:
+            forbidden-major-packages: posthog-js
+            script-ref: feat/changeset-hygiene

--- a/.github/workflows/changeset-hygiene.yml
+++ b/.github/workflows/changeset-hygiene.yml
@@ -17,5 +17,4 @@ jobs:
         # NOTE: pinned to feat/changeset-hygiene for testing — change to @main once merged.
         uses: PostHog/.github/.github/workflows/changeset-hygiene.yml@feat/changeset-hygiene
         with:
-            forbidden-major-packages: posthog-js
             script-ref: feat/changeset-hygiene

--- a/packages/browser/SIMULATION_DELETE_BEFORE_MERGE.md
+++ b/packages/browser/SIMULATION_DELETE_BEFORE_MERGE.md
@@ -1,0 +1,11 @@
+# Changeset hygiene simulation marker
+
+This file exists only to verify the new shared `changeset-hygiene` workflow
+in PostHog/.github with the `forbidden-major-packages: posthog-js` input.
+
+It's a no-op file inside `packages/browser/` (the directory for the
+`posthog-js` package) paired with a changeset that intentionally declares
+a `'posthog-js': major` bump. The shared workflow should post a sticky
+comment warning that posthog-js should never receive a major bump.
+
+Delete this file (and the matching changeset) before merging.


### PR DESCRIPTION
## :bulb: Motivation and Context

**Draft / test — do not merge.** Verifies the new shared workflow at `PostHog/.github/.github/workflows/changeset-hygiene.yml@feat/changeset-hygiene` against posthog-js, specifically the `forbidden-major-packages` input.

This PR contains:
- A tiny caller workflow at `.github/workflows/changeset-hygiene.yml` that delegates to the shared one with `forbidden-major-packages: posthog-js`.
- A simulated `'posthog-js': major` changeset that should trigger the warning.
- A no-op file inside `packages/browser/` so the source change is attributed to `posthog-js` and the only warning section fired is the forbidden-major one (clean test, no extra noise).

Note: the existing `check-posthog-major-version.yml` workflow will *also* run on this PR and post its own block-and-comment. That's expected during the transition — once the shared workflow is verified end-to-end, the eventual posthog-js caller PR will delete `check-posthog-major-version.yml` since the shared workflow handles the same concern (warn-only).

## :green_heart: How did you test it?

- Local dry-run of the shared script (`~/Develop/posthog-dotgithub/.github/scripts/check-changeset-coverage.mjs`) against this branch's diff with `FORBIDDEN_MAJOR_PACKAGES=posthog-js`. Output:

  > `posthog-js` should not receive a major bump

  …with the appropriate body and `<!-- changeset-hygiene -->` marker.
- This PR is the live integration test for the shared workflow's forbidden-major path.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
