### PR TITLE
feat(js-sdk): Enable $web_vitals reporting when cookieless mode is enabled

### DIFF
--- a/.changeset/cookieless-web-vitals.md
+++ b/.changeset/cookieless-web-vitals.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/types': patch
+---
+
+Enable $web_vitals reporting when cookieless mode is enabled

--- a/packages/browser/playwright/mocked/cookieless-web-vitals.spec.ts
+++ b/packages/browser/playwright/mocked/cookieless-web-vitals.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from './utils/posthog-playwright-test-base'
+import { start } from './utils/setup'
+import { pollUntilEventCaptured } from './utils/event-capture-utils'
+
+const startOptions = {
+    options: {
+        cookieless_mode: 'always' as const,
+        capture_performance: {
+            web_vitals: true,
+        },
+    },
+    flagsResponseOverrides: {
+        capturePerformance: true,
+    },
+    url: '/playground/cypress/index.html',
+}
+
+test.describe('Web Vitals in cookieless mode', () => {
+    test('captures web vitals without session or window ids when cookieless', async ({ page, context }) => {
+        await start(startOptions, page, context)
+
+        await pollUntilEventCaptured(page, '$web_vitals')
+
+        const webVitalsEvents = (await page.capturedEvents()).filter((event) => event.event === '$web_vitals')
+        expect(webVitalsEvents.length).toBeGreaterThan(0)
+
+        const webVitalsEvent = webVitalsEvents[0]
+        expect(webVitalsEvent.properties).toMatchObject({
+            $current_url: expect.any(String),
+            $cookieless_mode: true,
+            $web_vitals_FCP_value: expect.any(Number),
+        })
+
+        expect(webVitalsEvent.properties.$session_id).toBeUndefined()
+        expect(webVitalsEvent.properties.$window_id).toBeUndefined()
+        expect(webVitalsEvent.properties.distinct_id).toBe('$posthog_cookieless')
+
+        expect(webVitalsEvent.properties.$web_vitals_FCP_event).toMatchObject({
+            name: 'FCP',
+            value: expect.any(Number),
+            $current_url: expect.any(String),
+            timestamp: expect.any(Number),
+        })
+
+        expect(webVitalsEvent.properties.$web_vitals_FCP_event.$session_id).toBeUndefined()
+        expect(webVitalsEvent.properties.$web_vitals_FCP_event.$window_id).toBeUndefined()
+    })
+
+    test('does not capture web vitals when cookieless but vitals disabled', async ({ page, context }) => {
+        await start(
+            {
+                ...startOptions,
+                options: {
+                    cookieless_mode: 'always' as const,
+                    capture_performance: {
+                        web_vitals: false,
+                    },
+                },
+            },
+            page,
+            context
+        )
+
+        await page.waitForTimeout(5000)
+
+        const webVitalsEvents = (await page.capturedEvents()).filter((event) => event.event === '$web_vitals')
+        expect(webVitalsEvents.length).toBe(0)
+    })
+})

--- a/packages/browser/src/__tests__/extensions/web-vitals.test.ts
+++ b/packages/browser/src/__tests__/extensions/web-vitals.test.ts
@@ -6,7 +6,11 @@ import { PostHog } from '../../posthog-core'
 import { FlagsResponse, PerformanceCaptureConfig, RemoteConfig, SupportedWebVitalsMetrics } from '../../types'
 import { assignableWindow } from '../../utils/globals'
 import { DEFAULT_FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS, FIFTEEN_MINUTES_IN_MILLIS } from '../../extensions/web-vitals'
-import { WEB_VITALS_ENABLED_SERVER_SIDE, WEB_VITALS_ALLOWED_METRICS, COOKIELESS_MODE_FLAG_PROPERTY } from '../../constants'
+import {
+    WEB_VITALS_ENABLED_SERVER_SIDE,
+    WEB_VITALS_ALLOWED_METRICS,
+    COOKIELESS_MODE_FLAG_PROPERTY,
+} from '../../constants'
 
 jest.useFakeTimers()
 

--- a/packages/browser/src/__tests__/extensions/web-vitals.test.ts
+++ b/packages/browser/src/__tests__/extensions/web-vitals.test.ts
@@ -331,6 +331,82 @@ describe('web vitals', () => {
         })
     })
 
