### PR TITLE
fix(ai): preserve Error message, stack, and cause chain on $ai_error

### DIFF
--- a/packages/ai/src/captureAiGeneration.ts
+++ b/packages/ai/src/captureAiGeneration.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { uuidv7, ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { version } from '../package.json'
 import type { TokenUsage } from './types'
-import { AIEvent, CostOverride, getTokensSource, sanitizeValues, withPrivacyMode } from './utils'
+import { AIEvent, CostOverride, getTokensSource, sanitizeValues, serializeError, withPrivacyMode } from './utils'
 
 type AnthropicTool = AnthropicOriginal.Tool
 
@@ -115,7 +115,12 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
 
     errorData = {
       $ai_is_error: true,
-      $ai_error: sanitizeValues(JSON.stringify(options.error)),
+      // JSON.stringify on an Error instance drops `message`, `stack`, and the
+      // `cause` chain because those fields are non-enumerable, which made
+      // `$ai_error` show up as an empty-ish blob on the dashboard. Normalize
+      // Errors to plain objects first so the fields survive serialization.
+      // See https://github.com/PostHog/posthog-js/issues/3556
+      $ai_error: sanitizeValues(JSON.stringify(serializeError(options.error))),
       $exception_event_id: exceptionId,
     }
   }

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -591,6 +591,53 @@ export function sanitizeValues(obj: any): any {
   return jsonSafe
 }
 
