### PR TITLE
fix(react-native): survey modal close-flash and Modal snapshot-reuse flash

### DIFF
--- a/.changeset/rn-survey-modal-bug-fixes.md
+++ b/.changeset/rn-survey-modal-bug-fixes.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+React Native surveys: closing a survey from Q2+ or the Thank You screen no longer flashes the first question during the fade-out. Opening another survey shortly after closing one no longer flashes the previous survey's content for the first frame on iOS — survey content unmounts one frame before the Modal dismisses so the UIKit snapshot the OS recycles is blank.

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -25,14 +25,16 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
   const { survey, surveyLanguage, appearance, onShow, androidKeyboardBehavior = 'height' } = props
   const [isSurveySent, setIsSurveySent] = useState(false)
   const [responses, setResponses] = useState<SurveyResponses>({})
-  const onClose = useCallback(() => props.onClose(isSurveySent, responses), [isSurveySent, props, responses])
+  const [isVisible, setIsVisible] = useState(true)
+  const onClose = useCallback(() => {
+    setIsVisible(false)
+    props.onClose(isSurveySent, responses)
+  }, [isSurveySent, props, responses])
   const insets = useOptionalSafeAreaInsets()
   const { height: windowHeight } = useWindowDimensions()
   const [keyboardHeight, setKeyboardHeight] = useState(0)
   const { vertical, horizontal } = resolveSurveyAlignment(appearance.position)
   const isBottom = vertical === 'flex-end'
-
-  const [isVisible] = useState(true)
 
   const shouldShowConfirmation = isSurveySent && appearance.thankYouMessageHeader
 
@@ -88,7 +90,18 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
                 <View style={styles.topIconContainer}>
                   <Cancel onPress={onClose} appearance={appearance} />
                 </View>
