### PR TITLE
fix: skip remote config refresh without document

### DIFF
--- a/.changeset/quiet-foxes-listen.md
+++ b/.changeset/quiet-foxes-listen.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/types': patch
+---
+
+Skip remote config background refreshes when no document is available.

--- a/packages/browser/src/__tests__/remote-config.test.ts
+++ b/packages/browser/src/__tests__/remote-config.test.ts
@@ -247,6 +247,30 @@ describe('RemoteConfigLoader', () => {
 
             loader.stop()
         })
+
+        it('skips refresh when no document is available', async () => {
+            try {
+                await jest.isolateModulesAsync(async () => {
+                    jest.doMock('../utils/globals', () => ({
+                        ...jest.requireActual('../utils/globals'),
+                        document: undefined,
+                    }))
+
+                    // Re-import with no globals document to simulate browser extension background contexts.
+                    const { RemoteConfigLoader: NoDocumentRemoteConfigLoader } = await import('../remote-config')
+                    const reloadFeatureFlags = jest.fn()
+
+                    new NoDocumentRemoteConfigLoader({
+                        _shouldDisableFlags: () => false,
+                        reloadFeatureFlags,
+                    } as any).refresh()
+
+                    expect(reloadFeatureFlags).not.toHaveBeenCalled()
+                })
+            } finally {
+                jest.dontMock('../utils/globals')
+            }
+        })
     })
 
     describe('configurable refresh interval', () => {

--- a/packages/browser/src/remote-config.ts
+++ b/packages/browser/src/remote-config.ts
@@ -90,7 +90,7 @@ export class RemoteConfigLoader {
      * is a no-op when flags are disabled. This avoids an unnecessary network round-trip.
      */
     refresh(): void {
-        if (this._instance._shouldDisableFlags() || document?.visibilityState === 'hidden') {
+        if (this._instance._shouldDisableFlags() || !document || document.visibilityState === 'hidden') {
             return
         }
 

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1350,7 +1350,7 @@ export interface PostHogConfig {
      * - **Disabled (0)**: No background refreshes. Flags only update on page load or manual `reloadFeatureFlags()` calls.
      *   Use this if you control flag updates manually or have infrequent flag changes.
      *
-     * Note: Refreshes are automatically skipped when the browser tab is hidden.
+     * Note: Refreshes are automatically skipped when the browser tab is hidden or no document is available.
      *
      * @default 300000 (5 minutes)
      */


### PR DESCRIPTION
## Problem

Browser extension background contexts may not have a `document` object. Remote config refreshes only skipped polling when `document.visibilityState === 'hidden'`, so extensions without a document kept refreshing feature flags in the background.

Fixes #3551.

## Changes

- Treat missing `document` as a non-visible context in `RemoteConfigLoader.refresh()`.
- Add a unit test that simulates no globals document and verifies refresh does not reload feature flags.
- Update the `remote_config_refresh_interval_ms` docs to mention refreshes are skipped when no document is available.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
