### PR TITLE
chore: stabilize logs performance test

### DIFF
--- a/packages/browser/src/__tests__/entrypoints/logs.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/logs.test.ts
@@ -419,7 +419,7 @@ describe('logs entrypoint', () => {
             console.log(`Performance test (big body): wrapped=${wrappedTime.toFixed(2)}ms`)
         })
 
-        it('should not take more than 100ms to log a 2MB object with lots of keys', () => {
+        it('should not take more than 150ms to log a 2MB object with lots of keys', () => {
             const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
 
             // Create a 2MB object with lots of keys (each key-value pair ~40 bytes)
@@ -443,7 +443,8 @@ describe('logs entrypoint', () => {
 
             const wrappedTime = (performance.now() - wrappedStart) / iterations
 
-            expect(wrappedTime).toBeLessThanOrEqual(100)
+            // GitHub runners can vary enough that this occasionally lands a little above 100ms.
+            expect(wrappedTime).toBeLessThanOrEqual(150)
 
             console.log(`Performance test (big body): wrapped=${wrappedTime.toFixed(2)}ms`)
         })


### PR DESCRIPTION
## Problem

The logs entrypoint unit test for logging a 2MB object with many keys is flaky on GitHub runners. A recent run measured ~111ms against a strict 100ms threshold, causing an otherwise passing unit test job to fail.

## Changes

Raised the threshold for that specific performance assertion from 100ms to 150ms and added a comment documenting runner variance. This keeps the regression check while avoiding failures from small CI timing fluctuations.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