-                {!shouldShowConfirmation ? (
+                {isSurveySent ? (
+                  shouldShowConfirmation ? (
+                    <ConfirmationMessage
+                      appearance={appearance}
+                      header={appearance.thankYouMessageHeader}
+                      description={appearance.thankYouMessageDescription}
+                      contentType={appearance.thankYouMessageDescriptionContentType}
+                      onClose={onClose}
+                      isModal={true}
+                    />
+                  ) : null
+                ) : (
                   <Questions
                     survey={survey}
                     surveyLanguage={surveyLanguage}
@@ -96,15 +109,6 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
                     responses={responses}
                     onResponsesChange={setResponses}
                     onSubmit={() => setIsSurveySent(true)}
-                  />
-                ) : (
-                  <ConfirmationMessage
-                    appearance={appearance}
-                    header={appearance.thankYouMessageHeader}
-                    description={appearance.thankYouMessageDescription}
-                    contentType={appearance.thankYouMessageDescriptionContentType}
-                    onClose={onClose}
-                    isModal={true}
                   />
                 )}
               </View>

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Keyboard, KeyboardAvoidingView, Modal, Platform, StyleSheet, View, useWindowDimensions } from 'react-native'
 
 import { Cancel } from './Cancel'
@@ -21,15 +21,47 @@ export type SurveyModalProps = {
 // edges. Insets already keep it clear of the status bar and home indicator.
 const VIEWPORT_BUFFER = 0
 
+// Matches RN Modal's fade animation duration on Android, where Modal has no
+// onDismiss callback. On iOS we use Modal.onDismiss to know exactly when the
+// fade finishes.
+const MODAL_FADE_DURATION_MS = 250
+
 export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
   const { survey, surveyLanguage, appearance, onShow, androidKeyboardBehavior = 'height' } = props
   const [isSurveySent, setIsSurveySent] = useState(false)
   const [responses, setResponses] = useState<SurveyResponses>({})
   const [isVisible, setIsVisible] = useState(true)
-  const onClose = useCallback(() => {
-    setIsVisible(false)
+  // Two-step hide works around RN Fabric's UIKit snapshot recycling:
+  // https://github.com/facebook/react-native/issues/48245
+  // RN reuses the previous Modal's snapshot for the first paint of the next
+  // presentation. Unmounting children before dismissing the Modal makes that
+  // snapshot blank, so the next survey opens without flashing prior content.
+  const [contentMounted, setContentMounted] = useState(true)
+  // Guard refs so the close sequence runs exactly once even if onClose fires
+  // multiple times rapidly (hardware back button + cancel tap, double-tap, etc.).
+  const isClosingRef = useRef(false)
+  const closeNotifiedRef = useRef(false)
+  const notifyParentClosed = useCallback(() => {
+    if (closeNotifiedRef.current) return
+    closeNotifiedRef.current = true
     props.onClose(isSurveySent, responses)
   }, [isSurveySent, props, responses])
+  const onClose = useCallback(() => {
+    if (isClosingRef.current) return
+    isClosingRef.current = true
+    // Step 1: unmount children — Modal renders blank for at least one frame.
+    setContentMounted(false)
+    // Step 2: on the next frame, dismiss the (now-blank) Modal. The snapshot
+    // RN reuses for the next presentation will be of the blank Modal.
+    requestAnimationFrame(() => {
+      setIsVisible(false)
+      // Android has no Modal.onDismiss — schedule the parent notification
+      // to match the fade duration so the modal animates out cleanly.
+      if (Platform.OS !== 'ios') {
+        setTimeout(notifyParentClosed, MODAL_FADE_DURATION_MS)
+      }
+    })
+  }, [notifyParentClosed])
   const insets = useOptionalSafeAreaInsets()
   const { height: windowHeight } = useWindowDimensions()
   const [keyboardHeight, setKeyboardHeight] = useState(0)
@@ -58,64 +90,69 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
     }
   }, [])
 
-  if (!isVisible) {
-    return null
-  }
-
   const maxModalHeight = Math.max(windowHeight - keyboardHeight - insets.top - insets.bottom - VIEWPORT_BUFFER, 200)
 
   const keyboardBehavior = Platform.OS === 'ios' ? 'padding' : androidKeyboardBehavior
 
   return (
-    <Modal animationType="fade" transparent onRequestClose={onClose} statusBarTranslucent={true}>
-      <KeyboardAvoidingView behavior={keyboardBehavior} style={styles.fill}>
-        <View style={[styles.fill, { justifyContent: vertical }]} onTouchStart={Keyboard.dismiss}>
-          <View style={[styles.modalRow, { justifyContent: horizontal }]}>
-            <View style={styles.modalContent} pointerEvents="box-none">
-              <View
-                style={[
-                  styles.modalContentInner,
-                  {
-                    borderColor: appearance.borderColor,
-                    backgroundColor: appearance.backgroundColor,
-                    marginTop: vertical === 'flex-start' ? insets.top + 10 : 0,
-                    // When keyboard is up, sit flush against it (no extra gap).
-                    // When keyboard is down, leave room for the home indicator.
-                    marginBottom: isBottom ? (keyboardHeight > 0 ? 0 : insets.bottom + 10) : 0,
-                    marginHorizontal: 10,
-                    maxHeight: maxModalHeight,
-                  },
-                ]}
-              >
-                <View style={styles.topIconContainer}>
-                  <Cancel onPress={onClose} appearance={appearance} />
-                </View>
-                {isSurveySent ? (
-                  shouldShowConfirmation ? (
-                    <ConfirmationMessage
+    <Modal
+      visible={isVisible}
+      animationType="fade"
+      transparent
+      onRequestClose={onClose}
+      onDismiss={Platform.OS === 'ios' ? notifyParentClosed : undefined}
+      statusBarTranslucent={true}
+    >
+      {contentMounted && (
+        <KeyboardAvoidingView behavior={keyboardBehavior} style={styles.fill}>
+          <View style={[styles.fill, { justifyContent: vertical }]} onTouchStart={Keyboard.dismiss}>
+            <View style={[styles.modalRow, { justifyContent: horizontal }]}>
+              <View style={styles.modalContent} pointerEvents="box-none">
+                <View
+                  style={[
+                    styles.modalContentInner,
+                    {
+                      borderColor: appearance.borderColor,
+                      backgroundColor: appearance.backgroundColor,
+                      marginTop: vertical === 'flex-start' ? insets.top + 10 : 0,
+                      // When keyboard is up, sit flush against it (no extra gap).
+                      // When keyboard is down, leave room for the home indicator.
+                      marginBottom: isBottom ? (keyboardHeight > 0 ? 0 : insets.bottom + 10) : 0,
+                      marginHorizontal: 10,
+                      maxHeight: maxModalHeight,
+                    },
+                  ]}
+                >
+                  <View style={styles.topIconContainer}>
+                    <Cancel onPress={onClose} appearance={appearance} />
+                  </View>
+                  {isSurveySent ? (
+                    shouldShowConfirmation ? (
+                      <ConfirmationMessage
+                        appearance={appearance}
+                        header={appearance.thankYouMessageHeader}
+                        description={appearance.thankYouMessageDescription}
+                        contentType={appearance.thankYouMessageDescriptionContentType}
+                        onClose={onClose}
+                        isModal={true}
+                      />
+                    ) : null
+                  ) : (
+                    <Questions
+                      survey={survey}
+                      surveyLanguage={surveyLanguage}
                       appearance={appearance}
-                      header={appearance.thankYouMessageHeader}
-                      description={appearance.thankYouMessageDescription}
-                      contentType={appearance.thankYouMessageDescriptionContentType}
-                      onClose={onClose}
-                      isModal={true}
+                      responses={responses}
+                      onResponsesChange={setResponses}
+                      onSubmit={() => setIsSurveySent(true)}
                     />
-                  ) : null
-                ) : (
-                  <Questions
-                    survey={survey}
-                    surveyLanguage={surveyLanguage}
-                    appearance={appearance}
-                    responses={responses}
-                    onResponsesChange={setResponses}
-                    onSubmit={() => setIsSurveySent(true)}
-                  />
-                )}
+                  )}
+                </View>
               </View>
             </View>
           </View>
-        </View>
-      </KeyboardAvoidingView>
+        </KeyboardAvoidingView>
+      )}
     </Modal>
   )
 }

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -25,7 +25,7 @@ const VIEWPORT_BUFFER = 0
 const MODAL_FADE_DURATION_MS = 250
 
 export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
