### PR TITLE
chore: update rrweb repository links

### DIFF
--- a/packages/rrweb/all/package.json
+++ b/packages/rrweb/all/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+    "url": "git+https://github.com/PostHog/posthog-js.git"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/rrweb/packer/package.json
+++ b/packages/rrweb/packer/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+    "url": "git+https://github.com/PostHog/posthog-js.git"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/rrweb/plugins/rrweb-plugin-canvas-webrtc-record/package.json
+++ b/packages/rrweb/plugins/rrweb-plugin-canvas-webrtc-record/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+    "url": "git+https://github.com/PostHog/posthog-js.git"
   },
   "author": "justin@recordonce.com",
   "license": "MIT",

--- a/packages/rrweb/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
+++ b/packages/rrweb/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+    "url": "git+https://github.com/PostHog/posthog-js.git"
   },
   "author": "justin@recordonce.com",
   "license": "MIT",

--- a/packages/rrweb/plugins/rrweb-plugin-console-record/package.json
+++ b/packages/rrweb/plugins/rrweb-plugin-console-record/package.json
@@ -33,7 +33,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+        "url": "git+https://github.com/PostHog/posthog-js.git"
     },
     "author": "yanzhen@smartx.com",
     "license": "MIT",

--- a/packages/rrweb/plugins/rrweb-plugin-console-replay/package.json
+++ b/packages/rrweb/plugins/rrweb-plugin-console-replay/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+    "url": "git+https://github.com/PostHog/posthog-js.git"
   },
   "author": "yanzhen@smartx.com",
   "license": "MIT",

--- a/packages/rrweb/plugins/rrweb-plugin-sequential-id-record/package.json
+++ b/packages/rrweb/plugins/rrweb-plugin-sequential-id-record/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+    "url": "git+https://github.com/PostHog/posthog-js.git"
   },
   "author": "yanzhen@smartx.com",
   "license": "MIT",

--- a/packages/rrweb/plugins/rrweb-plugin-sequential-id-replay/package.json
+++ b/packages/rrweb/plugins/rrweb-plugin-sequential-id-replay/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+    "url": "git+https://github.com/PostHog/posthog-js.git"
   },
   "author": "yanzhen@smartx.com",
   "license": "MIT",

--- a/packages/rrweb/record/package.json
+++ b/packages/rrweb/record/package.json
@@ -15,7 +15,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+        "url": "git+https://github.com/PostHog/posthog-js.git"
     },
     "license": "MIT",
     "type": "module",

--- a/packages/rrweb/replay/package.json
+++ b/packages/rrweb/replay/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+    "url": "git+https://github.com/PostHog/posthog-js.git"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/rrweb/rrdom/package.json
+++ b/packages/rrweb/rrdom/package.json
@@ -25,7 +25,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+        "url": "git+https://github.com/PostHog/posthog-js.git"
     },
     "scripts": {
         "dev": "vite build --watch",

--- a/packages/rrweb/rrweb-snapshot/package.json
+++ b/packages/rrweb/rrweb-snapshot/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+    "url": "git+https://github.com/PostHog/posthog-js.git"
   },
   "main": "./dist/rrweb-snapshot.cjs",
   "module": "./dist/rrweb-snapshot.js",

--- a/packages/rrweb/rrweb/package.json
+++ b/packages/rrweb/rrweb/package.json
@@ -21,7 +21,7 @@
     "type": "module",
     "repository": {
         "type": "git",
-        "url": "https://github.com/PostHog/posthog-rrweb"
+        "url": "https://github.com/PostHog/posthog-js"
     },
     "main": "./dist/rrweb.umd.cjs",
     "module": "./dist/rrweb.js",
@@ -49,9 +49,9 @@
     "author": "yanzhen@smartx.com",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/PostHog/posthog-rrweb/issues"
+        "url": "https://github.com/PostHog/posthog-js/issues"
     },
-    "homepage": "https://github.com/PostHog/posthog-rrweb#readme",
+    "homepage": "https://github.com/PostHog/posthog-js#readme",
     "devDependencies": {
         "@types/dom-mediacapture-transform": "0.1.4",
         "@types/jest-image-snapshot": "^6.1.0",

--- a/packages/rrweb/types/package.json
+++ b/packages/rrweb/types/package.json
@@ -10,7 +10,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+        "url": "git+https://github.com/PostHog/posthog-js.git"
     },
     "license": "MIT",
     "type": "module",

--- a/packages/rrweb/utils/package.json
+++ b/packages/rrweb/utils/package.json
@@ -10,7 +10,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/PostHog/posthog-rrweb.git"
+        "url": "git+https://github.com/PostHog/posthog-js.git"
     },
     "license": "MIT",
     "type": "module",


### PR DESCRIPTION
## Problem

The rrweb packages were moved into this repository, but their package metadata still pointed at the old `PostHog/posthog-rrweb` repository.

## Changes

Updated rrweb package `repository` URLs to `PostHog/posthog-js`. Also updated the rrweb package `bugs` URL and `homepage` to point at this repository.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