+    describe('cookieless_mode on_reject after opt_out', () => {
+        const expectedEmittedWebVitalsCookieless = (name: string) => ({
+            $current_url: 'http://localhost/',
+            timestamp: expect.any(Number),
+            name: name,
+            value: 123.45,
+            extra: 'property',
+        })
+
+        beforeEach(async () => {
+            beforeSendMock.mockClear()
+            onLCPCallback = undefined
+            onCLSCallback = undefined
+            onFCPCallback = undefined
+            onINPCallback = undefined
+
+            posthog = await createPosthogInstance(uuidv7(), {
+                before_send: beforeSendMock,
+                cookieless_mode: 'on_reject',
+                capture_performance: { web_vitals: true, web_vitals_allowed_metrics: ['CLS', 'FCP'] },
+                capture_pageview: false,
+            })
+
+            posthog.opt_out_capturing()
+            beforeSendMock.mockClear()
+
+            expect(posthog.sessionManager).toBeUndefined()
+
+            loadScriptMock.mockImplementation((_ph, _path, callback) => {
+                assignableWindow.__PosthogExtensions__ = {}
+                assignableWindow.__PosthogExtensions__.postHogWebVitalsCallbacks = {
+                    onLCP: (cb: any) => {
+                        onLCPCallback = cb
+                    },
+                    onCLS: (cb: any) => {
+                        onCLSCallback = cb
+                    },
+                    onFCP: (cb: any) => {
+                        onFCPCallback = cb
+                    },
+                    onINP: (cb: any) => {
+                        onINPCallback = cb
+                    },
+                }
+                callback()
+            })
+
+            assignableWindow.__PosthogExtensions__ = {}
+            assignableWindow.__PosthogExtensions__.loadExternalDependency = loadScriptMock
+
+            posthog.webVitalsAutocapture!.onRemoteConfig({
+                capturePerformance: { web_vitals: true },
+            } as unknown as FlagsResponse)
+
+            expect(posthog.webVitalsAutocapture!.allowedMetrics).toEqual(['CLS', 'FCP'])
+        })
+
+        it('emits cookieless web vitals after opt_out with no nested session ids', async () => {
+            onCLSCallback?.({ name: 'CLS', value: 123.45, extra: 'property' })
+            onFCPCallback?.({ name: 'FCP', value: 123.45, extra: 'property' })
+
+            expect(beforeSendMock).toBeCalledTimes(1)
+
+            const payload = beforeSendMock.mock.calls[0][0]
+            expect(payload.event).toBe('$web_vitals')
+            expect(payload.properties[COOKIELESS_MODE_FLAG_PROPERTY]).toBe(true)
+            expect(payload.properties.distinct_id).toBe('$posthog_cookieless')
+            expect(payload.properties.$session_id).toBeUndefined()
+            expect(payload.properties.$window_id).toBeUndefined()
+            expect(payload.properties.$web_vitals_CLS_event).toEqual(expectedEmittedWebVitalsCookieless('CLS'))
+            expect(payload.properties.$web_vitals_FCP_event).toEqual(expectedEmittedWebVitalsCookieless('FCP'))
+            expect(payload.properties.$web_vitals_CLS_event).not.toHaveProperty('$session_id')
+            expect(payload.properties.$web_vitals_FCP_event).not.toHaveProperty('$session_id')
+        })
+    })
+
     describe('web_vitals_attribution config', () => {
         it.each([
             [undefined, false],

--- a/packages/browser/src/__tests__/extensions/web-vitals.test.ts
+++ b/packages/browser/src/__tests__/extensions/web-vitals.test.ts
@@ -6,7 +6,7 @@ import { PostHog } from '../../posthog-core'
 import { FlagsResponse, PerformanceCaptureConfig, RemoteConfig, SupportedWebVitalsMetrics } from '../../types'
 import { assignableWindow } from '../../utils/globals'
 import { DEFAULT_FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS, FIFTEEN_MINUTES_IN_MILLIS } from '../../extensions/web-vitals'
-import { WEB_VITALS_ENABLED_SERVER_SIDE, WEB_VITALS_ALLOWED_METRICS } from '../../constants'
+import { WEB_VITALS_ENABLED_SERVER_SIDE, WEB_VITALS_ALLOWED_METRICS, COOKIELESS_MODE_FLAG_PROPERTY } from '../../constants'
 
 jest.useFakeTimers()
 
@@ -241,6 +241,91 @@ describe('web vitals', () => {
             })
         }
     )
+
+    describe('cookieless_mode (no SessionIdManager)', () => {
+        const expectedEmittedWebVitalsCookieless = (name: string) => ({
+            $current_url: 'http://localhost/',
+            timestamp: expect.any(Number),
+            name: name,
+            value: 123.45,
+            extra: 'property',
+        })
+
+        beforeEach(async () => {
+            beforeSendMock.mockClear()
+            onLCPCallback = undefined
+            onCLSCallback = undefined
+            onFCPCallback = undefined
+            onINPCallback = undefined
+
+            posthog = await createPosthogInstance(uuidv7(), {
+                before_send: beforeSendMock,
+                cookieless_mode: 'always',
+                capture_performance: { web_vitals: true, web_vitals_allowed_metrics: ['CLS', 'FCP'] },
+                capture_pageview: false,
+            })
+
+            expect(posthog.sessionManager).toBeUndefined()
+
+            loadScriptMock.mockImplementation((_ph, _path, callback) => {
+                assignableWindow.__PosthogExtensions__ = {}
+                assignableWindow.__PosthogExtensions__.postHogWebVitalsCallbacks = {
+                    onLCP: (cb: any) => {
+                        onLCPCallback = cb
+                    },
+                    onCLS: (cb: any) => {
+                        onCLSCallback = cb
+                    },
+                    onFCP: (cb: any) => {
+                        onFCPCallback = cb
+                    },
+                    onINP: (cb: any) => {
+                        onINPCallback = cb
+                    },
+                }
+                callback()
+            })
+
+            assignableWindow.__PosthogExtensions__ = {}
+            assignableWindow.__PosthogExtensions__.loadExternalDependency = loadScriptMock
+
+            posthog.webVitalsAutocapture!.onRemoteConfig({
+                capturePerformance: { web_vitals: true },
+            } as unknown as FlagsResponse)
+
+            expect(posthog.webVitalsAutocapture!.allowedMetrics).toEqual(['CLS', 'FCP'])
+        })
+
+        it('emits web vitals without nested $session_id or $window_id; sets $cookieless_mode on payload', async () => {
+            onCLSCallback?.({ name: 'CLS', value: 123.45, extra: 'property' })
+            onFCPCallback?.({ name: 'FCP', value: 123.45, extra: 'property' })
+
+            expect(beforeSendMock).toBeCalledTimes(1)
+
+            const payload = beforeSendMock.mock.calls[0][0]
+            expect(payload.event).toBe('$web_vitals')
+            expect(payload.properties[COOKIELESS_MODE_FLAG_PROPERTY]).toBe(true)
+            expect(payload.properties.$web_vitals_CLS_event).toEqual(expectedEmittedWebVitalsCookieless('CLS'))
+            expect(payload.properties.$web_vitals_FCP_event).toEqual(expectedEmittedWebVitalsCookieless('FCP'))
+            expect(payload.properties.$web_vitals_CLS_event).not.toHaveProperty('$session_id')
+            expect(payload.properties.$web_vitals_CLS_event).not.toHaveProperty('$window_id')
+            expect(payload.properties.$web_vitals_FCP_event).not.toHaveProperty('$session_id')
+            expect(payload.properties.$web_vitals_FCP_event).not.toHaveProperty('$window_id')
+        })
+
+        it('emits on delayed flush without nested session ids when only one metric is captured', async () => {
+            onCLSCallback?.({ name: 'CLS', value: 123.45, extra: 'property' })
+
+            jest.advanceTimersByTime(DEFAULT_FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS + 1)
+
+            expect(beforeSendMock).toBeCalledTimes(1)
+            const payload = beforeSendMock.mock.calls[0][0]
+            expect(payload.event).toBe('$web_vitals')
+            expect(payload.properties[COOKIELESS_MODE_FLAG_PROPERTY]).toBe(true)
+            expect(payload.properties.$web_vitals_CLS_event).not.toHaveProperty('$session_id')
+            expect(payload.properties.$web_vitals_CLS_event).not.toHaveProperty('$window_id')
+        })
+    })
 
     describe('web_vitals_attribution config', () => {
         it.each([

--- a/packages/browser/src/extensions/web-vitals/index.ts
+++ b/packages/browser/src/extensions/web-vitals/index.ts
@@ -1,11 +1,12 @@
 import { PostHog } from '../../posthog-core'
-import { PostHogConfig, RemoteConfig, SupportedWebVitalsMetrics } from '../../types'
+import { RemoteConfig, SupportedWebVitalsMetrics } from '../../types'
 import { createLogger } from '../../utils/logger'
 import { isBoolean, isNullish, isNumber, isUndefined, isObject } from '@posthog/core'
 import { WEB_VITALS_ALLOWED_METRICS, WEB_VITALS_ENABLED_SERVER_SIDE } from '../../constants'
 import { assignableWindow, window, location } from '../../utils/globals'
 import { maskQueryParams } from '../../utils/request-utils'
 import { PERSONAL_DATA_CAMPAIGN_PARAMS, MASKED } from '../../utils/event-utils'
+import { extendArray } from '../../utils'
 
 const logger = createLogger('[Web Vitals]')
 
@@ -30,14 +31,11 @@ export class WebVitalsAutocapture {
         this.startIfEnabled()
     }
 
-    /** Shorthand for performance config to reduce bundle size */
-    private get _perfConfig(): PostHogConfig['capture_performance'] {
-        return this._instance.config.capture_performance
-    }
-
     public get allowedMetrics(): SupportedWebVitalsMetrics[] {
-        const clientConfigMetricAllowList: SupportedWebVitalsMetrics[] | undefined = isObject(this._perfConfig)
-            ? this._perfConfig?.web_vitals_allowed_metrics
+        const clientConfigMetricAllowList: SupportedWebVitalsMetrics[] | undefined = isObject(
+            this._instance.config.capture_performance
+        )
+            ? this._instance.config.capture_performance?.web_vitals_allowed_metrics
             : undefined
         return !isNullish(clientConfigMetricAllowList)
             ? clientConfigMetricAllowList
@@ -45,23 +43,24 @@ export class WebVitalsAutocapture {
     }
 
     public get flushToCaptureTimeoutMs(): number {
-        const clientConfig: number | undefined = isObject(this._perfConfig)
-            ? this._perfConfig.web_vitals_delayed_flush_ms
+        const clientConfig: number | undefined = isObject(this._instance.config.capture_performance)
+            ? this._instance.config.capture_performance.web_vitals_delayed_flush_ms
             : undefined
         return clientConfig || DEFAULT_FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS
     }
 
     public get useAttribution(): boolean {
-        const clientConfig: boolean | undefined = isObject(this._perfConfig)
-            ? this._perfConfig.web_vitals_attribution
+        const clientConfig: boolean | undefined = isObject(this._instance.config.capture_performance)
+            ? this._instance.config.capture_performance.web_vitals_attribution
             : undefined
         return clientConfig ?? false
     }
 
     public get _maxAllowedValue(): number {
         const configured =
-            isObject(this._perfConfig) && isNumber(this._perfConfig.__web_vitals_max_value)
-                ? this._perfConfig.__web_vitals_max_value
+            isObject(this._instance.config.capture_performance) &&
+            isNumber(this._instance.config.capture_performance.__web_vitals_max_value)
+                ? this._instance.config.capture_performance.__web_vitals_max_value
                 : FIFTEEN_MINUTES_IN_MILLIS
         // you can set to 0 to disable the check or any value over ten seconds
         // 1 milli to 1 minute will be set to 15 minutes, cos that would be a silly low maximum
@@ -77,10 +76,10 @@ export class WebVitalsAutocapture {
         }
 
         // Otherwise, check config
-        const clientConfig = isObject(this._perfConfig)
-            ? this._perfConfig.web_vitals
-            : isBoolean(this._perfConfig)
-              ? this._perfConfig
+        const clientConfig = isObject(this._instance.config.capture_performance)
+            ? this._instance.config.capture_performance.web_vitals
+            : isBoolean(this._instance.config.capture_performance)
+              ? this._instance.config.capture_performance
               : undefined
         return isBoolean(clientConfig) ? clientConfig : this._enabledServerSide
     }
@@ -149,7 +148,7 @@ export class WebVitalsAutocapture {
         const customPersonalDataProperties = this._instance.config.custom_personal_data_properties
 
         const paramsToMask = maskPersonalDataProperties
-            ? [...PERSONAL_DATA_CAMPAIGN_PARAMS, ...(customPersonalDataProperties || [])]
+            ? extendArray([], PERSONAL_DATA_CAMPAIGN_PARAMS, customPersonalDataProperties || [])
             : []
 
         return maskQueryParams(href, paramsToMask, MASKED)
@@ -177,12 +176,6 @@ export class WebVitalsAutocapture {
     }
 
     private _addToBuffer = (metric: any) => {
-        const sessionIds = this._instance.sessionManager?.checkAndGetSessionAndWindowId(true)
-        if (isUndefined(sessionIds)) {
-            logger.error('Could not read session ID. Dropping metrics!')
-            return
-        }
-
         this._buffer = this._buffer || { url: undefined, metrics: [], firstMetricTimestamp: undefined }
 
         const $currentUrl = this._currentURL()
@@ -230,13 +223,18 @@ export class WebVitalsAutocapture {
             metric.attribution.interactionTargetElement = undefined
         }
 
-        this._buffer.metrics.push({
+        const sessionIds = this._instance.sessionManager?.checkAndGetSessionAndWindowId(true)
+        const bufferedMetric: Record<string, unknown> = {
             ...metric,
             $current_url: $currentUrl,
-            $session_id: sessionIds.sessionId,
-            $window_id: sessionIds.windowId,
             timestamp: Date.now(),
-        })
+        }
+        if (!isUndefined(sessionIds)) {
+            bufferedMetric.$session_id = sessionIds.sessionId
+            bufferedMetric.$window_id = sessionIds.windowId
+        }
+
+        this._buffer.metrics.push(bufferedMetric)
 
         if (this._buffer.metrics.length === this.allowedMetrics.length) {
             // we have all allowed metrics

--- a/packages/browser/src/extensions/web-vitals/index.ts
+++ b/packages/browser/src/extensions/web-vitals/index.ts
@@ -1,12 +1,11 @@
 import { PostHog } from '../../posthog-core'
-import { RemoteConfig, SupportedWebVitalsMetrics } from '../../types'
+import { PostHogConfig, RemoteConfig, SupportedWebVitalsMetrics } from '../../types'
 import { createLogger } from '../../utils/logger'
 import { isBoolean, isNullish, isNumber, isUndefined, isObject } from '@posthog/core'
 import { WEB_VITALS_ALLOWED_METRICS, WEB_VITALS_ENABLED_SERVER_SIDE } from '../../constants'
 import { assignableWindow, window, location } from '../../utils/globals'
 import { maskQueryParams } from '../../utils/request-utils'
 import { PERSONAL_DATA_CAMPAIGN_PARAMS, MASKED } from '../../utils/event-utils'
-import { extendArray } from '../../utils'
 
 const logger = createLogger('[Web Vitals]')
 
@@ -31,11 +30,13 @@ export class WebVitalsAutocapture {
         this.startIfEnabled()
     }
 
+    private get _perfConfig(): PostHogConfig['capture_performance'] {
+        return this._instance.config.capture_performance
+    }
+
     public get allowedMetrics(): SupportedWebVitalsMetrics[] {
-        const clientConfigMetricAllowList: SupportedWebVitalsMetrics[] | undefined = isObject(
-            this._instance.config.capture_performance
-        )
-            ? this._instance.config.capture_performance?.web_vitals_allowed_metrics
+        const clientConfigMetricAllowList: SupportedWebVitalsMetrics[] | undefined = isObject(this._perfConfig)
+            ? this._perfConfig?.web_vitals_allowed_metrics
             : undefined
         return !isNullish(clientConfigMetricAllowList)
             ? clientConfigMetricAllowList
@@ -43,24 +44,23 @@ export class WebVitalsAutocapture {
     }
 
     public get flushToCaptureTimeoutMs(): number {
-        const clientConfig: number | undefined = isObject(this._instance.config.capture_performance)
-            ? this._instance.config.capture_performance.web_vitals_delayed_flush_ms
+        const clientConfig: number | undefined = isObject(this._perfConfig)
+            ? this._perfConfig.web_vitals_delayed_flush_ms
             : undefined
         return clientConfig || DEFAULT_FLUSH_TO_CAPTURE_TIMEOUT_MILLISECONDS
     }
 
     public get useAttribution(): boolean {
-        const clientConfig: boolean | undefined = isObject(this._instance.config.capture_performance)
-            ? this._instance.config.capture_performance.web_vitals_attribution
+        const clientConfig: boolean | undefined = isObject(this._perfConfig)
+            ? this._perfConfig.web_vitals_attribution
             : undefined
         return clientConfig ?? false
     }
 
     public get _maxAllowedValue(): number {
         const configured =
-            isObject(this._instance.config.capture_performance) &&
-            isNumber(this._instance.config.capture_performance.__web_vitals_max_value)
-                ? this._instance.config.capture_performance.__web_vitals_max_value
+            isObject(this._perfConfig) && isNumber(this._perfConfig.__web_vitals_max_value)
+                ? this._perfConfig.__web_vitals_max_value
                 : FIFTEEN_MINUTES_IN_MILLIS
         // you can set to 0 to disable the check or any value over ten seconds
         // 1 milli to 1 minute will be set to 15 minutes, cos that would be a silly low maximum
@@ -76,10 +76,10 @@ export class WebVitalsAutocapture {
         }
 
         // Otherwise, check config
-        const clientConfig = isObject(this._instance.config.capture_performance)
-            ? this._instance.config.capture_performance.web_vitals
-            : isBoolean(this._instance.config.capture_performance)
-              ? this._instance.config.capture_performance
+        const clientConfig = isObject(this._perfConfig)
+            ? this._perfConfig.web_vitals
+            : isBoolean(this._perfConfig)
+              ? this._perfConfig
               : undefined
         return isBoolean(clientConfig) ? clientConfig : this._enabledServerSide
     }
@@ -148,7 +148,7 @@ export class WebVitalsAutocapture {
         const customPersonalDataProperties = this._instance.config.custom_personal_data_properties
 
         const paramsToMask = maskPersonalDataProperties
-            ? extendArray([], PERSONAL_DATA_CAMPAIGN_PARAMS, customPersonalDataProperties || [])
+            ? [...PERSONAL_DATA_CAMPAIGN_PARAMS, ...(customPersonalDataProperties || [])]
             : []
 
         return maskQueryParams(href, paramsToMask, MASKED)

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -151,6 +151,10 @@ export interface PerformanceCaptureConfig {
 
     /**
      * Use chrome's web vitals library to wrap fetch and capture web vitals
+     *
+     * When `cookieless_mode` is active, there is no client-side SessionIdManager; vitals are still
+     * captured. Nested `$web_vitals_*_event` payloads omit `$session_id` / `$window_id`; PostHog ingestion assigns
+     * `$session_id` server-side for cookieless traffic when project cookieless settings are enabled (same as other events).
      */
     web_vitals?: boolean
 
@@ -1561,6 +1565,10 @@ export interface PostHogConfig {
     /**
      * Enables cookieless mode. In this mode, PostHog will not set any cookies, or use session or local storage. User
      * identity is handled by generating a privacy-preserving hash on PostHog's servers.
+     *
+     * Web Vitals (`capture_performance.web_vitals`) are supported: metrics are sent without client session IDs;
+     * ingestion assigns `$session_id` when cookieless mode is enabled for the project.
+     *
      * - 'always' - enable cookieless mode immediately on startup, use this if you do not intend to show a cookie banner
      * - 'on_reject' - enable cookieless mode only if the user rejects cookies, use this if you want to show a cookie banner. If the user accepts cookies, cookieless mode will not be used, and PostHog will use cookies and local storage as usual.
      *


### PR DESCRIPTION
## Problem
Right now reporting of `$web_vitals` is disabled when `cookieless_mode` is enabled, because cookieless mode disables the session ID manager, which gates vitals logic.

I think this is a safe change because the ingestion (backend) processing because:
* Web vitals events carry the cookieless mode property 
* A top-level `$session_id` is generated for cookieless-enabled events
* Cookieless enabled events that can't be hashed or generate a proper session ID are dropped

I think this is safe on the product (access path side) because:
* Access patterns I found in the product rely on page path not session ID
* Replay inspector relies on name, rating and value, not session ID
* Top level `$session_id` is available on cookieless web vitals events

Ad-hoc HogQL queries _could_ attempt to access a _nested_ session ID (_available on cookieless-disabled events only_) and this could break in the product. I'm not sure whether this is a blocker on shipping the change

## Verification

After getting this PR through CI, I build the local distribution and replaced the `posthog/frontend/` copy of the SDK in `dist` with my `posthog-js` feature branch `dist`. Next, I updated the local PostHog app config for the test team (cookieless mode enabled, web vitals enabled.)

Finally, I ran a Python script to generate and publish cookieless web vitals events along with some control events to the test account, then verified in ClickHouse that the results were well formed and the ingestion pipeline did not reject them.

## Changes
* Enable publishing of `$web_vitals` events even when cookieless mode is enabled (session ID manager not present)
* Related test changes
<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
