### PR TITLE
chore(replay): bump posthog-js to ship canvas context-lost fix

### DIFF
--- a/.changeset/posthog-js-canvas-context-lost.md
+++ b/.changeset/posthog-js-canvas-context-lost.md
@@ -1,0 +1,10 @@
+---
+'posthog-js': patch
+---
+
+Pull in the canvas-manager fix from `@posthog/rrweb` 0.0.61: skip canvas
+snapshots while the WebGL context is lost so transparent bitmaps don't
+poison the worker's fingerprint dedup map and silently kill canvas
+recording for the rest of the session. Also wraps `getCanvas()` in
+try/catch so DOM/shadow-root traversal errors can't cancel the rAF
+loop. See PR #3527 for context.


### PR DESCRIPTION
## Problem

PR #3527 landed a canvas-manager fix on main, but no published `posthog-js` version contains it. The release bot ran after that PR merged and bumped the internal `@posthog/rrweb` packages (per the changeset there), but `packages/browser/package.json` is still at the pre-fix version.

The reason: `posthog-js` consumes `@posthog/rrweb-record` as a `devDependency` (via `workspace:*`), since rrweb is bundled into the browser SDK at build time. Changesets' `updateInternalDependencies: "patch"` rule doesn't propagate through devDependencies, so my original changeset bumping `@posthog/rrweb` and `@posthog/rrweb-record` didn't trigger a corresponding `posthog-js` bump.

## Changes

Adds a `posthog-js: patch` changeset so the next release picks up the fix and ships it to end users.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code (the fix itself in #3527)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file