### PR TITLE
fix: apply tracing headers to XHR requests

### DIFF
--- a/.changeset/fresh-xhrs-trace.md
+++ b/.changeset/fresh-xhrs-trace.md
@@ -1,0 +1,5 @@
+---
+"posthog-js": patch
+---
+
+Apply tracing headers to matching XMLHttpRequest requests

--- a/packages/browser/src/__tests__/tracing-headers.test.ts
+++ b/packages/browser/src/__tests__/tracing-headers.test.ts
@@ -1,0 +1,88 @@
+import { COOKIELESS_SENTINEL_VALUE } from '../constants'
+import patchFns from '../entrypoints/tracing-headers'
+
+class TestHeaders {
+    private _headers: Record<string, string> = {}
+
+    set(name: string, value: string): void {
+        this._headers[name.toLowerCase()] = value
+    }
+
+    get(name: string): string | null {
+        return this._headers[name.toLowerCase()] ?? null
+    }
+}
+
+class TestRequest {
+    url: string
+    headers = new TestHeaders()
+
+    constructor(url: string | URL) {
+        this.url = url.toString()
+    }
+}
+
+describe('tracing headers', () => {
+    const originalRequest = globalThis.Request
+    let restoreXHRPatch: (() => void) | undefined
+
+    beforeAll(() => {
+        const globalAny = globalThis as any
+        globalAny.Request = TestRequest
+    })
+
+    afterAll(() => {
+        const globalAny = globalThis as any
+        globalAny.Request = originalRequest
+    })
+
+    afterEach(() => {
+        restoreXHRPatch?.()
+        restoreXHRPatch = undefined
+        jest.restoreAllMocks()
+    })
+
+    const sessionManager = {
+        checkAndGetSessionAndWindowId: jest.fn(() => ({ sessionId: 'session-id', windowId: 'window-id' })),
+    }
+
+    it('adds tracing headers to matching XHR requests', () => {
+        const setRequestHeaderSpy = jest
+            .spyOn(XMLHttpRequest.prototype, 'setRequestHeader')
+            .mockImplementation(() => {})
+        restoreXHRPatch = patchFns._patchXHR(['example.com'], 'distinct-id', sessionManager as any)
+
+        const xhr = new XMLHttpRequest()
+        xhr.open('GET', 'https://example.com/path')
+
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-POSTHOG-SESSION-ID', 'session-id')
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-POSTHOG-WINDOW-ID', 'window-id')
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-POSTHOG-DISTINCT-ID', 'distinct-id')
+    })
+
+    it('does not add tracing headers to non-matching XHR requests', () => {
+        const setRequestHeaderSpy = jest
+            .spyOn(XMLHttpRequest.prototype, 'setRequestHeader')
+            .mockImplementation(() => {})
+        restoreXHRPatch = patchFns._patchXHR(['example.com'], 'distinct-id', sessionManager as any)
+
+        const xhr = new XMLHttpRequest()
+        xhr.open('GET', 'https://other.example/path')
+
+        expect(setRequestHeaderSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not add the distinct ID header to XHR requests when cookieless mode is active', () => {
+        const setRequestHeaderSpy = jest
+            .spyOn(XMLHttpRequest.prototype, 'setRequestHeader')
+            .mockImplementation(() => {})
+        restoreXHRPatch = patchFns._patchXHR(['example.com'], COOKIELESS_SENTINEL_VALUE, sessionManager as any)
+
+        const xhr = new XMLHttpRequest()
+        xhr.open('GET', 'https://example.com/path')
+
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-POSTHOG-SESSION-ID', 'session-id')
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-POSTHOG-WINDOW-ID', 'window-id')
+        expect(setRequestHeaderSpy).not.toHaveBeenCalledWith('X-POSTHOG-DISTINCT-ID', expect.anything())
+    })
+})

--- a/packages/browser/src/__tests__/tracing-headers.test.ts
+++ b/packages/browser/src/__tests__/tracing-headers.test.ts
@@ -46,43 +46,53 @@ describe('tracing headers', () => {
         checkAndGetSessionAndWindowId: jest.fn(() => ({ sessionId: 'session-id', windowId: 'window-id' })),
     }
 
-    it('adds tracing headers to matching XHR requests', () => {
+    test.each([
+        {
+            name: 'adds tracing headers to matching XHR requests',
+            url: 'https://example.com/path',
+            distinctId: 'distinct-id',
+            expectedHeaders: [
+                ['X-POSTHOG-SESSION-ID', 'session-id'],
+                ['X-POSTHOG-WINDOW-ID', 'window-id'],
+                ['X-POSTHOG-DISTINCT-ID', 'distinct-id'],
+            ],
+            absentHeaders: [],
+        },
+        {
+            name: 'does not add tracing headers to non-matching XHR requests',
+            url: 'https://other.example/path',
+            distinctId: 'distinct-id',
+            expectedHeaders: [],
+            absentHeaders: [
+                ['X-POSTHOG-SESSION-ID', 'session-id'],
+                ['X-POSTHOG-WINDOW-ID', 'window-id'],
+                ['X-POSTHOG-DISTINCT-ID', 'distinct-id'],
+            ],
+        },
+        {
+            name: 'does not add the distinct ID header to XHR requests when cookieless mode is active',
+            url: 'https://example.com/path',
+            distinctId: COOKIELESS_SENTINEL_VALUE,
+            expectedHeaders: [
+                ['X-POSTHOG-SESSION-ID', 'session-id'],
+                ['X-POSTHOG-WINDOW-ID', 'window-id'],
+            ],
+            absentHeaders: [['X-POSTHOG-DISTINCT-ID', 'distinct-id']],
+        },
+    ])('$name', ({ url, distinctId, expectedHeaders, absentHeaders }) => {
         const setRequestHeaderSpy = jest
             .spyOn(XMLHttpRequest.prototype, 'setRequestHeader')
             .mockImplementation(() => {})
-        restoreXHRPatch = patchFns._patchXHR(['example.com'], 'distinct-id', sessionManager as any)
+        restoreXHRPatch = patchFns._patchXHR(['example.com'], distinctId, sessionManager as any)
 
         const xhr = new XMLHttpRequest()
-        xhr.open('GET', 'https://example.com/path')
+        xhr.open('GET', url)
 
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-POSTHOG-SESSION-ID', 'session-id')
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-POSTHOG-WINDOW-ID', 'window-id')
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-POSTHOG-DISTINCT-ID', 'distinct-id')
-    })
-
-    it('does not add tracing headers to non-matching XHR requests', () => {
-        const setRequestHeaderSpy = jest
-            .spyOn(XMLHttpRequest.prototype, 'setRequestHeader')
-            .mockImplementation(() => {})
-        restoreXHRPatch = patchFns._patchXHR(['example.com'], 'distinct-id', sessionManager as any)
-
-        const xhr = new XMLHttpRequest()
-        xhr.open('GET', 'https://other.example/path')
-
-        expect(setRequestHeaderSpy).not.toHaveBeenCalled()
-    })
-
-    it('does not add the distinct ID header to XHR requests when cookieless mode is active', () => {
-        const setRequestHeaderSpy = jest
-            .spyOn(XMLHttpRequest.prototype, 'setRequestHeader')
-            .mockImplementation(() => {})
-        restoreXHRPatch = patchFns._patchXHR(['example.com'], COOKIELESS_SENTINEL_VALUE, sessionManager as any)
-
-        const xhr = new XMLHttpRequest()
-        xhr.open('GET', 'https://example.com/path')
-
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-POSTHOG-SESSION-ID', 'session-id')
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-POSTHOG-WINDOW-ID', 'window-id')
-        expect(setRequestHeaderSpy).not.toHaveBeenCalledWith('X-POSTHOG-DISTINCT-ID', expect.anything())
+        expectedHeaders.forEach(([header, value]) => {
+            expect(setRequestHeaderSpy).toHaveBeenCalledWith(header, value)
+        })
+        absentHeaders.forEach(([header, value]) => {
+            expect(setRequestHeaderSpy).not.toHaveBeenCalledWith(header, value)
+        })
     })
 })

--- a/packages/browser/src/entrypoints/tracing-headers.ts
+++ b/packages/browser/src/entrypoints/tracing-headers.ts
@@ -4,6 +4,10 @@ import { assignableWindow, window } from '../utils/globals'
 import { COOKIELESS_SENTINEL_VALUE } from '../constants'
 import { isArray } from '@posthog/core'
 
+const SESSION_ID_HEADER = 'X-POSTHOG-SESSION-ID'
+const WINDOW_ID_HEADER = 'X-POSTHOG-WINDOW-ID'
+const DISTINCT_ID_HEADER = 'X-POSTHOG-DISTINCT-ID'
+
 const addTracingHeaders = (
     hostnames: string[],
     distinctId: string,
@@ -27,11 +31,11 @@ const addTracingHeaders = (
 
     if (sessionManager) {
         const { sessionId, windowId } = sessionManager.checkAndGetSessionAndWindowId(true)
-        req.headers.set('X-POSTHOG-SESSION-ID', sessionId)
-        req.headers.set('X-POSTHOG-WINDOW-ID', windowId)
+        req.headers.set(SESSION_ID_HEADER, sessionId)
+        req.headers.set(WINDOW_ID_HEADER, windowId)
     }
     if (distinctId !== COOKIELESS_SENTINEL_VALUE) {
-        req.headers.set('X-POSTHOG-DISTINCT-ID', distinctId)
+        req.headers.set(DISTINCT_ID_HEADER, distinctId)
     }
 }
 
@@ -77,7 +81,17 @@ const patchXHR = (hostnames: string[], distinctId: string, sessionManager?: Sess
 
                 addTracingHeaders(hostnames, distinctId, sessionManager, req)
 
-                return originalOpen.call(xhr, method, req.url, async, username, password)
+                const result = originalOpen.call(xhr, method, req.url, async, username, password)
+                const tracingHeaders = [SESSION_ID_HEADER, WINDOW_ID_HEADER, DISTINCT_ID_HEADER]
+
+                tracingHeaders.forEach((header) => {
+                    const value = req.headers.get(header)
+                    if (value) {
+                        xhr.setRequestHeader(header, value)
+                    }
+                })
+
+                return result
             }
         }
     )

--- a/packages/browser/src/entrypoints/tracing-headers.ts
+++ b/packages/browser/src/entrypoints/tracing-headers.ts
@@ -7,6 +7,7 @@ import { isArray } from '@posthog/core'
 const SESSION_ID_HEADER = 'X-POSTHOG-SESSION-ID'
 const WINDOW_ID_HEADER = 'X-POSTHOG-WINDOW-ID'
 const DISTINCT_ID_HEADER = 'X-POSTHOG-DISTINCT-ID'
+const TRACING_HEADERS = [SESSION_ID_HEADER, WINDOW_ID_HEADER, DISTINCT_ID_HEADER]
 
 const addTracingHeaders = (
     hostnames: string[],
@@ -82,9 +83,8 @@ const patchXHR = (hostnames: string[], distinctId: string, sessionManager?: Sess
                 addTracingHeaders(hostnames, distinctId, sessionManager, req)
 
                 const result = originalOpen.call(xhr, method, req.url, async, username, password)
-                const tracingHeaders = [SESSION_ID_HEADER, WINDOW_ID_HEADER, DISTINCT_ID_HEADER]
 
-                tracingHeaders.forEach((header) => {
+                TRACING_HEADERS.forEach((header) => {
                     const value = req.headers.get(header)
                     if (value) {
                         xhr.setRequestHeader(header, value)


### PR DESCRIPTION
## Problem

`addTracingHeaders` / `__add_tracing_headers` worked for `fetch`, but matching `XMLHttpRequest` calls did not receive the PostHog tracing headers. The XHR patch populated headers on a temporary `Request` object, then only forwarded the URL to `XMLHttpRequest.open()`, dropping the headers.

Fixes #3637.

## Changes

- Reuse constants for the PostHog tracing header names.
- After the patched XHR `open()` call, apply any generated tracing headers with `xhr.setRequestHeader(...)`.
- Add unit coverage for matching hosts, non-matching hosts, and cookieless mode skipping the distinct ID header.

Verified with:
- `pnpm exec jest src/__tests__/tracing-headers.test.ts --runInBand`
- `pnpm exec eslint src/entrypoints/tracing-headers.ts src/__tests__/tracing-headers.test.ts`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
