### PR TITLE
fix: guard iframe buffer cleanup race

### DIFF
--- a/.changeset/brave-iframes-clean.md
+++ b/.changeset/brave-iframes-clean.md
@@ -1,0 +1,5 @@
+---
+'@posthog/rrweb': patch
+---
+
+Fix iframe mutation buffer cleanup when iframe pagehide events overlap.

--- a/packages/rrweb/rrweb/src/record/observer.ts
+++ b/packages/rrweb/rrweb/src/record/observer.ts
@@ -379,7 +379,7 @@ function initViewportResizeObserver(
 export function findAndRemoveIframeBuffer(iframeEl: HTMLIFrameElement) {
   for (let i = mutationBuffers.length - 1; i >= 0; i--) {
     const buf = mutationBuffers[i];
-    if (buf.bufferBelongsToIframe(iframeEl)) {
+    if (buf?.bufferBelongsToIframe(iframeEl)) {
       buf.reset();
       mutationBuffers.splice(i, 1);
     }

--- a/packages/rrweb/rrweb/test/record/memory-leaks.test.ts
+++ b/packages/rrweb/rrweb/test/record/memory-leaks.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 import record from '../../src/record';
-import { mutationBuffers } from '../../src/record/observer';
+import {
+  findAndRemoveIframeBuffer,
+  mutationBuffers,
+} from '../../src/record/observer';
 import { IframeManager } from '../../src/record/iframe-manager';
 import type { eventWithTime } from '@posthog/rrweb-types';
 import { createMirror } from '@posthog/rrweb-snapshot';
@@ -787,6 +790,24 @@ describe('memory leak prevention', () => {
       expect(mutationBuffers.length).toBe(buffersWithIframes - 3);
 
       stopRecording?.();
+    });
+
+    it('should not throw when mutationBuffers shrinks during iframe cleanup', () => {
+      const iframe = document.createElement('iframe');
+      const nonMatchingBuffer = {
+        bufferBelongsToIframe: () => false,
+        reset: () => {},
+      };
+      const matchingBuffer = {
+        bufferBelongsToIframe: () => true,
+        reset: () => {
+          mutationBuffers.length = 0;
+        },
+      };
+
+      mutationBuffers.push(nonMatchingBuffer as any, matchingBuffer as any);
+
+      expect(() => findAndRemoveIframeBuffer(iframe)).not.toThrow();
     });
 
     it('should cleanup observers via safety net when iframe becomes inaccessible', async () => {


### PR DESCRIPTION
## Problem

Multiple same-origin iframes can fire `pagehide` close together during navigation or tab close. `findAndRemoveIframeBuffer` iterates the shared `mutationBuffers` array while cleanup can shrink it, leaving an `undefined` entry that is dereferenced and reported as `Cannot read properties of undefined (reading 'bufferBelongsToIframe')`.

Fixes #3557.

## Changes

- Guard `findAndRemoveIframeBuffer` with optional chaining before calling `bufferBelongsToIframe`.
- Add a regression test that simulates `mutationBuffers` shrinking during iframe cleanup.
- Add a patch changeset for `@posthog/rrweb`.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

Additional affected package: `@posthog/rrweb`.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

Test note: attempted `pnpm --filter @posthog/rrweb retest -- test/record/memory-leaks.test.ts`, but local `node_modules` is missing/broken (`Cannot find module .../vitest.mjs`).
