### PR TITLE
fix: preserve error fields in $ai_error

### DIFF
--- a/.changeset/bright-crews-beg.md
+++ b/.changeset/bright-crews-beg.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': minor
+---
+
+Improved error serialization to capture cause, message and stack

--- a/packages/ai/src/captureAiGeneration.ts
+++ b/packages/ai/src/captureAiGeneration.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { uuidv7, ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { version } from '../package.json'
 import type { TokenUsage } from './types'
+import { serializeError } from './serializeError'
 import { AIEvent, CostOverride, getTokensSource, sanitizeValues, withPrivacyMode } from './utils'
 
 type AnthropicTool = AnthropicOriginal.Tool
@@ -115,7 +116,7 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
 
     errorData = {
       $ai_is_error: true,
-      $ai_error: sanitizeValues(JSON.stringify(options.error)),
+      $ai_error: JSON.stringify(sanitizeValues(serializeError(options.error))),
       $exception_event_id: exceptionId,
     }
   }

--- a/packages/ai/src/captureAiGeneration.ts
+++ b/packages/ai/src/captureAiGeneration.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { uuidv7, ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { version } from '../package.json'
 import type { TokenUsage } from './types'
-import { serializeError } from './serializeError'
+import { stringifyError } from './serializeError'
 import { AIEvent, CostOverride, getTokensSource, sanitizeValues, withPrivacyMode } from './utils'
 
 type AnthropicTool = AnthropicOriginal.Tool
@@ -116,7 +116,7 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
 
     errorData = {
       $ai_is_error: true,
-      $ai_error: JSON.stringify(sanitizeValues(serializeError(options.error))),
+      $ai_error: stringifyError(options.error),
       $exception_event_id: exceptionId,
     }
   }

--- a/packages/ai/src/langchain/callbacks.ts
+++ b/packages/ai/src/langchain/callbacks.ts
@@ -10,6 +10,7 @@ import type { DocumentInterface } from '@langchain/core/documents'
 import { ToolCall } from '@langchain/core/messages/tool'
 import { BaseMessage } from '@langchain/core/messages'
 import { sanitizeLangChain } from '../sanitization'
