### PR TITLE
fix(release): drop @posthog/rrweb* from changesets ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,22 +8,5 @@
     "baseBranch": "main",
     "updateInternalDependencies": "patch",
     "bumpVersionsWithWorkspaceProtocolOnly": true,
-    "ignore": [
-        "rrdom-nodejs",
-        "@posthog/rrweb",
-        "@posthog/rrweb-types",
-        "@posthog/rrweb-utils",
-        "@posthog/rrdom",
-        "@posthog/rrweb-snapshot",
-        "@posthog/rrweb-record",
-        "@posthog/rrweb-plugin-console-record",
-        "@posthog/rrweb-replay",
-        "@posthog/rrweb-packer",
-        "@posthog/rrweb-all",
-        "@posthog/rrweb-plugin-console-replay",
-        "@posthog/rrweb-plugin-sequential-id-record",
-        "@posthog/rrweb-plugin-sequential-id-replay",
-        "@posthog/rrweb-plugin-canvas-webrtc-record",
-        "@posthog/rrweb-plugin-canvas-webrtc-replay"
-    ]
+    "ignore": []
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,10 +230,8 @@ jobs:
                     # are consumed as `workspace:*` devDependencies of `posthog-js`,
                     # then bundled into the browser SDK at build time (see
                     # `packages/browser/src/entrypoints/{recorder,posthog-recorder}.ts`).
-                    # We deliberately do NOT publish them to npm — their entries
-                    # in `.changeset/config.json` `ignore` ensure no version bumps
-                    # are produced for them either. To deprecate already-published
-                    # versions on npm, run `scripts/deprecate-rrweb-packages.sh`.
+                    # We deliberately do NOT publish them to npm — they are
+                    # omitted from this matrix on purpose.
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
## Summary

`pnpm bump` started failing in the Release workflow with a `ValidationError` from `@changesets/config`:

```
🦋  error ValidationError: Some errors occurred when validating the changesets config:
🦋  error The package "posthog-js" depends on the ignored package "@posthog/rrweb-types", but "posthog-js" is not being ignored. Please add "posthog-js" to the `ignore` option.
🦋  error The package "posthog-js" depends on the ignored package "@posthog/rrweb-record", but "posthog-js" is not being ignored. Please add "posthog-js" to the `ignore` option.
🦋  error The package "posthog-js" depends on the ignored package "@posthog/rrweb-plugin-console-record", but "posthog-js" is not being ignored. Please add "posthog-js" to the `ignore` option.
```

Changesets requires every dependent of an ignored package to also be ignored. `posthog-js` consumes those three rrweb packages as `workspace:*` devDependencies (they get bundled into the recorder entrypoint at build time, see `packages/browser/src/entrypoints/{recorder,posthog-recorder}.ts`). Adding `posthog-js` itself to `ignore` would stop publishing the SDK, which we obviously don't want.

The original goal of the `ignore` list (added in #3532) was to keep the `@posthog/rrweb*` packages off npm. That's already enforced independently by the `publish` matrix in `release.yml`, which simply doesn't list them. Dropping the entries from `ignore` therefore restores `pnpm bump` without changing what actually reaches npm — the rrweb packages may now receive internal version bumps and CHANGELOG entries, but they are still never published.

Also updates the explanatory comment in the publish matrix so the rationale matches reality (matrix-omission, not changesets-ignore).

## Test plan

- [x] `pnpm bump` no longer hits the `ValidationError` locally (now only fails on the unrelated `GITHUB_TOKEN` requirement of `@posthog-tooling/changelog`, which CI provides)
- [x] `pnpm turbo --filter=posthog-js build --dry=json` still includes all 6 rrweb workspace build tasks before `posthog-js#build` (no Turbo build-graph regression)
- [ ] Release workflow runs `pnpm bump && pnpm generate-references` cleanly on next merge to main


Made with [Cursor](https://cursor.com)