### PR TITLE
ci: strip content hashes from bundled-size diff filenames

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -47,3 +47,4 @@ jobs:
       - uses: preactjs/compressed-size-action@946a292cd35bd1088e0d7eb92b69d1a8d5b5d76a # pin v2.8.0
         with:
           compression: "none"
+          strip-hash: '-(\w{8})\.'


### PR DESCRIPTION
## Summary

The Bundled Size CI check was reporting rollup chunks like `types-D5C8ej05.cjs` and `types-yQPl9Qhh.js` as `+N kB (new file)` on every PR. They aren't new — the source changed, so the rollup content hash changed, and `preactjs/compressed-size-action` was comparing names verbatim. The result is a phantom delete + new file pair on every chunked source change, which drowns the real signal.

`compressed-size-action` already handles this via a `strip-hash` regex input (capture-group contents replaced with `*` before name comparison) — we just weren't passing it.

This PR adds:

```yaml
strip-hash: '-(\w{8})\.'
```

to `.github/workflows/bundled-size.yaml`. It captures the 8-character rollup hash sandwiched between the chunk name and its first extension dot, normalising every variant we emit:

| input                          | normalised                    |
|--------------------------------|-------------------------------|
| `types-D5C8ej05.cjs`           | `types-********.cjs`          |
| `types-yQPl9Qhh.js`            | `types-********.js`           |
| `types-D5C8ej05.umd.cjs`       | `types-********.umd.cjs`      |
| `types-D5C8ej05.umd.min.cjs`   | `types-********.umd.min.cjs`  |

`\w` does not match `-`, so chunk names that contain dashes (e.g. `vendor-react-utils.js`) cannot be misread as a hash. The trailing `\.` anchor keeps the match tight to the hash position.

## Test plan

- [ ] Bundled Size check runs on this PR.
- [ ] PR comment reports rrweb-snapshot chunks under their normalised (`*`) names.
- [ ] No `(new file)` annotations for chunks whose source merely changed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*