### PR TITLE
fix: validate gzip body before browser send

### DIFF
--- a/.changeset/safe-gzip-send-boundary.md
+++ b/.changeset/safe-gzip-send-boundary.md
@@ -1,0 +1,6 @@
+---
+'@posthog/core': patch
+'posthog-js': patch
+---
+
+Validate gzip request bodies at the browser send boundary and fall back to JSON if the outgoing body is not gzip data.

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -25,6 +25,7 @@ const flushPromises = async () => {
     jest.useRealTimers()
 }
 
+const invalidGzipBody = () => new Uint8Array([0, 1, 2]).buffer
 const bodyData = () => ({ key: uuidv7() })
 const arrayOfBodyData = (n: number) => {
     const arr = []
@@ -203,6 +204,25 @@ describe('request', () => {
                 json: undefined,
                 text: 'oh no!',
             })
+        })
+
+        it('falls back to JSON if a pre-encoded gzip body is not actually gzip before fetch send', () => {
+            request(
+                createRequest({
+                    method: 'POST',
+                    compression: Compression.GZipJS,
+                    data: { foo: 'bar' },
+                    _encodedBody: {
+                        contentType: 'text/plain',
+                        body: invalidGzipBody(),
+                        estimatedSize: 3,
+                    },
+                } as any)
+            )
+
+            expect(mockedFetch.mock.calls[0][0]).not.toContain('compression=gzip-js')
+            expect(mockedFetch.mock.calls[0][1].body).toBe('{"foo":"bar"}')
+            expect((mockedFetch.mock.calls[0][1].headers as Headers).get('Content-Type')).toBe('application/json')
         })
 
         it('supports nextOptions parameter', async () => {
@@ -434,6 +454,26 @@ describe('request', () => {
                     'application/x-www-form-urlencoded'
                 )
             })
+
+            it('falls back to JSON if a pre-encoded gzip body is not actually gzip before XHR send', () => {
+                request(
+                    createRequest({
+                        url: 'https://any.posthog-instance.com/',
+                        method: 'POST',
+                        compression: Compression.GZipJS,
+                        data: { foo: 'bar' },
+                        _encodedBody: {
+                            contentType: 'text/plain',
+                            body: invalidGzipBody(),
+                            estimatedSize: 3,
+                        },
+                    } as any)
+                )
+
+                expect(mockedXHR.open.mock.calls[0][1]).not.toContain('compression=gzip-js')
+                expect(mockedXHR.send.mock.calls[0][0]).toBe('{"foo":"bar"}')
+                expect(mockedXHR.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/json')
+            })
         })
 
         describe('sendBeacon', () => {
@@ -530,6 +570,32 @@ describe('request', () => {
                 )
 
                 expect(mockedNavigator?.sendBeacon).not.toHaveBeenCalled()
+            })
+
+            it('falls back to JSON if a pre-encoded gzip body is not actually gzip before beacon send', async () => {
+                request(
+                    createRequest({
+                        url: 'https://any.posthog-instance.com/',
+                        method: 'POST',
+                        compression: Compression.GZipJS,
+                        data: { foo: 'bar' },
+                        _encodedBody: {
+                            contentType: 'text/plain',
+                            body: invalidGzipBody(),
+                            estimatedSize: 3,
+                        },
+                    } as any)
+                )
+
+                expect(mockedNavigator?.sendBeacon.mock.calls[0][0]).not.toContain('compression=gzip-js')
+                const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
+                expect(blob.type).toBe('application/json')
+                const result = await new Promise<string>((resolve) => {
+                    const reader = new FileReader()
+                    reader.onload = () => resolve(reader.result as string)
+                    reader.readAsText(blob)
+                })
+                expect(result).toBe('{"foo":"bar"}')
             })
 
             it.each([
@@ -685,8 +751,33 @@ describe('request', () => {
             expect(mockedIsolatedFetch.mock.calls[0][1].body).toBeInstanceOf(ArrayBuffer)
         })
 
+        it('falls back to JSON if native async gzip resolves a non-gzip body before sending', async () => {
+            mockedIsolatedGzipCompress.mockResolvedValueOnce({
+                arrayBuffer: () => Promise.resolve(invalidGzipBody()),
+            })
+
+            isolatedRequestModule.request({
+                url: 'https://any.posthog-instance.com?ver=1.23.45',
+                data: { foo: 'bar' },
+                headers: {},
+                callback: jest.fn(),
+                transport: 'fetch',
+                method: 'POST',
+                compression: isolatedCompression.GZipJS,
+            })
+
+            await flushPromises()
+
+            expect(mockedIsolatedGzipCompress).toHaveBeenCalledTimes(1)
+            expect(mockedIsolatedFetch).toHaveBeenCalledTimes(1)
+            expect(mockedIsolatedFetch.mock.calls[0][0]).not.toContain('&compression=gzip-js')
+            expect(mockedIsolatedFetch.mock.calls[0][1].body).toBe('{"foo":"bar"}')
+        })
+
         it('starts with native async gzip enabled in a fresh module instance', async () => {
-            mockedIsolatedGzipCompress.mockResolvedValueOnce(new Blob(['compressed'], { type: 'text/plain' }))
+            mockedIsolatedGzipCompress.mockResolvedValueOnce({
+                arrayBuffer: () => Promise.resolve(new Uint8Array([0x1f, 0x8b]).buffer),
+            })
 
             isolatedRequestModule.request({
                 url: 'https://any.posthog-instance.com?ver=1.23.45',

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -206,24 +206,62 @@ describe('request', () => {
             })
         })
 
-        it('falls back to JSON if a pre-encoded gzip body is not actually gzip before fetch send', () => {
-            request(
-                createRequest({
-                    method: 'POST',
-                    compression: Compression.GZipJS,
-                    data: { foo: 'bar' },
-                    _encodedBody: {
-                        contentType: 'text/plain',
-                        body: invalidGzipBody(),
-                        estimatedSize: 3,
-                    },
-                } as any)
-            )
+        const invalidPreEncodedGzipRequest = (overrides?: Partial<RequestWithOptions>) =>
+            createRequest({
+                method: 'POST',
+                compression: Compression.GZipJS,
+                data: { foo: 'bar' },
+                _encodedBody: {
+                    contentType: 'text/plain',
+                    body: invalidGzipBody(),
+                    estimatedSize: 3,
+                },
+                ...overrides,
+            } as any)
 
-            expect(mockedFetch.mock.calls[0][0]).not.toContain('compression=gzip-js')
-            expect(mockedFetch.mock.calls[0][1].body).toBe('{"foo":"bar"}')
-            expect((mockedFetch.mock.calls[0][1].headers as Headers).get('Content-Type')).toBe('application/json')
-        })
+        it.each([
+            [
+                'fetch',
+                { transport: 'fetch' as const },
+                () => {
+                    expect(mockedFetch.mock.calls[0][0]).not.toContain('compression=gzip-js')
+                    expect(mockedFetch.mock.calls[0][1].body).toBe('{"foo":"bar"}')
+                    expect((mockedFetch.mock.calls[0][1].headers as Headers).get('Content-Type')).toBe(
+                        'application/json'
+                    )
+                },
+            ],
+            [
+                'XHR',
+                { transport: 'XHR' as const, url: 'https://any.posthog-instance.com/' },
+                () => {
+                    expect(mockedXHR.open.mock.calls[0][1]).not.toContain('compression=gzip-js')
+                    expect(mockedXHR.send.mock.calls[0][0]).toBe('{"foo":"bar"}')
+                    expect(mockedXHR.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/json')
+                },
+            ],
+            [
+                'sendBeacon',
+                { transport: 'sendBeacon' as const, url: 'https://any.posthog-instance.com/' },
+                async () => {
+                    expect(mockedNavigator?.sendBeacon.mock.calls[0][0]).not.toContain('compression=gzip-js')
+                    const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
+                    expect(blob.type).toBe('application/json')
+                    const result = await new Promise<string>((resolve) => {
+                        const reader = new FileReader()
+                        reader.onload = () => resolve(reader.result as string)
+                        reader.readAsText(blob)
+                    })
+                    expect(result).toBe('{"foo":"bar"}')
+                },
+            ],
+        ])(
+            'falls back to JSON if a pre-encoded gzip body is not actually gzip before %s send',
+            async (_name, overrides, assertTransport) => {
+                request(invalidPreEncodedGzipRequest(overrides))
+                await assertTransport()
+            }
+        )
 
         it('supports nextOptions parameter', async () => {
             request(
@@ -454,26 +492,6 @@ describe('request', () => {
                     'application/x-www-form-urlencoded'
                 )
             })
-
-            it('falls back to JSON if a pre-encoded gzip body is not actually gzip before XHR send', () => {
-                request(
-                    createRequest({
-                        url: 'https://any.posthog-instance.com/',
-                        method: 'POST',
-                        compression: Compression.GZipJS,
-                        data: { foo: 'bar' },
-                        _encodedBody: {
-                            contentType: 'text/plain',
-                            body: invalidGzipBody(),
-                            estimatedSize: 3,
-                        },
-                    } as any)
-                )
-
-                expect(mockedXHR.open.mock.calls[0][1]).not.toContain('compression=gzip-js')
-                expect(mockedXHR.send.mock.calls[0][0]).toBe('{"foo":"bar"}')
-                expect(mockedXHR.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/json')
-            })
         })
 
         describe('sendBeacon', () => {
@@ -570,32 +588,6 @@ describe('request', () => {
                 )
 
                 expect(mockedNavigator?.sendBeacon).not.toHaveBeenCalled()
-            })
-
-            it('falls back to JSON if a pre-encoded gzip body is not actually gzip before beacon send', async () => {
-                request(
-                    createRequest({
-                        url: 'https://any.posthog-instance.com/',
-                        method: 'POST',
-                        compression: Compression.GZipJS,
-                        data: { foo: 'bar' },
-                        _encodedBody: {
-                            contentType: 'text/plain',
-                            body: invalidGzipBody(),
-                            estimatedSize: 3,
-                        },
-                    } as any)
-                )
-
-                expect(mockedNavigator?.sendBeacon.mock.calls[0][0]).not.toContain('compression=gzip-js')
-                const blob = mockedNavigator?.sendBeacon.mock.calls[0][1] as Blob
-                expect(blob.type).toBe('application/json')
-                const result = await new Promise<string>((resolve) => {
-                    const reader = new FileReader()
-                    reader.onload = () => resolve(reader.result as string)
-                    reader.readAsText(blob)
-                })
-                expect(result).toBe('{"foo":"bar"}')
             })
 
             it.each([

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -1,14 +1,20 @@
 import { each, find } from './utils'
 import Config from './config'
 import { Compression, RequestWithOptions, RequestResponse } from './types'
-import { formDataToQuery } from './utils/request-utils'
+import { formDataToQuery, getQueryParam } from './utils/request-utils'
 
 import { logger } from './utils/logger'
 import { AbortController, CompressionStream, fetch, navigator, XMLHttpRequest } from './utils/globals'
 import { gzipSync, strToU8 } from 'fflate'
 
 import { _base64Encode } from './utils/encode-utils'
-import { gzipCompress, isNativeAsyncGzipError, isNativeAsyncGzipReadError } from '@posthog/core'
+import {
+    gzipCompress,
+    isGzipData,
+    isGzipRequest,
+    isNativeAsyncGzipError,
+    isNativeAsyncGzipReadError,
+} from '@posthog/core'
 
 interface RequestWithEncodedBody extends RequestWithOptions {
     _encodedBody?: EncodedBody
@@ -29,10 +35,31 @@ const SIXTY_FOUR_KILOBYTES = 64 * 1024
 const KEEP_ALIVE_THRESHOLD = SIXTY_FOUR_KILOBYTES * 0.8
 let nativeAsyncGzipDisabled = false
 
+const removeURLParam = (url: string, param: string): string => {
+    const [urlWithoutHash, hash] = url.split('#')
+    const [baseUrl, search] = urlWithoutHash.split('?')
+
+    if (!search) {
+        return url
+    }
+
+    const updatedSearch = search
+        .split('&')
+        .filter((pair) => pair.split('=')[0] !== param)
+        .join('&')
+
+    return `${baseUrl}${updatedSearch ? `?${updatedSearch}` : ''}${hash ? `#${hash}` : ''}`
+}
+
 type EncodedBody = {
     contentType: string
     body: string | BlobPart | ArrayBuffer
     estimatedSize: number
+}
+
+type EncodedRequest = {
+    url: string
+    encodedBody?: EncodedBody
 }
 
 /**
@@ -114,6 +141,29 @@ const encodePostData = (options: RequestWithEncodedBody): EncodedBody | undefine
     }
 }
 
+const encodePostDataSafely = (options: RequestWithEncodedBody): EncodedRequest => {
+    const encodedBody = encodePostData(options)
+
+    if (
+        !encodedBody ||
+        !isGzipRequest(options.compression, getQueryParam(options.url, 'compression')) ||
+        isGzipData(encodedBody.body)
+    ) {
+        return { url: options.url, encodedBody }
+    }
+
+    nativeAsyncGzipDisabled = true
+
+    return {
+        url: removeURLParam(options.url, 'compression'),
+        encodedBody: encodePostData({
+            ...options,
+            compression: undefined,
+            _encodedBody: undefined,
+        }),
+    }
+}
+
 /**
  * Pre-encode the request body using async native CompressionStream.
  * This avoids blocking the main thread with fflate's synchronous gzip,
@@ -142,8 +192,9 @@ const preEncodeAsync = async (options: RequestWithEncodedBody): Promise<RequestW
 
 const xhr = (options: RequestWithOptions) => {
     const req = new XMLHttpRequest!()
-    req.open(options.method || 'GET', options.url, true)
-    const { contentType, body } = encodePostData(options) ?? {}
+    const { url, encodedBody } = encodePostDataSafely(options)
+    req.open(options.method || 'GET', url, true)
+    const { contentType, body } = encodedBody ?? {}
 
     each(options.headers, function (headerValue, headerName) {
         req.setRequestHeader(headerName, headerValue)
@@ -183,7 +234,8 @@ const xhr = (options: RequestWithOptions) => {
 }
 
 const _fetch = (options: RequestWithOptions) => {
-    const { contentType, body, estimatedSize } = encodePostData(options) ?? {}
+    const { url, encodedBody } = encodePostDataSafely(options)
+    const { contentType, body, estimatedSize } = encodedBody ?? {}
 
     // eslint-disable-next-line compat/compat
     const headers = new Headers()
@@ -195,7 +247,6 @@ const _fetch = (options: RequestWithOptions) => {
         headers.append('Content-Type', contentType)
     }
 
-    const url = options.url
     let aborter: { signal: any; timeout: ReturnType<typeof setTimeout> } | null = null
 
     if (AbortController) {
@@ -252,12 +303,12 @@ const _sendBeacon = (options: RequestWithOptions) => {
     // beacon documentation https://w3c.github.io/beacon/
     // beacons format the message and use the type property
 
-    const url = extendURLParams(options.url, {
-        beacon: '1',
-    })
-
     try {
-        const { contentType, body } = encodePostData(options) ?? {}
+        const { url: safeUrl, encodedBody } = encodePostDataSafely(options)
+        const url = extendURLParams(safeUrl, {
+            beacon: '1',
+        })
+        const { contentType, body } = encodedBody ?? {}
         if (!body) {
             return
         }

--- a/packages/core/src/__tests__/gzip.spec.ts
+++ b/packages/core/src/__tests__/gzip.spec.ts
@@ -77,21 +77,25 @@ describe('gzip', () => {
     })
   })
   describe('isGzipData', () => {
-    it('checks for the gzip magic header in ArrayBuffer and ArrayBufferView bodies', () => {
-      expect(isGzipData(new Uint8Array([0x1f, 0x8b]).buffer)).toBe(true)
-      expect(isGzipData(new Uint8Array([0, 0x1f, 0x8b]).subarray(1))).toBe(true)
-      expect(isGzipData(new Uint8Array([0, 1, 2]).buffer)).toBe(false)
-      expect(isGzipData('not gzip')).toBe(false)
-      expect(isGzipData(new Blob([new Uint8Array([0x1f, 0x8b])]))).toBe(false)
+    it.each([
+      ['ArrayBuffer with gzip magic', new Uint8Array([0x1f, 0x8b]).buffer, true],
+      ['ArrayBufferView with gzip magic', new Uint8Array([0, 0x1f, 0x8b]).subarray(1), true],
+      ['ArrayBuffer without gzip magic', new Uint8Array([0, 1, 2]).buffer, false],
+      ['string body', 'not gzip', false],
+      ['Blob body', new Blob([new Uint8Array([0x1f, 0x8b])]), false],
+    ])('returns %s => %s', (_name, input, expected) => {
+      expect(isGzipData(input)).toBe(expected)
     })
   })
   describe('isGzipRequest', () => {
-    it('detects gzip compression from request options and URL params', () => {
-      expect(isGzipRequest('gzip-js')).toBe(true)
-      expect(isGzipRequest(undefined, 'gzip-js')).toBe(true)
-      expect(isGzipRequest(undefined, 'gzip')).toBe(true)
-      expect(isGzipRequest('base64', 'base64')).toBe(false)
-      expect(isGzipRequest(undefined, undefined)).toBe(false)
+    it.each([
+      ['option gzip-js', 'gzip-js', undefined, true],
+      ['url gzip-js', undefined, 'gzip-js', true],
+      ['url gzip', undefined, 'gzip', true],
+      ['base64', 'base64', 'base64', false],
+      ['no compression', undefined, undefined, false],
+    ])('returns %s => %s', (_name, compression, urlCompression, expected) => {
+      expect(isGzipRequest(compression, urlCompression)).toBe(expected)
     })
   })
   describe('isNativeAsyncGzipReadError', () => {

--- a/packages/core/src/__tests__/gzip.spec.ts
+++ b/packages/core/src/__tests__/gzip.spec.ts
@@ -1,4 +1,11 @@
-import { isGzipSupported, gzipCompress, isNativeAsyncGzipError, isNativeAsyncGzipReadError } from '@/gzip'
+import {
+  isGzipSupported,
+  gzipCompress,
+  isGzipData,
+  isGzipRequest,
+  isNativeAsyncGzipError,
+  isNativeAsyncGzipReadError,
+} from '@/gzip'
 import { gzip } from 'node:zlib'
 import { randomBytes, randomUUID } from 'node:crypto'
 import { promisify } from 'node:util'
@@ -67,6 +74,24 @@ describe('gzip', () => {
       } finally {
         restoreDependency()
       }
+    })
+  })
+  describe('isGzipData', () => {
+    it('checks for the gzip magic header in ArrayBuffer and ArrayBufferView bodies', () => {
+      expect(isGzipData(new Uint8Array([0x1f, 0x8b]).buffer)).toBe(true)
+      expect(isGzipData(new Uint8Array([0, 0x1f, 0x8b]).subarray(1))).toBe(true)
+      expect(isGzipData(new Uint8Array([0, 1, 2]).buffer)).toBe(false)
+      expect(isGzipData('not gzip')).toBe(false)
+      expect(isGzipData(new Blob([new Uint8Array([0x1f, 0x8b])]))).toBe(false)
+    })
+  })
+  describe('isGzipRequest', () => {
+    it('detects gzip compression from request options and URL params', () => {
+      expect(isGzipRequest('gzip-js')).toBe(true)
+      expect(isGzipRequest(undefined, 'gzip-js')).toBe(true)
+      expect(isGzipRequest(undefined, 'gzip')).toBe(true)
+      expect(isGzipRequest('base64', 'base64')).toBe(false)
+      expect(isGzipRequest(undefined, undefined)).toBe(false)
     })
   })
   describe('isNativeAsyncGzipReadError', () => {

--- a/packages/core/src/gzip.ts
+++ b/packages/core/src/gzip.ts
@@ -1,3 +1,5 @@
+import { Compression } from './types'
+
 /**
  * Older browsers and some runtimes don't support this yet
  * This API (as of 2025-05-07) is not available on React Native.
@@ -12,6 +14,29 @@ export function isGzipSupported(): boolean {
 }
 
 const NATIVE_GZIP_VALIDATION_ERROR = 'NativeGzipValidationError'
+const GZIP_MAGIC_FIRST_BYTE = 0x1f
+const GZIP_MAGIC_SECOND_BYTE = 0x8b
+const GZIP_DEFLATE_METHOD = 0x08
+
+const hasGzipMagic = (bytes: Uint8Array): boolean => {
+  return bytes.length >= 2 && bytes[0] === GZIP_MAGIC_FIRST_BYTE && bytes[1] === GZIP_MAGIC_SECOND_BYTE
+}
+
+export const isGzipData = (body: unknown): boolean => {
+  if (body instanceof ArrayBuffer) {
+    return hasGzipMagic(new Uint8Array(body))
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    return hasGzipMagic(new Uint8Array(body.buffer, body.byteOffset, body.byteLength))
+  }
+
+  return false
+}
+
+export const isGzipRequest = (compression?: unknown, urlCompression?: unknown): boolean => {
+  return compression === Compression.GZipJS || urlCompression === Compression.GZipJS || urlCompression === 'gzip'
+}
 
 export const isNativeAsyncGzipReadError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') {
@@ -74,7 +99,7 @@ const validateNativeGzip = async (compressed: Blob, inputBytes: Uint8Array): Pro
   }
 
   const header = new Uint8Array(await compressed.slice(0, 10).arrayBuffer())
-  if (header[0] !== 0x1f || header[1] !== 0x8b || header[2] !== 0x08) {
+  if (!hasGzipMagic(header) || header[2] !== GZIP_DEFLATE_METHOD) {
     throwNativeGzipValidationError('invalid-header')
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { getFeatureFlagValue } from './featureFlagUtils'
-export { gzipCompress, isNativeAsyncGzipError, isNativeAsyncGzipReadError } from './gzip'
+export { gzipCompress, isGzipData, isGzipRequest, isNativeAsyncGzipError, isNativeAsyncGzipReadError } from './gzip'
 export * from './utils'
 export * as ErrorTracking from './error-tracking'
 export {


### PR DESCRIPTION
## Problem

Some browser requests can be marked as gzip-compressed even when the final outgoing body is not gzip data, causing capture to reject and drop events for affected users.

## Changes

- Add shared gzip helpers in `@posthog/core` to detect gzip request intent and gzip magic bytes.
- Reuse the gzip magic-byte check inside native gzip validation.
- Add a browser send-boundary guard for fetch, XHR, and sendBeacon: if a request claims gzip but the encoded body does not start with the gzip magic bytes, disable native async gzip for the page lifetime, remove the compression query param, and send JSON instead.
- Add regression coverage for fetch, XHR, sendBeacon, and native async gzip fallback paths.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
