### PR TITLE
fix: preserve OpenAI API promise helpers

### DIFF
--- a/.changeset/openai-api-promise-helpers.md
+++ b/.changeset/openai-api-promise-helpers.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Preserve OpenAI APIPromise response helpers on instrumented OpenAI wrapper calls.

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -51,6 +51,16 @@ function captureAiGenerationInBackground(...args: Parameters<typeof captureAiGen
   void captureAiGeneration(...args).catch(() => undefined)
 }
 
+async function captureAiGenerationAfterSuccess(...args: Parameters<typeof captureAiGeneration>): Promise<void> {
+  const [, options] = args
+
+  if (options.captureImmediate) {
+    await captureAiGeneration(...args)
+  } else {
+    captureAiGenerationInBackground(...args)
+  }
+}
+
 function preserveAPIPromiseHelpers<Input, Output>(
   parentPromise: APIPromise<Input>,
   wrappedPromise: Promise<Output>
@@ -353,7 +363,7 @@ export class WrappedCompletions extends Completions {
             const latency = (Date.now() - startTime) / 1000
             const availableTools = extractAvailableToolCalls('openai', openAIParams)
             const formattedOutput = formatResponseOpenAI(result)
-            captureAiGenerationInBackground(this.phClient, {
+            await captureAiGenerationAfterSuccess(this.phClient, {
               ...posthogParams,
               model: openAIParams.model ?? result.model,
               provider: 'openai',
@@ -586,7 +596,7 @@ export class WrappedResponses extends Responses {
             const latency = (Date.now() - startTime) / 1000
             const availableTools = extractAvailableToolCalls('openai', openAIParams)
             const formattedOutput = formatResponseOpenAI({ output: result.output })
-            captureAiGenerationInBackground(this.phClient, {
+            await captureAiGenerationAfterSuccess(this.phClient, {
               ...posthogParams,
               model: openAIParams.model ?? result.model,
               provider: 'openai',
@@ -868,7 +878,7 @@ export class WrappedTranscriptions extends Transcriptions {
       : super.create(openAIParams, options)
 
     if (openAIParams.stream) {
-      return parentPromise.then((value) => {
+      const wrappedPromise = parentPromise.then((value) => {
         if ('tee' in value && typeof (value as any).tee === 'function') {
           const [stream1, stream2] = (value as any).tee()
           ;(async () => {
@@ -941,13 +951,18 @@ export class WrappedTranscriptions extends Transcriptions {
           return stream2
         }
         return value
-      }) as APIPromise<Stream<OpenAIOrignal.Audio.Transcriptions.TranscriptionStreamEvent>>
+      })
+
+      return preserveAPIPromiseHelpers(
+        parentPromise as APIPromise<Stream<OpenAIOrignal.Audio.Transcriptions.TranscriptionStreamEvent>>,
+        wrappedPromise
+      )
     } else {
       const wrappedPromise = parentPromise.then(
         async (result) => {
-          if ('text' in result) {
+          if (result && typeof result === 'object' && 'text' in result) {
             const latency = (Date.now() - startTime) / 1000
-            await captureAiGeneration(this.phClient, {
+            await captureAiGenerationAfterSuccess(this.phClient, {
               ...posthogParams,
               model: openAIParams.model,
               provider: 'openai',
@@ -963,8 +978,8 @@ export class WrappedTranscriptions extends Transcriptions {
                 rawUsage: result.usage,
               },
             })
-            return result
           }
+          return result
         },
         async (error: unknown) => {
           await captureAiGeneration(this.phClient, {
@@ -984,9 +999,12 @@ export class WrappedTranscriptions extends Transcriptions {
           })
           throw error
         }
-      ) as APIPromise<OpenAIOrignal.Audio.Transcriptions.TranscriptionCreateResponse>
+      )
 
-      return wrappedPromise
+      return preserveAPIPromiseHelpers(
+        parentPromise as APIPromise<OpenAIOrignal.Audio.Transcriptions.TranscriptionCreateResponse>,
+        wrappedPromise
+      )
     }
   }
 }

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -45,6 +45,31 @@ interface MonitoringOpenAIConfig extends ClientOptions {
 }
 
 type RequestOptions = Record<string, unknown>
+type APIPromiseWithResponse<T> = Awaited<ReturnType<APIPromise<T>['withResponse']>>
+
+function captureAiGenerationInBackground(...args: Parameters<typeof captureAiGeneration>): void {
+  void captureAiGeneration(...args).catch(() => undefined)
+}
+
+function preserveAPIPromiseHelpers<Input, Output>(
+  parentPromise: APIPromise<Input>,
+  wrappedPromise: Promise<Output>
+): APIPromise<Output> {
+  const apiPromise = wrappedPromise as APIPromise<Output>
+
+  if (typeof parentPromise.asResponse === 'function') {
+    apiPromise.asResponse = () => parentPromise.asResponse()
+  }
+
+  if (typeof parentPromise.withResponse === 'function') {
+    apiPromise.withResponse = async () => {
+      const [response, data] = await Promise.all([parentPromise.withResponse(), wrappedPromise])
+      return { ...response, data } as APIPromiseWithResponse<Output>
+    }
+  }
+
+  return apiPromise
+}
 
 export class PostHogOpenAI extends OpenAIOrignal {
   private readonly phClient: PostHog
@@ -112,7 +137,7 @@ export class WrappedCompletions extends Completions {
     const parentPromise = super.create(openAIParams, options)
 
     if (openAIParams.stream) {
-      return parentPromise.then((value) => {
+      const wrappedPromise = parentPromise.then((value) => {
         if ('tee' in value) {
           const [stream1, stream2] = value.tee()
           ;(async () => {
@@ -318,7 +343,9 @@ export class WrappedCompletions extends Completions {
           return stream2
         }
         return value
-      }) as APIPromise<Stream<ChatCompletionChunk>>
+      })
+
+      return preserveAPIPromiseHelpers(parentPromise, wrappedPromise)
     } else {
       const wrappedPromise = parentPromise.then(
         async (result) => {
@@ -326,7 +353,7 @@ export class WrappedCompletions extends Completions {
             const latency = (Date.now() - startTime) / 1000
             const availableTools = extractAvailableToolCalls('openai', openAIParams)
             const formattedOutput = formatResponseOpenAI(result)
-            await captureAiGeneration(this.phClient, {
+            captureAiGenerationInBackground(this.phClient, {
               ...posthogParams,
               model: openAIParams.model ?? result.model,
               provider: 'openai',
@@ -379,9 +406,9 @@ export class WrappedCompletions extends Completions {
           })
           throw error
         }
-      ) as APIPromise<ChatCompletion>
+      )
 
-      return wrappedPromise
+      return preserveAPIPromiseHelpers(parentPromise, wrappedPromise)
     }
   }
 }
@@ -425,7 +452,7 @@ export class WrappedResponses extends Responses {
     const parentPromise = super.create(openAIParams, options)
 
     if (openAIParams.stream) {
-      return parentPromise.then((value) => {
+      const wrappedPromise = parentPromise.then((value) => {
         if ('tee' in value && typeof value.tee === 'function') {
           const [stream1, stream2] = value.tee()
           ;(async () => {
@@ -549,7 +576,9 @@ export class WrappedResponses extends Responses {
           return stream2
         }
         return value
-      }) as APIPromise<Stream<OpenAIOrignal.Responses.ResponseStreamEvent>>
+      })
+
+      return preserveAPIPromiseHelpers(parentPromise, wrappedPromise)
     } else {
       const wrappedPromise = parentPromise.then(
         async (result) => {
@@ -557,7 +586,7 @@ export class WrappedResponses extends Responses {
             const latency = (Date.now() - startTime) / 1000
             const availableTools = extractAvailableToolCalls('openai', openAIParams)
             const formattedOutput = formatResponseOpenAI({ output: result.output })
-            await captureAiGeneration(this.phClient, {
+            captureAiGenerationInBackground(this.phClient, {
               ...posthogParams,
               model: openAIParams.model ?? result.model,
               provider: 'openai',
@@ -607,9 +636,9 @@ export class WrappedResponses extends Responses {
           })
           throw error
         }
-      ) as APIPromise<OpenAIOrignal.Responses.Response>
+      )
 
-      return wrappedPromise
+      return preserveAPIPromiseHelpers(parentPromise, wrappedPromise)
     }
   }
 
@@ -674,7 +703,7 @@ export class WrappedResponses extends Responses {
         }
       )
 
-      return wrappedPromise as APIPromise<ParsedResponse<ParsedT>>
+      return preserveAPIPromiseHelpers(parentPromise, wrappedPromise) as APIPromise<ParsedResponse<ParsedT>>
     } finally {
       // Restore our wrapped create method
       originalSelfRecord['create'] = tempCreate
@@ -744,9 +773,9 @@ export class WrappedEmbeddings extends Embeddings {
         })
         throw error
       }
-    ) as APIPromise<CreateEmbeddingResponse>
+    )
 
-    return wrappedPromise
+    return preserveAPIPromiseHelpers(parentPromise, wrappedPromise)
   }
 }
 

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -511,6 +511,36 @@ describe('PostHogOpenAI - Jest test suite', () => {
     expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
   })
 
+  test('chat completions create waits for captureImmediate before resolving', async () => {
+    let resolveCapture: () => void
+    const captureDelivery = new Promise<void>((resolve) => {
+      resolveCapture = resolve
+    })
+    ;(mockPostHogClient.captureImmediate as jest.Mock).mockReturnValue(captureDelivery)
+
+    const promise = client.chat.completions.create({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Hello' }],
+      posthogDistinctId: 'test-id',
+      posthogCaptureImmediate: true,
+    })
+
+    let settled = false
+    promise.then(() => {
+      settled = true
+    })
+
+    await flushPromises()
+
+    expect(mockPostHogClient.captureImmediate).toHaveBeenCalledTimes(1)
+    expect(settled).toBe(false)
+
+    resolveCapture!()
+
+    await expect(promise).resolves.toEqual(mockOpenAiChatResponse)
+    expect(settled).toBe(true)
+  })
+
   conditionalTest('groups', async () => {
     await client.chat.completions.create({
       model: 'gpt-4',
@@ -1365,7 +1395,32 @@ describe('PostHogOpenAI - Jest test suite', () => {
       // Mock the Audio.Transcriptions.prototype.create method
       const AudioMock: any = openaiModule.Audio
       const TranscriptionsMock = AudioMock.Transcriptions
-      TranscriptionsMock.prototype.create = jest.fn().mockResolvedValue(mockTranscriptionResponse)
+      TranscriptionsMock.prototype.create = jest
+        .fn()
+        .mockImplementation(() => createMockAPIPromise(mockTranscriptionResponse))
+    })
+
+    test('audio transcriptions create preserves OpenAI APIPromise helpers', async () => {
+      const mockFile = new Blob(['mock audio data'], { type: 'audio/mpeg' }) as any
+      mockFile.name = 'test.mp3'
+
+      const promise = client.audio.transcriptions.create({
+        file: mockFile,
+        model: 'whisper-1',
+        posthogDistinctId: 'test-transcription-user',
+      })
+
+      expect(typeof promise.asResponse).toBe('function')
+      expect(typeof promise.withResponse).toBe('function')
+
+      const rawResponse = await promise.asResponse()
+      const { data, response, request_id } = await promise.withResponse()
+
+      expect(rawResponse.headers.get('x-ratelimit-remaining-requests')).toBe('42')
+      expect(response.headers.get('x-ratelimit-remaining-requests')).toBe('42')
+      expect(request_id).toBe('req_test')
+      expect(data).toEqual(mockTranscriptionResponse)
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
     })
 
     conditionalTest('basic transcription', async () => {

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -18,17 +18,30 @@ let mockOpenAiParsedResponse: ParsedResponse<any> = {} as ParsedResponse<any>
 let mockOpenAiEmbeddingResponse: any = {}
 let mockStreamChunks: ChatCompletionChunk[] = []
 
-jest.mock('posthog-node', () => {
-  return {
-    PostHog: jest.fn().mockImplementation(() => {
-      return {
-        capture: jest.fn(),
-        captureImmediate: jest.fn(),
-        privacy_mode: false,
-      }
-    }),
-  }
-})
+jest.mock(
+  'posthog-node',
+  () => {
+    return {
+      PostHog: jest.fn().mockImplementation(() => {
+        return {
+          capture: jest.fn(),
+          captureImmediate: jest.fn(),
+          privacy_mode: false,
+        }
+      }),
+    }
+  },
+  { virtual: true }
+)
+
+jest.mock(
+  '@posthog/core',
+  () => ({
+    uuidv7: jest.fn(() => 'uuid-v7'),
+    ErrorTracking: {},
+  }),
+  { virtual: true }
+)
 
 jest.mock('openai', () => {
   // Mock Completions class – `create` is declared on the prototype so that
@@ -137,6 +150,26 @@ const createMockAsyncIterator = <T>(chunks: T[]): MockAsyncIterator<T> => {
       }
     },
   }
+}
+
+const createMockAPIPromise = <T>(
+  data: T,
+  withResponseData: unknown = { stale: true }
+): Promise<T> & { asResponse: jest.Mock; withResponse: jest.Mock } => {
+  const response = new Response(JSON.stringify(data), {
+    headers: {
+      'x-ratelimit-remaining-requests': '42',
+    },
+    status: 200,
+  })
+  return Object.assign(Promise.resolve(data), {
+    asResponse: jest.fn().mockResolvedValue(response),
+    withResponse: jest.fn().mockResolvedValue({
+      data: withResponseData,
+      response,
+      request_id: 'req_test',
+    }),
+  })
 }
 
 /**
@@ -270,17 +303,12 @@ describe('PostHogOpenAI - Jest test suite', () => {
   })
 
   beforeEach(() => {
-    // Skip all tests if no API key is present
-    if (!process.env.OPENAI_API_KEY) {
-      return
-    }
-
     jest.clearAllMocks()
 
     // Reset the default mocks
     mockPostHogClient = new (PostHog as any)()
     client = new PostHogOpenAI({
-      apiKey: process.env.OPENAI_API_KEY || '',
+      apiKey: process.env.OPENAI_API_KEY || 'test-api-key',
       posthog: mockPostHogClient as any,
     })
 
@@ -394,19 +422,21 @@ describe('PostHogOpenAI - Jest test suite', () => {
             .fn()
             .mockReturnValue([createMockAsyncIterator(mockStreamChunks), createMockAsyncIterator(mockStreamChunks)]),
         }
-        return Promise.resolve(mockStream)
+        return createMockAPIPromise(mockStream)
       }
-      return Promise.resolve(mockOpenAiChatResponse)
+      return createMockAPIPromise(mockOpenAiChatResponse)
     })
 
     // Mock the Responses.prototype.parse method that super.parse() will call
     const ResponsesMock: any = openaiModule.Responses
-    ResponsesMock.prototype.parse = jest.fn().mockResolvedValue(mockOpenAiParsedResponse)
-    ResponsesMock.prototype.create = jest.fn().mockResolvedValue(mockOpenAiParsedResponse)
+    ResponsesMock.prototype.parse = jest.fn().mockImplementation(() => createMockAPIPromise(mockOpenAiParsedResponse))
+    ResponsesMock.prototype.create = jest.fn().mockImplementation(() => createMockAPIPromise(mockOpenAiParsedResponse))
 
     // Mock the Embeddings class
     const EmbeddingsMock: any = openaiModule.Embeddings || class MockEmbeddings {}
-    EmbeddingsMock.prototype.create = jest.fn().mockResolvedValue(mockOpenAiEmbeddingResponse)
+    EmbeddingsMock.prototype.create = jest
+      .fn()
+      .mockImplementation(() => createMockAPIPromise(mockOpenAiEmbeddingResponse))
   })
 
   // Conditionally run tests based on API key availability
@@ -459,6 +489,26 @@ describe('PostHogOpenAI - Jest test suite', () => {
       system_fingerprint: 'fp_test123',
       request_id: 'req_test-request-id',
     })
+  })
+
+  test('chat completions create preserves OpenAI APIPromise helpers', async () => {
+    const promise = client.chat.completions.create({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Hello' }],
+      posthogDistinctId: 'test-id',
+    })
+
+    expect(typeof promise.asResponse).toBe('function')
+    expect(typeof promise.withResponse).toBe('function')
+
+    const rawResponse = await promise.asResponse()
+    const { data, response, request_id } = await promise.withResponse()
+
+    expect(rawResponse.headers.get('x-ratelimit-remaining-requests')).toBe('42')
+    expect(response.headers.get('x-ratelimit-remaining-requests')).toBe('42')
+    expect(request_id).toBe('req_test')
+    expect(data).toEqual(mockOpenAiChatResponse)
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
   })
 
   conditionalTest('groups', async () => {
@@ -643,6 +693,24 @@ describe('PostHogOpenAI - Jest test suite', () => {
     expect(properties['$ai_completion_id']).toBe('test-parsed-response-id')
     // Responses API has no system_fingerprint, so only request_id is reported.
     expect(properties['$ai_provider_metadata']).toEqual({ request_id: 'req_test-parsed-request-id' })
+  })
+
+  test('responses create preserves OpenAI APIPromise helpers', async () => {
+    const promise = client.responses.create({
+      model: 'gpt-4o-2024-08-06',
+      input: [{ role: 'user', content: 'Hello' }],
+      posthogDistinctId: 'test-id',
+    })
+
+    expect(typeof promise.asResponse).toBe('function')
+    expect(typeof promise.withResponse).toBe('function')
+
+    const { data, response, request_id } = await promise.withResponse()
+
+    expect(response.headers.get('x-ratelimit-remaining-requests')).toBe('42')
+    expect(request_id).toBe('req_test')
+    expect(data).toEqual(mockOpenAiParsedResponse)
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
   })
 
   conditionalTest('responses parse with instructions parameter', async () => {


### PR DESCRIPTION
## Summary
- preserve OpenAI APIPromise helpers after wrapping `chat.completions.create`, `responses.create`, `responses.parse`, and `embeddings.create`
- keep PostHog capture behavior on the wrapped data path while allowing callers to use `.asResponse()` / `.withResponse()` for headers
- add regression coverage for chat completions and responses `.withResponse()` plus a patch changeset

Fixes #3580.

## Verification
- `npx --yes pnpm@10.23.0 install --frozen-lockfile --filter @posthog/ai...`
- `npx --yes pnpm@10.23.0 --filter @posthog/ai exec prettier --check src/openai/index.ts tests/openai.test.ts ../../.changeset/openai-api-promise-helpers.md`
- `npx --yes pnpm@10.23.0 --filter @posthog/ai exec eslint src/openai/index.ts tests/openai.test.ts`
- `OPENAI_API_KEY=test-key npx --yes pnpm@10.23.0 --filter @posthog/ai exec jest --runTestsByPath tests/openai.test.ts --runInBand -t "APIPromise helpers"`

Notes from this Windows/Node 25 environment:
- `pnpm --filter @posthog/ai build` is blocked by a missing optional Rollup native package: `@rollup/rollup-win32-x64-msvc`.
- `tsc --noEmit --project packages/ai/tsconfig.json` is blocked by workspace packages whose declarations resolve to unbuilt `dist` outputs (`posthog-node`, `@posthog/core`). After narrowing output, there were no remaining `src/openai/index.ts` errors besides that unresolved workspace import.
- The full `openai.test.ts` file hits an existing streaming-error test that rethrows from a background async task and exits under Node 25, so I ran the focused APIPromise regression tests directly.
