### PR TITLE
feat(dead-clicks): support .ph-no-deadclick css class

### DIFF
--- a/.changeset/dead-clicks-ph-no-deadclick.md
+++ b/.changeset/dead-clicks-ph-no-deadclick.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/types': patch
+---
+
+Dead clicks: add a `.ph-no-deadclick` CSS class (and `capture_dead_clicks.css_selector_ignorelist` config option) to exclude specific elements from dead-click detection without affecting autocapture, session replay, or heatmaps. Mirrors the existing `.ph-no-rageclick` pattern.

--- a/.changeset/dead-clicks-ph-no-deadclick.md
+++ b/.changeset/dead-clicks-ph-no-deadclick.md
@@ -1,6 +1,6 @@
 ---
-'posthog-js': patch
-'@posthog/types': patch
+'posthog-js': minor
+'@posthog/types': minor
 ---
 
 Dead clicks: add a `.ph-no-deadclick` CSS class (and `capture_dead_clicks.css_selector_ignorelist` config option) to exclude specific elements from dead-click detection without affecting autocapture, session replay, or heatmaps. Mirrors the existing `.ph-no-rageclick` pattern.

--- a/packages/browser/src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts
@@ -158,6 +158,61 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
             expect(lazyLoadedDeadClicksAutocapture['_clicks']).toHaveLength(0)
             expect(fakeInstance.capture).not.toHaveBeenCalled()
         })
+
+        it('ignores clicks on elements with the ph-no-deadclick class', () => {
+            const el = document.createElement('div')
+            el.className = 'ph-no-deadclick'
+            document.body.append(el)
+
+            triggerMouseEvent(el, 'click')
+
+            expect(lazyLoadedDeadClicksAutocapture['_clicks']).toHaveLength(0)
+        })
+
+        it('ignores clicks on parents with the ph-no-deadclick class', () => {
+            const parent = document.createElement('div')
+            parent.className = 'ph-no-deadclick'
+            const child = document.createElement('div')
+            parent.appendChild(child)
+            document.body.append(parent)
+
+            triggerMouseEvent(child, 'click')
+
+            expect(lazyLoadedDeadClicksAutocapture['_clicks']).toHaveLength(0)
+        })
+
+        it('ignores clicks on elements with the ph-no-capture class', () => {
+            const el = document.createElement('div')
+            el.className = 'ph-no-capture'
+            document.body.append(el)
+
+            triggerMouseEvent(el, 'click')
+
+            expect(lazyLoadedDeadClicksAutocapture['_clicks']).toHaveLength(0)
+        })
+
+        it('respects a custom css_selector_ignorelist', () => {
+            lazyLoadedDeadClicksAutocapture.stop()
+            const customIgnore = new LazyLoadedDeadClicksAutocapture(fakeInstance, {
+                css_selector_ignorelist: ['.custom-no-deadclick'],
+            })
+            customIgnore.start(document)
+
+            const ignored = document.createElement('div')
+            ignored.className = 'custom-no-deadclick'
+            document.body.append(ignored)
+
+            const notIgnoredWhenCustom = document.createElement('div')
+            notIgnoredWhenCustom.className = 'ph-no-deadclick'
+            document.body.append(notIgnoredWhenCustom)
+
+            triggerMouseEvent(ignored, 'click')
+            triggerMouseEvent(notIgnoredWhenCustom, 'click')
+
+            // only the explicitly ignored element should be filtered out
+            expect(customIgnore['_clicks'].map((c) => (c.node as Element).className)).toEqual(['ph-no-deadclick'])
+            customIgnore.stop()
+        })
     })
 
     describe('dead click detection', () => {

--- a/packages/browser/src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts
@@ -159,9 +159,9 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
             expect(fakeInstance.capture).not.toHaveBeenCalled()
         })
 