+import { serializeError } from '../serializeError'
 
 interface SpanMetadata {
   /** Name of the trace/span (e.g. chain name) */
@@ -376,7 +377,7 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
       eventProperties['$process_person_profile'] = false
     }
     if (outputs instanceof Error) {
-      eventProperties['$ai_error'] = outputs.toString()
+      eventProperties['$ai_error'] = JSON.stringify(serializeError(outputs))
       eventProperties['$ai_is_error'] = true
     } else if (outputs !== undefined) {
       eventProperties['$ai_output_state'] = withPrivacyMode(this.client, this.privacyMode, outputs)
@@ -436,7 +437,7 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
 
     if (output instanceof Error) {
       eventProperties['$ai_http_status'] = (output as any).status || 500
-      eventProperties['$ai_error'] = output.toString()
+      eventProperties['$ai_error'] = JSON.stringify(serializeError(output))
       eventProperties['$ai_is_error'] = true
     } else {
       // Handle token usage

--- a/packages/ai/src/langchain/callbacks.ts
+++ b/packages/ai/src/langchain/callbacks.ts
@@ -10,7 +10,7 @@ import type { DocumentInterface } from '@langchain/core/documents'
 import { ToolCall } from '@langchain/core/messages/tool'
 import { BaseMessage } from '@langchain/core/messages'
 import { sanitizeLangChain } from '../sanitization'
-import { serializeError } from '../serializeError'
+import { stringifyError } from '../serializeError'
 
 interface SpanMetadata {
   /** Name of the trace/span (e.g. chain name) */
@@ -377,7 +377,7 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
       eventProperties['$process_person_profile'] = false
     }
     if (outputs instanceof Error) {
-      eventProperties['$ai_error'] = JSON.stringify(serializeError(outputs))
+      eventProperties['$ai_error'] = stringifyError(outputs)
       eventProperties['$ai_is_error'] = true
     } else if (outputs !== undefined) {
       eventProperties['$ai_output_state'] = withPrivacyMode(this.client, this.privacyMode, outputs)
@@ -437,7 +437,7 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
 
     if (output instanceof Error) {
       eventProperties['$ai_http_status'] = (output as any).status || 500
-      eventProperties['$ai_error'] = JSON.stringify(serializeError(output))
+      eventProperties['$ai_error'] = stringifyError(output)
       eventProperties['$ai_is_error'] = true
     } else {
       // Handle token usage

--- a/packages/ai/src/serializeError.ts
+++ b/packages/ai/src/serializeError.ts
@@ -1,3 +1,5 @@
+import { sanitizeValues } from './utils'
+
 const DEFAULT_MAX_DEPTH = 3
 const MAX_STACK_LINES = 20
 
@@ -23,6 +25,17 @@ export function serializeError(value: unknown, depth = DEFAULT_MAX_DEPTH): unkno
     return value.map((item) => serializeError(item, depth - 1))
   }
   return value
+}
+
+export function stringifyError(error: unknown): string {
+  try {
+    return JSON.stringify(sanitizeValues(serializeError(error)))
+  } catch {
+    if (error instanceof Error) {
+      return JSON.stringify({ name: error.name, message: error.message })
+    }
+    return JSON.stringify({ message: String(error) })
+  }
 }
 
 function truncateStack(stack: string | undefined): string | undefined {

--- a/packages/ai/src/serializeError.ts
+++ b/packages/ai/src/serializeError.ts
@@ -1,0 +1,37 @@
+const DEFAULT_MAX_DEPTH = 3
+const MAX_STACK_LINES = 20
+
+export function serializeError(value: unknown, depth = DEFAULT_MAX_DEPTH): unknown {
+  if (depth < 0 || value === null || typeof value !== 'object') {
+    return value
+  }
+  if (value instanceof Error) {
+    const out: Record<string, unknown> = {
+      name: value.name,
+      message: value.message,
+      stack: truncateStack(value.stack),
+    }
+    for (const key of Object.keys(value)) {
+      out[key] = serializeError((value as unknown as Record<string, unknown>)[key], depth - 1)
+    }
+    if (value.cause !== undefined) {
+      out.cause = serializeError(value.cause, depth - 1)
+    }
+    return out
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => serializeError(item, depth - 1))
+  }
+  return value
+}
+
+function truncateStack(stack: string | undefined): string | undefined {
+  if (!stack) {
+    return stack
+  }
+  const lines = stack.split('\n')
+  if (lines.length <= MAX_STACK_LINES) {
+    return stack
+  }
+  return [...lines.slice(0, MAX_STACK_LINES), '... (truncated)'].join('\n')
+}

--- a/packages/ai/tests/captureAiGeneration.test.ts
+++ b/packages/ai/tests/captureAiGeneration.test.ts
@@ -140,7 +140,33 @@ describe('captureAiGeneration', () => {
     const properties = lastCaptureProperties(client)
     expect(properties.$ai_is_error).toBe(true)
     expect(properties.$ai_error).toEqual(expect.any(String))
+    const decoded = JSON.parse(properties.$ai_error as string)
+    expect(decoded).toEqual(
+      expect.objectContaining({
+        name: 'Error',
+        message: error.message,
+        stack: expect.any(String),
+      })
+    )
     expect(properties.$ai_http_status).toBe(expected)
+  })
+
+  it('preserves message, stack, custom fields, and the cause chain in $ai_error', async () => {
+    const client = buildClient()
+    const root = new Error('root cause')
+    const error = Object.assign(new Error('outer', { cause: root }), { statusCode: 502 })
+
+    await captureAiGeneration(client, { ...baseRequiredOptions, error })
+
+    const properties = lastCaptureProperties(client)
+    const decoded = JSON.parse(properties.$ai_error as string) as Record<string, unknown>
+    expect(decoded.name).toBe('Error')
+    expect(decoded.message).toBe('outer')
+    expect(typeof decoded.stack).toBe('string')
+    expect(decoded.statusCode).toBe(502)
+    expect(decoded.cause).toEqual(
+      expect.objectContaining({ name: 'Error', message: 'root cause', stack: expect.any(String) })
+    )
   })
 
   it('mutates the original error in place when autocapture is enabled, so callers can re-throw safely', async () => {

--- a/packages/ai/tests/serializeError.test.ts
+++ b/packages/ai/tests/serializeError.test.ts
@@ -1,0 +1,92 @@
+import { serializeError } from '../src/serializeError'
+
+interface SerializedShape {
+  name: string
+  message: string
+  stack?: string
+  cause?: unknown
+  [key: string]: unknown
+}
+
+describe('serializeError', () => {
+  it('preserves name, message, and stack on a plain Error', () => {
+    const result = serializeError(new Error('boom')) as SerializedShape
+    expect(result.name).toBe('Error')
+    expect(result.message).toBe('boom')
+    expect(result.stack).toContain('boom')
+  })
+
+  it('preserves custom own-enumerable properties (statusCode, response, …)', () => {
+    const error = Object.assign(new Error('rate limited'), { statusCode: 429, response: { id: 'req_123' } })
+    const result = serializeError(error) as SerializedShape
+    expect(result.statusCode).toBe(429)
+    expect(result.response).toEqual({ id: 'req_123' })
+  })
+
+  it('walks the cause chain', () => {
+    const root = new Error('root')
+    const middle = new Error('middle', { cause: root })
+    const top = new Error('top', { cause: middle })
+
+    const result = serializeError(top) as SerializedShape
+    expect((result.cause as SerializedShape).message).toBe('middle')
+    expect(((result.cause as SerializedShape).cause as SerializedShape).message).toBe('root')
+  })
+
+  it('returns plain-object containers as-is (does not expand Errors nested inside non-Error containers)', () => {
+    const nested = new Error('inner')
+    const result = serializeError({ retries: 3, err: nested }) as { retries: number; err: Error }
+    expect(result).toEqual({ retries: 3, err: nested })
+    expect(result.err).toBe(nested)
+  })
+
+  it('truncates stacks longer than 20 lines', () => {
+    const error = new Error('long stack')
+    error.stack = Array.from({ length: 50 }, (_, i) => `line ${i}`).join('\n')
+
+    const result = serializeError(error) as { stack: string }
+    const lines = result.stack.split('\n')
+
+    expect(lines).toHaveLength(21)
+    expect(lines.slice(0, 20)).toEqual(Array.from({ length: 20 }, (_, i) => `line ${i}`))
+    expect(lines[20]).toBe('... (truncated)')
+  })
+
+  it('leaves stacks of 20 or fewer lines untouched', () => {
+    const error = new Error('short stack')
+    error.stack = Array.from({ length: 20 }, (_, i) => `line ${i}`).join('\n')
+
+    const result = serializeError(error) as { stack: string }
+    expect(result.stack).toBe(error.stack)
+  })
+
+  it('expands a custom error class wrapping a chain of nested error causes', () => {
+    class ZodError extends Error {
+      constructor() {
+        super('expected object, received undefined')
+        this.name = 'ZodError'
+      }
+    }
+    class TypeValidationError extends Error {
+      constructor(cause: unknown) {
+        super('type validation failed', { cause })
+        this.name = 'AI_TypeValidationError'
+      }
+    }
+    const gateway = Object.assign(new Error('gateway responded', { cause: new TypeValidationError(new ZodError()) }), {
+      name: 'GatewayResponseError',
+      statusCode: 500,
+    })
+
+    const result = serializeError(gateway) as SerializedShape
+    const validation = result.cause as SerializedShape
+    const zod = validation.cause as SerializedShape
+
+    expect(result.name).toBe('GatewayResponseError')
+    expect(result.message).toBe('gateway responded')
+    expect(result.statusCode).toBe(500)
+    expect(validation.message).toBe('type validation failed')
+    expect(zod.name).toBe('ZodError')
+    expect(zod.message).toBe('expected object, received undefined')
+  })
+})

--- a/packages/ai/tests/serializeError.test.ts
+++ b/packages/ai/tests/serializeError.test.ts
@@ -1,4 +1,4 @@
-import { serializeError } from '../src/serializeError'
+import { serializeError, stringifyError } from '../src/serializeError'
 
 interface SerializedShape {
   name: string
@@ -88,5 +88,41 @@ describe('serializeError', () => {
     expect(validation.message).toBe('type validation failed')
     expect(zod.name).toBe('ZodError')
     expect(zod.message).toBe('expected object, received undefined')
+  })
+})
+
+describe('stringifyError', () => {
+  it('round-trips a normal error', () => {
+    const result = JSON.parse(stringifyError(new Error('boom')))
+    expect(result.name).toBe('Error')
+    expect(result.message).toBe('boom')
+  })
+
+  it('sanitises lone UTF-16 surrogates in messages', () => {
+    const result = JSON.parse(stringifyError(new Error('bad \uD800 surrogate')))
+    expect(result.message).not.toContain('\uD800')
+  })
+
+  it('falls back to name and message when the value contains a circular reference', () => {
+    const error: Error & { ref?: unknown } = new Error('cycle')
+    const container: Record<string, unknown> = { error }
+    container.self = container
+    error.ref = container
+
+    const result = JSON.parse(stringifyError(error))
+    expect(result).toEqual({ name: 'Error', message: 'cycle' })
+  })
+
+  it('falls back to name and message when the value contains a BigInt', () => {
+    const error = Object.assign(new Error('big'), { code: 1n })
+    const result = JSON.parse(stringifyError(error))
+    expect(result).toEqual({ name: 'Error', message: 'big' })
+  })
+
+  it('falls back to a string message when the original is not an Error', () => {
+    const value: Record<string, unknown> = { description: 'cyclic value' }
+    value.self = value
+    const result = JSON.parse(stringifyError(value))
+    expect(result).toEqual({ message: String(value) })
   })
 })


### PR DESCRIPTION
## Problem

`$ai_error` was set with `JSON.stringify(error)`, which silently drops `message`, `stack`, and `cause`. That made it impossible to debug. 

## Changes

Uses a custom serialisation function to preserve these properties and capture nested errors through `cause`. Has a maximum nested error depth and a maximum stack line count to avoid bloat.

Closes #3556. 

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/ai

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

Authored with Claude Code (Opus 4.7). Iterated on the serializer shape: started with a richer version (AggregateError handling, separate WeakSet cycle detection, `[Circular]`/`[Truncated]` sentinels, plain-object container recursion) and trimmed it down to the current minimal version on Carlos's direction — depth-bound only, no cycle bookkeeping, plain objects pass through. Stack truncation at 20 lines was added afterwards to bound payload size on deep cause chains. `$ai_error` deliberately remains a JSON-encoded string rather than a structured object so existing `.toContain(...)` test assertions and any downstream HogQL consumers keep working.
