### PR TITLE
fix(node): identifyImmediate does not await its network request

### DIFF
--- a/.changeset/identify-immediate-return-promise.md
+++ b/.changeset/identify-immediate-return-promise.md
@@ -1,0 +1,5 @@
+---
+"posthog-node": patch
+---
+
+Fix `identifyImmediate` to await the underlying network request. Previously the returned promise resolved before the `$identify` event was sent, causing events to be dropped when called from short-lived runtimes (Vercel/Cloudflare Workers, Convex actions) that exit immediately after `await`.

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -236,6 +236,28 @@ describe('PostHog Node.js', () => {
       ])
     })
 
+    it('should await the network request when identifyImmediate is awaited', async () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(0)
+
+      await posthog.identifyImmediate({ distinctId: '123', properties: { foo: 'bar' } })
+
+      // Without awaiting the underlying request, the batch endpoint would not have been hit yet
+      // (regression guard for the missing-await bug in identifyImmediate).
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents).toMatchObject([
+        {
+          distinct_id: '123',
+          event: '$identify',
+          properties: {
+            $set: {
+              foo: 'bar',
+            },
+            $geoip_disable: true,
+          },
+        },
+      ])
+    })
+
     it('should allow overriding timestamp', async () => {
       expect(mockedFetch).toHaveBeenCalledTimes(0)
       posthog.capture({ event: 'custom-time', distinctId: '123', timestamp: new Date('2021-02-03') })

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -671,7 +671,7 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
       $set_once: setOnceProps,
       $anon_distinct_id: $anon_distinct_id ?? undefined,
     }
-    super.identifyStatelessImmediate(distinctId, eventProperties, { disableGeoip })
+    await super.identifyStatelessImmediate(distinctId, eventProperties, { disableGeoip })
   }
 
   /**


### PR DESCRIPTION
## Problem

`PostHogBackendClient.identifyImmediate` is documented as the synchronous variant of `identify` — callers `await` the returned promise to make sure the `$identify` event is on the wire before short-lived runtimes (Vercel, Cloudflare Workers, Convex actions) tear down.

Today it is missing an `await` (or `return`) on the underlying `super.identifyStatelessImmediate(...)` call:

```ts
async identifyImmediate({ distinctId, properties = {}, disableGeoip }: IdentifyMessage): Promise<void> {
  // ...
  super.identifyStatelessImmediate(distinctId, eventProperties, { disableGeoip }) // <- not awaited
}
```

so the returned promise resolves before the network request completes, and `$identify` events are silently dropped in serverless contexts.

### Related to #3238

This was found by following up on the suggestion in #3238 — that PR fixed the same class of bug for `captureExceptionImmediate` and explicitly recommended a scan of the other `*Immediate` methods for the same shape. This PR is that scan: of the four `*Immediate` methods on `PostHogBackendClient`, `identifyImmediate` is the remaining one that drops its inner promise. (`captureImmediate` was fixed in #2225, `aliasImmediate` already `await`s correctly, `captureExceptionImmediate` is #3238.)

The `@posthog/convex` package already documents the workaround for this exact bug in [`packages/convex/src/component/lib.ts`](https://github.com/PostHog/posthog-js/blob/main/packages/convex/src/component/lib.ts#L91-L94), routing `$identify` through `captureImmediate` instead.

Refs #3238

## Changes

```ts
// before
async identifyImmediate(...): Promise<void> {
  // ...
  super.identifyStatelessImmediate(distinctId, eventProperties, { disableGeoip })
}

// after
async identifyImmediate(...): Promise<void> {
  // ...
  await super.identifyStatelessImmediate(distinctId, eventProperties, { disableGeoip })
}
```

Also added a regression test that asserts the batch endpoint has been hit by the time `await posthog.identifyImmediate(...)` resolves. The convex workaround comment is left in place — removing it is a separate change for the `@posthog/convex` package with its own release implications, and the workaround keeps working after this fix.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
