### PR TITLE
fix: send absolute current URLs for Next pageviews

### DIFF
--- a/.changeset/quiet-pandas-dance.md
+++ b/.changeset/quiet-pandas-dance.md
@@ -1,0 +1,5 @@
+---
+'@posthog/next': patch
+---
+
+Fix Next.js pageview tracking to send absolute current URLs

--- a/packages/next/src/client/PostHogPageView.tsx
+++ b/packages/next/src/client/PostHogPageView.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect } from 'react'
 import { usePathname, useSearchParams } from 'next/navigation.js'
 import { usePostHog } from '@posthog/react'
+import { getCurrentUrl } from '../shared/browser.js'
 
 /**
  * Tracks pageviews on route change in Next.js App Router.
@@ -46,17 +47,12 @@ function PageViewTracker() {
     const posthog = usePostHog()
 
     useEffect(() => {
-        if (!posthog) {
+        const currentUrl = getCurrentUrl()
+        if (!posthog || !currentUrl) {
             return
         }
 
-        let url = pathname
-        const search = searchParams.toString()
-        if (search) {
-            url = `${pathname}?${search}`
-        }
-
-        posthog.capture('$pageview', { $current_url: url })
+        posthog.capture('$pageview', { $current_url: currentUrl })
     }, [pathname, searchParams, posthog])
 
     return null

--- a/packages/next/src/client/PostHogPageView.tsx
+++ b/packages/next/src/client/PostHogPageView.tsx
@@ -47,7 +47,8 @@ function PageViewTracker() {
     const posthog = usePostHog()
 
     useEffect(() => {
-        const currentUrl = getCurrentUrl()
+        const search = searchParams.toString()
+        const currentUrl = getCurrentUrl(search ? `${pathname}?${search}` : pathname)
         if (!posthog || !currentUrl) {
             return
         }

--- a/packages/next/src/pages/PostHogPageView.tsx
+++ b/packages/next/src/pages/PostHogPageView.tsx
@@ -31,7 +31,7 @@ export function PostHogPageView() {
     const posthog = usePostHog()
 
     useEffect(() => {
-        const currentUrl = getCurrentUrl()
+        const currentUrl = getCurrentUrl(router.asPath)
         if (!posthog || !router.isReady || !currentUrl) {
             return
         }

--- a/packages/next/src/pages/PostHogPageView.tsx
+++ b/packages/next/src/pages/PostHogPageView.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/router.js'
 import { usePostHog } from '@posthog/react'
+import { getCurrentUrl } from '../shared/browser.js'
 
 /**
  * Tracks pageviews on route change in Next.js Pages Router.
@@ -30,11 +31,12 @@ export function PostHogPageView() {
     const posthog = usePostHog()
 
     useEffect(() => {
-        if (!posthog || !router.isReady) {
+        const currentUrl = getCurrentUrl()
+        if (!posthog || !router.isReady || !currentUrl) {
             return
         }
 
-        posthog.capture('$pageview', { $current_url: router.asPath })
+        posthog.capture('$pageview', { $current_url: currentUrl })
     }, [router.asPath, router.isReady, posthog])
 
     return null

--- a/packages/next/src/shared/browser.ts
+++ b/packages/next/src/shared/browser.ts
@@ -1,7 +1,7 @@
-export function getCurrentUrl(): string | undefined {
-    if (typeof window === 'undefined' || !window.location.href) {
+export function getCurrentUrl(path: string): string | undefined {
+    if (typeof window === 'undefined') {
         return undefined
     }
 
-    return window.location.href
+    return `${window.location.origin}${path}`
 }

--- a/packages/next/src/shared/browser.ts
+++ b/packages/next/src/shared/browser.ts
@@ -1,0 +1,7 @@
+export function getCurrentUrl(): string | undefined {
+    if (typeof window === 'undefined' || !window.location.href) {
+        return undefined
+    }
+
+    return window.location.href
+}

--- a/packages/next/tests/PagesPostHogPageView.test.tsx
+++ b/packages/next/tests/PagesPostHogPageView.test.tsx
@@ -30,7 +30,6 @@ describe('Pages PostHogPageView', () => {
 
     it('includes query params and hash fragments from asPath', () => {
         mockRouter = { asPath: '/search?q=hello&page=2#section', isReady: true }
-        window.history.pushState({}, '', '/search?q=hello&page=2#section')
         render(<PostHogPageView />)
         expect(mockCapture).toHaveBeenCalledWith('$pageview', {
             $current_url: 'http://localhost/search?q=hello&page=2#section',

--- a/packages/next/tests/PagesPostHogPageView.test.tsx
+++ b/packages/next/tests/PagesPostHogPageView.test.tsx
@@ -18,20 +18,22 @@ describe('Pages PostHogPageView', () => {
         mockCapture.mockClear()
         mockUsePostHog.mockClear()
         mockRouter = { asPath: '/initial', isReady: true }
+        window.history.pushState({}, '', '/initial')
     })
 
     it('captures a $pageview event on mount', () => {
         render(<PostHogPageView />)
         expect(mockCapture).toHaveBeenCalledWith('$pageview', {
-            $current_url: '/initial',
+            $current_url: 'http://localhost/initial',
         })
     })
 
-    it('includes query params from asPath', () => {
-        mockRouter = { asPath: '/search?q=hello&page=2', isReady: true }
+    it('includes query params and hash fragments from asPath', () => {
+        mockRouter = { asPath: '/search?q=hello&page=2#section', isReady: true }
+        window.history.pushState({}, '', '/search?q=hello&page=2#section')
         render(<PostHogPageView />)
         expect(mockCapture).toHaveBeenCalledWith('$pageview', {
-            $current_url: '/search?q=hello&page=2',
+            $current_url: 'http://localhost/search?q=hello&page=2#section',
         })
     })
 
@@ -40,10 +42,11 @@ describe('Pages PostHogPageView', () => {
         expect(mockCapture).toHaveBeenCalledTimes(1)
 
         mockRouter = { asPath: '/new-page', isReady: true }
+        window.history.pushState({}, '', '/new-page')
         rerender(<PostHogPageView />)
         expect(mockCapture).toHaveBeenCalledTimes(2)
         expect(mockCapture).toHaveBeenLastCalledWith('$pageview', {
-            $current_url: '/new-page',
+            $current_url: 'http://localhost/new-page',
         })
     })
 
@@ -68,7 +71,7 @@ describe('Pages PostHogPageView', () => {
         rerender(<PostHogPageView />)
         expect(mockCapture).toHaveBeenCalledTimes(1)
         expect(mockCapture).toHaveBeenCalledWith('$pageview', {
-            $current_url: '/initial',
+            $current_url: 'http://localhost/initial',
         })
     })
 })

--- a/packages/next/tests/PagesPostHogPageView.test.tsx
+++ b/packages/next/tests/PagesPostHogPageView.test.tsx
@@ -18,7 +18,6 @@ describe('Pages PostHogPageView', () => {
         mockCapture.mockClear()
         mockUsePostHog.mockClear()
         mockRouter = { asPath: '/initial', isReady: true }
-        window.history.pushState({}, '', '/initial')
     })
 
     it('captures a $pageview event on mount', () => {
@@ -41,7 +40,6 @@ describe('Pages PostHogPageView', () => {
         expect(mockCapture).toHaveBeenCalledTimes(1)
 
         mockRouter = { asPath: '/new-page', isReady: true }
-        window.history.pushState({}, '', '/new-page')
         rerender(<PostHogPageView />)
         expect(mockCapture).toHaveBeenCalledTimes(2)
         expect(mockCapture).toHaveBeenLastCalledWith('$pageview', {

--- a/packages/next/tests/PostHogPageView.test.tsx
+++ b/packages/next/tests/PostHogPageView.test.tsx
@@ -33,7 +33,6 @@ describe('PostHogPageView', () => {
 
     it('includes search params in the captured URL', () => {
         mockSearchParams = new URLSearchParams('q=hello&page=2')
-        window.history.pushState({}, '', '/initial?q=hello&page=2')
         render(<PostHogPageView />)
         expect(mockCapture).toHaveBeenCalledWith('$pageview', {
             $current_url: 'http://localhost/initial?q=hello&page=2',
@@ -45,7 +44,6 @@ describe('PostHogPageView', () => {
         expect(mockCapture).toHaveBeenCalledTimes(1)
 
         mockPathname = '/new-page'
-        window.history.pushState({}, '', '/new-page')
         rerender(<PostHogPageView />)
         expect(mockCapture).toHaveBeenCalledTimes(2)
         expect(mockCapture).toHaveBeenLastCalledWith('$pageview', {

--- a/packages/next/tests/PostHogPageView.test.tsx
+++ b/packages/next/tests/PostHogPageView.test.tsx
@@ -21,20 +21,22 @@ describe('PostHogPageView', () => {
         mockUsePostHog.mockClear()
         mockPathname = '/initial'
         mockSearchParams = new URLSearchParams()
+        window.history.pushState({}, '', '/initial')
     })
 
     it('captures a $pageview event on mount', () => {
         render(<PostHogPageView />)
         expect(mockCapture).toHaveBeenCalledWith('$pageview', {
-            $current_url: '/initial',
+            $current_url: 'http://localhost/initial',
         })
     })
 
     it('includes search params in the captured URL', () => {
         mockSearchParams = new URLSearchParams('q=hello&page=2')
+        window.history.pushState({}, '', '/initial?q=hello&page=2')
         render(<PostHogPageView />)
         expect(mockCapture).toHaveBeenCalledWith('$pageview', {
-            $current_url: '/initial?q=hello&page=2',
+            $current_url: 'http://localhost/initial?q=hello&page=2',
         })
     })
 
@@ -43,10 +45,11 @@ describe('PostHogPageView', () => {
         expect(mockCapture).toHaveBeenCalledTimes(1)
 
         mockPathname = '/new-page'
+        window.history.pushState({}, '', '/new-page')
         rerender(<PostHogPageView />)
         expect(mockCapture).toHaveBeenCalledTimes(2)
         expect(mockCapture).toHaveBeenLastCalledWith('$pageview', {
-            $current_url: '/new-page',
+            $current_url: 'http://localhost/new-page',
         })
     })
 

--- a/packages/next/tests/PostHogPageView.test.tsx
+++ b/packages/next/tests/PostHogPageView.test.tsx
@@ -21,7 +21,6 @@ describe('PostHogPageView', () => {
         mockUsePostHog.mockClear()
         mockPathname = '/initial'
         mockSearchParams = new URLSearchParams()
-        window.history.pushState({}, '', '/initial')
     })
 
     it('captures a $pageview event on mount', () => {


### PR DESCRIPTION
## Problem

`@posthog/next` pageview tracking was sending relative `$current_url` values for App Router and Pages Router pageviews. Heatmaps expect absolute URLs, so these pageview events can produce `invalid_heatmap_data` ingestion warnings.

Closes https://github.com/PostHog/posthog-js/issues/3606

## Changes

- Add a shared `getCurrentUrl(path)` helper that safely prefixes router-derived paths with `window.location.origin`.
- Send absolute `$current_url` values from both App Router and Pages Router `PostHogPageView` components while preserving each router's URL source of truth.
- Update pageview tests to assert absolute URLs, including query params and hash fragments.
- Add a patch changeset for `@posthog/next`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [x] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