-        it('ignores clicks on elements with the ph-no-deadclick class', () => {
+        it.each(['ph-no-deadclick', 'ph-no-capture'])('ignores clicks on elements with the %s class', (className) => {
             const el = document.createElement('div')
-            el.className = 'ph-no-deadclick'
+            el.className = className
             document.body.append(el)
 
             triggerMouseEvent(el, 'click')
@@ -177,16 +177,6 @@ describe('LazyLoadedDeadClicksAutocapture', () => {
             document.body.append(parent)
 
             triggerMouseEvent(child, 'click')
-
-            expect(lazyLoadedDeadClicksAutocapture['_clicks']).toHaveLength(0)
-        })
-
-        it('ignores clicks on elements with the ph-no-capture class', () => {
-            const el = document.createElement('div')
-            el.className = 'ph-no-capture'
-            document.body.append(el)
-
-            triggerMouseEvent(el, 'click')
 
             expect(lazyLoadedDeadClicksAutocapture['_clicks']).toHaveLength(0)
         })

--- a/packages/browser/src/autocapture-utils.ts
+++ b/packages/browser/src/autocapture-utils.ts
@@ -187,6 +187,24 @@ function shouldIgnoreByContent(
     })
 }
 
+// dead click capture does not run through autocapture's ph-no-capture check,
+// so we include it here so that ph-no-capture also suppresses dead click capture
+const DEFAULT_DEAD_CLICK_IGNORE_LIST = ['.ph-no-deadclick', '.ph-no-capture']
+export function shouldCaptureDeadClick(el: Element | null, _config: PostHogConfig['capture_dead_clicks']) {
+    if (!window || cannotCheckForAutocapture(el)) {
+        return false
+    }
+
+    const selectorIgnoreList = isBoolean(_config)
+        ? DEFAULT_DEAD_CLICK_IGNORE_LIST
+        : (_config?.css_selector_ignorelist ?? DEFAULT_DEAD_CLICK_IGNORE_LIST)
+
+    const { targetElementList } = getElementAndParentsForElement(el, false)
+
+    // we don't capture if we match the ignore list
+    return !checkIfElementsMatchCSSSelector(targetElementList, selectorIgnoreList)
+}
+
 // autocapture check will already filter for ph-no-capture,
 // but we include it here to protect against future changes accidentally removing that check
 const DEFAULT_RAGE_CLICK_IGNORE_LIST = ['.ph-no-rageclick', '.ph-no-capture']

--- a/packages/browser/src/entrypoints/dead-clicks-autocapture.ts
+++ b/packages/browser/src/entrypoints/dead-clicks-autocapture.ts
@@ -1,7 +1,7 @@
 import { assignableWindow, document, LazyLoadedDeadClicksAutocaptureInterface } from '../utils/globals'
 import { PostHog } from '../posthog-core'
 import { isNull, isNumber, isUndefined } from '@posthog/core'
-import { autocaptureCompatibleElements, getEventTarget } from '../autocapture-utils'
+import { autocaptureCompatibleElements, getEventTarget, shouldCaptureDeadClick } from '../autocapture-utils'
 import { DeadClickCandidate, DeadClicksAutoCaptureConfig, Properties } from '../types'
 import { autocapturePropertiesForElement } from '../autocapture'
 import { isElementInToolbar, isElementNode, isTag } from '../utils/element-utils'
@@ -35,7 +35,8 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
     private _lastVisibilityChange: number | undefined
     private _clicks: DeadClickCandidate[] = []
     private _checkClickTimer: number | undefined
-    private _config: Required<DeadClicksAutoCaptureConfig>
+    private _config: Required<Omit<DeadClicksAutoCaptureConfig, 'css_selector_ignorelist'>> &
+        Pick<DeadClicksAutoCaptureConfig, 'css_selector_ignorelist'>
     private _onCapture: (click: DeadClickCandidate, properties: Properties) => void
 
     private _defaultConfig = (defaultOnCapture: (click: DeadClickCandidate, properties: Properties) => void) => ({
@@ -47,7 +48,10 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
         __onCapture: defaultOnCapture,
     })
 
-    private _asRequiredConfig(providedConfig?: DeadClicksAutoCaptureConfig): Required<DeadClicksAutoCaptureConfig> {
+    private _asRequiredConfig(
+        providedConfig?: DeadClicksAutoCaptureConfig
+    ): Required<Omit<DeadClicksAutoCaptureConfig, 'css_selector_ignorelist'>> &
+        Pick<DeadClicksAutoCaptureConfig, 'css_selector_ignorelist'> {
         const defaultConfig = this._defaultConfig(providedConfig?.__onCapture || this._captureDeadClick.bind(this))
         return {
             element_attribute_ignorelist:
@@ -58,6 +62,7 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
             mutation_threshold_ms: providedConfig?.mutation_threshold_ms ?? defaultConfig.mutation_threshold_ms,
             capture_clicks_with_modifier_keys:
                 providedConfig?.capture_clicks_with_modifier_keys ?? defaultConfig.capture_clicks_with_modifier_keys,
+            css_selector_ignorelist: providedConfig?.css_selector_ignorelist,
             __onCapture: defaultConfig.__onCapture,
         }
     }
@@ -195,6 +200,10 @@ class LazyLoadedDeadClicksAutocapture implements LazyLoadedDeadClicksAutocapture
             !isElementNode(click.node) ||
             autocaptureCompatibleElements.includes(click.node.tagName.toLowerCase())
         ) {
+            return true
+        }
+
+        if (!shouldCaptureDeadClick(click.node, { css_selector_ignorelist: this._config.css_selector_ignorelist })) {
             return true
         }
 

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -637,7 +637,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "false",
     "true",
     [
-      "{ scroll_threshold_ms?: number | undefined; selection_change_threshold_ms?: number | undefined; mutation_threshold_ms?: number | undefined; capture_clicks_with_modifier_keys?: boolean | undefined; __onCapture?: ((click: DeadClickCandidate, properties: Properties) => void) | undefined; }",
+      "{ scroll_threshold_ms?: number | undefined; selection_change_threshold_ms?: number | undefined; mutation_threshold_ms?: number | undefined; capture_clicks_with_modifier_keys?: boolean | undefined; css_selector_ignorelist?: string[] | undefined; __onCapture?: ((click: DeadClickCandidate, properties: Properties) => vo...",
       "Pick<AutocaptureConfig, \\"element_attribute_ignorelist\\">"
     ]
   ],

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -289,6 +289,20 @@ export type DeadClicksAutoCaptureConfig = {
     capture_clicks_with_modifier_keys?: boolean
 
     /**
+     * List of CSS selectors to ignore dead clicks on
+     * e.g. ['.my-download-link']
+     * we consider the tree of elements from the root to the target element of the click event
+     * so for the tree div > div > a > svg
+     * and ignore list config `['[download]']`
+     * we will ignore the dead click if the click-target or its parents has any download attribute
+     *
+     * Nothing is ignored when there's an empty ignorelist, e.g. []
+     * If no ignorelist is set, we default to ignoring .ph-no-deadclick
+     * If an element has .ph-no-capture, it will always be ignored by dead click and autocapture
+     */
+    css_selector_ignorelist?: string[]
+
+    /**
      * Allows setting behavior for when a dead click is captured.
      * For e.g. to support capture to heatmaps
      *
@@ -1443,6 +1457,8 @@ export interface PostHogConfig {
 
     /**
      * Determines whether to capture dead clicks.
+     *
+     * by default dead clicks are ignored on elements that match a `ph-no-capture` or `ph-no-deadclick` css class on the element or a parent
      *
      * @see {DeadClicksAutoCaptureConfig}
      * @default undefined

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -297,8 +297,8 @@ export type DeadClicksAutoCaptureConfig = {
      * we will ignore the dead click if the click-target or its parents has any download attribute
      *
      * Nothing is ignored when there's an empty ignorelist, e.g. []
-     * If no ignorelist is set, we default to ignoring .ph-no-deadclick
-     * If an element has .ph-no-capture, it will always be ignored by dead click and autocapture
+     * If no ignorelist is set, we default to ignoring .ph-no-deadclick and .ph-no-capture
+     * A custom ignorelist fully replaces the default — include .ph-no-capture if you want it to suppress dead-click capture as well
      */
     css_selector_ignorelist?: string[]
 


### PR DESCRIPTION
## Summary

- Adds a `.ph-no-deadclick` CSS class (and a `css_selector_ignorelist` option on `capture_dead_clicks`) so callers can exclude specific elements from dead-click detection without losing autocapture, session replay, or heatmap data for those elements.
- Mirrors the existing `.ph-no-rageclick` pattern: defaults to `['.ph-no-deadclick', '.ph-no-capture']` and walks the click target plus its parents.
- Refs PostHog/posthog-js#3619.

## Behaviour

- `capture_dead_clicks: true` (or remote-enabled): elements (or their parents) with `.ph-no-deadclick` / `.ph-no-capture` are skipped before being added to the dead-click candidate list.
- `capture_dead_clicks: { css_selector_ignorelist: ['.my-download'] }`: overrides the default. An empty array (`[]`) means \"don't ignore anything\".
- The check is gated in `_ignoreClick`, so it doesn't affect autocapture, replay, or heatmaps.

## Test plan

- [x] `pnpm exec jest src/__tests__/entrypoints/lazy-loaded-dead-clicks-autocapture.test.ts` — added cases for `.ph-no-deadclick` on the target, on a parent, `.ph-no-capture`, and a custom `css_selector_ignorelist`.
- [x] `pnpm test:unit` in `packages/browser` (3977 passed).
- [x] `pnpm exec jest -u` in `packages/types` to refresh the `PostHogConfig` snapshot for the new field.
- [x] `pnpm typecheck` and `pnpm lint` in `packages/browser`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*