### PR TITLE
fix(replay): skip canvas snapshot while WebGL context is lost

### DIFF
--- a/.changeset/canvas-skip-while-context-lost.md
+++ b/.changeset/canvas-skip-while-context-lost.md
@@ -1,0 +1,16 @@
+---
+'@posthog/rrweb': patch
+'@posthog/rrweb-record': patch
+---
+
+Skip canvas snapshot while WebGL context is lost. On mobile under GPU
+pressure or tab backgrounding, `createImageBitmap` returns a transparent
+bitmap rather than throwing for a context-lost WebGL canvas. The worker's
+first-frame transparency check then suppresses emission and stores the
+transparent fingerprint in `lastFingerprintMap`, so once the context
+restores and three.js re-renders, identical-fingerprint frames get
+deduped against the transparent baseline and the canvas appears to never
+record. Pre-flight `gl.isContextLost()` and skip the snapshot while the
+context is down. Also wrap the `getCanvas()` shadow-root walk in
+try/catch so a traversal exception cannot cancel the rAF loop and
+silently kill canvas recording for the rest of the session.

--- a/packages/rrweb/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -184,16 +184,20 @@ export class CanvasManager {
     const getCanvas = (): HTMLCanvasElement[] => {
       const matchedCanvas: HTMLCanvasElement[] = [];
       const searchCanvas = (haystack: ParentNode) => {
-        haystack.querySelectorAll('canvas').forEach((canvas) => {
-          if (!isBlocked(canvas, blockClass, blockSelector, true)) {
-            matchedCanvas.push(canvas);
-          }
-        });
-        haystack.querySelectorAll('*').forEach((elem) => {
-          if (elem.shadowRoot) {
-            searchCanvas(elem.shadowRoot);
-          }
-        });
+        try {
+          haystack.querySelectorAll('canvas').forEach((canvas) => {
+            if (!isBlocked(canvas, blockClass, blockSelector, true)) {
+              matchedCanvas.push(canvas);
+            }
+          });
+          haystack.querySelectorAll('*').forEach((elem) => {
+            if (elem.shadowRoot) {
+              searchCanvas(elem.shadowRoot);
+            }
+          });
+        } catch {
+          // Don't let traversal errors cancel the rAF loop.
+        }
       };
       searchCanvas(win.document);
       return matchedCanvas;
@@ -230,6 +234,12 @@ export class CanvasManager {
               const context = canvas.getContext(
                 (canvas as ICanvas).__context,
               ) as WebGLRenderingContext | WebGL2RenderingContext | null;
+              // Snapshotting a lost context produces a transparent bitmap
+              // that poisons the worker's fingerprint dedup map; skip it.
+              if (context?.isContextLost?.()) {
+                snapshotInProgressMap.set(id, false);
+                return;
+              }
               if (
                 context?.getContextAttributes()?.preserveDrawingBuffer === false
               ) {

--- a/packages/rrweb/rrweb/test/record/canvas-manager.test.ts
+++ b/packages/rrweb/rrweb/test/record/canvas-manager.test.ts
@@ -150,4 +150,130 @@ describe('CanvasManager FPS observer', () => {
     // The canvas should have been attempted again (not permanently stuck)
     expect(vi.mocked(createImageBitmap)).toHaveBeenCalled();
   });
+
+  it('should skip WebGL canvases while the GL context is lost', async () => {
+    const isContextLost = vi.fn().mockReturnValue(true);
+    const getContextAttributes = vi.fn();
+    const fakeContext = {
+      isContextLost,
+      getContextAttributes,
+    } as unknown as WebGLRenderingContext;
+
+    const fakeCanvas = {
+      width: 300,
+      height: 150,
+      clientWidth: 300,
+      clientHeight: 150,
+      __context: 'webgl',
+      getContext: vi.fn().mockReturnValue(fakeContext),
+    } as unknown as HTMLCanvasElement;
+
+    const mirror = createMirror();
+    // @ts-expect-error -- using internal method to set up mirror state
+    mirror.add(fakeCanvas, { id: 99 });
+
+    const win = {
+      document: {
+        querySelectorAll: vi.fn((selector: string) => {
+          if (selector === 'canvas') return [fakeCanvas];
+          return [];
+        }),
+      },
+      OffscreenCanvas: class {},
+      HTMLCanvasElement: { prototype: { getContext: vi.fn() } },
+    };
+
+    new CanvasManager({
+      recordCanvas: true,
+      mutationCb: vi.fn(),
+      win,
+      blockClass: 'rr-block',
+      blockSelector: null,
+      mirror,
+      sampling: 4,
+      dataURLOptions: {},
+    });
+
+    const createImageBitmapMock = vi.fn();
+    vi.stubGlobal('createImageBitmap', createImageBitmapMock);
+
+    // Tick the snapshot loop while the context is lost.
+    flushRaf(1000);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // While the context is lost we must not call createImageBitmap, otherwise
+    // we capture a transparent bitmap and poison lastFingerprintMap.
+    expect(isContextLost).toHaveBeenCalled();
+    expect(createImageBitmapMock).not.toHaveBeenCalled();
+    // The preserveDrawingBuffer attribute branch must not run either —
+    // calling getContextAttributes on a lost context is wasted work.
+    expect(getContextAttributes).not.toHaveBeenCalled();
+
+    // Once the GL context is restored, the next tick should snapshot normally.
+    isContextLost.mockReturnValue(false);
+    getContextAttributes.mockReturnValue({ preserveDrawingBuffer: true });
+    const fakeBitmap = { close: vi.fn() } as unknown as ImageBitmap;
+    createImageBitmapMock.mockResolvedValue(fakeBitmap);
+
+    flushRaf(2000);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(createImageBitmapMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep the rAF loop alive when getCanvas throws', async () => {
+    const fakeCanvas = {
+      width: 300,
+      height: 150,
+      clientWidth: 300,
+      clientHeight: 150,
+    } as unknown as HTMLCanvasElement;
+
+    const mirror = createMirror();
+    // @ts-expect-error -- using internal method to set up mirror state
+    mirror.add(fakeCanvas, { id: 7 });
+
+    let throwOnNextCall = true;
+    const win = {
+      document: {
+        querySelectorAll: vi.fn((selector: string) => {
+          if (throwOnNextCall) {
+            throwOnNextCall = false;
+            throw new Error('shadow root traversal blew up');
+          }
+          if (selector === 'canvas') return [fakeCanvas];
+          return [];
+        }),
+      },
+      OffscreenCanvas: class {},
+      HTMLCanvasElement: { prototype: { getContext: vi.fn() } },
+    };
+
+    new CanvasManager({
+      recordCanvas: true,
+      mutationCb: vi.fn(),
+      win,
+      blockClass: 'rr-block',
+      blockSelector: null,
+      mirror,
+      sampling: 4,
+      dataURLOptions: {},
+    });
+
+    const fakeBitmap = { close: vi.fn() } as unknown as ImageBitmap;
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn().mockResolvedValue(fakeBitmap),
+    );
+
+    // First tick — querySelectorAll throws. The loop must survive.
+    flushRaf(1000);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Second tick — querySelectorAll behaves and returns the canvas.
+    flushRaf(2000);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(vi.mocked(createImageBitmap)).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Problem

A customer's three.js WebGL canvas isn't being recorded on mobile Chrome — desktop works fine, the rest of the recording (DOM, mouse, console) works fine. Their session has zero `source: 9` canvas mutations across 142s, with `THREE.WebGLRenderer: Context Lost.` repeatedly in the console.

When the WebGL context is lost, `createImageBitmap` behavior is [unspecified](https://github.com/whatwg/html/issues/12252). It can either:

- **Return a transparent bitmap** (WebKit's documented behavior) — the worker's first-frame transparency check then suppresses emission and stores the transparent fingerprint in `lastFingerprintMap`. Subsequent transparent frames match and get deduped. The canvas appears to never record.
- **Throw** — PR #160 catches and retries, but if the context stays lost we burn CPU on retries that emit nothing.

Both modes produce the same "zero canvas mutations" symptom we see.

Also: any exception thrown from `getCanvas()`'s shadow-root walk propagates up and cancels the rAF loop, silently killing canvas recording for the rest of the session. Same symptom shape, worth fixing alongside.

## Changes

- `canvas-manager.ts`: pre-flight `gl.isContextLost()` for WebGL canvases and skip the snapshot while the context is down — avoids both failure modes.
- `canvas-manager.ts`: try/catch around `getCanvas()` so traversal errors can't kill the rAF loop.
- `canvas-manager.test.ts`: two new tests, both verified to fail without the fix.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web) — via `@posthog/rrweb-record`

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file