### PR TITLE
fix: set default next pages export to client version, matching the default export

### DIFF
--- a/.changeset/posthog-next-pages-default-client.md
+++ b/.changeset/posthog-next-pages-default-client.md
@@ -1,0 +1,5 @@
+---
+'@posthog/next': patch
+---
+
+Fix `@posthog/next/pages` default export condition to resolve to the client barrel (`pages.client.js`) instead of the server barrel (`pages.js`), matching the behavior of the root `"."` export. This prevents bundlers that don't match a more specific condition from pulling in `server-only` and `posthog-node` unnecessarily.

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -38,7 +38,7 @@
             "worker": "./dist/pages.edge.js",
             "browser": "./dist/pages.client.js",
             "react-server": "./dist/pages.js",
-            "default": "./dist/pages.js"
+            "default": "./dist/pages.client.js"
         }
     },
     "main": "./dist/index.client.js",

--- a/packages/next/tests/packaging.test.ts
+++ b/packages/next/tests/packaging.test.ts
@@ -50,7 +50,7 @@ describe('package.json#exports routing', () => {
         expect(pages.edge).toBe('./dist/pages.edge.js')
         expect(pages.worker).toBe('./dist/pages.edge.js')
         expect(pages['react-server']).toBe('./dist/pages.js')
-        expect(pages.default).toBe('./dist/pages.js')
+        expect(pages.default).toBe('./dist/pages.client.js')
     })
 
     it('. (root entry) keeps the existing per-runtime split intact', () => {


### PR DESCRIPTION
## Problem

Users importing from `@posthog/next/pages` in environments where no specific export condition matches (i.e. the `default` fallback is used) will resolve to the server barrel (`pages.js`), which transitively imports `server-only` and `posthog-node`. This causes build failures in client-side contexts. The root `"."` export already defaults to the client barrel, but `"./pages"` was inconsistent.

## Changes

Updated the `default` export condition for `"./pages"` in `package.json` from `./dist/pages.js` (server) to `./dist/pages.client.js` (client), matching the pattern used by the root `"."` export. Updated the corresponding packaging test assertion to reflect the new default.


## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [X] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [X] Tests for new code
- [X] Accounted for the impact of any changes across different platforms
- [X] Accounted for backwards compatibility of any changes (no breaking changes!)
- [X] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [X] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
