### PR TITLE
fix(replay): stop rrweb before destroying sessionManager on cookieless opt-out

### DIFF
--- a/.changeset/fix-cookieless-opt-out-rrweb-teardown.md
+++ b/.changeset/fix-cookieless-opt-out-rrweb-teardown.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix: stop session recording before destroying sessionManager in `opt_out_capturing()` with `cookieless_mode: "on_reject"`. Previously, queued/throttled rrweb events (e.g. mousemove) could fire after the sessionManager was set to `undefined` and throw `[SessionRecording] must be started with a valid sessionManager`. Also adds a defensive early-return in `onRRwebEmit` so any remaining late events bail out instead of throwing.

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -2694,10 +2694,12 @@ describe('Lazy SessionRecording', () => {
 
             // simulate sessionManager teardown (cookieless opt-out) before a late rrweb event
             ;(posthog as any).sessionManager = undefined
+            ;(posthog.capture as jest.Mock).mockClear()
 
             expect(() =>
                 sessionRecording.onRRwebEmit(createIncrementalSnapshot({ data: { source: 1 } }) as eventWithTime)
             ).not.toThrow()
+            expect(posthog.capture).not.toHaveBeenCalled()
         })
     })
 

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -2692,9 +2692,7 @@ describe('Lazy SessionRecording', () => {
                 })
             )
 
-            // Simulate opt_out_capturing in cookieless_mode "on_reject":
-            // sessionManager is destroyed and cleared on the parent posthog instance,
-            // but a queued/throttled rrweb event can still fire after stopRecording.
+            // simulate sessionManager teardown (cookieless opt-out) before a late rrweb event
             ;(posthog as any).sessionManager = undefined
 
             expect(() =>

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -2700,7 +2700,6 @@ describe('Lazy SessionRecording', () => {
                 sessionRecording.onRRwebEmit(createIncrementalSnapshot({ data: { source: 1 } }) as eventWithTime)
             ).not.toThrow()
             expect(posthog.capture).not.toHaveBeenCalled()
-            expect(posthog.capture).not.toHaveBeenCalled()
         })
     })
 

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -2682,6 +2682,25 @@ describe('Lazy SessionRecording', () => {
             )
             expect(sessionRecording.stopRecording).toHaveBeenCalled()
         })
+
+        it('does not throw on rrweb emit after sessionManager is gone (regression for #58017)', () => {
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({
+                    sessionRecording: {
+                        endpoint: '/s/',
+                    },
+                })
+            )
+
+            // Simulate opt_out_capturing in cookieless_mode "on_reject":
+            // sessionManager is destroyed and cleared on the parent posthog instance,
+            // but a queued/throttled rrweb event can still fire after stopRecording.
+            ;(posthog as any).sessionManager = undefined
+
+            expect(() =>
+                sessionRecording.onRRwebEmit(createIncrementalSnapshot({ data: { source: 1 } }) as eventWithTime)
+            ).not.toThrow()
+        })
     })
 
     describe('sampling', () => {

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -2700,6 +2700,7 @@ describe('Lazy SessionRecording', () => {
                 sessionRecording.onRRwebEmit(createIncrementalSnapshot({ data: { source: 1 } }) as eventWithTime)
             ).not.toThrow()
             expect(posthog.capture).not.toHaveBeenCalled()
+            expect(posthog.capture).not.toHaveBeenCalled()
         })
     })
 

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1035,6 +1035,14 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     }
 
     onRRwebEmit(rawEvent: eventWithTime) {
+        // Defensive: if the parent posthog instance has torn down its sessionManager
+        // (e.g. opt_out_capturing in cookieless_mode "on_reject") we may still receive a
+        // queued/throttled rrweb event after stop. Bail out instead of throwing when the
+        // _sessionManager getter is later accessed.
+        if (!this._instance.sessionManager) {
+            return
+        }
+
         this._processQueuedEvents()
 
         if (!rawEvent || !isObject(rawEvent)) {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1035,10 +1035,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     }
 
     onRRwebEmit(rawEvent: eventWithTime) {
-        // Defensive: if the parent posthog instance has torn down its sessionManager
-        // (e.g. opt_out_capturing in cookieless_mode "on_reject") we may still receive a
-        // queued/throttled rrweb event after stop. Bail out instead of throwing when the
-        // _sessionManager getter is later accessed.
+        // late event after sessionManager teardown (e.g. cookieless opt-out) — _sessionManager would throw
         if (!this._instance.sessionManager) {
             return
         }

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -3663,12 +3663,15 @@ export class PostHog implements PostHogInterface {
                 distinct_id: COOKIELESS_SENTINEL_VALUE,
                 $device_id: null,
             })
+            // Stop session recording before destroying sessionManager so rrweb observers
+            // are torn down first — otherwise queued/throttled rrweb events can fire after
+            // sessionManager is gone and throw.
+            this.sessionRecording?.stopRecording()
+            this.sessionRecording = undefined
             this.sessionManager?.destroy()
             this.pageViewManager?.destroy()
             this.sessionManager = undefined
             this.sessionPropsManager = undefined
-            this.sessionRecording?.stopRecording()
-            this.sessionRecording = undefined
             this._captureInitialPageview()
         }
     }

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -3663,9 +3663,7 @@ export class PostHog implements PostHogInterface {
                 distinct_id: COOKIELESS_SENTINEL_VALUE,
                 $device_id: null,
             })
-            // Stop session recording before destroying sessionManager so rrweb observers
-            // are torn down first — otherwise queued/throttled rrweb events can fire after
-            // sessionManager is gone and throw.
+            // tear down rrweb observers before sessionManager goes away — late events would throw
             this.sessionRecording?.stopRecording()
             this.sessionRecording = undefined
             this.sessionManager?.destroy()


### PR DESCRIPTION
## Problem

Reported in PostHog/posthog#58017.

When a user transitions from opted-in to opted-out via `opt_out_capturing()` with `cookieless_mode: "on_reject"`, the session manager is torn down but rrweb observer hooks (e.g. mousemove callbacks) remain active. When those callbacks fire, they try to access `_sessionManager`, which no longer exists, and throw:

```
Uncaught Error: [SessionRecording] must be started with a valid sessionManager.
    at get _sessionManager (lazy-loaded-session-recorder.ts)
    at _updateWindowAndSessionIds (lazy-loaded-session-recorder.ts)
    at onRRwebEmit (lazy-loaded-session-recorder.ts)
```

## Changes

- In `posthog-core.ts` `opt_out_capturing()`, call `sessionRecording.stopRecording()` (and clear the field) **before** destroying `sessionManager`. rrweb observers are torn down before the manager goes away.
- Add a defensive early-return in `LazyLoadedSessionRecording.onRRwebEmit()` so any queued/throttled rrweb event that still fires after teardown bails out instead of throwing.
- Add a regression test in `lazy-sessionrecording.test.ts` that simulates the post-teardown emit.
- Add a changeset.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*