### PR TITLE
fix: handle invalid session replay config JSON

### DIFF
--- a/.changeset/quiet-badgers-parse.md
+++ b/.changeset/quiet-badgers-parse.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Handle invalid persisted session replay config JSON gracefully

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -410,6 +410,26 @@ describe('Lazy SessionRecording', () => {
                 expect(result?.enabled).toBe(true)
             })
 
+            it('ignores invalid persisted JSON config when checking freshness', () => {
+                posthog.persistence?.register({
+                    [SESSION_RECORDING_REMOTE_CONFIG]: '{not json',
+                })
+
+                expect(sessionRecording['_isRemoteConfigFresh']()).toBe(false)
+                expect(posthog.get_property(SESSION_RECORDING_REMOTE_CONFIG)).toBe('{not json')
+            })
+
+            it('ignores invalid persisted JSON config when reading remote config', () => {
+                posthog.persistence?.register({
+                    [SESSION_RECORDING_REMOTE_CONFIG]: '{not json',
+                })
+
+                const result = sessionRecording['_lazyLoadedSessionRecording']['_remoteConfig']
+
+                expect(result).toBeUndefined()
+                expect(posthog.get_property(SESSION_RECORDING_REMOTE_CONFIG)).toBe('{not json')
+            })
+
             it('trusts stale config once recording has started (long-lived SPA)', () => {
                 expect(sessionRecording['_lazyLoadedSessionRecording'].isStarted).toBe(true)
 

--- a/packages/browser/src/__tests__/posthog-core.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.test.ts
@@ -585,5 +585,22 @@ describe('posthog core', () => {
             registerSpy.mockRestore()
             captureSpy.mockRestore()
         })
+
+        it('should not abort queued calls when one call throws', () => {
+            const posthog = defaultPostHog()
+            const captureSpy = jest.spyOn(posthog, 'capture').mockImplementation()
+            ;(posthog as any).parseInvalidJson = (payload: string) => JSON.parse(payload)
+
+            expect(() => {
+                posthog._execute_array([
+                    ['parseInvalidJson', '{not json'],
+                    ['capture', 'test-event'],
+                ])
+            }).not.toThrow()
+
+            expect(captureSpy).toHaveBeenCalledWith('test-event')
+            captureSpy.mockRestore()
+            delete (posthog as any).parseInvalidJson
+        })
     })
 })

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -743,7 +743,15 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         if (!persistedConfig) {
             return undefined
         }
-        const parsedConfig = isObject(persistedConfig) ? persistedConfig : JSON.parse(persistedConfig)
+        let parsedConfig: SessionRecordingPersistedConfig
+        try {
+            parsedConfig = isObject(persistedConfig) ? persistedConfig : JSON.parse(persistedConfig)
+        } catch (e) {
+            // Do not unregister here: the SDK only registers structured configs, and this read path should
+            // ignore corrupt legacy/external values without mutating persistence.
+            logger.warn('persisted remote config for session recording is invalid and will be ignored', e)
+            return undefined
+        }
 
         // Only check TTL if recording hasn't started yet
         // Once started, trust the config until a hard page load

--- a/packages/browser/src/extensions/replay/session-recording.ts
+++ b/packages/browser/src/extensions/replay/session-recording.ts
@@ -273,7 +273,15 @@ export class SessionRecording implements Extension {
         if (!persistedConfig) {
             return false
         }
-        const config = typeof persistedConfig === 'object' ? persistedConfig : JSON.parse(persistedConfig)
+        let config: SessionRecordingPersistedConfig
+        try {
+            config = typeof persistedConfig === 'object' ? persistedConfig : JSON.parse(persistedConfig)
+        } catch (e) {
+            // Do not unregister here: the SDK only registers structured configs, and this read path should
+            // ignore corrupt legacy/external values without mutating persistence.
+            logger.warn('persisted remote config for session recording is invalid and will be ignored', e)
+            return false
+        }
         // default to now so that configs persisted by older SDK versions
         // (which never set cache_timestamp) are treated as fresh
         const cacheTimestamp = config.cache_timestamp ?? Date.now()

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1090,7 +1090,11 @@ export class PostHog implements PostHogInterface {
                     if (isArray(fn_name)) {
                         capturing_calls.push(item) // chained call e.g. posthog.get_group().set()
                     } else if (isFunction(item)) {
-                        ;(item as any).call(this)
+                        try {
+                            ;(item as any).call(this)
+                        } catch (e) {
+                            logger.error('Error executing queued PostHog call', item, e)
+                        }
                     } else if (isArray(item) && fn_name === 'alias') {
                         alias_calls.push(item)
                     } else if (
@@ -1107,14 +1111,18 @@ export class PostHog implements PostHogInterface {
 
             const execute = function (calls: SnippetArrayItem[], thisArg: any) {
                 eachArray(calls, function (item) {
-                    if (isArray(item[0])) {
-                        // chained call
-                        let caller = thisArg
-                        each(item, function (call) {
-                            caller = caller[call[0]].apply(caller, call.slice(1))
-                        })
-                    } else {
-                        thisArg[item[0]].apply(thisArg, item.slice(1))
+                    try {
+                        if (isArray(item[0])) {
+                            // chained call
+                            let caller = thisArg
+                            each(item, function (call) {
+                                caller = caller[call[0]].apply(caller, call.slice(1))
+                            })
+                        } else {
+                            thisArg[item[0]].apply(thisArg, item.slice(1))
+                        }
+                    } catch (e) {
+                        logger.error('Error executing queued PostHog call', item, e)
                     }
                 })
             }


### PR DESCRIPTION
## Problem

Invalid JSON in persisted session replay config, or in a queued snippet call executed during SDK startup, can throw and interrupt PostHog initialization/queued call processing instead of failing gracefully.

Closes https://github.com/PostHog/posthog-js/issues/3540

## Changes

- Catch errors per item in `_execute_array` so one bad queued call does not abort later queued calls.
- Safely parse persisted session replay remote config in both freshness checks and lazy recorder config reads.
- Ignore invalid persisted replay config without mutating persistence.
- Add regression tests for queued-call failures and invalid persisted replay config JSON.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
