### PR TITLE
fix: validate native gzip output

### DIFF
--- a/.changeset/native-gzip-validation.md
+++ b/.changeset/native-gzip-validation.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/core': patch
+---
+
+Validate native gzip output before sending requests and fall back when CompressionStream returns malformed data.

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -594,6 +594,11 @@ describe('request', () => {
             jest.doMock('@posthog/core', () => ({
                 ...jest.requireActual('@posthog/core'),
                 gzipCompress: mockedIsolatedGzipCompress,
+                isNativeAsyncGzipError: (error: unknown) =>
+                    error &&
+                    typeof error === 'object' &&
+                    'name' in error &&
+                    (error.name === 'NotReadableError' || error.name === 'NativeGzipValidationError'),
             }))
 
             isolatedRequestModule = await import('../request')

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -640,6 +640,46 @@ describe('request', () => {
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
         })
 
+        it('falls back to fflate and disables native async gzip after invalid native gzip output', async () => {
+            mockedIsolatedGzipCompress.mockRejectedValueOnce({ name: 'NativeGzipValidationError' })
+
+            isolatedRequestModule.request({
+                url: 'https://any.posthog-instance.com?ver=1.23.45',
+                data: { foo: 'bar' },
+                headers: {},
+                callback: jest.fn(),
+                transport: 'fetch',
+                method: 'POST',
+                compression: isolatedCompression.GZipJS,
+            })
+
+            await flushPromises()
+
+            expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
+            expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
+            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
+
+            mockedIsolatedFetch.mockClear()
+
+            isolatedRequestModule.request({
+                url: 'https://any.posthog-instance.com?ver=1.23.45',
+                data: { foo: 'baz' },
+                headers: {},
+                callback: jest.fn(),
+                transport: 'fetch',
+                method: 'POST',
+                compression: isolatedCompression.GZipJS,
+            })
+
+            await flushPromises()
+
+            expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
+            expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
+            expect(mockedIsolatedFetch.mock.calls[0][0]).toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
+        })
+
         it('starts with native async gzip enabled in a fresh module instance', async () => {
             mockedIsolatedGzipCompress.mockResolvedValueOnce(new Blob(['compressed'], { type: 'text/plain' }))
 

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -8,7 +8,7 @@ import { AbortController, CompressionStream, fetch, navigator, XMLHttpRequest } 
 import { gzipSync, strToU8 } from 'fflate'
 
 import { _base64Encode } from './utils/encode-utils'
-import { gzipCompress, isNativeAsyncGzipReadError } from '@posthog/core'
+import { gzipCompress, isNativeAsyncGzipError, isNativeAsyncGzipReadError } from '@posthog/core'
 
 interface RequestWithEncodedBody extends RequestWithOptions {
     _encodedBody?: EncodedBody
@@ -353,12 +353,7 @@ export const request = (_options: RequestWithOptions) => {
                     return
                 }
 
-                if (
-                    error &&
-                    typeof error === 'object' &&
-                    'name' in error &&
-                    error.name === 'NativeGzipValidationError'
-                ) {
+                if (isNativeAsyncGzipError(error)) {
                     nativeAsyncGzipDisabled = true
                 }
 

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -353,6 +353,15 @@ export const request = (_options: RequestWithOptions) => {
                     return
                 }
 
+                if (
+                    error &&
+                    typeof error === 'object' &&
+                    'name' in error &&
+                    error.name === 'NativeGzipValidationError'
+                ) {
+                    nativeAsyncGzipDisabled = true
+                }
+
                 // If async compression fails for another reason, fall back to the synchronous fflate path
                 transportMethod(options)
             })

--- a/packages/core/src/__tests__/gzip.spec.ts
+++ b/packages/core/src/__tests__/gzip.spec.ts
@@ -1,4 +1,4 @@
-import { isGzipSupported, gzipCompress, isNativeAsyncGzipReadError } from '@/gzip'
+import { isGzipSupported, gzipCompress, isNativeAsyncGzipError, isNativeAsyncGzipReadError } from '@/gzip'
 import { gzip } from 'node:zlib'
 import { randomBytes, randomUUID } from 'node:crypto'
 import { promisify } from 'node:util'
@@ -72,11 +72,19 @@ describe('gzip', () => {
   describe('isNativeAsyncGzipReadError', () => {
     it('returns true for NotReadableError', () => {
       expect(isNativeAsyncGzipReadError({ name: 'NotReadableError' })).toBe(true)
+      expect(isNativeAsyncGzipError({ name: 'NotReadableError' })).toBe(true)
+    })
+
+    it('returns true for native gzip validation errors', () => {
+      expect(isNativeAsyncGzipReadError({ name: 'NativeGzipValidationError' })).toBe(false)
+      expect(isNativeAsyncGzipError({ name: 'NativeGzipValidationError' })).toBe(true)
     })
 
     it('returns false for other errors', () => {
       expect(isNativeAsyncGzipReadError({ name: 'TypeError' })).toBe(false)
+      expect(isNativeAsyncGzipError({ name: 'TypeError' })).toBe(false)
       expect(isNativeAsyncGzipReadError(null)).toBe(false)
+      expect(isNativeAsyncGzipError(null)).toBe(false)
     })
   })
   describe('gzipCompress', () => {
@@ -121,6 +129,35 @@ describe('gzip', () => {
       try {
         await expect(gzipCompress(API_TEST_INPUT, false, { rethrow: true })).rejects.toBe(writeError)
         expect(abort).toHaveBeenCalledWith(writeError)
+      } finally {
+        ;(globalThis as any).CompressionStream = CompressionStream
+      }
+    })
+
+    it('rejects malformed native gzip output when no stream error is thrown', async () => {
+      const CompressionStream = globalThis.CompressionStream
+
+      ;(globalThis as any).CompressionStream = jest.fn(() => ({
+        writable: {
+          getWriter: () => ({
+            write: jest.fn(() => Promise.resolve()),
+            close: jest.fn(() => Promise.resolve()),
+            abort: jest.fn(() => Promise.resolve()),
+          }),
+        },
+        readable: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array([1, 2, 3, 4]))
+            controller.close()
+          },
+        }),
+      }))
+
+      try {
+        await expect(gzipCompress(API_TEST_INPUT, false, { rethrow: true })).rejects.toHaveProperty(
+          'name',
+          'NativeGzipValidationError'
+        )
       } finally {
         ;(globalThis as any).CompressionStream = CompressionStream
       }

--- a/packages/core/src/gzip.ts
+++ b/packages/core/src/gzip.ts
@@ -11,6 +11,8 @@ export function isGzipSupported(): boolean {
   )
 }
 
+const NATIVE_GZIP_VALIDATION_ERROR = 'NativeGzipValidationError'
+
 export const isNativeAsyncGzipReadError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') {
     return false
@@ -19,6 +21,72 @@ export const isNativeAsyncGzipReadError = (error: unknown): boolean => {
   const name = 'name' in error ? String(error.name) : ''
 
   return name === 'NotReadableError'
+}
+
+export const isNativeAsyncGzipError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const name = 'name' in error ? String(error.name) : ''
+
+  return isNativeAsyncGzipReadError(error) || name === NATIVE_GZIP_VALIDATION_ERROR
+}
+
+type NativeGzipValidationReason = 'too-short' | 'invalid-header' | 'invalid-crc' | 'invalid-size'
+
+let crc32Table: number[] | undefined
+
+const getCrc32Table = (): number[] => {
+  if (crc32Table) {
+    return crc32Table
+  }
+
+  crc32Table = []
+  for (let i = 0; i < 256; i++) {
+    let crc = i
+    for (let j = 0; j < 8; j++) {
+      crc = crc & 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1
+    }
+    crc32Table[i] = crc >>> 0
+  }
+  return crc32Table
+}
+
+const crc32 = (bytes: Uint8Array): number => {
+  const table = getCrc32Table()
+  let crc = 0xffffffff
+  for (let i = 0; i < bytes.length; i++) {
+    crc = table[(crc ^ bytes[i]) & 0xff] ^ (crc >>> 8)
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+const throwNativeGzipValidationError = (reason: NativeGzipValidationReason): never => {
+  const error = new Error(`Native gzip produced invalid output: ${reason}`)
+  error.name = NATIVE_GZIP_VALIDATION_ERROR
+  throw error
+}
+
+const validateNativeGzip = async (compressed: Blob, inputBytes: Uint8Array): Promise<void> => {
+  if (compressed.size < 18) {
+    throwNativeGzipValidationError('too-short')
+  }
+
+  const header = new Uint8Array(await compressed.slice(0, 10).arrayBuffer())
+  if (header[0] !== 0x1f || header[1] !== 0x8b || header[2] !== 0x08) {
+    throwNativeGzipValidationError('invalid-header')
+  }
+
+  const trailer = new DataView(await compressed.slice(compressed.size - 8).arrayBuffer())
+  if (trailer.getUint32(0, true) !== crc32(inputBytes)) {
+    throwNativeGzipValidationError('invalid-crc')
+  }
+
+  const inputSize = inputBytes.length >>> 0
+  if (trailer.getUint32(4, true) !== inputSize) {
+    throwNativeGzipValidationError('invalid-size')
+  }
 }
 
 export type GzipCompressOptions = {
@@ -36,11 +104,12 @@ export type GzipCompressOptions = {
  */
 export async function gzipCompress(input: string, isDebug = true, options?: GzipCompressOptions): Promise<Blob | null> {
   try {
+    const inputBytes = new TextEncoder().encode(input)
     const compressedStream = new CompressionStream('gzip')
     const writer = compressedStream.writable.getWriter()
 
     const writePromise = writer
-      .write(new TextEncoder().encode(input))
+      .write(inputBytes)
       .then(() => writer.close())
       .catch(async (err) => {
         try {
@@ -53,6 +122,7 @@ export async function gzipCompress(input: string, isDebug = true, options?: Gzip
     const responsePromise = new Response(compressedStream.readable).blob()
 
     const [compressed] = await Promise.all([responsePromise, writePromise])
+    await validateNativeGzip(compressed, inputBytes)
     return compressed
   } catch (error) {
     if (options?.rethrow) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { getFeatureFlagValue } from './featureFlagUtils'
-export { gzipCompress, isNativeAsyncGzipReadError } from './gzip'
+export { gzipCompress, isNativeAsyncGzipError, isNativeAsyncGzipReadError } from './gzip'
 export * from './utils'
 export * as ErrorTracking from './error-tracking'
 export {


### PR DESCRIPTION
## Problem

Native browser `CompressionStream("gzip")` can fail by resolving malformed or partial gzip output without throwing. When that happens, posthog-js sends the bad payload with gzip compression enabled and capture drops the event instead of retrying safely.

## Changes

- Validate native gzip output before returning it from `@posthog/core` by checking the gzip header, CRC32 trailer, and uncompressed size trailer.
- Throw a recognizable `NativeGzipValidationError` when native gzip output is malformed.
- Disable native async gzip for the current page lifetime after validation failures and fall back to the existing synchronous `fflate` gzip path, preserving compression.
- Add regression tests for malformed native gzip output and browser request fallback behavior.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
