### PR TITLE
fix(rrweb-snapshot): capture <link> hrefs from sheet.href, not the detached anchor

### DIFF
--- a/.changeset/snapshot-prefer-sheet-href.md
+++ b/.changeset/snapshot-prefer-sheet-href.md
@@ -1,0 +1,5 @@
+---
+'@posthog/rrweb-snapshot': patch
+---
+
+Capture `<link rel="stylesheet">` URLs from `link.sheet.href` and try `link.sheet` directly for inlining, so recordings survive SPA `history.pushState` navigations between routes of different path depths (where `link.href` re-resolves against a new baseURI but `link.sheet.href` preserves the URL the browser actually fetched).

--- a/packages/rrweb/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb/rrweb-snapshot/src/snapshot.ts
@@ -191,6 +191,13 @@ export function transformAttribute(
     name === 'src' ||
     (name === 'href' && !(tagName === 'use' && value[0] === '#'))
   ) {
+    // Prefer the loaded sheet's href — survives baseURI changes from SPA pushState.
+    if (tagName === 'link' && element) {
+      const sheetHref = (element as HTMLLinkElement).sheet?.href;
+      if (sheetHref) {
+        return sheetHref;
+      }
+    }
     // href starts with a # is an id pointer for svg
     const transformedValue = absoluteToDoc(doc, value);
 
@@ -655,25 +662,29 @@ function serializeElementNode(
   }
   // remote css
   if (tagName === 'link' && inlineStylesheet) {
-    //TODO: maybe replace this `.styleSheets` with original one
-    const href: string | undefined = hrefFrom(n);
-    if (href) {
-      let stylesheet = findStylesheet(doc, href);
-      if (!stylesheet && href.includes('.css')) {
-        const rootDomain = window.location.origin;
-        const stylesheetPath = href.replace(window.location.href, '');
-        const potentialStylesheetHref = rootDomain + '/' + stylesheetPath;
-        stylesheet = findStylesheet(doc, potentialStylesheetHref);
+    // Direct sheet reference survives baseURI drift; href lookup is the fallback.
+    let stylesheet: CSSStyleSheet | null | undefined = (n as HTMLLinkElement)
+      .sheet;
+    if (!stylesheet) {
+      const href: string | undefined = hrefFrom(n);
+      if (href) {
+        stylesheet = findStylesheet(doc, href);
+        if (!stylesheet && href.includes('.css')) {
+          const rootDomain = window.location.origin;
+          const stylesheetPath = href.replace(window.location.href, '');
+          const potentialStylesheetHref = rootDomain + '/' + stylesheetPath;
+          stylesheet = findStylesheet(doc, potentialStylesheetHref);
+        }
       }
-      let cssText: string | null = null;
-      if (stylesheet) {
-        cssText = stringifyStylesheet(stylesheet);
-      }
-      if (cssText) {
-        delete attributes.rel;
-        delete attributes.href;
-        attributes._cssText = cssText;
-      }
+    }
+    let cssText: string | null = null;
+    if (stylesheet) {
+      cssText = stringifyStylesheet(stylesheet);
+    }
+    if (cssText) {
+      delete attributes.rel;
+      delete attributes.href;
+      attributes._cssText = cssText;
     }
   }
   // dynamic stylesheet

--- a/packages/rrweb/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb/rrweb-snapshot/test/snapshot.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import snapshot, {
   _isBlockedElement,
   DEFAULT_MAX_DEPTH,
+  transformAttribute,
   wasMaxDepthReached,
   resetMaxDepthState,
   serializeNodeWithId,
@@ -507,5 +508,79 @@ describe('maxDepth', () => {
     warnSpy.mockClear();
     serializeWithMaxDepth(root, 5);
     expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('link href capture across SPA navigations', () => {
+  function makeLinkWithSheet(
+    rawAttr: string,
+    sheetHref: string | null,
+  ): HTMLLinkElement {
+    const link = document.createElement('link');
+    link.setAttribute('rel', 'stylesheet');
+    link.setAttribute('href', rawAttr);
+    Object.defineProperty(link, 'sheet', {
+      configurable: true,
+      get: () =>
+        sheetHref === null
+          ? null
+          : ({
+              href: sheetHref,
+              cssRules: [],
+            } as unknown as CSSStyleSheet),
+    });
+    return link;
+  }
+
+  it('prefers link.sheet.href over the detached-anchor resolution', () => {
+    const link = makeLinkWithSheet(
+      '../../_app/auth.css',
+      'http://localhost/_app/auth.css',
+    );
+
+    const result = transformAttribute(
+      document,
+      'link',
+      'href',
+      '../../_app/auth.css',
+      link,
+    );
+
+    expect(result).toBe('http://localhost/_app/auth.css');
+  });
+
+  it('falls back to detached-anchor resolution when the sheet has not loaded', () => {
+    const link = makeLinkWithSheet('../../_app/auth.css', null);
+
+    const result = transformAttribute(
+      document,
+      'link',
+      'href',
+      '../../_app/auth.css',
+      link,
+    );
+
+    expect(result).not.toBeNull();
+    expect(typeof result).toBe('string');
+  });
+
+  it('does not divert non-link tags through the sheet branch', () => {
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', '/elsewhere');
+    Object.defineProperty(anchor, 'sheet', {
+      configurable: true,
+      get: () =>
+        ({ href: 'should-not-be-used' } as unknown as CSSStyleSheet),
+    });
+
+    const result = transformAttribute(
+      document,
+      'a',
+      'href',
+      '/elsewhere',
+      anchor,
+    );
+
+    expect(result).not.toBe('should-not-be-used');
   });
 });


### PR DESCRIPTION
## Problem

SPA routers (e.g. SvelteKit) use `history.pushState()` to navigate between routes of different path depths without re-fetching layout-level `<link rel=stylesheet>` tags. After such a navigation the link's raw `href` attribute is unchanged, but `link.href` re-resolves against the new (deeper) `document.baseURI` and returns a URL the server never served — even though the stylesheet is still loaded in memory under its original-fetch URL.

rrweb-snapshot then captures the broken URL (via the detached-anchor resolution) and inlining silently fails (`findStylesheet(doc, link.href)` misses the loaded sheet, whose `.href` is the original-fetch URL). Playback 404s on a recording that was visually fine in the user's browser.

## Changes

- `transformAttribute` for `<link>` prefers `link.sheet.href` (the URL the browser actually fetched) over the detached-anchor resolution.
- Inlining branch tries `link.sheet` directly before falling back to the `findStylesheet(doc, link.href)` key lookup.

Both are additive — when `link.sheet` is null the existing paths still run.

## Release info

### Libraries affected

- [x] @posthog/rrweb-snapshot (transitively: posthog-js)

## Checklist

- [x] Tests for new code
- [x] Accounted for backwards compatibility (no breaking changes)
- [x] Took care not to unnecessarily increase the bundle size
- [x] Ran `pnpm changeset`

## 🤖 Agent context

Authored via Claude Code. Customer recording (Mantel — SvelteKit multi-workspace SPA) 404'd stylesheets at playback. Ruled out: inlining-disabled (default is on), server-side URL bug (live page loads cleanly), rrweb URL-resolution bug (Chromium and jsdom both resolve correctly). Only reproduces when the user enters via a shallower URL and the SPA pushes state to a deeper one.