### PR TITLE
fix: handle unreadable console log properties

### DIFF
--- a/.changeset/fuzzy-keys-omit.md
+++ b/.changeset/fuzzy-keys-omit.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Prevent browser log capture from throwing when console arguments contain unreadable properties.

--- a/packages/browser/src/__tests__/entrypoints/logs.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/logs.test.ts
@@ -295,6 +295,38 @@ describe('logs entrypoint', () => {
             )
         })
 
+        it('should omit unreadable properties when logging', () => {
+            const originalConsoleLog = assignableWindow.console.log as jest.Mock
+            const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
+            initializeLogs(mockPostHog)
+
+            const objectWithUnreadableProperties: any = { readable: 'value' }
+            Object.defineProperty(objectWithUnreadableProperties, 'toJSON', {
+                get() {
+                    throw new Error('SecurityError')
+                },
+            })
+            Object.defineProperty(objectWithUnreadableProperties, 'unreadable', {
+                enumerable: true,
+                get() {
+                    throw new Error('SecurityError')
+                },
+            })
+
+            expect(() => assignableWindow.console.log(objectWithUnreadableProperties)).not.toThrow()
+
+            expect(originalConsoleLog).toHaveBeenCalledWith(objectWithUnreadableProperties)
+            expect(mockEmit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: '{"readable":"value"}',
+                    attributes: expect.objectContaining({
+                        readable: 'value',
+                    }),
+                })
+            )
+            expect(mockEmit.mock.calls[0][0].attributes).not.toHaveProperty('unreadable')
+        })
+
         it('should not add attributes_truncated when within limits', () => {
             const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
             initializeLogs(mockPostHog)

--- a/packages/browser/src/__tests__/entrypoints/logs.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/logs.test.ts
@@ -300,7 +300,7 @@ describe('logs entrypoint', () => {
             const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
             initializeLogs(mockPostHog)
 
-            const objectWithUnreadableProperties: any = { readable: 'value' }
+            const objectWithUnreadableProperties: any = {}
             Object.defineProperty(objectWithUnreadableProperties, 'toJSON', {
                 get() {
                     throw new Error('SecurityError')
@@ -312,6 +312,7 @@ describe('logs entrypoint', () => {
                     throw new Error('SecurityError')
                 },
             })
+            objectWithUnreadableProperties.readable = 'value'
 
             expect(() => assignableWindow.console.log(objectWithUnreadableProperties)).not.toThrow()
 

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -5,7 +5,7 @@ import { resourceFromAttributes } from '@opentelemetry/resources'
 
 import { assignableWindow } from '../utils/globals'
 import { PostHog } from '../posthog-core'
-import { isNull, isObject } from '@posthog/core'
+import { isArray, isNull, isObject } from '@posthog/core'
 
 const setupOpenTelemetry = (posthog: PostHog) => {
     const serviceName = posthog.config.logs?.serviceName || 'posthog-browser-logs'
@@ -44,6 +44,61 @@ const setupOpenTelemetry = (posthog: PostHog) => {
 const LOG_BODY_SIZE_LIMIT = 10000
 const LOG_ATTRIBUTES_LIMIT = 50
 
+// This protects console logging from throwing when JSON.stringify hits unreadable properties.
+// The fallback safely copies readable properties and omits unreadable ones.
+// E.g., cross origin windows, exceptions raised in property getter
+const sanitizeForStringify = (value: any, seen = new WeakSet()): any => {
+    if (!isObject(value) && !isArray(value)) {
+        return value
+    }
+
+    if (seen.has(value)) {
+        return '[Circular]'
+    }
+    seen.add(value)
+
+    const result: any = isArray(value) ? [] : {}
+    let keys: string[]
+    try {
+        keys = Object.keys(value)
+    } catch {
+        return undefined
+    }
+    for (const key of keys) {
+        try {
+            result[key] = sanitizeForStringify(value[key], seen)
+        } catch {
+            // omit properties that cannot be read
+        }
+    }
+
+    if (value instanceof Error) {
+        try {
+            result.name = value.name
+        } catch {}
+        try {
+            result.message = value.message
+        } catch {}
+        try {
+            result.stack = value.stack
+        } catch {}
+    }
+
+    return result
+}
+
+const stringifySafely = (value: any, replacer: (_: any, value: any) => any): string | undefined => {
+    try {
+        return JSON.stringify(value, replacer)
+    } catch {
+        try {
+            return JSON.stringify(sanitizeForStringify(value))
+        } catch {
+            return undefined
+        }
+    }
+}
+
 /**
  * Flattens a nested object into a single level dot-notation object.
  * By default limit to 200kB or 50 keys.
@@ -62,8 +117,11 @@ const flattenObject = (
     }
     seen.add(obj)
 
-    for (const key in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+    try {
+        for (const key in obj) {
+            if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+                continue
+            }
             const value = obj[key]
             const newKey = prefix ? `${prefix}.${key}` : key
 
@@ -81,6 +139,8 @@ const flattenObject = (
                 }
             }
         }
+    } catch {
+        // we'll omit this object's properties considering we can't enumerate them
     }
     return result
 }
@@ -132,7 +192,7 @@ const initializeLogs = (posthog: PostHog) => {
             (originalConsoleLog: any) =>
             (...args: any[]) => {
                 if (args.length > 0) {
-                    let body = args.map((a) => JSON.stringify(a, createReplacer())).join(' ')
+                    let body = args.map((a) => stringifySafely(a, createReplacer())).join(' ')
                     if (body.length > LOG_BODY_SIZE_LIMIT) {
                         body = body.slice(0, LOG_BODY_SIZE_LIMIT) + '...'
                         attributes.body_truncated = 'true'

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -119,24 +119,28 @@ const flattenObject = (
 
     try {
         for (const key in obj) {
-            if (!Object.prototype.hasOwnProperty.call(obj, key)) {
-                continue
-            }
-            const value = obj[key]
-            const newKey = prefix ? `${prefix}.${key}` : key
-
-            if (isObject(value)) {
-                flattenObject(value, newKey, result, keys_limit, size_limit, seen)
-            } else {
-                keys_limit -= 1
-                size_limit -= String(value).length
-                size_limit -= newKey.length
-                if (keys_limit <= 0 || size_limit <= 0) {
-                    result['attributes_truncated'] = true
-                    return
-                } else {
-                    result[newKey] = value
+            try {
+                if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+                    continue
                 }
+                const value = obj[key]
+                const newKey = prefix ? `${prefix}.${key}` : key
+
+                if (isObject(value)) {
+                    flattenObject(value, newKey, result, keys_limit, size_limit, seen)
+                } else {
+                    keys_limit -= 1
+                    size_limit -= String(value).length
+                    size_limit -= newKey.length
+                    if (keys_limit <= 0 || size_limit <= 0) {
+                        result['attributes_truncated'] = true
+                        return
+                    } else {
+                        result[newKey] = value
+                    }
+                }
+            } catch {
+                continue
             }
         }
     } catch {

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -66,7 +66,7 @@ const sanitizeForStringify = (value: any, seen = new WeakSet()): any => {
     }
     for (const key of keys) {
         try {
-            result[key] = sanitizeForStringify(value[key], seen)
+            result[key] = sanitizeForStringify((value as any)[key], seen)
         } catch {
             // omit properties that cannot be read
         }


### PR DESCRIPTION
## Problem

Browser log capture can throw an uncaught `SecurityError` when console arguments contain objects with unreadable properties, such as a cross-origin `Window`. In that case `JSON.stringify` can fail before the original console method is called, so customers may need to disable console log capture.

See https://posthoghelp.zendesk.com/agent/tickets/57618 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/59130)

## Changes

- Add a safe stringify fallback for browser console log capture that copies readable properties and omits properties that throw when read.
- Keep the existing replacer as the normal fast path for circular references and Error serialization.
- Guard attribute flattening so unreadable objects do not crash log capture.
- Add a regression test covering unreadable `toJSON` and enumerable properties while preserving the original console call.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
