### PR TITLE
feat: add browser flag_keys config

### DIFF
--- a/.changeset/fresh-goats-relax.md
+++ b/.changeset/fresh-goats-relax.md
@@ -1,6 +1,6 @@
 ---
-"posthog-js": patch
-"@posthog/types": patch
+'posthog-js': minor
+'@posthog/types': minor
 ---
 
 Add `flag_keys` config to restrict browser feature flag remote evaluation to specific flag keys.

--- a/.changeset/fresh-goats-relax.md
+++ b/.changeset/fresh-goats-relax.md
@@ -1,0 +1,6 @@
+---
+"posthog-js": patch
+"@posthog/types": patch
+---
+
+Add `flag_keys` config to restrict browser feature flag remote evaluation to specific flag keys.

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../posthog-featureflags'
 import { PostHogPersistence } from '../posthog-persistence'
 import { RequestRouter } from '../utils/request-router'
+import { isUndefined } from '@posthog/core'
 import { PostHogConfig } from '../types'
 import { createMockPostHog, createPosthogInstance } from './helpers/posthog-instance'
 import { SimpleEventEmitter } from '../utils/simple-event-emitter'
@@ -1094,7 +1095,7 @@ describe('featureflags', () => {
             ['not configured', undefined, undefined, 0],
         ])('should handle flag_keys when %s', (_description, configuredFlagKeys, expectedFlagKeys, expectedErrors) => {
             const errorSpy = jest.spyOn(window.console, 'error').mockImplementation()
-            if (configuredFlagKeys !== undefined) {
+            if (!isUndefined(configuredFlagKeys)) {
                 instance.config.flag_keys = configuredFlagKeys as any
             }
 
@@ -1102,7 +1103,7 @@ describe('featureflags', () => {
             jest.runOnlyPendingTimers()
 
             expect(instance._send_request).toHaveBeenCalledTimes(1)
-            if (expectedFlagKeys === undefined) {
+            if (isUndefined(expectedFlagKeys)) {
                 expect(instance._send_request.mock.calls[0][0].data).not.toHaveProperty('flag_keys')
             } else {
                 expect(instance._send_request.mock.calls[0][0].data.flag_keys).toEqual(expectedFlagKeys)
@@ -3187,7 +3188,7 @@ describe('getRemoteConfigPayload', () => {
         ['configured as an empty array', [], []],
         ['not configured', undefined, undefined],
     ])('should handle flag_keys when %s', (_description, configuredFlagKeys, expectedFlagKeys) => {
-        if (configuredFlagKeys !== undefined) {
+        if (!isUndefined(configuredFlagKeys)) {
             instance.config.flag_keys = configuredFlagKeys as any
         }
 
@@ -3205,7 +3206,7 @@ describe('getRemoteConfigPayload', () => {
             })
         )
 
-        if (expectedFlagKeys === undefined) {
+        if (isUndefined(expectedFlagKeys)) {
             expect(instance._send_request.mock.calls[0][0].data).not.toHaveProperty('flag_keys')
         } else {
             expect(instance._send_request.mock.calls[0][0].data.flag_keys).toEqual(expectedFlagKeys)

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -1076,6 +1076,90 @@ describe('featureflags', () => {
             expect(instance._send_request.mock.calls[0][0].data.evaluation_contexts).toEqual(['production', 'web'])
         })
 
+        it('should call /flags with flag_keys when configured', () => {
+            instance.config.flag_keys = ['beta-feature', 'checkout-redesign']
+            featureFlags.reloadFeatureFlags()
+            jest.runOnlyPendingTimers()
+
+            expect(instance._send_request).toHaveBeenCalledTimes(1)
+            expect(instance._send_request.mock.calls[0][0].data.flag_keys).toEqual([
+                'beta-feature',
+                'checkout-redesign',
+            ])
+        })
+
+        it('should call /flags with empty flag_keys when configured as an empty array', () => {
+            instance.config.flag_keys = []
+            featureFlags.reloadFeatureFlags()
+            jest.runOnlyPendingTimers()
+
+            expect(instance._send_request).toHaveBeenCalledTimes(1)
+            expect(instance._send_request.mock.calls[0][0].data.flag_keys).toEqual([])
+        })
+
+        it('should filter invalid flag_keys before sending', () => {
+            const errorSpy = jest.spyOn(window.console, 'error').mockImplementation()
+            instance.config.flag_keys = ['beta-feature', '', null as any, 'checkout-redesign', '   ']
+            featureFlags.reloadFeatureFlags()
+            jest.runOnlyPendingTimers()
+
+            expect(instance._send_request).toHaveBeenCalledTimes(1)
+            expect(instance._send_request.mock.calls[0][0].data.flag_keys).toEqual([
+                'beta-feature',
+                'checkout-redesign',
+            ])
+
+            errorSpy.mockRestore()
+        })
+
+        it('should not include flag_keys when configured with an invalid non-array value', () => {
+            const errorSpy = jest.spyOn(window.console, 'error').mockImplementation()
+            instance.config.flag_keys = 'beta-feature' as any
+            featureFlags.reloadFeatureFlags()
+            jest.runOnlyPendingTimers()
+
+            expect(instance._send_request).toHaveBeenCalledTimes(1)
+            expect(instance._send_request.mock.calls[0][0].data).not.toHaveProperty('flag_keys')
+
+            errorSpy.mockRestore()
+        })
+
+        it('should replace existing flags with the flag_keys response', () => {
+            const requestedFlagDetail = {
+                key: 'checkout-redesign',
+                enabled: true,
+                variant: undefined,
+                reason: { code: 'condition_match', condition_index: 0, description: undefined },
+                metadata: { id: 42, version: 1, payload: undefined, description: undefined },
+            }
+            instance.config.flag_keys = ['checkout-redesign']
+            instance._send_request = jest.fn().mockImplementation(({ callback }) =>
+                callback({
+                    statusCode: 200,
+                    json: {
+                        flags: {
+                            'checkout-redesign': requestedFlagDetail,
+                        },
+                    },
+                })
+            )
+
+            featureFlags.reloadFeatureFlags()
+            jest.runOnlyPendingTimers()
+
+            expect(instance.persistence.props.$enabled_feature_flags).toEqual({
+                'checkout-redesign': true,
+            })
+        })
+
+        it('should not include flag_keys when not configured', () => {
+            featureFlags.reloadFeatureFlags()
+            jest.runOnlyPendingTimers()
+
+            expect(instance._send_request).toHaveBeenCalledTimes(1)
+            expect(instance._send_request.mock.calls[0][0].data).not.toHaveProperty('flag_keys')
+        })
+
         it('should not include evaluation_contexts when not configured', () => {
             featureFlags.reloadFeatureFlags()
             jest.runOnlyPendingTimers()
@@ -3099,6 +3183,62 @@ describe('getRemoteConfigPayload', () => {
                 }),
             })
         )
+    })
+
+    it('should include flag_keys when configured', () => {
+        instance.config.flag_keys = ['remote-config-flag']
+
+        const callback = jest.fn()
+        featureFlags.getRemoteConfigPayload('test-flag', callback)
+
+        expect(instance._send_request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'POST',
+                url: 'flags/flags/?v=2',
+                data: expect.objectContaining({
+                    distinct_id: 'test-distinct-id',
+                    token: 'test-token',
+                    flag_keys: ['remote-config-flag'],
+                }),
+            })
+        )
+    })
+
+    it('should include empty flag_keys when configured as an empty array', () => {
+        instance.config.flag_keys = []
+
+        const callback = jest.fn()
+        featureFlags.getRemoteConfigPayload('test-flag', callback)
+
+        expect(instance._send_request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'POST',
+                url: 'flags/flags/?v=2',
+                data: expect.objectContaining({
+                    distinct_id: 'test-distinct-id',
+                    token: 'test-token',
+                    flag_keys: [],
+                }),
+            })
+        )
+    })
+
+    it('should not include flag_keys when not configured', () => {
+        const callback = jest.fn()
+        featureFlags.getRemoteConfigPayload('test-flag', callback)
+
+        expect(instance._send_request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'POST',
+                url: 'flags/flags/?v=2',
+                data: expect.objectContaining({
+                    distinct_id: 'test-distinct-id',
+                    token: 'test-token',
+                }),
+            })
+        )
+
+        expect(instance._send_request.mock.calls[0][0].data).not.toHaveProperty('flag_keys')
     })
 
     it('should not include evaluation_contexts when not configured', () => {

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -1076,50 +1076,38 @@ describe('featureflags', () => {
             expect(instance._send_request.mock.calls[0][0].data.evaluation_contexts).toEqual(['production', 'web'])
         })
 
-        it('should call /flags with flag_keys when configured', () => {
-            instance.config.flag_keys = ['beta-feature', 'checkout-redesign']
-            featureFlags.reloadFeatureFlags()
-            jest.runOnlyPendingTimers()
-
-            expect(instance._send_request).toHaveBeenCalledTimes(1)
-            expect(instance._send_request.mock.calls[0][0].data.flag_keys).toEqual([
-                'beta-feature',
-                'checkout-redesign',
-            ])
-        })
-
-        it('should call /flags with empty flag_keys when configured as an empty array', () => {
-            instance.config.flag_keys = []
-            featureFlags.reloadFeatureFlags()
-            jest.runOnlyPendingTimers()
-
-            expect(instance._send_request).toHaveBeenCalledTimes(1)
-            expect(instance._send_request.mock.calls[0][0].data.flag_keys).toEqual([])
-        })
-
-        it('should filter invalid flag_keys before sending', () => {
+        it.each([
+            [
+                'configured with flag keys',
+                ['beta-feature', 'checkout-redesign'],
+                ['beta-feature', 'checkout-redesign'],
+                0,
+            ],
+            ['configured as an empty array', [], [], 0],
+            [
+                'configured with invalid entries',
+                ['beta-feature', '', null as any, 'checkout-redesign', '   '],
+                ['beta-feature', 'checkout-redesign'],
+                3,
+            ],
+            ['configured with an invalid non-array value', 'beta-feature' as any, undefined, 1],
+            ['not configured', undefined, undefined, 0],
+        ])('should handle flag_keys when %s', (_description, configuredFlagKeys, expectedFlagKeys, expectedErrors) => {
             const errorSpy = jest.spyOn(window.console, 'error').mockImplementation()
-            instance.config.flag_keys = ['beta-feature', '', null as any, 'checkout-redesign', '   ']
+            if (configuredFlagKeys !== undefined) {
+                instance.config.flag_keys = configuredFlagKeys as any
+            }
+
             featureFlags.reloadFeatureFlags()
             jest.runOnlyPendingTimers()
 
             expect(instance._send_request).toHaveBeenCalledTimes(1)
-            expect(instance._send_request.mock.calls[0][0].data.flag_keys).toEqual([
-                'beta-feature',
-                'checkout-redesign',
-            ])
-
-            errorSpy.mockRestore()
-        })
-
-        it('should not include flag_keys when configured with an invalid non-array value', () => {
-            const errorSpy = jest.spyOn(window.console, 'error').mockImplementation()
-            instance.config.flag_keys = 'beta-feature' as any
-            featureFlags.reloadFeatureFlags()
-            jest.runOnlyPendingTimers()
-
-            expect(instance._send_request).toHaveBeenCalledTimes(1)
-            expect(instance._send_request.mock.calls[0][0].data).not.toHaveProperty('flag_keys')
+            if (expectedFlagKeys === undefined) {
+                expect(instance._send_request.mock.calls[0][0].data).not.toHaveProperty('flag_keys')
+            } else {
+                expect(instance._send_request.mock.calls[0][0].data.flag_keys).toEqual(expectedFlagKeys)
+            }
+            expect(errorSpy).toHaveBeenCalledTimes(expectedErrors as number)
 
             errorSpy.mockRestore()
         })
@@ -1132,6 +1120,23 @@ describe('featureflags', () => {
                 reason: { code: 'condition_match', condition_index: 0, description: undefined },
                 metadata: { id: 42, version: 1, payload: undefined, description: undefined },
             }
+            const unrequestedFlagDetail = {
+                ...requestedFlagDetail,
+                key: 'other-flag',
+                metadata: { id: 43, version: 1, payload: undefined, description: undefined },
+            }
+
+            featureFlags.receivedFeatureFlags({
+                flags: {
+                    'checkout-redesign': requestedFlagDetail,
+                    'other-flag': unrequestedFlagDetail,
+                },
+            })
+            expect(instance.persistence.props.$enabled_feature_flags).toEqual({
+                'checkout-redesign': true,
+                'other-flag': true,
+            })
+
             instance.config.flag_keys = ['checkout-redesign']
             instance._send_request = jest.fn().mockImplementation(({ callback }) =>
                 callback({
@@ -1150,14 +1155,6 @@ describe('featureflags', () => {
             expect(instance.persistence.props.$enabled_feature_flags).toEqual({
                 'checkout-redesign': true,
             })
-        })
-
-        it('should not include flag_keys when not configured', () => {
-            featureFlags.reloadFeatureFlags()
-            jest.runOnlyPendingTimers()
-
-            expect(instance._send_request).toHaveBeenCalledTimes(1)
-            expect(instance._send_request.mock.calls[0][0].data).not.toHaveProperty('flag_keys')
         })
 
         it('should not include evaluation_contexts when not configured', () => {
@@ -3185,45 +3182,15 @@ describe('getRemoteConfigPayload', () => {
         )
     })
 
-    it('should include flag_keys when configured', () => {
-        instance.config.flag_keys = ['remote-config-flag']
+    it.each([
+        ['configured with flag keys', ['remote-config-flag'], ['remote-config-flag']],
+        ['configured as an empty array', [], []],
+        ['not configured', undefined, undefined],
+    ])('should handle flag_keys when %s', (_description, configuredFlagKeys, expectedFlagKeys) => {
+        if (configuredFlagKeys !== undefined) {
+            instance.config.flag_keys = configuredFlagKeys as any
+        }
 
-        const callback = jest.fn()
-        featureFlags.getRemoteConfigPayload('test-flag', callback)
-
-        expect(instance._send_request).toHaveBeenCalledWith(
-            expect.objectContaining({
-                method: 'POST',
-                url: 'flags/flags/?v=2',
-                data: expect.objectContaining({
-                    distinct_id: 'test-distinct-id',
-                    token: 'test-token',
-                    flag_keys: ['remote-config-flag'],
-                }),
-            })
-        )
-    })
-
-    it('should include empty flag_keys when configured as an empty array', () => {
-        instance.config.flag_keys = []
-
-        const callback = jest.fn()
-        featureFlags.getRemoteConfigPayload('test-flag', callback)
-
-        expect(instance._send_request).toHaveBeenCalledWith(
-            expect.objectContaining({
-                method: 'POST',
-                url: 'flags/flags/?v=2',
-                data: expect.objectContaining({
-                    distinct_id: 'test-distinct-id',
-                    token: 'test-token',
-                    flag_keys: [],
-                }),
-            })
-        )
-    })
-
-    it('should not include flag_keys when not configured', () => {
         const callback = jest.fn()
         featureFlags.getRemoteConfigPayload('test-flag', callback)
 
@@ -3238,7 +3205,11 @@ describe('getRemoteConfigPayload', () => {
             })
         )
 
-        expect(instance._send_request.mock.calls[0][0].data).not.toHaveProperty('flag_keys')
+        if (expectedFlagKeys === undefined) {
+            expect(instance._send_request.mock.calls[0][0].data).not.toHaveProperty('flag_keys')
+        } else {
+            expect(instance._send_request.mock.calls[0][0].data.flag_keys).toEqual(expectedFlagKeys)
+        }
     })
 
     it('should not include evaluation_contexts when not configured', () => {

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -288,6 +288,27 @@ export class PostHogFeatureFlags implements Extension {
         return this._getValidEvaluationEnvironments().length > 0
     }
 
+    private _getValidFlagKeys(): string[] | undefined {
+        const flagKeys = this._config.flag_keys
+
+        if (isUndefined(flagKeys)) {
+            return undefined
+        }
+
+        if (!isArray(flagKeys)) {
+            logger.error('Invalid flag_keys found:', flagKeys, 'Expected array of non-empty strings')
+            return undefined
+        }
+
+        return flagKeys.filter((flagKey: string) => {
+            const isValid = flagKey && typeof flagKey === 'string' && flagKey.trim().length > 0
+            if (!isValid) {
+                logger.error('Invalid flag key found:', flagKey, 'Expected non-empty string')
+            }
+            return isValid
+        })
+    }
+
     initialize() {
         const { config } = this._instance
         const bootstrapFlags = config.bootstrap?.featureFlags ?? {}
@@ -562,9 +583,15 @@ export class PostHogFeatureFlags implements Extension {
             data.evaluation_contexts = this._getValidEvaluationEnvironments()
         }
 
+        const flagKeys = this._getValidFlagKeys()
+        if (!isUndefined(flagKeys)) {
+            data.flag_keys = flagKeys
+        }
+
         const queryParams = this._config.advanced_only_evaluate_survey_feature_flags
             ? '&only_evaluate_survey_feature_flags=true'
             : ''
+        const isPartialFlagsResponse = !!this._config.advanced_only_evaluate_survey_feature_flags
 
         const url = this._instance.requestRouter.endpointFor('flags', '/flags/?v=2' + queryParams)
 
@@ -634,7 +661,7 @@ export class PostHogFeatureFlags implements Extension {
 
                 if (!data.disable_flags) {
                     this.receivedFeatureFlags(response.json ?? {}, errorsLoading, {
-                        partialResponse: !!this._config.advanced_only_evaluate_survey_feature_flags,
+                        partialResponse: isPartialFlagsResponse,
                     })
                 }
 
@@ -879,6 +906,11 @@ export class PostHogFeatureFlags implements Extension {
         // Add evaluation contexts if configured
         if (this._shouldIncludeEvaluationEnvironments()) {
             data.evaluation_contexts = this._getValidEvaluationEnvironments()
+        }
+
+        const flagKeys = this._getValidFlagKeys()
+        if (!isUndefined(flagKeys)) {
+            data.flag_keys = flagKeys
         }
 
         this._instance._send_request({

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -201,6 +201,7 @@
         "_getToolbarState",
         "_getTracer",
         "_getValidEvaluationEnvironments",
+        "_getValidFlagKeys",
         "_getWindowId",
         "_groupId",
         "_handleBackToTickets",

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -513,6 +513,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "undefined",
     "readonly string[]"
   ],
+  "flag_keys": [
+    "undefined",
+    "readonly string[]"
+  ],
   "evaluation_environments": [
     "undefined",
     "readonly string[]"

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1293,6 +1293,19 @@ export interface PostHogConfig {
      * @default undefined
      */
     evaluation_contexts?: readonly string[]
+
+    /**
+     * List of feature flag keys to remotely evaluate for this SDK instance.
+     * When set, only these flags are evaluated by `/flags`; omitted flags are not remotely evaluated.
+     * Dependencies of the requested flags may still be evaluated internally by PostHog.
+     * If unset, all eligible flags are evaluated.
+     *
+     * Examples: ['checkout-redesign', 'new-onboarding']
+     *
+     * @default undefined
+     */
+    flag_keys?: readonly string[]
+
     /**
      * Evaluation environments for feature flags.
      * @deprecated Use evaluation_contexts instead. This property will be removed in a future version.


### PR DESCRIPTION
## Problem

Customers sometimes want the browser SDK to evaluate only a specific subset of feature flags instead of requesting all eligible flags. This is inspired by https://posthog.com/questions/allow-for-client-to-request-for-specific-set-of-feature-flips.

This seems reasonable given we support `flag_keys` in server-side SDKs.

## Changes

- Adds a `flag_keys` browser config option, typed in `@posthog/types`, to restrict remote `/flags` evaluation to specific flag keys.
- Sends validated `flag_keys` on regular feature flag reloads and remote config payload requests.
- Filters invalid entries, omits `flag_keys` for invalid non-array config values, and keeps explicit `flag_keys: []` behavior.
- Keeps normal `/flags` responses replacing cached flag state rather than merging, with existing partial/error merge behavior unchanged.

Tested with:

```bash
pnpm --filter posthog-js exec jest src/__tests__/featureflags.test.ts --runInBand
```

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
