### PR TITLE
fix(core): detect Oculus Browser instead of falling back to Chrome

### DIFF
--- a/.changeset/oculus-browser-detection.md
+++ b/.changeset/oculus-browser-detection.md
@@ -1,0 +1,5 @@
+---
+"@posthog/core": patch
+---
+
+Detect Oculus Browser (Meta Quest headsets) correctly instead of falling back to Chrome

--- a/packages/browser/src/__tests__/utils/user-agent-utils.test.ts
+++ b/packages/browser/src/__tests__/utils/user-agent-utils.test.ts
@@ -205,6 +205,25 @@ describe('user-agent-utils', () => {
                 expectedVersion: 28.0,
                 expectedBrowser: 'Chrome',
             },
+            {
+                // see https://github.com/PostHog/posthog-js/issues/3574
+                // Oculus Browser is Chromium-based, so its UA includes both
+                // `OculusBrowser` and `Chrome` (and on newer headsets also `SamsungBrowser`).
+                name: 'Oculus Browser on Quest 2',
+                userAgent:
+                    'Mozilla/5.0 (X11; Linux x86_64; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/27.0.0.4.7.391926553 SamsungBrowser/4.0 Chrome/100.0.4896.58 VR Safari/537.36',
+                vendor: '',
+                expectedVersion: 27.0,
+                expectedBrowser: 'Oculus Browser',
+            },
+            {
+                name: 'Oculus Browser on Quest 3 (no SamsungBrowser segment)',
+                userAgent:
+                    'Mozilla/5.0 (Linux; Android 12; Quest 3) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/30.0.0.5.10 Chrome/119.0.6045.193 VR Safari/537.36',
+                vendor: '',
+                expectedVersion: 30.0,
+                expectedBrowser: 'Oculus Browser',
+            },
         ]
 
         test.each(browserTestcases)('browser version %s', ({ userAgent, vendor, expectedVersion }) => {

--- a/packages/core/src/utils/user-agent-utils.ts
+++ b/packages/core/src/utils/user-agent-utils.ts
@@ -49,8 +49,7 @@ const GENERIC = 'Generic'
 const GENERIC_MOBILE = GENERIC + ' ' + MOBILE.toLowerCase()
 const GENERIC_TABLET = GENERIC + ' ' + TABLET.toLowerCase()
 const KONQUEROR = 'Konqueror'
-const OCULUS = 'Oculus'
-const OCULUS_BROWSER = OCULUS + ' Browser'
+const OCULUS_BROWSER = 'Oculus Browser'
 
 const BROWSER_VERSION_REGEX_SUFFIX = '(\\d+(\\.\\d+)?)'
 const DEFAULT_BROWSER_VERSION_REGEX = new RegExp('Version/' + BROWSER_VERSION_REGEX_SUFFIX)

--- a/packages/core/src/utils/user-agent-utils.ts
+++ b/packages/core/src/utils/user-agent-utils.ts
@@ -49,6 +49,8 @@ const GENERIC = 'Generic'
 const GENERIC_MOBILE = GENERIC + ' ' + MOBILE.toLowerCase()
 const GENERIC_TABLET = GENERIC + ' ' + TABLET.toLowerCase()
 const KONQUEROR = 'Konqueror'
+const OCULUS = 'Oculus'
+const OCULUS_BROWSER = OCULUS + ' Browser'
 
 const BROWSER_VERSION_REGEX_SUFFIX = '(\\d+(\\.\\d+)?)'
 const DEFAULT_BROWSER_VERSION_REGEX = new RegExp('Version/' + BROWSER_VERSION_REGEX_SUFFIX)
@@ -100,6 +102,13 @@ export const detectBrowser = function (user_agent: string, vendor: string | unde
   } else if (includes(user_agent, 'IE' + MOBILE) || includes(user_agent, 'WPDesktop')) {
     return INTERNET_EXPLORER_MOBILE
   }
+  // Oculus Browser (Meta Quest) is Chromium-based, so its UA includes
+  // `OculusBrowser` alongside `Chrome` (and sometimes `SamsungBrowser`).
+  // We must check for it before those, otherwise it would be misdetected.
+  // See https://github.com/PostHog/posthog-js/issues/3574
+  else if (includes(user_agent, 'OculusBrowser')) {
+    return OCULUS_BROWSER
+  }
   // https://developer.samsung.com/internet/user-agent-string-format
   else if (includes(user_agent, SAMSUNG_BROWSER)) {
     return SAMSUNG_INTERNET
@@ -150,6 +159,7 @@ const versionRegexes: Record<string, RegExp[]> = {
   [BLACKBERRY]: [new RegExp(BLACKBERRY + ' ' + BROWSER_VERSION_REGEX_SUFFIX), DEFAULT_BROWSER_VERSION_REGEX],
   [ANDROID_MOBILE]: [new RegExp('android\\s' + BROWSER_VERSION_REGEX_SUFFIX, 'i')],
   [SAMSUNG_INTERNET]: [new RegExp(SAMSUNG_BROWSER + '\\/' + BROWSER_VERSION_REGEX_SUFFIX)],
+  [OCULUS_BROWSER]: [new RegExp('OculusBrowser\\/' + BROWSER_VERSION_REGEX_SUFFIX)],
   [INTERNET_EXPLORER]: [new RegExp('(rv:|MSIE )' + BROWSER_VERSION_REGEX_SUFFIX)],
   Mozilla: [new RegExp('rv:' + BROWSER_VERSION_REGEX_SUFFIX)],
 }


### PR DESCRIPTION
## Problem

Events generated on Meta Quest headsets are reported with browser `Chrome`
instead of `Oculus` because the Oculus Browser user agent contains both
`OculusBrowser` and `Chrome` (and on newer firmware also `SamsungBrowser`),
and the existing detection order returns the first matching branch.

Closes #3574

## Fix

- Add `OculusBrowser` detection in `detectBrowser` *before* the
  `SamsungBrowser` / `Chrome` branches in `packages/core/src/utils/user-agent-utils.ts`.
- Add a corresponding entry in `versionRegexes` so `detectBrowserVersion`
  returns the actual Oculus Browser version.
- Constants follow the existing pre-uglifying string-concatenation style noted
  in the file header comment.

## Tests

Added two new cases to `packages/browser/src/__tests__/utils/user-agent-utils.test.ts`:

- Quest 2 UA (older format, with `SamsungBrowser` segment).
- Quest 3-style UA (no `SamsungBrowser` segment).

Both assert `expectedBrowser: 'Oculus Browser'` and the correct
`expectedVersion`, exercising the same `detectBrowser` / `detectBrowserVersion`
suite the other browsers in this file go through.

Reference UA list: https://whatmyuseragent.com/browser/oc/oculus-browser