### PR TITLE
fix: skip PostHogProvider init without api key

### DIFF
--- a/.changeset/quiet-keys-warn.md
+++ b/.changeset/quiet-keys-warn.md
@@ -1,6 +1,7 @@
 ---
 "@posthog/react": patch
+"@posthog/next": patch
 "posthog-js": patch
 ---
 
-Avoid initializing PostHogProvider when no API key or client is provided
+Avoid throwing or initializing PostHogProvider when no API key or client is provided

--- a/.changeset/quiet-keys-warn.md
+++ b/.changeset/quiet-keys-warn.md
@@ -1,0 +1,6 @@
+---
+"@posthog/react": patch
+"posthog-js": patch
+---
+
+Avoid initializing PostHogProvider when no API key or client is provided

--- a/packages/next/src/app/PostHogProvider.tsx
+++ b/packages/next/src/app/PostHogProvider.tsx
@@ -5,7 +5,7 @@ import type { BootstrapConfig } from '../client/ClientPostHogProvider.js'
 import { cookies } from 'next/headers.js'
 import type { PostHogOptions } from 'posthog-node'
 import { getOrCreateNodeClient } from '../server/nodeClientCache.js'
-import { NEXTJS_CLIENT_DEFAULTS, resolveApiKey, resolveHostOrDefault } from '../shared/config.js'
+import { NEXTJS_CLIENT_DEFAULTS, normalizeConfigValue, resolveHostOrDefault } from '../shared/config.js'
 import { readPostHogCookie, isOptedOut } from '../shared/cookie.js'
 
 type AllFlagsOptions = {
@@ -74,7 +74,13 @@ export async function PostHogProvider({
     bootstrapFlags,
     children,
 }: PostHogProviderProps) {
-    const apiKey = resolveApiKey(apiKeyProp)
+    const apiKey = normalizeConfigValue(apiKeyProp) ?? normalizeConfigValue(process.env.NEXT_PUBLIC_POSTHOG_KEY)
+    if (!apiKey) {
+        // eslint-disable-next-line no-console
+        console.warn('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
+        return <>{children}</>
+    }
+
     if (!apiKey.startsWith('phc_')) {
         // eslint-disable-next-line no-console
         console.warn(

--- a/packages/next/src/app/PostHogProvider.tsx
+++ b/packages/next/src/app/PostHogProvider.tsx
@@ -5,7 +5,7 @@ import type { BootstrapConfig } from '../client/ClientPostHogProvider.js'
 import { cookies } from 'next/headers.js'
 import type { PostHogOptions } from 'posthog-node'
 import { getOrCreateNodeClient } from '../server/nodeClientCache.js'
-import { NEXTJS_CLIENT_DEFAULTS, normalizeConfigValue, resolveHostOrDefault } from '../shared/config.js'
+import { NEXTJS_CLIENT_DEFAULTS, resolveApiKey, resolveHostOrDefault } from '../shared/config.js'
 import { readPostHogCookie, isOptedOut } from '../shared/cookie.js'
 
 type AllFlagsOptions = {
@@ -74,10 +74,8 @@ export async function PostHogProvider({
     bootstrapFlags,
     children,
 }: PostHogProviderProps) {
-    const apiKey = normalizeConfigValue(apiKeyProp) ?? normalizeConfigValue(process.env.NEXT_PUBLIC_POSTHOG_KEY)
+    const apiKey = resolveApiKey(apiKeyProp)
     if (!apiKey) {
-        // eslint-disable-next-line no-console
-        console.warn('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
         return <>{children}</>
     }
 

--- a/packages/next/src/middleware/postHogMiddleware.ts
+++ b/packages/next/src/middleware/postHogMiddleware.ts
@@ -142,9 +142,13 @@ export function postHogMiddleware(config: PostHogMiddlewareOptions = {}) {
             return rewriteToPostHog(request, proxyConfig)
         }
 
+        const response = config.response ?? NextResponse.next()
+        if (!apiKey) {
+            return response
+        }
+
         const cookieName = getPostHogCookieName(apiKey)
         const state = readPostHogCookie(request.cookies, apiKey)
-        const response = config.response ?? NextResponse.next()
 
         const shouldSeed = config.seedAnonymousCookie ?? true
         const optedOut = isOptedOut(request.cookies, apiKey, {

--- a/packages/next/src/pages/PostHogProvider.tsx
+++ b/packages/next/src/pages/PostHogProvider.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { PostHogConfig, BootstrapConfig } from 'posthog-js'
 import { ClientPostHogProvider } from '../client/ClientPostHogProvider.js'
-import { NEXTJS_CLIENT_DEFAULTS, normalizeConfigValue, resolveHostOrDefault } from '../shared/config.js'
+import { NEXTJS_CLIENT_DEFAULTS, resolveApiKey, resolveHostOrDefault } from '../shared/config.js'
 
 export interface PagesPostHogProviderProps {
     /**
@@ -37,10 +37,8 @@ export interface PagesPostHogProviderProps {
 let apiKeyWarned = false
 
 export function PostHogProvider({ apiKey: apiKeyProp, clientOptions, bootstrap, children }: PagesPostHogProviderProps) {
-    const apiKey = normalizeConfigValue(apiKeyProp) ?? normalizeConfigValue(process.env.NEXT_PUBLIC_POSTHOG_KEY)
+    const apiKey = resolveApiKey(apiKeyProp)
     if (!apiKey) {
-        // eslint-disable-next-line no-console
-        console.warn('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
         return <>{children}</>
     }
 

--- a/packages/next/src/pages/PostHogProvider.tsx
+++ b/packages/next/src/pages/PostHogProvider.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { PostHogConfig, BootstrapConfig } from 'posthog-js'
 import { ClientPostHogProvider } from '../client/ClientPostHogProvider.js'
-import { NEXTJS_CLIENT_DEFAULTS, resolveApiKey, resolveHostOrDefault } from '../shared/config.js'
+import { NEXTJS_CLIENT_DEFAULTS, normalizeConfigValue, resolveHostOrDefault } from '../shared/config.js'
 
 export interface PagesPostHogProviderProps {
     /**
@@ -37,7 +37,13 @@ export interface PagesPostHogProviderProps {
 let apiKeyWarned = false
 
 export function PostHogProvider({ apiKey: apiKeyProp, clientOptions, bootstrap, children }: PagesPostHogProviderProps) {
-    const apiKey = resolveApiKey(apiKeyProp)
+    const apiKey = normalizeConfigValue(apiKeyProp) ?? normalizeConfigValue(process.env.NEXT_PUBLIC_POSTHOG_KEY)
+    if (!apiKey) {
+        // eslint-disable-next-line no-console
+        console.warn('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
+        return <>{children}</>
+    }
+
     if (!apiKeyWarned && !apiKey.startsWith('phc_')) {
         apiKeyWarned = true
         // eslint-disable-next-line no-console

--- a/packages/next/src/pages/getServerSidePostHog.ts
+++ b/packages/next/src/pages/getServerSidePostHog.ts
@@ -36,7 +36,11 @@ export async function getServerSidePostHog(
     const resolvedApiKey = resolveApiKey(apiKey)
     const host = resolveHostOrDefault(options?.host)
     const resolvedOptions = { ...options, host }
-    const client = await getOrCreateNodeClient(resolvedApiKey, resolvedOptions)
+    const client = await getOrCreateNodeClient(resolvedApiKey ?? '', resolvedOptions)
+
+    if (!resolvedApiKey) {
+        return client
+    }
 
     const cookieStore = cookieStoreFromHeader(ctx.req.headers.cookie || '')
 

--- a/packages/next/src/server/getPostHog.ts
+++ b/packages/next/src/server/getPostHog.ts
@@ -37,7 +37,12 @@ export async function getPostHog(apiKey?: string, options?: Partial<PostHogOptio
     const resolvedApiKey = resolveApiKey(apiKey)
     const host = resolveHostOrDefault(options?.host)
     const resolvedOptions = { ...options, host }
-    const client = await getOrCreateNodeClient(resolvedApiKey, resolvedOptions)
+    const client = await getOrCreateNodeClient(resolvedApiKey ?? '', resolvedOptions)
+
+    if (!resolvedApiKey) {
+        return client
+    }
+
     const cookieStore = await cookies()
 
     if (isOptedOut(cookieStore, resolvedApiKey)) {

--- a/packages/next/src/shared/config.ts
+++ b/packages/next/src/shared/config.ts
@@ -18,19 +18,18 @@ export type PostHogServerConfig = PostHogOptions
  * Resolves the PostHog API key from an explicit value or the
  * `NEXT_PUBLIC_POSTHOG_KEY` environment variable.
  *
- * Throws if neither is available.
+ * Warns and returns undefined if neither is available.
  */
 export function normalizeConfigValue(value?: unknown): string | undefined {
     const normalizedValue = typeof value === 'string' ? value.trim() : ''
     return normalizedValue || undefined
 }
 
-export function resolveApiKey(apiKey?: string): string {
+export function resolveApiKey(apiKey?: string): string | undefined {
     const resolved = normalizeConfigValue(apiKey) ?? normalizeConfigValue(process.env.NEXT_PUBLIC_POSTHOG_KEY)
     if (!resolved) {
-        throw new Error(
-            '[PostHog Next.js] apiKey is required. Either pass it explicitly or set the NEXT_PUBLIC_POSTHOG_KEY environment variable.'
-        )
+        // eslint-disable-next-line no-console
+        console.warn('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
     }
     return resolved
 }

--- a/packages/next/src/shared/config.ts
+++ b/packages/next/src/shared/config.ts
@@ -25,7 +25,7 @@ export function normalizeConfigValue(value?: unknown): string | undefined {
     return normalizedValue || undefined
 }
 
-export function resolveApiKey(apiKey?: string): string | undefined {
+export function resolveApiKey(apiKey?: unknown): string | undefined {
     const resolved = normalizeConfigValue(apiKey) ?? normalizeConfigValue(process.env.NEXT_PUBLIC_POSTHOG_KEY)
     if (!resolved) {
         // eslint-disable-next-line no-console
@@ -34,11 +34,11 @@ export function resolveApiKey(apiKey?: string): string | undefined {
     return resolved
 }
 
-export function resolveHost(host?: string): string | undefined {
+export function resolveHost(host?: unknown): string | undefined {
     return normalizeConfigValue(host) ?? normalizeConfigValue(process.env.NEXT_PUBLIC_POSTHOG_HOST)
 }
 
-export function resolveHostOrDefault(host?: string): string {
+export function resolveHostOrDefault(host?: unknown): string {
     return resolveHost(host) ?? DEFAULT_API_HOST
 }
 

--- a/packages/next/tests/PagesPostHogProvider.test.tsx
+++ b/packages/next/tests/PagesPostHogProvider.test.tsx
@@ -33,6 +33,22 @@ describe('Pages PostHogProvider', () => {
         expect(mockClientPostHogProvider).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'phc_test123' }))
     })
 
+    it('warns and renders children without ClientPostHogProvider when apiKey is empty and env var is not set', () => {
+        delete process.env.NEXT_PUBLIC_POSTHOG_KEY
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+        render(
+            <PostHogProvider apiKey="">
+                <div data-testid="child">Child</div>
+            </PostHogProvider>
+        )
+
+        expect(screen.getByTestId('child')).toBeInTheDocument()
+        expect(mockClientPostHogProvider).not.toHaveBeenCalled()
+        expect(warnSpy).toHaveBeenCalledWith('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
+        warnSpy.mockRestore()
+    })
+
     it('trims apiKey and api_host before passing them to ClientPostHogProvider', () => {
         render(
             <PostHogProvider

--- a/packages/next/tests/PostHogProvider.test.tsx
+++ b/packages/next/tests/PostHogProvider.test.tsx
@@ -147,14 +147,20 @@ describe('PostHogProvider', () => {
         expect(cookies).not.toHaveBeenCalled()
     })
 
-    it('throws when apiKey is empty and env var is not set', async () => {
+    it('warns and renders children without ClientPostHogProvider when apiKey is empty and env var is not set', async () => {
         delete process.env.NEXT_PUBLIC_POSTHOG_KEY
-        await expect(
-            PostHogProvider({
-                apiKey: '',
-                children: <div>Child</div>,
-            })
-        ).rejects.toThrow('[PostHog Next.js] apiKey is required')
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+        const element = await PostHogProvider({
+            apiKey: '',
+            children: <div data-testid="child">Child</div>,
+        })
+        render(element)
+
+        expect(screen.getByTestId('child')).toBeInTheDocument()
+        expect(mockClientProvider).not.toHaveBeenCalled()
+        expect(warnSpy).toHaveBeenCalledWith('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
+        warnSpy.mockRestore()
     })
 
     it('warns when apiKey does not start with phc_', async () => {

--- a/packages/next/tests/config.test.ts
+++ b/packages/next/tests/config.test.ts
@@ -1,0 +1,47 @@
+import { DEFAULT_API_HOST } from '../src/shared/constants'
+import { normalizeConfigValue, resolveApiKey, resolveHostOrDefault } from '../src/shared/config'
+
+describe('shared config', () => {
+    const originalEnv = process.env
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        process.env = { ...originalEnv }
+        delete process.env.NEXT_PUBLIC_POSTHOG_KEY
+        delete process.env.NEXT_PUBLIC_POSTHOG_HOST
+    })
+
+    afterAll(() => {
+        process.env = originalEnv
+    })
+
+    it('normalizes strings and returns undefined for non-strings', () => {
+        expect(normalizeConfigValue('  phc_test123\n')).toBe('phc_test123')
+        expect(normalizeConfigValue('   ')).toBeUndefined()
+        expect(normalizeConfigValue(undefined)).toBeUndefined()
+        expect(normalizeConfigValue(null)).toBeUndefined()
+        expect(normalizeConfigValue(123)).toBeUndefined()
+        expect(normalizeConfigValue({ value: 'phc_test123' })).toBeUndefined()
+    })
+
+    it('warns and returns undefined when apiKey is not a string and no env fallback exists', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+        expect(resolveApiKey({ value: 'phc_test123' })).toBeUndefined()
+
+        expect(warnSpy).toHaveBeenCalledWith('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
+        warnSpy.mockRestore()
+    })
+
+    it('falls back to env apiKey when explicit apiKey is not a string', () => {
+        process.env.NEXT_PUBLIC_POSTHOG_KEY = '  phc_from_env\n'
+
+        expect(resolveApiKey({ value: 'phc_test123' })).toBe('phc_from_env')
+    })
+
+    it('uses the default host when explicit and env hosts are not strings', () => {
+        process.env.NEXT_PUBLIC_POSTHOG_HOST = ''
+
+        expect(resolveHostOrDefault({ value: 'https://custom.posthog.com' })).toBe(DEFAULT_API_HOST)
+    })
+})

--- a/packages/next/tests/getPostHog.test.ts
+++ b/packages/next/tests/getPostHog.test.ts
@@ -163,12 +163,20 @@ describe('getPostHog', () => {
         })
     })
 
-    it('throws when no apiKey provided and env var missing', async () => {
+    it('warns and returns a disabled client when no apiKey provided and env var missing', async () => {
         delete process.env.NEXT_PUBLIC_POSTHOG_KEY
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
 
-        await expect(getPostHog()).rejects.toThrow(
-            '[PostHog Next.js] apiKey is required. Either pass it explicitly or set the NEXT_PUBLIC_POSTHOG_KEY environment variable.'
-        )
+        const client = await getPostHog()
+
+        expect(client).toBeDefined()
+        expect(mockGetOrCreateNodeClient).toHaveBeenCalledWith('', {
+            host: 'https://us.i.posthog.com',
+        })
+        expect(cookies).not.toHaveBeenCalled()
+        expect(headers).not.toHaveBeenCalled()
+        expect(warnSpy).toHaveBeenCalledWith('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
+        warnSpy.mockRestore()
     })
 
     it('passes host from options to getOrCreateNodeClient', async () => {

--- a/packages/next/tests/getServerSidePostHog.test.ts
+++ b/packages/next/tests/getServerSidePostHog.test.ts
@@ -83,9 +83,20 @@ describe('getServerSidePostHog', () => {
         })
     })
 
-    it('throws when no apiKey provided and env not set', async () => {
+    it('warns and returns a disabled client when no apiKey provided and env not set', async () => {
+        const { PostHog } = require('posthog-node')
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
         const ctx = createMockContext({})
-        await expect(getServerSidePostHog(ctx)).rejects.toThrow('apiKey is required')
+
+        const posthog = await getServerSidePostHog(ctx)
+
+        expect(posthog).toBeDefined()
+        expect(PostHog).toHaveBeenCalledWith('', {
+            host: 'https://us.i.posthog.com',
+        })
+        expect(mockEnterContext).not.toHaveBeenCalled()
+        expect(warnSpy).toHaveBeenCalledWith('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
+        warnSpy.mockRestore()
     })
 
     it('trims apiKey and host before creating the node client', async () => {

--- a/packages/next/tests/postHogMiddleware.test.ts
+++ b/packages/next/tests/postHogMiddleware.test.ts
@@ -114,9 +114,18 @@ describe('postHogMiddleware', () => {
             expect(mockCookiesSet).toHaveBeenCalledWith(COOKIE_NAME, expect.any(String), expect.any(Object))
         })
 
-        it('throws when neither config nor env var provides apiKey', () => {
+        it('warns and skips cookie seeding when neither config nor env var provides apiKey', async () => {
             delete process.env.NEXT_PUBLIC_POSTHOG_KEY
-            expect(() => postHogMiddleware({})).toThrow('[PostHog Next.js] apiKey is required')
+            const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+            const middleware = postHogMiddleware({})
+            const req = new MockNextRequest('https://example.com/')
+
+            await middleware(req as any)
+
+            expect(warnSpy).toHaveBeenCalledWith('[PostHog Next.js] apiKey is required — PostHog will not be initialized')
+            expect(mockCookiesSet).not.toHaveBeenCalled()
+            expect(mockNextResponseNext).toHaveBeenCalled()
+            warnSpy.mockRestore()
         })
     })
 

--- a/packages/react/src/context/PostHogProvider.tsx
+++ b/packages/react/src/context/PostHogProvider.tsx
@@ -81,8 +81,9 @@ export function PostHogProvider({ children, client, apiKey, options }: WithOptio
     // TRICKY: The init needs to happen in a useEffect rather than useMemo, as useEffect does not happen during SSR. Otherwise
     // we'd end up trying to call posthogJs.init() on the server, which can cause issues around hydration and double-init.
     useEffect(() => {
-        if (client) {
+        if (client || !apiKey) {
             // if the user has passed their own client, assume they will also handle calling init().
+            // if no apiKey was provided, assume the user will initialize the default instance manually.
             return
         }
         // See comment in useMemo above for why this indirection exists.

--- a/packages/react/src/context/__tests__/PostHogProvider.test.tsx
+++ b/packages/react/src/context/__tests__/PostHogProvider.test.tsx
@@ -42,6 +42,23 @@ describe('PostHogProvider component', () => {
             jest.clearAllMocks()
         })
 
+        it('does not initialize when apiKey is missing', () => {
+            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+            render(
+                <PostHogProvider apiKey={undefined as any} options={initialOptions}>
+                    <div>Test</div>
+                </PostHogProvider>
+            )
+
+            expect(posthogJs.init).not.toHaveBeenCalled()
+            expect(consoleSpy).toHaveBeenCalledWith(
+                '[PostHog.js] No `apiKey` or `client` were provided to `PostHogProvider`. Using default global `window.posthog` instance. You must initialize it manually. This is not recommended behavior.'
+            )
+
+            consoleSpy.mockRestore()
+        })
+
         it('should call set_config when options change', () => {
             const { rerender } = render(
                 <PostHogProvider apiKey={apiKey} options={initialOptions}>


### PR DESCRIPTION
## Problem

A user reported errors when rendering `PostHogProvider` without an API key/project token. The React provider warned about the missing `apiKey`/`client`, but still attempted to initialize the default PostHog instance with an undefined token. The Next.js helpers also threw when no API key was configured, which can unnecessarily break apps.

## Changes

- Return early from the React provider effect when neither `client` nor `apiKey` is provided, preserving the documented/manual global-instance behavior.
- Update Next.js API key resolution to warn and return `undefined` instead of throwing when no API key is configured.
- Make Next.js config resolution accept unknown runtime values safely: non-string API keys/hosts normalize to `undefined` and fall back to env/defaults where applicable.
- Update Next.js App Router and Pages Router providers to render children without initializing PostHog when no API key is available.
- Update Next.js middleware to skip cookie seeding when no API key is available, while still allowing proxy rewrites.
- Update Next.js server helpers to return a disabled PostHog client when no API key is available instead of throwing.
- Add regression tests covering missing/non-string API key behavior for React, Next App Router, Next Pages Router, middleware, server helpers, and shared config.
- Add a patch changeset for `posthog-js`, `@posthog/react`, and `@posthog/next`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [x] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
