### PR TITLE
chore: Run ES check on main pushes

### DIFF
--- a/.github/workflows/es-check.yml
+++ b/.github/workflows/es-check.yml
@@ -1,7 +1,10 @@
 name: ES5 support check
 
 on:
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Problem

The ES5 support check runs for pull requests, but not after changes land on `main`. Running it on the default branch helps catch regressions introduced by merges.

## Changes

Adds a `push` trigger for the `main` branch to `.github/workflows/es-check.yml`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
