### PR TITLE
chore(release): bump posthog-js to ship sheet.href snapshot fix

### DIFF
--- a/.changeset/release-sheet-href-fix.md
+++ b/.changeset/release-sheet-href-fix.md
@@ -1,0 +1,7 @@
+---
+'posthog-js': patch
+---
+
+Capture `<link rel="stylesheet">` URLs from `link.sheet.href` and try `link.sheet` directly for inlining, so recordings survive SPA `history.pushState` navigations between routes of different path depths (where `link.href` re-resolves against a new baseURI but `link.sheet.href` preserves the URL the browser actually fetched).
+
+Ships the fix landed in #3635, which only bumped the internal `@posthog/rrweb-snapshot` package — that package is bundled into `posthog-js` at build time but is not published to npm on its own, so a `posthog-js` bump is needed to actually deliver the change.


### PR DESCRIPTION
## Problem

PR #3635 fixed `<link>` href capture across SPA `pushState` navigations, but the changeset bumped `@posthog/rrweb-snapshot`. That package is bundled into `posthog-js` at build time and is not published to npm on its own (the release matrix in `.github/workflows/release.yml` deliberately omits all `@posthog/rrweb*` packages). The bump consumed the changeset without producing a `posthog-js` release, so the fix is in `main` but not on npm.

## Changes

Adds a `posthog-js: patch` changeset describing the same fix, so the next release ships it.

## Release info

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Ran `pnpm changeset` to generate a changeset file