### PR TITLE
ci: add caller for PostHog/.github changeset-hygiene workflow

### DIFF
--- a/.github/workflows/changeset-hygiene.yml
+++ b/.github/workflows/changeset-hygiene.yml
@@ -1,0 +1,17 @@
+name: Changeset hygiene
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    uses: PostHog/.github/.github/workflows/changeset-hygiene.yml@main


### PR DESCRIPTION
## Summary

Adds a tiny caller workflow for the shared `changeset-hygiene` reusable workflow at [PostHog/.github](https://github.com/PostHog/.github/blob/main/.github/workflows/changeset-hygiene.yml). Catches changeset coverage mistakes by surfacing a sticky PR comment when:

- a changeset declares a package the PR didn't modify
- a PR modifies a package no changeset declares
- a changeset declares a name not in the workspace (typo)

The workflow **never blocks merging** — output is informational only. Equivalent caller already opened for posthog-android in PostHog/posthog-android#509.

## Scope

This is purely additive. `check-posthog-major-version.yml` keeps doing its job (the autoload-protection major-bump check) — that policy was intentionally left out of the shared workflow.

## What it does

- Triggers on `pull_request` with `types: [opened, synchronize, reopened]`.
- Delegates to the reusable workflow via `uses: PostHog/.github/.github/workflows/changeset-hygiene.yml@main`.
- Posts a single sticky comment under the marker `<!-- changeset-hygiene -->` when there's a coverage issue. Auto-deletes when fixed.

## Test plan

- [x] Verified end-to-end on PostHog/posthog-js#3520 (test PR with simulation files), which validated the workflow runs cleanly against posthog-js's pnpm-workspace structure (globs, exclusions, scoped `@posthog/*` package names, 20 packages).
- [x] Verified this caller's behavior on PostHog/posthog-android#510 (parallel test PR for posthog-android) where simulated mismatches correctly produced the expected sticky comment.
- [ ] CI on this PR: should run cleanly with no comment posted (no workspace package code is touched, no changeset needed).
