### PR TITLE
fix: respect capture transport option

### DIFF
--- a/.changeset/bright-badgers-send.md
+++ b/.changeset/bright-badgers-send.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Respect transport overrides passed to posthog.capture.

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -351,17 +351,20 @@ describe('posthog core', () => {
             )
         })
 
-        it('passes the transport override to the request', () => {
-            const posthog = posthogWith({ ...defaultConfig, request_batching: false }, defaultOverrides)
+        it.each(['XHR', 'fetch', 'sendBeacon'] as const)(
+            'passes the %s transport override to the request',
+            (transport) => {
+                const posthog = posthogWith({ ...defaultConfig, request_batching: false }, defaultOverrides)
 
-            posthog.capture('event-name', { foo: 'bar', length: 0 }, { transport: 'sendBeacon' })
+                posthog.capture('event-name', { foo: 'bar', length: 0 }, { transport })
 
-            expect(posthog._send_request).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    transport: 'sendBeacon',
-                })
-            )
-        })
+                expect(posthog._send_request).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        transport,
+                    })
+                )
+            }
+        )
 
         it('does not allow you to set complex current url', () => {
             const posthog = posthogWith(defaultConfig, defaultOverrides)

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -351,6 +351,18 @@ describe('posthog core', () => {
             )
         })
 
+        it('passes the transport override to the request', () => {
+            const posthog = posthogWith({ ...defaultConfig, request_batching: false }, defaultOverrides)
+
+            posthog.capture('event-name', { foo: 'bar', length: 0 }, { transport: 'sendBeacon' })
+
+            expect(posthog._send_request).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    transport: 'sendBeacon',
+                })
+            )
+        })
+
         it('does not allow you to set complex current url', () => {
             const posthog = posthogWith(defaultConfig, defaultOverrides)
             const captureResult = posthog.capture('event-name', { $current_url: new URL('https://app.posthog.com/s/') })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1364,7 +1364,7 @@ export class PostHog implements PostHogInterface {
             data,
             compression: 'best-available',
             batchKey: options?._batchKey,
-            ...(options?.transport ? { transport: options.transport } : {}),
+            transport: options?.transport,
         }
 
         if (this.config.request_batching && (!options || options?._batchKey) && !options?.send_instantly) {

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1364,6 +1364,7 @@ export class PostHog implements PostHogInterface {
             data,
             compression: 'best-available',
             batchKey: options?._batchKey,
+            ...(options?.transport ? { transport: options.transport } : {}),
         }
 
         if (this.config.request_batching && (!options || options?._batchKey) && !options?.send_instantly) {


### PR DESCRIPTION
## Problem

`posthog.capture()` accepted a `transport` option, but the browser SDK dropped it when constructing the request options. As a result, callers could request `sendBeacon`/`XHR`/`fetch` without that choice being respected.

## Changes

- Forward `CaptureOptions.transport` from `capture()` to the request layer.
- Add parameterized unit test coverage for `XHR`, `fetch`, and `sendBeacon` transport overrides on capture.
- Add a patch changeset for `posthog-js`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