-  const { survey, surveyLanguage, appearance, onShow, androidKeyboardBehavior = 'height' } = props
+  const { survey, surveyLanguage, appearance, onShow, onClose: onCloseProp, androidKeyboardBehavior = 'height' } = props
   const [isSurveySent, setIsSurveySent] = useState(false)
   const [responses, setResponses] = useState<SurveyResponses>({})
   const [isVisible, setIsVisible] = useState(true)
@@ -37,8 +37,8 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
   const notifyParentClosed = useCallback(() => {
     if (closeNotifiedRef.current) return
     closeNotifiedRef.current = true
-    props.onClose(isSurveySent, responses)
-  }, [isSurveySent, props, responses])
+    onCloseProp(isSurveySent, responses)
+  }, [isSurveySent, onCloseProp, responses])
   const onClose = useCallback(() => {
     if (isClosingRef.current) return
     isClosingRef.current = true

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -21,9 +21,7 @@ export type SurveyModalProps = {
 // edges. Insets already keep it clear of the status bar and home indicator.
 const VIEWPORT_BUFFER = 0
 
-// Matches RN Modal's fade animation duration on Android, where Modal has no
-// onDismiss callback. On iOS we use Modal.onDismiss to know exactly when the
-// fade finishes.
+// Matches RN Modal's fade animation duration (Android only).
 const MODAL_FADE_DURATION_MS = 250
 
 export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
@@ -31,14 +29,9 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
   const [isSurveySent, setIsSurveySent] = useState(false)
   const [responses, setResponses] = useState<SurveyResponses>({})
   const [isVisible, setIsVisible] = useState(true)
-  // Two-step hide works around RN Fabric's UIKit snapshot recycling:
+  // Two-step hide for RN Fabric snapshot recycling — see
   // https://github.com/facebook/react-native/issues/48245
-  // RN reuses the previous Modal's snapshot for the first paint of the next
-  // presentation. Unmounting children before dismissing the Modal makes that
-  // snapshot blank, so the next survey opens without flashing prior content.
   const [contentMounted, setContentMounted] = useState(true)
-  // Guard refs so the close sequence runs exactly once even if onClose fires
-  // multiple times rapidly (hardware back button + cancel tap, double-tap, etc.).
   const isClosingRef = useRef(false)
   const closeNotifiedRef = useRef(false)
   const notifyParentClosed = useCallback(() => {
@@ -49,14 +42,10 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
   const onClose = useCallback(() => {
     if (isClosingRef.current) return
     isClosingRef.current = true
-    // Step 1: unmount children — Modal renders blank for at least one frame.
     setContentMounted(false)
-    // Step 2: on the next frame, dismiss the (now-blank) Modal. The snapshot
-    // RN reuses for the next presentation will be of the blank Modal.
     requestAnimationFrame(() => {
       setIsVisible(false)
-      // Android has no Modal.onDismiss — schedule the parent notification
-      // to match the fade duration so the modal animates out cleanly.
+      // Android Modal has no onDismiss; wait the fade duration before notifying.
       if (Platform.OS !== 'ios') {
         setTimeout(notifyParentClosed, MODAL_FADE_DURATION_MS)
       }

--- a/packages/react-native/test/SurveyModal.spec.tsx
+++ b/packages/react-native/test/SurveyModal.spec.tsx
@@ -1,0 +1,196 @@
+/** @jest-environment jsdom */
+import React from 'react'
+import { act, fireEvent, render, cleanup } from '@testing-library/react'
+import { Survey, SurveyQuestionType, SurveyType } from '@posthog/core'
+
+// Minimal react-native shim — jest-expo's full preset chain pulls in
+// TurboModule code that explodes under jsdom. We only need a handful of
+// primitives here, all rendering as plain divs so children appear in the DOM.
+jest.mock('react-native', () => {
+  const RealReact = jest.requireActual('react')
+  const Box = RealReact.forwardRef(({ children, testID, onTouchStart, ...rest }: any, ref: any) =>
+    RealReact.createElement('div', { ref, 'data-testid': testID, onMouseDown: onTouchStart, ...rest }, children)
+  )
+  const Pressable = RealReact.forwardRef(({ children, testID, onPress, ...rest }: any, ref: any) =>
+    RealReact.createElement('div', { ref, 'data-testid': testID, onClick: onPress, ...rest }, children)
+  )
+  return {
+    View: Box,
+    Modal: Box,
+    KeyboardAvoidingView: Box,
+    Pressable,
+    TouchableOpacity: Pressable,
+    Text: Box,
+    Keyboard: { dismiss: jest.fn(), addListener: () => ({ remove: jest.fn() }) },
+    Platform: { OS: 'ios', select: (o: any) => o.ios },
+    StyleSheet: {
+      create: (s: any) => s,
+      flatten: (s: any) => s,
+      absoluteFill: {},
+    },
+    useWindowDimensions: () => ({ width: 375, height: 800 }),
+  }
+})
+
+// Stub Questions / ConfirmationMessage / Cancel so we can assert exactly
+// which path SurveyModal is rendering, and trigger the submit/close callbacks.
+jest.mock('../src/surveys/components/Surveys', () => {
+  const RealReact = jest.requireActual('react')
+  return {
+    Questions: ({ onSubmit }: { onSubmit: () => void }) =>
+      RealReact.createElement('div', { 'data-testid': 'questions-stub', onClick: onSubmit }, 'QUESTIONS_RENDERED'),
+    sendSurveyShownEvent: jest.fn(),
+    dismissedSurveyEvent: jest.fn(),
+    sendSurveyEvent: jest.fn(),
+  }
+})
+
+jest.mock('../src/surveys/components/ConfirmationMessage', () => {
+  const RealReact = jest.requireActual('react')
+  return {
+    ConfirmationMessage: ({ header }: { header: string }) =>
+      RealReact.createElement('div', { 'data-testid': 'confirmation-stub' }, header),
+  }
+})
+
+jest.mock('../src/surveys/components/Cancel', () => {
+  const RealReact = jest.requireActual('react')
+  return {
+    Cancel: ({ onPress }: { onPress: () => void }) =>
+      RealReact.createElement('div', { 'data-testid': 'cancel-stub', onClick: onPress }, 'X'),
+  }
+})
+
+import { SurveyModal } from '../src/surveys/components/SurveyModal'
+import { defaultSurveyAppearance, SurveyAppearanceTheme } from '../src/surveys/surveys-utils'
+
+const baseSurvey: Survey = {
+  id: 'test-survey',
+  name: 'Test Survey',
+  type: SurveyType.Popover,
+  questions: [
+    {
+      id: 'q1',
+      type: SurveyQuestionType.Open,
+      question: 'What do you think?',
+      originalQuestionIndex: 0,
+    },
+  ],
+}
+
+const appearanceWithThankYou: SurveyAppearanceTheme = {
+  ...defaultSurveyAppearance,
+  thankYouMessageHeader: 'Thanks!',
+}
+
+const appearanceWithoutThankYou: SurveyAppearanceTheme = {
+  ...defaultSurveyAppearance,
+  thankYouMessageHeader: '',
+}
+
+describe('SurveyModal close behavior', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('does not flash Questions when appearance loses thankYouMessageHeader after submit', () => {
+    const onClose = jest.fn()
+    const { queryByTestId, getByTestId, rerender } = render(
+      <SurveyModal
+        survey={baseSurvey}
+        surveyLanguage={null}
+        appearance={appearanceWithThankYou}
+        onShow={() => {}}
+        onClose={onClose}
+      />
+    )
+
+    // Sanity: Questions is rendered initially.
+    expect(queryByTestId('questions-stub')).not.toBeNull()
+
+    // Drive isSurveySent=true via the stubbed Questions submit.
+    act(() => {
+      fireEvent.click(getByTestId('questions-stub'))
+    })
+
+    // Confirmation now showing.
+    expect(queryByTestId('confirmation-stub')).not.toBeNull()
+    expect(queryByTestId('questions-stub')).toBeNull()
+
+    // Parent provider clears activeSurvey on close — surveyAppearance recomputes
+    // to defaults without thankYouMessageHeader. Simulate that rerender.
+    rerender(
+      <SurveyModal
+        survey={baseSurvey}
+        surveyLanguage={null}
+        appearance={appearanceWithoutThankYou}
+        onShow={() => {}}
+        onClose={onClose}
+      />
+    )
+
+    // BUG: shouldShowConfirmation flips false, so Questions remounts with Q1.
+    // After the fix the conditional branches on isSurveySent first → null.
+    expect(queryByTestId('questions-stub')).toBeNull()
+  })
+
+  it('hides content immediately when the cancel button is pressed', () => {
+    const onClose = jest.fn()
+    const { queryByTestId, getByTestId } = render(
+      <SurveyModal
+        survey={baseSurvey}
+        surveyLanguage={null}
+        appearance={appearanceWithThankYou}
+        onShow={() => {}}
+        onClose={onClose}
+      />
+    )
+
+    expect(queryByTestId('questions-stub')).not.toBeNull()
+
+    act(() => {
+      fireEvent.click(getByTestId('cancel-stub'))
+    })
+
+    // After setIsVisible(false), the component returns null on its next
+    // render — Questions is gone from the DOM immediately.
+    expect(queryByTestId('questions-stub')).toBeNull()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('hides content before the parent unmounts (race with parent)', () => {
+    // This simulates the real-world flow: parent unmounts SurveyModal in
+    // the same event that SurveyModal calls setIsVisible(false). Under
+    // React 18 batching, the parent's update can win and SurveyModal
+    // never gets to commit its null render. If that happens, Questions
+    // is still in the tree at the moment the modal disappears, which is
+    // what the user sees during the fade-out.
+    const Wrapper = () => {
+      const [show, setShow] = React.useState(true)
+      if (!show) return <div data-testid="parent-unmounted" />
+      return (
+        <SurveyModal
+          survey={baseSurvey}
+          surveyLanguage={null}
+          appearance={appearanceWithThankYou}
+          onShow={() => {}}
+          onClose={() => setShow(false)}
+        />
+      )
+    }
+    const { queryByTestId, getByTestId } = render(<Wrapper />)
+
+    expect(queryByTestId('questions-stub')).not.toBeNull()
+
+    act(() => {
+      fireEvent.click(getByTestId('cancel-stub'))
+    })
+
+    // Parent has unmounted SurveyModal entirely.
+    expect(queryByTestId('parent-unmounted')).not.toBeNull()
+    // Questions must NOT have been rendered in any commit between the
+    // click and the unmount — i.e. no last-frame Q1 for the native modal
+    // to fade out with.
+    expect(queryByTestId('questions-stub')).toBeNull()
+  })
+})

--- a/packages/react-native/test/SurveyModal.spec.tsx
+++ b/packages/react-native/test/SurveyModal.spec.tsx
@@ -22,7 +22,9 @@ jest.mock('react-native', () => {
     TouchableOpacity: Pressable,
     Text: Box,
     Keyboard: { dismiss: jest.fn(), addListener: () => ({ remove: jest.fn() }) },
-    Platform: { OS: 'ios', select: (o: any) => o.ios },
+    // Use Android so the timer-based close-notification path runs (iOS would
+    // rely on Modal.onDismiss, which the mocked Modal cannot fire).
+    Platform: { OS: 'android', select: (o: any) => o.android ?? o.default },
     StyleSheet: {
       create: (s: any) => s,
       flatten: (s: any) => s,
@@ -152,19 +154,22 @@ describe('SurveyModal close behavior', () => {
       fireEvent.click(getByTestId('cancel-stub'))
     })
 
-    // After setIsVisible(false), the component returns null on its next
-    // render — Questions is gone from the DOM immediately.
+    // Content unmounts on the very next render — blank Modal before fade.
     expect(queryByTestId('questions-stub')).toBeNull()
+    // Parent notification is deferred until the fade completes.
+    expect(onClose).not.toHaveBeenCalled()
+
+    act(() => {
+      jest.runAllTimers()
+    })
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('hides content before the parent unmounts (race with parent)', () => {
-    // This simulates the real-world flow: parent unmounts SurveyModal in
-    // the same event that SurveyModal calls setIsVisible(false). Under
-    // React 18 batching, the parent's update can win and SurveyModal
-    // never gets to commit its null render. If that happens, Questions
-    // is still in the tree at the moment the modal disappears, which is
-    // what the user sees during the fade-out.
+  it('defers parent unmount until the fade completes', () => {
+    // The two-step hide unmounts children immediately but delays the parent's
+    // onClose until the fade duration elapses (Android timer / iOS onDismiss),
+    // so the Modal animates out cleanly with blank children before the parent
+    // tears it down.
     const Wrapper = () => {
       const [show, setShow] = React.useState(true)
       if (!show) return <div data-testid="parent-unmounted" />
@@ -180,17 +185,44 @@ describe('SurveyModal close behavior', () => {
     }
     const { queryByTestId, getByTestId } = render(<Wrapper />)
 
-    expect(queryByTestId('questions-stub')).not.toBeNull()
-
     act(() => {
       fireEvent.click(getByTestId('cancel-stub'))
     })
 
-    // Parent has unmounted SurveyModal entirely.
-    expect(queryByTestId('parent-unmounted')).not.toBeNull()
-    // Questions must NOT have been rendered in any commit between the
-    // click and the unmount — i.e. no last-frame Q1 for the native modal
-    // to fade out with.
+    // Two-step hide: content gone, but parent still rendering SurveyModal
+    // because onClose is deferred until the fade completes.
     expect(queryByTestId('questions-stub')).toBeNull()
+    expect(queryByTestId('parent-unmounted')).toBeNull()
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    // After the fade duration, the parent's onClose fires and it unmounts.
+    expect(queryByTestId('parent-unmounted')).not.toBeNull()
+  })
+
+  it('notifies the parent only once even if close is pressed multiple times', () => {
+    const onClose = jest.fn()
+    const { getByTestId } = render(
+      <SurveyModal
+        survey={baseSurvey}
+        surveyLanguage={null}
+        appearance={appearanceWithThankYou}
+        onShow={() => {}}
+        onClose={onClose}
+      />
+    )
+
+    act(() => {
+      fireEvent.click(getByTestId('cancel-stub'))
+      fireEvent.click(getByTestId('cancel-stub'))
+      fireEvent.click(getByTestId('cancel-stub'))
+    })
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/react-native/test/SurveyModal.spec.tsx
+++ b/packages/react-native/test/SurveyModal.spec.tsx
@@ -90,6 +90,27 @@ const appearanceWithoutThankYou: SurveyAppearanceTheme = {
   thankYouMessageHeader: '',
 }
 
+// Mount SurveyModal with the standard test fixture. Returns the rendered
+// result plus the onClose spy so tests can assert against either.
+const renderSurveyModal = (onClose: jest.Mock = jest.fn()) => {
+  const result = render(
+    <SurveyModal
+      survey={baseSurvey}
+      surveyLanguage={null}
+      appearance={appearanceWithThankYou}
+      onShow={() => {}}
+      onClose={onClose}
+    />
+  )
+  return { ...result, onClose }
+}
+
+const clickCancel = (getByTestId: (id: string) => HTMLElement) => {
+  act(() => {
+    fireEvent.click(getByTestId('cancel-stub'))
+  })
+}
+
 describe('SurveyModal close behavior', () => {
   afterEach(() => {
     cleanup()
@@ -137,22 +158,10 @@ describe('SurveyModal close behavior', () => {
   })
 
   it('hides content immediately when the cancel button is pressed', () => {
-    const onClose = jest.fn()
-    const { queryByTestId, getByTestId } = render(
-      <SurveyModal
-        survey={baseSurvey}
-        surveyLanguage={null}
-        appearance={appearanceWithThankYou}
-        onShow={() => {}}
-        onClose={onClose}
-      />
-    )
-
+    const { queryByTestId, getByTestId, onClose } = renderSurveyModal()
     expect(queryByTestId('questions-stub')).not.toBeNull()
 
-    act(() => {
-      fireEvent.click(getByTestId('cancel-stub'))
-    })
+    clickCancel(getByTestId)
 
     // Content unmounts on the very next render — blank Modal before fade.
     expect(queryByTestId('questions-stub')).toBeNull()
@@ -185,9 +194,7 @@ describe('SurveyModal close behavior', () => {
     }
     const { queryByTestId, getByTestId } = render(<Wrapper />)
 
-    act(() => {
-      fireEvent.click(getByTestId('cancel-stub'))
-    })
+    clickCancel(getByTestId)
 
     // Two-step hide: content gone, but parent still rendering SurveyModal
     // because onClose is deferred until the fade completes.
@@ -203,16 +210,7 @@ describe('SurveyModal close behavior', () => {
   })
 
   it('notifies the parent only once even if close is pressed multiple times', () => {
-    const onClose = jest.fn()
-    const { getByTestId } = render(
-      <SurveyModal
-        survey={baseSurvey}
-        surveyLanguage={null}
-        appearance={appearanceWithThankYou}
-        onShow={() => {}}
-        onClose={onClose}
-      />
-    )
+    const { getByTestId, onClose } = renderSurveyModal()
 
     act(() => {
       fireEvent.click(getByTestId('cancel-stub'))


### PR DESCRIPTION
## Problem

Two visual bugs in the React Native survey modal:

- **[#3529](https://github.com/PostHog/posthog-js/issues/3529)** — closing a survey on Q2+ or the Thank You screen briefly flashes Q1 during the fade-out.
- **Snapshot reuse flash** — opening a new survey shortly after closing one shows the previous survey's content for the first frame. iOS Fabric reuses the previous Modal's UIKit snapshot.

## Changes

- `fix(react-native): prevent first-question flash on survey close` — wires the unused `setIsVisible` setter into `onClose` and reorders the `isSurveySent` conditional so `<Questions>` can't remount with index 0 after submit.
- `fix(react-native): two-step hide to avoid Modal snapshot reuse flash` — unmount children one frame before `Modal.visible=false`, defer parent `onClose` until the fade finishes (`Modal.onDismiss` on iOS, fade-duration timer on Android), and latch against double-close.

## Why the workaround given the Meta fix?

Meta's [22cd3b1](https://github.com/facebook/react-native/commit/22cd3b1023205e4c5a9355aeb0d7d53804b23edf) for [facebook/react-native#48245](https://github.com/facebook/react-native/issues/48245) is partial — the underlying behavior still surfaces on iOS 26, confirmed on iPhone 17 / RN 0.79.6 and tracked in [react-navigation#12827](https://github.com/react-navigation/react-navigation/issues/12827). The workaround is ~5 lines, no API change, and can be removed once iOS 26 is fixed upstream.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code — 4 unit tests in `packages/react-native/test/SurveyModal.spec.tsx`
- [x] Accounted for impact across platforms — verified on iOS 26 (iPhone 17 sim) and Android (Pixel 9 emulator)
- [x] Backwards compatible — no public API changes
- [x] Bundle size impact minimal

### If releasing new changes

- [x] Ran `pnpm changeset` (`.changeset/rn-survey-modal-bug-fixes.md`, `patch` bump)

## Test plan

- [x] `pnpm --filter posthog-react-native test:unit` — 4/4 pass
- [x] `pnpm --filter posthog-react-native lint` clean
- [x] Manual: close from any screen (Q1/Q2/Q3/Thank You) → clean fade, no flash
- [x] Manual: open → close → open another → no flash of previous content
- [x] Manual: Android hardware back button dismisses correctly

## Demo


https://github.com/user-attachments/assets/33b2851d-b8dc-4729-a8c3-ec0fee1e455c


https://github.com/user-attachments/assets/341c6dcd-82a1-43f0-a32f-0c0e3185697c

Uploading multiple-surveys.mov…


