### PR TITLE
fix: use Vue error info in Nuxt capture

### DIFF
--- a/.changeset/smart-owls-fix.md
+++ b/.changeset/smart-owls-fix.md
@@ -1,0 +1,5 @@
+---
+'@posthog/nuxt': patch
+---
+
+Fix Vue error capture to report the Nuxt error info string instead of the component instance.

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -26,7 +26,8 @@
     "prepare": "nuxt prepare",
     "build": "nuxt-module-build build",
     "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test:unit": "node tests/vue-plugin.test.mjs"
   },
   "dependencies": {
     "@posthog/cli": "catalog:",

--- a/packages/nuxt/src/runtime/vue-plugin.ts
+++ b/packages/nuxt/src/runtime/vue-plugin.ts
@@ -25,7 +25,7 @@ export default defineNuxtPlugin({
     }
 
     if (autocaptureEnabled(posthogClientConfig)) {
-      nuxtApp.hook('vue:error', (error, info) => {
+      nuxtApp.hook('vue:error', (error, _target, info) => {
         posthog.captureException(error, { info })
       })
     }

--- a/packages/nuxt/tests/vue-plugin.test.mjs
+++ b/packages/nuxt/tests/vue-plugin.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const source = readFileSync(new URL('../src/runtime/vue-plugin.ts', import.meta.url), 'utf8')
+
+const executableSource = source
+  .replace(/^import .*$/gm, '')
+  .replace('export default defineNuxtPlugin({', 'return defineNuxtPlugin({')
+  .replace(/ as (PostHogCommon|PostHogClientConfig)/g, '')
+  .replace('function autocaptureEnabled(config: PostHogClientConfig): boolean', 'function autocaptureEnabled(config)')
+
+function loadPlugin({ posthog, useRuntimeConfig }) {
+  return new Function('defineNuxtPlugin', 'useRuntimeConfig', 'posthog', 'window', executableSource)(
+    plugin => plugin,
+    useRuntimeConfig,
+    posthog,
+    {},
+  )
+}
+
+function testVueErrorHandlerCapturesInfoString() {
+  const captureExceptionCalls = []
+  const posthog = {
+    __loaded: false,
+    init() {},
+    debug() {},
+    captureException(...args) {
+      captureExceptionCalls.push(args)
+    },
+  }
+  const useRuntimeConfig = () => ({
+    public: {
+      posthog: {
+        publicKey: 'test-token',
+        host: 'https://us.i.posthog.com',
+      },
+      posthogClientConfig: {
+        capture_exceptions: true,
+      },
+    },
+  })
+  const hookCalls = []
+  const plugin = loadPlugin({ posthog, useRuntimeConfig })
+
+  plugin.setup({
+    hook(name, handler) {
+      hookCalls.push([name, handler])
+    },
+  })
+
+  const vueErrorHandler = hookCalls.find(([name]) => name === 'vue:error')?.[1]
+  assert.equal(typeof vueErrorHandler, 'function')
+
+  const error = new Error('test Vue render error')
+  const target = { component: 'instance' }
+
+  vueErrorHandler(error, target, 'setup function')
+
+  assert.deepEqual(captureExceptionCalls, [[error, { info: 'setup function' }]])
+  assert.notEqual(captureExceptionCalls[0][1].info, target)
+}
+
+testVueErrorHandlerCapturesInfoString()


### PR DESCRIPTION
## Problem

`@posthog/nuxt` captures client-side Vue errors from Nuxt's `vue:error` hook. The hook passes `(err, instance, info)`, but the current handler treats the component instance as `info`, causing the Vue component instance to be sent as an event property and triggering Vue warnings in development.

Fixes #3548.

## Changes

- Update the Nuxt client plugin `vue:error` hook handler to ignore the component instance argument.
- Pass the third hook argument, the Vue error info string, to `posthog.captureException`.
- Add a focused unit test that verifies the captured exception uses the third hook argument and not the component instance.
- Add a `test:unit` script for `@posthog/nuxt`.
- Add a patch changeset for `@posthog/nuxt`.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [x] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
