### PR TITLE
fix(node): reject leading-zero semver values in local evaluation

### DIFF
--- a/.changeset/strict-semver-leading-zeros.md
+++ b/.changeset/strict-semver-leading-zeros.md
@@ -1,0 +1,5 @@
+---
+"posthog-node": patch
+---
+
+Reject semver values with leading zeros in local flag evaluation. Per semver 2.0.0 §2, numeric identifiers must not include leading zeros — values like `1.07.3` are not valid semver and should not match targeting conditions. Both override values and flag values are now validated; invalid inputs surface as `InconclusiveMatchError` so the condition does not match.

--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -3291,8 +3291,14 @@ describe('semver parsing', () => {
     expect(parseSemver('1.2.3.4.5.6')).toEqual([1, 2, 3])
   })
 
-  it('handles leading zeros', () => {
-    expect(parseSemver('01.02.03')).toEqual([1, 2, 3])
+  it('rejects leading zeros per semver 2.0.0 §2', () => {
+    expect(() => parseSemver('01.02.03')).toThrow(InconclusiveMatchError)
+    expect(() => parseSemver('1.07.3')).toThrow(InconclusiveMatchError)
+    expect(() => parseSemver('001.2.3')).toThrow(InconclusiveMatchError)
+    // Literal "0" components remain valid.
+    expect(parseSemver('0.1.0')).toEqual([0, 1, 0])
+    expect(parseSemver('1.0.0')).toEqual([1, 0, 0])
+    expect(parseSemver('0.0.0')).toEqual([0, 0, 0])
   })
 
   it('throws on invalid input', () => {
@@ -3639,10 +3645,37 @@ describe('semver operators', () => {
       )
     })
 
-    it('handles leading zeros', () => {
-      expect(matchProperty({ key: 'version', value: '01.02.03', operator: 'semver_eq' }, { version: '1.2.3' })).toBe(
-        true
-      )
+    it('rejects leading zeros in override values across operators', () => {
+      // Per semver 2.0.0 §2, numeric identifiers MUST NOT include leading zeros.
+      for (const bad of ['01.2.3', '1.02.3', '1.2.03', '1.07.3', '001.2.3']) {
+        expect(() =>
+          matchProperty({ key: 'version', value: '1.2.3', operator: 'semver_eq' }, { version: bad })
+        ).toThrow(InconclusiveMatchError)
+      }
+    })
+
+    it('rejects leading zeros in flag values across range operators', () => {
+      expect(() =>
+        matchProperty({ key: 'version', value: '1.07.3', operator: 'semver_gt' }, { version: '1.8.0' })
+      ).toThrow(InconclusiveMatchError)
+      expect(() =>
+        matchProperty({ key: 'version', value: '01.2.3', operator: 'semver_caret' }, { version: '1.2.3' })
+      ).toThrow(InconclusiveMatchError)
+      expect(() =>
+        matchProperty({ key: 'version', value: '1.02.3', operator: 'semver_tilde' }, { version: '1.2.3' })
+      ).toThrow(InconclusiveMatchError)
+      expect(() =>
+        matchProperty({ key: 'version', value: '01.*', operator: 'semver_wildcard' }, { version: '1.2.3' })
+      ).toThrow(InconclusiveMatchError)
+      expect(() =>
+        matchProperty({ key: 'version', value: '1.07.*', operator: 'semver_wildcard' }, { version: '1.7.3' })
+      ).toThrow(InconclusiveMatchError)
+    })
+
+    it('still accepts literal zero components', () => {
+      expect(matchProperty({ key: 'version', value: '0.1.0', operator: 'semver_eq' }, { version: '0.1.0' })).toBe(true)
+      expect(matchProperty({ key: 'version', value: '1.0.0', operator: 'semver_eq' }, { version: '1.0.0' })).toBe(true)
+      expect(matchProperty({ key: 'version', value: '0.0.0', operator: 'semver_eq' }, { version: '0.0.0' })).toBe(true)
     })
 
     it('handles 4-part versions', () => {

--- a/packages/node/src/__tests__/feature-flags.spec.ts
+++ b/packages/node/src/__tests__/feature-flags.spec.ts
@@ -3645,30 +3645,31 @@ describe('semver operators', () => {
       )
     })
 
-    it('rejects leading zeros in override values across operators', () => {
-      // Per semver 2.0.0 §2, numeric identifiers MUST NOT include leading zeros.
-      for (const bad of ['01.2.3', '1.02.3', '1.2.03', '1.07.3', '001.2.3']) {
-        expect(() =>
-          matchProperty({ key: 'version', value: '1.2.3', operator: 'semver_eq' }, { version: bad })
-        ).toThrow(InconclusiveMatchError)
-      }
+    // Per semver 2.0.0 §2, numeric identifiers MUST NOT include leading zeros.
+    it.each(['01.2.3', '1.02.3', '1.2.03', '1.07.3', '001.2.3'])('rejects leading-zero override value %p', (bad) => {
+      expect(() => matchProperty({ key: 'version', value: '1.2.3', operator: 'semver_eq' }, { version: bad })).toThrow(
+        InconclusiveMatchError
+      )
     })
 
-    it('rejects leading zeros in flag values across range operators', () => {
+    it.each<[string]>([
+      ['semver_eq'],
+      ['semver_neq'],
+      ['semver_gt'],
+      ['semver_gte'],
+      ['semver_lt'],
+      ['semver_lte'],
+      ['semver_tilde'],
+      ['semver_caret'],
+    ])('rejects leading-zero flag value for %s', (operator) => {
+      expect(() => matchProperty({ key: 'version', value: '1.07.3', operator }, { version: '1.8.0' })).toThrow(
+        InconclusiveMatchError
+      )
+    })
+
+    it.each(['01.*', '1.07.*'])('rejects leading-zero wildcard pattern %p', (pattern) => {
       expect(() =>
-        matchProperty({ key: 'version', value: '1.07.3', operator: 'semver_gt' }, { version: '1.8.0' })
-      ).toThrow(InconclusiveMatchError)
-      expect(() =>
-        matchProperty({ key: 'version', value: '01.2.3', operator: 'semver_caret' }, { version: '1.2.3' })
-      ).toThrow(InconclusiveMatchError)
-      expect(() =>
-        matchProperty({ key: 'version', value: '1.02.3', operator: 'semver_tilde' }, { version: '1.2.3' })
-      ).toThrow(InconclusiveMatchError)
-      expect(() =>
-        matchProperty({ key: 'version', value: '01.*', operator: 'semver_wildcard' }, { version: '1.2.3' })
-      ).toThrow(InconclusiveMatchError)
-      expect(() =>
-        matchProperty({ key: 'version', value: '1.07.*', operator: 'semver_wildcard' }, { version: '1.7.3' })
+        matchProperty({ key: 'version', value: pattern, operator: 'semver_wildcard' }, { version: '1.2.3' })
       ).toThrow(InconclusiveMatchError)
     })
 

--- a/packages/node/src/extensions/feature-flags/feature-flags.ts
+++ b/packages/node/src/extensions/feature-flags/feature-flags.ts
@@ -1330,6 +1330,20 @@ function isValidRegex(regex: string): boolean {
 type SemverTuple = [number, number, number]
 
 /**
+ * Parse a single numeric identifier from a semver string.
+ * Per semver 2.0.0 §2, numeric identifiers MUST NOT include leading zeros.
+ */
+function parseSemverNumericIdentifier(part: string, raw: string): number {
+  if (!/^\d+$/.test(part)) {
+    throw new InconclusiveMatchError(`Invalid semver: ${raw}`)
+  }
+  if (part.length > 1 && part[0] === '0') {
+    throw new InconclusiveMatchError(`Invalid semver: ${raw}`)
+  }
+  return parseInt(part, 10)
+}
+
+/**
  * Parse a version string into a [major, minor, patch] tuple.
  * - Strips leading/trailing whitespace
  * - Strips 'v' or 'V' prefix
@@ -1354,10 +1368,7 @@ function parseSemver(value: string): SemverTuple {
     if (part === undefined || part === '') {
       return 0
     }
-    if (!/^\d+$/.test(part)) {
-      throw new InconclusiveMatchError(`Invalid semver: ${value}`)
-    }
-    return parseInt(part, 10)
+    return parseSemverNumericIdentifier(part, value)
   }
 
   const major = parsePart(parts[0])
@@ -1428,10 +1439,14 @@ function computeWildcardBounds(value: string): { lower: SemverTuple; upper: Semv
   }
 
   const parts = cleanedText.split('.')
-  const major = parseInt(parts[0], 10)
-  if (isNaN(major)) {
-    throw new InconclusiveMatchError(`Invalid wildcard semver: ${value}`)
+  const parseWildcardPart = (part: string): number => {
+    try {
+      return parseSemverNumericIdentifier(part, value)
+    } catch {
+      throw new InconclusiveMatchError(`Invalid wildcard semver: ${value}`)
+    }
   }
+  const major = parseWildcardPart(parts[0])
 
   let lower: SemverTuple
   let upper: SemverTuple
@@ -1442,10 +1457,7 @@ function computeWildcardBounds(value: string): { lower: SemverTuple; upper: Semv
     upper = [major + 1, 0, 0]
   } else {
     // X.Y.* pattern
-    const minor = parseInt(parts[1], 10)
-    if (isNaN(minor)) {
-      throw new InconclusiveMatchError(`Invalid wildcard semver: ${value}`)
-    }
+    const minor = parseWildcardPart(parts[1])
     lower = [major, minor, 0]
     upper = [major, minor + 1, 0]
   }


### PR DESCRIPTION
## Summary

Per [semver 2.0.0 §2](https://semver.org/#spec-item-2), numeric identifiers MUST NOT include leading zeros. Values like `1.07.3` or `01.2.3` are not valid semver — posthog-node's local feature flag evaluator currently parses them silently (via `parseInt("07", 10) → 7`), which means a person property of `1.07.3` would incorrectly match a `semver_eq` condition against `1.7.3`.

This PR makes `posthog-node`'s parser reject leading zeros in numeric identifiers. Both override values and flag values are validated; invalid inputs throw `InconclusiveMatchError` so the condition simply does not match.

Scope: changes are limited to `packages/node/`. No other packages in this monorepo are affected.

This mirrors the equivalent fixes in [posthog-python #601](https://github.com/PostHog/posthog-python/pull/601) and [posthog-go #200](https://github.com/PostHog/posthog-go/pull/200).

## Changes

- `parseSemver` now delegates numeric-identifier parsing to a `parseSemverNumericIdentifier` helper that rejects strings with leading zeros (except literal `"0"`).
- `computeWildcardBounds` uses the same helper, so `01.*` and `1.07.*` are rejected.
- Updated the existing edge-case tests that previously asserted `01.02.03` parsed/matched as `1.2.3` — they now correctly reject.
- Added new tests covering rejection across `semver_eq`, `semver_gt`, `semver_caret`, `semver_tilde`, and `semver_wildcard` for both override values and flag values, plus tests confirming literal-zero components (`0.1.0`, `1.0.0`, `0.0.0`) still parse.

## Test plan

- [x] `pnpm --filter posthog-node test:unit -- --testPathPattern feature-flags` — 315 passed
- [x] New rejection tests pass; previously-incorrect "accepts leading zeros" assertions are inverted
- [x] `pnpm --filter posthog-node lint` clean
- [x] No changes outside `packages/node/`