### PR TITLE
docs: clarify session idle config descriptions

### DIFF
--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1174,14 +1174,14 @@ export interface PostHogConfig {
     error_tracking: ErrorTrackingOptions
 
     /**
-     * Controls when the SDK rotates the `$session_id` after inactivity.
+     * Determines the session idle timeout in seconds.
      *
-     * If no event updates session activity for this many seconds, the next activity event starts a
+     * If no events are captured for this many seconds, the next event starts a
      * new session with a new `$session_id` (and `$window_id`). The SDK may also proactively reset the stored session
-     * after the timeout while the page is idle, so the next activity creates a new session.
+     * after the timeout while the page is idle, so the next event creates a new session.
      *
      * Session recording has a separate idle threshold: `session_recording.session_idle_threshold_ms`. That setting
-     * only controls when replay capture is considered idle; it does not rotate `$session_id`.
+     * only controls when the user is considered idle, it does not rotate `$session_id`.
      *
      * Must be between 60 seconds and 10 hours. Values outside this range are clamped.
      *

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -538,8 +538,15 @@ export interface SessionRecordingOptions {
     compress_events?: boolean
 
     /**
-     * ADVANCED: alters the threshold before a recording considers a user has become idle.
-     * Normally only altered alongside changes to session_idle_timeout_ms.
+     * ADVANCED: Controls when session recording considers the user idle.
+     *
+     * If no replay user interaction occurs for this many milliseconds, the recorder marks the recording idle,
+     * emits a `sessionIdle` replay marker, flushes buffered replay events, and drops most subsequent replay
+     * events until user activity resumes. If activity resumes before `session_idle_timeout_seconds`, recording
+     * continues under the same `$session_id`.
+     *
+     * This does not control `$session_id` rotation. Session rotation is controlled by `session_idle_timeout_seconds`,
+     * so this value should usually be lower than `session_idle_timeout_seconds * 1000`.
      *
      * @default 1000 * 60 * 5 (5 minutes)
      */
@@ -1167,8 +1174,16 @@ export interface PostHogConfig {
     error_tracking: ErrorTrackingOptions
 
     /**
-     * Determines the session idle timeout in seconds.
-     * Any new event that's happened after this timeout will create a new session.
+     * Controls when the SDK rotates the PostHog `$session_id` after inactivity.
+     *
+     * If no non-read-only event updates session activity for this many seconds, the next activity event starts a
+     * new session with a new `$session_id` and `$window_id`. The SDK may also proactively reset the stored session
+     * after the timeout while the page is idle, so the next activity creates a new session.
+     *
+     * Session recording has a separate idle threshold: `session_recording.session_idle_threshold_ms`. That setting
+     * only controls when replay capture is considered idle; it does not rotate `$session_id`.
+     *
+     * Must be between 60 seconds and 10 hours. Values outside this range are clamped.
      *
      * @default 30 * 60 -- 30 minutes
      */

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -546,7 +546,7 @@ export interface SessionRecordingOptions {
      * continues under the same `$session_id`.
      *
      * This does not control `$session_id` rotation. Session rotation is controlled by `session_idle_timeout_seconds`,
-     * so this value should usually be lower than `session_idle_timeout_seconds * 1000`.
+     * so this value should be lower than `session_idle_timeout_seconds * 1000`.
      *
      * @default 1000 * 60 * 5 (5 minutes)
      */
@@ -1174,10 +1174,10 @@ export interface PostHogConfig {
     error_tracking: ErrorTrackingOptions
 
     /**
-     * Controls when the SDK rotates the PostHog `$session_id` after inactivity.
+     * Controls when the SDK rotates the `$session_id` after inactivity.
      *
-     * If no non-read-only event updates session activity for this many seconds, the next activity event starts a
-     * new session with a new `$session_id` and `$window_id`. The SDK may also proactively reset the stored session
+     * If no event updates session activity for this many seconds, the next activity event starts a
+     * new session with a new `$session_id` (and `$window_id`). The SDK may also proactively reset the stored session
      * after the timeout while the page is idle, so the next activity creates a new session.
      *
      * Session recording has a separate idle threshold: `session_recording.session_idle_threshold_ms`. That setting


### PR DESCRIPTION
## Problem

The browser SDK has two similarly named idle configuration options, but their docs did not clearly explain which one rotates `$session_id` and which one only affects session replay idle behavior.

## Changes

- Clarify that `session_recording.session_idle_threshold_ms` marks replay capture idle, flushes the replay buffer, and drops most replay events until user activity resumes.
- Clarify that `session_idle_timeout_seconds` controls `$session_id` / `$window_id` rotation after inactivity.
- Document that replay idle does not rotate `$session_id`, and that session timeout values are clamped between 60 seconds and 10 hours.
- No changeset/changelog entry because this is documentation-only.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
