### PR TITLE
feat(react-native): dark backdrop and opt-in close-on-backdrop-tap

### DIFF
--- a/.changeset/rn-survey-modal-backdrop.md
+++ b/.changeset/rn-survey-modal-backdrop.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': minor
+---
+
+React Native surveys: the modal now renders with a dark semi-transparent backdrop so it stands out from underlying UI. Embedders can opt in to closing the survey by tapping that backdrop via the new `appearance.closeOnBackdropPress` flag (default `false`; the X button still closes regardless). Tapping outside the modal dismisses the keyboard either way.

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -1,5 +1,14 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { Keyboard, KeyboardAvoidingView, Modal, Platform, StyleSheet, View, useWindowDimensions } from 'react-native'
+import {
+  Keyboard,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  View,
+  useWindowDimensions,
+} from 'react-native'
 
 import { Cancel } from './Cancel'
 import { ConfirmationMessage } from './ConfirmationMessage'
@@ -94,10 +103,22 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
     >
       {contentMounted && (
         <KeyboardAvoidingView behavior={keyboardBehavior} style={styles.fill}>
-          <View style={[styles.fill, { justifyContent: vertical }]} onTouchStart={Keyboard.dismiss}>
+          <Pressable
+            testID="survey-modal-backdrop"
+            style={[styles.fill, styles.backdrop, { justifyContent: vertical }]}
+            onPress={() => {
+              // Always dismiss the keyboard so users can tap-outside to lower it
+              // even when backdrop-close is disabled.
+              Keyboard.dismiss()
+              if (appearance.closeOnBackdropPress) {
+                onClose()
+              }
+            }}
+          >
             <View style={[styles.modalRow, { justifyContent: horizontal }]}>
               <View style={styles.modalContent} pointerEvents="box-none">
                 <View
+                  onStartShouldSetResponder={() => true}
                   style={[
                     styles.modalContentInner,
                     {
@@ -139,7 +160,7 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
                 </View>
               </View>
             </View>
-          </View>
+          </Pressable>
         </KeyboardAvoidingView>
       )}
     </Modal>
@@ -149,6 +170,9 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
 const styles = StyleSheet.create({
   fill: {
     flex: 1,
+  },
+  backdrop: {
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
   modalRow: {
     flexDirection: 'row',

--- a/packages/react-native/src/surveys/surveys-utils.ts
+++ b/packages/react-native/src/surveys/surveys-utils.ts
@@ -128,6 +128,12 @@ export type SurveyAppearanceTheme = Omit<
 > & {
   textColor?: string
   inputTextColor?: string
+  /**
+   * When true, tapping the dimmed area outside the survey modal dismisses it
+   * (same outcome as tapping the X). Default false because accidental
+   * dismissals can lose unsent responses.
+   */
+  closeOnBackdropPress?: boolean
 }
 export const defaultSurveyAppearance: SurveyAppearanceTheme = {
   backgroundColor: defaultBackgroundColor,

--- a/packages/react-native/test/SurveyModal.spec.tsx
+++ b/packages/react-native/test/SurveyModal.spec.tsx
@@ -8,11 +8,29 @@ import { Survey, SurveyQuestionType, SurveyType } from '@posthog/core'
 // primitives here, all rendering as plain divs so children appear in the DOM.
 jest.mock('react-native', () => {
   const RealReact = jest.requireActual('react')
-  const Box = RealReact.forwardRef(({ children, testID, onTouchStart, ...rest }: any, ref: any) =>
-    RealReact.createElement('div', { ref, 'data-testid': testID, onMouseDown: onTouchStart, ...rest }, children)
+  const Box = RealReact.forwardRef(
+    ({ children, testID, onTouchStart, onStartShouldSetResponder, ...rest }: any, ref: any) => {
+      // onStartShouldSetResponder() === true mirrors RN's responder system claiming
+      // the touch; we approximate that in jsdom by stopping click propagation so
+      // an inner View shields ancestors (e.g. a Pressable backdrop) from the event.
+      const onClick = onStartShouldSetResponder ? (e: any) => e.stopPropagation() : undefined
+      return RealReact.createElement(
+        'div',
+        { ref, 'data-testid': testID, onMouseDown: onTouchStart, onClick, ...rest },
+        children
+      )
+    }
   )
-  const Pressable = RealReact.forwardRef(({ children, testID, onPress, ...rest }: any, ref: any) =>
-    RealReact.createElement('div', { ref, 'data-testid': testID, onClick: onPress, ...rest }, children)
+  // Flatten RN-style arrays into a single inline-style object so jsdom can
+  // expose them via element.style (e.g. for backgroundColor assertions).
+  const flatten = (s: any): any =>
+    Array.isArray(s) ? Object.assign({}, ...s.filter(Boolean).map(flatten)) : (s ?? undefined)
+  const Pressable = RealReact.forwardRef(({ children, testID, onPress, style, ...rest }: any, ref: any) =>
+    RealReact.createElement(
+      'div',
+      { ref, 'data-testid': testID, onClick: onPress, style: flatten(style), ...rest },
+      children
+    )
   )
   return {
     View: Box,
@@ -90,6 +108,12 @@ const appearanceWithoutThankYou: SurveyAppearanceTheme = {
   thankYouMessageHeader: '',
 }
 
+const appearanceWithBackdropClose: SurveyAppearanceTheme = {
+  ...defaultSurveyAppearance,
+  thankYouMessageHeader: 'Thanks!',
+  closeOnBackdropPress: true,
+}
+
 // Mount SurveyModal with the standard test fixture. Returns the rendered
 // result plus the onClose spy so tests can assert against either.
 const renderSurveyModal = (onClose: jest.Mock = jest.fn()) => {
@@ -155,6 +179,63 @@ describe('SurveyModal close behavior', () => {
     // BUG: shouldShowConfirmation flips false, so Questions remounts with Q1.
     // After the fix the conditional branches on isSurveySent first → null.
     expect(queryByTestId('questions-stub')).toBeNull()
+  })
+
+  it('closes when the backdrop is tapped if closeOnBackdropPress is true', () => {
+    const onClose = jest.fn()
+    const { getByTestId } = render(
+      <SurveyModal
+        survey={baseSurvey}
+        surveyLanguage={null}
+        appearance={appearanceWithBackdropClose}
+        onShow={() => {}}
+        onClose={onClose}
+      />
+    )
+
+    act(() => {
+      fireEvent.click(getByTestId('survey-modal-backdrop'))
+    })
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(onClose).toHaveBeenCalledWith(false, {})
+  })
+
+  it('does NOT close on backdrop tap by default (closeOnBackdropPress omitted)', () => {
+    const { getByTestId, onClose } = renderSurveyModal()
+
+    act(() => {
+      fireEvent.click(getByTestId('survey-modal-backdrop'))
+    })
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    // Default behavior: backdrop tap only dismisses the keyboard, not the survey.
+    // Prevents accidental dismissals that lose unsent responses.
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not close when a tap lands inside the modal content', () => {
+    const { getByTestId, onClose } = renderSurveyModal()
+
+    // A tap on Questions itself fires onSubmit (drives isSurveySent),
+    // but it must NOT bubble up and trigger the backdrop close.
+    act(() => {
+      fireEvent.click(getByTestId('questions-stub'))
+    })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('renders a dark semi-transparent backdrop behind the modal', () => {
+    const { getByTestId } = renderSurveyModal()
+
+    const backdrop = getByTestId('survey-modal-backdrop')
+    // jsdom serializes any rgba/rgb value into a string on .style.backgroundColor.
+    expect(backdrop.style.backgroundColor).toMatch(/rgba?\(/)
   })
 
   it('hides content immediately when the cancel button is pressed', () => {


### PR DESCRIPTION
## Problem

Two UX gaps in the React Native survey modal:

- **[#3523](https://github.com/PostHog/posthog-js/issues/3523)** — The survey blends into busy UI behind it because there's no backdrop dimming.
- **[#3524](https://github.com/PostHog/posthog-js/issues/3524)** — Some embedders want users to be able to dismiss the survey by tapping outside it. Today only the X button works.

The companion close-flash and snapshot-reuse bug fixes shipped in [#3629](https://github.com/PostHog/posthog-js/pull/3629).

## Changes

One commit in `SurveyModal.tsx` + matching tests:

- **Dark backdrop** (Closes [#3523](https://github.com/PostHog/posthog-js/issues/3523)) — adds `rgba(0, 0, 0, 0.5)` to the backdrop via a new `styles.backdrop` entry.
- **Opt-in close-on-backdrop-tap** (Closes [#3524](https://github.com/PostHog/posthog-js/issues/3524)) — wraps the outer area in a `<Pressable>` that fires `onClose` on tap **only when** `appearance.closeOnBackdropPress` is `true`. Default is `false` to prevent accidental dismissals. Uses RN's gesture-responder system (`onStartShouldSetResponder` on `modalContentInner`) so taps on the modal content don't bubble to the backdrop. Tapping outside dismisses the keyboard regardless of the flag.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code — 4 new unit tests in `packages/react-native/test/SurveyModal.spec.tsx`: backdrop closes when opt-in is set, backdrop does NOT close by default, tap inside modal content does not bubble, dark backdrop is rendered.
- [x] Accounted for impact across platforms — verified on iOS 26 (iPhone 17 sim) and Android (Pixel 9 emulator).
- [x] Backwards compatible — default `closeOnBackdropPress: false` preserves existing X-only close behavior. Dark backdrop is purely visual.
- [x] Bundle size impact minimal — adds one style entry and one `<Pressable>` wrap.

### If releasing new changes

- [x] Ran `pnpm changeset` (`.changeset/rn-survey-modal-backdrop.md`, `minor` bump)

## Test plan

- [x] `pnpm --filter posthog-react-native test:unit` — 8/8 pass
- [x] `pnpm --filter posthog-react-native lint` clean
- [x] Manual on iOS 26 (iPhone 17 sim): default modal closes only via X; with `closeOnBackdropPress: true`, tapping outside dismisses. Dark backdrop visible behind every state.
- [x] Manual on Android (Pixel 9 emulator): same checklist; hardware back button still dismisses normally.

## Demos

https://github.com/user-attachments/assets/611db8e0-b7b0-4164-90ff-8d1fc723f007

https://github.com/user-attachments/assets/2a1f5c59-fbcc-42c2-8017-0e5715fce1f3

