### PR TITLE
fix(replay): preserve recording remote config across posthog.reset()

### DIFF
--- a/.changeset/preserve-recording-config-on-reset.md
+++ b/.changeset/preserve-recording-config-on-reset.md
@@ -1,0 +1,16 @@
+---
+'posthog-js': patch
+---
+
+Preserve session-recording remote config across `posthog.reset()`.
+
+`posthog.reset()` was clearing the entire persistence store, which wiped
+`$session_recording_remote_config` along with user state. On the next session
+rotation triggered by the reset, `start('session_id_changed')` would early-return
+because the remote config was missing — leaving rrweb torn down and the new
+session opening with no Meta + FullSnapshot until the next periodic 5-minute
+checkout.
+
+This affected any flow where an app calls `posthog.reset()` mid-session
+(e.g. on sign-out / sign-in) and was particularly visible on Flutter Web
+recordings that depend on a fresh FullSnapshot to anchor the CanvasKit DOM.

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1329,6 +1329,45 @@ describe('Lazy SessionRecording', () => {
             })
         })
 
+        describe('rotation after persistence is cleared (posthog.reset)', () => {
+            beforeEach(() => {
+                sessionRecording.onRemoteConfig(
+                    makeFlagsResponse({
+                        sessionRecording: {
+                            endpoint: '/s/',
+                        },
+                    })
+                )
+            })
+
+            it('restarts rrweb on the rotation that follows posthog.reset() when remote config is preserved', () => {
+                // Sanity: the recorder started on remote-config arrival.
+                const recordMock = assignableWindow.__PosthogExtensions__.rrweb.record as Mock
+                expect(recordMock).toHaveBeenCalledTimes(1)
+
+                // Simulate posthog.reset() with the fix in place: snapshot the
+                // recording remote config, clear all persistence, then re-register
+                // the snapshotted config. This is exactly what posthog-core.ts does.
+                const preservedConfig = posthog.get_property(SESSION_RECORDING_REMOTE_CONFIG)
+                expect(preservedConfig).toBeDefined()
+                posthog.persistence?.clear()
+                posthog.persistence?.register({ [SESSION_RECORDING_REMOTE_CONFIG]: preservedConfig })
+
+                // resetSessionId() forces a new session id on the next
+                // checkAndGetSessionAndWindowId() call.
+                sessionManager.resetSessionId()
+                sessionId = 'rotated-session-id'
+
+                // An interactive event drives _updateWindowAndSessionIds, which
+                // detects the rotation and calls stop() then start('session_id_changed').
+                _emit(createIncrementalSnapshot({ data: { source: IncrementalSource.MouseInteraction } }))
+
+                // start('session_id_changed') was able to read remote config and
+                // restart rrweb — confirmed by a second record() call.
+                expect(recordMock).toHaveBeenCalledTimes(2)
+            })
+        })
+
         describe('when pageview capture is disabled', () => {
             beforeEach(() => {
                 jest.spyOn(sessionRecording, 'tryAddCustomEvent')

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -4,7 +4,7 @@ import * as globals from '../utils/globals'
 import { document, window } from '../utils/globals'
 import { uuidv7 } from '../uuidv7'
 import { isUndefined } from '@posthog/core'
-import { ENABLE_PERSON_PROCESSING, USER_STATE } from '../constants'
+import { ENABLE_PERSON_PROCESSING, SESSION_RECORDING_REMOTE_CONFIG, USER_STATE } from '../constants'
 import { createPosthogInstance, defaultPostHog } from './helpers/posthog-instance'
 import { PostHogConfig, RemoteConfig } from '../types'
 import { PostHog } from '../posthog-core'
@@ -1400,6 +1400,43 @@ describe('posthog core', () => {
 
                 expect(posthog.reloadFeatureFlags).toHaveBeenCalledTimes(3)
             })
+        })
+    })
+
+    describe('reset()', () => {
+        it('preserves session-recording remote config across reset()', async () => {
+            const posthog = await createPosthogInstance(uuidv7(), { persistence: 'memory' })
+
+            // Simulate the recording remote config landing in persistence,
+            // as RemoteConfigLoader would do after a /decide round trip.
+            const remoteConfig = {
+                cache_timestamp: Date.now(),
+                enabled: true,
+                endpoint: '/s/',
+                sampleRate: 0.5,
+                masking: { maskAllInputs: true },
+                canvasRecording: { enabled: true, fps: 4, quality: '0.6' },
+            }
+            posthog.persistence!.register({ [SESSION_RECORDING_REMOTE_CONFIG]: remoteConfig })
+
+            // And some user state that *should* be cleared.
+            posthog.persistence!.register({ some_user_prop: 'should-be-gone' })
+
+            posthog.reset()
+
+            // Recording remote config survives — without this, start('session_id_changed')
+            // bails on the next session rotation and the new session opens with no FullSnapshot.
+            expect(posthog.persistence!.props[SESSION_RECORDING_REMOTE_CONFIG]).toEqual(remoteConfig)
+
+            // User state is still cleared.
+            expect(posthog.persistence!.props['some_user_prop']).toBeUndefined()
+        })
+
+        it('does not crash when no recording remote config has been stored', async () => {
+            const posthog = await createPosthogInstance(uuidv7(), { persistence: 'memory' })
+
+            expect(() => posthog.reset()).not.toThrow()
+            expect(posthog.persistence!.props[SESSION_RECORDING_REMOTE_CONFIG]).toBeUndefined()
         })
     })
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -19,6 +19,7 @@ import {
     PEOPLE_DISTINCT_ID_KEY,
     SDK_DEBUG_EXTENSIONS_INIT_METHOD,
     SDK_DEBUG_EXTENSIONS_INIT_TIME_MS,
+    SESSION_RECORDING_REMOTE_CONFIG,
     SURVEYS_REQUEST_TIMEOUT_MS,
     USER_STATE,
     COOKIELESS_ALWAYS,
@@ -2746,9 +2747,21 @@ export class PostHog implements PostHogInterface {
             return logger.uninitializedWarning('posthog.reset')
         }
         const device_id = this.get_property(DEVICE_ID)
+        // Snapshot the session-recording remote config before clearing persistence.
+        // It's server-defined config (sample rate, masking, canvas, triggers, …),
+        // not user state, and must survive reset(). Otherwise start('session_id_changed')
+        // bails on the next session rotation: rrweb is torn down with no replacement
+        // and the new session opens with no FullSnapshot until the next periodic
+        // checkout (~5 min later).
+        const recordingRemoteConfig = this.get_property(SESSION_RECORDING_REMOTE_CONFIG)
+
         this.consent.reset()
         this.persistence?.clear()
         this.sessionPersistence?.clear()
+
+        if (!isUndefined(recordingRemoteConfig)) {
+            this.persistence?.register({ [SESSION_RECORDING_REMOTE_CONFIG]: recordingRemoteConfig })
+        }
         this.surveys?.reset()
         // Stop the refresh interval before resetting flags — featureFlags.reset() clears
         // the debouncer, so if the order were reversed a pending refresh could fire after reset.


### PR DESCRIPTION
## Problem

When an app calls `posthog.reset()` mid-session (e.g. on sign-out / sign-in), session recording can break for the new session: the recording opens with no Meta + FullSnapshot until the next periodic 5-minute checkout, leaving the player buffering against incremental events that reference an rrweb mirror it never received.

Root cause:

1. `posthog.reset()` calls `this.persistence?.clear()`, which removes **everything** from persistence, including `$session_recording_remote_config`.
2. `posthog.reset()` then calls `sessionManager.resetSessionId()`, which forces a session rotation on the next `checkAndGetSessionAndWindowId(...)` call.
3. The session rotation flows through `_updateWindowAndSessionIds` → `stop()` → `start('session_id_changed')`.
4. `start()` reads `_remoteConfig` (which is just `get_property(SESSION_RECORDING_REMOTE_CONFIG)`), gets `undefined`, and **early-returns** without calling `_startRecorder()`.
5. rrweb has been torn down by `stop()` but never restarted in the rotation path. Subsequent events flow once the SDK eventually re-fetches remote config — but they reference whatever rrweb mirror state was current when rotation happened, not a fresh FullSnapshot. The player buffers until the periodic checkout interval fires.

The remote config is server-defined recording configuration (sample rate, masking, canvas, network capture, triggers, …), not user state. There's no privacy or correctness reason for it to be wiped on `reset()`.

## Changes

- In `reset()`, snapshot `$session_recording_remote_config` before `persistence.clear()` and re-register it afterwards if it was present. Keys whose original value was `undefined` are not re-introduced.
- New `describe('reset()')` block in `posthog-core-also.test.ts` covering:
    - The recording remote config survives `reset()`, while regular user state still gets cleared.
    - `reset()` doesn't crash when no recording remote config has ever been stored.

Other persistence keys (per-session sampling decisions, trigger activations, etc.) correctly continue to be cleared, because they're tied to the session that's about to be discarded.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
