### PR TITLE
chore: stop publishing @posthog/rrweb* packages to npm

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,6 +10,13 @@
     "bumpVersionsWithWorkspaceProtocolOnly": true,
     "ignore": [
         "rrdom-nodejs",
+        "@posthog/rrweb",
+        "@posthog/rrweb-types",
+        "@posthog/rrweb-utils",
+        "@posthog/rrdom",
+        "@posthog/rrweb-snapshot",
+        "@posthog/rrweb-record",
+        "@posthog/rrweb-plugin-console-record",
         "@posthog/rrweb-replay",
         "@posthog/rrweb-packer",
         "@posthog/rrweb-all",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,13 +226,14 @@ jobs:
                     - name: '@posthog/rollup-plugin'
                     - name: '@posthog/types'
                     - name: '@posthog/webpack-plugin'
-                    - name: '@posthog/rrweb'
-                    - name: '@posthog/rrweb-types'
-                    - name: '@posthog/rrweb-utils'
-                    - name: '@posthog/rrdom'
-                    - name: '@posthog/rrweb-snapshot'
-                    - name: '@posthog/rrweb-record'
-                    - name: '@posthog/rrweb-plugin-console-record'
+                    # The @posthog/rrweb* packages live in `packages/rrweb/**` and
+                    # are consumed as `workspace:*` devDependencies of `posthog-js`,
+                    # then bundled into the browser SDK at build time (see
+                    # `packages/browser/src/entrypoints/{recorder,posthog-recorder}.ts`).
+                    # We deliberately do NOT publish them to npm — their entries
+                    # in `.changeset/config.json` `ignore` ensure no version bumps
+                    # are produced for them either. To deprecate already-published
+                    # versions on npm, run `scripts/deprecate-rrweb-packages.sh`.
 
         steps:
             - name: Checkout repository

--- a/scripts/deprecate-rrweb-packages.sh
+++ b/scripts/deprecate-rrweb-packages.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Deprecates the @posthog/rrweb* npm packages.
+#
+# These packages used to live in PostHog/posthog-rrweb but were moved into
+# this monorepo (see PR #3510). The code is now bundled inside posthog-js,
+# so external consumers should install posthog-js instead of importing
+# the standalone packages.
+#
+# Re-running the script is safe: `npm deprecate` is idempotent.
+#
+# Usage:
+#   scripts/deprecate-rrweb-packages.sh             # dry-run (prints commands, no side effects)
+#   scripts/deprecate-rrweb-packages.sh --apply     # actually deprecate every version
+#   scripts/deprecate-rrweb-packages.sh --apply --otp 123456
+#   scripts/deprecate-rrweb-packages.sh --undeprecate --apply
+#
+# Requirements:
+#   - npm CLI installed
+#   - Logged in as a @posthog org member with publish rights (`npm whoami`)
+#   - 2FA OTP if your account requires `auth-and-writes`
+
+set -euo pipefail
+
+PACKAGES=(
+    '@posthog/rrweb'
+    '@posthog/rrweb-types'
+    '@posthog/rrweb-utils'
+    '@posthog/rrdom'
+    '@posthog/rrweb-snapshot'
+    '@posthog/rrweb-record'
+    '@posthog/rrweb-plugin-console-record'
+)
+
+MESSAGE='This package has been moved into posthog-js and is no longer maintained as a standalone package. Install posthog-js instead: https://www.npmjs.com/package/posthog-js'
+
+apply=false
+undeprecate=false
+otp=''
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --apply)
+            apply=true
+            shift
+            ;;
+        --undeprecate)
+            undeprecate=true
+            shift
+            ;;
+        --otp)
+            otp="$2"
+            shift 2
+            ;;
+        --otp=*)
+            otp="${1#--otp=}"
+            shift
+            ;;
+        -h|--help)
+            sed -n '3,21p' "$0" | sed 's|^# \{0,1\}||'
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 64
+            ;;
+    esac
+done
+
+if [[ "$undeprecate" == true ]]; then
+    msg=''
+    action='Undeprecating'
+else
+    msg="$MESSAGE"
+    action='Deprecating'
+fi
+
+if [[ "$apply" != true ]]; then
+    echo
+    echo '!!! Dry run — no packages will be modified. Re-run with --apply to execute. !!!'
+    echo
+fi
+
+# Sanity check: confirm npm login state, but don't block in dry-run.
+if [[ "$apply" == true ]]; then
+    if ! whoami_output=$(npm whoami 2>&1); then
+        echo "ERROR: not logged in to npm. Run \`npm login\` first." >&2
+        echo "  npm whoami output: $whoami_output" >&2
+        exit 1
+    fi
+    echo "Logged in to npm as: $whoami_output"
+    echo
+fi
+
+failed=()
+for pkg in "${PACKAGES[@]}"; do
+    echo "=== $action $pkg ==="
+
+    cmd=(npm deprecate "$pkg" "$msg")
+    if [[ -n "$otp" ]]; then
+        cmd+=(--otp="$otp")
+    fi
+
+    if [[ "$apply" != true ]]; then
+        printf '  (dry-run) '
+        printf '%q ' "${cmd[@]}"
+        printf '\n'
+        continue
+    fi
+
+    if ! "${cmd[@]}"; then
+        echo "  FAILED to $action $pkg" >&2
+        failed+=("$pkg")
+        continue
+    fi
+
+    # Verify by reading back the deprecation field for the latest version.
+    current=$(npm view "$pkg" deprecated 2>/dev/null || true)
+    if [[ "$undeprecate" == true ]]; then
+        if [[ -z "$current" ]]; then
+            echo "  OK: $pkg is no longer deprecated"
+        else
+            echo "  WARN: $pkg still reports deprecated='$current'" >&2
+        fi
+    else
+        if [[ -n "$current" ]]; then
+            echo "  OK: $pkg deprecated"
+        else
+            echo "  WARN: $pkg did not report a deprecated field after deprecate" >&2
+        fi
+    fi
+done
+
+echo
+if [[ ${#failed[@]} -gt 0 ]]; then
+    echo "Failed packages:"
+    printf '  - %s\n' "${failed[@]}"
+    exit 1
+fi
+echo "Done."


### PR DESCRIPTION
## Summary

- Drops the 7 `@posthog/rrweb*` packages from the release publish matrix in `.github/workflows/release.yml`. They now live as workspace deps only and are bundled into `posthog-js` at build time.
- Adds them to `.changeset/config.json` `ignore` so changesets stops bumping their versions and stops producing changelog entries for them (matching the pattern already used for `@posthog/rrweb-all`, `@posthog/rrweb-replay`, etc.).
- Ships `scripts/deprecate-rrweb-packages.sh` for marking existing versions on the npm registry as deprecated with a migration message pointing consumers at `posthog-js`.

## Why

Since #3510 moved `posthog-rrweb` into this monorepo, `posthog-js` consumes the rrweb packages via `workspace:*` and bundles them into the browser SDK in `packages/browser/src/entrypoints/{recorder,posthog-recorder}.ts`. External consumers should install `posthog-js`, not the standalone `@posthog/rrweb*` packages. Continuing to publish them is dead weight and a potential source of version skew between the bundled recorder shipped inside `posthog-js` and the npm-published copies.

The 7 affected packages:

- `@posthog/rrweb`
- `@posthog/rrweb-types`
- `@posthog/rrweb-utils`
- `@posthog/rrdom`
- `@posthog/rrweb-snapshot`
- `@posthog/rrweb-record`
- `@posthog/rrweb-plugin-console-record`

## Test plan

- [ ] CI is green on this PR
- [ ] After merge, the next release run does **not** include `Publish packages (@posthog/rrweb*)` jobs in the matrix
- [ ] After merge, `pnpm bump` on a subsequent changeset does not bump versions in `packages/rrweb/**/package.json`
- [ ] `scripts/deprecate-rrweb-packages.sh` dry-run prints `npm deprecate` commands for all 7 packages without making any registry changes
- [ ] Once a maintainer with `@posthog` npm publish rights runs `scripts/deprecate-rrweb-packages.sh --apply`, `npm view @posthog/rrweb deprecated` (and the other 6) returns the migration message

## Follow-ups (not blocking this PR)

- Run `scripts/deprecate-rrweb-packages.sh --apply` on the registry once this lands so existing consumers get the warning.
- Watch npm download numbers for the 7 packages and consider unpublishing or further communication after a sensible deprecation window.


Made with [Cursor](https://cursor.com)