### PR TITLE
fix(node): remove generated reference entries from #3599

### DIFF
--- a/packages/node/references/posthog-node-references-5.33.4.json
+++ b/packages/node/references/posthog-node-references-5.33.4.json
@@ -1631,12 +1631,6 @@
       "path": "src/extensions/context/types.ts"
     },
     {
-      "id": "CookieStore",
-      "name": "CookieStore",
-      "properties": [],
-      "path": "../core/src/cookie.ts"
-    },
-    {
       "id": "EndBranching",
       "name": "EndBranching",
       "properties": [],
@@ -2105,29 +2099,6 @@
       "properties": [],
       "path": "../core/src/types.ts",
       "example": "{\n    uuid?: string;\n    timestamp?: Date;\n    disableGeoip?: boolean;\n    _originatedFromCaptureException?: boolean;\n}"
-    },
-    {
-      "id": "PostHogCookieState",
-      "name": "PostHogCookieState",
-      "properties": [
-        {
-          "type": "string",
-          "name": "deviceId"
-        },
-        {
-          "type": "string",
-          "name": "distinctId"
-        },
-        {
-          "type": "boolean",
-          "name": "isIdentified"
-        },
-        {
-          "type": "string",
-          "name": "sessionId"
-        }
-      ],
-      "path": "../core/src/cookie.ts"
     },
     {
       "id": "PostHogCoreOptions",

--- a/packages/node/references/posthog-node-references-latest.json
+++ b/packages/node/references/posthog-node-references-latest.json
@@ -1631,12 +1631,6 @@
       "path": "src/extensions/context/types.ts"
     },
     {
-      "id": "CookieStore",
-      "name": "CookieStore",
-      "properties": [],
-      "path": "../core/src/cookie.ts"
-    },
-    {
       "id": "EndBranching",
       "name": "EndBranching",
       "properties": [],
@@ -2105,29 +2099,6 @@
       "properties": [],
       "path": "../core/src/types.ts",
       "example": "{\n    uuid?: string;\n    timestamp?: Date;\n    disableGeoip?: boolean;\n    _originatedFromCaptureException?: boolean;\n}"
-    },
-    {
-      "id": "PostHogCookieState",
-      "name": "PostHogCookieState",
-      "properties": [
-        {
-          "type": "string",
-          "name": "deviceId"
-        },
-        {
-          "type": "string",
-          "name": "distinctId"
-        },
-        {
-          "type": "boolean",
-          "name": "isIdentified"
-        },
-        {
-          "type": "string",
-          "name": "sessionId"
-        }
-      ],
-      "path": "../core/src/cookie.ts"
     },
     {
       "id": "PostHogCoreOptions",


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