+/**
+ * Convert an unknown thrown value into a JSON-serializable representation that
+ * preserves Error fields the engine marks non-enumerable (`name`, `message`,
+ * `stack`, `cause`), so they survive `JSON.stringify` for storage on
+ * `$ai_error`. Recurses into the `cause` chain and into any own enumerable
+ * properties (e.g. SDK-attached fields like `status`, `response`,
+ * `validationError`). Tracks a `seen` set to guard against circular cause
+ * graphs. Non-object inputs are returned as-is.
+ *
+ * Fixes https://github.com/PostHog/posthog-js/issues/3556
+ */
+export function serializeError(err: unknown, seen: WeakSet<object> = new WeakSet()): unknown {
+  if (err === null || (typeof err !== 'object' && typeof err !== 'function')) {
+    return err
+  }
+  if (seen.has(err as object)) {
+    return '[Circular]'
+  }
+  seen.add(err as object)
+  if (err instanceof Error) {
+    const obj: Record<string, unknown> = {
+      name: err.name,
+      message: err.message,
+      stack: err.stack,
+    }
+    if ('cause' in err && (err as { cause?: unknown }).cause !== undefined) {
+      obj.cause = serializeError((err as { cause: unknown }).cause, seen)
+    }
+    // Pick up own enumerable properties added by SDKs (statusCode, response, ...).
+    for (const key of Object.keys(err)) {
+      if (!(key in obj)) {
+        obj[key] = serializeError((err as Record<string, unknown>)[key], seen)
+      }
+    }
+    return obj
+  }
+  if (Array.isArray(err)) {
+    return err.map((v) => serializeError(v, seen))
+  }
+  // Plain object — recurse so nested Errors (e.g. inside `validationError`) are unwrapped too.
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(err as Record<string, unknown>)) {
+    out[k] = serializeError(v, seen)
+  }
+  return out
+}
+
 const POSTHOG_PARAMS_MAP: Record<keyof MonitoringParams, string> = {
   posthogDistinctId: 'distinctId',
   posthogTraceId: 'traceId',

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -600,6 +600,16 @@ export function sanitizeValues(obj: any): any {
  * `validationError`). Tracks a `seen` set to guard against circular cause
  * graphs. Non-object inputs are returned as-is.
  *
+ * NOTE: `seen` is shared across the entire traversal rather than scoped to the
+ * current ancestor path. Any object that appears at two distinct locations in
+ * the error structure — a "diamond" reference such as the same `response`
+ * object attached to both `err.response` and `err.cause.response` — will be
+ * serialized the first time it is encountered and replaced with `'[Circular]'`
+ * on subsequent visits, even when no actual cycle exists. This is intentional:
+ * it keeps allocation O(visited) and is correct for the primary use case
+ * (linear `cause` chains). Callers that need exact graph reproduction should
+ * not use this function.
+ *
  * Fixes https://github.com/PostHog/posthog-js/issues/3556
  */
 export function serializeError(err: unknown, seen: WeakSet<object> = new WeakSet()): unknown {

--- a/packages/ai/tests/captureAiGeneration.test.ts
+++ b/packages/ai/tests/captureAiGeneration.test.ts
@@ -143,6 +143,43 @@ describe('captureAiGeneration', () => {
     expect(properties.$ai_http_status).toBe(expected)
   })
 
+  // https://github.com/PostHog/posthog-js/issues/3556
+  it('serializes the message, stack, and cause chain of an Error onto $ai_error', async () => {
+    const client = buildClient()
+    const root = new Error('zod validation failed')
+    const middle = Object.assign(new Error('type validation'), { cause: root })
+    const top = Object.assign(new Error('gateway responded with error'), {
+      name: 'GatewayResponseError',
+      statusCode: 500,
+      cause: middle,
+    })
+
+    await captureAiGeneration(client, { ...baseRequiredOptions, error: top })
+
+    const properties = lastCaptureProperties(client)
+    const parsed = JSON.parse(properties.$ai_error as string)
+    expect(parsed.name).toBe('GatewayResponseError')
+    expect(parsed.message).toBe('gateway responded with error')
+    expect(parsed.statusCode).toBe(500)
+    expect(typeof parsed.stack).toBe('string')
+    expect(parsed.cause.message).toBe('type validation')
+    expect(parsed.cause.cause.message).toBe('zod validation failed')
+  })
+
+  it('marks circular cause chains instead of recursing forever on $ai_error', async () => {
+    const client = buildClient()
+    const a = new Error('a')
+    const b = Object.assign(new Error('b'), { cause: a })
+    ;(a as { cause?: unknown }).cause = b
+
+    await captureAiGeneration(client, { ...baseRequiredOptions, error: a })
+
+    const parsed = JSON.parse(lastCaptureProperties(client).$ai_error as string)
+    expect(parsed.message).toBe('a')
+    expect(parsed.cause.message).toBe('b')
+    expect(parsed.cause.cause).toBe('[Circular]')
+  })
+
   it('mutates the original error in place when autocapture is enabled, so callers can re-throw safely', async () => {
     const client = buildClient({ enableExceptionAutocapture: true })
     const error = new Error('boom')


### PR DESCRIPTION
## Problem

`JSON.stringify` on a JavaScript `Error` instance returns `{}` because
`name`, `message`, `stack`, and `cause` are non-enumerable. The
`captureAiGeneration` path stored `JSON.stringify(options.error)` directly
on ``, so events captured via `withTracing` ended up with a
stripped-down blob — no message, no stack, no usable cause chain — making
`GatewayResponseError` and friends nearly impossible to debug from the
dashboard.

Closes #3556

## Fix

- New `serializeError` helper in `packages/ai/src/utils.ts` that
  normalizes `Error` instances to plain objects (`name` / `message` /
  `stack` / `cause` plus own enumerable properties such as `statusCode`,
  `response`, `validationError`), recurses through the cause chain and
  through nested plain objects, and guards against circular cause graphs
  with a `WeakSet`.
- `captureAiGeneration` now passes the error through `serializeError`
  before `JSON.stringify`, so `` keeps the same string shape
  (backwards compatible with anything that already reads it as JSON text)
  but carries the actual error data.

## Tests

Added to `packages/ai/tests/captureAiGeneration.test.ts`:

- A three-level cause chain `Error` is captured and the test asserts
  `message`, `stack`, `statusCode`, and the recursive `cause` levels
  are all present on the parsed `` JSON.
- A circular cause chain is captured and the test asserts the inner cycle
  is replaced with `'[Circular]'` rather than overflowing the stack.

The existing `error path` parametric tests are untouched and still
assert `` is a string, so this is backwards compatible.

## Reproducer (from the issue)

The original reproducer aborts mid-stream against `@ai-sdk/gateway`;
after this change the dashboard's `` payload contains the
`GatewayResponseError` `message`, `statusCode`, and the full
`validationError` -> `ZodError` cause chain instead of a blob like
`{ statusCode: 500, cause: {}, name: 'GatewayResponseError' }`.