### PR TITLE
feat(mcp): add @posthog/mcp package ported from standalone repo

### DIFF
--- a/.changeset/posthog-mcp-initial.md
+++ b/.changeset/posthog-mcp-initial.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': minor
+---
+
+Initial release of `@posthog/mcp` inside the posthog-js monorepo. Ports the previous standalone `@posthog/mcp` SDK onto `@posthog/core`, removes the `posthog-node` runtime dependency and the bring-your-own-client option, drops the `eventTags` callback (use `eventProperties` instead), prefixes every captured PostHog event name with `$` (e.g. `mcp_tool_call` → `$mcp_tool_call`), and removes the SDK-managed `~/posthog-mcp-analytics.log` file in favor of an opt-in `logger` callback option.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -68,6 +68,7 @@ module.exports = {
         {
             files: [
                 'packages/core/**',
+                'packages/mcp/**',
                 'packages/nextjs-config/**',
                 'packages/nuxt/**',
                 'packages/react-native/**',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,6 +220,7 @@ jobs:
                     - name: '@posthog/react'
                     - name: '@posthog/ai'
                     - name: '@posthog/convex'
+                    - name: '@posthog/mcp'
                     - name: '@posthog/next'
                     - name: '@posthog/nextjs-config'
                     - name: '@posthog/nuxt'

--- a/packages/mcp/.prettierrc
+++ b/packages/mcp/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 2,
+    "semi": false,
+    "singleQuote": true,
+    "printWidth": 120
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,26 @@
+# @posthog/mcp
+
+PostHog SDK for instrumenting Model Context Protocol (MCP) servers. Tracks tool calls, tool listing, initialization, user intent, identity, and errors — without changing your tool handler logic.
+
+## Install
+
+```bash
+npm install @posthog/mcp
+```
+
+## Usage
+
+```typescript
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { track } from '@posthog/mcp'
+
+const server = new McpServer({ name: 'my-mcp-server', version: '1.0.0' })
+
+track(server, {
+  apiKey: 'phc_your_project_api_key',
+})
+
+// Register your tools as usual — `track()` instruments them automatically.
+```
+
+See the documentation in [`docs/`](./docs) for the full configuration reference, including `identify`, `intentFallback`, `redactSensitiveInformation`, `eventProperties`, `enableConversationId`, and `reportMissing`.

--- a/packages/mcp/babel.config.mjs
+++ b/packages/mcp/babel.config.mjs
@@ -1,0 +1,3 @@
+export default {
+  presets: [['@babel/preset-env', { targets: { node: '20.0' } }], '@babel/preset-typescript'],
+}

--- a/packages/mcp/docs/ARCHITECTURE.md
+++ b/packages/mcp/docs/ARCHITECTURE.md
@@ -1,0 +1,398 @@
+# `@posthog/mcp` — Architecture
+
+This document describes the internals of the `@posthog/mcp` SDK and the exact PostHog event/property contract it emits.
+
+## TL;DR
+
+- `track(server, options)` wraps an MCP server, intercepts request handlers, and pushes structured events through a small in-memory pipeline into PostHog via `@posthog/core`.
+- Every PostHog **event name** is `$`-prefixed (`$mcp_tool_call`, `$mcp_custom`, `$mcp_initialize`, …) per the PostHog naming convention for SDK-owned events.
+- Every PostHog **property key** is also `$`-prefixed (`$mcp_tool_name`, `$mcp_intent`, `$mcp_duration_ms`, …) so MCP keys never collide with PostHog autocapture, web analytics, or other product events.
+- `$session_id` ties one MCP connection to one PostHog session. `distinct_id` falls back through `identified user → session id → "anonymous"`.
+- Tool calls can additionally emit `$ai_span` for the PostHog LLM analytics UI and `$exception` whenever a tool errors.
+
+---
+
+## 1. Wire-up
+
+The public surface in `src/index.ts` is two functions plus a class:
+
+- `track(server, options)` — installs the SDK on an MCP server. Idempotent per server (re-calling logs and returns early).
+- `publishCustomEvent(server, eventData)` — emit an arbitrary `$mcp_custom` event onto the same pipeline. The server must already have been passed to `track()`.
+- `PostHogMCP` — the stateless PostHog client (subclass of `PostHogCoreStateless` from `@posthog/core`). Most apps don't instantiate this directly; `track()` does it for you. Exposed for users who want to share one client across instrumentation or for tests.
+
+`track()` does five things (`src/index.ts`):
+
+1. Validate `server` is either a low-level `Server` or a high-level `McpServer`, and unwrap the latter to get the underlying `Server`.
+2. Resolve the PostHog client: use `options.client` if provided, else construct a new `PostHogMCP(apiKey, { host, ...options.clientOptions })`.
+3. Build per-server tracking state (session id, identity cache, callbacks, the resolved client) stored in a module-level `WeakMap`.
+4. Replace the `tools/call` and `initialize` handlers on the underlying `Server` instance with wrappers, and (for `McpServer`) install a `Proxy` on `_registeredTools` so any tool registered _after_ `track()` is also wrapped.
+5. Optionally register the `get_more_tools` virtual tool when `options.reportMissing: true`.
+
+Two implementations exist for the two MCP server shapes:
+
+| Server type                              | File                       | Entry                       |
+| ---------------------------------------- | -------------------------- | --------------------------- |
+| Low-level `Server` (raw protocol SDK)    | `src/modules/tracing.ts`   | `setupToolCallTracing()`    |
+| High-level `McpServer` (typed wrapper)   | `src/modules/tracing-v2.ts`| `setupTracking()`           |
+
+Both converge on the same internal `UnredactedEvent` shape (`src/types.ts`) and the same publish pipeline.
+
+## 2. Request lifecycle (tool call, high-level path)
+
+```
+client → MCP server → tools/call wrapper (tracing-v2.ts)
+  ├─ initializeToolCallEvent      ← build UnredactedEvent, resolve session
+  ├─ handleIdentify               ← fires $identify only if identity changed
+  ├─ applyResolvedMetadata        ← runs eventProperties callback
+  ├─ resolveToolCallIntent        ← context arg OR intentFallback callback
+  ├─ originalHandler(request,extra)
+  ├─ publishSuccessfulToolEvent   ← attaches result, duration
+  └─ publishEvent(server, event)  → PostHogMCP.ingest()
+```
+
+The wrapper strips the `context` argument from `params.arguments` before forwarding to the user's tool callback, so tool implementations never see the analytics-only arg.
+
+## 3. Event pipeline
+
+Once an `UnredactedEvent` reaches `PostHogMCP.ingest()` (`src/modules/client.ts`), it runs through:
+
+1. **Customer redaction** — `redactEvent(event, redactionFn)` if `options.redactSensitiveInformation` was set (`src/modules/redaction.ts`). The redactor is called on every string in the event _except_ a protected field allowlist (`sessionId`, `id`, `apiKey`, `server`, identify-\* fields, `resourceName`, `eventType`, `actorId`, `properties`).
+2. **Sanitization** — `sanitizeEvent` (`src/modules/sanitization.ts`):
+   - `type: "image" | "audio"` content blocks → replaced with a text stub.
+   - `type: "resource"` blocks with `.blob` → replaced.
+   - Long base64-looking strings (≥10KB) → `"[binary data redacted...]"`.
+   - Keys matching `SENSITIVE_KEY_PATTERN` (`authorization`, `cookie`, `password`, `token`, `secret`, `api_key`, `private_key`, …) → value replaced with `"[redacted]"`.
+   - PostHog API-key patterns (`ph[a-z]_...`) in string values → `"[redacted]"`.
+3. **Truncation** — `truncateEvent` (`src/modules/truncation.ts`): per-field caps, recursive normalization (max depth 10, max breadth 100, max string 32KB), and a 100KB total event budget with progressive falloff.
+4. **Build PostHog events** — `buildPostHogCaptureEvents` (`src/modules/posthog-events.ts`) fans one internal event out to up to **3 PostHog events**:
+   - Always: the main `$mcp_*` capture event.
+   - If `event.isError && event.error`: a sibling `$exception` event.
+   - If `enableAITracing && eventType === mcpToolsCall`: a sibling `$ai_span` event.
+5. **Dispatch** — each event is handed to `PostHogCoreStateless.captureStateless()`. Batching, retries, and flushing are owned by `@posthog/core`. Consumers call `client.shutdown()` / `client.flush()` on the `PostHogMCP` instance to drain. No process-signal handlers are installed by the SDK — that's the host application's choice.
+
+## 4. Session & identity
+
+- **Session ID format**: `ses_<uuidv7>` (`src/modules/ids.ts`). Uses `uuidv7` from `@posthog/core`.
+- **Session resolution order** (`src/modules/session.ts`):
+  1. If `extra.sessionId` (MCP protocol session) is present, derive a deterministic id by hashing it (`deterministicPrefixedId("ses", mcpSessionId)`). This means the same protocol session always maps to the same PostHog session across server restarts.
+  2. If the MCP session id disappears mid-stream, keep using the last derived id (transient drops don't split sessions).
+  3. Otherwise, generate `ses_<uuidv7>` and rotate after **30 minutes of inactivity** (`INACTIVITY_TIMEOUT_IN_MINUTES`).
+- **`distinct_id`** (`posthog-events.ts`): `identifyActorGivenId || sessionId || "anonymous"`. Pre-identify events are session-scoped; once `options.identify()` returns a user, subsequent events attribute to that user and PostHog's standard identity merge takes over.
+- **`$identify` event**: fires only when the identity returned by `options.identify()` _changes_ for a given session. There is a module-level LRU (max 1000 entries) keyed by session id (`src/modules/internal.ts`), so an unchanged identity is silently deduped.
+- **Person properties (`$set`)**: built from `UserIdentity.userName` (→ `name`) and any `userData` keys.
+
+## 5. Event catalog
+
+All events are emitted by `buildPostHogCaptureEvents`. The main event name is computed by looking up the internal `MCPAnalyticsEventType` in `BUILT_IN_EVENT_NAME_BY_TYPE`.
+
+| PostHog event          | When                                                          | Notable extras                                                                                                                                                                  |
+| ---------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$mcp_tool_call`       | Every tool invocation                                         | `$mcp_tool_name`, `$mcp_tool_description`, `$mcp_parameters`, `$mcp_response`, `$mcp_duration_ms`, `$mcp_is_error`, optionally `$mcp_intent` / `$mcp_intent_source`, AI trace refs if AI tracing on |
+| `$mcp_tools_list`      | Client lists tools                                            | `$mcp_listed_tool_names` (array of tool names advertised); useful for "did this client discover us?" and "which advertised tools never get called?"                              |
+| `$mcp_initialize`      | Client/server handshake                                       | `$mcp_client_name`, `$mcp_client_version`, `$mcp_server_name`, `$mcp_server_version`                                                                                            |
+| `$mcp_resources_list`  | Client lists resources                                        | —                                                                                                                                                                               |
+| `$mcp_resource_read`   | Resource fetched                                              | `$mcp_resource_name`, `$mcp_parameters`, `$mcp_response`                                                                                                                        |
+| `$mcp_prompts_list`    | Client lists prompts                                          | —                                                                                                                                                                               |
+| `$mcp_prompt_get`      | Prompt fetched                                                | `$mcp_resource_name` (= prompt name)                                                                                                                                            |
+| `$mcp_custom`          | `publishCustomEvent()`                                        | Whatever the caller passed in `properties`                                                                                                                                      |
+| `$identify`            | `options.identify` returned a new identity for the session    | `$set` populated                                                                                                                                                                |
+| `$exception`           | Sibling to any errored event                                  | `$exception_message`, `$exception_type`, `$exception_stacktrace`, `$exception_source = "backend"`                                                                               |
+| `$ai_span`             | Sibling to `$mcp_tool_call` when `enableAITracing: true`      | Full `$ai_*` set — see §6                                                                                                                                                       |
+
+## 6. Property catalog
+
+All wire keys live in `PostHogMCPAnalyticsProperty` (`src/modules/constants.ts`).
+
+### Core properties (present on most `$mcp_*` events)
+
+| Constant         | Wire key                  | Type                                  | Source                                                                                                                                                                                |
+| ---------------- | ------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SessionId`      | `$session_id`             | string                                | `event.sessionId` (`ses_…`)                                                                                                                                                           |
+| `Source`         | `$mcp_source`             | string                                | Hardcoded `"posthog_mcp_analytics"`                                                                                                                                                   |
+| `ResourceName`   | `$mcp_resource_name`      | string                                | Tool / resource / prompt name                                                                                                                                                         |
+| `ToolName`       | `$mcp_tool_name`          | string                                | Same as `ResourceName`, but **only on `$mcp_tool_call`**                                                                                                                              |
+| `ToolDescription`| `$mcp_tool_description`   | string                                | Tool's current `description` at call time. Cached from `tools/list` and (for `McpServer`) seeded from `_registeredTools`. Only on `$mcp_tool_call` and the paired `$exception` event |
+| `ListedToolNames`| `$mcp_listed_tool_names`  | string[]                              | Names of tools advertised in a `tools/list` response. Only on `$mcp_tools_list` events.                                                                                               |
+| `DurationMs`     | `$mcp_duration_ms`        | number (ms)                           | Wall-clock duration                                                                                                                                                                   |
+| `IsError`        | `$mcp_is_error`           | boolean                               | Set from tool result or thrown exception                                                                                                                                              |
+| `ServerName`     | `$mcp_server_name`        | string                                | `server._serverInfo.name`                                                                                                                                                             |
+| `ServerVersion`  | `$mcp_server_version`     | string                                | `server._serverInfo.version`                                                                                                                                                          |
+| `ClientName`     | `$mcp_client_name`        | string                                | `server.getClientVersion().name`                                                                                                                                                      |
+| `ClientVersion`  | `$mcp_client_version`     | string                                | `server.getClientVersion().version`                                                                                                                                                   |
+| `Intent`         | `$mcp_intent`             | string                                | `context` argument when present, else `intentFallback()` return                                                                                                                       |
+| `IntentSource`   | `$mcp_intent_source`      | `"context_parameter" \| "inferred"`   | Where the intent came from                                                                                                                                                            |
+| `ConversationId` | `$mcp_conversation_id`    | string                                | Optional; only set when `enableConversationId: true`                                                                                                                                  |
+| `Parameters`     | `$mcp_parameters`         | object                                | Sanitized MCP request payload (see §3)                                                                                                                                                |
+| `Response`       | `$mcp_response`           | object                                | Sanitized tool result                                                                                                                                                                 |
+
+### Person properties (`$set`)
+
+| Key           | Source                                |
+| ------------- | ------------------------------------- |
+| `name`        | `UserIdentity.userName`               |
+| `<anything>`  | Top-level keys of `UserIdentity.userData` |
+
+### AI tracing properties (`$ai_span` event + duplicated on `$mcp_tool_call`)
+
+| Constant       | Wire key             | Type                  | Notes                                                          |
+| -------------- | -------------------- | --------------------- | -------------------------------------------------------------- |
+| `AiSessionId`  | `$ai_session_id`     | string                | `posthog_mcp_analytics_${sessionId}` — namespaced               |
+| `AiTraceId`    | `$ai_trace_id`       | string                | `event.sessionId` — all tool calls in a session share this     |
+| `AiSpanId`     | `$ai_span_id`        | string                | `event.id` — unique per tool call (`evt_…`)                    |
+| `AiSpanName`   | `$ai_span_name`      | string                | Tool name                                                      |
+| `AiIsError`    | `$ai_is_error`       | boolean               | —                                                              |
+| `AiLatency`    | `$ai_latency`        | number (**seconds**)  | `duration_ms / 1000` — different unit from `$mcp_duration_ms`  |
+| `AiInputState` | `$ai_input_state`    | object                | Same content as `$mcp_parameters`                              |
+| `AiOutputState`| `$ai_output_state`   | object                | Same content as `$mcp_response`                                |
+| `$ai_error`    | `$ai_error`          | object                | Set as a literal property, not via the constants enum          |
+
+`$ai_trace_id` and `$ai_span_id` are also stamped onto the main `$mcp_tool_call` event so the two events can be joined.
+
+### Exception properties (`$exception` event)
+
+`$exception_source = "backend"`, `$exception_message`, `$exception_type`, `$exception_stacktrace`, plus `$session_id`, `$mcp_resource_name`, `$mcp_tool_name` and `$mcp_tool_description` (tool calls only), `$mcp_server_*`, `$mcp_client_*`.
+
+### Customer-defined properties
+
+The `eventProperties` callback returns key/value pairs that are **spread flat at the top level of the PostHog event properties**, alongside the `$mcp_*` keys. They can therefore override built-in `$mcp_*` keys — intentional, so customers can backfill missing context. Values must be JSON-serializable; the SDK does not validate keys or values beyond truncation.
+
+## 7. Customer extension points (`MCPAnalyticsOptions`, `src/types.ts`)
+
+| Option                       | Default                                   | Use case                                                                                                                                |
+| ---------------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `apiKey`                     | —                                         | PostHog project key (`phc_…`). Required unless you pass `client`.                                                                       |
+| `host`                       | `https://us.i.posthog.com`                | Ingestion host. Equivalent to `clientOptions.host`.                                                                                     |
+| `clientOptions`              | —                                         | Forwarded to `PostHogMCP` constructor — tune `flushAt`, `flushInterval`, `requestTimeout`, custom `fetch`, etc.                          |
+| `client`                     | —                                         | BYO existing `PostHogMCP` instance; bypasses construction.                                                                              |
+| `logger`                     | no-op                                     | STDIO-safe log sink for SDK-internal warnings. Receives single string messages.                                                         |
+| `enableTracing`              | `true`                                    | Master kill switch for event emission.                                                                                                  |
+| `enableAITracing`            | `false`                                   | Emit `$ai_span` so MCP activity shows up in PostHog LLM analytics.                                                                      |
+| `enableConversationId`       | `false`                                   | Inject the `conversation_id` parameter into every tool and stamp `$mcp_conversation_id` on events.                                      |
+| `reportMissing`              | `false`                                   | Register the `get_more_tools` virtual tool.                                                                                             |
+| `context`                    | `true` (object form: `{ description }`)   | Inject required `context` arg into every tool schema.                                                                                   |
+| `intentFallback`             | —                                         | Consumer-supplied callback returning a `$mcp_intent` string when the client didn't pass a `context` argument. SDK does no inference.    |
+| `identify`                   | —                                         | Async function returning `UserIdentity \| null`.                                                                                        |
+| `redactSensitiveInformation` | —                                         | Async string-level redactor. Runs before sanitization.                                                                                  |
+| `eventProperties`            | —                                         | Freeform JSON, spread flat.                                                                                                             |
+
+## 8. Useful queries
+
+All queries assume `event` is the PostHog event name column. Property names use the literal wire keys (with `$`).
+
+### Top tools per server (last 7d)
+
+```sql
+SELECT
+  properties.$mcp_server_name AS server,
+  properties.$mcp_tool_name   AS tool,
+  count() AS calls
+FROM events
+WHERE event = '$mcp_tool_call' AND timestamp > now() - INTERVAL 7 DAY
+GROUP BY server, tool
+ORDER BY calls DESC
+LIMIT 50
+```
+
+### Error rate per tool
+
+```sql
+SELECT
+  properties.$mcp_tool_name AS tool,
+  countIf(properties.$mcp_is_error)        AS errors,
+  count()                                  AS total,
+  countIf(properties.$mcp_is_error) / count() AS error_rate
+FROM events
+WHERE event = '$mcp_tool_call' AND timestamp > now() - INTERVAL 7 DAY
+GROUP BY tool
+ORDER BY total DESC
+```
+
+### P95 latency per tool
+
+```sql
+SELECT
+  properties.$mcp_tool_name AS tool,
+  quantile(0.95)(toFloat(properties.$mcp_duration_ms)) AS p95_ms
+FROM events
+WHERE event = '$mcp_tool_call' AND timestamp > now() - INTERVAL 7 DAY
+GROUP BY tool
+ORDER BY p95_ms DESC
+```
+
+### Intent samples split by source
+
+```sql
+SELECT
+  properties.$mcp_intent_source AS source,
+  properties.$mcp_tool_name     AS tool,
+  any(properties.$mcp_intent)   AS sample_intent,
+  count()                       AS calls
+FROM events
+WHERE event = '$mcp_tool_call' AND timestamp > now() - INTERVAL 24 HOUR
+GROUP BY source, tool
+ORDER BY calls DESC
+```
+
+### Joining `$mcp_tool_call` to its `$ai_span` sibling
+
+```sql
+SELECT
+  c.properties.$mcp_tool_name    AS tool,
+  c.properties.$mcp_duration_ms  AS duration_ms,
+  s.properties.$ai_latency       AS ai_latency_s,
+  c.properties.$mcp_intent       AS intent
+FROM events c
+INNER JOIN events s
+  ON s.event = '$ai_span'
+ AND s.properties.$ai_span_id = c.properties.$ai_span_id
+WHERE c.event = '$mcp_tool_call'
+  AND c.timestamp > now() - INTERVAL 24 HOUR
+LIMIT 100
+```
+
+### Advertised tools that never get called
+
+```sql
+WITH listed AS (
+  SELECT DISTINCT arrayJoin(properties.$mcp_listed_tool_names) AS tool_name
+  FROM events
+  WHERE event = '$mcp_tools_list'
+    AND timestamp > now() - INTERVAL 30 DAY
+),
+called AS (
+  SELECT DISTINCT properties.$mcp_tool_name AS tool_name
+  FROM events
+  WHERE event = '$mcp_tool_call'
+    AND timestamp > now() - INTERVAL 30 DAY
+)
+SELECT tool_name AS zombie_tool
+FROM listed
+WHERE tool_name NOT IN (SELECT tool_name FROM called)
+ORDER BY tool_name
+```
+
+### Active sessions per client
+
+```sql
+SELECT
+  properties.$mcp_client_name AS client,
+  uniq(properties.$session_id) AS sessions
+FROM events
+WHERE event IN ('$mcp_initialize', '$mcp_tool_call')
+  AND timestamp > now() - INTERVAL 7 DAY
+GROUP BY client
+ORDER BY sessions DESC
+```
+
+## 9. Migration from the previous standalone `@posthog/mcp` (0.0.x)
+
+The previous version of this SDK lived in a separate repo and depended on `posthog-node`. This first monorepo release (`0.1.0`) is a clean break — there were no production users, so the contract is intentionally rebuilt rather than maintained.
+
+### Breaking changes
+
+| Concern                                | Old (standalone 0.0.x)                                          | New (monorepo 0.1.0)                                                                  |
+| -------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| PostHog client                         | Required `posthog-node` runtime dep, or BYO via `posthogClient` | Uses `@posthog/core`'s `PostHogCoreStateless` directly via the bundled `PostHogMCP`   |
+| `posthogClient` option                 | Accepted any duck-typed client                                  | Removed; use `client: PostHogMCP` (or just `apiKey`)                                  |
+| `posthogOptions` option                | Forwarded to `posthog-node`                                     | Renamed to `clientOptions` and forwarded to `PostHogMCP`                              |
+| `eventTags` callback                   | Constrained string map; spread flat on events                   | Removed — fold all metadata into `eventProperties`                                    |
+| `~/posthog-mcp-analytics.log`          | SDK wrote to the user's home directory                          | Removed; pass `logger?: (msg: string) => void` if you want to capture internal logs   |
+| PostHog event names                    | Plain (`mcp_tool_call`, `mcp_custom`, `posthog_identify`, …)    | `$`-prefixed (`$mcp_tool_call`, `$mcp_custom`, `$identify`, …) per PostHog convention |
+| `POSTHOG_MCP_ANALYTICS_HOST` env var   | Read at `track()` time                                          | Removed; pass `host` directly                                                         |
+| Session id source                      | `uuidv4` via `node:crypto`                                      | `uuidv7` from `@posthog/core`                                                         |
+
+### Insight migration checklist
+
+1. `event = 'mcp_tool_call'` → `event = '$mcp_tool_call'` (same for every other `mcp_*` event).
+2. `event = 'posthog_identify'` → `event = '$identify'`.
+3. Replace `properties.$mcp_source = 'posthog_mcp_analytics'` filters with `event LIKE '$mcp_%'` if you want a broader funnel.
+4. Drop any filters on customer tags — fold them into `eventProperties`.
+
+## 10. Intent resolution in depth
+
+Intent is the most semantically-loaded property the SDK emits. Lives in `src/modules/intent.ts`.
+
+### Two sources, one property
+
+`$mcp_intent` can come from either:
+
+1. **The `context` argument the LLM/client passed** — the SDK-injected JSON-Schema parameter. Tagged `$mcp_intent_source = "context_parameter"`.
+2. **The `intentFallback` callback you supplied** — runs only when no `context` argument is present. Tagged `$mcp_intent_source = "inferred"`.
+
+Explicit context always wins. If `context` is non-empty, `intentFallback` is **not invoked**.
+
+### Why the fallback exists
+
+The `context` parameter is advertised as required in JSON Schema but **not enforced at the SDK validation layer** — a tool call with `arguments: {}` succeeds and lands in PostHog with `$mcp_intent` empty.
+
+The MCP SDK validates against the Zod schema the tool was originally registered with, and `@posthog/mcp` does not (and can't safely) re-derive Zod from the mutated JSON Schema. So for clients that ignore the JSON Schema hint — raw cURL, in-house agents, schema-blind crawlers — `intentFallback` is the only way to keep intent coverage non-zero.
+
+For a tightly-controlled internal MCP server with a single well-behaved client, the fallback is dead code.
+
+### What the SDK does NOT do
+
+`intentFallback` is **a slot**, not a strategy. The SDK:
+
+- Awaits whatever async function you pass.
+- Trims and null-guards the result.
+- Tags it `source: "inferred"`.
+- Swallows + logs any thrown exception.
+
+The SDK does **not**: call an LLM, inspect tool arguments, build heuristics, or cache results across calls. If you want any of that, your callback implements it.
+
+### Recommended `intentFallback` patterns
+
+1. **Deterministic, per-tool** (cheapest, sync, runs on every uncontextualized call):
+
+   ```ts
+   intentFallback: (request) => {
+     const tool = request.params?.name
+     const args = request.params?.arguments ?? {}
+     if (tool === 'search_events') return `Searching events for "${args.query}"`
+     return tool ? `Invoking ${tool}` : null
+   }
+   ```
+
+2. **Transport metadata** (when `extra` carries user-agent or session info worth surfacing):
+
+   ```ts
+   intentFallback: (request, extra) => {
+     const ua = extra?.requestInfo?.headers?.['user-agent']
+     return `${ua ?? 'unknown client'} invoked ${request.params?.name}`
+   }
+   ```
+
+3. **LLM-derived** (async, expensive — push back unless the value is high). Sits on the hot path of every uncontextualized tool call.
+
+### Known sharp edges
+
+- The `get_more_tools` virtual tool always reports `$mcp_intent_source = "context_parameter"`. It's defensible — the LLM did type a context string — but worth knowing if you segment by source.
+- `$mcp_intent_source` is currently **only** present when an intent was captured. Events with neither a context arg nor a fallback result have no `$mcp_intent` and no `$mcp_intent_source`. Dashboards filtering on `$mcp_intent_source = "inferred"` won't see them — that's the desired behavior; just don't expect a synthetic `"none"` value.
+
+---
+
+## File map quick reference
+
+| Concern                                          | File                                                       |
+| ------------------------------------------------ | ---------------------------------------------------------- |
+| Public API entry                                 | `src/index.ts`                                             |
+| Public types & options                           | `src/types.ts`                                             |
+| Property/event constants                         | `src/modules/constants.ts`                                 |
+| Event serialization to PostHog                   | `src/modules/posthog-events.ts`                            |
+| Internal event types                             | `src/modules/event-types.ts`                               |
+| `PostHogMCP` client + ingest pipeline            | `src/modules/client.ts`                                    |
+| Per-server `publishEvent` helper                 | `src/modules/publish.ts`                                   |
+| High-level `McpServer` wrapping                  | `src/modules/tracing-v2.ts`                                |
+| Low-level `Server` wrapping                      | `src/modules/tracing.ts`                                   |
+| Intent resolution (context arg + fallback)       | `src/modules/intent.ts`                                    |
+| Identity cache + identify dispatch               | `src/modules/internal.ts`                                  |
+| Session id derivation & timeout                  | `src/modules/session.ts`, `src/modules/ids.ts`             |
+| `conversation_id` injection + minting            | `src/modules/conversation-id.ts`                           |
+| `get_more_tools` virtual tool                    | `src/modules/tools.ts`                                     |
+| Customer redaction                               | `src/modules/redaction.ts`                                 |
+| Auto-redaction & binary stubbing                 | `src/modules/sanitization.ts`, `src/modules/mcp-payloads.ts` |
+| Size / depth / breadth caps                      | `src/modules/truncation.ts`                                |
+| `context` JSON-Schema injection                  | `src/modules/context-parameters.ts`                        |
+| STDIO-safe logger sink                           | `src/modules/logger.ts`                                    |
+| Exception capture & stack-trace parsing          | `src/modules/exceptions.ts`                                |
+| MCP SDK version compat shims                     | `src/modules/compatibility.ts`, `src/modules/mcp-sdk-compat.ts` |

--- a/packages/mcp/jest.config.mjs
+++ b/packages/mcp/jest.config.mjs
@@ -1,0 +1,12 @@
+export default {
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  modulePathIgnorePatterns: ['<rootDir>/src/__tests__/test-utils/*'],
+  collectCoverage: true,
+  clearMocks: true,
+  fakeTimers: { enableGlobally: false },
+  coverageDirectory: 'coverage',
+  silent: true,
+  verbose: false,
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@posthog/mcp",
+  "version": "0.1.0",
+  "description": "PostHog SDK for Model Context Protocol (MCP) servers — tracks tool usage, intent, and identity",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PostHog/posthog-js.git",
+    "directory": "packages/mcp"
+  },
+  "scripts": {
+    "clean": "rimraf dist coverage",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "test:unit": "jest",
+    "prebuild": "node -p \"'export const version = \\'' + require('./package.json').version + '\\''\" > src/version.ts",
+    "build": "rslib build",
+    "dev": "rslib build -w",
+    "prepublishOnly": "pnpm lint && pnpm test:unit && pnpm build",
+    "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz"
+  },
+  "engines": {
+    "node": "^20.20.0 || >=22.22.0"
+  },
+  "files": [
+    "src",
+    "dist",
+    "!src/__tests__"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "PostHog",
+    "email": "engineering@posthog.com",
+    "url": "https://posthog.com"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "dependencies": {
+    "@posthog/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "catalog:",
+    "@babel/preset-typescript": "catalog:",
+    "@modelcontextprotocol/sdk": "~1.24.2",
+    "@posthog-tooling/tsconfig-base": "workspace:*",
+    "@rslib/core": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "^20.0.0",
+    "jest": "catalog:",
+    "zod": "^3.25.0"
+  },
+  "peerDependencies": {
+    "@modelcontextprotocol/sdk": ">=1.11"
+  },
+  "keywords": [
+    "posthog",
+    "mcp",
+    "model-context-protocol",
+    "analytics",
+    "llm"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  }
+}

--- a/packages/mcp/rslib.config.ts
+++ b/packages/mcp/rslib.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rslib/core'
+
+export default defineConfig({
+  lib: [
+    { format: 'esm', syntax: 'es2023', dts: true, bundle: false },
+    { format: 'cjs', syntax: 'es2023', dts: true, bundle: false },
+  ],
+  source: {
+    entry: {
+      index: ['src/**/*', '!src/__tests__/**/*', '!src/**/*.spec.ts'],
+    },
+    tsconfigPath: './tsconfig.build.json',
+  },
+})

--- a/packages/mcp/src/__tests__/api-base-url.test.ts
+++ b/packages/mcp/src/__tests__/api-base-url.test.ts
@@ -1,0 +1,33 @@
+import { PostHogMCP } from '../modules/client'
+import type { MCPAnalyticsOptions } from '../types'
+
+describe('MCPAnalyticsOptions host', () => {
+  it('should accept host as an optional string property', () => {
+    const options: MCPAnalyticsOptions = {
+      host: 'https://custom.example.com',
+    }
+    expect(options.host).toBe('https://custom.example.com')
+  })
+
+  it('should be undefined when not set', () => {
+    const options: MCPAnalyticsOptions = {}
+    expect(options.host).toBeUndefined()
+  })
+})
+
+describe('PostHogMCP construction', () => {
+  it('reports the library id and version on the client', () => {
+    const client = new PostHogMCP('phc_test')
+    expect(client.getLibraryId()).toBe('posthog-mcp')
+    expect(client.getLibraryVersion()).toMatch(/^\d+\.\d+\.\d+/)
+    expect(client.getCustomUserAgent()).toBe(`posthog-mcp/${client.getLibraryVersion()}`)
+  })
+
+  it('accepts a custom host without throwing', () => {
+    expect(() => new PostHogMCP('phc_test', { host: 'https://custom.example.com' })).not.toThrow()
+  })
+
+  it('accepts no host (defaults to the US ingestion host)', () => {
+    expect(() => new PostHogMCP('phc_test')).not.toThrow()
+  })
+})

--- a/packages/mcp/src/__tests__/basic-server.test.ts
+++ b/packages/mcp/src/__tests__/basic-server.test.ts
@@ -1,0 +1,580 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+import { MCPAnalyticsEventType } from '../modules/event-types'
+import { EventCapture } from './test-utils'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+
+describe('Basic Server Test', () => {
+  it('should be able to call tools without tracking', async () => {
+    resetTodos()
+    const { client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // List tools first to ensure they're available
+      const toolsResponse = await client.request(
+        {
+          method: 'tools/list',
+          params: {},
+        },
+        ListToolsResultSchema
+      )
+
+      expect(toolsResponse.tools).toBeDefined()
+      expect(toolsResponse.tools.length).toBeGreaterThan(0)
+
+      // Call add_todo
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Test todo',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result).toBeDefined()
+      expect(result.content).toBeDefined()
+      expect(result.content[0].text).toContain('Added todo')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should be able to access server info from regular Server instance', async () => {
+    const { server, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // McpServer stores server info in the underlying server.server property
+      const underlyingServer = (server as any).server || server
+      const serverInfo = (underlyingServer as any)._serverInfo
+
+      expect(serverInfo).toBeDefined()
+      expect(serverInfo.name).toBe('test server')
+      expect(serverInfo.version).toBe('1.0')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should be able to access server info with McpServer if available', async () => {
+    // Try to import McpServer
+    let McpServer: any
+    let hasCompatibleVersion = false
+
+    try {
+      const { McpServer: ImportedMcpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js')
+      McpServer = ImportedMcpServer
+      hasCompatibleVersion = true
+    } catch {
+      // McpServer not available in this version
+      hasCompatibleVersion = false
+    }
+
+    if (!hasCompatibleVersion) {
+      console.log('Skipping McpServer server info test - requires @modelcontextprotocol/sdk v1.3.0 or higher')
+      return
+    }
+
+    // Create McpServer instance
+    const mcpServer = new McpServer({
+      name: 'test-mcp-server-info',
+      version: '2.0.0',
+    })
+
+    // Access server info from the underlying server
+    const underlyingServer = mcpServer.server
+    const serverInfo = (underlyingServer as any)._serverInfo
+
+    expect(serverInfo).toBeDefined()
+    expect(serverInfo.name).toBe('test-mcp-server-info')
+    expect(serverInfo.version).toBe('2.0.0')
+  })
+
+  it('should verify that server info is used by isCompatibleServerType', async () => {
+    const { server, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Import our compatibility function
+      const { isCompatibleServerType } = await import('../modules/compatibility')
+
+      // This should not throw since our test server has proper _serverInfo
+      const result = isCompatibleServerType(server)
+      expect(result).toBe(server)
+
+      // Verify we can still access server info after compatibility check
+      // McpServer stores server info in the underlying server.server property
+      const underlyingServer = (result as any).server || result
+      const serverInfo = (underlyingServer as any)._serverInfo
+      expect(serverInfo).toBeDefined()
+      expect(serverInfo.name).toBe('test server')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should properly trace tools added after track() is called', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Import track function
+      const { track } = await import('../index')
+
+      // Call track first with a project ID
+      await track(server, {
+        apiKey: 'test-project',
+        context: true,
+        enableTracing: true,
+      })
+
+      // Add a new tool after track() has been called using server.tool()
+      server.tool(
+        'new_tool_after_track',
+        'A tool added after track() was called',
+        {
+          data: z.string().optional().describe('Optional data parameter'),
+        },
+        async (args) => ({
+          content: [
+            {
+              type: 'text',
+              text: `New tool called with data: ${args.data || 'no data'}`,
+            },
+          ],
+        })
+      )
+
+      // List tools to verify the new tool appears with context parameter
+      const toolsResponse = await client.request(
+        {
+          method: 'tools/list',
+          params: {},
+        },
+        ListToolsResultSchema
+      )
+
+      const newTool = toolsResponse.tools.find((t) => t.name === 'new_tool_after_track')
+      expect(newTool).toBeDefined()
+      expect(newTool?.inputSchema).toBeDefined()
+
+      // Verify that the context parameter was injected
+      const inputSchema = newTool?.inputSchema as any
+      expect(inputSchema.properties?.context).toBeDefined()
+      expect(inputSchema.properties?.context.type).toBe('string')
+
+      // Verify the original data parameter is still there
+      expect(inputSchema.properties?.data).toBeDefined()
+
+      // Call the new tool with context to verify it works
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'new_tool_after_track',
+            arguments: {
+              context: 'Testing new tool after track',
+              data: 'test data',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result).toBeDefined()
+      expect(result.content[0].text).toContain('test data')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should handle tools with shorthand Zod schema syntax (reproduces context injection issue)', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Import track function
+      const { track } = await import('../index')
+
+      // Call track first with a project ID
+      await track(server, {
+        apiKey: 'test-project',
+        context: true,
+        enableTracing: true,
+      })
+
+      // Add a tool using shorthand Zod schema syntax (without description string)
+      // This mimics the user's code pattern: server.tool("add", { a: z.number(), b: z.number() }, handler)
+      server.tool('calculator_add', { a: z.number(), b: z.number() }, async ({ a, b }) => ({
+        content: [{ type: 'text', text: String(a + b) }],
+      }))
+
+      // List tools to verify the new tool appears with context parameter
+      const toolsResponse = await client.request(
+        {
+          method: 'tools/list',
+          params: {},
+        },
+        ListToolsResultSchema
+      )
+
+      const calculatorTool = toolsResponse.tools.find((t) => t.name === 'calculator_add')
+      expect(calculatorTool).toBeDefined()
+      expect(calculatorTool?.inputSchema).toBeDefined()
+
+      // Verify that the context parameter was injected
+      const inputSchema = calculatorTool?.inputSchema as any
+      expect(inputSchema.properties?.context).toBeDefined()
+      expect(inputSchema.properties?.context.type).toBe('string')
+
+      // Verify the original parameters are still there
+      expect(inputSchema.properties?.a).toBeDefined()
+      expect(inputSchema.properties?.b).toBeDefined()
+
+      // Call the tool with context to verify it works
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'calculator_add',
+            arguments: {
+              context: 'Testing calculator with shorthand syntax',
+              a: 5,
+              b: 3,
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result).toBeDefined()
+      expect(result.content[0].text).toBe('8')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should publish events only once (no duplicates)', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    // Set up event capture
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    try {
+      // Import track function
+      const { track } = await import('../index')
+
+      // Call track with tracing enabled
+      await track(server, {
+        apiKey: 'test-dedup-project',
+        context: true,
+        enableTracing: true,
+      })
+
+      // Make multiple tool calls to generate events with unique IDs
+      const timestamp1 = Date.now()
+      const timestamp2 = timestamp1 + 1
+
+      const toolCalls = [
+        {
+          name: 'add_todo',
+          arguments: {
+            context: 'test context 1',
+            text: `First todo with unique ID: ${timestamp1}`,
+          },
+        },
+        {
+          name: 'add_todo',
+          arguments: {
+            context: 'test context 2',
+            text: `Second todo with unique ID: ${timestamp2}`,
+          },
+        },
+        { name: 'list_todos', arguments: { context: 'test context 3' } },
+      ]
+
+      for (const toolCall of toolCalls) {
+        await client.request(
+          {
+            method: 'tools/call',
+            params: toolCall,
+          },
+          CallToolResultSchema
+        )
+      }
+
+      // Wait a bit for events to be processed
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Get captured events
+      const events = eventCapture.getEvents()
+
+      // Filter for tool call events
+      const toolCallEvents = events.filter((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+
+      // Verify we captured some events
+      expect(toolCallEvents.length).toBeGreaterThan(0)
+
+      // Check for duplicates by creating a unique ID for each event
+      const eventIds = new Set<string>()
+      let duplicateFound = false
+
+      for (const event of toolCallEvents) {
+        // Create a unique ID based on event properties
+        const eventId = `${event.eventType}_${event.resourceName}_${JSON.stringify(event.parameters)}`
+
+        if (eventIds.has(eventId)) {
+          duplicateFound = true
+          console.error('Duplicate event detected:', eventId)
+        } else {
+          eventIds.add(eventId)
+        }
+      }
+
+      // Verify no duplicates were found
+      expect(duplicateFound).toBe(false)
+
+      // Verify each tool call resulted in exactly one event
+      const addTodoEvents = toolCallEvents.filter((e) => e.resourceName === 'add_todo')
+      const listTodosEvents = toolCallEvents.filter((e) => e.resourceName === 'list_todos')
+
+      expect(addTodoEvents.length).toBe(2)
+      expect(listTodosEvents.length).toBe(1)
+
+      // Verify unique text in each add_todo event
+      const todoTexts = addTodoEvents.map((e) => (e.parameters as any)?.request?.params?.arguments?.text)
+      expect(new Set(todoTexts).size).toBe(2) // Should have 2 unique texts
+
+      await eventCapture.stop()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should handle tools defined BEFORE track() with shorthand Zod schema', async () => {
+    resetTodos()
+
+    // Create server instance
+    const server = new McpServer({
+      name: 'test calculator server',
+      version: '1.0.0',
+    })
+
+    // Define tools BEFORE calling track() - exactly like the user's code
+    server.tool('add', { a: z.number(), b: z.number() }, async ({ a, b }) => ({
+      content: [{ type: 'text', text: String(a + b) }],
+    }))
+
+    server.tool(
+      'calculate',
+      {
+        operation: z.enum(['add', 'subtract', 'multiply', 'divide']),
+        a: z.number(),
+        b: z.number(),
+      },
+      async ({ operation, a, b }) => {
+        let result: number
+        switch (operation) {
+          case 'add':
+            result = a + b
+            break
+          case 'subtract':
+            result = a - b
+            break
+          case 'multiply':
+            result = a * b
+            break
+          case 'divide':
+            if (b === 0) {
+              return {
+                content: [
+                  {
+                    type: 'text',
+                    text: 'Error: Cannot divide by zero',
+                  },
+                ],
+              }
+            }
+            result = a / b
+            break
+          default:
+            throw new Error(`Unsupported operation: ${operation}`)
+        }
+        return {
+          content: [{ type: 'text', text: String(result) }],
+        }
+      }
+    )
+
+    // Create client instance
+    const client = new Client(
+      {
+        name: 'test client',
+        version: '1.0',
+      },
+      {
+        capabilities: {
+          sampling: {},
+        },
+      }
+    )
+
+    // Create transport pair and connect
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+    await Promise.all([client.connect(clientTransport), server.server.connect(serverTransport)])
+
+    try {
+      // Import track function
+      const { track } = await import('../index')
+
+      // NOW call track - after tools are already defined
+      await track(server, {
+        apiKey: 'test-project',
+        context: true,
+        enableTracing: true,
+      })
+
+      // List tools to verify they have context parameter injected
+      const toolsResponse = await client.request(
+        {
+          method: 'tools/list',
+          params: {},
+        },
+        ListToolsResultSchema
+      )
+
+      // Check the "add" tool
+      const addTool = toolsResponse.tools.find((t) => t.name === 'add')
+      expect(addTool).toBeDefined()
+      expect(addTool?.inputSchema).toBeDefined()
+
+      const addSchema = addTool?.inputSchema as any
+      expect(addSchema.properties?.context).toBeDefined()
+      expect(addSchema.properties?.context.type).toBe('string')
+      expect(addSchema.properties?.a).toBeDefined()
+      expect(addSchema.properties?.b).toBeDefined()
+
+      // Check the "calculate" tool
+      const calculateTool = toolsResponse.tools.find((t) => t.name === 'calculate')
+      expect(calculateTool).toBeDefined()
+      expect(calculateTool?.inputSchema).toBeDefined()
+
+      const calculateSchema = calculateTool?.inputSchema as any
+      expect(calculateSchema.properties?.context).toBeDefined()
+      expect(calculateSchema.properties?.operation).toBeDefined()
+
+      // Call the tools to verify they work
+      const addResult = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add',
+            arguments: {
+              context: 'Testing add with context',
+              a: 5,
+              b: 3,
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(addResult).toBeDefined()
+      expect(addResult.content[0].text).toBe('8')
+
+      const calcResult = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'calculate',
+            arguments: {
+              context: 'Testing calculate with context',
+              operation: 'multiply',
+              a: 4,
+              b: 7,
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(calcResult).toBeDefined()
+      expect(calcResult.content[0].text).toBe('28')
+    } finally {
+      await clientTransport.close?.()
+      await serverTransport.close?.()
+    }
+  })
+
+  it('captures the tool description on tool call events', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    try {
+      const { track } = await import('../index')
+      await track(server, {
+        apiKey: 'test-tool-description',
+        enableTracing: true,
+      })
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: { text: 'with description' },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      const toolCallEvent = eventCapture
+        .getEvents()
+        .find((event) => event.eventType === MCPAnalyticsEventType.mcpToolsCall && event.resourceName === 'add_todo')
+
+      expect(toolCallEvent?.toolDescription).toBe('Add a new todo item')
+      await eventCapture.stop()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('captures listed tool names on mcp_tools_list events', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    try {
+      const { track } = await import('../index')
+      await track(server, {
+        apiKey: 'test-listed-tool-names',
+        enableTracing: true,
+      })
+
+      await client.request({ method: 'tools/list', params: {} }, ListToolsResultSchema)
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      const listEvent = eventCapture.getEvents().find((event) => event.eventType === MCPAnalyticsEventType.mcpToolsList)
+
+      expect(listEvent?.listedToolNames).toEqual(expect.arrayContaining(['add_todo', 'list_todos', 'complete_todo']))
+      await eventCapture.stop()
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/packages/mcp/src/__tests__/compatibility.test.ts
+++ b/packages/mcp/src/__tests__/compatibility.test.ts
@@ -1,0 +1,462 @@
+import { getMCPCompatibleErrorMessage, isCompatibleServerType, logCompatibilityWarning } from '../modules/compatibility'
+
+// Mock the logging module
+jest.mock('../modules/logger', () => ({
+  log: jest.fn(),
+}))
+
+// Import after mocking
+import { log } from '../modules/logger'
+
+const COMPATIBILITY_PATTERN = /compatibility/i
+const GET_CLIENT_VERSION_PATTERN = /getClientVersion/
+const MCP_NAME_PATTERN = /Model Context Protocol|MCP/
+const REQUEST_HANDLERS_PATTERN = /_requestHandlers/
+const SERVER_INFO_PATTERN = /_serverInfo/
+const SERVER_OBJECT_ERROR_PATTERN = /Server must be an object/
+const SET_REQUEST_HANDLER_PATTERN = /setRequestHandler/
+
+describe('Compatibility Module', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('isCompatibleServerType', () => {
+    it('should validate a fully compatible server', () => {
+      const validServer = {
+        setRequestHandler: jest.fn(),
+        _requestHandlers: new Map([['test', jest.fn()]]),
+        getClientVersion: jest.fn(),
+        _serverInfo: { name: 'TestServer' },
+      }
+
+      const result = isCompatibleServerType(validServer)
+      expect(result).toBe(validServer)
+      expect(log).not.toHaveBeenCalled()
+    })
+
+    it('should throw error and log warning for null server', () => {
+      expect(() => isCompatibleServerType(null)).toThrowError(SERVER_OBJECT_ERROR_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+
+    it('should throw error and log warning for undefined server', () => {
+      expect(() => isCompatibleServerType(undefined)).toThrowError(SERVER_OBJECT_ERROR_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+
+    it('should throw error and log warning for non-object server', () => {
+      expect(() => isCompatibleServerType('not an object')).toThrowError(SERVER_OBJECT_ERROR_PATTERN)
+      expect(log).toHaveBeenCalledTimes(1)
+
+      jest.clearAllMocks()
+
+      expect(() => isCompatibleServerType(42)).toThrowError(SERVER_OBJECT_ERROR_PATTERN)
+      expect(log).toHaveBeenCalledTimes(1)
+
+      jest.clearAllMocks()
+
+      expect(() => isCompatibleServerType(true)).toThrowError(SERVER_OBJECT_ERROR_PATTERN)
+      expect(log).toHaveBeenCalledTimes(1)
+    })
+
+    it('should throw error and log warning when setRequestHandler is missing', () => {
+      const server = {
+        _requestHandlers: new Map(),
+        getClientVersion: jest.fn(),
+        _serverInfo: { name: 'TestServer' },
+      }
+
+      expect(() => isCompatibleServerType(server)).toThrowError(SET_REQUEST_HANDLER_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+
+    it('should throw error and log warning when setRequestHandler is not a function', () => {
+      const server = {
+        setRequestHandler: 'not a function',
+        _requestHandlers: new Map(),
+        getClientVersion: jest.fn(),
+        _serverInfo: { name: 'TestServer' },
+      }
+
+      expect(() => isCompatibleServerType(server)).toThrowError(SET_REQUEST_HANDLER_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+
+    it('should throw error and log warning when _requestHandlers is missing', () => {
+      const server = {
+        setRequestHandler: jest.fn(),
+        getClientVersion: jest.fn(),
+        _serverInfo: { name: 'TestServer' },
+      }
+
+      expect(() => isCompatibleServerType(server)).toThrowError(REQUEST_HANDLERS_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+
+    it('should throw error and log warning when _requestHandlers is not a Map', () => {
+      const server = {
+        setRequestHandler: jest.fn(),
+        _requestHandlers: {},
+        getClientVersion: jest.fn(),
+        _serverInfo: { name: 'TestServer' },
+      }
+
+      expect(() => isCompatibleServerType(server)).toThrowError(REQUEST_HANDLERS_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+
+    it('should throw error and log warning when _requestHandlers.get is not a function', () => {
+      const server = {
+        setRequestHandler: jest.fn(),
+        _requestHandlers: { get: 'not a function' },
+        getClientVersion: jest.fn(),
+        _serverInfo: { name: 'TestServer' },
+      }
+
+      expect(() => isCompatibleServerType(server)).toThrowError(REQUEST_HANDLERS_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+
+    it('should throw error and log warning when getClientVersion is missing', () => {
+      const server = {
+        setRequestHandler: jest.fn(),
+        _requestHandlers: new Map(),
+        _serverInfo: { name: 'TestServer' },
+      }
+
+      expect(() => isCompatibleServerType(server)).toThrowError(GET_CLIENT_VERSION_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+
+    it('should throw error and log warning when getClientVersion is not a function', () => {
+      const server = {
+        setRequestHandler: jest.fn(),
+        _requestHandlers: new Map(),
+        getClientVersion: 'not a function',
+        _serverInfo: { name: 'TestServer' },
+      }
+
+      expect(() => isCompatibleServerType(server)).toThrowError(GET_CLIENT_VERSION_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+
+    it('should throw error and log warning when _serverInfo is missing', () => {
+      const server = {
+        setRequestHandler: jest.fn(),
+        _requestHandlers: new Map(),
+        getClientVersion: jest.fn(),
+      }
+
+      expect(() => isCompatibleServerType(server)).toThrowError(SERVER_INFO_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+
+    it('should throw error and log warning when _serverInfo is not an object', () => {
+      const server = {
+        setRequestHandler: jest.fn(),
+        _requestHandlers: new Map(),
+        getClientVersion: jest.fn(),
+        _serverInfo: 'not an object',
+      }
+
+      expect(() => isCompatibleServerType(server)).toThrowError(SERVER_INFO_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+
+    it('should throw error and log warning when _serverInfo.name is missing', () => {
+      const server = {
+        setRequestHandler: jest.fn(),
+        _requestHandlers: new Map(),
+        getClientVersion: jest.fn(),
+        _serverInfo: {},
+      }
+
+      expect(() => isCompatibleServerType(server)).toThrowError(SERVER_INFO_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+  })
+
+  describe('getMCPCompatibleErrorMessage', () => {
+    it('should handle Error instances with standard properties', () => {
+      const error = new Error('Test error message')
+      const result = getMCPCompatibleErrorMessage(error)
+      const parsed = JSON.parse(result)
+
+      expect(parsed.message).toBe('Test error message')
+      // Note: name property might not be enumerable in all environments
+      if (parsed.name !== undefined) {
+        expect(parsed.name).toBe('Error')
+      }
+      expect(parsed.stack).toBeDefined()
+    })
+
+    it('should handle Error instances with custom properties', () => {
+      const error: any = new Error('Test error')
+      error.code = 'CUSTOM_ERROR'
+      error.statusCode = 500
+
+      const result = getMCPCompatibleErrorMessage(error)
+      const parsed = JSON.parse(result)
+
+      expect(parsed.message).toBe('Test error')
+      expect(parsed.code).toBe('CUSTOM_ERROR')
+      expect(parsed.statusCode).toBe(500)
+    })
+
+    it('should handle string errors', () => {
+      const result = getMCPCompatibleErrorMessage('String error message')
+      expect(result).toBe('String error message')
+    })
+
+    it('should handle plain objects', () => {
+      const errorObj = { code: 'ERROR_CODE', details: 'Some details' }
+      const result = getMCPCompatibleErrorMessage(errorObj)
+      expect(result).toBe(JSON.stringify(errorObj))
+    })
+
+    it('should handle null', () => {
+      const result = getMCPCompatibleErrorMessage(null)
+      expect(result).toBe('Unknown error')
+    })
+
+    it('should handle undefined', () => {
+      const result = getMCPCompatibleErrorMessage(undefined)
+      expect(result).toBe('Unknown error')
+    })
+
+    it('should handle numbers', () => {
+      const result = getMCPCompatibleErrorMessage(42)
+      expect(result).toBe('Unknown error')
+    })
+
+    it('should handle booleans', () => {
+      const result = getMCPCompatibleErrorMessage(false)
+      expect(result).toBe('Unknown error')
+    })
+
+    it('should handle circular reference errors', () => {
+      const error: any = new Error('Circular error')
+      error.circular = error // Create circular reference
+
+      const result = getMCPCompatibleErrorMessage(error)
+      expect(result).toBe('Unknown error')
+    })
+
+    it('should handle arrays', () => {
+      const errorArray = ['error1', 'error2']
+      const result = getMCPCompatibleErrorMessage(errorArray)
+      expect(result).toBe(JSON.stringify(errorArray))
+    })
+  })
+
+  describe('McpServer compatibility', () => {
+    it('should handle McpServer instances with server property', () => {
+      const underlyingServer = {
+        setRequestHandler: jest.fn(),
+        _requestHandlers: new Map([['test', jest.fn()]]),
+        getClientVersion: jest.fn(),
+        _serverInfo: { name: 'TestServer' },
+      }
+
+      const mcpServerWrapper = {
+        server: underlyingServer,
+        // Other McpServer properties
+        requestContext: {},
+        toolCallId: 'test-id',
+        _registeredTools: {},
+        tool: () => {},
+      }
+
+      const result = isCompatibleServerType(mcpServerWrapper)
+      expect(result).toBe(mcpServerWrapper)
+      expect(log).not.toHaveBeenCalled()
+    })
+
+    it('should validate the underlying server when McpServer wrapper is provided', () => {
+      const invalidUnderlyingServer = {
+        // Missing setRequestHandler
+        _requestHandlers: new Map(),
+        getClientVersion: jest.fn(),
+        _serverInfo: { name: 'TestServer' },
+      }
+
+      const mcpServerWrapper = {
+        server: invalidUnderlyingServer,
+        _registeredTools: {},
+        tool: () => {},
+      }
+
+      expect(() => isCompatibleServerType(mcpServerWrapper)).toThrowError(SET_REQUEST_HANDLER_PATTERN)
+      expect(log).toHaveBeenCalled()
+    })
+
+    it('should handle objects with server property that is not an object', () => {
+      const mcpServerWrapper = {
+        server: 'not an object',
+        setRequestHandler: jest.fn(),
+        _requestHandlers: new Map(),
+        getClientVersion: jest.fn(),
+        _serverInfo: { name: 'TestServer' },
+      }
+
+      // Should use the wrapper itself since server property is not an object
+      const result = isCompatibleServerType(mcpServerWrapper)
+      expect(result).toBe(mcpServerWrapper)
+      expect(log).not.toHaveBeenCalled()
+    })
+
+    it('should handle objects with null server property', () => {
+      const mcpServerWrapper = {
+        server: null,
+        setRequestHandler: jest.fn(),
+        _requestHandlers: new Map(),
+        getClientVersion: jest.fn(),
+        _serverInfo: { name: 'TestServer' },
+      }
+
+      // Should use the wrapper itself since server property is null
+      const result = isCompatibleServerType(mcpServerWrapper)
+      expect(result).toBe(mcpServerWrapper)
+      expect(log).not.toHaveBeenCalled()
+    })
+
+    it('should validate all required properties on the underlying server', () => {
+      const testCases = [
+        {
+          name: 'missing _requestHandlers',
+          server: {
+            setRequestHandler: jest.fn(),
+            getClientVersion: jest.fn(),
+            _serverInfo: { name: 'TestServer' },
+          },
+          expectedPattern: REQUEST_HANDLERS_PATTERN,
+        },
+        {
+          name: 'missing getClientVersion',
+          server: {
+            setRequestHandler: jest.fn(),
+            _requestHandlers: new Map(),
+            _serverInfo: { name: 'TestServer' },
+          },
+          expectedPattern: GET_CLIENT_VERSION_PATTERN,
+        },
+        {
+          name: 'missing _serverInfo',
+          server: {
+            setRequestHandler: jest.fn(),
+            _requestHandlers: new Map(),
+            getClientVersion: jest.fn(),
+          },
+          expectedPattern: SERVER_INFO_PATTERN,
+        },
+      ]
+
+      for (const testCase of testCases) {
+        jest.clearAllMocks()
+        const mcpServerWrapper = {
+          server: testCase.server,
+          _registeredTools: {},
+          tool: () => {},
+        }
+
+        expect(() => isCompatibleServerType(mcpServerWrapper)).toThrowError(testCase.expectedPattern)
+        expect(log).toHaveBeenCalled()
+      }
+    })
+  })
+
+  describe('logCompatibilityWarning', () => {
+    it('should log the correct compatibility message to the log file', () => {
+      logCompatibilityWarning()
+
+      expect(log).toHaveBeenCalled()
+      expect(log).toHaveBeenCalledTimes(1)
+      // Check that it contains key compatibility info rather than exact message
+      const [[message]] = (log as any).mock.calls
+      expect(message).toMatch(COMPATIBILITY_PATTERN)
+      expect(message).toMatch(MCP_NAME_PATTERN)
+    })
+  })
+
+  describe('McpServer integration tests', () => {
+    // Dynamically check if McpServer is available (v1.3.0+)
+    let McpServer: any
+    let hasCompatibleVersion = false
+
+    beforeEach(async () => {
+      try {
+        // Try to import McpServer - it's available in v1.3.0+
+        const { McpServer: ImportedMcpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js')
+        McpServer = ImportedMcpServer
+        hasCompatibleVersion = true
+      } catch {
+        // McpServer not available in this version
+        hasCompatibleVersion = false
+      }
+    })
+
+    it('should work with real McpServer instances if available', async () => {
+      if (!hasCompatibleVersion) {
+        console.log('Skipping McpServer test - requires @modelcontextprotocol/sdk v1.3.0 or higher')
+        return
+      }
+
+      // Create a real McpServer instance with server info
+      const mcpServer = new McpServer({
+        name: 'test-mcp-server',
+        version: '1.0.0',
+      })
+
+      // Test that isCompatibleServerType correctly handles it
+      const result = isCompatibleServerType(mcpServer)
+
+      // Should return the underlying server
+      expect(result).toBe(mcpServer)
+      expect(result).toBeDefined()
+      // Note: _serverInfo exists but may be private - our compatibility check should handle this
+    })
+
+    it('should validate real McpServer underlying server properties', async () => {
+      if (!hasCompatibleVersion) {
+        console.log('Skipping McpServer validation test - requires @modelcontextprotocol/sdk v1.3.0 or higher')
+        return
+      }
+
+      const mcpServer = new McpServer({
+        name: 'test-validation-server',
+        version: '1.0.0',
+      })
+      const underlyingServer = mcpServer.server
+
+      // Verify all required properties exist on the real server
+      expect(underlyingServer).toBeDefined()
+      expect(typeof underlyingServer.setRequestHandler).toBe('function')
+      expect(underlyingServer._requestHandlers).toBeInstanceOf(Map)
+      expect(typeof underlyingServer.getClientVersion).toBe('function')
+
+      // Check if _serverInfo exists (it might be private but still accessible)
+      // TypeScript will complain but JavaScript can still access it
+      const serverInfo = (underlyingServer as any)._serverInfo
+      if (serverInfo) {
+        expect(serverInfo).toBeDefined()
+        expect(serverInfo.name).toBe('test-validation-server')
+        expect(serverInfo.version).toBe('1.0.0')
+      } else {
+        // If truly private and inaccessible, we should update our compatibility check
+        console.log('Note: _serverInfo is not accessible in this MCP SDK version')
+      }
+    })
+
+    it('should show compatibility message when McpServer is not available', () => {
+      if (hasCompatibleVersion) {
+        console.log('Skipping version check test - McpServer is available')
+        return
+      }
+
+      // This test only runs on older versions
+      expect(hasCompatibleVersion).toBe(false)
+      console.log('McpServer not available - using @modelcontextprotocol/sdk < v1.3.0')
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/context-parameters-edge-cases.test.ts
+++ b/packages/mcp/src/__tests__/context-parameters-edge-cases.test.ts
@@ -1,0 +1,221 @@
+import { addContextParameterToTool, addContextParameterToTools } from '../modules/context-parameters'
+import { log } from '../modules/logger'
+
+jest.mock('../modules/logger', () => ({
+  log: jest.fn(),
+}))
+
+describe('Context Parameters Edge Cases', () => {
+  beforeEach(() => {
+    jest.mocked(log).mockClear()
+    jest.mocked(log).mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('existing context parameter collision', () => {
+    it('should skip injection for tools with existing context parameter', () => {
+      const tool = {
+        name: 'test-tool',
+        inputSchema: {
+          type: 'object',
+          properties: { context: { type: 'number', description: 'existing' } },
+        },
+      }
+
+      const result = addContextParameterToTool(tool)
+
+      // Should preserve the original context parameter type
+      expect(result.inputSchema.properties.context.type).toBe('number')
+      expect(result.inputSchema.properties.context.description).toBe('existing')
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("already has 'context' parameter"))
+    })
+
+    it('should warn with tool name when context exists', () => {
+      const tool = {
+        name: 'my-special-tool',
+        inputSchema: {
+          type: 'object',
+          properties: { context: { type: 'boolean' } },
+        },
+      }
+
+      addContextParameterToTool(tool)
+
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('my-special-tool'))
+    })
+  })
+
+  describe('complex schema handling', () => {
+    it('should skip injection for oneOf schemas', () => {
+      const tool = {
+        name: 'union-tool',
+        inputSchema: {
+          oneOf: [
+            { type: 'object', properties: { email: { type: 'string' } } },
+            { type: 'object', properties: { phone: { type: 'string' } } },
+          ],
+        },
+      }
+
+      const result = addContextParameterToTool(tool)
+
+      // Should not add properties to oneOf schema
+      expect(result.inputSchema.properties).toBeUndefined()
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('complex schema'))
+    })
+
+    it('should skip injection for allOf schemas', () => {
+      const tool = {
+        name: 'intersection-tool',
+        inputSchema: {
+          allOf: [
+            { type: 'object', properties: { a: { type: 'string' } } },
+            { type: 'object', properties: { b: { type: 'string' } } },
+          ],
+        },
+      }
+
+      const result = addContextParameterToTool(tool)
+
+      expect(result.inputSchema.properties).toBeUndefined()
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('complex schema'))
+    })
+
+    it('should skip injection for anyOf schemas', () => {
+      const tool = {
+        name: 'anyof-tool',
+        inputSchema: { anyOf: [{ type: 'string' }, { type: 'number' }] },
+      }
+
+      const result = addContextParameterToTool(tool)
+
+      expect(result.inputSchema.properties).toBeUndefined()
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('complex schema'))
+    })
+  })
+
+  describe('additionalProperties constraint', () => {
+    it('should inject context and remove additionalProperties:false constraint', () => {
+      const tool = {
+        name: 'strict-tool',
+        inputSchema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          additionalProperties: false,
+        },
+      }
+
+      const result = addContextParameterToTool(tool)
+
+      // Should add context property and remove additionalProperties constraint
+      expect(result.inputSchema.properties.context).toBeDefined()
+      expect(result.inputSchema.properties.context.type).toBe('string')
+      expect(result.inputSchema.additionalProperties).toBeUndefined()
+    })
+
+    it('should preserve additionalProperties:true when injecting', () => {
+      const tool = {
+        name: 'flexible-tool',
+        inputSchema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          additionalProperties: true,
+        },
+      }
+
+      const result = addContextParameterToTool(tool)
+
+      // Should add context property and keep additionalProperties: true
+      expect(result.inputSchema.properties.context).toBeDefined()
+      expect(result.inputSchema.properties.context.type).toBe('string')
+      expect(result.inputSchema.additionalProperties).toBe(true)
+    })
+  })
+
+  describe('edge case schemas', () => {
+    it('should handle empty object schema {}', () => {
+      const tool = { name: 'empty-tool', inputSchema: {} }
+
+      const result = addContextParameterToTool(tool)
+
+      expect(result.inputSchema?.properties?.context).toBeDefined()
+      expect(result.inputSchema?.properties?.context?.type).toBe('string')
+    })
+
+    it('should handle schema with no inputSchema', () => {
+      const tool = { name: 'no-schema-tool' }
+
+      const result = addContextParameterToTool(tool)
+
+      expect(result.inputSchema?.properties?.context).toBeDefined()
+      expect(result.inputSchema?.type).toBe('object')
+    })
+
+    it('should handle schema with only type specified', () => {
+      const tool = {
+        name: 'type-only-tool',
+        inputSchema: { type: 'object' },
+      }
+
+      const result = addContextParameterToTool(tool)
+
+      expect(result.inputSchema?.properties?.context).toBeDefined()
+    })
+  })
+
+  describe('addContextParameterToTools batch handling', () => {
+    it('should skip get_more_tools entirely', () => {
+      const tools = [
+        { name: 'get_more_tools', inputSchema: {} },
+        { name: 'other-tool', inputSchema: {} },
+      ]
+
+      const result = addContextParameterToTools(tools)
+
+      // get_more_tools should not have context added
+      expect(result[0].inputSchema.properties).toBeUndefined()
+      // other-tool should have context added
+      expect(result[1].inputSchema.properties?.context).toBeDefined()
+    })
+
+    it('should handle mixed valid and complex schemas', () => {
+      const tools = [
+        { name: 'valid-tool', inputSchema: { type: 'object', properties: {} } },
+        { name: 'complex-tool', inputSchema: { oneOf: [{ type: 'string' }] } },
+        {
+          name: 'collision-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { context: { type: 'number' } },
+          },
+        },
+        {
+          name: 'strict-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            additionalProperties: false,
+          },
+        },
+      ]
+
+      const result = addContextParameterToTools(tools)
+
+      // valid-tool gets context
+      expect(result[0].inputSchema.properties.context).toBeDefined()
+      // complex-tool skipped
+      expect(result[1].inputSchema.properties).toBeUndefined()
+      // collision-tool keeps original context type
+      expect(result[2].inputSchema.properties.context.type).toBe('number')
+      // strict-tool gets context and additionalProperties removed
+      expect(result[3].inputSchema.properties.context).toBeDefined()
+      expect(result[3].inputSchema.additionalProperties).toBeUndefined()
+
+      // Should have logged warnings for complex and collision tools only
+      expect(log).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/context-parameters.test.ts
+++ b/packages/mcp/src/__tests__/context-parameters.test.ts
@@ -1,0 +1,485 @@
+import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { track } from '../index'
+import { DEFAULT_CONTEXT_PARAMETER_DESCRIPTION } from '../modules/constants'
+import { addContextParameterToTools } from '../modules/context-parameters'
+import { MCPAnalyticsEventType } from '../modules/event-types'
+import { EventCapture } from './test-utils'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+
+describe('Context Parameters', () => {
+  let server: any
+  let client: any
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    resetTodos()
+    const setup = await setupTestServerAndClient()
+    server = setup.server
+    client = setup.client
+    cleanup = setup.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  describe('addContextParameterToTools', () => {
+    it('should add context parameter to tools without inputSchema', () => {
+      const tools = [
+        {
+          name: 'simple_tool',
+          description: 'A simple tool',
+        },
+      ]
+
+      const modifiedTools = addContextParameterToTools(tools)
+
+      expect(modifiedTools[0].inputSchema).toBeDefined()
+      expect(modifiedTools[0].inputSchema.type).toBe('object')
+      expect(modifiedTools[0].inputSchema.properties.context).toBeDefined()
+      expect(modifiedTools[0].inputSchema.properties.context.type).toBe('string')
+      expect(modifiedTools[0].inputSchema.required).toContain('context')
+    })
+
+    it('should add context parameter to tools with existing inputSchema', () => {
+      const tools = [
+        {
+          name: 'existing_tool',
+          description: 'A tool with existing schema',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              text: {
+                type: 'string',
+                description: 'Some text',
+              },
+            },
+            required: ['text'],
+          },
+        },
+      ]
+
+      const modifiedTools = addContextParameterToTools(tools)
+
+      expect(modifiedTools[0].inputSchema.properties.text).toBeDefined()
+      expect(modifiedTools[0].inputSchema.properties.context).toBeDefined()
+      expect(modifiedTools[0].inputSchema.properties.context.type).toBe('string')
+      expect(modifiedTools[0].inputSchema.required).toContain('text')
+      expect(modifiedTools[0].inputSchema.required).toContain('context')
+    })
+
+    it('should not duplicate context parameter if already exists', () => {
+      const tools = [
+        {
+          name: 'tool_with_context',
+          description: 'A tool that already has context',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              context: {
+                type: 'string',
+                description: 'Existing context',
+              },
+            },
+            required: ['context'],
+          },
+        },
+      ]
+
+      const modifiedTools = addContextParameterToTools(tools)
+
+      expect(modifiedTools[0].inputSchema.properties.context.description).toBe('Existing context')
+      expect(modifiedTools[0].inputSchema.required.filter((r: string) => r === 'context')).toHaveLength(1)
+    })
+
+    it('should handle tools with empty required array', () => {
+      const tools = [
+        {
+          name: 'optional_tool',
+          description: 'A tool with no required fields',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              optional: {
+                type: 'string',
+              },
+            },
+            required: [],
+          },
+        },
+      ]
+
+      const modifiedTools = addContextParameterToTools(tools)
+
+      expect(modifiedTools[0].inputSchema.required).toContain('context')
+      expect(modifiedTools[0].inputSchema.required).toHaveLength(1)
+    })
+  })
+
+  describe('Integration with MCP server tracking', () => {
+    it('should capture context parameter when tools are called after tracking', async () => {
+      // Set up event capture
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking on the server
+      track(server, {
+        apiKey: 'test-project',
+        reportMissing: true,
+        enableTracing: true,
+        context: true,
+      })
+
+      // Call a tool with context
+      const contextString = 'Testing context parameter injection for analytics'
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Test todo item',
+              context: contextString,
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result.content[0].text).toContain('Added todo')
+
+      // Wait a bit for the event to be processed
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Verify that an event was published with the context as userIntent
+      const events = eventCapture.getEvents()
+      const toolCallEvent = events.find(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'add_todo'
+      )
+
+      expect(toolCallEvent).toBeDefined()
+      expect(toolCallEvent?.userIntent).toBe(contextString)
+
+      await eventCapture.stop()
+    })
+
+    it('should work with tools that have context parameter', async () => {
+      // Set up event capture
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking
+      track(server, { apiKey: 'test-project', context: true })
+
+      // Call complete_todo with context
+      // First add a todo
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Todo to complete',
+              context: 'Creating a todo to test completion',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Then complete it with context
+      const completionContext = 'Testing completion with context tracking'
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'complete_todo',
+            arguments: {
+              id: '1',
+              context: completionContext,
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result.content[0].text).toContain('Completed todo')
+
+      // Wait for events to be processed
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Verify the complete_todo event has the context as userIntent
+      const events = eventCapture.getEvents()
+      const completeEvent = events.find(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'complete_todo'
+      )
+
+      expect(completeEvent).toBeDefined()
+      expect(completeEvent?.userIntent).toBe(completionContext)
+
+      await eventCapture.stop()
+    })
+
+    it('should capture userIntent only when context is provided', async () => {
+      // Set up event capture
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking
+      track(server, { apiKey: 'test-project', context: true })
+
+      // Call list_todos without context - should succeed but have no userIntent
+      // Note: Context is advertised as required in JSON Schema (for client/LLM),
+      // but not enforced at SDK validation level (Zod schema is not modified)
+      const result1 = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'list_todos',
+            arguments: {},
+          },
+        },
+        CallToolResultSchema
+      )
+      expect(result1.content[0].text).toBeDefined()
+
+      // Call with valid context - should succeed and capture userIntent
+      const result2 = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'list_todos',
+            arguments: {
+              context: 'Listing todos to check current status',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result2.content[0].text).toBeDefined()
+
+      // Wait for events to be processed
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Verify events were published
+      const events = eventCapture.getEvents()
+      const listEvents = events.filter(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'list_todos'
+      )
+
+      // Should have at least 2 events (one without context, one with)
+      expect(listEvents.length).toBeGreaterThanOrEqual(2)
+
+      // Find event without context - should have no userIntent
+      const eventWithoutContext = listEvents.find((e) => !e.userIntent)
+      expect(eventWithoutContext).toBeDefined()
+
+      // Find event with context - should have userIntent
+      const eventWithContext = listEvents.find((e) => e.userIntent === 'Listing todos to check current status')
+      expect(eventWithContext).toBeDefined()
+
+      await eventCapture.stop()
+    })
+
+    it('should capture intent from intentFallback when context is missing', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      track(server, {
+        apiKey: 'test-project',
+        context: true,
+        intentFallback: (request) => (request.params?.name === 'list_todos' ? 'Inspecting the todo list' : undefined),
+      })
+
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'list_todos',
+            arguments: {},
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result.content[0].text).toBeDefined()
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      const event = eventCapture
+        .getEvents()
+        .find(
+          (candidate) =>
+            candidate.eventType === MCPAnalyticsEventType.mcpToolsCall && candidate.resourceName === 'list_todos'
+        )
+
+      expect(event?.userIntent).toBe('Inspecting the todo list')
+      expect(event?.userIntentSource).toBe('inferred')
+
+      await eventCapture.stop()
+    })
+
+    it('should prefer explicit context over intentFallback', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+      const intentFallback = jest.fn(() => 'Fallback intent')
+
+      track(server, {
+        apiKey: 'test-project',
+        context: true,
+        intentFallback,
+      })
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'list_todos',
+            arguments: {
+              context: 'Listing todos to inspect current work',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      const event = eventCapture
+        .getEvents()
+        .find(
+          (candidate) =>
+            candidate.eventType === MCPAnalyticsEventType.mcpToolsCall && candidate.resourceName === 'list_todos'
+        )
+
+      expect(event?.userIntent).toBe('Listing todos to inspect current work')
+      expect(event?.userIntentSource).toBe('context_parameter')
+      expect(intentFallback).not.toHaveBeenCalled()
+
+      await eventCapture.stop()
+    })
+
+    it('should inject context into tool schemas when listing tools', async () => {
+      // Enable tracking
+      track(server, { apiKey: 'test-project', context: true })
+
+      // Get the tools list
+      const toolsResponse = await client.request(
+        {
+          method: 'tools/list',
+          params: {},
+        },
+        ListToolsResultSchema
+      )
+
+      // Apply context parameter injection to simulate what the client would see
+      const modifiedTools = addContextParameterToTools(toolsResponse.tools)
+
+      // The tracking might add additional tools like report_missing_tool
+      // We should check for at least 3 tools (the original ones)
+      expect(modifiedTools.length).toBeGreaterThanOrEqual(3)
+
+      // Find the original tools
+      const originalTools = ['add_todo', 'list_todos', 'complete_todo']
+      const originalModifiedTools = modifiedTools.filter((tool: any) => originalTools.includes(tool.name))
+
+      // Verify the original tools have context parameter in their schema
+      expect(originalModifiedTools).toHaveLength(3)
+      for (const tool of originalModifiedTools) {
+        expect(tool.inputSchema.properties.context).toBeDefined()
+        expect(tool.inputSchema.properties.context.type).toBe('string')
+        expect(tool.inputSchema.properties.context.description).toBe(DEFAULT_CONTEXT_PARAMETER_DESCRIPTION)
+      }
+    })
+
+    it('should use default context description when no custom description is provided', async () => {
+      // Enable tracking WITHOUT custom context description
+      track(server, { apiKey: 'test-project', context: true })
+
+      // Get the tools list
+      const toolsResponse = await client.request(
+        {
+          method: 'tools/list',
+          params: {},
+        },
+        ListToolsResultSchema
+      )
+
+      // Find all original tools
+      const originalTools = ['add_todo', 'list_todos', 'complete_todo']
+      const toolsToCheck = toolsResponse.tools.filter((tool: any) => originalTools.includes(tool.name))
+
+      expect(toolsToCheck.length).toBe(3)
+
+      // Verify all tools use the default description
+      for (const tool of toolsToCheck) {
+        expect(tool.inputSchema.properties.context).toBeDefined()
+        expect(tool.inputSchema.properties.context.description).toBe(DEFAULT_CONTEXT_PARAMETER_DESCRIPTION)
+      }
+    })
+
+    it('should remove context parameter before calling tool callback', async () => {
+      // Variable to capture what arguments the tool callback actually receives
+      let capturedCallbackArguments: any = null
+
+      // Register a test tool that captures its arguments
+      const { z } = await import('zod')
+      server.tool(
+        'test_context_removal',
+        'Test tool that captures callback arguments',
+        {
+          testParam: z.string().describe('A test parameter'),
+        },
+        async (args: any) => {
+          // Capture exactly what arguments this callback receives
+          capturedCallbackArguments = { ...args }
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Arguments captured',
+              },
+            ],
+          }
+        }
+      )
+
+      // Enable tracking with context parameters
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      // Call the test tool WITH context parameter
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'test_context_removal',
+            arguments: {
+              testParam: 'test-value',
+              context: 'This context should be removed before callback',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Wait for processing
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // The tool call should succeed.
+      expect(result).toBeDefined()
+      expect(result.isError).not.toBe(true)
+
+      // Verify that the callback received the testParam
+      expect(capturedCallbackArguments).not.toBeNull()
+      expect(capturedCallbackArguments).toHaveProperty('testParam')
+      expect(capturedCallbackArguments.testParam).toBe('test-value')
+
+      // This is the key assertion: context should NOT be in the arguments
+      // that the tool callback received (it should have been removed by the wrapper)
+      expect(capturedCallbackArguments).not.toHaveProperty('context')
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/context-preservation.test.ts
+++ b/packages/mcp/src/__tests__/context-preservation.test.ts
@@ -1,0 +1,52 @@
+import { DEFAULT_CONTEXT_PARAMETER_DESCRIPTION } from '../modules/constants'
+import { addContextParameterToTool } from '../modules/context-parameters'
+import type { RegisteredTool } from '../types'
+
+describe('Context Parameter Preservation', () => {
+  it('should preserve existing context parameter with custom description', () => {
+    const toolWithCustomContext: RegisteredTool = {
+      description: 'Test tool',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          context: {
+            type: 'string',
+            description: 'A custom context description that should be preserved',
+          },
+        },
+        required: ['context'],
+      },
+      callback: async () => ({ content: [] }),
+    }
+
+    const result = addContextParameterToTool(toolWithCustomContext)
+
+    // The custom context description should be preserved
+    expect(result.inputSchema.properties.context.description).toBe(
+      'A custom context description that should be preserved'
+    )
+
+    // It should NOT be replaced with the default description
+    expect(result.inputSchema.properties.context.description).not.toBe(DEFAULT_CONTEXT_PARAMETER_DESCRIPTION)
+  })
+
+  it("should add context parameter when it doesn't exist", () => {
+    const toolWithoutContext: RegisteredTool = {
+      description: 'Test tool',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          foo: { type: 'string' },
+        },
+        required: ['foo'],
+      },
+      callback: async () => ({ content: [] }),
+    }
+
+    const result = addContextParameterToTool(toolWithoutContext)
+
+    // Context should be added with default description
+    expect(result.inputSchema.properties.context).toBeDefined()
+    expect(result.inputSchema.properties.context.description).toBe(DEFAULT_CONTEXT_PARAMETER_DESCRIPTION)
+  })
+})

--- a/packages/mcp/src/__tests__/conversation-id-tracing.test.ts
+++ b/packages/mcp/src/__tests__/conversation-id-tracing.test.ts
@@ -1,0 +1,212 @@
+import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { track } from '../index'
+import type { HighLevelMCPServerLike } from '../types'
+import { EventCapture } from './test-utils'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+
+describe('conversation_id tool parameter', () => {
+  let server: HighLevelMCPServerLike
+  let client: any
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    resetTodos()
+    const setup = await setupTestServerAndClient()
+    server = setup.server
+    client = setup.client
+    cleanup = setup.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  describe('tools/list schema injection', () => {
+    it('adds an optional conversation_id parameter to every tool when enabled', async () => {
+      track(server, { apiKey: 'phc_test', enableConversationId: true })
+
+      const result = await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+
+      for (const tool of result.tools) {
+        const schema = tool.inputSchema as {
+          properties: Record<string, { type: string }>
+          required?: string[]
+        }
+        expect(schema.properties.conversation_id).toBeDefined()
+        expect(schema.properties.conversation_id.type).toBe('string')
+        expect(schema.required ?? []).not.toContain('conversation_id')
+      }
+    })
+
+    it('does not inject when enableConversationId is false', async () => {
+      track(server, { apiKey: 'phc_test', enableConversationId: false })
+
+      const result = await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+
+      for (const tool of result.tools) {
+        const schema = tool.inputSchema as {
+          properties: Record<string, unknown>
+        }
+        expect(schema.properties.conversation_id).toBeUndefined()
+      }
+    })
+  })
+
+  describe('tools/call conversation_id propagation', () => {
+    it('captures the agent-supplied conversation_id verbatim on the event', async () => {
+      const capture = new EventCapture()
+      await capture.start()
+      track(server, { apiKey: 'phc_test', enableConversationId: true })
+
+      const agentConversationId = 'conversation-abc-1'
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: { text: 'first', conversation_id: agentConversationId },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((r) => setTimeout(r, 50))
+      const toolCall = capture.getEvents().find((e) => e.resourceName === 'add_todo')
+      expect(toolCall?.conversationId).toBe(agentConversationId)
+      await capture.stop()
+    })
+
+    it('mints a conversation_id and appends a prompt-back text block when the agent omits it', async () => {
+      track(server, { apiKey: 'phc_test', enableConversationId: true })
+
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: { text: 'first' },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      const promptBack = result.content.find(
+        (c) => c.type === 'text' && typeof c.text === 'string' && c.text.includes('conversation_id=')
+      )
+      expect(promptBack).toBeDefined()
+    })
+
+    it('sets event.conversationId on the captured event when minted', async () => {
+      const capture = new EventCapture()
+      await capture.start()
+
+      track(server, { apiKey: 'phc_test', enableConversationId: true })
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: { name: 'add_todo', arguments: { text: 'x' } },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((r) => setTimeout(r, 50))
+      const toolCall = capture.getEvents().find((e) => e.resourceName === 'add_todo')
+      expect(toolCall).toBeDefined()
+      expect(typeof toolCall?.conversationId).toBe('string')
+      expect(toolCall?.conversationId?.length).toBeGreaterThan(0)
+      await capture.stop()
+    })
+
+    it('sets event.conversationId on the captured event when agent supplies one', async () => {
+      const capture = new EventCapture()
+      await capture.start()
+
+      track(server, { apiKey: 'phc_test', enableConversationId: true })
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: { text: 'x', conversation_id: 'agent-supplied-1' },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((r) => setTimeout(r, 50))
+      const toolCall = capture.getEvents().find((e) => e.resourceName === 'add_todo')
+      expect(toolCall?.conversationId).toBe('agent-supplied-1')
+      await capture.stop()
+    })
+
+    it('does not inject the prompt-back into error results', async () => {
+      track(server, { apiKey: 'phc_test', enableConversationId: true })
+
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'complete_todo',
+            arguments: { id: 'does-not-exist' },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      const hasPromptBack = (result.content ?? []).some(
+        (c) => c.type === 'text' && typeof c.text === 'string' && c.text.includes('conversation_id=')
+      )
+      expect(hasPromptBack).toBe(false)
+    })
+
+    it('clears event.conversationId on error when we minted it (agent never received it)', async () => {
+      const capture = new EventCapture()
+      await capture.start()
+      track(server, { apiKey: 'phc_test', enableConversationId: true })
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'complete_todo',
+            arguments: { id: 'does-not-exist' },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((r) => setTimeout(r, 50))
+      const toolCall = capture.getEvents().find((e) => e.resourceName === 'complete_todo')
+      expect(toolCall).toBeDefined()
+      expect(toolCall?.conversationId).toBeUndefined()
+      await capture.stop()
+    })
+
+    it('keeps event.conversationId on error when the agent supplied it', async () => {
+      const capture = new EventCapture()
+      await capture.start()
+      track(server, { apiKey: 'phc_test', enableConversationId: true })
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'complete_todo',
+            arguments: {
+              id: 'does-not-exist',
+              conversation_id: 'agent-supplied-on-error',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((r) => setTimeout(r, 50))
+      const toolCall = capture.getEvents().find((e) => e.resourceName === 'complete_todo')
+      expect(toolCall?.conversationId).toBe('agent-supplied-on-error')
+      await capture.stop()
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/conversation-id.test.ts
+++ b/packages/mcp/src/__tests__/conversation-id.test.ts
@@ -1,0 +1,195 @@
+import { DEFAULT_CONVERSATION_ID_DESCRIPTION } from '../modules/constants'
+import {
+  addConversationIdToTool,
+  addConversationIdToTools,
+  buildConversationIdPromptBack,
+  CONVERSATION_ID_PARAM_NAME,
+  extractConversationId,
+  injectConversationIdPromptBack,
+  stripConversationId,
+} from '../modules/conversation-id'
+
+describe('conversation-id', () => {
+  describe('addConversationIdToTool', () => {
+    it('adds an optional conversation_id property to a bare tool', () => {
+      const result = addConversationIdToTool({
+        name: 'tool',
+        description: 'test',
+      })
+
+      const schema = result.inputSchema as {
+        properties: Record<string, { type: string; description: string }>
+        required?: string[]
+      }
+
+      expect(schema.properties.conversation_id.type).toBe('string')
+      expect(schema.properties.conversation_id.description).toBe(DEFAULT_CONVERSATION_ID_DESCRIPTION)
+      expect(schema.required ?? []).not.toContain('conversation_id')
+    })
+
+    it('preserves existing required fields and does not require conversation_id', () => {
+      const result = addConversationIdToTool({
+        name: 'tool',
+        inputSchema: {
+          type: 'object',
+          properties: { text: { type: 'string' } },
+          required: ['text'],
+        },
+      })
+      const schema = result.inputSchema as {
+        properties: Record<string, unknown>
+        required: string[]
+      }
+
+      expect(schema.required).toContain('text')
+      expect(schema.required).not.toContain('conversation_id')
+      expect(schema.properties.conversation_id).toBeDefined()
+    })
+
+    it('strips additionalProperties:false so the new property is valid', () => {
+      const result = addConversationIdToTool({
+        name: 'tool',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        },
+      })
+      const schema = result.inputSchema as { additionalProperties?: boolean }
+      expect(schema.additionalProperties).toBeUndefined()
+    })
+
+    it('skips tools that already define conversation_id', () => {
+      const original = {
+        name: 'tool',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            conversation_id: { type: 'number', description: 'preexisting' },
+          },
+        },
+      }
+      const result = addConversationIdToTool(original)
+      const schema = result.inputSchema as {
+        properties: Record<string, { type: string; description: string }>
+      }
+      expect(schema.properties.conversation_id.type).toBe('number')
+      expect(schema.properties.conversation_id.description).toBe('preexisting')
+    })
+
+    it('skips complex schemas (oneOf/allOf/anyOf)', () => {
+      for (const key of ['oneOf', 'allOf', 'anyOf']) {
+        const result = addConversationIdToTool({
+          name: `tool_${key}`,
+          inputSchema: { [key]: [] } as never,
+        })
+        const schema = result.inputSchema as {
+          properties?: Record<string, unknown>
+        }
+        expect(schema.properties?.conversation_id).toBeUndefined()
+      }
+    })
+
+    it('does not mutate the original tool', () => {
+      const original = {
+        name: 'tool',
+        inputSchema: {
+          type: 'object',
+          properties: { text: { type: 'string' } },
+          required: ['text'],
+        },
+      }
+      const snapshot = JSON.stringify(original)
+      addConversationIdToTool(original)
+      expect(JSON.stringify(original)).toBe(snapshot)
+    })
+  })
+
+  describe('addConversationIdToTools', () => {
+    it('skips the get_more_tools tool', () => {
+      const tools = [
+        { name: 'get_more_tools', description: 'report missing' },
+        { name: 'other_tool', description: 'fine' },
+      ]
+      const result = addConversationIdToTools(tools)
+      expect(result[0]).toBe(tools[0])
+      expect(
+        (
+          result[1].inputSchema as {
+            properties?: Record<string, unknown>
+          }
+        ).properties?.conversation_id
+      ).toBeDefined()
+    })
+  })
+
+  describe('extractConversationId', () => {
+    it('returns trimmed non-empty string values', () => {
+      expect(extractConversationId({ conversation_id: '  abc  ' })).toBe('abc')
+    })
+
+    it('returns undefined for missing, empty, or non-string values', () => {
+      expect(extractConversationId(undefined)).toBeUndefined()
+      expect(extractConversationId(null)).toBeUndefined()
+      expect(extractConversationId({})).toBeUndefined()
+      expect(extractConversationId({ conversation_id: '' })).toBeUndefined()
+      expect(extractConversationId({ conversation_id: '   ' })).toBeUndefined()
+      expect(extractConversationId({ conversation_id: 42 })).toBeUndefined()
+    })
+  })
+
+  describe('stripConversationId', () => {
+    it('returns args without conversation_id and leaves other keys intact', () => {
+      const result = stripConversationId({
+        conversation_id: 'abc',
+        keep: 1,
+      })
+      expect(result).toEqual({ keep: 1 })
+    })
+
+    it('returns the args unchanged when conversation_id is absent', () => {
+      const args = { keep: 1 }
+      expect(stripConversationId(args)).toBe(args)
+    })
+  })
+
+  describe('injectConversationIdPromptBack', () => {
+    it('appends the prompt-back content block on a successful result', () => {
+      const result = injectConversationIdPromptBack({ content: [{ type: 'text', text: 'hello' }] }, 'conv-123')
+      const { content } = result as {
+        content: Array<{ type: string; text: string }>
+      }
+      expect(content).toHaveLength(2)
+      expect(content[1].type).toBe('text')
+      expect(content[1].text).toContain('conversation_id=conv-123')
+    })
+
+    it('does not inject when result.isError is true', () => {
+      const original = {
+        isError: true,
+        content: [{ type: 'text', text: 'oops' }],
+      }
+      expect(injectConversationIdPromptBack(original, 'conv-123')).toBe(original)
+    })
+
+    it('does not inject when content is missing or not an array', () => {
+      expect(injectConversationIdPromptBack({}, 'conv-123')).toEqual({})
+      expect(injectConversationIdPromptBack({ content: 'not-an-array' }, 'conv-123')).toEqual({
+        content: 'not-an-array',
+      })
+    })
+
+    it('does not inject on non-object results', () => {
+      expect(injectConversationIdPromptBack(null, 'conv-123')).toBeNull()
+      expect(injectConversationIdPromptBack('string', 'conv-123')).toBe('string')
+    })
+  })
+
+  describe('buildConversationIdPromptBack', () => {
+    it('references the conversation_id argument name', () => {
+      const block = buildConversationIdPromptBack('xyz')
+      expect(block.text).toContain(CONVERSATION_ID_PARAM_NAME)
+      expect(block.text).toContain('xyz')
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/custom-context-description.test.ts
+++ b/packages/mcp/src/__tests__/custom-context-description.test.ts
@@ -1,0 +1,308 @@
+import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { track } from '../index'
+import { DEFAULT_CONTEXT_PARAMETER_DESCRIPTION } from '../modules/constants'
+import { MCPAnalyticsEventType } from '../modules/event-types'
+import { EventCapture } from './test-utils'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+
+describe('Custom Context Description', () => {
+  let server: any
+  let client: any
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    resetTodos()
+    const setup = await setupTestServerAndClient()
+    server = setup.server
+    client = setup.client
+    cleanup = setup.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('should use custom description instead of default for JSON Schema tools', async () => {
+    const customDescription = 'Explain your reasoning for this action'
+
+    // Enable tracking with custom context description
+    track(server, {
+      apiKey: 'test-project',
+      context: { description: customDescription },
+    })
+
+    // Get the tools list
+    const toolsResponse = await client.request(
+      {
+        method: 'tools/list',
+        params: {},
+      },
+      ListToolsResultSchema
+    )
+
+    // Find the add_todo tool (uses shorthand Zod syntax)
+    const addTodoTool = toolsResponse.tools.find((tool: any) => tool.name === 'add_todo')
+
+    expect(addTodoTool).toBeDefined()
+    expect(addTodoTool.inputSchema.properties.context).toBeDefined()
+    expect(addTodoTool.inputSchema.properties.context.description).toBe(customDescription)
+    expect(addTodoTool.inputSchema.properties.context.description).not.toBe(DEFAULT_CONTEXT_PARAMETER_DESCRIPTION)
+  })
+
+  it('should use custom description for Zod object schemas', async () => {
+    const customDescription = "Provide context about why you're doing this"
+
+    // Enable tracking with custom context description
+    track(server, {
+      apiKey: 'test-project',
+      context: { description: customDescription },
+    })
+
+    // Get the tools list
+    const toolsResponse = await client.request(
+      {
+        method: 'tools/list',
+        params: {},
+      },
+      ListToolsResultSchema
+    )
+
+    // Find the complete_todo tool (uses registerTool with Zod schema)
+    const completeTodoTool = toolsResponse.tools.find((tool: any) => tool.name === 'complete_todo')
+
+    expect(completeTodoTool).toBeDefined()
+    expect(completeTodoTool.inputSchema.properties.context).toBeDefined()
+    expect(completeTodoTool.inputSchema.properties.context.description).toBe(customDescription)
+  })
+
+  it('should apply custom description to all tools when listing', async () => {
+    const customDescription = 'Why are you calling this tool?'
+
+    // Enable tracking with custom context description
+    track(server, {
+      apiKey: 'test-project',
+      context: { description: customDescription },
+    })
+
+    // Get the tools list
+    const toolsResponse = await client.request(
+      {
+        method: 'tools/list',
+        params: {},
+      },
+      ListToolsResultSchema
+    )
+
+    // Check all original tools (exclude PostHog MCP analytics-added tools)
+    const originalTools = ['add_todo', 'list_todos', 'complete_todo']
+    const toolsToCheck = toolsResponse.tools.filter((tool: any) => originalTools.includes(tool.name))
+
+    expect(toolsToCheck.length).toBe(3)
+
+    for (const tool of toolsToCheck) {
+      expect(tool.inputSchema.properties.context).toBeDefined()
+      expect(tool.inputSchema.properties.context.description).toBe(customDescription)
+    }
+  })
+
+  it('should capture tool calls with custom description configured', async () => {
+    const customDescription = "Tell me what you're trying to accomplish"
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    // Enable tracking with custom context description
+    track(server, {
+      apiKey: 'test-project',
+      context: { description: customDescription },
+      enableTracing: true,
+    })
+
+    // Call a tool with context
+    const contextString = 'I need to add a task to my list'
+    const result = await client.request(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'add_todo',
+          arguments: {
+            text: 'Test todo item',
+            context: contextString,
+          },
+        },
+      },
+      CallToolResultSchema
+    )
+
+    expect(result.content[0].text).toContain('Added todo')
+
+    // Wait for events to be processed
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // Verify that the event was captured with the user intent
+    const events = eventCapture.getEvents()
+    const toolCallEvent = events.find(
+      (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'add_todo'
+    )
+
+    expect(toolCallEvent).toBeDefined()
+    expect(toolCallEvent?.userIntent).toBe(contextString)
+
+    await eventCapture.stop()
+  })
+
+  it('should use default description when custom context description is not provided', async () => {
+    // Enable tracking WITHOUT custom context description
+    track(server, { apiKey: 'test-project', context: true })
+
+    // Get the tools list
+    const toolsResponse = await client.request(
+      {
+        method: 'tools/list',
+        params: {},
+      },
+      ListToolsResultSchema
+    )
+
+    // Find the add_todo tool
+    const addTodoTool = toolsResponse.tools.find((tool: any) => tool.name === 'add_todo')
+
+    expect(addTodoTool).toBeDefined()
+    expect(addTodoTool.inputSchema.properties.context).toBeDefined()
+    expect(addTodoTool.inputSchema.properties.context.description).toBe(DEFAULT_CONTEXT_PARAMETER_DESCRIPTION)
+  })
+
+  it('should work end-to-end with custom description and multiple tool calls', async () => {
+    const customDescription = 'Explain your intent for this operation'
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    // Enable tracking with custom context description
+    track(server, {
+      apiKey: 'test-project',
+      context: { description: customDescription },
+      enableTracing: true,
+    })
+
+    // Verify tools list has custom description
+    const toolsResponse = await client.request(
+      {
+        method: 'tools/list',
+        params: {},
+      },
+      ListToolsResultSchema
+    )
+
+    const addTodoTool = toolsResponse.tools.find((tool: any) => tool.name === 'add_todo')
+    expect(addTodoTool.inputSchema.properties.context.description).toBe(customDescription)
+
+    // Call add_todo
+    await client.request(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'add_todo',
+          arguments: {
+            text: 'First task',
+            context: 'Setting up my first task',
+          },
+        },
+      },
+      CallToolResultSchema
+    )
+
+    // Call complete_todo
+    await client.request(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'complete_todo',
+          arguments: {
+            id: '1',
+            context: 'Finishing the first task',
+          },
+        },
+      },
+      CallToolResultSchema
+    )
+
+    // Call list_todos
+    await client.request(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'list_todos',
+          arguments: {
+            context: 'Checking my progress',
+          },
+        },
+      },
+      CallToolResultSchema
+    )
+
+    // Wait for events to be processed
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    // Verify all events were captured with user intent
+    const events = eventCapture.getEvents()
+    const toolCallEvents = events.filter((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+
+    expect(toolCallEvents.length).toBeGreaterThanOrEqual(3)
+
+    const addEvent = toolCallEvents.find((e) => e.resourceName === 'add_todo')
+    const completeEvent = toolCallEvents.find((e) => e.resourceName === 'complete_todo')
+    const listEvent = toolCallEvents.find((e) => e.resourceName === 'list_todos')
+
+    expect(addEvent?.userIntent).toBe('Setting up my first task')
+    expect(completeEvent?.userIntent).toBe('Finishing the first task')
+    expect(listEvent?.userIntent).toBe('Checking my progress')
+
+    await eventCapture.stop()
+  })
+
+  it('should use custom description even with long descriptions', async () => {
+    const customDescription =
+      'Please provide a comprehensive explanation of your reasoning, including the broader context of this action within your workflow, the expected outcomes, and how this contributes to your overall objectives. Be as detailed as possible.'
+
+    // Enable tracking with long custom context description
+    track(server, {
+      apiKey: 'test-project',
+      context: { description: customDescription },
+    })
+
+    // Get the tools list
+    const toolsResponse = await client.request(
+      {
+        method: 'tools/list',
+        params: {},
+      },
+      ListToolsResultSchema
+    )
+
+    const addTodoTool = toolsResponse.tools.find((tool: any) => tool.name === 'add_todo')
+
+    expect(addTodoTool.inputSchema.properties.context.description).toBe(customDescription)
+  })
+
+  it('should use custom description with special characters', async () => {
+    const customDescription = 'Why? (explain in detail) - "Be specific!"'
+
+    // Enable tracking with special characters in description
+    track(server, {
+      apiKey: 'test-project',
+      context: { description: customDescription },
+    })
+
+    // Get the tools list
+    const toolsResponse = await client.request(
+      {
+        method: 'tools/list',
+        params: {},
+      },
+      ListToolsResultSchema
+    )
+
+    const addTodoTool = toolsResponse.tools.find((tool: any) => tool.name === 'add_todo')
+
+    expect(addTodoTool.inputSchema.properties.context.description).toBe(customDescription)
+  })
+})

--- a/packages/mcp/src/__tests__/debug-tool-schema.test.ts
+++ b/packages/mcp/src/__tests__/debug-tool-schema.test.ts
@@ -1,0 +1,90 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import { track } from '../index'
+
+describe('Debug Tool Schema Structure', () => {
+  let server: McpServer
+
+  beforeEach(() => {
+    server = new McpServer({
+      name: 'debug server',
+      version: '1.0.0',
+    })
+  })
+
+  it('should show the structure of tools registered with shorthand Zod syntax', async () => {
+    // Register tools with shorthand Zod syntax BEFORE track()
+    server.tool('add', { a: z.number(), b: z.number() }, async ({ a, b }) => ({
+      content: [{ type: 'text', text: String(a + b) }],
+    }))
+
+    // Log the registered tool structure BEFORE track()
+    console.log('\n=== BEFORE track() ===')
+    const toolsBefore = server._registeredTools
+    console.log('Tools registered:', Object.keys(toolsBefore))
+
+    if (toolsBefore.add) {
+      console.log("Tool 'add' structure:")
+      console.log('  - Has inputSchema?', !!toolsBefore.add.inputSchema)
+      console.log('  - inputSchema type:', typeof toolsBefore.add.inputSchema)
+      console.log('  - inputSchema value:', JSON.stringify(toolsBefore.add.inputSchema, null, 2))
+
+      if (toolsBefore.add.inputSchema) {
+        console.log('  - Has properties?', !!toolsBefore.add.inputSchema.properties)
+        console.log('  - Properties type:', typeof toolsBefore.add.inputSchema.properties)
+      }
+    }
+
+    // Now call track()
+    await track(server, {
+      apiKey: 'test-project',
+      context: true,
+      enableTracing: true,
+    })
+
+    // Log the registered tool structure AFTER track()
+    console.log('\n=== AFTER track() ===')
+    const toolsAfter = server._registeredTools
+    console.log('Tools registered:', Object.keys(toolsAfter))
+
+    if (toolsAfter.add) {
+      console.log("Tool 'add' structure:")
+      console.log('  - Has inputSchema?', !!toolsAfter.add.inputSchema)
+      console.log('  - inputSchema type:', typeof toolsAfter.add.inputSchema)
+      console.log('  - inputSchema value:', JSON.stringify(toolsAfter.add.inputSchema, null, 2))
+
+      if (toolsAfter.add.inputSchema) {
+        console.log('  - Has properties?', !!toolsAfter.add.inputSchema.properties)
+        console.log(
+          '  - Has context in properties?',
+          toolsAfter.add.inputSchema.properties && !!toolsAfter.add.inputSchema.properties.context
+        )
+      }
+    }
+
+    // Basic assertion to make the test pass
+    expect(server).toBeDefined()
+  })
+
+  it('should show the structure of tools registered with description and schema', async () => {
+    // Register tools with full syntax (description + schema)
+    server.tool('add_with_desc', 'Adds two numbers', { a: z.number(), b: z.number() }, async ({ a, b }) => ({
+      content: [{ type: 'text', text: String(a + b) }],
+    }))
+
+    // Log the registered tool structure
+    console.log('\n=== Tool with description ===')
+    const tools = server._registeredTools
+
+    if (tools.add_with_desc) {
+      console.log("Tool 'add_with_desc' structure:")
+      console.log('  - Has description?', !!tools.add_with_desc.description)
+      console.log('  - Description:', tools.add_with_desc.description)
+      console.log('  - Has inputSchema?', !!tools.add_with_desc.inputSchema)
+      console.log('  - inputSchema type:', typeof tools.add_with_desc.inputSchema)
+      console.log('  - inputSchema value:', JSON.stringify(tools.add_with_desc.inputSchema, null, 2))
+    }
+
+    expect(server).toBeDefined()
+  })
+})

--- a/packages/mcp/src/__tests__/e2e-sanitization.test.ts
+++ b/packages/mcp/src/__tests__/e2e-sanitization.test.ts
@@ -1,0 +1,270 @@
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+import { MCPAnalyticsEventType } from '../modules/event-types'
+import { EventCapture } from './test-utils'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+
+describe('E2E Sanitization - real MCP tool calls', () => {
+  it('should sanitize image content blocks in tool responses', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    try {
+      const { track } = await import('../index')
+      await track(server, {
+        apiKey: 'test-sanitization',
+        context: false,
+        enableTracing: true,
+        // Off: the prompt-back appended on first mint would add an extra
+        // content block and break this test's response-shape assertions.
+        enableConversationId: false,
+      })
+
+      // Register a tool that returns an image content block
+      server.tool(
+        'get_attachment',
+        'Returns an image attachment',
+        { id: z.string().describe('Attachment ID') },
+        async () => ({
+          content: [
+            { type: 'text', text: 'Here is the attachment:' },
+            {
+              type: 'image',
+              data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ',
+              mimeType: 'image/png',
+            },
+          ],
+        })
+      )
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: { name: 'get_attachment', arguments: { id: 'att_1' } },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const events = eventCapture.getEvents()
+      const toolEvent = events.find(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'get_attachment'
+      )
+
+      expect(toolEvent).toBeDefined()
+      const content = toolEvent!.response.content
+      expect(content).toHaveLength(2)
+      // Text block preserved
+      expect(content[0]).toEqual({
+        type: 'text',
+        text: 'Here is the attachment:',
+      })
+      // Image block redacted to text
+      expect(content[1]).toEqual({
+        type: 'text',
+        text: '[image content redacted - not supported by PostHog MCP analytics]',
+      })
+
+      await eventCapture.stop()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should sanitize audio content blocks in tool responses', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    try {
+      const { track } = await import('../index')
+      await track(server, {
+        apiKey: 'test-sanitization-audio',
+        context: false,
+        enableTracing: true,
+      })
+
+      server.tool('get_audio_clip', 'Returns an audio clip', { clipId: z.string() }, async () => ({
+        content: [
+          {
+            type: 'audio',
+            data: 'UklGRiQAAABXQVZFZm10IBAAAAABAAEA',
+            mimeType: 'audio/wav',
+          },
+        ],
+      }))
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: { name: 'get_audio_clip', arguments: { clipId: 'clip_1' } },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const events = eventCapture.getEvents()
+      const toolEvent = events.find(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'get_audio_clip'
+      )
+
+      expect(toolEvent).toBeDefined()
+      expect(toolEvent!.response.content[0]).toEqual({
+        type: 'text',
+        text: '[audio content redacted - not supported by PostHog MCP analytics]',
+      })
+
+      await eventCapture.stop()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should sanitize large base64 strings in tool call parameters', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    try {
+      const { track } = await import('../index')
+      await track(server, {
+        apiKey: 'test-sanitization-base64',
+        context: false,
+        enableTracing: true,
+      })
+
+      server.tool(
+        'upload_file',
+        'Upload a file as base64',
+        {
+          filename: z.string(),
+          data: z.string().describe('Base64-encoded file data'),
+        },
+        async (args) => ({
+          content: [{ type: 'text', text: `Uploaded ${args.filename} successfully` }],
+        })
+      )
+
+      // Create a large base64 string (>10KB to trigger the size gate)
+      const largeBase64 = `${'A'.repeat(12_000)}=`
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'upload_file',
+            arguments: { filename: 'photo.png', data: largeBase64 },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const events = eventCapture.getEvents()
+      const toolEvent = events.find(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'upload_file'
+      )
+
+      expect(toolEvent).toBeDefined()
+      // The base64 param should be redacted in the captured event's parameters
+      const args = toolEvent!.parameters?.request?.params?.arguments
+      expect(args.data).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+      // Non-base64 params should be preserved
+      expect(args.filename).toBe('photo.png')
+
+      await eventCapture.stop()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should preserve normal todo tool calls while sanitizing problematic ones', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    try {
+      const { track } = await import('../index')
+      await track(server, {
+        apiKey: 'test-sanitization-mixed',
+        context: false,
+        enableTracing: true,
+      })
+
+      // Register a tool with image response alongside existing todo tools
+      server.tool('get_todo_screenshot', 'Returns a screenshot of todos', {}, async () => ({
+        content: [
+          { type: 'text', text: 'Screenshot of current todos:' },
+          {
+            type: 'image',
+            data: 'iVBORw0KGgo=',
+            mimeType: 'image/png',
+          },
+        ],
+      }))
+
+      // Call a normal todo tool
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: { text: 'Buy groceries' },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Call the image-returning tool
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'get_todo_screenshot',
+            arguments: {},
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const events = eventCapture.getEvents()
+      const toolCallEvents = events.filter((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+
+      // Normal add_todo event should have its text response preserved
+      const addTodoEvent = toolCallEvents.find((e) => e.resourceName === 'add_todo')
+      expect(addTodoEvent).toBeDefined()
+      expect(addTodoEvent!.response.content[0].type).toBe('text')
+      expect(addTodoEvent!.response.content[0].text).toContain('Added todo')
+
+      // Screenshot event should have its image block sanitized
+      const screenshotEvent = toolCallEvents.find((e) => e.resourceName === 'get_todo_screenshot')
+      expect(screenshotEvent).toBeDefined()
+      expect(screenshotEvent!.response.content[0]).toEqual({
+        type: 'text',
+        text: 'Screenshot of current todos:',
+      })
+      expect(screenshotEvent!.response.content[1]).toEqual({
+        type: 'text',
+        text: '[image content redacted - not supported by PostHog MCP analytics]',
+      })
+
+      await eventCapture.stop()
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/packages/mcp/src/__tests__/e2e-truncation.test.ts
+++ b/packages/mcp/src/__tests__/e2e-truncation.test.ts
@@ -1,0 +1,256 @@
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+import { MCPAnalyticsEventType } from '../modules/event-types'
+import { EventCapture } from './test-utils'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+
+describe('E2E Truncation - real MCP tool calls', () => {
+  it('should truncate tool responses with text exceeding 32KB', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    try {
+      const { track } = await import('../index')
+      await track(server, {
+        apiKey: 'test-truncation',
+        context: false,
+        enableTracing: true,
+      })
+
+      // Register a tool that returns a very large text response
+      server.tool('get_large_report', 'Returns a large report', { topic: z.string() }, async (args) => ({
+        content: [
+          {
+            type: 'text',
+            text: `Report on ${args.topic}: ${'x'.repeat(50_000)}`,
+          },
+        ],
+      }))
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'get_large_report',
+            arguments: { topic: 'quarterly sales' },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const events = eventCapture.getEvents()
+      const toolEvent = events.find(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'get_large_report'
+      )
+
+      expect(toolEvent).toBeDefined()
+      const text = toolEvent!.response.content[0].text
+      // Text should be capped at 32KB + "..."
+      expect(text.length).toBeLessThanOrEqual(32_768 + 3)
+      expect(text.endsWith('...')).toBe(true)
+
+      await eventCapture.stop()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should keep total event size under 100KB for oversized parameters', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    try {
+      const { track } = await import('../index')
+      await track(server, {
+        apiKey: 'test-truncation-params',
+        context: false,
+        enableTracing: true,
+      })
+
+      // Register a tool that accepts very large parameters
+      server.tool(
+        'process_bulk_data',
+        'Processes a bulk data payload',
+        {
+          dataset: z.string().describe('Large dataset string'),
+          metadata: z.string().describe('Metadata string'),
+        },
+        async () => ({
+          content: [{ type: 'text', text: 'Processed successfully' }],
+        })
+      )
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'process_bulk_data',
+            arguments: {
+              dataset: 'd'.repeat(80_000),
+              metadata: 'm'.repeat(40_000),
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const events = eventCapture.getEvents()
+      const toolEvent = events.find(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'process_bulk_data'
+      )
+
+      expect(toolEvent).toBeDefined()
+      const eventSize = new TextEncoder().encode(JSON.stringify(toolEvent)).length
+      expect(eventSize).toBeLessThanOrEqual(102_400)
+
+      await eventCapture.stop()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should preserve normal todo responses while truncating large ones', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    try {
+      const { track } = await import('../index')
+      await track(server, {
+        apiKey: 'test-truncation-mixed',
+        context: false,
+        enableTracing: true,
+      })
+
+      server.tool('get_verbose_log', 'Returns a huge log dump', {}, async () => ({
+        content: [{ type: 'text', text: `LOG: ${'entry '.repeat(10_000)}` }],
+      }))
+
+      // Normal todo call
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: { text: 'Write tests' },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Oversized call
+      await client.request(
+        {
+          method: 'tools/call',
+          params: { name: 'get_verbose_log', arguments: {} },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const events = eventCapture.getEvents()
+      const toolCallEvents = events.filter((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+
+      // Normal add_todo response should be fully preserved
+      const addTodoEvent = toolCallEvents.find((e) => e.resourceName === 'add_todo')
+      expect(addTodoEvent).toBeDefined()
+      expect(addTodoEvent!.response.content[0].text).toContain('Added todo')
+
+      // Verbose log response should be truncated
+      const logEvent = toolCallEvents.find((e) => e.resourceName === 'get_verbose_log')
+      expect(logEvent).toBeDefined()
+      const logText = logEvent!.response.content[0].text
+      expect(logText.length).toBeLessThanOrEqual(32_768 + 3)
+
+      await eventCapture.stop()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should handle both sanitization and truncation in the same tool call', async () => {
+    resetTodos()
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    try {
+      const { track } = await import('../index')
+      await track(server, {
+        apiKey: 'test-sanitize-then-truncate',
+        context: false,
+        enableTracing: true,
+      })
+
+      // Tool that returns both an image block AND a huge text block
+      server.tool(
+        'get_annotated_screenshot',
+        'Returns a screenshot with annotations',
+        { page: z.string() },
+        async () => ({
+          content: [
+            { type: 'text', text: 'long text '.repeat(5000) },
+            {
+              type: 'image',
+              data: 'iVBORw0KGgo=',
+              mimeType: 'image/png',
+            },
+          ],
+        })
+      )
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'get_annotated_screenshot',
+            arguments: { page: 'dashboard' },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const events = eventCapture.getEvents()
+      const toolEvent = events.find(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'get_annotated_screenshot'
+      )
+
+      expect(toolEvent).toBeDefined()
+      const content = toolEvent!.response.content
+
+      // Text block should be truncated
+      expect(content[0].text.length).toBeLessThanOrEqual(32_768 + 3)
+      expect(content[0].text.endsWith('...')).toBe(true)
+
+      // Image block should be sanitized
+      expect(content[1]).toEqual({
+        type: 'text',
+        text: '[image content redacted - not supported by PostHog MCP analytics]',
+      })
+
+      // Total event size should still be under 100KB
+      const eventSize = new TextEncoder().encode(JSON.stringify(toolEvent)).length
+      expect(eventSize).toBeLessThanOrEqual(102_400)
+
+      await eventCapture.stop()
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/packages/mcp/src/__tests__/edge-runtime-compatibility.test.ts
+++ b/packages/mcp/src/__tests__/edge-runtime-compatibility.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Edge Runtime Compatibility Tests
+ *
+ * These tests verify that PostHog MCP analytics gracefully handles environments where
+ * certain Node.js modules may not be available or have limited functionality
+ * (like Cloudflare Workers, Vercel Edge, Deno Deploy).
+ *
+ * Note: For full edge runtime testing with actual Cloudflare Workers environment,
+ * consider using @cloudflare/vitest-pool-workers with a separate vitest config.
+ * These tests simulate edge-like conditions within the Node.js test environment.
+ */
+
+import { captureException } from '../modules/exceptions'
+
+describe('Edge Runtime Compatibility', () => {
+  describe('Exception Capture - Graceful Degradation', () => {
+    it('should capture basic exception info without filesystem access', () => {
+      const error = new Error('Test error')
+      const captured = captureException(error)
+
+      // Should capture basic error information regardless of environment
+      expect(captured.message).toBe('Test error')
+      expect(captured.type).toBe('Error')
+      expect(captured.platform).toBe('javascript')
+    })
+
+    it('should parse stack traces without requiring fs module', () => {
+      const error = new Error('Stack trace test')
+      const captured = captureException(error)
+
+      // Stack parsing doesn't require fs - only context_line extraction does
+      expect(captured.frames).toBeDefined()
+      expect(Array.isArray(captured.frames)).toBe(true)
+      expect(captured.frames!.length).toBeGreaterThan(0)
+
+      // Frames should have basic info
+      const firstFrame = captured.frames![0]
+      expect(firstFrame.filename).toBeDefined()
+      expect(typeof firstFrame.lineno).toBe('number')
+    })
+
+    it('should handle chained errors (Error.cause)', () => {
+      const rootCause = new Error('Root cause')
+      const wrapper = new Error('Wrapper error', { cause: rootCause })
+
+      const captured = captureException(wrapper)
+
+      expect(captured.message).toBe('Wrapper error')
+      expect(captured.chained_errors).toBeDefined()
+      expect(captured.chained_errors!.length).toBe(1)
+      expect(captured.chained_errors![0].message).toBe('Root cause')
+    })
+
+    it('should handle non-Error objects being thrown', () => {
+      const captured1 = captureException('string error')
+      expect(captured1.message).toBe('string error')
+
+      const captured2 = captureException({ code: 404 })
+      expect(captured2.message).toBe('{"code":404}')
+
+      const captured3 = captureException(null)
+      expect(captured3.message).toBe('null')
+
+      const captured4 = captureException(undefined)
+      expect(captured4.message).toBe('undefined')
+    })
+  })
+
+  describe('Process Object Availability', () => {
+    let originalProcess: typeof process
+
+    beforeEach(() => {
+      originalProcess = globalThis.process
+    })
+
+    afterEach(() => {
+      globalThis.process = originalProcess
+    })
+
+    it('should handle missing process.cwd gracefully', () => {
+      // Create a mock process without cwd
+      const mockProcess = { ...originalProcess } as typeof process
+      // @ts-expect-error - intentionally removing cwd for test
+      mockProcess.cwd = undefined
+      globalThis.process = mockProcess
+
+      // captureException should still work
+      const error = new Error('Test without cwd')
+      const captured = captureException(error)
+
+      expect(captured.message).toBe('Test without cwd')
+      expect(captured.type).toBe('Error')
+    })
+
+    it('should handle process.cwd throwing', () => {
+      const mockProcess = {
+        ...originalProcess,
+        cwd: () => {
+          throw new Error('cwd not available')
+        },
+      } as typeof process
+      globalThis.process = mockProcess
+
+      const error = new Error('Test with throwing cwd')
+      const captured = captureException(error)
+
+      expect(captured.message).toBe('Test with throwing cwd')
+    })
+  })
+
+  describe('Event Queue Signal Handlers', () => {
+    let originalProcess: typeof process
+
+    beforeEach(() => {
+      originalProcess = globalThis.process
+    })
+
+    afterEach(() => {
+      globalThis.process = originalProcess
+      jest.resetModules()
+    })
+
+    it('should not throw when process.once is unavailable', async () => {
+      // Create mock process without once
+      const mockProcess = { ...originalProcess } as typeof process
+      // @ts-expect-error - intentionally removing once for test
+      mockProcess.once = undefined
+      globalThis.process = mockProcess
+
+      // Reset modules to re-run module-level code
+      jest.resetModules()
+
+      // Should not throw when importing
+      await expect(import('../modules/publish')).resolves.toBeDefined()
+    })
+
+    it('should handle process being undefined', async () => {
+      // @ts-expect-error - intentionally removing process for test
+      globalThis.process = undefined
+
+      jest.resetModules()
+
+      // Should not throw - publish module should still load without process
+      const module = await import('../modules/publish')
+      expect(typeof module.publishEvent).toBe('function')
+
+      // Restore process before other tests run
+      globalThis.process = originalProcess
+    })
+  })
+
+  describe('Logging Module Behavior', () => {
+    it('should export log function', async () => {
+      const { log } = await import('../modules/logger')
+      expect(typeof log).toBe('function')
+    })
+
+    it('should not throw when called', async () => {
+      const { log } = await import('../modules/logger')
+
+      // log should never throw, regardless of environment
+      expect(() => log('Test message')).not.toThrow()
+      expect(() => log('')).not.toThrow()
+      expect(() => log('Special chars: \n\t\r')).not.toThrow()
+    })
+
+    it('should handle rapid successive calls', async () => {
+      const { log } = await import('../modules/logger')
+
+      // Should handle many calls without issues
+      expect(() => {
+        for (let i = 0; i < 100; i++) {
+          log(`Message ${i}`)
+        }
+      }).not.toThrow()
+    })
+  })
+
+  describe('Full SDK API Availability', () => {
+    it('should export track function', async () => {
+      const mcpAnalytics = await import('../index')
+      expect(typeof mcpAnalytics.track).toBe('function')
+    })
+
+    it('should export publishCustomEvent function', async () => {
+      const mcpAnalytics = await import('../index')
+      expect(typeof mcpAnalytics.publishCustomEvent).toBe('function')
+    })
+
+    it('should export type definitions', async () => {
+      // IdentifyFunction type is exported for users to define their identify callbacks
+      const mcpAnalytics = await import('../index')
+      // The module should load without issues
+      expect(mcpAnalytics).toBeDefined()
+    })
+  })
+
+  describe('Edge Environment Detection Patterns', () => {
+    it('should detect Node.js environment correctly', () => {
+      // Helper function that PostHog MCP analytics could use internally
+      const isNodeJs = () => typeof process !== 'undefined' && process.versions != null && process.versions.node != null
+
+      // In test environment, we should be in Node.js
+      expect(isNodeJs()).toBe(true)
+    })
+
+    it('should detect Cloudflare Workers pattern', () => {
+      // Pattern for detecting Cloudflare Workers
+      const isCloudflareWorkers = () => {
+        try {
+          // Cloudflare Workers have caches.default
+          return (
+            typeof caches !== 'undefined' &&
+            // @ts-expect-error - caches.default is Cloudflare-specific
+            typeof caches.default !== 'undefined'
+          )
+        } catch {
+          return false
+        }
+      }
+
+      // In Node.js test environment, should return false
+      expect(isCloudflareWorkers()).toBe(false)
+    })
+
+    it('should detect generic edge runtime pattern', () => {
+      // Generic pattern for detecting edge runtimes
+      const isEdgeRuntime = () => {
+        // Edge runtimes typically don't have full Node.js process
+        const hasFullNodeProcess =
+          typeof process !== 'undefined' &&
+          typeof process.versions?.node === 'string' &&
+          typeof process.cwd === 'function'
+
+        return !hasFullNodeProcess
+      }
+
+      // In Node.js test environment, should return false
+      expect(isEdgeRuntime()).toBe(false)
+    })
+  })
+
+  describe('Path Normalization Without cwd', () => {
+    it('should handle various path formats', () => {
+      // These patterns should work regardless of process.cwd availability
+      const testPaths = [
+        '/Users/john/project/src/index.ts',
+        'src/index.ts',
+        './relative/path.ts',
+        'node_modules/package/index.js',
+        'node:internal/modules/loader',
+        'native',
+        '<anonymous>',
+      ]
+
+      const error = new Error('Path test')
+      error.stack = testPaths.map((path, index) => `    at test${index} (${path}:1:1)`).join('\n')
+      const captured = captureException(error)
+
+      // Should have parsed the stack without errors
+      expect(captured.frames).toBeDefined()
+    })
+  })
+})
+
+describe('Integration: SDK in Limited Environment', () => {
+  let originalProcess: typeof process
+
+  beforeEach(() => {
+    originalProcess = globalThis.process
+  })
+
+  afterEach(() => {
+    globalThis.process = originalProcess
+    jest.resetModules()
+  })
+
+  it('should work when process has limited functionality', async () => {
+    // Simulate limited process object (like some edge runtimes)
+    const limitedProcess = {
+      env: {},
+      // Missing: cwd, once, versions, etc.
+    } as unknown as typeof process
+
+    globalThis.process = limitedProcess
+    jest.resetModules()
+
+    // SDK should still load
+    const mcpAnalytics = await import('../index')
+
+    // Core functions should exist
+    expect(mcpAnalytics.track).toBeDefined()
+    expect(mcpAnalytics.publishCustomEvent).toBeDefined()
+
+    // Exception capture should work
+    const { captureException: capture } = await import('../modules/exceptions')
+    const error = new Error('Limited env test')
+    const captured = capture(error)
+
+    expect(captured.message).toBe('Limited env test')
+
+    // Restore
+    globalThis.process = originalProcess
+  })
+
+  it('should handle environment transitions gracefully', async () => {
+    // First call in "normal" environment
+    const { log: writeLog1 } = await import('../modules/logger')
+    expect(() => writeLog1('Normal environment')).not.toThrow()
+
+    // Module state persists between calls (this is expected behavior)
+    expect(() => writeLog1('Second call')).not.toThrow()
+  })
+})
+
+describe('Error Handling Robustness', () => {
+  it('should not crash on malformed stack traces', () => {
+    const error = new Error('Malformed')
+    // Override stack with malformed content
+    error.stack = 'Error: Malformed\n    at malformed line without proper format\n    garbage data'
+
+    const captured = captureException(error)
+
+    // Should still capture basic info
+    expect(captured.message).toBe('Malformed')
+    expect(captured.type).toBe('Error')
+    // Should handle malformed frames gracefully
+    expect(captured.frames).toBeDefined()
+  })
+
+  it('should handle circular reference in error.cause', () => {
+    const error1 = new Error('Error 1') as Error & { cause?: Error }
+    const error2 = new Error('Error 2') as Error & { cause?: Error }
+
+    // Create circular reference
+    error1.cause = error2
+    error2.cause = error1
+
+    // Should not infinite loop
+    const captured = captureException(error1)
+
+    expect(captured.message).toBe('Error 1')
+    expect(captured.chained_errors).toBeDefined()
+    // Should stop before infinite loop
+    expect(captured.chained_errors!.length).toBeLessThanOrEqual(10)
+  })
+
+  it('should handle deeply nested error chains', () => {
+    // Create a deep chain of errors
+    let current = new Error('Root')
+    for (let i = 0; i < 20; i++) {
+      current = new Error(`Level ${i}`, { cause: current })
+    }
+
+    const captured = captureException(current)
+
+    expect(captured.message).toBe('Level 19')
+    // Should be capped at MAX_EXCEPTION_CHAIN_DEPTH (10)
+    expect(captured.chained_errors!.length).toBeLessThanOrEqual(10)
+  })
+})

--- a/packages/mcp/src/__tests__/error-capture.test.ts
+++ b/packages/mcp/src/__tests__/error-capture.test.ts
@@ -1,0 +1,630 @@
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+import { track } from '../index'
+import { MCPAnalyticsEventType } from '../modules/event-types'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+import { EventCapture } from './test-utils'
+
+describe('Error Capture Integration Tests', () => {
+  let eventCapture: EventCapture
+
+  beforeEach(async () => {
+    resetTodos()
+    eventCapture = new EventCapture()
+    await eventCapture.start()
+  })
+
+  afterEach(async () => {
+    await eventCapture.stop()
+  })
+
+  it('should capture stack traces when tool throws Error', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Track the server with mcpAnalytics (uses default settings including context parameters)
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      // Call a tool that throws an error (complete_todo with invalid ID)
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'complete_todo',
+            arguments: {
+              id: 'nonexistent-id',
+              context: 'Testing error capture',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // MCP returns errors as tool results with isError: true
+      expect(result.isError).toBe(true)
+
+      // Wait for event to be captured
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Find the tool call event
+      const events = eventCapture.findEventsByResourceName('complete_todo')
+      expect(events.length).toBeGreaterThan(0)
+
+      const errorEvent = events.find((e) => e.isError)
+      expect(errorEvent).toBeDefined()
+      expect(errorEvent!.isError).toBe(true)
+
+      // Verify error structure
+      expect(errorEvent!.error).toBeDefined()
+      expect(errorEvent!.error!.message).toContain('not found')
+
+      // Make sure execution error is properly recognized as an error
+      expect(errorEvent!.error!.type).toBe('Error')
+      expect(errorEvent!.error!.stack).toBeDefined()
+      expect(errorEvent!.error!.frames).toBeDefined()
+      expect(errorEvent!.error!.frames!.length).toBeGreaterThan(0)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should capture Error.cause chains', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Add a tool that throws an error with a cause
+      server.tool('error_with_cause', 'Throws error with cause', {}, async () => {
+        const rootCause = new Error('Root cause error')
+        const wrapperError = new Error('Wrapper error', { cause: rootCause })
+        throw wrapperError
+      })
+
+      // Track the server
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      // Call the error-throwing tool
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'error_with_cause',
+            arguments: {
+              context: 'Testing error.cause chains',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // MCP returns errors as tool results with isError: true
+      expect(result.isError).toBe(true)
+
+      // Wait for event
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Find the tool call event
+      const events = eventCapture.findEventsByResourceName('error_with_cause')
+      expect(events.length).toBeGreaterThan(0)
+
+      const errorEvent = events.find((e) => e.isError)
+      expect(errorEvent).toBeDefined()
+
+      // Ensure we get the real Error type
+      expect(errorEvent!.error!.type).toBe('Error')
+      expect(errorEvent!.error!.message).toContain('Wrapper error')
+
+      // Verify we captured the full error with stack trace
+      expect(errorEvent!.error!.stack).toBeDefined()
+      expect(errorEvent!.error!.frames).toBeDefined()
+
+      // Error.cause chains should be captured
+      expect(errorEvent!.error!.chained_errors).toBeDefined()
+      expect(errorEvent!.error!.chained_errors!.length).toBe(1)
+      expect(errorEvent!.error!.chained_errors![0].message).toBe('Root cause error')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should capture TypeError with correct type', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Add a tool that throws a TypeError
+      server.tool('type_error_tool', 'Throws TypeError', {}, async () => {
+        const obj: any = null
+        return obj.property // This will throw TypeError
+      })
+
+      // Track the server
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      // Call the error-throwing tool
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'type_error_tool',
+            arguments: {
+              context: 'Testing TypeError capture',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // MCP returns errors as tool results with isError: true
+      expect(result.isError).toBe(true)
+
+      // Wait for event
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Find the tool call event
+      const events = eventCapture.findEventsByResourceName('type_error_tool')
+      const errorEvent = events.find((e) => e.isError)
+
+      expect(errorEvent).toBeDefined()
+      // With callback-level capture, we preserve the specific error type
+      expect(errorEvent!.error!.type).toBe('TypeError')
+      expect(errorEvent!.error!.message).toContain('null')
+      expect(errorEvent!.error!.stack).toBeDefined()
+      expect(errorEvent!.error!.frames).toBeDefined()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should capture non-Error thrown values', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Add a tool that throws a string
+      server.tool('throw_string', 'Throws string', {}, async () => {
+        await Promise.reject('This is a string error')
+      })
+
+      // Track the server
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      // Call the error-throwing tool
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'throw_string',
+            arguments: {
+              context: 'Testing non-Error thrown values',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // MCP returns errors as tool results with isError: true
+      expect(result.isError).toBe(true)
+
+      // Wait for event
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Find the tool call event
+      const events = eventCapture.findEventsByResourceName('throw_string')
+      const errorEvent = events.find((e) => e.isError)
+
+      expect(errorEvent).toBeDefined()
+      expect(errorEvent!.error!.type).toBeUndefined()
+      expect(errorEvent!.error!.message).toContain('This is a string error')
+      // Non-Error throws don't have stack traces
+      // (SDK converts them, we can't capture at callback level)
+      expect(errorEvent!.error!.stack).toBeUndefined()
+      expect(errorEvent!.error!.frames).toBeUndefined()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it.skip('should detect in_app frames correctly', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Track the server
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      // Call a tool that throws an error
+      const result = await client.request({
+        method: 'tools/call',
+        params: {
+          name: 'complete_todo',
+          arguments: {
+            id: 'bad-id',
+            context: 'Testing in_app frame detection',
+          },
+        },
+        CallToolResultSchema,
+      })
+
+      // MCP returns errors as tool results with isError: true
+      expect(result.isError).toBe(true)
+
+      // Wait for event
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const events = eventCapture.findEventsByResourceName('complete_todo')
+      const errorEvent = events.find((e) => e.isError)
+
+      expect(errorEvent).toBeDefined()
+      expect(errorEvent!.error!.frames).toBeDefined()
+
+      // Check that we have both in_app and library frames
+      const hasInAppFrame = errorEvent!.error!.frames!.some((frame) => frame.in_app)
+      const hasLibraryFrame = errorEvent!.error!.frames!.some((frame) => !frame.in_app)
+
+      // At least one frame should be from user code
+      expect(hasInAppFrame).toBe(true)
+      expect(typeof hasLibraryFrame).toBe('boolean')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should still propagate errors to MCP client', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Track the server
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      // Verify that the error is still returned to the client
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'complete_todo',
+            arguments: {
+              id: 'invalid',
+              context: 'Testing error propagation',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // MCP returns errors as tool results with isError: true
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toContain('not found')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should NOT publish identify events when identify function throws', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Track with an identify function that throws
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+        identify: async () => {
+          throw new Error('Identify error')
+        },
+      })
+
+      // Make a tool call to trigger identify
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'list_todos',
+            arguments: {
+              context: 'Testing identify error capture',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Verify NO identify event was published (errors in identify should only be logged, not published)
+      const events = eventCapture.getEvents()
+      const identifyEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.identify)
+
+      expect(identifyEvent).toBeUndefined()
+
+      // Verify the tool call event was still published
+      const toolCallEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+      expect(toolCallEvent).toBeDefined()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should handle successful tool calls without errors', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Track the server
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      // Make a successful tool call
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Test todo',
+              context: 'Testing successful tool calls',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result).toBeDefined()
+
+      // Wait for event
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const events = eventCapture.findEventsByResourceName('add_todo')
+      expect(events.length).toBeGreaterThan(0)
+
+      const successEvent = events.at(-1)
+      expect(successEvent?.isError).toBe(false)
+      expect(successEvent?.duration).toEqual(expect.any(Number))
+      expect(successEvent?.error).toBeUndefined()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should capture validation errors for invalid enum values', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Add a tool with enum validation
+      server.tool(
+        'calculate',
+        'Perform calculations',
+        {
+          operation: z.enum(['add', 'subtract', 'multiply', 'divide']),
+          a: z.number(),
+          b: z.number(),
+        },
+        async (args) => ({
+          content: [{ type: 'text', text: `Result: ${args.a}` }],
+        })
+      )
+
+      // Track the server
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      // Call with invalid enum value - should throw before callback executes
+      try {
+        await client.request(
+          {
+            method: 'tools/call',
+            params: {
+              name: 'calculate',
+              arguments: {
+                operation: 'modulo', // Invalid enum value
+                a: 10,
+                b: 3,
+                context: 'Testing validation error capture',
+              },
+            },
+          },
+          CallToolResultSchema
+        )
+        expect.fail('Should have thrown validation error')
+      } catch (error: any) {
+        // MCP SDK throws validation errors, doesn't return CallToolResult
+        expect(error).toBeDefined()
+      }
+
+      // Wait for event
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Find the tool call event
+      const events = eventCapture.findEventsByResourceName('calculate')
+      expect(events.length).toBeGreaterThan(0)
+
+      const errorEvent = events.find((e) => e.isError)
+      expect(errorEvent).toBeDefined()
+
+      // Verify error captured
+      expect(errorEvent!.error).toBeDefined()
+      expect(errorEvent!.error!.message).toContain('Invalid')
+
+      // Type can vary by SDK version
+      // SDK 1.11.5: "McpError" (actual Error), SDK 1.21.0+: undefined (CallToolResult)
+      expect(['McpError', 'Error', undefined]).toContain(errorEvent!.error!.type)
+
+      // Stack trace may be present (older SDK) or not (newer SDK)
+      // Don't require it but verify format if present
+      if (errorEvent!.error!.stack) {
+        expect(errorEvent!.error!.stack!.length).toBeGreaterThan(0)
+      }
+
+      // Frames may be present
+      if (errorEvent!.error!.frames) {
+        expect(errorEvent!.error!.frames!.length).toBeGreaterThan(0)
+      }
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should capture errors for unknown tool names', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // Track the server
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      // Call non-existent tool
+      try {
+        await client.request(
+          {
+            method: 'tools/call',
+            params: {
+              name: 'nonexistent_tool',
+              arguments: {
+                context: 'Testing unknown tool error',
+              },
+            },
+          },
+          CallToolResultSchema
+        )
+        expect.fail('Should have thrown unknown tool error')
+      } catch (error: any) {
+        // SDK throws error for unknown tools
+        expect(error).toBeDefined()
+      }
+
+      // Wait for event
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Find the tool call event
+      const events = eventCapture.findEventsByResourceName('nonexistent_tool')
+      expect(events.length).toBeGreaterThan(0)
+
+      const errorEvent = events.find((e) => e.isError)
+      expect(errorEvent).toBeDefined()
+
+      // Verify error captured
+      expect(errorEvent!.error!.message).toContain('not found')
+
+      // Type can vary by SDK version
+      // SDK 1.11.5: "McpError" (actual Error), SDK 1.21.0+: undefined (CallToolResult)
+      expect(['McpError', 'Error', undefined]).toContain(errorEvent!.error!.type)
+
+      // Stack trace may be present (verify if present)
+      if (errorEvent!.error!.stack) {
+        expect(errorEvent!.error!.stack!.length).toBeGreaterThan(0)
+      }
+      if (errorEvent!.error!.frames) {
+        expect(errorEvent!.error!.frames!.length).toBeGreaterThan(0)
+      }
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should capture validation errors for missing required parameters', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      // add_todo requires 'text' parameter
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      // Call without required parameter
+      try {
+        await client.request(
+          {
+            method: 'tools/call',
+            params: {
+              name: 'add_todo',
+              arguments: {
+                context: 'Testing missing parameter',
+                // 'text' parameter is missing
+              },
+            },
+          },
+          CallToolResultSchema
+        )
+        expect.fail('Should have thrown validation error')
+      } catch (error: any) {
+        expect(error).toBeDefined()
+      }
+
+      // Wait for event
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const events = eventCapture.findEventsByResourceName('add_todo')
+      const errorEvent = events.find((e) => e.isError)
+
+      expect(errorEvent).toBeDefined()
+      expect(errorEvent!.error!.message).toContain('Invalid')
+
+      // Type can vary by SDK version
+      // SDK 1.11.5: "McpError" (actual Error), SDK 1.21.0+: undefined (CallToolResult)
+      expect(['McpError', 'Error', undefined]).toContain(errorEvent!.error!.type)
+
+      // Stack trace may be present (verify if present)
+      if (errorEvent!.error!.stack) {
+        expect(errorEvent!.error!.stack!.length).toBeGreaterThan(0)
+      }
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should publish exactly one event per tool call', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      // Make a successful tool call
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'list_todos',
+            arguments: {
+              context: 'Testing single event publishing',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Wait for event
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Verify exactly one event for this call
+      const events = eventCapture.findEventsByResourceName('list_todos')
+      const successEvents = events.filter((e) => !e.isError)
+
+      // Should be exactly 1 event, not 2 (which would indicate double publishing)
+      expect(successEvents.length).toBe(1)
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/packages/mcp/src/__tests__/exceptions.test.ts
+++ b/packages/mcp/src/__tests__/exceptions.test.ts
@@ -1,0 +1,827 @@
+import { captureException } from '../modules/exceptions'
+
+describe('captureException', () => {
+  describe('basic error capture', () => {
+    it('should capture Error with message and type', () => {
+      const error = new Error('Test error message')
+      const result = captureException(error)
+
+      expect(result.message).toBe('Test error message')
+      expect(result.type).toBe('Error')
+      expect(result.stack).toBeDefined()
+      expect(result.frames).toBeDefined()
+      expect(result.frames!.length).toBeGreaterThan(0)
+    })
+
+    it('should capture TypeError with correct type', () => {
+      const error = new TypeError('Type error message')
+      const result = captureException(error)
+
+      expect(result.message).toBe('Type error message')
+      expect(result.type).toBe('TypeError')
+    })
+
+    it('should capture ReferenceError with correct type', () => {
+      const error = new ReferenceError('Reference error message')
+      const result = captureException(error)
+
+      expect(result.message).toBe('Reference error message')
+      expect(result.type).toBe('ReferenceError')
+    })
+
+    it('should capture custom error class', () => {
+      class CustomError extends Error {
+        constructor(message: string) {
+          super(message)
+          this.name = 'CustomError'
+        }
+      }
+
+      const error = new CustomError('Custom error message')
+      const result = captureException(error)
+
+      expect(result.message).toBe('Custom error message')
+      expect(result.type).toBe('CustomError')
+    })
+
+    it("should always set platform to 'javascript'", () => {
+      const error = new Error('Test error')
+      const result = captureException(error)
+
+      expect(result.platform).toBe('javascript')
+    })
+
+    it("should set platform to 'javascript' for non-Error objects", () => {
+      const result = captureException('string error')
+
+      expect(result.platform).toBe('javascript')
+    })
+  })
+
+  describe('stack trace parsing', () => {
+    it('should parse stack frames with function names', () => {
+      const error = new Error('Test')
+      const result = captureException(error)
+
+      expect(result.frames).toBeDefined()
+      expect(result.frames!.length).toBeGreaterThan(0)
+
+      // Check that at least one frame has the expected structure
+      const frame = result.frames![0]
+      expect(frame).toHaveProperty('filename')
+      expect(frame).toHaveProperty('function')
+      expect(frame).toHaveProperty('in_app')
+      expect(typeof frame.in_app).toBe('boolean')
+    })
+
+    it('should detect in_app correctly for user code', () => {
+      const error = new Error('Test')
+      const result = captureException(error)
+
+      // At least one frame should be marked as in_app (this test file)
+      const hasInAppFrame = result.frames!.some((frame) => frame.in_app)
+      expect(hasInAppFrame).toBe(true)
+    })
+
+    it('should detect library code in node_modules', () => {
+      // Create a mock stack trace that includes node_modules
+      const error = new Error('Test')
+      error.stack = `Error: Test
+    at userFunction (/app/src/test.ts:10:5)
+    at libFunction (/app/node_modules/some-lib/index.js:42:10)
+    at internal (node:internal/process:123:45)`
+
+      const result = captureException(error)
+
+      expect(result.frames).toBeDefined()
+      expect(result.frames!.length).toBe(3)
+
+      // First frame should be in_app (user code)
+      expect(result.frames![0].in_app).toBe(true)
+      expect(result.frames![0].filename).toContain('test.ts')
+
+      // Second frame should NOT be in_app (node_modules)
+      expect(result.frames![1].in_app).toBe(false)
+      expect(result.frames![1].filename).toContain('node_modules')
+
+      // Third frame should NOT be in_app (node internal)
+      expect(result.frames![2].in_app).toBe(false)
+      expect(result.frames![2].filename).toContain('node:')
+    })
+
+    it('should parse line and column numbers', () => {
+      const error = new Error('Test')
+      error.stack = `Error: Test
+    at testFunction (/app/src/file.ts:42:15)`
+
+      const result = captureException(error)
+
+      expect(result.frames).toBeDefined()
+      expect(result.frames![0].lineno).toBe(42)
+      expect(result.frames![0].colno).toBe(15)
+    })
+
+    it('should handle anonymous functions', () => {
+      const error = new Error('Test')
+      error.stack = `Error: Test
+    at /app/src/file.ts:10:5`
+
+      const result = captureException(error)
+
+      expect(result.frames).toBeDefined()
+      expect(result.frames![0].function).toBe('<anonymous>')
+      expect(result.frames![0].lineno).toBe(10)
+      expect(result.frames![0].colno).toBe(5)
+    })
+
+    it('should handle async functions', () => {
+      const error = new Error('Test')
+      error.stack = `Error: Test
+    at async asyncFunction (/app/src/file.ts:20:10)`
+
+      const result = captureException(error)
+
+      expect(result.frames).toBeDefined()
+      expect(result.frames![0].function).toBe('async asyncFunction')
+    })
+
+    it('should handle native code frames', () => {
+      const error = new Error('Test')
+      error.stack = `Error: Test
+    at Array.map (native)
+    at userFunction (/app/src/file.ts:10:5)`
+
+      const result = captureException(error)
+
+      expect(result.frames).toBeDefined()
+      expect(result.frames![0].function).toBe('Array.map')
+      expect(result.frames![0].filename).toBe('native')
+      expect(result.frames![0].in_app).toBe(false)
+    })
+
+    it('should limit stack frames to 50', () => {
+      // Create an error with a very long stack trace
+      const error = new Error('Test')
+      const stackLines = ['Error: Test']
+      for (let i = 0; i < 100; i++) {
+        stackLines.push(`    at function${i} (/app/src/file.ts:${i}:5)`)
+      }
+      error.stack = stackLines.join('\n')
+
+      const result = captureException(error)
+
+      expect(result.frames).toBeDefined()
+      expect(result.frames!.length).toBeLessThanOrEqual(50)
+    })
+
+    it('should capture context_line for in_app frames', () => {
+      // This test throws a real error, so context_line should be captured
+      const error = new Error('Test error')
+      const result = captureException(error)
+
+      expect(result.frames).toBeDefined()
+      const inAppFrames = result.frames!.filter((frame) => frame.in_app)
+      expect(inAppFrames.length).toBeGreaterThan(0)
+
+      // At least one in_app frame should have context_line
+      const hasContextLine = inAppFrames.some((frame) => frame.context_line !== undefined)
+      expect(hasContextLine).toBe(true)
+    })
+
+    it('should NOT capture context_line for library code (in_app: false)', () => {
+      // Create a mock stack trace with node_modules
+      const error = new Error('Test')
+      error.stack = `Error: Test
+    at libFunction (/app/node_modules/some-lib/index.js:42:10)
+    at internal (node:internal/process:123:45)`
+
+      const result = captureException(error)
+
+      expect(result.frames).toBeDefined()
+      // All frames should be library code and should NOT have context_line
+      for (const frame of result.frames!) {
+        expect(frame.in_app).toBe(false)
+        expect(frame.context_line).toBeUndefined()
+      }
+    })
+
+    it('should handle missing files gracefully when extracting context_line', () => {
+      // Create a mock stack trace with a non-existent file
+      const error = new Error('Test')
+      error.stack = `Error: Test
+    at testFunction (/nonexistent/file/path.ts:10:5)`
+
+      const result = captureException(error)
+
+      expect(result.frames).toBeDefined()
+      expect(result.frames!.length).toBe(1)
+      // Frame should be in_app but context_line should be undefined (file not found)
+      expect(result.frames![0].in_app).toBe(true)
+      expect(result.frames![0].context_line).toBeUndefined()
+    })
+  })
+
+  describe('Error.cause chain', () => {
+    it('should unwrap single cause', () => {
+      const rootCause = new Error('Root cause')
+      const error = new Error('Wrapper error', { cause: rootCause })
+
+      const result = captureException(error)
+
+      expect(result.message).toBe('Wrapper error')
+      expect(result.chained_errors).toBeDefined()
+      expect(result.chained_errors!.length).toBe(1)
+      expect(result.chained_errors![0].message).toBe('Root cause')
+      expect(result.chained_errors![0].type).toBe('Error')
+    })
+
+    it('should unwrap multiple causes', () => {
+      const rootCause = new Error('Root cause')
+      const middleCause = new Error('Middle cause', { cause: rootCause })
+      const error = new Error('Top error', { cause: middleCause })
+
+      const result = captureException(error)
+
+      expect(result.chained_errors).toBeDefined()
+      expect(result.chained_errors!.length).toBe(2)
+      expect(result.chained_errors![0].message).toBe('Middle cause')
+      expect(result.chained_errors![1].message).toBe('Root cause')
+    })
+
+    it('should limit cause chain to 10', () => {
+      // Create a very long cause chain
+      let error: Error = new Error('Root')
+      for (let i = 0; i < 20; i++) {
+        error = new Error(`Level ${i}`, { cause: error })
+      }
+
+      const result = captureException(error)
+
+      expect(result.chained_errors).toBeDefined()
+      expect(result.chained_errors!.length).toBeLessThanOrEqual(10)
+    })
+
+    it('should handle non-Error causes', () => {
+      const error = new Error('Wrapper', { cause: 'string cause' })
+
+      const result = captureException(error)
+
+      expect(result.chained_errors).toBeDefined()
+      expect(result.chained_errors!.length).toBe(1)
+      expect(result.chained_errors![0].message).toBe('string cause')
+      expect(result.chained_errors![0].type).toBeUndefined()
+    })
+
+    it('should detect circular cause references', () => {
+      const error1 = new Error('Error 1')
+      const error2 = new Error('Error 2', { cause: error1 })
+      // Create circular reference
+      ;(error1 as any).cause = error2
+
+      const result = captureException(error2)
+
+      // Should not crash, should stop at circular reference
+      expect(result.chained_errors).toBeDefined()
+      expect(result.chained_errors!.length).toBeLessThanOrEqual(2)
+    })
+
+    it('should capture stack traces for each cause', () => {
+      const rootCause = new Error('Root cause')
+      const error = new Error('Wrapper', { cause: rootCause })
+
+      const result = captureException(error)
+
+      expect(result.stack).toBeDefined()
+      expect(result.frames).toBeDefined()
+      expect(result.chained_errors![0].stack).toBeDefined()
+      expect(result.chained_errors![0].frames).toBeDefined()
+    })
+  })
+
+  describe('non-Error objects', () => {
+    it('should handle string errors', () => {
+      const result = captureException('string error')
+
+      expect(result.message).toBe('string error')
+      expect(result.type).toBeUndefined()
+      expect(result.stack).toBeUndefined()
+      expect(result.frames).toBeUndefined()
+    })
+
+    it('should handle number errors', () => {
+      const result = captureException(42)
+
+      expect(result.message).toBe('42')
+      expect(result.type).toBeUndefined()
+    })
+
+    it('should handle boolean errors', () => {
+      const result = captureException(false)
+
+      expect(result.message).toBe('false')
+      expect(result.type).toBeUndefined()
+    })
+
+    it('should handle null', () => {
+      const result = captureException(null)
+
+      expect(result.message).toBe('null')
+      expect(result.type).toBeUndefined()
+    })
+
+    it('should handle undefined', () => {
+      const result = captureException(undefined)
+
+      expect(result.message).toBe('undefined')
+      expect(result.type).toBeUndefined()
+    })
+
+    it('should handle object errors', () => {
+      const result = captureException({ code: 404, message: 'Not found' })
+
+      expect(result.message).toBe('{"code":404,"message":"Not found"}')
+      expect(result.type).toBeUndefined()
+    })
+
+    it('should handle objects with circular references', () => {
+      const obj: any = { name: 'test' }
+      obj.self = obj // Circular reference
+
+      const result = captureException(obj)
+
+      expect(result.type).toBeUndefined()
+      // Should not throw, should return some string representation
+      expect(typeof result.message).toBe('string')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle errors without stack traces', () => {
+      const error = new Error('No stack')
+      error.stack = undefined
+
+      const result = captureException(error)
+
+      expect(result.message).toBe('No stack')
+      expect(result.type).toBe('Error')
+      expect(result.stack).toBeUndefined()
+      expect(result.frames).toBeUndefined()
+    })
+
+    it('should handle errors with empty messages', () => {
+      const error = new Error('placeholder')
+      Object.defineProperty(error, 'message', { value: '' })
+
+      const result = captureException(error)
+
+      expect(result.message).toBe('')
+      expect(result.type).toBe('Error')
+    })
+
+    it('should handle errors with only whitespace in stack', () => {
+      const error = new Error('Test')
+      error.stack = '   \n  \n  '
+
+      const result = captureException(error)
+
+      expect(result.stack).toBe('   \n  \n  ')
+      expect(result.frames).toEqual([])
+    })
+
+    it('should handle malformed stack traces gracefully', () => {
+      const error = new Error('Test')
+      error.stack = `Error: Test
+    at incomplete line without location
+    at /file:10:5
+    at functionWithNoParens /file:20:5`
+
+      const result = captureException(error)
+
+      // Should not crash, should parse what it can
+      expect(result.frames).toBeDefined()
+    })
+  })
+
+  describe('path normalization', () => {
+    describe('user home directory stripping', () => {
+      it('should strip macOS user home directories', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at userFunction (/Users/john/project/src/index.ts:10:5)`
+
+        const result = captureException(error)
+
+        // Should find /src/ boundary and normalize to that
+        expect(result.frames![0].filename).toBe('src/index.ts')
+        expect(result.frames![0].abs_path).toBe('/Users/john/project/src/index.ts')
+      })
+
+      it('should strip Linux user home directories', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at userFunction (/home/ubuntu/app/src/server.ts:20:8)`
+
+        const result = captureException(error)
+
+        // Should find /src/ boundary and normalize to that
+        expect(result.frames![0].filename).toBe('src/server.ts')
+        expect(result.frames![0].abs_path).toBe('/home/ubuntu/app/src/server.ts')
+      })
+
+      it('should strip Windows user home directories', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at userFunction (C:\\Users\\Jane\\projects\\myapp\\src\\index.ts:15:10)`
+
+        const result = captureException(error)
+
+        // Should find /src/ boundary and normalize to that
+        expect(result.frames![0].filename).toBe('src/index.ts')
+        expect(result.frames![0].abs_path).toBe('C:\\Users\\Jane\\projects\\myapp\\src\\index.ts')
+      })
+    })
+
+    describe('node_modules normalization', () => {
+      it('should normalize node_modules paths consistently', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at libFunction (/Users/john/project/node_modules/express/lib/router.js:42:10)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('node_modules/express/lib/router.js')
+        expect(result.frames![0].abs_path).toBe('/Users/john/project/node_modules/express/lib/router.js')
+        expect(result.frames![0].in_app).toBe(false)
+      })
+
+      it('should handle scoped packages in node_modules', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at handler (/app/node_modules/@scope/package/dist/index.js:15:20)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('node_modules/@scope/package/dist/index.js')
+        expect(result.frames![0].abs_path).toBe('/app/node_modules/@scope/package/dist/index.js')
+      })
+
+      it('should handle nested node_modules', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at deepFunction (/app/node_modules/pkg1/node_modules/pkg2/index.js:10:5)`
+
+        const result = captureException(error)
+
+        // Should take the last node_modules occurrence
+        expect(result.frames![0].filename).toBe('node_modules/pkg2/index.js')
+      })
+
+      it('should handle Windows-style node_modules paths', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at libFunction (C:\\projects\\app\\node_modules\\lodash\\index.js:100:20)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('node_modules/lodash/index.js')
+        expect(result.frames![0].abs_path).toBe('C:\\projects\\app\\node_modules\\lodash\\index.js')
+      })
+    })
+
+    describe('deployment path stripping', () => {
+      it('should strip /var/www/ paths', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at handler (/var/www/myapp/src/api/users.ts:25:12)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('src/api/users.ts')
+        expect(result.frames![0].abs_path).toBe('/var/www/myapp/src/api/users.ts')
+      })
+
+      it('should strip /app/ paths (Docker, Heroku)', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at processRequest (/app/dist/server.js:50:8)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('dist/server.js')
+        expect(result.frames![0].abs_path).toBe('/app/dist/server.js')
+      })
+
+      it('should strip AWS Lambda paths', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at lambdaHandler (/var/task/src/handler.ts:30:15)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('src/handler.ts')
+        expect(result.frames![0].abs_path).toBe('/var/task/src/handler.ts')
+      })
+
+      it('should strip Docker container paths', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at containerMain (/usr/src/app/src/index.ts:10:5)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('src/index.ts')
+        expect(result.frames![0].abs_path).toBe('/usr/src/app/src/index.ts')
+      })
+
+      it('should strip /opt/ paths', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at appMain (/opt/myservice/lib/main.ts:15:8)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('lib/main.ts')
+        expect(result.frames![0].abs_path).toBe('/opt/myservice/lib/main.ts')
+      })
+
+      it('should strip /srv/ paths', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at serviceHandler (/srv/webapp/src/routes.ts:42:20)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('src/routes.ts')
+        expect(result.frames![0].abs_path).toBe('/srv/webapp/src/routes.ts')
+      })
+    })
+
+    describe('project boundary detection', () => {
+      it('should find /src/ boundary', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at handler (/some/long/path/to/project/src/components/Button.tsx:20:10)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('src/components/Button.tsx')
+      })
+
+      it('should find /lib/ boundary', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at utility (/random/path/myproject/lib/utils/helper.ts:35:5)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('lib/utils/helper.ts')
+      })
+
+      it('should find /dist/ boundary', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at compiled (/deployment/path/dist/server.js:100:15)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('dist/server.js')
+      })
+
+      it('should use the last occurrence of project markers', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at handler (/Users/john/src/project/src/index.ts:10:5)`
+
+        const result = captureException(error)
+
+        // Should use the last /src/ occurrence
+        expect(result.frames![0].filename).toBe('src/index.ts')
+      })
+    })
+
+    describe('Node.js internal module normalization', () => {
+      it('should normalize node:internal/* to node:internal', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at Module._compile (node:internal/modules/cjs/loader:1105:14)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('node:internal')
+        expect(result.frames![0].in_app).toBe(false)
+      })
+
+      it('should normalize node:fs/promises to node:fs', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at readFile (node:fs/promises:50:10)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('node:fs')
+        expect(result.frames![0].in_app).toBe(false)
+      })
+
+      it('should preserve simple node: modules', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at processNextTick (node:process:400:5)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('node:process')
+        expect(result.frames![0].in_app).toBe(false)
+      })
+    })
+
+    describe('Windows path handling', () => {
+      it('should normalize Windows backslashes to forward slashes', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at handler (C:\\projects\\myapp\\src\\utils\\helper.ts:25:10)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).not.toContain('\\')
+        expect(result.frames![0].filename).toContain('/')
+      })
+
+      it('should handle Windows paths with mixed separators', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at mixed (C:\\projects/myapp\\src/index.ts:10:5)`
+
+        const result = captureException(error)
+
+        // Windows paths without Users directory won't match user home pattern
+        // But should still find /src/ boundary and normalize separators
+        expect(result.frames![0].filename).toBe('src/index.ts')
+        expect(result.frames![0].filename).not.toContain('\\')
+      })
+    })
+
+    describe('complex real-world scenarios', () => {
+      it('should handle mix of user code and library code', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at userHandler (/Users/dev/project/src/api/handler.ts:50:10)
+    at expressMiddleware (/Users/dev/project/node_modules/express/lib/router.js:100:5)
+    at Module._compile (node:internal/modules/cjs/loader:1105:14)`
+
+        const result = captureException(error)
+
+        // User code - should find /src/ boundary and normalize to that
+        expect(result.frames![0].filename).toBe('src/api/handler.ts')
+        expect(result.frames![0].in_app).toBe(true)
+
+        // Library code - should normalize node_modules
+        expect(result.frames![1].filename).toBe('node_modules/express/lib/router.js')
+        expect(result.frames![1].in_app).toBe(false)
+
+        // Node internal - should normalize
+        expect(result.frames![2].filename).toBe('node:internal')
+        expect(result.frames![2].in_app).toBe(false)
+      })
+
+      it('should handle Docker deployment with node_modules', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at apiHandler (/app/dist/api/users.ts:30:8)
+    at validator (/app/node_modules/validator/lib/index.js:42:15)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('dist/api/users.ts')
+        expect(result.frames![1].filename).toBe('node_modules/validator/lib/index.js')
+      })
+
+      it('should handle AWS Lambda with layers', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at handler (/var/task/src/lambda/handler.ts:20:5)
+    at runtime (/opt/nodejs/node_modules/aws-sdk/lib/service.js:150:10)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('src/lambda/handler.ts')
+        expect(result.frames![1].filename).toBe('node_modules/aws-sdk/lib/service.js')
+      })
+    })
+
+    describe('URL scheme normalization', () => {
+      it('should handle file:// URLs from ESM modules', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at handler (file:///Users/john/project/src/index.ts:10:5)`
+
+        const result = captureException(error)
+
+        // Should strip file:// and then normalize the path
+        expect(result.frames![0].filename).toBe('src/index.ts')
+        expect(result.frames![0].abs_path).toBe('file:///Users/john/project/src/index.ts')
+      })
+
+      it('should handle file:// URLs with Windows paths', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at handler (file:///C:/Users/Jane/project/src/index.ts:15:8)`
+
+        const result = captureException(error)
+
+        // Should strip file:// and then normalize the Windows path
+        expect(result.frames![0].filename).toBe('src/index.ts')
+        expect(result.frames![0].abs_path).toBe('file:///C:/Users/Jane/project/src/index.ts')
+      })
+
+      it('should handle file:// URLs in node_modules', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at libFunction (file:///Users/john/project/node_modules/express/lib/router.js:50:5)`
+
+        const result = captureException(error)
+
+        // Should normalize to node_modules path
+        expect(result.frames![0].filename).toBe('node_modules/express/lib/router.js')
+        expect(result.frames![0].in_app).toBe(false)
+      })
+    })
+
+    describe('special cases and edge cases', () => {
+      it('should preserve already-relative paths', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at handler (src/index.ts:10:5)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('src/index.ts')
+        expect(result.frames![0].abs_path).toBe('src/index.ts')
+      })
+
+      it('should preserve special paths like native', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at Array.map (native)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('native')
+        expect(result.frames![0].abs_path).toBe('native')
+      })
+
+      it('should handle paths without common markers', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at unknownPath (/random/path/without/markers/file.ts:10:5)`
+
+        const result = captureException(error)
+
+        // Should still strip leading slash, but can't normalize further
+        expect(result.frames![0].filename).toBe('random/path/without/markers/file.ts')
+      })
+
+      it('should handle very short paths', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at handler (/index.ts:1:1)`
+
+        const result = captureException(error)
+
+        expect(result.frames![0].filename).toBe('index.ts')
+      })
+    })
+
+    describe('backwards compatibility', () => {
+      it('should maintain abs_path field with original path', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at func (/Users/john/long/path/to/project/src/index.ts:10:5)`
+
+        const result = captureException(error)
+
+        // filename should be normalized
+        expect(result.frames![0].filename).toBe('src/index.ts')
+
+        // abs_path should be unchanged
+        expect(result.frames![0].abs_path).toBe('/Users/john/long/path/to/project/src/index.ts')
+      })
+
+      it('should maintain all other frame properties', () => {
+        const error = new Error('Test')
+        error.stack = `Error: Test
+    at myFunction (/app/src/test.ts:42:15)`
+
+        const result = captureException(error)
+
+        const frame = result.frames![0]
+        expect(frame.function).toBe('myFunction')
+        expect(frame.filename).toBeDefined()
+        expect(frame.abs_path).toBeDefined()
+        expect(frame.lineno).toBe(42)
+        expect(frame.colno).toBe(15)
+        expect(frame.in_app).toBeDefined()
+        expect(typeof frame.in_app).toBe('boolean')
+      })
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/handler-property.test.ts
+++ b/packages/mcp/src/__tests__/handler-property.test.ts
@@ -1,0 +1,102 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import { track } from '../index'
+
+// Helper to get the tool function property name for the current MCP SDK version
+function getToolFunctionPropertyName(tool: any): 'callback' | 'handler' {
+  if ('handler' in tool && typeof tool.handler === 'function') {
+    return 'handler'
+  }
+  if ('callback' in tool && typeof tool.callback === 'function') {
+    return 'callback'
+  }
+  throw new Error('Tool has neither callback nor handler')
+}
+
+describe('MCP SDK callback/handler compatibility', () => {
+  it('should have either callback or handler property (SDK version dependent)', () => {
+    const server = new McpServer({ name: 'test', version: '1.0.0' })
+
+    server.tool('test_tool', { a: z.number() }, async ({ a }) => ({
+      content: [{ type: 'text', text: String(a) }],
+    }))
+
+    const tools = (server as any)._registeredTools
+    const tool = tools.test_tool
+    const propName = getToolFunctionPropertyName(tool)
+
+    console.log('\n=== MCP SDK Tool Structure ===')
+    console.log('Tool properties:', Object.keys(tool))
+    console.log("Has 'callback':", 'callback' in tool)
+    console.log("Has 'handler':", 'handler' in tool)
+    console.log('Tool function property:', propName)
+
+    // Tool should have either 'handler' (1.24+) or 'callback' (1.23-)
+    const hasToolFunction =
+      ('handler' in tool && typeof tool.handler === 'function') ||
+      ('callback' in tool && typeof tool.callback === 'function')
+    expect(hasToolFunction).toBe(true)
+  })
+
+  it('should preserve the original property name after track() is called', () => {
+    const server = new McpServer({ name: 'test', version: '1.0.0' })
+
+    server.tool('test_tool', { a: z.number() }, async ({ a }) => ({
+      content: [{ type: 'text', text: String(a) }],
+    }))
+
+    // Get the property name BEFORE track()
+    const toolsBefore = (server as any)._registeredTools
+    const toolBefore = toolsBefore.test_tool
+    const originalPropName = getToolFunctionPropertyName(toolBefore)
+
+    // Call track() to apply PostHog MCP analytics's tracing
+    track(server, { apiKey: 'test-project-id' })
+
+    const toolsAfter = (server as any)._registeredTools
+    const toolAfter = toolsAfter.test_tool
+    const afterPropName = getToolFunctionPropertyName(toolAfter)
+
+    console.log('\n=== After track() ===')
+    console.log('Original property name:', originalPropName)
+    console.log('Property name after track():', afterPropName)
+    console.log("Has 'callback':", 'callback' in toolAfter)
+    console.log("Has 'handler':", 'handler' in toolAfter)
+
+    // PostHog MCP analytics should preserve the original property name
+    expect(afterPropName).toBe(originalPropName)
+    expect(typeof toolAfter[afterPropName]).toBe('function')
+  })
+
+  it('should preserve property name for tools registered after track()', () => {
+    const server = new McpServer({ name: 'test', version: '1.0.0' })
+
+    // Register a tool first to determine SDK's property name
+    server.tool('initial_tool', { a: z.number() }, async ({ a }) => ({
+      content: [{ type: 'text', text: String(a) }],
+    }))
+    const expectedPropName = getToolFunctionPropertyName((server as any)._registeredTools.initial_tool)
+
+    // Call track() first
+    track(server, { apiKey: 'test-project-id' })
+
+    // Then register a tool after track()
+    server.tool('late_tool', { b: z.string() }, async ({ b }) => ({
+      content: [{ type: 'text', text: b }],
+    }))
+
+    const tools = (server as any)._registeredTools
+    const tool = tools.late_tool
+    const propName = getToolFunctionPropertyName(tool)
+
+    console.log('\n=== Tool registered after track() ===')
+    console.log('Expected property name:', expectedPropName)
+    console.log('Actual property name:', propName)
+    console.log("Has 'callback':", 'callback' in tool)
+    console.log("Has 'handler':", 'handler' in tool)
+
+    // Tools registered after track() should also preserve the SDK's property name
+    expect(propName).toBe(expectedPropName)
+    expect(typeof tool[propName]).toBe('function')
+  })
+})

--- a/packages/mcp/src/__tests__/identify.test.ts
+++ b/packages/mcp/src/__tests__/identify.test.ts
@@ -1,0 +1,725 @@
+import { randomUUID } from 'node:crypto'
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+import { track } from '../index'
+import { MCPAnalyticsEventType } from '../modules/event-types'
+import { getServerTrackingData } from '../modules/internal'
+import type { HighLevelMCPServerLike, UserIdentity } from '../types'
+import { EventCapture } from './test-utils'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+
+describe('Identify Feature', () => {
+  let server: HighLevelMCPServerLike
+  let client: any
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    resetTodos()
+    const setup = await setupTestServerAndClient()
+    server = setup.server
+    client = setup.client
+    cleanup = setup.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  describe('Basic Identification Test', () => {
+    it('should call identify function on first tool invocation and store user identity', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      let identifyCalled = false
+      const testUserId = `user-${randomUUID()}`
+      const testUserData = {
+        name: `Test User ${randomUUID()}`,
+        email: `test-${randomUUID()}@example.com`,
+      }
+
+      // Enable tracking with identify function
+      track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+        identify: async (request, extra) => {
+          identifyCalled = true
+          expect(request).toBeDefined()
+          expect(extra).toBeDefined()
+          return {
+            userId: testUserId,
+            userData: testUserData,
+          }
+        },
+      })
+
+      // Call a tool - this should trigger identify
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Test todo for identification',
+              context: 'Adding a todo item for identification test',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result.content[0].text).toContain('Added todo')
+      expect(identifyCalled).toBe(true)
+
+      // Wait for events to be processed
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Verify that an identify event was published
+      const events = eventCapture.getEvents()
+      const identifyEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.identify)
+
+      expect(identifyEvent).toBeDefined()
+      expect(identifyEvent?.resourceName).toBe('add_todo')
+
+      // Verify user identity is stored in session
+      const data = getServerTrackingData(server.server)
+      const sessionId = data?.sessionId
+      expect(sessionId).toBeDefined()
+
+      const storedIdentity = data?.identifiedSessions.get(sessionId!)
+      expect(storedIdentity).toEqual({
+        userId: testUserId,
+        userData: testUserData,
+      })
+
+      await eventCapture.stop()
+    })
+
+    it('should call identify function on each tool call but only publish event when identity changes', async () => {
+      let identifyCallCount = 0
+      const userId = `user-${randomUUID()}`
+      const userName = `Another User ${randomUUID()}`
+
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking with identify function
+      track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+        identify: async () => {
+          identifyCallCount++
+          return {
+            userId,
+            userData: { name: userName },
+          }
+        },
+      })
+
+      // First tool call - should trigger identify and publish event
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'First todo',
+              context: 'Adding a todo item for identification test',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(identifyCallCount).toBe(1)
+      const events1 = await eventCapture.getEvents()
+      const identifyEvents1 = events1.filter((e) => e.eventType === 'posthog:identify')
+      expect(identifyEvents1.length).toBe(1) // First identify event published
+
+      // Second tool call - should call identify but NOT publish event (identity unchanged)
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'list_todos',
+            arguments: {
+              context: 'Adding a todo item for identification test',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(identifyCallCount).toBe(2) // Called again
+      const events2 = await eventCapture.getEvents()
+      const identifyEvents2 = events2.filter((e) => e.eventType === 'posthog:identify')
+      expect(identifyEvents2.length).toBe(1) // Still only 1 event (no new event published)
+
+      // Third tool call - should call identify but still NOT publish event
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'complete_todo',
+            arguments: {
+              id: '1',
+              context: 'Completing a todo item for identification test',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(identifyCallCount).toBe(3) // Called again
+      const events3 = await eventCapture.getEvents()
+      const identifyEvents3 = events3.filter((e) => e.eventType === 'posthog:identify')
+      expect(identifyEvents3.length).toBe(1) // Still only 1 event
+
+      await eventCapture.stop()
+    })
+
+    it('should properly identify when calling tools added after track()', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      let identifyCalled = false
+      const testUserId = `post-track-user-${randomUUID()}`
+      const testUserData = {
+        name: `Post Track User ${randomUUID()}`,
+        email: `post-track-${randomUUID()}@example.com`,
+      }
+
+      // Enable tracking with identify function FIRST
+      track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+        context: true,
+        identify: async (request, extra) => {
+          identifyCalled = true
+          expect(request).toBeDefined()
+          expect(extra).toBeDefined()
+          return {
+            userId: testUserId,
+            userData: testUserData,
+          }
+        },
+      })
+
+      // Add a new tool AFTER track() has been called
+      server.tool(
+        'post_track_tool',
+        'A tool added after tracking was enabled',
+        {
+          message: z.string().describe('A message to process'),
+        },
+        async (args) => ({
+          content: [
+            {
+              type: 'text',
+              text: `Processed message: ${args.message}`,
+            },
+          ],
+        })
+      )
+
+      // Call the newly added tool - this should trigger identify
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'post_track_tool',
+            arguments: {
+              message: 'Testing post-track identification',
+              context: 'Verifying identification works for dynamically added tools',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result.content[0].text).toContain('Processed message: Testing post-track identification')
+      expect(identifyCalled).toBe(true)
+
+      // Wait for events to be processed
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Verify that an identify event was published
+      const events = eventCapture.getEvents()
+      const identifyEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.identify)
+
+      expect(identifyEvent).toBeDefined()
+      expect(identifyEvent?.resourceName).toBe('post_track_tool')
+
+      // Verify tool call event was tracked with user intent
+      const toolCallEvent = events.find(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'post_track_tool'
+      )
+
+      expect(toolCallEvent).toBeDefined()
+      expect(toolCallEvent?.userIntent).toBe('Verifying identification works for dynamically added tools')
+
+      // Verify user identity is stored in session
+      const data = getServerTrackingData(server.server)
+      const sessionId = data?.sessionId
+      expect(sessionId).toBeDefined()
+
+      const storedIdentity = data?.identifiedSessions.get(sessionId!)
+      expect(storedIdentity).toEqual({
+        userId: testUserId,
+        userData: testUserData,
+      })
+
+      await eventCapture.stop()
+    })
+  })
+
+  describe('User Data Persistence Across Tool Calls', () => {
+    it('should maintain user identification across multiple tool calls', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      const testUserId = `persistent-user-${randomUUID()}`
+      const testUserData = {
+        name: `Persistent User ${randomUUID()}`,
+        department: 'Engineering',
+        customField: `custom-value-${randomUUID()}`,
+      }
+
+      // Enable tracking with identify function
+      track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+        identify: async () => ({
+          userId: testUserId,
+          userData: testUserData,
+        }),
+      })
+
+      // Make multiple tool calls
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Todo 1',
+              context: 'Adding a todo item for reset task',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Todo 2',
+              context: 'Adding a todo item for reset task',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'list_todos',
+            arguments: { context: 'Listing todos for reset task' },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Get all tool call events
+      const events = eventCapture.getEvents()
+      const toolCallEvents = events.filter((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+
+      // Verify all events have the same session ID
+      expect(toolCallEvents.length).toBe(3)
+      const sessionIds = toolCallEvents.map((e) => e.sessionId)
+      expect(new Set(sessionIds).size).toBe(1) // All should have same session ID
+
+      // Verify user identity persists
+      const data = getServerTrackingData(server.server)
+      const sessionId = data?.sessionId
+      const storedIdentity = data?.identifiedSessions.get(sessionId!)
+
+      expect(storedIdentity).toEqual({
+        userId: testUserId,
+        userData: testUserData,
+      })
+
+      await eventCapture.stop()
+    })
+  })
+
+  describe('Null/Undefined Identity Handling', () => {
+    it('should handle when identify function returns null', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking with identify function that returns null
+      track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+        identify: async () => null,
+      })
+
+      // Call a tool
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Test todo',
+              context: 'Adding a todo item for null identity test',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result.content[0].text).toContain('Added todo')
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Verify no identify event was published (since it returned null)
+      const events = eventCapture.getEvents()
+      const identifyEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.identify)
+
+      expect(identifyEvent).toBeUndefined()
+
+      // Verify no user identity is stored
+      const data = getServerTrackingData(server.server)
+      const sessionId = data?.sessionId
+      const storedIdentity = data?.identifiedSessions.get(sessionId!)
+
+      expect(storedIdentity).toBeUndefined()
+
+      await eventCapture.stop()
+    })
+
+    it('should work without identify function (anonymous sessions)', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking WITHOUT identify function
+      track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+        // No identify function provided
+      })
+
+      // Call tools
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Anonymous todo',
+              context: 'Adding a todo item for anonymous test',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'list_todos',
+            arguments: { context: 'Listing todos for anonymous test' },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Verify tool events were published with session IDs
+      const events = eventCapture.getEvents()
+      const toolCallEvents = events.filter((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+
+      expect(toolCallEvents.length).toBe(2)
+      for (const event of toolCallEvents) {
+        expect(event.sessionId).toBeDefined()
+        expect(event.sessionId).not.toBe('')
+      }
+
+      // Verify no identify events were published
+      const identifyEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.identify)
+      expect(identifyEvent).toBeUndefined()
+
+      await eventCapture.stop()
+    })
+  })
+
+  describe('Identity Data in Session Info', () => {
+    it('should populate actorGivenId, actorName, and actorData in session info', async () => {
+      const testUserId = `session-user-${randomUUID()}`
+      const testUserName = `Session User ${randomUUID()}`
+      const testUserData = {
+        name: `Session Test User ${randomUUID()}`,
+        role: 'Developer',
+        team: 'Platform',
+      }
+
+      // Enable tracking with identify function
+      track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+        identify: async () => ({
+          userId: testUserId,
+          userName: testUserName,
+          userData: testUserData,
+        }),
+      })
+
+      // Call a tool to trigger identification
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Test session info',
+              context: 'Adding a todo item for session info test',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Get session info from server data
+      const data = getServerTrackingData(server.server)
+      const sessionInfo = data?.sessionInfo
+
+      expect(sessionInfo).toBeDefined()
+      expect(sessionInfo?.identifyActorGivenId).toBe(testUserId)
+      expect(sessionInfo?.identifyActorName).toBe(testUserName)
+      expect(sessionInfo?.identifyActorData).toEqual(testUserData)
+    })
+
+    it('should include identity data in tracked events', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      const testUserId = `event-user-${randomUUID()}`
+      const testUserName = `Event User ${randomUUID()}`
+      const testUserData = {
+        name: `Event Test User ${randomUUID()}`,
+        subscription: 'premium',
+      }
+
+      // Enable tracking with identify function
+      track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+        identify: async () => ({
+          userId: testUserId,
+          userName: testUserName,
+          userData: testUserData,
+        }),
+      })
+
+      // Call a tool
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Test event data',
+              context: 'Adding a todo item for event data test',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Check that events include session info with actor data
+      const events = eventCapture.getEvents()
+      const toolCallEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+
+      expect(toolCallEvent).toBeDefined()
+      // The event should have access to session info through the server's session data
+
+      const data = getServerTrackingData(server.server)
+      expect(data?.sessionInfo.identifyActorGivenId).toBe(testUserId)
+      expect(data?.sessionInfo.identifyActorName).toBe(testUserName)
+      expect(data?.sessionInfo.identifyActorData).toEqual(testUserData)
+
+      await eventCapture.stop()
+    })
+  })
+
+  describe('Async Identity Resolution', () => {
+    it('should handle async operations in identify function', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      let asyncOperationCompleted = false
+
+      // Enable tracking with async identify function
+      track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+        identify: async (_request, _extra) => {
+          // Simulate async operation (e.g., database lookup, API call)
+          await new Promise((resolve) => setTimeout(resolve, 100))
+          asyncOperationCompleted = true
+
+          return {
+            userId: `async-user-${randomUUID()}`,
+            userData: {
+              name: `Async User ${randomUUID()}`,
+              source: 'async-lookup',
+            },
+          }
+        },
+      })
+
+      // Call a tool
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Async test todo',
+              context: 'Adding a todo item for async test',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result.content[0].text).toContain('Added todo')
+      expect(asyncOperationCompleted).toBe(true)
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Verify identify event was published with duration
+      const events = eventCapture.getEvents()
+      const identifyEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.identify)
+
+      expect(identifyEvent).toBeDefined()
+      expect(identifyEvent?.duration).toBeGreaterThan(0) // Should have measurable duration
+
+      await eventCapture.stop()
+    })
+
+    it('should handle errors in identify function gracefully', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      const errorMessage = 'Failed to identify user'
+
+      // Enable tracking with identify function that throws
+      track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+        identify: async () => {
+          throw new Error(errorMessage)
+        },
+      })
+
+      // Call a tool - should not fail despite identify error
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Error test todo',
+              context: 'Adding a todo item for error test',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result.content[0].text).toContain('Added todo')
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Verify NO identify event was published (errors in identify function should not publish events)
+      const events = eventCapture.getEvents()
+      const identifyEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.identify)
+
+      expect(identifyEvent).toBeUndefined()
+
+      // Verify no user identity was stored
+      const data = getServerTrackingData(server.server)
+      const sessionId = data?.sessionId
+      const storedIdentity = data?.identifiedSessions.get(sessionId!)
+
+      expect(storedIdentity).toBeUndefined()
+
+      await eventCapture.stop()
+    })
+
+    it('should handle identify function that returns invalid data', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking with identify function that returns invalid structure
+      track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+        identify: async () => {
+          // Return invalid structure (missing required fields)
+          return { invalidField: 'invalid' } as any as UserIdentity
+        },
+      })
+
+      // Call a tool
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Invalid identity test',
+              context: 'Adding a todo item for invalid identity test',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      expect(result.content[0].text).toContain('Added todo')
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // The system should handle this gracefully
+      const data = getServerTrackingData(server.server)
+      const sessionId = data?.sessionId
+      const storedIdentity = data?.identifiedSessions.get(sessionId!)
+
+      // It will store whatever was returned, even if invalid
+      expect(storedIdentity).toBeDefined()
+      expect((storedIdentity as any).invalidField).toBe('invalid')
+
+      await eventCapture.stop()
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/ids.test.ts
+++ b/packages/mcp/src/__tests__/ids.test.ts
@@ -1,0 +1,25 @@
+import { deterministicPrefixedId, newPrefixedId } from '../modules/ids'
+
+const EVENT_ID_PATTERN = /^evt_[0-9a-f-]{36}$/
+const DETERMINISTIC_SESSION_ID_PATTERN = /^ses_[0-9a-f]{32}$/
+const SESSION_ID_PATTERN = /^ses_[0-9a-f-]{36}$/
+
+describe('SDK IDs', () => {
+  it('generates prefixed IDs for new SDK events and sessions', () => {
+    const eventId = newPrefixedId('evt')
+    const sessionId = newPrefixedId('ses')
+
+    expect(eventId).toMatch(EVENT_ID_PATTERN)
+    expect(sessionId).toMatch(SESSION_ID_PATTERN)
+  })
+
+  it('derives stable prefixed IDs from MCP session inputs', () => {
+    const first = deterministicPrefixedId('ses', 'mcp-session:project')
+    const second = deterministicPrefixedId('ses', 'mcp-session:project')
+    const other = deterministicPrefixedId('ses', 'other-session:project')
+
+    expect(first).toBe(second)
+    expect(first).not.toBe(other)
+    expect(first).toMatch(DETERMINISTIC_SESSION_ID_PATTERN)
+  })
+})

--- a/packages/mcp/src/__tests__/mcp-payloads.test.ts
+++ b/packages/mcp/src/__tests__/mcp-payloads.test.ts
@@ -1,0 +1,67 @@
+import { buildCapturedMcpParameters } from '../modules/mcp-payloads'
+
+describe('buildCapturedMcpParameters', () => {
+  it('captures useful tool-call inputs without transport internals or duplicated intent', () => {
+    const parameters = buildCapturedMcpParameters({
+      id: 102,
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: {
+        name: 'projects-get',
+        arguments: {
+          context: 'Review local project access before inspecting MCP analytics capture results.',
+          projectId: 1,
+          api_token: 'phc_123456789012345678901234567890',
+        },
+      },
+      extra: {
+        requestInfo: {
+          headers: {
+            authorization: 'Bearer phx_123456789012345678901234567890',
+          },
+        },
+        signal: {},
+      },
+    })
+
+    expect(parameters).toEqual({
+      request: {
+        id: 102,
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        params: {
+          name: 'projects-get',
+          arguments: {
+            projectId: 1,
+            api_token: '[redacted]',
+          },
+        },
+      },
+    })
+  })
+
+  it('redacts PostHog tokens from captured string values', () => {
+    const parameters = buildCapturedMcpParameters({
+      method: 'tools/call',
+      params: {
+        name: 'projects-get',
+        arguments: {
+          summary: 'Default project token api_token: phc_123456789012345678901234567890.',
+        },
+      },
+    })
+
+    expect(JSON.stringify(parameters)).not.toContain('phc_')
+    expect(parameters).toEqual({
+      request: {
+        method: 'tools/call',
+        params: {
+          name: 'projects-get',
+          arguments: {
+            summary: 'Default project token api_token: [redacted].',
+          },
+        },
+      },
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/mcp-version-compatibility.test.ts
+++ b/packages/mcp/src/__tests__/mcp-version-compatibility.test.ts
@@ -1,0 +1,21 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { isCompatibleServerType } from '../modules/compatibility'
+
+describe('MCP Version Compatibility', () => {
+  it('should be compatible with currently installed MCP version', () => {
+    // Create a new server instance
+    const server = new Server(
+      {
+        name: 'test-server',
+        version: '1.0.0',
+      },
+      {
+        capabilities: {},
+      }
+    )
+
+    // Test compatibility using isCompatibleServerType
+    const result = isCompatibleServerType(server)
+    expect(result).toBe(server)
+  })
+})

--- a/packages/mcp/src/__tests__/posthog-events.test.ts
+++ b/packages/mcp/src/__tests__/posthog-events.test.ts
@@ -1,0 +1,546 @@
+import {
+  POSTHOG_MCP_ANALYTICS_SOURCE,
+  PostHogMCPAnalyticsEvent,
+  PostHogMCPAnalyticsProperty,
+} from '../modules/constants'
+import { MCPAnalyticsEventType } from '../modules/event-types'
+import { buildPostHogCaptureEvents, type PostHogCaptureEvent } from '../modules/posthog-events'
+import type { Event } from '../types'
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: 'evt_test123',
+    sessionId: 'ses_session456',
+    apiKey: 'proj_1',
+    eventType: MCPAnalyticsEventType.mcpToolsCall,
+    timestamp: new Date('2025-01-15T10:00:00Z'),
+    resourceName: 'get_weather',
+    serverName: 'weather-server',
+    serverVersion: '1.0.0',
+    clientName: 'claude-desktop',
+    clientVersion: '2.0.0',
+    duration: 150,
+    isError: false,
+    ...overrides,
+  }
+}
+
+function findEvent(events: PostHogCaptureEvent[], eventName: string): PostHogCaptureEvent | undefined {
+  return events.find((event) => event.event === eventName)
+}
+
+describe('buildPostHogCaptureEvents', () => {
+  it('builds the regular MCP tool-call event payload', () => {
+    const [event] = buildPostHogCaptureEvents(makeEvent())
+
+    expect(event.event).toBe(PostHogMCPAnalyticsEvent.ToolCall)
+    expect(event.type).toBe('capture')
+    expect(event.distinct_id).toBe('ses_session456')
+    expect(event.timestamp).toBe('2025-01-15T10:00:00.000Z')
+
+    expect(event.properties[PostHogMCPAnalyticsProperty.SessionId]).toBe('ses_session456')
+    expect(event.properties[PostHogMCPAnalyticsProperty.Source]).toBe(POSTHOG_MCP_ANALYTICS_SOURCE)
+    expect(event.properties[PostHogMCPAnalyticsProperty.ToolName]).toBe('get_weather')
+    expect(event.properties[PostHogMCPAnalyticsProperty.ResourceName]).toBe('get_weather')
+    expect(event.properties[PostHogMCPAnalyticsProperty.DurationMs]).toBe(150)
+    expect(event.properties[PostHogMCPAnalyticsProperty.ServerName]).toBe('weather-server')
+    expect(event.properties[PostHogMCPAnalyticsProperty.ServerVersion]).toBe('1.0.0')
+    expect(event.properties[PostHogMCPAnalyticsProperty.ClientName]).toBe('claude-desktop')
+    expect(event.properties[PostHogMCPAnalyticsProperty.ClientVersion]).toBe('2.0.0')
+    expect(event.properties[PostHogMCPAnalyticsProperty.IsError]).toBe(false)
+    expect(event.properties).not.toHaveProperty('project_id')
+  })
+
+  it('keeps the canonical MCP analytics event contract stable', () => {
+    const events = buildPostHogCaptureEvents(
+      makeEvent({
+        duration: 250,
+        parameters: { city: 'London' },
+        response: { temp: 15 },
+        userIntent: 'Check the weather in London',
+        userIntentSource: 'context_parameter',
+      }),
+      { enableAITracing: true }
+    )
+
+    const toolCall = findEvent(events, PostHogMCPAnalyticsEvent.ToolCall)
+    const span = findEvent(events, PostHogMCPAnalyticsEvent.AiSpan)
+
+    expect(toolCall?.properties).toEqual(
+      expect.objectContaining({
+        [PostHogMCPAnalyticsProperty.AiSpanId]: 'evt_test123',
+        [PostHogMCPAnalyticsProperty.AiTraceId]: 'ses_session456',
+        [PostHogMCPAnalyticsProperty.DurationMs]: 250,
+        [PostHogMCPAnalyticsProperty.Intent]: 'Check the weather in London',
+        [PostHogMCPAnalyticsProperty.IntentSource]: 'context_parameter',
+        [PostHogMCPAnalyticsProperty.IsError]: false,
+        [PostHogMCPAnalyticsProperty.Parameters]: { city: 'London' },
+        [PostHogMCPAnalyticsProperty.Response]: { temp: 15 },
+        [PostHogMCPAnalyticsProperty.SessionId]: 'ses_session456',
+        [PostHogMCPAnalyticsProperty.Source]: POSTHOG_MCP_ANALYTICS_SOURCE,
+        [PostHogMCPAnalyticsProperty.ToolName]: 'get_weather',
+      })
+    )
+    expect(toolCall?.properties).not.toHaveProperty('$mcp_context')
+
+    expect(span?.properties).toEqual(
+      expect.objectContaining({
+        [PostHogMCPAnalyticsProperty.AiInputState]: { city: 'London' },
+        [PostHogMCPAnalyticsProperty.AiIsError]: false,
+        [PostHogMCPAnalyticsProperty.AiLatency]: 0.25,
+        [PostHogMCPAnalyticsProperty.AiOutputState]: { temp: 15 },
+        [PostHogMCPAnalyticsProperty.AiSessionId]: 'posthog_mcp_analytics_ses_session456',
+        [PostHogMCPAnalyticsProperty.AiSpanId]: 'evt_test123',
+        [PostHogMCPAnalyticsProperty.AiSpanName]: 'get_weather',
+        [PostHogMCPAnalyticsProperty.AiTraceId]: 'ses_session456',
+        [PostHogMCPAnalyticsProperty.Intent]: 'Check the weather in London',
+        [PostHogMCPAnalyticsProperty.IntentSource]: 'context_parameter',
+        [PostHogMCPAnalyticsProperty.SessionId]: 'ses_session456',
+        [PostHogMCPAnalyticsProperty.Source]: POSTHOG_MCP_ANALYTICS_SOURCE,
+      })
+    )
+  })
+
+  it('uses identifyActorGivenId as distinct_id when available', () => {
+    const [event] = buildPostHogCaptureEvents(makeEvent({ identifyActorGivenId: 'user_abc123' }))
+
+    expect(event.distinct_id).toBe('user_abc123')
+  })
+
+  it('falls back to sessionId when identifyActorGivenId is not set', () => {
+    const [event] = buildPostHogCaptureEvents(makeEvent({ identifyActorGivenId: undefined }))
+
+    expect(event.distinct_id).toBe('ses_session456')
+  })
+
+  it('builds an $exception event alongside the regular event for errors', () => {
+    const events = buildPostHogCaptureEvents(
+      makeEvent({
+        isError: true,
+        error: {
+          message: 'Connection timeout',
+          type: 'TimeoutError',
+          stack: 'TimeoutError: Connection timeout\n    at fetch (/app/index.js:10:5)',
+        },
+      })
+    )
+
+    expect(events).toHaveLength(2)
+    expect(events[0].event).toBe('$mcp_tool_call')
+    expect(events[0].properties.$mcp_is_error).toBe(true)
+
+    const exceptionEvent = events[1]
+    expect(exceptionEvent.event).toBe('$exception')
+    expect(exceptionEvent.distinct_id).toBe('ses_session456')
+    expect(exceptionEvent.properties.$exception_message).toBe('Connection timeout')
+    expect(exceptionEvent.properties.$exception_type).toBe('TimeoutError')
+    expect(exceptionEvent.properties.$exception_stacktrace).toBe(
+      'TimeoutError: Connection timeout\n    at fetch (/app/index.js:10:5)'
+    )
+    expect(exceptionEvent.properties.$exception_source).toBe('backend')
+    expect(exceptionEvent.properties.$session_id).toBe('ses_session456')
+    expect(exceptionEvent.properties.$mcp_resource_name).toBe('get_weather')
+    expect(exceptionEvent.properties.$mcp_tool_name).toBe('get_weather')
+    expect(exceptionEvent.properties.$mcp_server_name).toBe('weather-server')
+  })
+
+  it('spreads customer eventProperties onto the $exception event', () => {
+    const events = buildPostHogCaptureEvents(
+      makeEvent({
+        isError: true,
+        error: { message: 'boom' },
+        properties: {
+          deployment: 'prod',
+          $mcp_exec_tool_call_description: 'Run a HogQL/SQL query.',
+          $groups: { organization: 'org_123' },
+        },
+      })
+    )
+
+    const exceptionEvent = findEvent(events, PostHogMCPAnalyticsEvent.Exception)
+
+    expect(exceptionEvent?.properties.deployment).toBe('prod')
+    expect(exceptionEvent?.properties.$mcp_exec_tool_call_description).toBe('Run a HogQL/SQL query.')
+    expect(exceptionEvent?.properties.$groups).toEqual({
+      organization: 'org_123',
+    })
+  })
+
+  it('does not build an $exception event when isError is false', () => {
+    const events = buildPostHogCaptureEvents(makeEvent({ isError: false }))
+
+    expect(events).toHaveLength(1)
+    expect(events[0].event).toBe('$mcp_tool_call')
+  })
+
+  it('includes $set person properties from identity data', () => {
+    const [event] = buildPostHogCaptureEvents(
+      makeEvent({
+        identifyActorGivenId: 'user_abc',
+        identifyActorName: 'Alice',
+        identifyActorData: { email: 'alice@example.com', plan: 'pro' },
+      })
+    )
+
+    expect(event.properties.$set).toEqual({
+      name: 'Alice',
+      email: 'alice@example.com',
+      plan: 'pro',
+    })
+  })
+
+  it('does not include $set when no identity data is present', () => {
+    const [event] = buildPostHogCaptureEvents(makeEvent())
+
+    expect(event.properties.$set).toBeUndefined()
+  })
+
+  it('passes through parameters and response as-is', () => {
+    const [event] = buildPostHogCaptureEvents(
+      makeEvent({
+        parameters: { city: 'London', units: 'celsius' },
+        response: { temperature: 15, condition: 'cloudy' },
+      })
+    )
+
+    expect(event.properties.$mcp_parameters).toEqual({
+      city: 'London',
+      units: 'celsius',
+    })
+    expect(event.properties.$mcp_response).toEqual({
+      temperature: 15,
+      condition: 'cloudy',
+    })
+  })
+
+  it('passes through string parameters and response as-is', () => {
+    const [event] = buildPostHogCaptureEvents(
+      makeEvent({
+        parameters: 'raw input',
+        response: 'raw output',
+      })
+    )
+
+    expect(event.properties.$mcp_parameters).toBe('raw input')
+    expect(event.properties.$mcp_response).toBe('raw output')
+  })
+
+  it('sets $mcp_listed_tool_names on mcp_tools_list events', () => {
+    const [event] = buildPostHogCaptureEvents(
+      makeEvent({
+        eventType: MCPAnalyticsEventType.mcpToolsList,
+        resourceName: undefined,
+        listedToolNames: ['get_weather', 'list_alerts', 'find_station'],
+      })
+    )
+
+    expect(event.properties[PostHogMCPAnalyticsProperty.ListedToolNames]).toEqual([
+      'get_weather',
+      'list_alerts',
+      'find_station',
+    ])
+  })
+
+  it('does not set $mcp_listed_tool_names on non-tools/list events', () => {
+    const [event] = buildPostHogCaptureEvents(
+      makeEvent({
+        listedToolNames: ['should_be_ignored'],
+      })
+    )
+
+    expect(event.properties[PostHogMCPAnalyticsProperty.ListedToolNames]).toBeUndefined()
+  })
+
+  it('does not set $mcp_listed_tool_names when the array is empty', () => {
+    const [event] = buildPostHogCaptureEvents(
+      makeEvent({
+        eventType: MCPAnalyticsEventType.mcpToolsList,
+        listedToolNames: [],
+      })
+    )
+
+    expect(event.properties[PostHogMCPAnalyticsProperty.ListedToolNames]).toBeUndefined()
+  })
+
+  it('sets $mcp_tool_description on tool-call and exception events', () => {
+    const description = 'Fetches the current weather for a given city, returning temperature and conditions.'
+    const events = buildPostHogCaptureEvents(
+      makeEvent({
+        toolDescription: description,
+        isError: true,
+        error: { message: 'boom' },
+      })
+    )
+
+    const toolCallEvent = findEvent(events, PostHogMCPAnalyticsEvent.ToolCall)
+    const exceptionEvent = findEvent(events, PostHogMCPAnalyticsEvent.Exception)
+
+    expect(toolCallEvent?.properties[PostHogMCPAnalyticsProperty.ToolDescription]).toBe(description)
+    expect(exceptionEvent?.properties[PostHogMCPAnalyticsProperty.ToolDescription]).toBe(description)
+  })
+
+  it('does not set $mcp_tool_description for non tools/call events', () => {
+    const [event] = buildPostHogCaptureEvents(
+      makeEvent({
+        eventType: MCPAnalyticsEventType.mcpResourcesRead,
+        toolDescription: 'should be omitted',
+      })
+    )
+
+    expect(event.properties[PostHogMCPAnalyticsProperty.ToolDescription]).toBeUndefined()
+  })
+
+  it('only sets $mcp_tool_name for tools/call events', () => {
+    const [toolCallEvent] = buildPostHogCaptureEvents(
+      makeEvent({
+        eventType: MCPAnalyticsEventType.mcpToolsCall,
+        resourceName: 'get_weather',
+      })
+    )
+    expect(toolCallEvent.properties.$mcp_tool_name).toBe('get_weather')
+    expect(toolCallEvent.properties.$mcp_resource_name).toBe('get_weather')
+
+    const [resourceEvent] = buildPostHogCaptureEvents(
+      makeEvent({
+        eventType: MCPAnalyticsEventType.mcpResourcesRead,
+        resourceName: 'my_resource',
+      })
+    )
+    expect(resourceEvent.properties.$mcp_tool_name).toBeUndefined()
+    expect(resourceEvent.properties.$mcp_resource_name).toBe('my_resource')
+  })
+
+  it('maps MCP event types to PostHog event names', () => {
+    const eventTypes = [
+      [MCPAnalyticsEventType.custom, PostHogMCPAnalyticsEvent.Custom],
+      [MCPAnalyticsEventType.identify, PostHogMCPAnalyticsEvent.Identify],
+      [MCPAnalyticsEventType.mcpToolsCall, PostHogMCPAnalyticsEvent.ToolCall],
+      [MCPAnalyticsEventType.mcpToolsList, PostHogMCPAnalyticsEvent.ToolsList],
+      [MCPAnalyticsEventType.mcpInitialize, PostHogMCPAnalyticsEvent.Initialize],
+      [MCPAnalyticsEventType.mcpResourcesRead, PostHogMCPAnalyticsEvent.ResourceRead],
+      [MCPAnalyticsEventType.mcpResourcesList, PostHogMCPAnalyticsEvent.ResourcesList],
+      [MCPAnalyticsEventType.mcpPromptsGet, PostHogMCPAnalyticsEvent.PromptGet],
+      [MCPAnalyticsEventType.mcpPromptsList, PostHogMCPAnalyticsEvent.PromptsList],
+    ] satisfies [MCPAnalyticsEventType, PostHogMCPAnalyticsEvent][]
+
+    for (const [input, expected] of eventTypes) {
+      const [event] = buildPostHogCaptureEvents(makeEvent({ eventType: input }))
+
+      expect(event.event).toBe(expected)
+    }
+  })
+
+  it('spreads customer-defined tags and properties directly into properties', () => {
+    const [event] = buildPostHogCaptureEvents(
+      makeEvent({
+        properties: {
+          env: 'production',
+          trace_id: 'abc-123',
+          device: 'mobile',
+          feature_flags: ['dark_mode'],
+        },
+      })
+    )
+
+    expect(event.properties.env).toBe('production')
+    expect(event.properties.trace_id).toBe('abc-123')
+    expect(event.properties.device).toBe('mobile')
+    expect(event.properties.feature_flags).toEqual(['dark_mode'])
+  })
+
+  it('does not include customer tag or property keys when not set on event', () => {
+    const [event] = buildPostHogCaptureEvents(makeEvent())
+
+    expect(event.properties.$mcp_source).toBe('posthog_mcp_analytics')
+    expect(event.properties.env).toBeUndefined()
+    expect(event.properties.device).toBeUndefined()
+  })
+
+  it('maps userIntent to the MCP intent property', () => {
+    const [event] = buildPostHogCaptureEvents(makeEvent({ userIntent: 'Check the weather in London' }))
+
+    expect(event.properties.$mcp_intent).toBe('Check the weather in London')
+  })
+
+  it('maps userIntentSource to the MCP intent source property', () => {
+    const [event] = buildPostHogCaptureEvents(
+      makeEvent({
+        userIntent: 'Check the weather in London',
+        userIntentSource: 'inferred',
+      })
+    )
+
+    expect(event.properties.$mcp_intent_source).toBe('inferred')
+  })
+
+  it('emits $ai_span alongside regular event for tool calls when enableAITracing is true', () => {
+    const events = buildPostHogCaptureEvents(
+      makeEvent({
+        eventType: MCPAnalyticsEventType.mcpToolsCall,
+        resourceName: 'get_weather',
+        duration: 250,
+        parameters: { city: 'London' },
+        response: { temp: 15 },
+      }),
+      { enableAITracing: true }
+    )
+
+    expect(events).toHaveLength(2)
+
+    const regular = findEvent(events, '$mcp_tool_call')
+    expect(regular).toBeDefined()
+
+    const span = findEvent(events, '$ai_span')
+    expect(span).toBeDefined()
+    expect(span?.type).toBe('capture')
+    expect(span?.distinct_id).toBe('ses_session456')
+    expect(span?.timestamp).toBe('2025-01-15T10:00:00.000Z')
+
+    expect(span?.properties.$ai_session_id).toBe('posthog_mcp_analytics_ses_session456')
+    expect(span?.properties.$ai_trace_id).toBeDefined()
+    expect(span?.properties.$ai_span_id).toBeDefined()
+    expect(span?.properties.$ai_trace_id).not.toBe(span?.properties.$ai_span_id)
+    expect(span?.properties.$ai_span_name).toBe('get_weather')
+    expect(span?.properties.$ai_latency).toBeCloseTo(0.25)
+    expect(span?.properties.$ai_is_error).toBe(false)
+    expect(span?.properties.$ai_input_state).toEqual({ city: 'London' })
+    expect(span?.properties.$ai_output_state).toEqual({ temp: 15 })
+    expect(span?.properties.$session_id).toBe('ses_session456')
+    expect(span?.properties.$mcp_source).toBe('posthog_mcp_analytics')
+    expect(span?.properties.$mcp_server_name).toBe('weather-server')
+    expect(span?.properties.$mcp_client_name).toBe('claude-desktop')
+
+    expect(regular?.properties.$ai_trace_id).toBe(span?.properties.$ai_trace_id)
+    expect(regular?.properties.$ai_span_id).toBe(span?.properties.$ai_span_id)
+  })
+
+  it('uses SDK event and session IDs directly for AI trace and span IDs', () => {
+    const sesId = 'ses_trace123'
+    const evtA = 'evt_a123'
+    const evtB = 'evt_b123'
+
+    const spanA = findEvent(
+      buildPostHogCaptureEvents(makeEvent({ id: evtA, sessionId: sesId }), {
+        enableAITracing: true,
+      }),
+      '$ai_span'
+    )
+    const spanB = findEvent(
+      buildPostHogCaptureEvents(makeEvent({ id: evtB, sessionId: sesId }), {
+        enableAITracing: true,
+      }),
+      '$ai_span'
+    )
+    const spanC = findEvent(
+      buildPostHogCaptureEvents(makeEvent({ id: evtA, sessionId: sesId }), {
+        enableAITracing: true,
+      }),
+      '$ai_span'
+    )
+
+    expect(spanA?.properties.$ai_session_id).toBe(`posthog_mcp_analytics_${sesId}`)
+    expect(spanA?.properties.$ai_session_id).toBe(spanB?.properties.$ai_session_id)
+    expect(spanA?.properties.$ai_trace_id).toBe(spanB?.properties.$ai_trace_id)
+    expect(spanA?.properties.$ai_span_id).not.toBe(spanB?.properties.$ai_span_id)
+    expect(spanA?.properties.$ai_span_id).toBe(spanC?.properties.$ai_span_id)
+    expect(spanA?.properties.$ai_trace_id).not.toBe(spanA?.properties.$ai_span_id)
+    expect(spanA?.properties.$ai_trace_id).toBe(sesId)
+    expect(spanA?.properties.$ai_span_id).toBe(evtA)
+  })
+
+  it('does not emit $ai_span when enableAITracing is false or unset', () => {
+    const defaultEvents = buildPostHogCaptureEvents(makeEvent({ eventType: MCPAnalyticsEventType.mcpToolsCall }))
+    expect(defaultEvents).toHaveLength(1)
+    expect(defaultEvents[0].event).toBe('$mcp_tool_call')
+
+    const disabledEvents = buildPostHogCaptureEvents(makeEvent({ eventType: MCPAnalyticsEventType.mcpToolsCall }), {
+      enableAITracing: false,
+    })
+    expect(disabledEvents).toHaveLength(1)
+    expect(disabledEvents[0].event).toBe('$mcp_tool_call')
+  })
+
+  it('does not emit $ai_span for non-tool-call events even with enableAITracing', () => {
+    const nonToolCallTypes = [
+      MCPAnalyticsEventType.mcpInitialize,
+      MCPAnalyticsEventType.mcpToolsList,
+      MCPAnalyticsEventType.mcpResourcesRead,
+      MCPAnalyticsEventType.mcpResourcesList,
+      MCPAnalyticsEventType.mcpPromptsGet,
+      MCPAnalyticsEventType.mcpPromptsList,
+    ]
+
+    for (const eventType of nonToolCallTypes) {
+      const events = buildPostHogCaptureEvents(makeEvent({ eventType }), {
+        enableAITracing: true,
+      })
+
+      expect(findEvent(events, '$ai_span')).toBeUndefined()
+    }
+  })
+
+  it('spreads customer properties directly on $ai_span', () => {
+    const events = buildPostHogCaptureEvents(
+      makeEvent({
+        eventType: MCPAnalyticsEventType.mcpToolsCall,
+        properties: {
+          env: 'production',
+          region: 'us-east',
+          feature_flag: 'new_ui',
+          count: 42,
+        },
+      }),
+      { enableAITracing: true }
+    )
+
+    const span = findEvent(events, '$ai_span')
+    expect(span?.properties.env).toBe('production')
+    expect(span?.properties.region).toBe('us-east')
+    expect(span?.properties.feature_flag).toBe('new_ui')
+    expect(span?.properties.count).toBe(42)
+
+    const regular = findEvent(events, '$mcp_tool_call')
+    expect(regular?.properties.env).toBe('production')
+    expect(regular?.properties.feature_flag).toBe('new_ui')
+    expect(regular?.properties.count).toBe(42)
+  })
+
+  it('allows customer properties to override $ai_* defaults on $ai_span', () => {
+    const customTraceId = 'custom-trace-uuid-from-customer'
+    const events = buildPostHogCaptureEvents(
+      makeEvent({
+        eventType: MCPAnalyticsEventType.mcpToolsCall,
+        properties: { $ai_trace_id: customTraceId, $ai_span_name: 'custom_name' },
+      }),
+      { enableAITracing: true }
+    )
+
+    const span = findEvent(events, '$ai_span')
+    expect(span?.properties.$ai_trace_id).toBe(customTraceId)
+    expect(span?.properties.$ai_span_name).toBe('custom_name')
+  })
+
+  it('emits regular + $exception + $ai_span for error tool calls with enableAITracing', () => {
+    const events = buildPostHogCaptureEvents(
+      makeEvent({
+        eventType: MCPAnalyticsEventType.mcpToolsCall,
+        isError: true,
+        error: {
+          message: 'Tool execution failed',
+          type: 'ExecutionError',
+        },
+      }),
+      { enableAITracing: true }
+    )
+
+    expect(events).toHaveLength(3)
+    expect(events[0].event).toBe('$mcp_tool_call')
+    expect(events[1].event).toBe('$exception')
+    expect(events[2].event).toBe('$ai_span')
+    expect(events[2].properties.$ai_is_error).toBe(true)
+    expect(events[2].properties.$ai_error).toEqual({
+      message: 'Tool execution failed',
+      type: 'ExecutionError',
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/publishCustomEvent.test.ts
+++ b/packages/mcp/src/__tests__/publishCustomEvent.test.ts
@@ -1,0 +1,135 @@
+import { publishCustomEvent, track } from '../index'
+import { MCPAnalyticsEventType } from '../modules/event-types'
+import type { MCPServerLike } from '../types'
+import { EventCapture } from './test-utils'
+
+function makeMockLowLevelServer(): MCPServerLike {
+  return {
+    _requestHandlers: new Map(),
+    _serverInfo: { name: 'test-server', version: '1.0.0' },
+    getClientVersion: () => ({ name: 'test-client', version: '1.0.0' }),
+    setRequestHandler: () => {},
+  }
+}
+
+describe('publishCustomEvent', () => {
+  it('publishes a $mcp_custom event for a tracked server', async () => {
+    const server = makeMockLowLevelServer()
+    track(server, { apiKey: 'phc_test' })
+
+    const capture = new EventCapture()
+    await capture.start()
+
+    await publishCustomEvent(server, {
+      resourceName: 'custom-action',
+      parameters: { action: 'user-feedback', rating: 5 },
+      message: 'User provided feedback',
+      properties: { source: 'survey' },
+    })
+
+    const events = capture.getEvents()
+    expect(events).toHaveLength(1)
+    const [event] = events
+    expect(event.eventType).toBe(MCPAnalyticsEventType.custom)
+    expect(event.resourceName).toBe('custom-action')
+    expect(event.parameters).toEqual({ action: 'user-feedback', rating: 5 })
+    expect(event.userIntent).toBe('User provided feedback')
+    expect(event.properties).toEqual({ source: 'survey' })
+
+    await capture.stop()
+  })
+
+  it('records error details when isError is true', async () => {
+    const server = makeMockLowLevelServer()
+    track(server, { apiKey: 'phc_test' })
+
+    const capture = new EventCapture()
+    await capture.start()
+
+    await publishCustomEvent(server, {
+      isError: true,
+      error: { message: 'Custom error', code: 'ERR_001' },
+    })
+
+    const [event] = capture.getEvents()
+    expect(event.isError).toBe(true)
+    expect((event.error as { message?: string } | undefined)?.message).toBe('Custom error')
+
+    await capture.stop()
+  })
+
+  it('also works with high-level McpServer-like wrappers', async () => {
+    const lowLevelServer = makeMockLowLevelServer()
+    const highLevelServer = { server: lowLevelServer, _registeredTools: {}, tool: () => {} }
+    track(highLevelServer, { apiKey: 'phc_test' })
+
+    const capture = new EventCapture()
+    await capture.start()
+
+    await publishCustomEvent(highLevelServer, { resourceName: 'wrapper-action' })
+
+    const [event] = capture.getEvents()
+    expect(event.resourceName).toBe('wrapper-action')
+
+    await capture.stop()
+  })
+
+  it('rejects when the server has not been tracked', async () => {
+    await expect(publishCustomEvent({}, { resourceName: 'whatever' })).rejects.toThrow(
+      'Server is not tracked. Call `track(server, options)` before `publishCustomEvent`.'
+    )
+  })
+
+  it('rejects when the first argument is not an object', async () => {
+    await expect(publishCustomEvent(undefined as unknown as object)).rejects.toThrow(
+      'First argument must be a tracked MCP server instance'
+    )
+  })
+
+  it('always uses the custom event type for publishCustomEvent', async () => {
+    const server = makeMockLowLevelServer()
+    track(server, { apiKey: 'phc_test' })
+
+    const capture = new EventCapture()
+    await capture.start()
+
+    await publishCustomEvent(server, {})
+
+    const [event] = capture.getEvents()
+    expect(event.eventType).toBe(MCPAnalyticsEventType.custom)
+
+    await capture.stop()
+  })
+
+  it('stamps a timestamp on the captured event', async () => {
+    const server = makeMockLowLevelServer()
+    track(server, { apiKey: 'phc_test' })
+
+    const capture = new EventCapture()
+    await capture.start()
+    const before = Date.now()
+
+    await publishCustomEvent(server, {})
+
+    const [event] = capture.getEvents()
+    expect(event.timestamp).toBeInstanceOf(Date)
+    expect((event.timestamp as Date).getTime()).toBeGreaterThanOrEqual(before)
+
+    await capture.stop()
+  })
+
+  it('accepts minimal event data', async () => {
+    const server = makeMockLowLevelServer()
+    track(server, { apiKey: 'phc_test' })
+
+    const capture = new EventCapture()
+    await capture.start()
+
+    await publishCustomEvent(server, {})
+    await publishCustomEvent(server)
+
+    expect(capture.getEvents()).toHaveLength(2)
+
+    await capture.stop()
+  })
+})

--- a/packages/mcp/src/__tests__/redaction.test.ts
+++ b/packages/mcp/src/__tests__/redaction.test.ts
@@ -1,0 +1,600 @@
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { track } from '../index'
+import { MCPAnalyticsEventType } from '../modules/event-types'
+import { redactEvent } from '../modules/redaction'
+import type { RedactFunction, UnredactedEvent } from '../types'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+import { EventCapture } from './test-utils'
+
+const CREDIT_CARD_PATTERN = /\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}/
+const SESSION_ID_PATTERN = /^ses_/
+
+describe('redactEvent', () => {
+  // Mock redaction function that replaces strings with "[REDACTED]"
+  const mockRedactFn: RedactFunction = jest.fn(async (text: string) => `[REDACTED-${text.length}]`)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should redact basic string fields', async () => {
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      userIntent: 'sensitive user intent',
+      timestamp: new Date('2024-01-01'),
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    expect(redacted.userIntent).toBe('[REDACTED-21]')
+    expect(mockRedactFn).toHaveBeenCalledWith('sensitive user intent')
+  })
+
+  it('should not redact protected fields', async () => {
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      id: 'evt_456',
+      apiKey: 'proj_789',
+      server: 'my-server',
+      identifyActorGivenId: 'actor_123',
+      identifyActorName: 'John Doe',
+      resourceName: 'my-resource',
+      eventType: 'mcp:tools/call',
+      actorId: 'actor_456',
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    // All protected fields should remain unchanged
+    expect(redacted.sessionId).toBe('ses_123')
+    expect(redacted.id).toBe('evt_456')
+    expect(redacted.apiKey).toBe('proj_789')
+    expect(redacted.server).toBe('my-server')
+    expect(redacted.identifyActorGivenId).toBe('actor_123')
+    expect(redacted.identifyActorName).toBe('John Doe')
+    expect(redacted.resourceName).toBe('my-resource')
+    expect(redacted.eventType).toBe('mcp:tools/call')
+    expect(redacted.actorId).toBe('actor_456')
+
+    // Redact function should not have been called for protected fields
+    expect(mockRedactFn).not.toHaveBeenCalled()
+  })
+
+  it('should redact nested string fields', async () => {
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      parameters: {
+        query: 'sensitive query',
+        options: {
+          apiKey: 'secret-key-123',
+          timeout: 5000,
+        },
+      },
+      response: {
+        data: 'sensitive response data',
+        metadata: {
+          source: 'sensitive source',
+        },
+      },
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    expect(redacted.parameters.query).toBe('[REDACTED-15]')
+    expect(redacted.parameters.options.apiKey).toBe('[REDACTED-14]')
+    expect(redacted.parameters.options.timeout).toBe(5000) // Numbers should not be redacted
+    expect(redacted.response.data).toBe('[REDACTED-23]')
+    expect(redacted.response.metadata.source).toBe('[REDACTED-16]')
+  })
+
+  it('should handle arrays of strings', async () => {
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      parameters: {
+        tags: ['sensitive1', 'sensitive2', 'sensitive3'],
+        numbers: [1, 2, 3],
+      },
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    expect(redacted.parameters.tags).toEqual(['[REDACTED-10]', '[REDACTED-10]', '[REDACTED-10]'])
+    expect(redacted.parameters.numbers).toEqual([1, 2, 3])
+  })
+
+  it('should handle mixed nested structures', async () => {
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      parameters: {
+        users: [
+          { name: 'John', age: 30, email: 'john@example.com' },
+          { name: 'Jane', age: 25, email: 'jane@example.com' },
+        ],
+      },
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    expect(redacted.parameters.users[0].name).toBe('[REDACTED-4]')
+    expect(redacted.parameters.users[0].age).toBe(30)
+    expect(redacted.parameters.users[0].email).toBe('[REDACTED-16]')
+    expect(redacted.parameters.users[1].name).toBe('[REDACTED-4]')
+    expect(redacted.parameters.users[1].age).toBe(25)
+    expect(redacted.parameters.users[1].email).toBe('[REDACTED-16]')
+  })
+
+  it('should preserve null and undefined values', async () => {
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      parameters: {
+        nullValue: null,
+        undefinedValue: undefined,
+        emptyString: '',
+      },
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    expect(redacted.parameters.nullValue).toBeNull()
+    expect(redacted.parameters.undefinedValue).toBeUndefined()
+    expect(redacted.parameters.emptyString).toBe('[REDACTED-0]')
+  })
+
+  it('should preserve Date objects', async () => {
+    const testDate = new Date('2024-01-01T12:00:00Z')
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      timestamp: testDate,
+      parameters: {
+        createdAt: new Date('2024-01-02T12:00:00Z'),
+      },
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    expect(redacted.timestamp).toEqual(testDate)
+    expect(redacted.parameters.createdAt).toEqual(new Date('2024-01-02T12:00:00Z'))
+    expect(redacted.parameters.createdAt).toBeInstanceOf(Date)
+  })
+
+  it('should skip functions in objects', async () => {
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      parameters: {
+        callback: () => console.log('test'),
+        data: 'sensitive data',
+      },
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    expect(redacted.parameters.callback).toBeUndefined()
+    expect(redacted.parameters.data).toBe('[REDACTED-14]')
+  })
+
+  it('should handle complex identifyData object without redacting it', async () => {
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      identifyData: {
+        email: 'user@example.com',
+        preferences: {
+          theme: 'dark',
+          notifications: true,
+        },
+        metadata: {
+          source: 'webapp',
+          version: '1.0.0',
+        },
+      },
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    // identifyData is a protected field, and its nested contents should NOT be redacted
+    expect(redacted.identifyData.email).toBe('user@example.com')
+    expect(redacted.identifyData.preferences.theme).toBe('dark')
+    expect(redacted.identifyData.preferences.notifications).toBe(true)
+    expect(redacted.identifyData.metadata.source).toBe('webapp')
+    expect(redacted.identifyData.metadata.version).toBe('1.0.0')
+
+    // Verify redact function was not called for protected field contents
+    expect(mockRedactFn).not.toHaveBeenCalledWith('user@example.com')
+    expect(mockRedactFn).not.toHaveBeenCalledWith('dark')
+    expect(mockRedactFn).not.toHaveBeenCalledWith('webapp')
+    expect(mockRedactFn).not.toHaveBeenCalledWith('1.0.0')
+  })
+
+  it('should handle error objects', async () => {
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      isError: true,
+      error: {
+        message: 'Sensitive error message',
+        code: 'ERR_001',
+        stack: 'Error: Sensitive error message\n    at functionName (file.js:10:5)',
+      },
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    expect(redacted.isError).toBe(true)
+    expect(redacted.error.message).toBe('[REDACTED-23]')
+    expect(redacted.error.code).toBe('[REDACTED-7]')
+    expect(redacted.error.stack).toBe('[REDACTED-65]')
+  })
+
+  it('should handle deeply nested protected fields correctly', async () => {
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      parameters: {
+        nested: {
+          deeply: {
+            sessionId: 'This should be redacted', // Not a top-level protected field
+            data: 'sensitive data',
+          },
+        },
+      },
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    expect(redacted.sessionId).toBe('ses_123') // Top-level protected
+    expect(redacted.parameters.nested.deeply.sessionId).toBe('[REDACTED-23]') // Nested not protected
+    expect(redacted.parameters.nested.deeply.data).toBe('[REDACTED-14]')
+  })
+
+  it('should handle custom redaction function errors gracefully', async () => {
+    const errorRedactFn: RedactFunction = jest.fn(async () => {
+      throw new Error('Redaction failed')
+    })
+
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      userIntent: 'sensitive data',
+    }
+
+    await expect(redactEvent(event, errorRedactFn)).rejects.toThrow('Redaction failed')
+  })
+
+  it('should not redact nested fields within any protected field', async () => {
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      // Test nested data in identifyData
+      identifyData: {
+        nested: {
+          deeply: {
+            sensitive: 'this should NOT be redacted',
+            data: ['array', 'of', 'strings'],
+          },
+        },
+      },
+      // Test that non-protected fields still get redacted
+      otherData: {
+        nested: {
+          deeply: {
+            sensitive: 'this SHOULD be redacted',
+          },
+        },
+      },
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    // Protected field contents should NOT be redacted
+    expect(redacted.identifyData.nested.deeply.sensitive).toBe('this should NOT be redacted')
+    expect(redacted.identifyData.nested.deeply.data).toEqual(['array', 'of', 'strings'])
+
+    // Non-protected field contents SHOULD be redacted
+    expect(redacted.otherData.nested.deeply.sensitive).toBe('[REDACTED-23]')
+
+    // Verify the redact function was only called for non-protected content
+    expect(mockRedactFn).toHaveBeenCalledWith('this SHOULD be redacted')
+    expect(mockRedactFn).not.toHaveBeenCalledWith('this should NOT be redacted')
+    expect(mockRedactFn).not.toHaveBeenCalledWith('array')
+    expect(mockRedactFn).not.toHaveBeenCalledWith('of')
+    expect(mockRedactFn).not.toHaveBeenCalledWith('strings')
+  })
+
+  it('should create a new object without modifying the original', async () => {
+    const event: UnredactedEvent = {
+      sessionId: 'ses_123',
+      userIntent: 'sensitive data',
+      parameters: {
+        query: 'sensitive query',
+      },
+    }
+
+    const originalEvent = JSON.parse(JSON.stringify(event))
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    // Original should be unchanged
+    expect(event).toEqual(originalEvent)
+
+    // Redacted should be different
+    expect(redacted.userIntent).not.toBe(event.userIntent)
+    expect(redacted.parameters.query).not.toBe(event.parameters.query)
+  })
+
+  it('should handle events with all possible fields', async () => {
+    const event: UnredactedEvent = {
+      id: 'evt_123',
+      apiKey: 'proj_123',
+      sessionId: 'ses_123',
+      actorId: 'actor_123',
+      eventId: 'custom_evt_123',
+      eventType: 'mcp:tools/call',
+      isError: false,
+      error: { message: 'error message' },
+      resourceName: 'resource_123',
+      duration: 1000,
+      timestamp: new Date(),
+      userIntent: 'user intent text',
+      parameters: { param1: 'value1' },
+      response: { result: 'success' },
+      identifyActorGivenId: 'given_id_123',
+      identifyActorName: 'Actor Name',
+      identifyData: { key: 'value' },
+      server: 'server_name',
+    }
+
+    const redacted = await redactEvent(event, mockRedactFn)
+
+    // Protected fields
+    expect(redacted.id).toBe('evt_123')
+    expect(redacted.apiKey).toBe('proj_123')
+    expect(redacted.sessionId).toBe('ses_123')
+    expect(redacted.actorId).toBe('actor_123')
+    expect(redacted.eventType).toBe('mcp:tools/call')
+    expect(redacted.resourceName).toBe('resource_123')
+    expect(redacted.identifyActorGivenId).toBe('given_id_123')
+    expect(redacted.identifyActorName).toBe('Actor Name')
+    expect(redacted.server).toBe('server_name')
+
+    // Non-protected fields
+    expect(redacted.eventId).toBe('[REDACTED-14]')
+    expect(redacted.userIntent).toBe('[REDACTED-16]')
+    expect(redacted.parameters.param1).toBe('[REDACTED-6]')
+    expect(redacted.response.result).toBe('[REDACTED-7]')
+    expect(redacted.error.message).toBe('[REDACTED-13]')
+    // identifyData is protected, so its nested contents should NOT be redacted
+    expect(redacted.identifyData.key).toBe('value')
+
+    // Non-string fields
+    expect(redacted.isError).toBe(false)
+    expect(redacted.duration).toBe(1000)
+    expect(redacted.timestamp).toBeInstanceOf(Date)
+  })
+})
+
+describe('redactEvent integration tests', () => {
+  let server: any
+  let client: any
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    resetTodos()
+    const setup = await setupTestServerAndClient()
+    server = setup.server
+    client = setup.client
+    cleanup = setup.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('should properly redact sensitive data in published events', async () => {
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    // Custom redaction function that clearly marks redacted content
+    const redactSensitiveData: RedactFunction = async (text: string) => {
+      // Redact email addresses
+      if (text.includes('@')) {
+        return '[REDACTED-EMAIL]'
+      }
+      // Redact anything that looks like a secret or key
+      if (text.toLowerCase().includes('secret') || text.toLowerCase().includes('key')) {
+        return '[REDACTED-SECRET]'
+      }
+      // Redact anything that looks like personal data
+      if (text.toLowerCase().includes('password') || text.toLowerCase().includes('ssn')) {
+        return '[REDACTED-SENSITIVE]'
+      }
+      // Default: return original text
+      return text
+    }
+
+    // Enable tracking with redaction
+    track(server, {
+      apiKey: 'test-project',
+      enableTracing: true,
+      redactSensitiveInformation: redactSensitiveData,
+      identify: async () => ({
+        userId: 'test-user-123',
+        userName: 'John Doe',
+        userData: {
+          email: 'user@example.com',
+          apiKey: 'secret-api-key-123',
+        },
+      }),
+    })
+
+    // Call a tool with sensitive data in arguments
+    await client.request(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'add_todo',
+          arguments: {
+            text: 'Send email to admin@company.com with password reset',
+            context: 'Adding a todo item for reset task',
+          },
+        },
+      },
+      CallToolResultSchema
+    )
+
+    // Wait for events to be processed
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // Get the captured events
+    const events = eventCapture.getEvents()
+
+    // Find the tool call event
+    const toolCallEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+
+    expect(toolCallEvent).toBeDefined()
+
+    // Verify sensitive data in parameters was redacted
+    const params = toolCallEvent?.parameters as any
+    expect(params.request.params.arguments.text).toBe('[REDACTED-EMAIL]') // Contains email
+    expect(toolCallEvent?.userIntent).toBe('Adding a todo item for reset task')
+
+    // Find the identify event
+    const identifyEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.identify)
+
+    expect(identifyEvent).toBeDefined()
+
+    // The identify event should have the same parameters structure as the tool call
+    // since it's created from the same base event
+    const identifyParams = identifyEvent?.parameters as any
+    expect(identifyParams.request.params.arguments.text).toBe('[REDACTED-EMAIL]')
+
+    // Verify protected fields were NOT redacted (apiKey is no longer carried on Event;
+    // it lives only on the PostHog client now)
+    expect(toolCallEvent?.sessionId).toMatch(SESSION_ID_PATTERN) // Should start with ses_
+    expect(toolCallEvent?.resourceName).toBe('add_todo')
+    expect(toolCallEvent?.eventType).toBe(MCPAnalyticsEventType.mcpToolsCall)
+
+    // The identify event includes actor info from sessionInfo
+    expect(identifyEvent?.identifyActorGivenId).toBe('test-user-123')
+    expect(identifyEvent?.identifyActorName).toBe('John Doe')
+
+    await eventCapture.stop()
+  })
+
+  it('should handle complex nested structures with redaction', async () => {
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    // Redaction function that redacts credit card numbers
+    const redactCreditCards: RedactFunction = async (text: string) => {
+      // Simple credit card detection (4 groups of 4 digits)
+      if (CREDIT_CARD_PATTERN.test(text)) {
+        return '[REDACTED-CC]'
+      }
+      return text
+    }
+
+    // Enable tracking with redaction
+    track(server, {
+      apiKey: 'test-project',
+      enableTracing: true,
+      redactSensitiveInformation: redactCreditCards,
+    })
+
+    // Call a tool with nested sensitive data
+    await client.request(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'add_todo',
+          arguments: {
+            text: 'Process payment for card 1234 5678 9012 3456',
+            context: 'Processing payment for order',
+          },
+        },
+      },
+      CallToolResultSchema
+    )
+
+    // Wait for events
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const events = eventCapture.getEvents()
+    const toolCallEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+
+    expect(toolCallEvent).toBeDefined()
+
+    const params = toolCallEvent?.parameters as any
+
+    // Verify credit card data in text was redacted
+    expect(params.request.params.arguments.text).toBe('[REDACTED-CC]')
+    expect(toolCallEvent?.userIntent).toBe('Processing payment for order')
+
+    await eventCapture.stop()
+  })
+
+  it('should not redact protected fields even if they contain sensitive patterns', async () => {
+    const eventCapture = new EventCapture()
+    await eventCapture.start()
+
+    // Aggressive redaction that would redact anything with 'id'
+    const aggressiveRedact: RedactFunction = async (text: string) => {
+      if (text.toLowerCase().includes('id')) {
+        return '[REDACTED-ID]'
+      }
+      return text
+    }
+
+    // Enable tracking
+    track(server, {
+      apiKey: 'test-project',
+      enableTracing: true,
+      redactSensitiveInformation: aggressiveRedact,
+      identify: async () => ({
+        userId: 'user-with-id-123',
+        userName: 'David Smith',
+        userData: {
+          internalId: 'internal-id-456',
+        },
+      }),
+    })
+
+    // Call a tool
+    await client.request(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'add_todo',
+          arguments: {
+            text: 'Task with id reference custom-id-789',
+            context: 'Adding task with id reference',
+          },
+        },
+      },
+      CallToolResultSchema
+    )
+
+    // Wait for events
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const events = eventCapture.getEvents()
+
+    // Check tool call event
+    const toolCallEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+
+    // Protected fields should NOT be redacted
+    expect(toolCallEvent?.sessionId).toMatch(SESSION_ID_PATTERN)
+    expect(toolCallEvent?.actorId).toBeUndefined() // Not set in this test
+
+    // Non-protected fields with 'id' should be redacted
+    const params = toolCallEvent?.parameters as any
+    expect(params.request.params.arguments.text).toBe('[REDACTED-ID]')
+    expect(toolCallEvent?.userIntent).toBe('[REDACTED-ID]')
+
+    // Check identify event
+    const identifyEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.identify)
+
+    // Protected identity fields should NOT be redacted
+    expect(identifyEvent?.identifyActorGivenId).toBe('user-with-id-123')
+    expect(identifyEvent?.identifyActorName).toBe('David Smith') // This should NOT be redacted as it's a protected field
+
+    // The identify event parameters should also be redacted
+    const identifyParams = identifyEvent?.parameters as any
+    expect(identifyParams.request.params.arguments.text).toBe('[REDACTED-ID]')
+
+    await eventCapture.stop()
+  })
+})

--- a/packages/mcp/src/__tests__/report-missing.test.ts
+++ b/packages/mcp/src/__tests__/report-missing.test.ts
@@ -1,0 +1,623 @@
+import { randomUUID } from 'node:crypto'
+import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { track } from '../index'
+import { DEFAULT_CONTEXT_PARAMETER_DESCRIPTION } from '../modules/constants'
+import { MCPAnalyticsEventType } from '../modules/event-types'
+import { getServerTrackingData } from '../modules/internal'
+import { EventCapture } from './test-utils'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+
+describe('Report Missing Tool', () => {
+  let server: any
+  let client: any
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    resetTodos()
+    const setup = await setupTestServerAndClient()
+    server = setup.server
+    client = setup.client
+    cleanup = setup.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  describe('1. Tool Injection Tests', () => {
+    it('should add report_missing to tools list when reportMissing is true', async () => {
+      // Enable tracking with report_missing enabled
+      track(server, {
+        apiKey: 'test-project',
+        reportMissing: true,
+        enableTracing: true,
+      })
+
+      // Get the tools list
+      const toolsResponse = await client.request(
+        {
+          method: 'tools/list',
+          params: {},
+        },
+        ListToolsResultSchema
+      )
+
+      // Find report_missing tool
+      const reportMissingTool = toolsResponse.tools.find((tool: any) => tool.name === 'get_more_tools')
+
+      // Verify the tool exists with correct properties
+      expect(reportMissingTool).toBeDefined()
+      expect(reportMissingTool.name).toBe('get_more_tools')
+      expect(reportMissingTool.description).toContain('Check for additional tools')
+
+      // Verify context is required
+      expect(reportMissingTool.inputSchema.required).toContain('context')
+    })
+
+    it('should NOT add get_more_tools when reportMissing is false', async () => {
+      // Enable tracking with get_more_tools disabled
+      track(server, {
+        apiKey: 'test-project',
+        reportMissing: false,
+        enableTracing: true,
+      })
+
+      // Get the tools list
+      const toolsResponse = await client.request(
+        {
+          method: 'tools/list',
+          params: {},
+        },
+        ListToolsResultSchema
+      )
+
+      // Verify report_missing is not in the list
+      const reportMissingTool = toolsResponse.tools.find((tool: any) => tool.name === 'get_more_tools')
+
+      expect(reportMissingTool).toBeUndefined()
+    })
+
+    it('should add report_missing WITHOUT context injection even when context is true', async () => {
+      // Enable tracking with both features enabled
+      track(server, {
+        apiKey: 'test-project',
+        reportMissing: true,
+        context: true,
+        enableTracing: true,
+      })
+
+      // Get the tools list
+      const toolsResponse = await client.request(
+        {
+          method: 'tools/list',
+          params: {},
+        },
+        ListToolsResultSchema
+      )
+
+      // Find report_missing tool
+      const reportMissingTool = toolsResponse.tools.find((tool: any) => tool.name === 'get_more_tools')
+
+      // Verify context is NOT required
+      expect(reportMissingTool.inputSchema.required).toContain('context')
+
+      // Check that other tools DO have injected context
+      const addTodoTool = toolsResponse.tools.find((tool: any) => tool.name === 'add_todo')
+      expect(addTodoTool.inputSchema.properties.context).toEqual({
+        type: 'string',
+        description: DEFAULT_CONTEXT_PARAMETER_DESCRIPTION,
+      })
+      expect(addTodoTool.inputSchema.required).toContain('context')
+    })
+  })
+
+  describe('2. Tool Execution Tests', () => {
+    it('should successfully call get_more_tools with only context', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking
+      track(server, {
+        apiKey: 'test-project',
+        reportMissing: true,
+        enableTracing: true,
+      })
+
+      const missingDescription = 'Need a database query tool for SQL operations'
+
+      // Call report_missing with only description
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'get_more_tools',
+            arguments: {
+              context: missingDescription,
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Verify response
+      expect(result.content[0].text).toContain('Unfortunately')
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Verify event was published
+      const events = eventCapture.getEvents()
+      const reportEvent = events.find(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'get_more_tools'
+      )
+
+      expect(reportEvent).toBeDefined()
+      expect(reportEvent?.userIntent).toBe(missingDescription)
+
+      await eventCapture.stop()
+    })
+
+    it('should successfully call get_more_tools with description and optional context', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking
+      track(server, {
+        apiKey: 'test-project',
+        reportMissing: true,
+        enableTracing: true,
+      })
+
+      const additionalContext = 'User wants to fetch data from external REST APIs'
+
+      // Call report_missing with both parameters
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'get_more_tools',
+            arguments: {
+              context: additionalContext,
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Verify response acknowledges the feedback
+      expect(result.content[0].text).toContain('Unfortunately')
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Verify both parameters were captured in the event
+      const events = eventCapture.getEvents()
+      const reportEvent = events.find(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'get_more_tools'
+      )
+
+      expect(reportEvent).toBeDefined()
+      expect(reportEvent?.userIntent).toBe(additionalContext)
+
+      await eventCapture.stop()
+    })
+
+    it('should handle missing description parameter gracefully', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking
+      track(server, {
+        apiKey: 'test-project',
+        reportMissing: true,
+        enableTracing: true,
+      })
+
+      // Call report_missing without required description
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'get_more_tools',
+            arguments: {
+              context: 'Some context without description',
+            } as any,
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // The function handles undefined gracefully
+      expect(result.content[0].text).toContain('Unfortunately')
+
+      await eventCapture.stop()
+    })
+  })
+
+  describe('3. Event Tracking Tests', () => {
+    it('should track report_missing events with proper structure', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking
+      track(server, { apiKey: 'proj_abc123xyz' })
+
+      const context = 'User wants to monitor file changes in real-time'
+
+      // Call report_missing
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'get_more_tools',
+            arguments: {
+              context,
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Get the event
+      const events = eventCapture.getEvents()
+      const reportEvent = events.find(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'get_more_tools'
+      )
+
+      // Verify event structure
+      expect(reportEvent).toBeDefined()
+      expect(reportEvent?.sessionId).toBeDefined()
+      expect(reportEvent?.sessionId).not.toBe('')
+      expect(reportEvent?.resourceName).toBe('get_more_tools')
+      expect(reportEvent?.parameters).toBeDefined()
+      expect((reportEvent?.parameters as any).request.params.name).toBe('get_more_tools')
+      expect((reportEvent?.parameters as any).request.params.arguments).toEqual({})
+      expect(reportEvent?.userIntent).toBe(context)
+
+      await eventCapture.stop()
+    })
+  })
+
+  describe('4. Integration Tests', () => {
+    it('should maintain session continuity when calling report_missing between other tools', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking
+      track(server, {
+        apiKey: 'test-project',
+        reportMissing: true,
+        enableTracing: true,
+      })
+
+      // Call add_todo
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'First todo',
+              context: 'Adding first todo to test session continuity',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Call report_missing
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'get_more_tools',
+            arguments: {
+              context: 'Need a bulk todo import tool',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Call list_todos
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'list_todos',
+            arguments: {
+              context: 'Listing todos after reporting missing tool',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Get all tool call events
+      const events = eventCapture.getEvents()
+      const toolCallEvents = events.filter((e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall)
+
+      // Should have 3 events
+      expect(toolCallEvents.length).toBe(3)
+
+      // All should have the same session ID
+      const sessionIds = toolCallEvents.map((e) => e.sessionId)
+      expect(new Set(sessionIds).size).toBe(1)
+
+      // Verify the order and tool names
+      expect(toolCallEvents[0].resourceName).toBe('add_todo')
+      expect(toolCallEvents[1].resourceName).toBe('get_more_tools')
+      expect(toolCallEvents[2].resourceName).toBe('list_todos')
+
+      await eventCapture.stop()
+    })
+
+    it('should work correctly with user identification', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      const testUserId = `report-user-${randomUUID()}`
+      const testUserData = {
+        name: `Report Test User ${randomUUID()}`,
+        role: 'Developer',
+      }
+
+      // Enable tracking with identify
+      track(server, {
+        apiKey: 'test-project',
+        reportMissing: true,
+        enableTracing: true,
+        identify: async () => ({
+          userId: testUserId,
+          userData: testUserData,
+        }),
+      })
+
+      // Call report_missing (should trigger identify on first tool call)
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'get_more_tools',
+            arguments: {
+              context: 'Need GraphQL query builder',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Verify identify event was triggered
+      const events = eventCapture.getEvents()
+      const identifyEvent = events.find((e) => e.eventType === MCPAnalyticsEventType.identify)
+
+      expect(identifyEvent).toBeDefined()
+      expect(identifyEvent?.resourceName).toBe('get_more_tools')
+
+      // Verify user identity was stored
+      const data = getServerTrackingData(server.server)
+      const sessionId = data?.sessionId
+      const storedIdentity = data?.identifiedSessions.get(sessionId!)
+
+      expect(storedIdentity).toEqual({
+        userId: testUserId,
+        userData: testUserData,
+      })
+
+      await eventCapture.stop()
+    })
+  })
+
+  describe('6. Analytics Value Tests', () => {
+    it('should provide actionable insights for missing tool reports', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking
+      track(server, {
+        apiKey: 'test-project',
+        reportMissing: true,
+        enableTracing: true,
+      })
+
+      // Simulate multiple reports for similar missing tools
+      const reports = [
+        {
+          context: 'Want to query PostgreSQL database',
+        },
+        {
+          context: 'Need to construct complex queries',
+        },
+        {
+          context: 'Managing schema changes',
+        },
+      ]
+
+      // Submit all reports
+      for (const report of reports) {
+        await client.request(
+          {
+            method: 'tools/call',
+            params: {
+              name: 'get_more_tools',
+              arguments: report,
+            },
+          },
+          CallToolResultSchema
+        )
+      }
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Analyze the events
+      const events = eventCapture.getEvents()
+      const reportEvents = events.filter(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'get_more_tools'
+      )
+
+      // Verify we captured all reports with useful data
+      expect(reportEvents.length).toBe(3)
+
+      // Each event should have structured data for analysis
+      reportEvents.forEach((event, index) => {
+        expect(event.userIntent).toBe(reports[index].context)
+        expect(event.sessionId).toBeDefined()
+        expect(event.timestamp).toBeDefined()
+      })
+
+      // This data structure allows for:
+      // - Grouping by similar keywords (database, SQL)
+      // - Time-based analysis
+      // - Session-based patterns
+
+      await eventCapture.stop()
+    })
+
+    it('should track get_more_tools across different sessions', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // First session
+      {
+        const setup1 = await setupTestServerAndClient()
+        track(setup1.server, {
+          apiKey: 'test-project',
+          reportMissing: true,
+          enableTracing: true,
+        })
+
+        await setup1.client.request(
+          {
+            method: 'tools/call',
+            params: {
+              name: 'get_more_tools',
+              arguments: {
+                context: 'Need OAuth integration tool',
+              },
+            },
+          },
+          CallToolResultSchema
+        )
+
+        await setup1.cleanup()
+      }
+
+      // Second session
+      {
+        const setup2 = await setupTestServerAndClient()
+        track(setup2.server, {
+          apiKey: 'test-project',
+          reportMissing: true,
+          enableTracing: true,
+        })
+
+        await setup2.client.request(
+          {
+            method: 'tools/call',
+            params: {
+              name: 'get_more_tools',
+              arguments: {
+                context: 'Need OAuth2 authentication tool',
+              },
+            },
+          },
+          CallToolResultSchema
+        )
+
+        await setup2.cleanup()
+      }
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Analyze cross-session patterns
+      const events = eventCapture.getEvents()
+      const reportEvents = events.filter(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'get_more_tools'
+      )
+
+      // Should have 2 events from different sessions
+      expect(reportEvents.length).toBe(2)
+
+      // Different session IDs
+      const sessionIds = reportEvents.map((e) => e.sessionId)
+      expect(new Set(sessionIds).size).toBe(2)
+
+      // Similar content (OAuth) from different sessions indicates a pattern
+      const contexts = reportEvents.map((e) => e.userIntent)
+      expect(contexts[0]).toContain('OAuth')
+      expect(contexts[1]).toContain('OAuth')
+
+      await eventCapture.stop()
+    })
+
+    it('should handle multiple missing tool reports in same session', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      // Enable tracking
+      track(server, {
+        apiKey: 'test-project',
+        reportMissing: true,
+        enableTracing: true,
+      })
+
+      // Simulate a user discovering multiple missing tools during their workflow
+      const missingTools = [
+        {
+          context: 'Importing data from spreadsheets',
+        },
+        {
+          context: 'Need to validate imported data',
+        },
+        {
+          context: 'Process large datasets',
+        },
+      ]
+
+      // Report all missing tools in sequence
+      for (const tool of missingTools) {
+        await client.request(
+          {
+            method: 'tools/call',
+            params: {
+              name: 'get_more_tools',
+              arguments: tool,
+            },
+          },
+          CallToolResultSchema
+        )
+      }
+
+      // Wait for events
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Analyze the pattern
+      const events = eventCapture.getEvents()
+      const reportEvents = events.filter(
+        (e) => e.eventType === MCPAnalyticsEventType.mcpToolsCall && e.resourceName === 'get_more_tools'
+      )
+
+      // All from same session
+      expect(reportEvents.length).toBe(3)
+      const sessionIds = reportEvents.map((e) => e.sessionId)
+      expect(new Set(sessionIds).size).toBe(1)
+
+      // The sequence shows a workflow pattern:
+      // Import -> Validate -> Process
+      // This provides valuable insight into user needs
+
+      await eventCapture.stop()
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/sanitization.test.ts
+++ b/packages/mcp/src/__tests__/sanitization.test.ts
@@ -1,0 +1,392 @@
+import { sanitizeEvent } from '../modules/sanitization'
+import type { Event } from '../types'
+
+function makeLargeBase64(sizeInChars = 12_000): string {
+  return `${'A'.repeat(sizeInChars - 1)}=`
+}
+
+function makeLargeNonBase64(sizeInChars = 12_000): string {
+  return 'Hello, world! This is NOT base64. '.repeat(Math.ceil(sizeInChars / 34))
+}
+
+function makeEvent(overrides: Partial<Event>): Event {
+  return {
+    id: 'evt_1',
+    sessionId: 'ses_1',
+    eventType: 'mcp:tools/call',
+    timestamp: new Date(),
+    ...overrides,
+  } as Event
+}
+
+describe('sanitizeEvent - response content blocks', () => {
+  it('should replace image and audio blocks but keep text blocks', () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          { type: 'text', text: 'Hello world' },
+          { type: 'image', data: 'base64imagedata...', mimeType: 'image/png' },
+          { type: 'audio', data: 'base64audiodata...', mimeType: 'audio/wav' },
+        ],
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.response.content).toHaveLength(3)
+    expect(result.response.content[0]).toEqual({
+      type: 'text',
+      text: 'Hello world',
+    })
+    expect(result.response.content[1]).toEqual({
+      type: 'text',
+      text: '[image content redacted - not supported by PostHog MCP analytics]',
+    })
+    expect(result.response.content[2]).toEqual({
+      type: 'text',
+      text: '[audio content redacted - not supported by PostHog MCP analytics]',
+    })
+  })
+
+  it('should leave text-only content unchanged', () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          { type: 'text', text: 'First' },
+          { type: 'text', text: 'Second' },
+        ],
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.response.content).toEqual([
+      { type: 'text', text: 'First' },
+      { type: 'text', text: 'Second' },
+    ])
+  })
+
+  it('should redact EmbeddedResource with blob', () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          {
+            type: 'resource',
+            resource: {
+              uri: 'file:///data.bin',
+              blob: 'base64blobdata...',
+              mimeType: 'application/octet-stream',
+            },
+          },
+        ],
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.response.content[0]).toEqual({
+      type: 'text',
+      text: '[binary resource content redacted - not supported by PostHog MCP analytics]',
+    })
+  })
+
+  it('should pass through EmbeddedResource with text', () => {
+    const textResource = {
+      type: 'resource',
+      resource: {
+        uri: 'file:///readme.txt',
+        text: 'This is a text resource',
+        mimeType: 'text/plain',
+      },
+    }
+
+    const event = makeEvent({
+      response: { content: [textResource] },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.response.content[0]).toEqual(textResource)
+  })
+
+  it('should redact unknown content types with type name in message', () => {
+    const event = makeEvent({
+      response: {
+        content: [{ type: 'video', data: 'somestuff', mimeType: 'video/mp4' }],
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.response.content[0]).toEqual({
+      type: 'text',
+      text: '[unsupported content type "video" redacted - not supported by PostHog MCP analytics]',
+    })
+  })
+
+  it('should pass through resource_link unchanged', () => {
+    const resourceLink = {
+      type: 'resource_link',
+      uri: 'file:///some/resource',
+      name: 'My Resource',
+    }
+
+    const event = makeEvent({
+      response: { content: [resourceLink] },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.response.content[0]).toEqual(resourceLink)
+  })
+
+  it('should redact large base64 inside structuredContent', () => {
+    const largeBase64 = makeLargeBase64()
+
+    const event = makeEvent({
+      response: {
+        structuredContent: {
+          data: largeBase64,
+          label: 'some label',
+        },
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.response.structuredContent.data).toBe(
+      '[binary data redacted - not supported by PostHog MCP analytics]'
+    )
+    expect(result.response.structuredContent.label).toBe('some label')
+  })
+
+  it('should handle response without content array', () => {
+    const event = makeEvent({
+      response: { result: 'success' },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.response).toEqual({ result: 'success' })
+  })
+
+  it('should redact token-shaped fields and PostHog tokens in text responses', () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          {
+            type: 'text',
+            text: 'Project api_token: phc_123456789012345678901234567890',
+          },
+        ],
+        structuredContent: {
+          project: 'Default project',
+          api_token: 'phc_123456789012345678901234567890',
+        },
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.response.content[0].text).toBe('Project api_token: [redacted]')
+    expect(result.response.structuredContent).toEqual({
+      project: 'Default project',
+      api_token: '[redacted]',
+    })
+  })
+
+  it('should handle null and undefined response without error', () => {
+    const resultNull = sanitizeEvent(makeEvent({ response: null }))
+    const resultUndef = sanitizeEvent(makeEvent({ response: undefined }))
+
+    expect(resultNull.response).toBeNull()
+    expect(resultUndef.response).toBeUndefined()
+  })
+})
+
+describe('sanitizeEvent - parameter scanning', () => {
+  it('should leave small strings unchanged', () => {
+    const event = makeEvent({
+      parameters: {
+        name: 'hello',
+        query: 'some query text',
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters).toEqual({
+      name: 'hello',
+      query: 'some query text',
+    })
+  })
+
+  it('should redact large base64 strings (>10KB)', () => {
+    const largeBase64 = makeLargeBase64()
+
+    const event = makeEvent({
+      parameters: { imageData: largeBase64 },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters.imageData).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+  })
+
+  it('should leave large non-base64 strings unchanged', () => {
+    const largeText = makeLargeNonBase64()
+
+    const event = makeEvent({
+      parameters: { longText: largeText },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters.longText).toBe(largeText)
+  })
+
+  it('should find and redact deeply nested large base64', () => {
+    const largeBase64 = makeLargeBase64()
+
+    const event = makeEvent({
+      parameters: {
+        level1: {
+          level2: {
+            level3: { data: largeBase64 },
+          },
+        },
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters.level1.level2.level3.data).toBe(
+      '[binary data redacted - not supported by PostHog MCP analytics]'
+    )
+  })
+
+  it('should only redact large base64 in mixed-type parameters', () => {
+    const largeBase64 = makeLargeBase64()
+
+    const event = makeEvent({
+      parameters: {
+        count: 42,
+        active: true,
+        name: 'short string',
+        binaryData: largeBase64,
+        tags: ['a', 'b', 'c'],
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters.count).toBe(42)
+    expect(result.parameters.active).toBe(true)
+    expect(result.parameters.name).toBe('short string')
+    expect(result.parameters.binaryData).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+    expect(result.parameters.tags).toEqual(['a', 'b', 'c'])
+  })
+
+  it('should redact large base64 inside an array', () => {
+    const largeBase64 = makeLargeBase64()
+
+    const event = makeEvent({
+      parameters: {
+        items: ['small string', largeBase64, 'another small'],
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters.items[0]).toBe('small string')
+    expect(result.parameters.items[1]).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+    expect(result.parameters.items[2]).toBe('another small')
+  })
+
+  it('should redact base64 string at exactly SIZE_GATE boundary (10240 chars)', () => {
+    const exactBoundary = makeLargeBase64(10_240)
+    const belowBoundary = makeLargeBase64(10_239)
+
+    const event = makeEvent({
+      parameters: {
+        atGate: exactBoundary,
+        belowGate: belowBoundary,
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters.atGate).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+    expect(result.parameters.belowGate).toBe(belowBoundary)
+  })
+
+  it('should handle null and undefined parameters without error', () => {
+    const resultNull = sanitizeEvent(makeEvent({ parameters: null }))
+    const resultUndef = sanitizeEvent(makeEvent({ parameters: undefined }))
+
+    expect(resultNull.parameters).toBeNull()
+    expect(resultUndef.parameters).toBeUndefined()
+  })
+})
+
+describe('sanitizeEvent - integration', () => {
+  it('should sanitize both parameters and response in a full event', () => {
+    const largeBase64 = makeLargeBase64()
+
+    const event = makeEvent({
+      apiKey: 'proj_1',
+      resourceName: 'my-tool',
+      parameters: {
+        imageData: largeBase64,
+        query: 'hello',
+      },
+      response: {
+        content: [
+          { type: 'text', text: 'Result text' },
+          { type: 'image', data: 'base64img', mimeType: 'image/png' },
+        ],
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    expect(result.parameters.imageData).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+    expect(result.parameters.query).toBe('hello')
+
+    expect(result.response.content[0]).toEqual({
+      type: 'text',
+      text: 'Result text',
+    })
+    expect(result.response.content[1]).toEqual({
+      type: 'text',
+      text: '[image content redacted - not supported by PostHog MCP analytics]',
+    })
+
+    expect(result.id).toBe('evt_1')
+    expect(result.sessionId).toBe('ses_1')
+    expect(result.apiKey).toBe('proj_1')
+    expect(result.resourceName).toBe('my-tool')
+  })
+
+  it('should not mutate the original event', () => {
+    const largeBase64 = makeLargeBase64()
+
+    const event = makeEvent({
+      parameters: { imageData: largeBase64 },
+      response: {
+        content: [{ type: 'image', data: 'base64img', mimeType: 'image/png' }],
+      },
+    })
+
+    const result = sanitizeEvent(event)
+
+    // Original should be unchanged
+    expect(event.parameters.imageData).toBe(largeBase64)
+    expect(event.response.content[0].type).toBe('image')
+    expect(event.response.content[0].data).toBe('base64img')
+
+    // Result should be different
+    expect(result.parameters.imageData).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+    expect(result.response.content[0].type).toBe('text')
+  })
+})

--- a/packages/mcp/src/__tests__/session-id.test.ts
+++ b/packages/mcp/src/__tests__/session-id.test.ts
@@ -1,0 +1,285 @@
+import { track } from '../index'
+import { getServerTrackingData } from '../modules/internal'
+import { deriveSessionIdFromMCPSession, getServerSessionId } from '../modules/session'
+import type { HighLevelMCPServerLike } from '../types'
+import { EventCapture } from './test-utils'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+
+const SESSION_ID_PATTERN = /^ses_/
+
+describe('Session ID Management', () => {
+  let server: HighLevelMCPServerLike
+  let cleanup: () => Promise<void>
+
+  beforeEach(async () => {
+    resetTodos()
+    const setup = await setupTestServerAndClient()
+    server = setup.server
+    cleanup = setup.cleanup
+  })
+
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  describe('Deterministic MCP session ID derivation', () => {
+    it('should generate deterministic session IDs from the same MCP sessionId', () => {
+      const mcpSessionId = 'test-session-123'
+
+      const sessionId1 = deriveSessionIdFromMCPSession(mcpSessionId)
+      const sessionId2 = deriveSessionIdFromMCPSession(mcpSessionId)
+
+      expect(sessionId1).toBe(sessionId2)
+      expect(sessionId1).toMatch(SESSION_ID_PATTERN)
+    })
+
+    it('should generate different session IDs for different MCP sessionIds', () => {
+      const sessionId1 = deriveSessionIdFromMCPSession('session-1')
+      const sessionId2 = deriveSessionIdFromMCPSession('session-2')
+
+      expect(sessionId1).not.toBe(sessionId2)
+      expect(sessionId1).toMatch(SESSION_ID_PATTERN)
+      expect(sessionId2).toMatch(SESSION_ID_PATTERN)
+    })
+
+    it('should not require project secrets to derive session IDs', () => {
+      expect(deriveSessionIdFromMCPSession('test-session-123')).toMatch(SESSION_ID_PATTERN)
+    })
+  })
+
+  describe('MCP SessionId Prioritization', () => {
+    it('should use MCP sessionId when provided in extra parameter', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      const apiKey = 'test-project-mcp'
+      const mcpSessionId = 'mcp-session-abc-123'
+
+      track(server, { apiKey, enableTracing: true })
+
+      // Get the low-level server
+      const lowLevelServer = server.server
+
+      // Simulate MCP sessionId in extra parameter
+      const extra = { sessionId: mcpSessionId }
+
+      // Get session ID with MCP sessionId provided
+      const sessionId = getServerSessionId(lowLevelServer, extra)
+
+      // Verify it's deterministically derived
+      const expectedSessionId = deriveSessionIdFromMCPSession(mcpSessionId)
+      expect(sessionId).toBe(expectedSessionId)
+
+      // Verify tracking data is updated
+      const data = getServerTrackingData(lowLevelServer)
+      expect(data?.lastMcpSessionId).toBe(mcpSessionId)
+      expect(data?.sessionSource).toBe('mcp')
+
+      await eventCapture.stop()
+    })
+
+    it('should use PostHog MCP analytics-generated sessionId when no MCP sessionId provided', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      track(server, { apiKey: 'test-project', enableTracing: true })
+
+      const lowLevelServer = server.server
+
+      // Get initial session ID without MCP sessionId
+      const sessionId1 = getServerSessionId(lowLevelServer)
+      expect(sessionId1).toMatch(SESSION_ID_PATTERN)
+
+      // Verify tracking data shows PostHog MCP analytics source
+      const data = getServerTrackingData(lowLevelServer)
+      expect(data?.sessionSource).toBe('generated')
+      expect(data?.lastMcpSessionId).toBeUndefined()
+
+      // Get session ID again - should be the same
+      const sessionId2 = getServerSessionId(lowLevelServer)
+      expect(sessionId2).toBe(sessionId1)
+
+      await eventCapture.stop()
+    })
+
+    it('should switch to MCP-derived sessionId when MCP sessionId appears', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      const apiKey = 'test-project-switch'
+      const mcpSessionId = 'mcp-session-appears'
+
+      track(server, { apiKey, enableTracing: true })
+
+      const lowLevelServer = server.server
+
+      // Start with no MCP sessionId
+      const generatedSessionId = getServerSessionId(lowLevelServer)
+      expect(generatedSessionId).toMatch(SESSION_ID_PATTERN)
+
+      let data = getServerTrackingData(lowLevelServer)
+      expect(data?.sessionSource).toBe('generated')
+
+      // Now provide MCP sessionId
+      const extra = { sessionId: mcpSessionId }
+      const mcpDerivedSessionId = getServerSessionId(lowLevelServer, extra)
+
+      // Verify it switched to MCP-derived ID
+      const expectedSessionId = deriveSessionIdFromMCPSession(mcpSessionId)
+      expect(mcpDerivedSessionId).toBe(expectedSessionId)
+      expect(mcpDerivedSessionId).not.toBe(generatedSessionId)
+
+      // Verify tracking data is updated
+      data = getServerTrackingData(lowLevelServer)
+      expect(data?.lastMcpSessionId).toBe(mcpSessionId)
+      expect(data?.sessionSource).toBe('mcp')
+
+      await eventCapture.stop()
+    })
+
+    it('should keep last derived sessionId when MCP sessionId disappears', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      const apiKey = 'test-project-disappear'
+      const mcpSessionId = 'mcp-session-disappears'
+
+      track(server, { apiKey, enableTracing: true })
+
+      const lowLevelServer = server.server
+
+      // Provide MCP sessionId
+      const extra = { sessionId: mcpSessionId }
+      const mcpDerivedSessionId = getServerSessionId(lowLevelServer, extra)
+
+      const expectedSessionId = deriveSessionIdFromMCPSession(mcpSessionId)
+      expect(mcpDerivedSessionId).toBe(expectedSessionId)
+
+      // Now call without MCP sessionId (it disappeared)
+      const sessionIdAfterDisappear = getServerSessionId(lowLevelServer)
+
+      // Should keep using the last derived sessionId
+      expect(sessionIdAfterDisappear).toBe(mcpDerivedSessionId)
+
+      // Verify tracking data still shows MCP source
+      const data = getServerTrackingData(lowLevelServer)
+      expect(data?.sessionSource).toBe('mcp')
+      expect(data?.lastMcpSessionId).toBe(mcpSessionId)
+
+      await eventCapture.stop()
+    })
+
+    it('should regenerate sessionId when MCP sessionId changes', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      const apiKey = 'test-project-change'
+      const mcpSessionId1 = 'mcp-session-first'
+      const mcpSessionId2 = 'mcp-session-second'
+
+      track(server, { apiKey, enableTracing: true })
+
+      const lowLevelServer = server.server
+
+      // Provide first MCP sessionId
+      const extra1 = { sessionId: mcpSessionId1 }
+      const sessionId1 = getServerSessionId(lowLevelServer, extra1)
+
+      const expectedSessionId1 = deriveSessionIdFromMCPSession(mcpSessionId1)
+      expect(sessionId1).toBe(expectedSessionId1)
+
+      // Change to second MCP sessionId
+      const extra2 = { sessionId: mcpSessionId2 }
+      const sessionId2 = getServerSessionId(lowLevelServer, extra2)
+
+      const expectedSessionId2 = deriveSessionIdFromMCPSession(mcpSessionId2)
+      expect(sessionId2).toBe(expectedSessionId2)
+      expect(sessionId2).not.toBe(sessionId1)
+
+      // Verify tracking data is updated
+      const data = getServerTrackingData(lowLevelServer)
+      expect(data?.lastMcpSessionId).toBe(mcpSessionId2)
+      expect(data?.sessionSource).toBe('mcp')
+
+      await eventCapture.stop()
+    })
+  })
+
+  describe('Session Timeout Behavior', () => {
+    it('should NOT apply timeout to MCP-derived sessions', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      const apiKey = 'test-project-timeout'
+      const mcpSessionId = 'mcp-session-persistent'
+
+      track(server, { apiKey, enableTracing: true })
+
+      const lowLevelServer = server.server
+
+      // Get MCP-derived session ID
+      const extra = { sessionId: mcpSessionId }
+      const sessionId1 = getServerSessionId(lowLevelServer, extra)
+
+      // Manually set lastActivity to simulate timeout (31 minutes ago)
+      const data = getServerTrackingData(lowLevelServer)
+      if (data) {
+        data.lastActivity = new Date(Date.now() - 31 * 60 * 1000)
+      }
+
+      // Get session ID again with same MCP sessionId
+      const sessionId2 = getServerSessionId(lowLevelServer, extra)
+
+      // Should still be the same (no timeout for MCP sessions)
+      expect(sessionId2).toBe(sessionId1)
+
+      await eventCapture.stop()
+    })
+
+    it('should apply timeout to PostHog MCP analytics-generated sessions', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      track(server, { apiKey: 'test-project', enableTracing: true })
+
+      const lowLevelServer = server.server
+
+      // Get PostHog MCP analytics-generated session ID
+      const sessionId1 = getServerSessionId(lowLevelServer)
+
+      // Manually set lastActivity to simulate timeout (31 minutes ago)
+      const data = getServerTrackingData(lowLevelServer)
+      if (data) {
+        data.lastActivity = new Date(Date.now() - 31 * 60 * 1000)
+      }
+
+      // Get session ID again without MCP sessionId
+      const sessionId2 = getServerSessionId(lowLevelServer)
+
+      // Should be different (timeout occurred)
+      expect(sessionId2).not.toBe(sessionId1)
+      expect(sessionId2).toMatch(SESSION_ID_PATTERN)
+
+      await eventCapture.stop()
+    })
+  })
+
+  describe('Event Publishing with Session IDs', () => {
+    it('should publish events with MCP-derived session IDs', async () => {
+      const eventCapture = new EventCapture()
+      await eventCapture.start()
+
+      const apiKey = 'test-project-events'
+      const mcpSessionId = 'mcp-session-for-events'
+      expect(deriveSessionIdFromMCPSession(mcpSessionId)).toMatch(SESSION_ID_PATTERN)
+
+      track(server, { apiKey, enableTracing: true })
+
+      // TODO: This test would require mocking the transport to inject sessionId into extra
+      // For now, we'll verify the logic with direct function calls above
+      // In a real MCP environment, the sessionId would come from the transport layer
+
+      await eventCapture.stop()
+    })
+  })
+})

--- a/packages/mcp/src/__tests__/test-utils.ts
+++ b/packages/mcp/src/__tests__/test-utils.ts
@@ -1,0 +1,77 @@
+import type { Event, UnredactedEvent } from '../types'
+import { PostHogMCP } from '../modules/client'
+import { redactEvent } from '../modules/redaction'
+import { sanitizeEvent } from '../modules/sanitization'
+import { truncateEvent } from '../modules/truncation'
+
+/**
+ * Intercepts events on the `PostHogMCP.ingest` boundary so tests can assert on the
+ * post-pipeline event without making an HTTP call. Runs the same
+ * redact → sanitize → truncate pipeline the real `ingest` runs, so tests that
+ * exercise redaction/sanitization/truncation see the transformed event.
+ *
+ * Patches the prototype so every `PostHogMCP` instance created by `track()`
+ * during the test is intercepted.
+ */
+export class EventCapture {
+  private capturedEvents: UnredactedEvent[] = []
+  private original?: (event: UnredactedEvent, enableAITracing: boolean) => Promise<void>
+
+  async start(): Promise<void> {
+    if (this.original) {
+      return
+    }
+    this.original = PostHogMCP.prototype.ingest
+    const capture = this
+    PostHogMCP.prototype.ingest = async function (
+      this: PostHogMCP,
+      event: UnredactedEvent,
+      _enableAITracing: boolean
+    ): Promise<void> {
+      let processed: UnredactedEvent = event
+      if (event.redactionFn) {
+        try {
+          processed = (await redactEvent(event, event.redactionFn)) as UnredactedEvent
+          processed.redactionFn = undefined
+        } catch {
+          // mirror client.ingest: drop event on redact failure
+          return
+        }
+      }
+      try {
+        processed = sanitizeEvent(processed)
+      } catch {
+        return
+      }
+      try {
+        processed = truncateEvent(processed)
+      } catch {
+        return
+      }
+      capture.capturedEvents.push(processed)
+    } as typeof PostHogMCP.prototype.ingest
+  }
+
+  async stop(): Promise<void> {
+    if (this.original) {
+      PostHogMCP.prototype.ingest = this.original
+      this.original = undefined
+    }
+  }
+
+  getEvents(): UnredactedEvent[] {
+    return [...this.capturedEvents]
+  }
+
+  clear(): void {
+    this.capturedEvents = []
+  }
+
+  findEventByType(eventType: string): Event | undefined {
+    return this.capturedEvents.find((e) => e.eventType === eventType) as Event | undefined
+  }
+
+  findEventsByResourceName(resourceName: string): Event[] {
+    return this.capturedEvents.filter((e) => e.resourceName === resourceName) as Event[]
+  }
+}

--- a/packages/mcp/src/__tests__/test-utils/client-server-factory.ts
+++ b/packages/mcp/src/__tests__/test-utils/client-server-factory.ts
@@ -1,0 +1,134 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { CreateMessageRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+
+interface Todo {
+  completed: boolean
+  id: string
+  text: string
+}
+
+let todos: Todo[] = []
+let nextId = 1
+
+export function resetTodos() {
+  todos = []
+  nextId = 1
+}
+
+export async function setupTestServerAndClient() {
+  // Create server instance
+  const server = new McpServer({
+    name: 'test server',
+    version: '1.0',
+  })
+
+  // Register tools with the server
+  server.tool(
+    'add_todo',
+    'Add a new todo item',
+    {
+      text: z.string().describe('The text of the todo item'),
+    },
+    async (args) => {
+      const todo: Todo = {
+        id: String(nextId++),
+        text: args.text,
+        completed: false,
+      }
+      todos.push(todo)
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Added todo: "${args.text}" with ID ${todo.id}`,
+          },
+        ],
+      }
+    }
+  )
+
+  server.tool('list_todos', 'List all todo items', {}, async () => {
+    const todoList = todos.map((todo) => `${todo.id}: ${todo.text} ${todo.completed ? '✓' : '○'}`).join('\n')
+    return {
+      content: [
+        {
+          type: 'text',
+          text: todoList || 'No todos found',
+        },
+      ],
+    }
+  })
+
+  server.registerTool(
+    'complete_todo',
+    {
+      description: 'Mark a todo item as completed',
+      inputSchema: {
+        id: z.string().describe('The ID of the todo to complete'),
+      },
+    },
+    async (args) => {
+      const todo = todos.find((t) => t.id === args.id)
+      if (!todo) {
+        throw new Error(`Todo with ID ${args.id} not found`)
+      }
+      todo.completed = true
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Completed todo: "${todo.text}"`,
+          },
+        ],
+      }
+    }
+  )
+
+  // Create client instance
+  const client = new Client(
+    {
+      name: 'test client',
+      version: '1.0',
+    },
+    {
+      capabilities: {
+        sampling: {},
+      },
+    }
+  )
+
+  // Set up default request handler for sampling/createMessage
+  client.setRequestHandler(CreateMessageRequestSchema, async () => ({
+    model: 'test-model',
+    role: 'assistant',
+    content: {
+      type: 'text',
+      text: 'This is a test response',
+    },
+  }))
+
+  // Create transport pair and connect
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+  await Promise.all([client.connect(clientTransport), server.server.connect(serverTransport)])
+
+  // Return everything you need
+  return {
+    server,
+    client,
+    clientTransport,
+    serverTransport,
+    // Cleanup function
+    async cleanup() {
+      if (clientTransport) {
+        await clientTransport.close?.()
+      }
+      if (serverTransport) {
+        await serverTransport.close?.()
+      }
+    },
+  }
+}

--- a/packages/mcp/src/__tests__/tracing-initialization.test.ts
+++ b/packages/mcp/src/__tests__/tracing-initialization.test.ts
@@ -1,0 +1,128 @@
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { track } from '../index'
+import { resetTodos, setupTestServerAndClient } from './test-utils/client-server-factory'
+import { EventCapture } from './test-utils'
+
+describe('Tracing Initialization Tests', () => {
+  let eventCapture: EventCapture
+
+  beforeEach(async () => {
+    resetTodos()
+    eventCapture = new EventCapture()
+    await eventCapture.start()
+  })
+
+  afterEach(async () => {
+    await eventCapture.stop()
+  })
+
+  it('should not create duplicate events when track() is called multiple times', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Test todo for double-wrapping',
+              context: 'Setup for double-wrapping test',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      eventCapture.clear()
+
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'complete_todo',
+            arguments: {
+              id: '1',
+              context: 'Testing double-wrapping protection',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(result).toBeDefined()
+      expect(result.isError).not.toBe(true)
+
+      const events = eventCapture.getEvents()
+
+      expect(events.length).toBe(1)
+      expect(events[0].resourceName).toBe('complete_todo')
+      expect(events[0].isError).toBe(false)
+      expect(events[0].duration).toEqual(expect.any(Number))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('should publish events for successful tool calls with handler-level architecture', async () => {
+    const { server, client, cleanup } = await setupTestServerAndClient()
+
+    try {
+      await track(server, {
+        apiKey: 'test-project',
+        enableTracing: true,
+      })
+
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'add_todo',
+            arguments: {
+              text: 'Test successful handler wrapping',
+              context: 'Testing handler-level event publishing',
+            },
+          },
+        },
+        CallToolResultSchema
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(result).toBeDefined()
+      expect(result.isError).not.toBe(true)
+
+      const events = eventCapture.getEvents()
+
+      expect(events.length).toBe(1)
+      expect(events[0].resourceName).toBe('add_todo')
+      expect(events[0].isError).toBe(false)
+      expect(events[0].duration).toEqual(expect.any(Number))
+      expect(events[0].userIntent).toBe('Testing handler-level event publishing')
+
+      expect(events[0]).toHaveProperty('eventType')
+      expect(events[0]).toHaveProperty('timestamp')
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/packages/mcp/src/__tests__/truncation.test.ts
+++ b/packages/mcp/src/__tests__/truncation.test.ts
@@ -1,0 +1,520 @@
+import { sanitizeEvent } from '../modules/sanitization'
+import { normalize, truncateEvent } from '../modules/truncation'
+import type { Event, StackFrame } from '../types'
+
+describe('normalize - string truncation', () => {
+  it('should leave short strings unchanged', () => {
+    expect(normalize('hello')).toBe('hello')
+  })
+
+  it("should truncate strings exceeding maxStringLength with '...'", () => {
+    const long = 'a'.repeat(33_000)
+    const result = normalize(long) as string
+    expect(result.length).toBe(32_768 + 3) // 32KB + "..."
+    expect(result.endsWith('...')).toBe(true)
+    expect(result.startsWith('a'.repeat(100))).toBe(true)
+  })
+
+  it('should leave strings at exactly maxStringLength unchanged', () => {
+    const exact = 'a'.repeat(32_768)
+    expect(normalize(exact)).toBe(exact)
+  })
+})
+
+describe('normalize - non-serializable values', () => {
+  it('should convert functions to descriptive string', () => {
+    function myFunc() {}
+    expect(normalize(myFunc)).toBe('[Function: myFunc]')
+  })
+
+  it('should convert anonymous functions', () => {
+    expect(normalize(() => {})).toBe('[Function: <anonymous>]')
+  })
+
+  it('should convert symbols', () => {
+    expect(normalize(Symbol('test'))).toBe('[Symbol(test)]')
+    expect(normalize(Symbol.for(''))).toBe('[Symbol()]')
+  })
+
+  it('should convert undefined to string marker', () => {
+    expect(normalize(undefined)).toBe('[undefined]')
+  })
+
+  it('should convert BigInt to string marker', () => {
+    expect(normalize(BigInt(123))).toBe('[BigInt: 123]')
+  })
+
+  it('should convert NaN to string marker', () => {
+    expect(normalize(Number.NaN)).toBe('[NaN]')
+  })
+
+  it('should convert Infinity to string marker', () => {
+    expect(normalize(Number.POSITIVE_INFINITY)).toBe('[Infinity]')
+    expect(normalize(Number.NEGATIVE_INFINITY)).toBe('[-Infinity]')
+  })
+
+  it('should convert Date to ISO string', () => {
+    const date = new Date('2025-01-15T12:00:00Z')
+    expect(normalize(date)).toBe('2025-01-15T12:00:00.000Z')
+  })
+
+  it('should handle Invalid Date gracefully', () => {
+    expect(normalize(new Date('not-a-date'))).toBe('[Invalid Date]')
+  })
+
+  it('should pass through numbers unchanged', () => {
+    expect(normalize(42)).toBe(42)
+    expect(normalize(0)).toBe(0)
+    expect(normalize(-3.14)).toBe(-3.14)
+  })
+
+  it('should pass through booleans unchanged', () => {
+    expect(normalize(true)).toBe(true)
+    expect(normalize(false)).toBe(false)
+  })
+
+  it('should pass through null as null', () => {
+    expect(normalize(null)).toBeNull()
+  })
+})
+
+describe('normalize - depth limiting', () => {
+  it("should collapse objects beyond max depth to '[Object]'", () => {
+    let obj: any = { value: 'deep' }
+    for (let i = 0; i < 15; i++) {
+      obj = { nested: obj }
+    }
+    const result = normalize(obj, 5) as any
+    expect(result.nested.nested.nested.nested.nested).toBe('[Object]')
+  })
+
+  it("should collapse arrays beyond max depth to '[Array]'", () => {
+    let arr: any = ['leaf']
+    for (let i = 0; i < 15; i++) {
+      arr = [arr]
+    }
+    const result = normalize(arr, 3) as any
+    expect(result[0][0][0]).toBe('[Array]')
+  })
+
+  it('should handle depth=0 by collapsing top-level objects', () => {
+    expect(normalize({ a: 1 }, 0)).toBe('[Object]')
+    expect(normalize([1, 2], 0)).toBe('[Array]')
+  })
+
+  it('should not collapse primitives regardless of depth', () => {
+    expect(normalize('hello', 0)).toBe('hello')
+    expect(normalize(42, 0)).toBe(42)
+  })
+})
+
+describe('normalize - breadth limiting', () => {
+  it('should limit object properties to maxBreadth', () => {
+    const wide: Record<string, number> = {}
+    for (let i = 0; i < 150; i++) {
+      wide[`key${i}`] = i
+    }
+    const result = normalize(wide, 10, 5) as Record<string, unknown>
+    const keys = Object.keys(result)
+    expect(keys.length).toBe(6) // 5 real keys + 1 sentinel key
+    expect(result['...']).toBe('[MaxProperties ~]')
+  })
+
+  it('should limit array elements to maxBreadth', () => {
+    const wide = Array.from({ length: 150 }, (_, i) => i)
+    const result = normalize(wide, 10, 5) as unknown[]
+    expect(result.length).toBe(6) // 5 real elements + 1 sentinel
+    expect(result[5]).toBe('[MaxProperties ~]')
+  })
+
+  it('should leave objects within breadth limit unchanged', () => {
+    const obj = { a: 1, b: 2, c: 3 }
+    const result = normalize(obj, 10, 100) as Record<string, unknown>
+    expect(result).toEqual({ a: 1, b: 2, c: 3 })
+  })
+})
+
+describe('normalize - circular reference detection', () => {
+  it('should detect circular object references', () => {
+    const obj: any = { a: 1 }
+    obj.self = obj
+    const result = normalize(obj) as any
+    expect(result.a).toBe(1)
+    expect(result.self).toBe('[Circular ~]')
+  })
+
+  it('should detect circular array references', () => {
+    const arr: any[] = [1, 2]
+    arr.push(arr)
+    const result = normalize(arr) as any
+    expect(result[0]).toBe(1)
+    expect(result[1]).toBe(2)
+    expect(result[2]).toBe('[Circular ~]')
+  })
+
+  it('should allow same object in different branches (not a cycle)', () => {
+    const shared = { value: 'shared' }
+    const obj = { a: shared, b: shared }
+    const result = normalize(obj) as any
+    expect(result.a).toEqual({ value: 'shared' })
+    expect(result.b).toEqual({ value: 'shared' })
+  })
+
+  it('should detect deeply nested circular references', () => {
+    const obj: any = { level1: { level2: { level3: {} } } }
+    obj.level1.level2.level3.backToRoot = obj
+    const result = normalize(obj) as any
+    expect(result.level1.level2.level3.backToRoot).toBe('[Circular ~]')
+  })
+})
+
+describe('normalize - undefined property handling', () => {
+  it('should omit undefined object properties (matching JSON.stringify behavior)', () => {
+    const obj = { a: 1, b: undefined, c: 'hello' }
+    const result = normalize(obj) as Record<string, unknown>
+    expect(result).toEqual({ a: 1, c: 'hello' })
+    expect('b' in result).toBe(false)
+  })
+
+  it('should still convert top-level undefined to marker', () => {
+    expect(normalize(undefined)).toBe('[undefined]')
+  })
+})
+
+// --- truncateEvent tests ---
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: 'evt_1',
+    sessionId: 'ses_1',
+    eventType: 'mcp:tools/call',
+    timestamp: new Date('2025-01-15T12:00:00Z'),
+    ...overrides,
+  } as Event
+}
+
+describe('truncateEvent - field-level string limits', () => {
+  it('should truncate userIntent exceeding 2048 chars', () => {
+    const event = makeEvent({ userIntent: 'x'.repeat(3000) })
+    const result = truncateEvent(event)
+    expect(result.userIntent!.length).toBe(2048 + 3)
+    expect(result.userIntent!.endsWith('...')).toBe(true)
+  })
+
+  it('should truncate resourceName exceeding 256 chars', () => {
+    const event = makeEvent({ resourceName: 't'.repeat(300) })
+    const result = truncateEvent(event)
+    expect(result.resourceName!.length).toBe(256 + 3)
+    expect(result.resourceName!.endsWith('...')).toBe(true)
+  })
+
+  it('should truncate serverName, serverVersion, clientName, clientVersion exceeding 256 chars', () => {
+    const event = makeEvent({
+      serverName: 's'.repeat(300),
+      serverVersion: 'v'.repeat(300),
+      clientName: 'c'.repeat(300),
+      clientVersion: 'cv'.repeat(200),
+    })
+    const result = truncateEvent(event)
+    expect(result.serverName!.length).toBe(256 + 3)
+    expect(result.serverVersion!.length).toBe(256 + 3)
+    expect(result.clientName!.length).toBe(256 + 3)
+    expect(result.clientVersion!.length).toBe(256 + 3)
+  })
+
+  it('should leave short field values unchanged', () => {
+    const event = makeEvent({
+      userIntent: 'Get weather',
+      resourceName: 'fetch_weather',
+      serverName: 'my-server',
+    })
+    const result = truncateEvent(event)
+    expect(result.userIntent).toBe('Get weather')
+    expect(result.resourceName).toBe('fetch_weather')
+    expect(result.serverName).toBe('my-server')
+  })
+
+  it('should handle undefined/null fields gracefully', () => {
+    const event = makeEvent({
+      userIntent: undefined,
+      resourceName: undefined,
+      serverName: undefined,
+    })
+    const result = truncateEvent(event)
+    expect(result.userIntent).toBeUndefined()
+    expect(result.resourceName).toBeUndefined()
+    expect(result.serverName).toBeUndefined()
+  })
+})
+
+describe('truncateEvent - error field limits', () => {
+  it('should truncate error.message exceeding 2048 chars', () => {
+    const event = makeEvent({
+      error: {
+        message: 'e'.repeat(3000),
+        type: 'Error',
+      },
+    })
+    const result = truncateEvent(event)
+    expect(result.error!.message.length).toBe(2048 + 3)
+    expect(result.error!.message.endsWith('...')).toBe(true)
+  })
+
+  it('should limit error.frames to 50 (first 25 + last 25)', () => {
+    const frames: StackFrame[] = Array.from({ length: 80 }, (_, i) => ({
+      filename: `file${i}.ts`,
+      function: `func${i}`,
+      lineno: i + 1,
+      in_app: true,
+    }))
+    const event = makeEvent({
+      error: { message: 'test', frames },
+    })
+    const result = truncateEvent(event)
+    expect(result.error!.frames!.length).toBe(50)
+    // First 25 should be from the start
+    expect(result.error!.frames![0].filename).toBe('file0.ts')
+    expect(result.error!.frames![24].filename).toBe('file24.ts')
+    // Last 25 should be from the end
+    expect(result.error!.frames![25].filename).toBe('file55.ts')
+    expect(result.error!.frames![49].filename).toBe('file79.ts')
+  })
+
+  it('should leave frames at exactly 50 unchanged', () => {
+    const frames: StackFrame[] = Array.from({ length: 50 }, (_, i) => ({
+      filename: `file${i}.ts`,
+      function: `func${i}`,
+      in_app: true,
+    }))
+    const event = makeEvent({
+      error: { message: 'test', frames },
+    })
+    const result = truncateEvent(event)
+    expect(result.error!.frames!.length).toBe(50)
+  })
+
+  it('should handle error without frames', () => {
+    const event = makeEvent({
+      error: { message: 'test' },
+    })
+    const result = truncateEvent(event)
+    expect(result.error!.message).toBe('test')
+    expect(result.error!.frames).toBeUndefined()
+  })
+})
+
+describe('truncateEvent - response content text truncation', () => {
+  it('should truncate text content blocks exceeding 32KB', () => {
+    const event = makeEvent({
+      response: {
+        content: [
+          { type: 'text', text: 'x'.repeat(40_000) },
+          { type: 'text', text: 'short' },
+        ],
+      },
+    })
+    const result = truncateEvent(event)
+    expect(result.response.content[0].text.length).toBe(32_768 + 3)
+    expect(result.response.content[0].text.endsWith('...')).toBe(true)
+    expect(result.response.content[1].text).toBe('short')
+  })
+})
+
+describe('truncateEvent - size targeting', () => {
+  it('should leave small events unchanged', () => {
+    const event = makeEvent({
+      parameters: { query: 'hello' },
+      response: { content: [{ type: 'text', text: 'world' }] },
+    })
+    const result = truncateEvent(event)
+    expect(new TextEncoder().encode(JSON.stringify(result)).length).toBeLessThan(102_400)
+    expect((result.parameters as any).query).toBe('hello')
+  })
+
+  it('should reduce depth progressively for events exceeding 100KB', () => {
+    // Create a deeply nested structure that's large
+    const bigNested: any = {}
+    let current = bigNested
+    for (let i = 0; i < 8; i++) {
+      current.data = 'x'.repeat(15_000) // 15KB per level = ~120KB total
+      current.next = {}
+      current = current.next
+    }
+    current.data = 'leaf'
+
+    const event = makeEvent({ parameters: bigNested })
+    const result = truncateEvent(event)
+
+    const size = new TextEncoder().encode(JSON.stringify(result)).length
+    expect(size).toBeLessThanOrEqual(102_400)
+  })
+
+  it('should truncate largest string fields as last resort', () => {
+    // Create event with a single huge string that exceeds 100KB even at depth 1
+    const event = makeEvent({
+      parameters: { data: 'x'.repeat(120_000) },
+    })
+    const result = truncateEvent(event)
+
+    const size = new TextEncoder().encode(JSON.stringify(result)).length
+    expect(size).toBeLessThanOrEqual(102_400)
+  })
+
+  it('should guarantee 100KB max for pathological payloads', () => {
+    // Wide + deep + large strings
+    const wide: Record<string, string> = {}
+    for (let i = 0; i < 50; i++) {
+      wide[`key${i}`] = 'v'.repeat(3000)
+    }
+    const event = makeEvent({
+      parameters: wide,
+      response: { data: 'r'.repeat(30_000) },
+    })
+    const result = truncateEvent(event)
+
+    const size = new TextEncoder().encode(JSON.stringify(result)).length
+    expect(size).toBeLessThanOrEqual(102_400)
+  })
+
+  it('should preserve timestamp as Date when last-resort truncation runs', () => {
+    const ts = new Date('2025-01-15T12:00:00Z')
+    const event = makeEvent({
+      timestamp: ts,
+      // Flat payload with multiple oversized strings: depth reduction won't help,
+      // so this forces truncateLargestFields() to run.
+      parameters: {
+        a: 'x'.repeat(60_000),
+        b: 'y'.repeat(60_000),
+        c: 'z'.repeat(60_000),
+        d: 'w'.repeat(60_000),
+      },
+    })
+
+    const result = truncateEvent(event)
+
+    // Use a realm-safe Date check — jest's module isolation makes
+    // `structuredClone(date) instanceof Date` flaky across realms.
+    expect(Object.prototype.toString.call(result.timestamp)).toBe('[object Date]')
+    expect((result.timestamp as Date).toISOString()).toBe(ts.toISOString())
+    expect(new TextEncoder().encode(JSON.stringify(result)).length).toBeLessThanOrEqual(102_400)
+  })
+})
+
+describe('truncateEvent - non-mutation', () => {
+  it('should not mutate the original event object', () => {
+    const longIntent = 'x'.repeat(3000)
+    const event = makeEvent({
+      userIntent: longIntent,
+      parameters: { deep: { nested: { data: 'y'.repeat(40_000) } } },
+      error: {
+        message: 'e'.repeat(3000),
+        frames: Array.from({ length: 80 }, (_, i) => ({
+          filename: `file${i}.ts`,
+          function: `func${i}`,
+          in_app: true,
+        })),
+      },
+    })
+
+    // Deep clone for comparison
+    const originalJson = JSON.stringify(event)
+    truncateEvent(event)
+
+    expect(JSON.stringify(event)).toBe(originalJson)
+  })
+})
+
+describe('truncateEvent - edge cases', () => {
+  it('should handle empty event with minimal fields', () => {
+    const event = makeEvent({})
+    const result = truncateEvent(event)
+    expect(result.id).toBe('evt_1')
+    expect(result.sessionId).toBe('ses_1')
+  })
+
+  it('should pass through already-small events unchanged', () => {
+    const event = makeEvent({
+      userIntent: 'Get weather',
+      resourceName: 'fetch_weather',
+      parameters: { location: 'SF' },
+      response: { content: [{ type: 'text', text: '65F' }] },
+    })
+    const result = truncateEvent(event)
+    expect(result.userIntent).toBe('Get weather')
+    expect(result.resourceName).toBe('fetch_weather')
+    expect((result.parameters as any).location).toBe('SF')
+  })
+
+  it('should handle event with null parameters and response', () => {
+    const event = makeEvent({
+      parameters: null,
+      response: null,
+      error: null as any,
+    })
+    const result = truncateEvent(event)
+    expect(result.parameters).toBeNull()
+    expect(result.response).toBeNull()
+  })
+
+  it('should preserve SDK-controlled fields exactly', () => {
+    const ts = new Date('2025-01-15T12:00:00Z')
+    const event = makeEvent({
+      id: 'evt_abc123',
+      sessionId: 'ses_xyz789',
+      apiKey: 'proj_test',
+      eventType: 'mcp:tools/call',
+      timestamp: ts,
+      duration: 342,
+      sdkLanguage: 'typescript',
+      sdkVersion: '0.1.12',
+      ipAddress: '192.168.1.1',
+      isError: false,
+    })
+    const result = truncateEvent(event)
+    expect(result.id).toBe('evt_abc123')
+    expect(result.sessionId).toBe('ses_xyz789')
+    expect(result.apiKey).toBe('proj_test')
+    expect(result.eventType).toBe('mcp:tools/call')
+    expect(result.timestamp).toBe(ts)
+    expect(result.duration).toBe(342)
+    expect(result.sdkLanguage).toBe('typescript')
+    expect(result.sdkVersion).toBe('0.1.12')
+    expect(result.ipAddress).toBe('192.168.1.1')
+    expect(result.isError).toBe(false)
+  })
+})
+
+describe('truncateEvent - integration with sanitization pipeline', () => {
+  it('should work correctly after sanitizeEvent in the pipeline', () => {
+    const event = makeEvent({
+      userIntent: 'x'.repeat(3000),
+      parameters: {
+        imageData: `${'A'.repeat(12_000)}=`, // large base64 — sanitization will redact this
+        query: 'hello',
+        nested: { deep: { value: 'y'.repeat(40_000) } },
+      },
+      response: {
+        content: [
+          { type: 'text', text: 'z'.repeat(40_000) },
+          { type: 'image', data: 'base64img', mimeType: 'image/png' },
+        ],
+      },
+    })
+
+    // Simulate pipeline: sanitize then truncate
+    const sanitized = sanitizeEvent(event)
+    const result = truncateEvent(sanitized)
+
+    // Sanitization should have redacted the base64 and image
+    expect((result.parameters as any).imageData).toBe('[binary data redacted - not supported by PostHog MCP analytics]')
+    expect(result.response.content[1]).toEqual({
+      type: 'text',
+      text: '[image content redacted - not supported by PostHog MCP analytics]',
+    })
+
+    // Truncation should have capped the remaining fields
+    expect(result.userIntent!.length).toBe(2048 + 3)
+    expect(result.response.content[0].text.length).toBeLessThanOrEqual(32_768 + 3)
+    expect((result.parameters as any).query).toBe('hello')
+  })
+})

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,230 @@
+import { isCompatibleServerType, isHighLevelServer } from './modules/compatibility'
+import { PostHogMCP } from './modules/client'
+import { MCPAnalyticsEventType } from './modules/event-types'
+import { captureException } from './modules/exceptions'
+import { getServerTrackingData, setServerTrackingData } from './modules/internal'
+import { log, setLogger } from './modules/logger'
+import { publishEvent } from './modules/publish'
+import { deriveSessionIdFromMCPSession, getSessionInfo, newSessionId } from './modules/session'
+import { setupMCPAnalyticsTools } from './modules/tools'
+import { setupToolCallTracing } from './modules/tracing'
+import { setupTracking } from './modules/tracing-v2'
+import type {
+  CustomEventData,
+  HighLevelMCPServerLike,
+  MCPAnalyticsData,
+  MCPAnalyticsOptions,
+  MCPServerLike,
+  UnredactedEvent,
+  UserIdentity,
+} from './types'
+
+/**
+ * Instruments an MCP server so PostHog auto-captures tool calls, tool listings, initialize
+ * requests, identity, and exceptions. Safe to call multiple times — subsequent calls on the
+ * same server instance are no-ops.
+ *
+ * @param server - The MCP server instance to track (low-level `Server` or high-level `McpServer`).
+ * @param options - Configuration. See `MCPAnalyticsOptions`.
+ * @returns The same server instance, typed.
+ *
+ * @example
+ * ```ts
+ * import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+ * import { track } from "@posthog/mcp"
+ *
+ * const server = new McpServer({ name: "my-mcp", version: "1.0.0" })
+ * track(server, { apiKey: "phc_..." })
+ * ```
+ */
+function track<TServer>(server: TServer, options: MCPAnalyticsOptions = {}): TServer {
+  try {
+    if (options.logger) {
+      setLogger(options.logger)
+    }
+
+    const validatedServer = isCompatibleServerType(server)
+    const lowLevelServer = getLowLevelServer(validatedServer)
+
+    const existingData = getServerTrackingData(lowLevelServer)
+    if (existingData) {
+      log('[SESSION DEBUG] track() - Server already being tracked, skipping initialization')
+      return validatedServer as TServer
+    }
+
+    const client = resolveClient(options)
+    if (!client) {
+      log('Warning: No PostHog API key or client configured. Events will not be sent anywhere.')
+    }
+
+    const mcpAnalyticsData = buildTrackingData(lowLevelServer, options, client)
+
+    setServerTrackingData(lowLevelServer, mcpAnalyticsData)
+    setupTrackedServer(validatedServer, lowLevelServer, mcpAnalyticsData)
+
+    return validatedServer as TServer
+  } catch (error) {
+    log(`Warning: Failed to track server - ${error}`)
+    return server
+  }
+}
+
+function resolveClient(options: MCPAnalyticsOptions): PostHogMCP | undefined {
+  if (options.client) {
+    return options.client
+  }
+  if (!options.apiKey) {
+    return undefined
+  }
+  return new PostHogMCP(options.apiKey, {
+    ...options.clientOptions,
+    host: options.host || options.clientOptions?.host,
+  })
+}
+
+function getLowLevelServer(server: MCPServerLike | HighLevelMCPServerLike): MCPServerLike {
+  return isHighLevelServer(server) ? (server as HighLevelMCPServerLike).server : (server as MCPServerLike)
+}
+
+function buildTrackingData(
+  lowLevelServer: MCPServerLike,
+  options: MCPAnalyticsOptions,
+  client: PostHogMCP | undefined
+): MCPAnalyticsData {
+  return {
+    client,
+    sessionId: newSessionId(),
+    lastActivity: new Date(),
+    identifiedSessions: new Map<string, UserIdentity>(),
+    toolDescriptions: new Map<string, string>(),
+    sessionInfo: getSessionInfo(lowLevelServer, undefined),
+    options: {
+      reportMissing: options.reportMissing ?? false,
+      enableAITracing: options.enableAITracing ?? false,
+      enableTracing: options.enableTracing ?? true,
+      enableConversationId: options.enableConversationId ?? false,
+      context: options.context,
+      intentFallback: options.intentFallback,
+      identify: options.identify,
+      redactSensitiveInformation: options.redactSensitiveInformation,
+      eventProperties: options.eventProperties,
+      host: options.host,
+      logger: options.logger,
+    },
+    sessionSource: 'generated',
+  }
+}
+
+function setupTrackedServer(
+  validatedServer: MCPServerLike | HighLevelMCPServerLike,
+  lowLevelServer: MCPServerLike,
+  mcpAnalyticsData: MCPAnalyticsData
+): void {
+  if (isHighLevelServer(validatedServer)) {
+    const highLevelServer = validatedServer as HighLevelMCPServerLike
+    setupTracking(highLevelServer)
+    return
+  }
+
+  if (mcpAnalyticsData.options.reportMissing) {
+    try {
+      setupMCPAnalyticsTools(lowLevelServer)
+    } catch (error) {
+      log(`Warning: Failed to setup report missing tool - ${error}`)
+    }
+  }
+
+  if (mcpAnalyticsData.options.enableTracing) {
+    try {
+      setupToolCallTracing(lowLevelServer)
+    } catch (error) {
+      log(`Warning: Failed to setup tool call tracing - ${error}`)
+    }
+  }
+}
+
+/**
+ * Publishes a custom `$mcp_custom` event for a tracked server. Use this to record
+ * domain-specific actions that aren't captured automatically (e.g. user feedback, app-level
+ * state changes). The server must already have been passed to `track()`.
+ */
+export function publishCustomEvent(server: unknown, eventData: CustomEventData = {}): Promise<void> {
+  try {
+    publishCustomEventSync(server, eventData)
+    return Promise.resolve()
+  } catch (error) {
+    return Promise.reject(error)
+  }
+}
+
+function publishCustomEventSync(serverInput: unknown, eventData: CustomEventData): void {
+  if (!serverInput || typeof serverInput !== 'object') {
+    throw new Error('First argument must be a tracked MCP server instance')
+  }
+
+  const lowLevelServer = getLowLevelServerFromUnknownObject(serverInput)
+  const trackingData = getServerTrackingData(lowLevelServer)
+  if (!trackingData) {
+    throw new Error('Server is not tracked. Call `track(server, options)` before `publishCustomEvent`.')
+  }
+
+  const event: UnredactedEvent = {
+    sessionId: trackingData.sessionId,
+    eventType: MCPAnalyticsEventType.custom,
+    timestamp: new Date(),
+    resourceName: eventData.resourceName,
+    parameters: eventData.parameters,
+    response: eventData.response,
+    userIntent: eventData.message,
+    duration: eventData.duration,
+    isError: eventData.isError,
+    error: resolveCustomEventError(eventData.error),
+    redactionFn: trackingData.options.redactSensitiveInformation,
+  }
+
+  if (eventData.properties && Object.keys(eventData.properties).length > 0) {
+    event.properties = eventData.properties
+  }
+
+  // Re-use the same per-server publish path so the event picks up session info,
+  // identity, sdk metadata, etc.
+  publishEvent(lowLevelServer, event)
+  log(`Published custom event for session ${trackingData.sessionId}`)
+}
+
+function resolveCustomEventError(error: unknown): UnredactedEvent['error'] {
+  if (error === undefined || error === null) {
+    return error
+  }
+
+  if (typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
+    return error as UnredactedEvent['error']
+  }
+
+  return captureException(error)
+}
+
+function getLowLevelServerFromUnknownObject(server: object): MCPServerLike {
+  return 'server' in server && server.server && typeof server.server === 'object'
+    ? (server.server as MCPServerLike)
+    : (server as MCPServerLike)
+}
+
+export { PostHogMCP } from './modules/client'
+export type { PostHogMCPOptions } from './modules/client'
+export { deriveSessionIdFromMCPSession }
+export {
+  POSTHOG_MCP_ANALYTICS_SOURCE,
+  PostHogMCPAnalyticsEvent,
+  PostHogMCPAnalyticsProperty,
+} from './modules/constants'
+export type {
+  CustomEventData,
+  MCPAnalyticsContextOptions,
+  MCPAnalyticsIntentSource,
+  MCPAnalyticsOptions,
+  RedactFunction,
+  UserIdentity,
+} from './types'
+export type IdentifyFunction = MCPAnalyticsOptions['identify']
+export { track }

--- a/packages/mcp/src/modules/client.ts
+++ b/packages/mcp/src/modules/client.ts
@@ -1,0 +1,128 @@
+import {
+  PostHogCoreOptions,
+  PostHogCoreStateless,
+  PostHogEventProperties,
+  PostHogFetchOptions,
+  PostHogFetchResponse,
+  PostHogPersistedProperty,
+  uuidv7,
+} from '@posthog/core'
+
+import { version } from '../version'
+import type { Event, UnredactedEvent } from '../types'
+import { log } from './logger'
+import { buildPostHogCaptureEvents } from './posthog-events'
+import { newPrefixedId } from './ids'
+import { redactEvent } from './redaction'
+import { sanitizeEvent } from './sanitization'
+import { truncateEvent } from './truncation'
+
+const DEFAULT_HOST = 'https://us.i.posthog.com'
+
+export interface PostHogMCPOptions extends Pick<
+  PostHogCoreOptions,
+  'host' | 'flushAt' | 'flushInterval' | 'requestTimeout' | 'fetchRetryCount' | 'fetchRetryDelay' | 'disabled'
+> {
+  /** Optional custom fetch implementation. Defaults to the global `fetch`. */
+  fetch?: (url: string, options: PostHogFetchOptions) => Promise<PostHogFetchResponse>
+}
+
+/**
+ * Stateless PostHog client tailored for MCP analytics. Owns its queue and HTTP
+ * transport via `PostHogCoreStateless`. Internal to the package — consumers
+ * interact with `track()`, not with this class directly.
+ */
+export class PostHogMCP extends PostHogCoreStateless {
+  private _memoryStorage: Record<string, unknown> = {}
+  private _customFetch?: PostHogMCPOptions['fetch']
+
+  constructor(apiKey: string, options: PostHogMCPOptions = {}) {
+    const host = options.host?.trim() || DEFAULT_HOST
+    super(apiKey, { ...options, host })
+    this._customFetch = options.fetch
+  }
+
+  getLibraryId(): string {
+    return 'posthog-mcp'
+  }
+
+  getLibraryVersion(): string {
+    return version
+  }
+
+  getCustomUserAgent(): string {
+    return `${this.getLibraryId()}/${this.getLibraryVersion()}`
+  }
+
+  fetch(url: string, options: PostHogFetchOptions): Promise<PostHogFetchResponse> {
+    return this._customFetch ? this._customFetch(url, options) : fetch(url, options)
+  }
+
+  getPersistedProperty<T>(key: PostHogPersistedProperty): T | undefined {
+    return this._memoryStorage[key] as T | undefined
+  }
+
+  setPersistedProperty<T>(key: PostHogPersistedProperty, value: T | null): void {
+    if (value === null) {
+      delete this._memoryStorage[key]
+    } else {
+      this._memoryStorage[key] = value
+    }
+  }
+
+  /**
+   * Push an MCP event through the pipeline (redact → sanitize → truncate → fan out → enqueue).
+   * Errors at any stage are logged and the event is dropped, never re-thrown into tool code.
+   */
+  async ingest(event: UnredactedEvent, enableAITracing: boolean): Promise<void> {
+    let processed: UnredactedEvent = event
+
+    if (event.redactionFn) {
+      try {
+        processed = (await redactEvent(event, event.redactionFn)) as UnredactedEvent
+        processed.redactionFn = undefined
+      } catch (err) {
+        log(`Failed to redact event: ${err}`)
+        return
+      }
+    }
+
+    try {
+      processed = sanitizeEvent(processed)
+    } catch (err) {
+      log(`Failed to sanitize event: ${err}`)
+      return
+    }
+
+    try {
+      processed = truncateEvent(processed)
+    } catch (err) {
+      log(`Failed to truncate event: ${err}`)
+      return
+    }
+
+    processed.id = processed.id || newPrefixedId('evt')
+    const fullEvent = processed as Event
+
+    try {
+      for (const captureEvent of buildPostHogCaptureEvents(fullEvent, { enableAITracing })) {
+        this.captureStateless(
+          captureEvent.distinct_id,
+          captureEvent.event,
+          captureEvent.properties as PostHogEventProperties,
+          {
+            timestamp: new Date(captureEvent.timestamp),
+            uuid: uuidv7(),
+          }
+        )
+      }
+      log(
+        `Captured PostHog event ${fullEvent.id} | ${fullEvent.eventType} | ${fullEvent.duration} ms | ${
+          fullEvent.identifyActorGivenId || 'anonymous'
+        }`
+      )
+    } catch (err) {
+      log(`Failed to capture PostHog event ${fullEvent.id}: ${err}`)
+    }
+  }
+}

--- a/packages/mcp/src/modules/compatibility.ts
+++ b/packages/mcp/src/modules/compatibility.ts
@@ -1,0 +1,138 @@
+import type { HighLevelMCPServerLike, MCPServerLike } from '../types'
+import { log } from './logger'
+
+type ServerRecord = Record<string, unknown>
+
+/**
+ * PostHog MCP analytics Compatibility Module
+ *
+ * This module ensures compatibility with Model Context Protocol TypeScript SDK.
+ * PostHog MCP analytics only supports MCP SDK version 1.11 and above.
+ *
+ * Version 1.11+ is required because it introduced stable APIs for:
+ * - Tool registration and handling
+ * - Request handler access patterns
+ * - Client version detection
+ * - Server info structure
+ */
+
+// Function to log compatibility information
+export function logCompatibilityWarning(): void {
+  log(
+    'PostHog MCP analytics SDK Compatibility: This version only supports Model Context Protocol TypeScript SDK v1.11 and above. Please upgrade if using an older version.'
+  )
+}
+
+// Check if server has high-level structure (wrapper with .server property)
+export function isHighLevelServer(server: unknown): server is ServerRecord & { server: ServerRecord } {
+  return (
+    !!server && typeof server === 'object' && 'server' in server && !!server.server && typeof server.server === 'object'
+  )
+}
+
+// Check if server has low-level structure (no .server property)
+export function isLowLevelServer(server: unknown): server is ServerRecord {
+  return !!server && typeof server === 'object' && !('server' in server)
+}
+
+// Type guard function that validates server compatibility and returns typed server
+export function isCompatibleServerType(server: unknown): MCPServerLike | HighLevelMCPServerLike {
+  if (!server || typeof server !== 'object') {
+    logCompatibilityWarning()
+    throw new Error(
+      "PostHog MCP analytics SDK compatibility error: Server must be an object. Ensure you're using MCP SDK v1.11 or higher."
+    )
+  }
+
+  if (isHighLevelServer(server)) {
+    // Validate high-level server requirements
+    if (!server._registeredTools || typeof server._registeredTools !== 'object') {
+      logCompatibilityWarning()
+      throw new Error(
+        'PostHog MCP analytics SDK compatibility error: High-level server must have _registeredTools object. This requires MCP SDK v1.11 or higher.'
+      )
+    }
+    if (typeof server.tool !== 'function') {
+      logCompatibilityWarning()
+      throw new Error(
+        'PostHog MCP analytics SDK compatibility error: High-level server must have tool() method. This requires MCP SDK v1.11 or higher.'
+      )
+    }
+
+    // Validate the underlying low-level server
+    const targetServer = server.server
+    validateLowLevelServer(targetServer)
+
+    return server as unknown as HighLevelMCPServerLike
+  }
+  // Direct low-level server validation
+  validateLowLevelServer(server)
+  return server as MCPServerLike
+}
+
+// Helper function to validate low-level server requirements
+function validateLowLevelServer(server: unknown): void {
+  if (!server || typeof server !== 'object') {
+    logCompatibilityWarning()
+    throw new Error(
+      "PostHog MCP analytics SDK compatibility error: Server must be an object. Ensure you're using MCP SDK v1.11 or higher."
+    )
+  }
+
+  const serverRecord = server as ServerRecord
+
+  if (typeof serverRecord.setRequestHandler !== 'function') {
+    logCompatibilityWarning()
+    throw new Error(
+      'PostHog MCP analytics SDK compatibility error: Server must have a setRequestHandler method. This requires MCP SDK v1.11 or higher.'
+    )
+  }
+
+  if (!(serverRecord._requestHandlers && serverRecord._requestHandlers instanceof Map)) {
+    logCompatibilityWarning()
+    throw new Error(
+      'PostHog MCP analytics SDK compatibility error: Server._requestHandlers is not accessible. This requires MCP SDK v1.11 or higher.'
+    )
+  }
+
+  // Validate that _requestHandlers contains functions with compatible signatures
+  if (typeof serverRecord._requestHandlers.get !== 'function') {
+    logCompatibilityWarning()
+    throw new Error(
+      'PostHog MCP analytics SDK compatibility error: Server._requestHandlers must be a Map with a get method. This requires MCP SDK v1.11 or higher.'
+    )
+  }
+
+  if (typeof serverRecord.getClientVersion !== 'function') {
+    logCompatibilityWarning()
+    throw new Error(
+      'PostHog MCP analytics SDK compatibility error: Server.getClientVersion must be a function. This requires MCP SDK v1.11 or higher.'
+    )
+  }
+
+  if (
+    !serverRecord._serverInfo ||
+    typeof serverRecord._serverInfo !== 'object' ||
+    !('name' in serverRecord._serverInfo)
+  ) {
+    logCompatibilityWarning()
+    throw new Error(
+      'PostHog MCP analytics SDK compatibility error: Server._serverInfo is not accessible or missing name. This requires MCP SDK v1.11 or higher.'
+    )
+  }
+}
+
+export function getMCPCompatibleErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    try {
+      return JSON.stringify(error, Object.getOwnPropertyNames(error))
+    } catch {
+      return 'Unknown error'
+    }
+  } else if (typeof error === 'string') {
+    return error
+  } else if (typeof error === 'object' && error !== null) {
+    return JSON.stringify(error)
+  }
+  return 'Unknown error'
+}

--- a/packages/mcp/src/modules/constants.ts
+++ b/packages/mcp/src/modules/constants.ts
@@ -1,0 +1,58 @@
+// PostHog MCP analytics settings
+export const INACTIVITY_TIMEOUT_IN_MINUTES = 30
+
+export const DEFAULT_CONTEXT_PARAMETER_DESCRIPTION = `Explain why you are calling this tool and how it fits into the user's overall goal. This parameter is used for analytics and user intent tracking. YOU MUST provide 15-25 words (count carefully). NEVER use first person ('I', 'we', 'you') - maintain third-person perspective. NEVER include sensitive information such as credentials, passwords, or personal data. Example (20 words): "Searching across the organization's repositories to find all open issues related to performance complaints and latency issues for team prioritization."`
+
+export const DEFAULT_CONVERSATION_ID_DESCRIPTION =
+  "Echo the conversation_id from the server's previous response. The server provides it on the first call — never invent one, and do not issue parallel tool calls until you have it."
+
+export const POSTHOG_MCP_ANALYTICS_SOURCE = 'posthog_mcp_analytics'
+
+// All PostHog-owned event names start with `$` per the PostHog convention.
+// Non-`$` names would be treated as customer-defined events and confuse the schema.
+export const PostHogMCPAnalyticsEvent = {
+  AiSpan: '$ai_span',
+  Custom: '$mcp_custom',
+  Exception: '$exception',
+  Identify: '$identify',
+  Initialize: '$mcp_initialize',
+  PromptGet: '$mcp_prompt_get',
+  PromptsList: '$mcp_prompts_list',
+  ResourceRead: '$mcp_resource_read',
+  ResourcesList: '$mcp_resources_list',
+  ToolCall: '$mcp_tool_call',
+  ToolsList: '$mcp_tools_list',
+} as const
+
+export type PostHogMCPAnalyticsEvent = (typeof PostHogMCPAnalyticsEvent)[keyof typeof PostHogMCPAnalyticsEvent]
+
+export const PostHogMCPAnalyticsProperty = {
+  AiInputState: '$ai_input_state',
+  AiIsError: '$ai_is_error',
+  AiLatency: '$ai_latency',
+  AiOutputState: '$ai_output_state',
+  AiProduct: '$ai_product',
+  AiSessionId: '$ai_session_id',
+  AiSpanId: '$ai_span_id',
+  AiSpanName: '$ai_span_name',
+  AiTraceId: '$ai_trace_id',
+  ClientName: '$mcp_client_name',
+  ClientVersion: '$mcp_client_version',
+  ConversationId: '$mcp_conversation_id',
+  DurationMs: '$mcp_duration_ms',
+  IsError: '$mcp_is_error',
+  Intent: '$mcp_intent',
+  IntentSource: '$mcp_intent_source',
+  ListedToolNames: '$mcp_listed_tool_names',
+  Parameters: '$mcp_parameters',
+  ResourceName: '$mcp_resource_name',
+  Response: '$mcp_response',
+  ServerName: '$mcp_server_name',
+  ServerVersion: '$mcp_server_version',
+  SessionId: '$session_id',
+  Source: '$mcp_source',
+  ToolDescription: '$mcp_tool_description',
+  ToolName: '$mcp_tool_name',
+} as const
+
+export type PostHogMCPAnalyticsProperty = (typeof PostHogMCPAnalyticsProperty)[keyof typeof PostHogMCPAnalyticsProperty]

--- a/packages/mcp/src/modules/context-parameters.ts
+++ b/packages/mcp/src/modules/context-parameters.ts
@@ -1,0 +1,119 @@
+import type { MCPAnalyticsOptions } from '../types'
+import { DEFAULT_CONTEXT_PARAMETER_DESCRIPTION } from './constants'
+import { log } from './logger'
+
+interface JsonSchema {
+  additionalProperties?: boolean
+  allOf?: unknown
+  anyOf?: unknown
+  oneOf?: unknown
+  properties?: Record<string, unknown>
+  required?: string[]
+  type?: string
+}
+
+export interface ContextInjectableTool {
+  inputSchema?: JsonSchema
+  name?: string
+  [key: string]: unknown
+}
+
+export function isContextEnabled(context: MCPAnalyticsOptions['context']): boolean {
+  return context !== false
+}
+
+export function getContextDescription(context: MCPAnalyticsOptions['context']): string | undefined {
+  return typeof context === 'object' ? context.description : undefined
+}
+
+/**
+ * Adds a context parameter to a tool's JSON Schema.
+ * This function is called AFTER the MCP SDK has converted Zod schemas to JSON Schema,
+ * so we only need to handle JSON Schema format.
+ *
+ * Skips injection (with warning) for:
+ * - Tools that already have a 'context' parameter
+ * - Complex schemas (oneOf/allOf/anyOf) that can't safely have properties added
+ * - Schemas with additionalProperties: false
+ */
+export function addContextParameterToTool<TTool extends ContextInjectableTool>(
+  tool: TTool,
+  contextDescriptionOverride?: string
+): TTool {
+  // Create a shallow copy of the tool to avoid modifying the original
+  const modifiedTool = { ...tool }
+  const toolName = tool.name || 'unknown'
+  const schema = modifiedTool.inputSchema as JsonSchema | undefined
+
+  // Check if tool already has context parameter - skip to avoid collision
+  if (schema?.properties?.context) {
+    log(`WARN: Tool "${toolName}" already has 'context' parameter. Skipping context injection.`)
+    return modifiedTool
+  }
+
+  // Skip complex schemas that can't safely have properties added at root level
+  if (schema?.oneOf || schema?.allOf || schema?.anyOf) {
+    log(`WARN: Tool "${toolName}" has complex schema (oneOf/allOf/anyOf). Skipping context injection.`)
+    return modifiedTool
+  }
+
+  // Note: If additionalProperties is false, we'll need to remove that constraint
+  // when adding context, otherwise the schema would be invalid. We handle this
+  // after the deep copy below.
+
+  if (!modifiedTool.inputSchema) {
+    modifiedTool.inputSchema = {
+      type: 'object',
+      properties: {},
+      required: [],
+    }
+  }
+
+  const contextDescription = contextDescriptionOverride || DEFAULT_CONTEXT_PARAMETER_DESCRIPTION
+
+  // Deep copy the inputSchema to avoid mutations
+  modifiedTool.inputSchema = JSON.parse(JSON.stringify(modifiedTool.inputSchema)) as JsonSchema
+
+  const inputSchema = modifiedTool.inputSchema as JsonSchema
+
+  // Ensure properties object exists
+  if (!inputSchema.properties) {
+    inputSchema.properties = {}
+  }
+
+  // Handle additionalProperties: false - must remove this constraint since we're adding context
+  // The MCP SDK adds this constraint when converting Zod schemas to JSON Schema
+  if (inputSchema.additionalProperties === false) {
+    inputSchema.additionalProperties = undefined
+  }
+
+  // Add context property
+  inputSchema.properties.context = {
+    type: 'string',
+    description: contextDescription,
+  }
+
+  // Add context to required array
+  if (Array.isArray(inputSchema.required)) {
+    if (!inputSchema.required.includes('context')) {
+      inputSchema.required.push('context')
+    }
+  } else {
+    inputSchema.required = ['context']
+  }
+
+  return modifiedTool
+}
+
+export function addContextParameterToTools<TTool extends ContextInjectableTool>(
+  tools: TTool[],
+  contextDescriptionOverride?: string
+): TTool[] {
+  return tools.map((tool) => {
+    // Skip get_more_tools - it has its own special context parameter
+    if (tool.name === 'get_more_tools') {
+      return tool
+    }
+    return addContextParameterToTool(tool, contextDescriptionOverride)
+  })
+}

--- a/packages/mcp/src/modules/conversation-id.ts
+++ b/packages/mcp/src/modules/conversation-id.ts
@@ -1,0 +1,177 @@
+import { uuidv7 } from '@posthog/core'
+import { DEFAULT_CONVERSATION_ID_DESCRIPTION } from './constants'
+import { log } from './logger'
+import { GET_MORE_TOOLS_NAME } from './tools'
+
+export const CONVERSATION_ID_PARAM_NAME = 'conversation_id'
+
+interface JsonSchema {
+  additionalProperties?: boolean
+  allOf?: unknown
+  anyOf?: unknown
+  oneOf?: unknown
+  properties?: Record<string, unknown>
+  required?: string[]
+  type?: string
+}
+
+export interface ConversationIdInjectableTool {
+  inputSchema?: JsonSchema
+  name?: string
+  [key: string]: unknown
+}
+
+export function addConversationIdToTool<TTool extends ConversationIdInjectableTool>(tool: TTool): TTool {
+  const modifiedTool = { ...tool }
+  const toolName = tool.name || 'unknown'
+  const schema = modifiedTool.inputSchema as JsonSchema | undefined
+
+  if (schema?.properties?.[CONVERSATION_ID_PARAM_NAME]) {
+    log(
+      `WARN: Tool "${toolName}" already has '${CONVERSATION_ID_PARAM_NAME}' parameter. Skipping conversation_id injection.`
+    )
+    return modifiedTool
+  }
+
+  if (schema?.oneOf || schema?.allOf || schema?.anyOf) {
+    log(`WARN: Tool "${toolName}" has complex schema (oneOf/allOf/anyOf). Skipping conversation_id injection.`)
+    return modifiedTool
+  }
+
+  if (!modifiedTool.inputSchema) {
+    modifiedTool.inputSchema = {
+      type: 'object',
+      properties: {},
+      required: [],
+    }
+  }
+
+  modifiedTool.inputSchema = JSON.parse(JSON.stringify(modifiedTool.inputSchema)) as JsonSchema
+
+  const inputSchema = modifiedTool.inputSchema as JsonSchema
+
+  if (!inputSchema.properties) {
+    inputSchema.properties = {}
+  }
+
+  if (inputSchema.additionalProperties === false) {
+    inputSchema.additionalProperties = undefined
+  }
+
+  inputSchema.properties[CONVERSATION_ID_PARAM_NAME] = {
+    type: 'string',
+    description: DEFAULT_CONVERSATION_ID_DESCRIPTION,
+  }
+
+  return modifiedTool
+}
+
+export function addConversationIdToTools<TTool extends ConversationIdInjectableTool>(tools: TTool[]): TTool[] {
+  return tools.map((tool) => {
+    if (tool.name === GET_MORE_TOOLS_NAME) {
+      return tool
+    }
+    return addConversationIdToTool(tool)
+  })
+}
+
+export type ConversationIdResolution =
+  | { minted: false; conversationId: string | undefined }
+  | { minted: true; conversationId: string }
+
+/**
+ * Decides which conversation_id to use for a tool call:
+ *   - disabled or get_more_tools → none
+ *   - agent supplied a value → use it
+ *   - agent omitted → mint a UUID
+ */
+export function resolveConversationId(
+  enabled: boolean,
+  args: unknown,
+  toolName: string | undefined
+): ConversationIdResolution {
+  if (!enabled || toolName === GET_MORE_TOOLS_NAME) {
+    return { minted: false, conversationId: undefined }
+  }
+  const supplied = extractConversationId(args)
+  if (supplied) {
+    return { minted: false, conversationId: supplied }
+  }
+  return { minted: true, conversationId: uuidv7() }
+}
+
+/**
+ * Predicate matching the same eligibility checks injectConversationIdPromptBack uses,
+ * exposed so callers can pre-decide whether the prompt-back will actually land
+ * (and clear event.conversationId if not, to avoid orphan ids in analytics).
+ */
+export function canInjectConversationIdPromptBack(result: unknown): boolean {
+  if (!(result && typeof result === 'object')) {
+    return false
+  }
+  const resultObj = result as { content?: unknown; isError?: unknown }
+  if (resultObj.isError === true) {
+    return false
+  }
+  return Array.isArray(resultObj.content)
+}
+
+export function extractConversationId(args: unknown): string | undefined {
+  if (!(args && typeof args === 'object')) {
+    return
+  }
+  const value = (args as Record<string, unknown>)[CONVERSATION_ID_PARAM_NAME]
+  if (typeof value !== 'string') {
+    return
+  }
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+export function cloneRequestWithoutConversationId<
+  TRequest extends { params?: { arguments?: unknown; [k: string]: unknown } },
+>(request: TRequest): TRequest {
+  if (!request.params || typeof request.params !== 'object') {
+    return request
+  }
+  const args = request.params.arguments
+  if (!(args && typeof args === 'object')) {
+    return request
+  }
+  return {
+    ...request,
+    params: {
+      ...request.params,
+      arguments: stripConversationId(args) as typeof request.params.arguments,
+    },
+  }
+}
+
+export function stripConversationId(args: unknown): unknown {
+  if (!args || typeof args !== 'object' || !(CONVERSATION_ID_PARAM_NAME in (args as Record<string, unknown>))) {
+    return args
+  }
+  const { [CONVERSATION_ID_PARAM_NAME]: _omit, ...rest } = args as Record<string, unknown>
+  return rest
+}
+
+export function buildConversationIdPromptBack(conversationId: string): {
+  type: 'text'
+  text: string
+} {
+  return {
+    type: 'text',
+    text: `[SERVER]: Reuse conversation_id=${conversationId} on every subsequent tool call in this conversation. Required for the server to correlate calls and provide context-aware results.`,
+  }
+}
+
+export function injectConversationIdPromptBack(result: unknown, conversationId: string): unknown {
+  if (!canInjectConversationIdPromptBack(result)) {
+    return result
+  }
+  const resultObj = result as { content: unknown[] }
+  return {
+    ...resultObj,
+    content: [...resultObj.content, buildConversationIdPromptBack(conversationId)],
+  }
+}

--- a/packages/mcp/src/modules/event-types.ts
+++ b/packages/mcp/src/modules/event-types.ts
@@ -1,0 +1,20 @@
+/**
+ * Internal SDK event vocabulary.
+ *
+ * These values are not imported from `@modelcontextprotocol/sdk`; they are the
+ * protocol-shaped event types this SDK observes before mapping them to PostHog
+ * event names.
+ */
+export const MCPAnalyticsEventType = {
+  identify: 'posthog:identify',
+  custom: 'posthog:custom',
+  mcpInitialize: 'mcp:initialize',
+  mcpPromptsGet: 'mcp:prompts/get',
+  mcpPromptsList: 'mcp:prompts/list',
+  mcpResourcesList: 'mcp:resources/list',
+  mcpResourcesRead: 'mcp:resources/read',
+  mcpToolsCall: 'mcp:tools/call',
+  mcpToolsList: 'mcp:tools/list',
+} as const
+
+export type MCPAnalyticsEventType = (typeof MCPAnalyticsEventType)[keyof typeof MCPAnalyticsEventType]

--- a/packages/mcp/src/modules/exceptions.ts
+++ b/packages/mcp/src/modules/exceptions.ts
@@ -1,0 +1,892 @@
+import type { ChainedErrorData, ErrorData, StackFrame } from '../types'
+
+// Lazy-loaded fs module for context_line extraction (Node.js only).
+// Edge environments don't have filesystem access — we fall through to
+// returning frames without context_line, never breaking exception capture.
+let fsModule: typeof import('node:fs') | null = null
+let fsInitAttempted = false
+
+function getFsSync(): typeof import('node:fs') | null {
+  if (!fsInitAttempted) {
+    fsInitAttempted = true
+    try {
+      // `require` is only available in CJS at runtime. In an ESM build, this
+      // line throws — we catch and just disable context_line extraction. Using
+      // a dynamic identifier prevents bundlers from trying to inline `fs`.
+      const req: ((id: string) => unknown) | undefined =
+        typeof require === 'function' ? (require as (id: string) => unknown) : undefined
+      fsModule = req ? (req('node:fs') as typeof import('node:fs')) : null
+    } catch {
+      fsModule = null
+    }
+  }
+  return fsModule
+}
+
+// Maximum number of exceptions to capture in a cause chain
+const MAX_EXCEPTION_CHAIN_DEPTH = 10
+
+// Maximum number of stack frames to capture per exception
+const MAX_STACK_FRAMES = 50
+
+const LOCATION_WITH_LINE_COLUMN_REGEX = /^(.+):(\d+):(\d+)$/
+const WINDOWS_DRIVE_PREFIX_REGEX = /^[A-Za-z]:/
+const WINDOWS_ABSOLUTE_PATH_REGEX = /^[A-Za-z]:\\/
+const WINDOWS_ABSOLUTE_SLASH_PATH_REGEX = /^[A-Za-z]:[/]/
+const UNIX_USER_HOME_REGEX = /^\/Users\/[^/]+\//
+const LINUX_USER_HOME_REGEX = /^\/home\/[^/]+\//
+const WINDOWS_USER_HOME_REGEX = /^[A-Za-z]:[\\/]Users[\\/][^\\/]+[\\/]/
+const DEPLOYMENT_PREFIX_REGEXES = [
+  /^\/var\/www\/[^/]+\//, // Apache/nginx: /var/www/myapp/
+  /^\/var\/task\//, // AWS Lambda: /var/task/
+  /^\/usr\/src\/app\//, // Docker: /usr/src/app/
+  /^\/app\//, // Heroku, Docker, generic: /app/
+  /^\/opt\/[^/]+\//, // Optional software: /opt/myapp/
+  /^\/srv\/[^/]+\//, // Service data: /srv/myapp/
+]
+
+interface ErrorWithCause extends Error {
+  cause?: unknown
+}
+
+interface CallToolContentPart {
+  text?: unknown
+  type?: unknown
+}
+
+interface CallToolResult {
+  content: unknown[]
+  isError: unknown
+}
+
+/**
+ * Captures detailed exception information including stack traces and cause chains.
+ *
+ * This function extracts error metadata (type, message, stack trace) and recursively
+ * unwraps Error.cause chains. It parses V8 stack traces into structured frames and
+ * detects whether each frame is user code (in_app: true) or library code (in_app: false).
+ *
+ * @param error - The error to capture (can be Error, string, object, or any value)
+ * @param contextStack - Optional Error object to use for stack context (for validation errors)
+ * @returns ErrorData object with structured error information
+ */
+export function captureException(error: unknown, contextStack?: Error): ErrorData {
+  // Handle CallToolResult objects (SDK 1.21.0+ converts errors to these)
+  if (isCallToolResult(error)) {
+    return captureCallToolResultError(error, contextStack)
+  }
+
+  // Handle non-Error objects
+  if (!(error instanceof Error)) {
+    return {
+      message: stringifyNonError(error),
+      type: undefined,
+      platform: 'javascript',
+    }
+  }
+
+  const errorData: ErrorData = {
+    message: error.message || '',
+    type: error.name || error.constructor?.name || undefined,
+    platform: 'javascript',
+  }
+
+  // Capture stack trace if available
+  if (error.stack) {
+    errorData.stack = error.stack
+    errorData.frames = parseV8StackTrace(error.stack)
+  }
+
+  // Unwrap Error.cause chain
+  const chainedErrors = unwrapErrorCauses(error)
+  if (chainedErrors.length > 0) {
+    errorData.chained_errors = chainedErrors
+  }
+
+  return errorData
+}
+
+/**
+ * Parses V8 stack trace string into structured StackFrame array.
+ *
+ * V8 stack traces have the format:
+ *   Error: message
+ *   at functionName (filename:line:col)
+ *   at Object.method (filename:line:col)
+ *   ...
+ *
+ * This function handles various V8 format variations including:
+ * - Regular functions: "at functionName (file:10:5)"
+ * - Anonymous functions: "at file:10:5"
+ * - Async functions: "at async functionName (file:10:5)"
+ * - Object methods: "at Object.method (file:10:5)"
+ * - Native code: "at Array.map (native)"
+ *
+ * @param stackTrace - Raw V8 stack trace string from Error.stack
+ * @returns Array of parsed StackFrame objects (limited to MAX_STACK_FRAMES)
+ */
+function parseV8StackTrace(stackTrace: string): StackFrame[] {
+  const frames: StackFrame[] = []
+  const lines = stackTrace.split('\n')
+
+  for (const line of lines) {
+    // Skip the first line (error message) and empty lines
+    if (!line.trim().startsWith('at ')) {
+      continue
+    }
+
+    const frame = parseV8StackFrame(line.trim())
+    if (frame) {
+      addContextToFrame(frame)
+      frames.push(frame)
+    }
+
+    // Limit number of frames
+    if (frames.length >= MAX_STACK_FRAMES) {
+      break
+    }
+  }
+
+  return frames
+}
+
+/**
+ * Adds context_line to a stack frame by reading the source file.
+ *
+ * This function extracts the line of code where the error occurred by:
+ * 1. Reading the source file using abs_path
+ * 2. Extracting the line at the specified line number
+ * 3. Setting the context_line field on the frame
+ *
+ * Only extracts context for user code (in_app: true)
+ * If the file cannot be read or the line number is invalid, context_line remains undefined.
+ *
+ * @param frame - The StackFrame to add context to (modified in place)
+ * @returns The modified StackFrame
+ */
+function addContextToFrame(frame: StackFrame): StackFrame {
+  if (!(frame.in_app && frame.abs_path && frame.lineno)) {
+    return frame
+  }
+
+  // Get fs module lazily - returns null in edge environments
+  const fs = getFsSync()
+  if (!fs) {
+    return frame // File reading not available in this environment
+  }
+
+  try {
+    const source = fs.readFileSync(frame.abs_path, 'utf8')
+    const lines = source.split('\n')
+    const lineIndex = frame.lineno - 1 // Convert to 0-based index
+
+    if (lineIndex >= 0 && lineIndex < lines.length) {
+      frame.context_line = lines[lineIndex]
+    }
+  } catch {
+    // File not found or not readable - silently skip
+  }
+
+  return frame
+}
+
+/**
+ * Parses a location string from a V8 stack frame.
+ *
+ * Handles different location formats:
+ * - "fileName:lineNumber:columnNumber" - normal file location
+ * - "eval at functionName (location)" - eval'd code (recursively unwraps)
+ * - "native" - V8 internal code
+ * - "unknown location" - location unavailable
+ *
+ * @param location - Location string from stack frame
+ * @returns Object with filename, abs_path, and optional lineno/colno, or null if unparseable
+ */
+function parseLocation(location: string): {
+  filename: string
+  abs_path: string
+  lineno?: number
+  colno?: number
+} | null {
+  // Handle special cases first
+  if (location === 'native') {
+    return { filename: 'native', abs_path: 'native' }
+  }
+
+  if (location === 'unknown location') {
+    return { filename: '<unknown>', abs_path: '<unknown>' }
+  }
+
+  // Handle eval locations
+  if (location.startsWith('eval at ')) {
+    return parseEvalOrigin(location)
+  }
+
+  // Handle normal location format: fileName:lineNumber:columnNumber
+  const match = location.match(LOCATION_WITH_LINE_COLUMN_REGEX)
+  if (match) {
+    const [, filename, lineStr, colStr] = match
+    return {
+      filename: makeRelativePath(filename),
+      abs_path: filename,
+      lineno: Number.parseInt(lineStr, 10),
+      colno: Number.parseInt(colStr, 10),
+    }
+  }
+
+  return null
+}
+
+/**
+ * Recursively unwraps eval location chains to extract the underlying file location.
+ *
+ * Eval locations have the format: "eval at functionName (location), <anonymous>:line:col"
+ * where location can be another eval or a file location.
+ *
+ * V8 formats:
+ * - "eval at Bar.z (myscript.js:10:3)" → extract myscript.js:10:3
+ * - "eval at Foo (eval at Bar (file.js:10:3)), <anonymous>:5:2" → extract file.js:10:3
+ *
+ * @param evalLocation - Eval location string starting with "eval at "
+ * @returns Object with extracted file location, or null if unparseable
+ */
+function parseEvalOrigin(evalLocation: string): {
+  filename: string
+  abs_path: string
+  lineno?: number
+  colno?: number
+} | null {
+  // V8 format: "eval at functionName (parentLocation), <anonymous>:line:col"
+  // or simpler: "eval at functionName (parentLocation)"
+  //
+  // Strategy: Find balanced parentheses to extract the parent location,
+  // then recursively parse it to find the actual file.
+
+  // First, check if there's a comma separating eval chain from eval code location
+  // Format: "eval at FUNC (...), <anonymous>:line:col"
+  // We want to extract just the "eval at FUNC (...)" part
+  let evalChainPart = evalLocation
+  const commaIndex = findCommaAfterBalancedParens(evalLocation)
+  if (commaIndex !== -1) {
+    evalChainPart = evalLocation.slice(0, commaIndex)
+  }
+
+  const innerLocation = extractTrailingParenthesizedContent(evalChainPart)
+  if (!(innerLocation && evalChainPart.startsWith('eval at '))) {
+    return null
+  }
+
+  // Recursively parse the inner location
+  if (innerLocation.startsWith('eval at ')) {
+    return parseEvalOrigin(innerLocation)
+  }
+
+  // Base case: parse as normal location
+  const locationMatch = innerLocation.match(LOCATION_WITH_LINE_COLUMN_REGEX)
+  if (locationMatch) {
+    const [, filename, lineStr, colStr] = locationMatch
+    return {
+      filename: makeRelativePath(filename),
+      abs_path: filename,
+      lineno: Number.parseInt(lineStr, 10),
+      colno: Number.parseInt(colStr, 10),
+    }
+  }
+
+  return null
+}
+
+/**
+ * Finds the index of the comma that appears after balanced parentheses.
+ *
+ * For "eval at f (eval at g (x)), <anonymous>:1:2", returns the index of the comma
+ * after the closing ")" and before "<anonymous>".
+ *
+ * @param str - String to search
+ * @returns Index of comma, or -1 if not found
+ */
+function findCommaAfterBalancedParens(str: string): number {
+  let depth = 0
+  let foundOpenParen = false
+
+  for (let i = 0; i < str.length; i++) {
+    if (str[i] === '(') {
+      depth++
+      foundOpenParen = true
+    } else if (str[i] === ')') {
+      depth--
+      if (depth === 0 && foundOpenParen) {
+        // Found the closing paren of the eval at (...) part
+        for (let j = i + 1; j < str.length; j++) {
+          if (str[j] === ',') {
+            return j
+          }
+          if (str[j] !== ' ') {
+            // Non-comma, non-space character found, no comma separator
+            return -1
+          }
+        }
+        return -1
+      }
+    }
+  }
+
+  return -1
+}
+
+function extractTrailingParenthesizedContent(value: string): string | null {
+  const trimmedValue = value.trim()
+  if (!trimmedValue.endsWith(')')) {
+    return null
+  }
+
+  const openingParenIndex = findMatchingOpeningParen(trimmedValue)
+  if (openingParenIndex === -1) {
+    return null
+  }
+
+  return trimmedValue.slice(openingParenIndex + 1, -1)
+}
+
+function findMatchingOpeningParen(value: string): number {
+  let depth = 0
+
+  for (let index = value.length - 1; index >= 0; index--) {
+    const char = value[index]
+    if (char === ')') {
+      depth++
+    } else if (char === '(') {
+      depth--
+      if (depth === 0) {
+        return index
+      }
+    }
+  }
+
+  return -1
+}
+
+/**
+ * Parses a single V8 stack frame line into a StackFrame object.
+ *
+ * Handles multiple V8 stack frame formats:
+ * - "at functionName (filename:line:col)"
+ * - "at filename:line:col" (top-level code)
+ * - "at async functionName (filename:line:col)"
+ * - "at Object.method (filename:line:col)"
+ * - "at Module._compile (node:internal/...)" (internal modules)
+ * - "at functionName (eval at ...)" (eval'd code)
+ * - "at functionName (native)" (native code)
+ *
+ * @param line - Single line from V8 stack trace (trimmed, starts with "at ")
+ * @returns Parsed StackFrame or null if line cannot be parsed
+ */
+function parseV8StackFrame(line: string): StackFrame | null {
+  // Remove "at " prefix
+  const withoutAt = line.slice(3)
+
+  // Try to extract function name and location
+  // Format 1: "functionName (location)"
+  // Location can be: filename:line:col, eval at ..., native, unknown location
+  const location = extractTrailingParenthesizedContent(withoutAt)
+  if (location) {
+    const openingParenIndex = findMatchingOpeningParen(withoutAt.trim())
+    const functionName = withoutAt.slice(0, openingParenIndex).trim()
+    const parsedLocation = parseLocation(location)
+
+    if (functionName && parsedLocation) {
+      return {
+        function: functionName,
+        filename: parsedLocation.filename,
+        abs_path: parsedLocation.abs_path,
+        lineno: parsedLocation.lineno,
+        colno: parsedLocation.colno,
+        in_app: isInApp(parsedLocation.abs_path),
+      }
+    }
+  }
+
+  // Format 2: "location" (no function name, top-level code)
+  // Try to parse as location directly
+  const parsedLocation = parseLocation(withoutAt)
+  if (parsedLocation) {
+    return {
+      function: '<anonymous>',
+      filename: parsedLocation.filename,
+      abs_path: parsedLocation.abs_path,
+      lineno: parsedLocation.lineno,
+      colno: parsedLocation.colno,
+      in_app: isInApp(parsedLocation.abs_path),
+    }
+  }
+
+  // Format 3: Unparseable
+  // Fallback for formats we don't recognize
+  return {
+    function: withoutAt,
+    filename: '<unknown>',
+    in_app: false,
+  }
+}
+
+/**
+ * Determines if a file path represents user code (in_app: true) or library code (in_app: false).
+ *
+ * Library code is identified by:
+ * - Paths containing "/node_modules/"
+ * - Node.js internal modules (e.g., "node:internal/...")
+ * - Native code
+ *
+ * @param filename - File path from stack frame
+ * @returns true if user code, false if library code
+ */
+function isInApp(filename: string): boolean {
+  // Exclude node_modules
+  if (filename.includes('/node_modules/') || filename.includes('\\node_modules\\')) {
+    return false
+  }
+
+  // Exclude Node.js internal modules (node:internal/...)
+  if (filename.startsWith('node:')) {
+    return false
+  }
+
+  // Exclude native code
+  if (filename === 'native' || filename === '<unknown>') {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Normalizes URL schemes to regular file paths.
+ *
+ * Handles file:// URLs commonly seen in ESM modules and local testing:
+ * - "file:///Users/john/project/src/index.ts" → "/Users/john/project/src/index.ts"
+ * - "file:///C:/projects/app/src/index.ts" → "C:/projects/app/src/index.ts"
+ *
+ * @param filename - File path that may be a file:// URL
+ * @returns Clean file path without URL scheme
+ */
+function normalizeUrl(filename: string): string {
+  // Handle file:// URLs (common in ESM modules and local testing)
+  if (filename.startsWith('file://')) {
+    let result = filename.slice(7) // Remove "file://"
+
+    // Ensure Unix paths start with /
+    if (!(result.startsWith('/') || WINDOWS_DRIVE_PREFIX_REGEX.test(result))) {
+      result = `/${result}`
+    }
+
+    return result
+  }
+
+  return filename
+}
+
+/**
+ * Normalizes Node.js internal module paths for consistent error grouping.
+ *
+ * Examples:
+ * - "node:internal/modules/cjs/loader" → "node:internal"
+ * - "node:fs/promises" → "node:fs"
+ * - "node:fs" → "node:fs" (unchanged)
+ *
+ * @param filename - File path that may be a Node.js internal module
+ * @returns Simplified module path or original filename
+ */
+function normalizeNodeInternals(filename: string): string {
+  if (filename.startsWith('node:internal')) {
+    return 'node:internal'
+  }
+
+  if (filename.startsWith('node:')) {
+    // Extract just the module name: node:fs/promises → node:fs
+    const parts = filename.split('/')
+    return parts[0]
+  }
+
+  return filename
+}
+
+/**
+ * Strips user-specific and system path prefixes.
+ *
+ * Removes prefixes like:
+ * - /Users/username/ → ~/
+ * - /home/username/ → ~/
+ * - C:\Users\username\ → ~\
+ * - C:/Users/username/ → ~/ (mixed separators)
+ *
+ * @param path - File path to normalize
+ * @returns Path with system prefixes removed
+ */
+function stripSystemPrefixes(path: string): string {
+  let result = path
+
+  // Unix/macOS: /Users/username/
+  result = result.replace(UNIX_USER_HOME_REGEX, '~/')
+
+  // Linux: /home/username/
+  result = result.replace(LINUX_USER_HOME_REGEX, '~/')
+
+  // Windows: C:\Users\username\ or C:/Users/username/ (with any separator)
+  result = result.replace(WINDOWS_USER_HOME_REGEX, '~/')
+
+  return result
+}
+
+/**
+ * Normalizes node_modules paths to be consistent across deployments.
+ *
+ * Extracts only the package-relative portion of the path:
+ * - /Users/john/project/node_modules/express/lib/router.js → node_modules/express/lib/router.js
+ * - /app/node_modules/@scope/pkg/index.js → node_modules/@scope/pkg/index.js
+ *
+ * @param path - File path that may contain node_modules
+ * @returns Normalized node_modules path or original path
+ */
+function normalizeNodeModules(path: string): string {
+  // Find the last occurrence of /node_modules/ or \node_modules\
+  const unixIndex = path.lastIndexOf('/node_modules/')
+  const winIndex = path.lastIndexOf('\\node_modules\\')
+
+  if (unixIndex !== -1) {
+    return path.slice(unixIndex + 1) // +1 to exclude leading slash
+  }
+
+  if (winIndex !== -1) {
+    return path.slice(winIndex + 1).replace(/\\/g, '/')
+  }
+
+  return path
+}
+
+/**
+ * Strips common deployment-specific path prefixes.
+ *
+ * Removes prefixes like:
+ * - /var/www/app/ → ""
+ * - /app/ → ""
+ * - /opt/project/ → ""
+ * - /var/task/ → "" (AWS Lambda)
+ * - /usr/src/app/ → "" (Docker)
+ *
+ * @param path - File path to normalize
+ * @returns Path with deployment prefixes removed
+ */
+function stripDeploymentPaths(path: string): string {
+  let result = path
+
+  for (const prefix of DEPLOYMENT_PREFIX_REGEXES) {
+    result = result.replace(prefix, '')
+  }
+
+  return result
+}
+
+/**
+ * Finds project-relative path using common project boundary markers.
+ *
+ * Looks for markers like /src/, /lib/, /dist/, /build/ and extracts the path
+ * from that marker onwards:
+ * - /Users/john/project/src/components/Button.tsx → src/components/Button.tsx
+ * - /app/dist/index.js → dist/index.js
+ *
+ * Priority order: looks for primary markers first (src, lib, dist, build),
+ * then secondary markers. Uses the highest-priority marker found.
+ *
+ * @param path - File path to search for project boundaries
+ * @returns Project-relative path or original path if no marker found
+ */
+function findProjectPath(path: string): string {
+  // Project boundary markers in priority order
+  // Primary markers (most likely to be project root)
+  const primaryMarkers = ['/src/', '/lib/', '/dist/', '/build/']
+
+  // Secondary markers (could be subdirectories)
+  const secondaryMarkers = ['/app/', '/components/', '/pages/', '/api/', '/utils/', '/services/', '/modules/']
+
+  // Check primary markers first
+  for (const marker of primaryMarkers) {
+    const index = path.lastIndexOf(marker)
+    if (index !== -1) {
+      return path.slice(index + 1) // +1 to remove leading slash
+    }
+  }
+
+  // If no primary marker, check secondary markers
+  for (const marker of secondaryMarkers) {
+    const index = path.lastIndexOf(marker)
+    if (index !== -1) {
+      return path.slice(index + 1)
+    }
+  }
+
+  return path
+}
+
+/**
+ * Converts absolute file paths to normalized relative paths for consistent error grouping.
+ *
+ * This function performs comprehensive path normalization to ensure errors from the same
+ * code location group together regardless of deployment environment, user directories,
+ * or system-specific paths. The original absolute path is always preserved in abs_path.
+ *
+ * Normalization steps:
+ * 1. Normalize URL schemes (file://, etc.) - must be first to strip URL prefixes
+ * 2. Preserve special paths (already relative, Node internals, etc.)
+ * 3. Normalize path separators to forward slashes (for consistent processing)
+ * 4. Normalize Node.js internal modules (node:internal/*, node:fs/*)
+ * 5. Normalize node_modules paths to package-relative format
+ * 6. Strip user home directories (/Users/*, /home/*, C:\Users\*)
+ * 7. Strip deployment-specific paths (/var/www/*, /app/, AWS Lambda, Docker)
+ * 8. Strip current working directory
+ * 9. Find project boundaries (/src/, /lib/, /dist/, etc.)
+ * 10. Remove leading slashes for clean relative paths
+ *
+ * @param filename - Absolute or relative file path from stack trace
+ * @returns Normalized relative path for error grouping
+ *
+ * @example
+ * makeRelativePath('/Users/john/project/src/index.ts')
+ * // Returns: 'src/index.ts'
+ *
+ * @example
+ * makeRelativePath('/home/ubuntu/app/node_modules/express/lib/router.js')
+ * // Returns: 'node_modules/express/lib/router.js'
+ *
+ * @example
+ * makeRelativePath('/var/www/myapp/dist/server.js')
+ * // Returns: 'dist/server.js'
+ *
+ * @example
+ * makeRelativePath('node:internal/modules/cjs/loader')
+ * // Returns: 'node:internal'
+ *
+ * @example
+ * makeRelativePath('C:\\Users\\John\\projects\\myapp\\src\\index.ts')
+ * // Returns: 'src/index.ts'
+ */
+function makeRelativePath(filename: string): string {
+  let result = filename
+
+  // Step 1: Normalize URL schemes (file://, etc.)
+  result = normalizeUrl(result)
+
+  // Step 2: Handle already-relative paths and special cases
+  if (!(result.startsWith('/') || WINDOWS_ABSOLUTE_PATH_REGEX.test(result))) {
+    // Already relative or special path (native, <unknown>, etc.)
+    // Still normalize Node internals
+    if (result.startsWith('node:')) {
+      return normalizeNodeInternals(result)
+    }
+    return result
+  }
+
+  // Step 3: Normalize path separators early for consistent processing
+  result = result.replace(/\\/g, '/')
+
+  // Step 4: Normalize Node.js internal modules (should be rare at this point)
+  if (result.startsWith('node:')) {
+    return normalizeNodeInternals(result)
+  }
+
+  // Step 5: Handle node_modules specially - preserve package structure
+  if (result.includes('/node_modules/')) {
+    return normalizeNodeModules(result)
+  }
+
+  // Step 6: Strip user home directories
+  result = stripSystemPrefixes(result)
+
+  // Step 7: Strip deployment-specific paths
+  result = stripDeploymentPaths(result)
+
+  // Step 8: Strip current working directory (if available)
+  // process.cwd() may not be available in edge environments
+  let cwd: string | null = null
+  try {
+    if (typeof process !== 'undefined' && typeof process.cwd === 'function') {
+      cwd = process.cwd()
+    }
+  } catch {
+    // process.cwd() not available in this environment
+  }
+
+  if (cwd && result.startsWith(cwd)) {
+    result = result.slice(cwd.length + 1) // +1 to remove leading /
+  }
+
+  // Step 9: Find project boundaries if still absolute-looking
+  // Also apply to tilde paths that might have project markers after the tilde
+  if (result.startsWith('/') || WINDOWS_ABSOLUTE_SLASH_PATH_REGEX.test(result)) {
+    result = findProjectPath(result)
+  } else if (result.startsWith('~')) {
+    // For tilde paths, strip the tilde and find markers in the remaining path
+    const withoutTilde = result.slice(2) // Remove ~/
+    const absoluteWithoutTilde = `/${withoutTilde}`
+    const projectPath = findProjectPath(absoluteWithoutTilde)
+    // If a marker was found (path changed), use it; otherwise keep the tilde version
+    if (projectPath !== absoluteWithoutTilde) {
+      result = projectPath
+    }
+  }
+
+  // Step 10: Remove leading slash if present (prefer relative paths)
+  if (result.startsWith('/')) {
+    result = result.slice(1)
+  }
+
+  return result
+}
+
+/**
+ * Recursively unwraps Error.cause chain and returns array of chained errors.
+ *
+ * Error.cause is a standard JavaScript feature that allows chaining errors:
+ *   const cause = new Error("Root cause");
+ *   const error = new Error("Wrapper error", { cause });
+ *
+ * This function extracts all errors in the cause chain up to MAX_EXCEPTION_CHAIN_DEPTH.
+ *
+ * @param error - Error object to unwrap
+ * @returns Array of ChainedErrorData objects representing the error chain
+ */
+function unwrapErrorCauses(error: Error): ChainedErrorData[] {
+  const chainedErrors: ChainedErrorData[] = []
+  const seenErrors = new Set<Error>()
+  let currentError: unknown = (error as ErrorWithCause).cause
+  let depth = 0
+
+  while (currentError && depth < MAX_EXCEPTION_CHAIN_DEPTH) {
+    // If cause is not an Error, stringify it and stop
+    if (!(currentError instanceof Error)) {
+      chainedErrors.push({
+        message: stringifyNonError(currentError),
+        type: undefined,
+      })
+      break
+    }
+
+    // Check for circular reference
+    if (seenErrors.has(currentError)) {
+      break
+    }
+    seenErrors.add(currentError)
+
+    const chainedErrorData: ChainedErrorData = {
+      message: currentError.message || '',
+      type: currentError.name || currentError.constructor?.name || 'Error',
+    }
+
+    if (currentError.stack) {
+      chainedErrorData.stack = currentError.stack
+      chainedErrorData.frames = parseV8StackTrace(currentError.stack)
+    }
+
+    chainedErrors.push(chainedErrorData)
+
+    // Move to next cause in chain
+    currentError = (currentError as ErrorWithCause).cause
+    depth++
+  }
+
+  return chainedErrors
+}
+
+/**
+ * Detects if a value is a CallToolResult object (SDK 1.21.0+ error format).
+ *
+ * SDK 1.21.0+ converts errors to CallToolResult format:
+ * { content: [{ type: "text", text: "error message" }], isError: true }
+ *
+ * @param value - Value to check
+ * @returns True if value is a CallToolResult object
+ */
+function isCallToolResult(value: unknown): value is CallToolResult {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'isError' in value &&
+    'content' in value &&
+    Array.isArray((value as { content?: unknown }).content)
+  )
+}
+
+function isTextContentPart(value: unknown): value is { text: string } {
+  if (value === null || typeof value !== 'object') {
+    return false
+  }
+
+  const contentPart = value as CallToolContentPart
+  return contentPart.type === 'text' && typeof contentPart.text === 'string'
+}
+
+/**
+ * Extracts error information from CallToolResult objects.
+ *
+ * SDK 1.21.0+ converts errors to CallToolResult, losing original stack traces.
+ * This extracts the error message from the content array.
+ *
+ * @param result - CallToolResult object with error
+ * @param _contextStack - Optional Error object for stack context (unused, kept for compatibility)
+ * @returns ErrorData with extracted message (no stack trace)
+ */
+function captureCallToolResultError(result: CallToolResult, _contextStack?: Error): ErrorData {
+  // Extract message from content array
+  const message =
+    result.content
+      .filter(isTextContentPart)
+      .map((contentPart) => contentPart.text)
+      .join(' ')
+      .trim() || 'Unknown error'
+
+  const errorData: ErrorData = {
+    message,
+    type: undefined, // Can't determine actual type from CallToolResult
+    platform: 'javascript',
+    // No stack or frames - SDK stripped the original error information
+  }
+
+  return errorData
+}
+
+/**
+ * Converts non-Error objects to string representation for error messages.
+ *
+ * In JavaScript, anything can be thrown (not just Error objects):
+ *   throw "string error";
+ *   throw { code: 404 };
+ *   throw null;
+ *
+ * This function handles these cases by converting them to meaningful strings.
+ *
+ * @param value - Non-Error value that was thrown
+ * @returns String representation of the value
+ */
+function stringifyNonError(value: unknown): string {
+  if (value === null) {
+    return 'null'
+  }
+
+  if (value === undefined) {
+    return 'undefined'
+  }
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  // Try to stringify objects with fallback
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}

--- a/packages/mcp/src/modules/ids.ts
+++ b/packages/mcp/src/modules/ids.ts
@@ -1,0 +1,32 @@
+import { uuidv7 } from '@posthog/core'
+
+export type MCPAnalyticsIDPrefix = 'evt' | 'ses'
+
+export function newPrefixedId(prefix: MCPAnalyticsIDPrefix): string {
+  return `${prefix}_${uuidv7()}`
+}
+
+/**
+ * Deterministic id derived from an arbitrary string. Used to map MCP protocol
+ * session ids to SDK session ids so the same MCP session reuses the same
+ * `$session_id` across server restarts.
+ *
+ * Uses the FNV-1a 64-bit hash (mixed twice to fill 32 hex chars), which works
+ * everywhere — no `node:crypto`, no Web Crypto async API. Not cryptographic; we
+ * only need stable, low-collision input → output mapping.
+ */
+export function deterministicPrefixedId(prefix: MCPAnalyticsIDPrefix, input: string): string {
+  return `${prefix}_${fnv1aHex(input)}${fnv1aHex(`${input}::salt`)}`
+}
+
+function fnv1aHex(input: string): string {
+  // 64-bit FNV-1a implemented with two 32-bit halves to stay within safe-integer range.
+  let h1 = 0x84222325
+  let h2 = 0xcbf29ce4
+  for (let i = 0; i < input.length; i++) {
+    const c = input.charCodeAt(i)
+    h1 = Math.imul(h1 ^ c, 0x000001b3)
+    h2 = Math.imul(h2 ^ c, 0x00000193)
+  }
+  return (h1 >>> 0).toString(16).padStart(8, '0') + (h2 >>> 0).toString(16).padStart(8, '0')
+}

--- a/packages/mcp/src/modules/intent.ts
+++ b/packages/mcp/src/modules/intent.ts
@@ -1,0 +1,78 @@
+import type {
+  CompatibleRequestHandlerExtra,
+  MCPAnalyticsData,
+  MCPAnalyticsIntentSource,
+  MCPRequestLike,
+  UnredactedEvent,
+} from '../types'
+import { isContextEnabled } from './context-parameters'
+import { log } from './logger'
+
+interface ResolvedIntent {
+  intent: string
+  source: MCPAnalyticsIntentSource
+}
+
+function getContextArgument(request: MCPRequestLike): string | undefined {
+  const context = request.params?.arguments?.context
+  return typeof context === 'string' && context.trim() ? context : undefined
+}
+
+function normalizeIntent(intent: string | null | undefined): string | null {
+  if (typeof intent !== 'string') {
+    return null
+  }
+
+  const trimmed = intent.trim()
+  return trimmed ? trimmed : null
+}
+
+async function runIntentFallback(
+  data: MCPAnalyticsData,
+  request: MCPRequestLike,
+  extra?: CompatibleRequestHandlerExtra
+): Promise<ResolvedIntent | null> {
+  if (!data.options.intentFallback) {
+    return null
+  }
+
+  try {
+    const intent = normalizeIntent(await data.options.intentFallback(request, extra))
+    return intent ? { intent, source: 'inferred' } : null
+  } catch (error) {
+    log(`intentFallback callback error: ${error}`)
+    return null
+  }
+}
+
+export async function resolveToolCallIntent(
+  data: MCPAnalyticsData,
+  request: MCPRequestLike,
+  extra?: CompatibleRequestHandlerExtra
+): Promise<ResolvedIntent | null> {
+  const contextArgument = getContextArgument(request)
+  if (isContextEnabled(data.options.context) && request.params?.name !== 'get_more_tools' && contextArgument) {
+    return { intent: contextArgument, source: 'context_parameter' }
+  }
+
+  return await runIntentFallback(data, request, extra)
+}
+
+export function setEventIntent(event: UnredactedEvent, resolvedIntent: ResolvedIntent | null): void {
+  if (!resolvedIntent) {
+    return
+  }
+
+  event.userIntent = resolvedIntent.intent
+  event.userIntentSource = resolvedIntent.source
+}
+
+export function setExplicitContextIntent(event: UnredactedEvent, context: string): void {
+  const intent = normalizeIntent(context)
+  if (!intent) {
+    return
+  }
+
+  event.userIntent = intent
+  event.userIntentSource = 'context_parameter'
+}

--- a/packages/mcp/src/modules/internal.ts
+++ b/packages/mcp/src/modules/internal.ts
@@ -1,0 +1,200 @@
+import type {
+  CompatibleRequestHandlerExtra,
+  MCPAnalyticsData,
+  MCPRequestLike,
+  MCPServerLike,
+  UnredactedEvent,
+  UserIdentity,
+} from '../types'
+import { MCPAnalyticsEventType } from './event-types'
+import { log } from './logger'
+import { publishEvent } from './publish'
+
+/**
+ * Simple LRU cache for session identities.
+ * Prevents memory leaks by capping at maxSize entries.
+ * This cache persists across server instance restarts.
+ */
+class IdentityCache {
+  private readonly _cache: Map<string, { identity: UserIdentity; timestamp: number }>
+  private readonly _maxSize: number
+
+  constructor(maxSize = 1000) {
+    this._cache = new Map()
+    this._maxSize = maxSize
+  }
+
+  get(sessionId: string): UserIdentity | undefined {
+    const entry = this._cache.get(sessionId)
+    if (entry) {
+      entry.timestamp = Date.now()
+      this._cache.delete(sessionId)
+      this._cache.set(sessionId, entry)
+      return entry.identity
+    }
+    return
+  }
+
+  set(sessionId: string, identity: UserIdentity): void {
+    this._cache.delete(sessionId)
+
+    if (this._cache.size >= this._maxSize) {
+      const oldestKey = this._cache.keys().next().value
+      if (oldestKey !== undefined) {
+        this._cache.delete(oldestKey)
+      }
+    }
+
+    this._cache.set(sessionId, { identity, timestamp: Date.now() })
+  }
+
+  has(sessionId: string): boolean {
+    return this._cache.has(sessionId)
+  }
+
+  size(): number {
+    return this._cache.size
+  }
+}
+
+// Global identity cache shared across all server instances so dedupe survives
+// server-instance recreation.
+const _globalIdentityCache = new IdentityCache(1000)
+
+// Internal tracking storage
+const _serverTracking = new WeakMap<MCPServerLike, MCPAnalyticsData>()
+
+export function getServerTrackingData(server: MCPServerLike): MCPAnalyticsData | undefined {
+  return _serverTracking.get(server)
+}
+
+export function setServerTrackingData(server: MCPServerLike, data: MCPAnalyticsData): void {
+  _serverTracking.set(server, data)
+}
+
+export function areIdentitiesEqual(a: UserIdentity, b: UserIdentity): boolean {
+  if (a.userId !== b.userId) {
+    return false
+  }
+  if (a.userName !== b.userName) {
+    return false
+  }
+
+  const aData = a.userData || {}
+  const bData = b.userData || {}
+
+  const aKeys = Object.keys(aData)
+  const bKeys = Object.keys(bData)
+
+  if (aKeys.length !== bKeys.length) {
+    return false
+  }
+
+  for (const key of aKeys) {
+    if (!(key in bData)) {
+      return false
+    }
+    if (JSON.stringify(aData[key]) !== JSON.stringify(bData[key])) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export function mergeIdentities(previous: UserIdentity | undefined, next: UserIdentity): UserIdentity {
+  if (!previous) {
+    return next
+  }
+
+  return {
+    userId: next.userId,
+    userName: next.userName,
+    userData: {
+      ...(previous.userData || {}),
+      ...(next.userData || {}),
+    },
+  }
+}
+
+/**
+ * Resolves the optional `identify` callback, dedupes against the global identity cache,
+ * and publishes an `$identify` event only when the identity has materially changed.
+ */
+export async function handleIdentify(
+  server: MCPServerLike,
+  data: MCPAnalyticsData,
+  request: MCPRequestLike,
+  extra?: CompatibleRequestHandlerExtra
+): Promise<void> {
+  if (!data.options.identify) {
+    return
+  }
+
+  const sessionId = data.sessionId
+  const identifyEvent: UnredactedEvent = {
+    sessionId,
+    resourceName: getRequestResourceName(request),
+    eventType: MCPAnalyticsEventType.identify,
+    parameters: { request, extra },
+    timestamp: new Date(),
+    redactionFn: data.options.redactSensitiveInformation,
+  }
+
+  try {
+    const identityResult =
+      typeof data.options.identify === 'function' ? await data.options.identify(request, extra) : data.options.identify
+
+    if (identityResult) {
+      const currentSessionId = data.sessionId
+      const previousIdentity = _globalIdentityCache.get(currentSessionId)
+      const mergedIdentity = mergeIdentities(previousIdentity, identityResult)
+      const hasChanged = !(previousIdentity && areIdentitiesEqual(previousIdentity, mergedIdentity))
+
+      _globalIdentityCache.set(currentSessionId, mergedIdentity)
+      data.identifiedSessions.set(data.sessionId, mergedIdentity)
+
+      if (hasChanged) {
+        log(`Identified session ${currentSessionId} with identity: ${JSON.stringify(mergedIdentity)}`)
+        publishEvent(server, identifyEvent)
+      }
+    } else {
+      log(`Warning: Supplied identify function returned null for session ${sessionId}`)
+    }
+  } catch (error) {
+    log(`Error: User supplied identify function threw an error while identifying session ${sessionId} - ${error}`)
+  }
+}
+
+/**
+ * Resolves the eventProperties callback and returns the result.
+ * Returns null if no callback is configured, the callback returns nullish, or the callback throws.
+ */
+export async function resolveEventProperties(
+  data: MCPAnalyticsData,
+  request: MCPRequestLike,
+  extra?: CompatibleRequestHandlerExtra
+): Promise<Record<string, unknown> | null> {
+  if (!data.options.eventProperties) {
+    return null
+  }
+  try {
+    return (await data.options.eventProperties(request, extra)) ?? null
+  } catch (e) {
+    log(`eventProperties callback error: ${e}`)
+    return null
+  }
+}
+
+function getRequestResourceName(request: unknown): string {
+  if (!request || typeof request !== 'object' || !('params' in request)) {
+    return 'Unknown'
+  }
+
+  const params = request.params
+  if (!params || typeof params !== 'object' || !('name' in params)) {
+    return 'Unknown'
+  }
+
+  return typeof params.name === 'string' ? params.name : 'Unknown'
+}

--- a/packages/mcp/src/modules/logger.ts
+++ b/packages/mcp/src/modules/logger.ts
@@ -1,0 +1,27 @@
+/**
+ * STDIO-safe logger.
+ *
+ * MCP servers running over the STDIO transport use stdout/stderr to exchange
+ * protocol messages, so we cannot use the default `console.log`. We accept a
+ * `logger` option on the public API; when omitted, log calls are silently
+ * dropped. Errors that affect tracking should still be observable in apps that
+ * want them, so the consumer can plug in any function (e.g. `console.error`
+ * for non-STDIO transports, a file logger, etc.).
+ */
+export type LoggerFn = (message: string) => void
+
+let activeLogger: LoggerFn | undefined
+
+export function setLogger(logger: LoggerFn | undefined): void {
+  activeLogger = logger
+}
+
+export function log(message: string): void {
+  if (activeLogger) {
+    try {
+      activeLogger(message)
+    } catch {
+      // never let logging blow up the tracking pipeline
+    }
+  }
+}

--- a/packages/mcp/src/modules/mcp-payloads.ts
+++ b/packages/mcp/src/modules/mcp-payloads.ts
@@ -1,0 +1,98 @@
+const CONTEXT_ARGUMENT_NAME = 'context'
+const REDACTED_VALUE = '[redacted]'
+const BASE64_PATTERN = /^[A-Za-z0-9+/\n\r]+=*$/
+const SIZE_GATE = 10_240
+const POSTHOG_TOKEN_PATTERN = /\bph[a-z]_[A-Za-z0-9_-]{20,}\b/g
+const SENSITIVE_KEY_PATTERN =
+  /^(authorization|cookie|set-cookie|x-api-key|api[-_]?key|api[-_]?token|access[-_]?token|refresh[-_]?token|token|password|secret|client[-_]?secret|private[-_]?key)$/i
+
+type JsonRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is JsonRecord {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function shouldRedactKey(key: string): boolean {
+  return SENSITIVE_KEY_PATTERN.test(key)
+}
+
+function sanitizeString(value: string): string {
+  if (value.length >= SIZE_GATE && BASE64_PATTERN.test(value)) {
+    return '[binary data redacted - not supported by PostHog MCP analytics]'
+  }
+  return value.replace(POSTHOG_TOKEN_PATTERN, REDACTED_VALUE)
+}
+
+export function sanitizeCapturedValue(value: unknown): unknown {
+  if (value == null) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    return sanitizeString(value)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(sanitizeCapturedValue)
+  }
+
+  if (value instanceof Date) {
+    return value
+  }
+
+  if (typeof value !== 'object') {
+    return value
+  }
+
+  const result: JsonRecord = {}
+  for (const [key, nestedValue] of Object.entries(value)) {
+    result[key] = shouldRedactKey(key) ? REDACTED_VALUE : sanitizeCapturedValue(nestedValue)
+  }
+  return result
+}
+
+function buildCapturedMcpArguments(argumentsValue: unknown): unknown {
+  if (!isRecord(argumentsValue)) {
+    return sanitizeCapturedValue(argumentsValue)
+  }
+
+  const capturedArguments: JsonRecord = {}
+  for (const [key, value] of Object.entries(argumentsValue)) {
+    if (key === CONTEXT_ARGUMENT_NAME) {
+      continue
+    }
+    capturedArguments[key] = sanitizeCapturedValue(value)
+  }
+  return capturedArguments
+}
+
+function buildCapturedMcpParams(params: unknown): unknown {
+  if (!isRecord(params)) {
+    return sanitizeCapturedValue(params)
+  }
+
+  const capturedParams: JsonRecord = {}
+  for (const [key, value] of Object.entries(params)) {
+    capturedParams[key] = key === 'arguments' ? buildCapturedMcpArguments(value) : sanitizeCapturedValue(value)
+  }
+  return capturedParams
+}
+
+export function buildCapturedMcpParameters(request: unknown): JsonRecord {
+  if (!isRecord(request)) {
+    return { request: sanitizeCapturedValue(request) }
+  }
+
+  const capturedRequest: JsonRecord = {}
+  for (const key of ['id', 'jsonrpc', 'method'] as const) {
+    if (key in request) {
+      capturedRequest[key] = sanitizeCapturedValue(request[key])
+    }
+  }
+
+  if ('params' in request) {
+    capturedRequest.params = buildCapturedMcpParams(request.params)
+  }
+
+  return { request: capturedRequest }
+}

--- a/packages/mcp/src/modules/mcp-sdk-compat.ts
+++ b/packages/mcp/src/modules/mcp-sdk-compat.ts
@@ -1,0 +1,160 @@
+/**
+ * MCP SDK Compatibility Helpers
+ *
+ * Internal utilities for handling differences between MCP SDK versions.
+ * These helpers abstract away SDK-internal details like:
+ * - Tool callback/handler property names (changed in SDK 1.24)
+ * - Zod schema internal structures (v3 vs v4)
+ */
+
+import type { RegisteredTool, ToolCallback } from '../types'
+
+// --- Tool function property utilities for MCP SDK version compatibility ---
+// MCP SDK 1.23 and earlier use "callback", 1.24+ uses "handler"
+
+export type ToolFunctionKey = 'callback' | 'handler'
+
+/**
+ * Returns the tool function (callback/handler) from a RegisteredTool.
+ * Supports both MCP SDK 1.23- (callback) and 1.24+ (handler).
+ */
+export function getToolFunction(tool: RegisteredTool): ToolCallback {
+  if ('handler' in tool && typeof tool.handler === 'function') {
+    return tool.handler
+  }
+  if ('callback' in tool && typeof tool.callback === 'function') {
+    return tool.callback
+  }
+  throw new Error('Tool has neither callback nor handler property')
+}
+
+/**
+ * Returns the property key name used for the tool function ("callback" or "handler").
+ * This preserves the original property name when wrapping tools.
+ */
+export function getToolFunctionKey(tool: RegisteredTool): ToolFunctionKey {
+  if ('handler' in tool && typeof tool.handler === 'function') {
+    return 'handler'
+  }
+  return 'callback'
+}
+
+/**
+ * Returns true if the tool has a callback or handler property.
+ */
+export function hasToolFunction(tool: unknown): tool is RegisteredTool {
+  if (!tool || typeof tool !== 'object') {
+    return false
+  }
+  const t = tool as Record<string, unknown>
+  return ('handler' in t && typeof t.handler === 'function') || ('callback' in t && typeof t.callback === 'function')
+}
+
+/**
+ * Creates a new tool object with the wrapped function, preserving the original property name.
+ * This ensures MCP SDK 1.24+ gets back a tool with "handler" and 1.23- gets "callback".
+ */
+export function createWrappedTool(originalTool: RegisteredTool, wrappedFunction: ToolCallback): RegisteredTool {
+  const key = getToolFunctionKey(originalTool)
+  return {
+    ...originalTool,
+    [key]: wrappedFunction,
+  } as RegisteredTool
+}
+
+// --- Zod schema internal property helpers ---
+// These access internal properties to extract method names from MCP SDK schemas
+// No Zod import needed - we introspect the internal structure directly
+
+interface ZodV3Internal {
+  _def?: {
+    value?: unknown
+    values?: unknown[] // For enums - some Zod versions store literal values here
+    shape?: Record<string, unknown> | (() => Record<string, unknown>)
+  }
+  shape?: Record<string, unknown> | (() => Record<string, unknown>)
+}
+
+interface ZodV4Internal {
+  _zod?: {
+    def?: {
+      value?: unknown
+      values?: unknown[] // For enums - some Zod versions store literal values here
+      shape?: Record<string, unknown> | (() => Record<string, unknown>)
+    }
+  }
+}
+
+export function isZ4Schema(schema: unknown): boolean {
+  if (!schema || typeof schema !== 'object') {
+    return false
+  }
+  return !!(schema as ZodV4Internal)._zod
+}
+
+export function getObjectShape(schema: unknown): Record<string, unknown> | undefined {
+  if (!schema || typeof schema !== 'object') {
+    return
+  }
+
+  let rawShape: Record<string, unknown> | (() => Record<string, unknown>) | undefined
+
+  if (isZ4Schema(schema)) {
+    const v4Schema = schema as ZodV4Internal
+    rawShape = v4Schema._zod?.def?.shape
+  } else {
+    const v3Schema = schema as ZodV3Internal
+    // Try .shape first, then fall back to _def.shape (some v3 schema types store it there)
+    rawShape = v3Schema.shape ?? v3Schema._def?.shape
+  }
+
+  if (!rawShape) {
+    return
+  }
+
+  if (typeof rawShape === 'function') {
+    try {
+      return rawShape()
+    } catch {
+      return
+    }
+  }
+
+  return rawShape
+}
+
+export function getLiteralValue(schema: unknown): unknown {
+  if (!schema || typeof schema !== 'object') {
+    return
+  }
+
+  if (isZ4Schema(schema)) {
+    const v4Schema = schema as ZodV4Internal
+    const def = v4Schema._zod?.def
+    if (def?.value !== undefined) {
+      return def.value
+    }
+    // Fallback: values array (for enums)
+    if (Array.isArray(def?.values) && def.values.length > 0) {
+      return def.values[0]
+    }
+  } else {
+    const v3Schema = schema as ZodV3Internal
+    const def = v3Schema._def
+    if (def?.value !== undefined) {
+      return def.value
+    }
+    // Fallback: values array (for enums)
+    if (Array.isArray(def?.values) && def.values.length > 0) {
+      return def.values[0]
+    }
+  }
+
+  // Final fallback: direct .value property (some Zod versions)
+  const directValue = (schema as { value?: unknown }).value
+  if (directValue !== undefined) {
+    return directValue
+  }
+
+  return
+}

--- a/packages/mcp/src/modules/posthog-events.ts
+++ b/packages/mcp/src/modules/posthog-events.ts
@@ -1,0 +1,285 @@
+import type { Event } from '../types'
+import { POSTHOG_MCP_ANALYTICS_SOURCE, PostHogMCPAnalyticsEvent, PostHogMCPAnalyticsProperty } from './constants'
+import { MCPAnalyticsEventType } from './event-types'
+
+const BUILT_IN_EVENT_NAME_BY_TYPE = {
+  [MCPAnalyticsEventType.custom]: PostHogMCPAnalyticsEvent.Custom,
+  [MCPAnalyticsEventType.identify]: PostHogMCPAnalyticsEvent.Identify,
+  [MCPAnalyticsEventType.mcpInitialize]: PostHogMCPAnalyticsEvent.Initialize,
+  [MCPAnalyticsEventType.mcpPromptsGet]: PostHogMCPAnalyticsEvent.PromptGet,
+  [MCPAnalyticsEventType.mcpPromptsList]: PostHogMCPAnalyticsEvent.PromptsList,
+  [MCPAnalyticsEventType.mcpResourcesList]: PostHogMCPAnalyticsEvent.ResourcesList,
+  [MCPAnalyticsEventType.mcpResourcesRead]: PostHogMCPAnalyticsEvent.ResourceRead,
+  [MCPAnalyticsEventType.mcpToolsCall]: PostHogMCPAnalyticsEvent.ToolCall,
+  [MCPAnalyticsEventType.mcpToolsList]: PostHogMCPAnalyticsEvent.ToolsList,
+} satisfies Record<MCPAnalyticsEventType, PostHogMCPAnalyticsEvent>
+
+function getDistinctId(event: Event): string {
+  return event.identifyActorGivenId || event.sessionId || 'anonymous'
+}
+
+function getTimestamp(event: Event): string {
+  return event.timestamp ? event.timestamp.toISOString() : new Date().toISOString()
+}
+
+export interface PostHogCaptureEvent {
+  distinct_id: string
+  event: string
+  properties: Record<string, unknown>
+  timestamp: string
+  type: 'capture'
+}
+
+export interface BuildPostHogCaptureEventsOptions {
+  enableAITracing?: boolean
+}
+
+export function buildPostHogCaptureEvents(
+  event: Event,
+  options: BuildPostHogCaptureEventsOptions = {}
+): PostHogCaptureEvent[] {
+  const batch = [buildCaptureEvent(event, options)]
+
+  if (event.isError && event.error) {
+    batch.push(buildExceptionEvent(event))
+  }
+
+  if (shouldBuildAISpan(event, options)) {
+    batch.push(buildAISpanEvent(event))
+  }
+
+  return batch
+}
+
+function buildCaptureEvent(event: Event, options: BuildPostHogCaptureEventsOptions): PostHogCaptureEvent {
+  const distinctId = getDistinctId(event)
+  const timestamp = getTimestamp(event)
+
+  const properties: Record<string, unknown> = {
+    [PostHogMCPAnalyticsProperty.SessionId]: event.sessionId,
+    [PostHogMCPAnalyticsProperty.Source]: POSTHOG_MCP_ANALYTICS_SOURCE,
+  }
+  addConversationIdProperty(event, properties)
+
+  addCommonEventProperties(event, properties)
+  addTraceReferenceProperties(event, properties, options)
+  addCustomEventProperties(event, properties)
+
+  return {
+    event: BUILT_IN_EVENT_NAME_BY_TYPE[event.eventType],
+    distinct_id: distinctId,
+    properties,
+    timestamp,
+    type: 'capture',
+  }
+}
+
+function shouldBuildAISpan(event: Event, options: BuildPostHogCaptureEventsOptions): boolean {
+  return options.enableAITracing === true && event.eventType === MCPAnalyticsEventType.mcpToolsCall
+}
+
+function getAITraceId(event: Event): string {
+  return event.sessionId
+}
+
+function getAISpanId(event: Event): string {
+  return event.id
+}
+
+function addTraceReferenceProperties(
+  event: Event,
+  properties: Record<string, unknown>,
+  options: BuildPostHogCaptureEventsOptions
+): void {
+  if (!shouldBuildAISpan(event, options)) {
+    return
+  }
+
+  properties[PostHogMCPAnalyticsProperty.AiTraceId] = getAITraceId(event)
+  properties[PostHogMCPAnalyticsProperty.AiSpanId] = getAISpanId(event)
+}
+
+function addConversationIdProperty(event: Event, properties: Record<string, unknown>): void {
+  if (event.conversationId !== undefined && event.conversationId !== '') {
+    properties[PostHogMCPAnalyticsProperty.ConversationId] = event.conversationId
+  }
+}
+
+function addCommonEventProperties(event: Event, properties: Record<string, unknown>): void {
+  if (event.resourceName) {
+    properties[PostHogMCPAnalyticsProperty.ResourceName] = event.resourceName
+    if (event.eventType === MCPAnalyticsEventType.mcpToolsCall) {
+      properties[PostHogMCPAnalyticsProperty.ToolName] = event.resourceName
+    }
+  }
+  if (event.toolDescription && event.eventType === MCPAnalyticsEventType.mcpToolsCall) {
+    properties[PostHogMCPAnalyticsProperty.ToolDescription] = event.toolDescription
+  }
+  if (
+    event.listedToolNames &&
+    event.listedToolNames.length > 0 &&
+    event.eventType === MCPAnalyticsEventType.mcpToolsList
+  ) {
+    properties[PostHogMCPAnalyticsProperty.ListedToolNames] = event.listedToolNames
+  }
+  if (event.duration !== undefined) {
+    properties[PostHogMCPAnalyticsProperty.DurationMs] = event.duration
+  }
+  if (event.serverName) {
+    properties[PostHogMCPAnalyticsProperty.ServerName] = event.serverName
+  }
+  if (event.serverVersion) {
+    properties[PostHogMCPAnalyticsProperty.ServerVersion] = event.serverVersion
+  }
+  if (event.clientName) {
+    properties[PostHogMCPAnalyticsProperty.ClientName] = event.clientName
+  }
+  if (event.clientVersion) {
+    properties[PostHogMCPAnalyticsProperty.ClientVersion] = event.clientVersion
+  }
+  if (event.userIntent) {
+    properties[PostHogMCPAnalyticsProperty.Intent] = event.userIntent
+  }
+  if (event.userIntentSource) {
+    properties[PostHogMCPAnalyticsProperty.IntentSource] = event.userIntentSource
+  }
+  if (event.isError !== undefined) {
+    properties[PostHogMCPAnalyticsProperty.IsError] = event.isError
+  }
+
+  if (event.parameters !== undefined) {
+    properties[PostHogMCPAnalyticsProperty.Parameters] = event.parameters
+  }
+  if (event.response !== undefined) {
+    properties[PostHogMCPAnalyticsProperty.Response] = event.response
+  }
+
+  const $set: Record<string, unknown> = {}
+  if (event.identifyActorName) {
+    $set.name = event.identifyActorName
+  }
+  if (event.identifyActorData) {
+    Object.assign($set, event.identifyActorData)
+  }
+  if (Object.keys($set).length > 0) {
+    properties.$set = $set
+  }
+}
+
+function addCustomEventProperties(event: Event, properties: Record<string, unknown>): void {
+  if (event.properties) {
+    for (const [key, value] of Object.entries(event.properties)) {
+      properties[key] = value
+    }
+  }
+}
+
+function buildExceptionEvent(event: Event): PostHogCaptureEvent {
+  const distinctId = getDistinctId(event)
+  const timestamp = getTimestamp(event)
+
+  const properties: Record<string, unknown> = {
+    $exception_source: 'backend',
+    [PostHogMCPAnalyticsProperty.SessionId]: event.sessionId,
+  }
+  addConversationIdProperty(event, properties)
+
+  if (event.error) {
+    if (event.error.message) {
+      properties.$exception_message = event.error.message
+    }
+    if (event.error.type) {
+      properties.$exception_type = event.error.type
+    }
+    if (event.error.stack) {
+      properties.$exception_stacktrace = event.error.stack
+    }
+  }
+
+  if (event.resourceName) {
+    properties[PostHogMCPAnalyticsProperty.ResourceName] = event.resourceName
+    if (event.eventType === MCPAnalyticsEventType.mcpToolsCall) {
+      properties[PostHogMCPAnalyticsProperty.ToolName] = event.resourceName
+    }
+  }
+  if (event.toolDescription && event.eventType === MCPAnalyticsEventType.mcpToolsCall) {
+    properties[PostHogMCPAnalyticsProperty.ToolDescription] = event.toolDescription
+  }
+  if (event.serverName) {
+    properties[PostHogMCPAnalyticsProperty.ServerName] = event.serverName
+  }
+  if (event.serverVersion) {
+    properties[PostHogMCPAnalyticsProperty.ServerVersion] = event.serverVersion
+  }
+  if (event.clientName) {
+    properties[PostHogMCPAnalyticsProperty.ClientName] = event.clientName
+  }
+  if (event.clientVersion) {
+    properties[PostHogMCPAnalyticsProperty.ClientVersion] = event.clientVersion
+  }
+
+  addCustomEventProperties(event, properties)
+
+  return {
+    event: PostHogMCPAnalyticsEvent.Exception,
+    distinct_id: distinctId,
+    properties,
+    timestamp,
+    type: 'capture',
+  }
+}
+
+function buildAISpanEvent(event: Event): PostHogCaptureEvent {
+  const distinctId = getDistinctId(event)
+  const timestamp = getTimestamp(event)
+
+  const properties: Record<string, unknown> = {
+    [PostHogMCPAnalyticsProperty.AiSessionId]: `posthog_mcp_analytics_${event.sessionId}`,
+    [PostHogMCPAnalyticsProperty.AiTraceId]: getAITraceId(event),
+    [PostHogMCPAnalyticsProperty.AiSpanId]: getAISpanId(event),
+    [PostHogMCPAnalyticsProperty.AiSpanName]: event.resourceName || 'unknown_tool',
+    [PostHogMCPAnalyticsProperty.AiIsError]: event.isError,
+    [PostHogMCPAnalyticsProperty.SessionId]: event.sessionId,
+    [PostHogMCPAnalyticsProperty.Source]: POSTHOG_MCP_ANALYTICS_SOURCE,
+  }
+  addConversationIdProperty(event, properties)
+
+  if (event.duration !== undefined) {
+    properties[PostHogMCPAnalyticsProperty.AiLatency] = event.duration / 1000
+  }
+  if (event.isError && event.error) {
+    properties.$ai_error = event.error
+  }
+  if (event.parameters !== undefined) {
+    properties[PostHogMCPAnalyticsProperty.AiInputState] = event.parameters
+  }
+  if (event.response !== undefined) {
+    properties[PostHogMCPAnalyticsProperty.AiOutputState] = event.response
+  }
+  if (event.serverName) {
+    properties[PostHogMCPAnalyticsProperty.ServerName] = event.serverName
+  }
+  if (event.clientName) {
+    properties[PostHogMCPAnalyticsProperty.ClientName] = event.clientName
+  }
+  if (event.userIntent) {
+    properties[PostHogMCPAnalyticsProperty.Intent] = event.userIntent
+  }
+  if (event.userIntentSource) {
+    properties[PostHogMCPAnalyticsProperty.IntentSource] = event.userIntentSource
+  }
+
+  if (event.properties) {
+    for (const [key, value] of Object.entries(event.properties)) {
+      properties[key] = value
+    }
+  }
+
+  return {
+    event: PostHogMCPAnalyticsEvent.AiSpan,
+    distinct_id: distinctId,
+    properties,
+    timestamp,
+    type: 'capture',
+  }
+}

--- a/packages/mcp/src/modules/publish.ts
+++ b/packages/mcp/src/modules/publish.ts
@@ -1,0 +1,65 @@
+import type { MCPServerLike, UnredactedEvent } from '../types'
+import { MCPAnalyticsEventType } from './event-types'
+import { getServerTrackingData } from './internal'
+import { log } from './logger'
+import { getSessionInfo } from './session'
+
+/**
+ * Materializes an `UnredactedEvent` against the server's tracking data + session info,
+ * then hands it to the configured `PostHogMCP` client for the redact/sanitize/truncate
+ * pipeline and capture. No-ops if tracing is disabled, the server isn't tracked, or no
+ * client is attached.
+ */
+export function publishEvent(server: MCPServerLike, eventInput: UnredactedEvent): void {
+  const data = getServerTrackingData(server)
+  if (!data) {
+    log('Warning: Server tracking data not found. Event will not be published.')
+    return
+  }
+
+  if (!data.options.enableTracing) {
+    return
+  }
+
+  const client = data.client
+  if (!client) {
+    return
+  }
+
+  const sessionInfo = getSessionInfo(server, data)
+
+  const duration =
+    eventInput.duration || (eventInput.timestamp ? Date.now() - eventInput.timestamp.getTime() : undefined)
+
+  const fullEvent: UnredactedEvent = {
+    id: eventInput.id || '',
+    sessionId: eventInput.sessionId || data.sessionId,
+    eventType: eventInput.eventType || MCPAnalyticsEventType.custom,
+    timestamp: eventInput.timestamp || new Date(),
+    duration,
+    ipAddress: sessionInfo.ipAddress,
+    sdkLanguage: sessionInfo.sdkLanguage,
+    sdkVersion: sessionInfo.sdkVersion,
+    serverName: sessionInfo.serverName,
+    serverVersion: sessionInfo.serverVersion,
+    clientName: sessionInfo.clientName,
+    clientVersion: sessionInfo.clientVersion,
+    identifyActorGivenId: sessionInfo.identifyActorGivenId,
+    identifyActorName: sessionInfo.identifyActorName,
+    identifyActorData: sessionInfo.identifyActorData,
+    resourceName: eventInput.resourceName,
+    toolDescription: eventInput.toolDescription,
+    listedToolNames: eventInput.listedToolNames,
+    parameters: eventInput.parameters,
+    response: eventInput.response,
+    userIntent: eventInput.userIntent,
+    userIntentSource: eventInput.userIntentSource,
+    isError: eventInput.isError,
+    error: eventInput.error,
+    conversationId: eventInput.conversationId,
+    redactionFn: eventInput.redactionFn,
+    properties: eventInput.properties,
+  }
+
+  void client.ingest(fullEvent, data.options.enableAITracing ?? false)
+}

--- a/packages/mcp/src/modules/redaction.ts
+++ b/packages/mcp/src/modules/redaction.ts
@@ -1,0 +1,101 @@
+import type { Event, RedactFunction, UnredactedEvent } from '../types'
+
+/**
+ * Set of field names that should be protected from redaction.
+ * These fields contain system-level identifiers and metadata that
+ * need to be preserved for analytics tracking.
+ */
+const PROTECTED_FIELDS = new Set([
+  'sessionId',
+  'id',
+  'apiKey',
+  'server',
+  'identifyActorGivenId',
+  'identifyActorName',
+  'identifyData',
+  'resourceName',
+  'toolDescription',
+  'listedToolNames',
+  'eventType',
+  'actorId',
+  'properties',
+])
+
+/**
+ * Recursively applies a redaction function to all string values in an object.
+ * This ensures that sensitive information is removed from all string fields
+ * before events are sent to the analytics service.
+ *
+ * @param obj - The object to redact strings from
+ * @param redactFn - The redaction function to apply to each string
+ * @param path - The current path in the object tree (used to check protected fields)
+ * @param isProtected - Whether the current object/value is within a protected field
+ * @returns A new object with all strings redacted
+ */
+async function redactStringsInObject(
+  obj: unknown,
+  redactFn: RedactFunction,
+  path = '',
+  isProtected = false
+): Promise<unknown> {
+  if (obj === null || obj === undefined) {
+    return obj
+  }
+
+  // Handle strings
+  if (typeof obj === 'string') {
+    // Don't redact if this field or any parent field is protected
+    if (isProtected) {
+      return obj
+    }
+    return await redactFn(obj)
+  }
+
+  // Handle arrays
+  if (Array.isArray(obj)) {
+    return Promise.all(
+      obj.map((item, index) => redactStringsInObject(item, redactFn, `${path}[${index}]`, isProtected))
+    )
+  }
+
+  // Handle dates (don't redact)
+  if (obj instanceof Date) {
+    return obj
+  }
+
+  // Handle objects
+  if (typeof obj === 'object') {
+    const redactedObj: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(obj)) {
+      // Skip functions and undefined values
+      if (typeof value === 'function' || value === undefined) {
+        continue
+      }
+
+      // Build the path for nested fields
+      const fieldPath = path ? `${path}.${key}` : key
+      // Check if this field is protected (only check at top level)
+      const isFieldProtected = isProtected || (path === '' && PROTECTED_FIELDS.has(key))
+      redactedObj[key] = await redactStringsInObject(value, redactFn, fieldPath, isFieldProtected)
+    }
+
+    return redactedObj
+  }
+
+  // For all other types (numbers, booleans, etc.), return as-is
+  return obj
+}
+
+/**
+ * Applies the customer's redaction function to all string fields in an Event object.
+ * This is the main entry point for redacting sensitive information from events
+ * before they are sent to the analytics service.
+ *
+ * @param event - The event to redact
+ * @param redactFn - The customer's redaction function
+ * @returns A new event object with all strings redacted
+ */
+export function redactEvent(event: UnredactedEvent, redactFn: RedactFunction): Promise<Event> {
+  return redactStringsInObject(event, redactFn, '', false) as Promise<Event>
+}

--- a/packages/mcp/src/modules/sanitization.ts
+++ b/packages/mcp/src/modules/sanitization.ts
@@ -1,0 +1,121 @@
+import type { Event, UnredactedEvent } from '../types'
+import { sanitizeCapturedValue } from './mcp-payloads'
+
+type SanitizedRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is SanitizedRecord {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Sanitizes an event by redacting non-text content blocks from responses
+ * and large base64-encoded strings from parameters.
+ *
+ * This is a synchronous operation that returns a new object without mutating the original.
+ * It should run after customer redaction in the event pipeline.
+ */
+export function sanitizeEvent<T extends Event | UnredactedEvent>(event: T): T {
+  const result = { ...event }
+
+  if (result.response != null) {
+    result.response = sanitizeResponse(result.response)
+  }
+
+  if (result.parameters != null) {
+    result.parameters = sanitizeParameters(result.parameters)
+  }
+
+  return result
+}
+
+/**
+ * Sanitizes response content blocks by replacing non-text content types
+ * with informative redaction messages.
+ */
+function sanitizeResponse(response: unknown): unknown {
+  if (response == null || typeof response !== 'object') {
+    return sanitizeCapturedValue(response)
+  }
+
+  const sanitized = sanitizeCapturedValue(response)
+  if (!isRecord(sanitized)) {
+    return sanitized
+  }
+
+  const result: SanitizedRecord = { ...sanitized }
+  const content = result.content
+  if (Array.isArray(content)) {
+    result.content = content.map(sanitizeContentBlock)
+  }
+
+  if (result.structuredContent != null && typeof result.structuredContent === 'object') {
+    result.structuredContent = sanitizeCapturedValue(result.structuredContent)
+  }
+
+  return result
+}
+
+/**
+ * Sanitizes a single content block based on its type discriminator.
+ */
+function sanitizeContentBlock(block: unknown): unknown {
+  if (block == null || typeof block !== 'object') {
+    return block
+  }
+
+  if (!isRecord(block)) {
+    return block
+  }
+
+  switch (block.type) {
+    case 'text':
+      return sanitizeCapturedValue(block)
+
+    case 'image':
+      return {
+        type: 'text',
+        text: '[image content redacted - not supported by PostHog MCP analytics]',
+      }
+
+    case 'audio':
+      return {
+        type: 'text',
+        text: '[audio content redacted - not supported by PostHog MCP analytics]',
+      }
+
+    case 'resource':
+      return sanitizeResourceBlock(block)
+
+    case 'resource_link':
+      return sanitizeCapturedValue(block)
+
+    default:
+      return {
+        type: 'text',
+        text: `[unsupported content type "${block.type}" redacted - not supported by PostHog MCP analytics]`,
+      }
+  }
+}
+
+/**
+ * Sanitizes an embedded resource content block.
+ * BlobResourceContents (has `blob` field) are redacted.
+ * TextResourceContents (has `text` field) pass through.
+ */
+function sanitizeResourceBlock(block: SanitizedRecord): unknown {
+  if (isRecord(block.resource) && 'blob' in block.resource) {
+    return {
+      type: 'text',
+      text: '[binary resource content redacted - not supported by PostHog MCP analytics]',
+    }
+  }
+  return sanitizeCapturedValue(block)
+}
+
+/**
+ * Recursively scans parameters for large base64-encoded strings and replaces them.
+ * Uses a size gate (10KB) to avoid regex testing on small strings.
+ */
+function sanitizeParameters(obj: unknown): unknown {
+  return sanitizeCapturedValue(obj)
+}

--- a/packages/mcp/src/modules/session.ts
+++ b/packages/mcp/src/modules/session.ts
@@ -1,0 +1,119 @@
+import { version } from '../version'
+import type {
+  CompatibleRequestHandlerExtra,
+  MCPAnalyticsData,
+  MCPServerLike,
+  ServerClientInfoLike,
+  SessionInfo,
+} from '../types'
+import { INACTIVITY_TIMEOUT_IN_MINUTES } from './constants'
+import { deterministicPrefixedId, newPrefixedId } from './ids'
+import { getServerTrackingData, setServerTrackingData } from './internal'
+
+export function newSessionId(): string {
+  return newPrefixedId('ses')
+}
+
+/**
+ * Creates a deterministic SDK session ID from an MCP sessionId.
+ * The same inputs will always produce the same session ID, enabling correlation across server restarts.
+ *
+ * @param mcpSessionId - The session ID from the MCP protocol
+ * @returns An SDK session ID with "ses" prefix derived deterministically from the inputs
+ */
+export function deriveSessionIdFromMCPSession(mcpSessionId: string): string {
+  return deterministicPrefixedId('ses', mcpSessionId)
+}
+
+/**
+ * Gets or generates a session ID for the server.
+ * Prioritizes MCP protocol sessionId over PostHog MCP analytics-generated sessionId.
+ *
+ * @param server - The MCP server instance
+ * @param extra - Optional extra data containing MCP sessionId
+ * @returns The session ID to use for events
+ */
+export function getServerSessionId(server: MCPServerLike, extra?: CompatibleRequestHandlerExtra): string {
+  const data = getServerTrackingData(server)
+
+  if (!data) {
+    throw new Error('Server tracking data not found')
+  }
+
+  const mcpSessionId = extra?.sessionId
+
+  // If MCP sessionId is provided
+  if (mcpSessionId) {
+    // Derive deterministic SDK session ID from MCP sessionId
+    data.sessionId = deriveSessionIdFromMCPSession(mcpSessionId)
+    data.lastMcpSessionId = mcpSessionId
+    data.sessionSource = 'mcp'
+    setServerTrackingData(server, data)
+    // If MCP sessionId hasn't changed, continue using the existing derived ID
+    setLastActivity(server)
+    return data.sessionId
+  }
+
+  // No MCP sessionId provided - handle PostHog MCP analytics-generated sessions
+  // If we had an MCP sessionId before but it disappeared, keep using the last derived ID
+  if (data.sessionSource === 'mcp' && data.lastMcpSessionId) {
+    setLastActivity(server)
+    return data.sessionId
+  }
+
+  // For PostHog MCP analytics-generated sessions, apply timeout logic
+  const now = Date.now()
+  const timeoutMs = INACTIVITY_TIMEOUT_IN_MINUTES * 60 * 1000
+  // If last activity timed out
+  if (now - data.lastActivity.getTime() > timeoutMs) {
+    data.sessionId = newSessionId()
+    data.sessionSource = 'generated'
+    setServerTrackingData(server, data)
+  }
+  setLastActivity(server)
+
+  return data.sessionId
+}
+
+export function setLastActivity(server: MCPServerLike): void {
+  const data = getServerTrackingData(server)
+
+  if (!data) {
+    throw new Error('Server tracking data not found')
+  }
+
+  data.lastActivity = new Date()
+  setServerTrackingData(server, data)
+}
+
+export function getSessionInfo(server: MCPServerLike, data: MCPAnalyticsData | undefined): SessionInfo {
+  let clientInfo: ServerClientInfoLike | undefined = {
+    name: undefined,
+    version: undefined,
+  }
+  if (!data?.sessionInfo.clientName) {
+    clientInfo = server.getClientVersion()
+  }
+  const actorInfo = data?.identifiedSessions.get(data.sessionId)
+
+  const sessionInfo: SessionInfo = {
+    ipAddress: undefined, // grab from django
+    sdkLanguage: 'TypeScript', // hardcoded for now
+    sdkVersion: version,
+    serverName: server._serverInfo?.name,
+    serverVersion: server._serverInfo?.version,
+    clientName: clientInfo?.name,
+    clientVersion: clientInfo?.version,
+    identifyActorGivenId: actorInfo?.userId,
+    identifyActorName: actorInfo?.userName,
+    identifyActorData: actorInfo?.userData || {},
+  }
+
+  if (!data) {
+    return sessionInfo
+  }
+
+  data.sessionInfo = sessionInfo
+  setServerTrackingData(server, data)
+  return data.sessionInfo
+}

--- a/packages/mcp/src/modules/tools.ts
+++ b/packages/mcp/src/modules/tools.ts
@@ -1,0 +1,145 @@
+import { type CallToolResult, ListToolsRequestSchema, type ListToolsResult } from '@modelcontextprotocol/sdk/types.js'
+import type { MCPServerLike, UnredactedEvent } from '../types'
+import { getMCPCompatibleErrorMessage } from './compatibility'
+import { addContextParameterToTools, getContextDescription, isContextEnabled } from './context-parameters'
+import { publishEvent } from './publish'
+import { MCPAnalyticsEventType } from './event-types'
+import { getServerTrackingData } from './internal'
+import { log } from './logger'
+import { getServerSessionId } from './session'
+
+export const GET_MORE_TOOLS_NAME = 'get_more_tools' as const
+
+type ReportMissingToolDescriptor = ListToolsResult['tools'][number]
+
+export function getReportMissingToolDescriptor(): ReportMissingToolDescriptor {
+  return {
+    name: GET_MORE_TOOLS_NAME,
+    description:
+      'Check for additional tools whenever your task might benefit from specialized capabilities - even if existing tools could work as a fallback.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        context: {
+          type: 'string',
+          description: 'A description of your goal and what kind of tool would help accomplish it.',
+        },
+      },
+      required: ['context'],
+    },
+    annotations: {
+      title: 'Get More Tools',
+      // Doesn't mutate state on the MCP server
+      readOnlyHint: true,
+      // Interacts with external entities because we store this in analytics
+      openWorldHint: true,
+      // A tool like `get_more_tools` would usually NOT be idempontent, but since we are
+      // only using this to keep track of missing tools/feedback/analytics, it is actually idempontent.
+      // It's also preferable to track it as idempontent to make agents more prone to call it proactively.
+      idempotentHint: true,
+      // Never deletes any data from the MCP server
+      destructiveHint: false,
+    },
+  }
+}
+
+export function handleReportMissing(args: { context: string }): CallToolResult {
+  log(`Missing tool reported: ${JSON.stringify(args)}`)
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: 'Unfortunately, we have shown you the full tool list. We have noted your feedback and will work to improve the tool list in the future.',
+      },
+    ],
+  }
+}
+
+export function setupMCPAnalyticsTools(server: MCPServerLike): void {
+  // Store reference to original handlers - need to use the method name, not the schema
+  const handlers = server._requestHandlers
+
+  const originalListToolsHandler = handlers.get('tools/list')
+  const originalCallToolHandler = handlers.get('tools/call')
+
+  if (!(originalListToolsHandler && originalCallToolHandler)) {
+    log('Warning: Original tool handlers not found. Your tools may not be setup before PostHog MCP analytics .track().')
+    return
+  }
+
+  // Override tools list to include get_more_tools and add context parameter
+  try {
+    server.setRequestHandler(ListToolsRequestSchema, async (request, extra) => {
+      let tools: ListToolsResult['tools'] = []
+      const data = getServerTrackingData(server)
+      const event: UnredactedEvent = {
+        sessionId: getServerSessionId(server, extra),
+        parameters: {
+          request,
+          extra,
+        },
+        eventType: MCPAnalyticsEventType.mcpToolsList,
+        timestamp: new Date(),
+        redactionFn: data?.options.redactSensitiveInformation,
+      }
+      try {
+        const originalResponse = (await originalListToolsHandler(request, extra)) as ListToolsResult
+        tools = originalResponse.tools || []
+      } catch (error) {
+        // If original handler fails, start with empty tools
+        log(
+          `Warning: Original list tools handler failed, this suggests an error PostHog MCP analytics did not cause - ${error}`
+        )
+        event.error = { message: getMCPCompatibleErrorMessage(error) }
+        event.isError = true
+        event.duration = (event.timestamp && Date.now() - event.timestamp.getTime()) || 0
+        publishEvent(server, event)
+        throw error
+      }
+
+      if (!data) {
+        log(
+          'Warning: PostHog MCP analytics is unable to find server tracking data. Please ensure you have called track(server, options) before using tool calls.'
+        )
+        return { tools }
+      }
+
+      if (tools.length === 0) {
+        log(
+          'Warning: No tools found in the original list. This is likely due to the tools not being registered before PostHog MCP analytics.track().'
+        )
+        event.error = { message: 'No tools were sent to MCP client.' }
+        event.isError = true
+        event.duration = (event.timestamp && Date.now() - event.timestamp.getTime()) || 0
+        publishEvent(server, event)
+        return { tools }
+      }
+
+      // Add context parameter to all existing tools when context capture is enabled
+      if (isContextEnabled(data.options.context)) {
+        tools = addContextParameterToTools(tools, getContextDescription(data.options.context))
+      }
+
+      // Add report_missing tool if enabled
+      if (data.options.reportMissing) {
+        const alreadyPresent = tools.some((tool) => tool?.name === GET_MORE_TOOLS_NAME)
+        if (alreadyPresent) {
+          log(
+            "Warning: report_missing tool already present in tools list. Skipping addition. This is likely due to the server already including a report_missing tool. If you want to rely on the PostHog MCP Analytics report_missing tool, you should disable the server's report_missing tool."
+          )
+        } else {
+          tools.push(getReportMissingToolDescriptor())
+        }
+      }
+
+      event.response = { tools }
+      event.isError = false
+      event.duration = (event.timestamp && Date.now() - event.timestamp.getTime()) || 0
+      publishEvent(server, event)
+      return { tools }
+    })
+  } catch (error) {
+    log(`Warning: Failed to override list tools handler - ${error}`)
+  }
+}

--- a/packages/mcp/src/modules/tracing-v2.ts
+++ b/packages/mcp/src/modules/tracing-v2.ts
@@ -1,0 +1,474 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import type {
+  CompatibleRequestHandlerExtra,
+  HighLevelMCPServerLike,
+  MCPServerLike,
+  RegisteredTool,
+  UnredactedEvent,
+} from '../types'
+import {
+  type ConversationIdResolution,
+  canInjectConversationIdPromptBack,
+  cloneRequestWithoutConversationId,
+  injectConversationIdPromptBack,
+  resolveConversationId,
+  stripConversationId,
+} from './conversation-id'
+import { publishEvent } from './publish'
+import { MCPAnalyticsEventType } from './event-types'
+import { captureException } from './exceptions'
+import { resolveToolCallIntent, setEventIntent, setExplicitContextIntent } from './intent'
+import { getServerTrackingData, handleIdentify, resolveEventProperties } from './internal'
+import { log } from './logger'
+import { buildCapturedMcpParameters } from './mcp-payloads'
+import { createWrappedTool, getLiteralValue, getObjectShape, getToolFunction, hasToolFunction } from './mcp-sdk-compat'
+import { getServerSessionId } from './session'
+import { GET_MORE_TOOLS_NAME, handleReportMissing } from './tools'
+import { setupInitializeTracing, setupListToolsTracing } from './tracing'
+
+type MCPRequestHandler = NonNullable<
+  MCPServerLike['_requestHandlers'] extends Map<string, infer THandler> ? THandler : never
+>
+type MCPRequest = Parameters<MCPRequestHandler>[0]
+type MCPRequestExtra = Parameters<MCPRequestHandler>[1]
+
+const wrappedCallbacks = new WeakMap<object, boolean>()
+
+const MCP_ANALYTICS_PROCESSED = Symbol('__posthog_mcp_analytics_processed__')
+
+type ProcessedRegisteredTool = RegisteredTool & {
+  [MCP_ANALYTICS_PROCESSED]?: boolean
+}
+
+function isToolResultError(result: unknown): boolean {
+  return !!result && typeof result === 'object' && 'isError' in result && result.isError === true
+}
+
+function isCallbackUpdate(value: unknown): value is { callback: unknown } {
+  return !!value && typeof value === 'object' && 'callback' in value && typeof value.callback === 'function'
+}
+
+function addTracingToToolRegistry(
+  tools: Record<string, RegisteredTool>,
+  server: HighLevelMCPServerLike
+): Record<string, RegisteredTool> {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, tool]) => [name, addTracingToToolCallbackInternal(tool, name, server)])
+  )
+}
+
+function setupListenerToRegisteredTools(server: HighLevelMCPServerLike): void {
+  try {
+    const data = getServerTrackingData(server.server as MCPServerLike)
+    if (!data) {
+      log('Warning: Cannot setup listener - no tracking data found')
+      return
+    }
+
+    const handler: ProxyHandler<Record<string, RegisteredTool>> = {
+      set(target: Record<string, RegisteredTool>, property: string | symbol, value: RegisteredTool): boolean {
+        try {
+          if (typeof property === 'string' && value && typeof value === 'object' && hasToolFunction(value)) {
+            if (typeof value.description === 'string') {
+              data.toolDescriptions.set(property, value.description)
+            }
+            if ((value as ProcessedRegisteredTool)[MCP_ANALYTICS_PROCESSED]) {
+              log(`Tool ${String(property)} already processed, skipping proxy wrapping`)
+              return Reflect.set(target, property, value)
+            }
+
+            if (wrappedCallbacks.has(getToolFunction(value))) {
+              log(`Tool ${String(property)} callback already wrapped, skipping proxy wrapping`)
+              return Reflect.set(target, property, value)
+            }
+
+            const nextValue = addTracingToToolCallbackInternal(value, property, server)
+
+            setupListToolsTracing(server)
+
+            if (typeof nextValue.update === 'function') {
+              const originalUpdate = nextValue.update
+              nextValue.update = function (...updateArgs: unknown[]) {
+                if (updateArgs[0]) {
+                  const updateObj = updateArgs[0]
+                  if (isCallbackUpdate(updateObj)) {
+                    const wrappedTool = addTracingToToolCallbackInternal(
+                      { callback: updateObj.callback } as RegisteredTool,
+                      property,
+                      server
+                    )
+                    updateObj.callback = getToolFunction(wrappedTool)
+                  }
+                }
+                return originalUpdate.apply(this, updateArgs)
+              }
+            }
+            return Reflect.set(target, property, nextValue)
+          }
+
+          return Reflect.set(target, property, value)
+        } catch (error) {
+          log(`Warning: Error in proxy set handler for tool ${String(property)} - ${error}`)
+          return Reflect.set(target, property, value)
+        }
+      },
+
+      get(target: Record<string, RegisteredTool>, property: string | symbol): unknown {
+        return Reflect.get(target, property)
+      },
+
+      deleteProperty(target: Record<string, RegisteredTool>, property: string | symbol): boolean {
+        return Reflect.deleteProperty(target, property)
+      },
+
+      has(target: Record<string, RegisteredTool>, property: string | symbol): boolean {
+        return Reflect.has(target, property)
+      },
+    }
+
+    const originalTools = server._registeredTools || {}
+    server._registeredTools = new Proxy(originalTools, handler)
+
+    log('Successfully set up listener for new tool registrations')
+  } catch (error) {
+    log(`Warning: Failed to setup listener for registered tools - ${error}`)
+  }
+}
+
+function addTracingToToolCallbackInternal(
+  tool: RegisteredTool,
+  toolName: string,
+  _server: HighLevelMCPServerLike
+): RegisteredTool {
+  const originalCallback = getToolFunction(tool)
+
+  if (wrappedCallbacks.has(originalCallback)) {
+    log(`Tool ${toolName} callback already wrapped, skipping re-wrap`)
+    return tool
+  }
+
+  if ((tool as ProcessedRegisteredTool)[MCP_ANALYTICS_PROCESSED]) {
+    log(`Tool ${toolName} already processed, skipping re-wrap`)
+    return tool
+  }
+
+  const wrappedCallback = async (...params: unknown[]): Promise<CallToolResult> => {
+    let args: unknown
+    let extra: CompatibleRequestHandlerExtra
+
+    if (params.length === 2) {
+      args = params[0]
+      extra = params[1] as CompatibleRequestHandlerExtra
+    } else {
+      args = undefined
+      extra = params[0] as CompatibleRequestHandlerExtra
+    }
+
+    const removeContextFromArgs = (input: unknown): unknown => {
+      if (input && typeof input === 'object' && 'context' in input) {
+        const { context: _context, ...rest } = input
+        return rest
+      }
+      return input
+    }
+
+    const cleanedArgs = toolName === 'get_more_tools' ? args : stripConversationId(removeContextFromArgs(args))
+
+    try {
+      if (cleanedArgs === undefined) {
+        const handler = originalCallback as (extra: CompatibleRequestHandlerExtra) => Promise<CallToolResult>
+        return await handler(extra)
+      }
+      const handler = originalCallback as (
+        args: unknown,
+        extra: CompatibleRequestHandlerExtra
+      ) => Promise<CallToolResult>
+      return await handler(cleanedArgs, extra)
+    } catch (error) {
+      if (error instanceof Error) {
+        extra.__mcp_analytics_error = error
+      }
+      throw error
+    }
+  }
+
+  wrappedCallbacks.set(originalCallback, true)
+  wrappedCallbacks.set(wrappedCallback, true)
+
+  const wrappedTool = createWrappedTool(tool, wrappedCallback)
+
+  ;(wrappedTool as ProcessedRegisteredTool)[MCP_ANALYTICS_PROCESSED] = true
+
+  return wrappedTool
+}
+
+function setupToolsCallHandlerWrapping(server: HighLevelMCPServerLike): void {
+  const lowLevelServer = server.server as MCPServerLike
+
+  const existingHandler = lowLevelServer._requestHandlers.get('tools/call')
+  if (existingHandler) {
+    const wrappedHandler = createToolsCallWrapper(existingHandler, lowLevelServer)
+    lowLevelServer._requestHandlers.set('tools/call', wrappedHandler)
+  }
+
+  const originalSetRequestHandler = lowLevelServer.setRequestHandler.bind(lowLevelServer)
+
+  lowLevelServer.setRequestHandler = ((requestSchema: unknown, handler: MCPRequestHandler) => {
+    const shape = getObjectShape(requestSchema)
+    const method = shape?.method ? getLiteralValue(shape.method) : undefined
+
+    if (method === 'tools/call') {
+      const wrappedHandler = createToolsCallWrapper(handler, lowLevelServer)
+      return originalSetRequestHandler(requestSchema, wrappedHandler)
+    }
+
+    return originalSetRequestHandler(requestSchema, handler)
+  }) as MCPServerLike['setRequestHandler']
+}
+
+function createToolsCallWrapper(originalHandler: MCPRequestHandler, server: MCPServerLike): MCPRequestHandler {
+  return async (request: MCPRequest, extra: MCPRequestExtra) =>
+    await handleWrappedToolsCall(originalHandler, server, request, extra)
+}
+
+interface ToolCallTracing {
+  event: UnredactedEvent | null
+  mintedConversationId: string | undefined
+  shouldPublishEvent: boolean
+}
+
+async function handleWrappedToolsCall(
+  originalHandler: MCPRequestHandler,
+  server: MCPServerLike,
+  request: MCPRequest,
+  extra: MCPRequestExtra
+): Promise<unknown> {
+  const startTime = new Date()
+  const conversation = resolveConversationId(
+    getServerTrackingData(server)?.options.enableConversationId ?? false,
+    request.params?.arguments,
+    request.params?.name
+  )
+  const downstreamRequest = conversation.conversationId ? cloneRequestWithoutConversationId(request) : request
+  const tracing = await initializeToolCallEvent(server, request, downstreamRequest, extra, startTime, conversation)
+
+  if (request?.params?.name === GET_MORE_TOOLS_NAME) {
+    return executeReportMissingTool(server, request, tracing, startTime)
+  }
+
+  return await executeOriginalTool(originalHandler, server, request, extra, tracing, startTime)
+}
+
+async function initializeToolCallEvent(
+  server: MCPServerLike,
+  request: MCPRequest,
+  downstreamRequest: MCPRequest,
+  extra: MCPRequestExtra,
+  startTime: Date,
+  conversation: ConversationIdResolution
+): Promise<ToolCallTracing> {
+  try {
+    const data = getServerTrackingData(server)
+    if (!data) {
+      log(
+        'Warning: PostHog MCP analytics is unable to find server tracking data. Please ensure you have called track(server, options) before using tool calls.'
+      )
+      return {
+        event: null,
+        mintedConversationId: undefined,
+        shouldPublishEvent: false,
+      }
+    }
+
+    const toolName = request.params?.name
+    const event: UnredactedEvent = {
+      sessionId: getServerSessionId(server, extra),
+      conversationId: conversation.conversationId,
+      resourceName: toolName || 'Unknown Tool',
+      parameters: buildCapturedMcpParameters(downstreamRequest),
+      eventType: MCPAnalyticsEventType.mcpToolsCall,
+      timestamp: startTime,
+      toolDescription: toolName ? data.toolDescriptions.get(toolName) : undefined,
+      redactionFn: data.options.redactSensitiveInformation,
+    }
+
+    await handleIdentify(server, data, request, extra)
+    event.sessionId = data.sessionId
+    await applyResolvedMetadata(event, data, request, extra)
+
+    setEventIntent(event, await resolveToolCallIntent(data, request, extra))
+
+    return {
+      event,
+      mintedConversationId: conversation.minted ? conversation.conversationId : undefined,
+      shouldPublishEvent: true,
+    }
+  } catch (error) {
+    log(
+      `Warning: PostHog MCP analytics tracing failed for tool ${request.params?.name}, falling back to original handler - ${error}`
+    )
+    return {
+      event: null,
+      mintedConversationId: undefined,
+      shouldPublishEvent: false,
+    }
+  }
+}
+
+async function applyResolvedMetadata(
+  event: UnredactedEvent,
+  data: NonNullable<ReturnType<typeof getServerTrackingData>>,
+  request: MCPRequest,
+  extra: MCPRequestExtra
+): Promise<void> {
+  const resolvedProperties = await resolveEventProperties(data, request, extra)
+  if (resolvedProperties) {
+    event.properties = resolvedProperties
+  }
+}
+
+function executeReportMissingTool(
+  server: MCPServerLike,
+  request: MCPRequest,
+  tracing: ToolCallTracing,
+  startTime: Date
+): CallToolResult {
+  try {
+    const context = getContextArgument(request) || ''
+    const result = handleReportMissing({ context })
+
+    publishSuccessfulToolEvent(server, tracing, result, startTime, {
+      userIntent: context,
+      userIntentSource: 'context_parameter',
+    })
+
+    return result
+  } catch (error) {
+    publishFailedToolEvent(server, tracing, error, startTime)
+    throw error
+  }
+}
+
+async function executeOriginalTool(
+  originalHandler: MCPRequestHandler,
+  server: MCPServerLike,
+  request: MCPRequest,
+  extra: MCPRequestExtra,
+  tracing: ToolCallTracing,
+  startTime: Date
+): Promise<unknown> {
+  try {
+    const result = await originalHandler(request, extra)
+    let finalResult = result
+    if (tracing.mintedConversationId) {
+      if (canInjectConversationIdPromptBack(result)) {
+        finalResult = injectConversationIdPromptBack(result, tracing.mintedConversationId)
+      } else if (tracing.event) {
+        // Minted but undeliverable — agent will never see the id; drop it
+        // from the captured event so it doesn't appear as an orphan.
+        tracing.event.conversationId = undefined
+      }
+    }
+    publishSuccessfulToolEvent(server, tracing, finalResult, startTime, {
+      capturedError: extra?.__mcp_analytics_error,
+      clearCapturedError: () => {
+        if (extra) {
+          extra.__mcp_analytics_error = undefined
+        }
+      },
+    })
+    return finalResult
+  } catch (error) {
+    if (tracing.mintedConversationId && tracing.event) {
+      tracing.event.conversationId = undefined
+    }
+    publishFailedToolEvent(server, tracing, error, startTime)
+    throw error
+  }
+}
+
+function getContextArgument(request: MCPRequest): string | undefined {
+  const context = request.params?.arguments?.context
+  return typeof context === 'string' ? context : undefined
+}
+
+function publishSuccessfulToolEvent(
+  server: MCPServerLike,
+  tracing: ToolCallTracing,
+  result: unknown,
+  startTime: Date,
+  options: {
+    capturedError?: unknown
+    clearCapturedError?: () => void
+    userIntent?: string
+    userIntentSource?: UnredactedEvent['userIntentSource']
+  } = {}
+): void {
+  if (!(tracing.event && tracing.shouldPublishEvent)) {
+    return
+  }
+
+  if (options.userIntent) {
+    setExplicitContextIntent(tracing.event, options.userIntent)
+    if (options.userIntentSource) {
+      tracing.event.userIntentSource = options.userIntentSource
+    }
+  }
+  if (isToolResultError(result)) {
+    tracing.event.isError = true
+    tracing.event.error = captureException(options.capturedError || result)
+    options.clearCapturedError?.()
+  } else {
+    tracing.event.isError = false
+  }
+
+  tracing.event.response = result
+  tracing.event.duration = Date.now() - startTime.getTime()
+  publishEvent(server, tracing.event)
+}
+
+function publishFailedToolEvent(
+  server: MCPServerLike,
+  tracing: ToolCallTracing,
+  error: unknown,
+  startTime: Date
+): void {
+  if (!(tracing.event && tracing.shouldPublishEvent)) {
+    return
+  }
+
+  tracing.event.isError = true
+  tracing.event.error = captureException(error)
+  tracing.event.duration = Date.now() - startTime.getTime()
+  publishEvent(server, tracing.event)
+}
+
+export function setupTracking(server: HighLevelMCPServerLike): void {
+  try {
+    const mcpAnalyticsData = getServerTrackingData(server.server)
+
+    setupToolsCallHandlerWrapping(server)
+
+    setupInitializeTracing(server)
+
+    server._registeredTools = addTracingToToolRegistry(server._registeredTools, server)
+
+    if (mcpAnalyticsData) {
+      seedToolDescriptionsFromRegistry(mcpAnalyticsData.toolDescriptions, server._registeredTools)
+    }
+
+    setupListToolsTracing(server)
+
+    setupListenerToRegisteredTools(server)
+  } catch (error) {
+    log(`Warning: Failed to setup tool call tracing - ${error}`)
+  }
+}
+
+function seedToolDescriptionsFromRegistry(cache: Map<string, string>, tools: Record<string, RegisteredTool>): void {
+  for (const [name, tool] of Object.entries(tools)) {
+    if (typeof tool?.description === 'string') {
+      cache.set(name, tool.description)
+    }
+  }
+}

--- a/packages/mcp/src/modules/tracing.ts
+++ b/packages/mcp/src/modules/tracing.ts
@@ -1,0 +1,395 @@
+import {
+  CallToolRequestSchema,
+  InitializeRequestSchema,
+  ListToolsRequestSchema,
+  type ListToolsResult,
+} from '@modelcontextprotocol/sdk/types.js'
+import type { HighLevelMCPServerLike, MCPServerLike, UnredactedEvent } from '../types'
+import { getMCPCompatibleErrorMessage } from './compatibility'
+import { addContextParameterToTools, getContextDescription, isContextEnabled } from './context-parameters'
+import {
+  addConversationIdToTools,
+  canInjectConversationIdPromptBack,
+  cloneRequestWithoutConversationId,
+  injectConversationIdPromptBack,
+  resolveConversationId,
+} from './conversation-id'
+import { publishEvent } from './publish'
+import { MCPAnalyticsEventType } from './event-types'
+import { captureException } from './exceptions'
+import { resolveToolCallIntent, setEventIntent, setExplicitContextIntent } from './intent'
+import { getServerTrackingData, handleIdentify, resolveEventProperties } from './internal'
+import { log } from './logger'
+import { buildCapturedMcpParameters } from './mcp-payloads'
+import { getServerSessionId } from './session'
+import { GET_MORE_TOOLS_NAME, getReportMissingToolDescriptor, handleReportMissing } from './tools'
+
+type MCPRequestHandler = NonNullable<
+  MCPServerLike['_requestHandlers'] extends Map<string, infer THandler> ? THandler : never
+>
+type MCPRequest = Parameters<MCPRequestHandler>[0]
+type MCPRequestExtra = Parameters<MCPRequestHandler>[1]
+type MCPServerWithCapabilities = MCPServerLike & {
+  _capabilities?: {
+    tools?: unknown
+  }
+}
+
+function isToolResultError(result: unknown): boolean {
+  return !!result && typeof result === 'object' && 'isError' in result && result.isError === true
+}
+
+const listToolsTracingSetup = new WeakMap<MCPServerLike, boolean>()
+
+export function setupListToolsTracing(highLevelServer: HighLevelMCPServerLike): void {
+  const server = highLevelServer.server
+
+  if (!(server as MCPServerWithCapabilities)._capabilities?.tools) {
+    return
+  }
+
+  if (listToolsTracingSetup.get(server)) {
+    return
+  }
+
+  const handlers = server._requestHandlers
+  const originalListToolsHandler = handlers.get('tools/list')
+
+  if (!originalListToolsHandler) {
+    return
+  }
+
+  try {
+    server.setRequestHandler(
+      ListToolsRequestSchema,
+      async (request, extra) => await handleListToolsRequest(server, originalListToolsHandler, request, extra)
+    )
+
+    listToolsTracingSetup.set(server, true)
+  } catch (error) {
+    log(`Warning: Failed to override list tools handler - ${error}`)
+  }
+}
+
+async function handleListToolsRequest(
+  server: MCPServerLike,
+  originalListToolsHandler: MCPRequestHandler,
+  request: MCPRequest,
+  extra: MCPRequestExtra
+): Promise<{ tools: ListToolsResult['tools'] }> {
+  const data = getServerTrackingData(server)
+  const event: UnredactedEvent = {
+    sessionId: getServerSessionId(server, extra),
+    parameters: buildCapturedMcpParameters(request),
+    eventType: MCPAnalyticsEventType.mcpToolsList,
+    timestamp: new Date(),
+    redactionFn: data?.options.redactSensitiveInformation,
+  }
+
+  if (data) {
+    await applyResolvedMetadata(event, data, request, extra)
+  }
+
+  const tools = await getTracedToolsList(server, originalListToolsHandler, request, extra, event)
+
+  if (!data) {
+    log(
+      'Warning: PostHog MCP analytics is unable to find server tracking data. Please ensure you have called track(server, options) before using tool calls.'
+    )
+    return { tools }
+  }
+
+  if (tools.length === 0) {
+    log(
+      'Warning: No tools found in the original list. This is likely due to the tools not being registered before PostHog MCP analytics.track().'
+    )
+    event.error = { message: 'No tools were sent to MCP client.' }
+    event.isError = true
+    event.duration = getEventDuration(event)
+    publishEvent(server, event)
+    return { tools }
+  }
+
+  event.response = { tools }
+  event.listedToolNames = collectListedToolNames(tools)
+  event.isError = false
+  event.duration = getEventDuration(event)
+  publishEvent(server, event)
+  return { tools }
+}
+
+function collectListedToolNames(tools: ListToolsResult['tools'] | undefined): string[] | undefined {
+  if (!tools || tools.length === 0) {
+    return
+  }
+  const names = tools.map((tool) => tool?.name).filter((name): name is string => typeof name === 'string')
+  return names.length > 0 ? names : undefined
+}
+
+async function getTracedToolsList(
+  server: MCPServerLike,
+  originalListToolsHandler: MCPRequestHandler,
+  request: MCPRequest,
+  extra: MCPRequestExtra,
+  event: UnredactedEvent
+): Promise<ListToolsResult['tools']> {
+  try {
+    const data = getServerTrackingData(server)
+    const originalResponse = (await originalListToolsHandler(request, extra)) as ListToolsResult
+    let tools = originalResponse.tools || []
+
+    if (data && isContextEnabled(data.options.context)) {
+      tools = addContextParameterToTools(tools, getContextDescription(data.options.context))
+    }
+
+    if (data?.options.enableConversationId) {
+      tools = addConversationIdToTools(tools)
+    }
+
+    if (data?.options.reportMissing) {
+      const alreadyPresent = tools.some((tool) => tool?.name === GET_MORE_TOOLS_NAME)
+      if (!alreadyPresent) {
+        tools.push(getReportMissingToolDescriptor())
+      }
+    }
+
+    if (data) {
+      cacheToolDescriptions(data.toolDescriptions, tools)
+    }
+
+    return tools
+  } catch (error) {
+    log(
+      `Warning: Original list tools handler failed, this suggests an error PostHog MCP analytics did not cause - ${error}`
+    )
+    event.error = { message: getMCPCompatibleErrorMessage(error) }
+    event.isError = true
+    event.duration = getEventDuration(event)
+    publishEvent(server, event)
+    throw error
+  }
+}
+
+export function setupInitializeTracing(highLevelServer: HighLevelMCPServerLike): void {
+  const server = highLevelServer.server
+  const handlers = server._requestHandlers
+  const originalInitializeHandler = handlers.get('initialize')
+
+  if (originalInitializeHandler) {
+    server.setRequestHandler(InitializeRequestSchema, async (request, extra) => {
+      const data = getServerTrackingData(server)
+      if (!data) {
+        log(
+          'Warning: PostHog MCP analytics is unable to find server tracking data. Please ensure you have called track(server, options) before using tool calls.'
+        )
+        return await originalInitializeHandler(request, extra)
+      }
+
+      const sessionId = getServerSessionId(server, extra)
+
+      await handleIdentify(server, data, request, extra)
+
+      const event: UnredactedEvent = {
+        sessionId,
+        resourceName: request.params?.name || 'Unknown Tool Name',
+        eventType: MCPAnalyticsEventType.mcpInitialize,
+        parameters: buildCapturedMcpParameters(request),
+        timestamp: new Date(),
+        redactionFn: data.options.redactSensitiveInformation,
+      }
+
+      const resolvedProperties = await resolveEventProperties(data, request, extra)
+      if (resolvedProperties) {
+        event.properties = resolvedProperties
+      }
+
+      const result = await originalInitializeHandler(request, extra)
+      event.response = result
+      publishEvent(server, event)
+      return result
+    })
+  }
+}
+
+export function setupToolCallTracing(server: MCPServerLike): void {
+  try {
+    const handlers = server._requestHandlers
+
+    const originalCallToolHandler = handlers.get('tools/call')
+    const originalInitializeHandler = handlers.get('initialize')
+
+    if (originalInitializeHandler) {
+      server.setRequestHandler(InitializeRequestSchema, async (request, extra) => {
+        const data = getServerTrackingData(server)
+        if (!data) {
+          log(
+            'Warning: PostHog MCP analytics is unable to find server tracking data. Please ensure you have called track(server, options) before using tool calls.'
+          )
+          return await originalInitializeHandler(request, extra)
+        }
+
+        const sessionId = getServerSessionId(server, extra)
+
+        await handleIdentify(server, data, request, extra)
+
+        const event: UnredactedEvent = {
+          sessionId,
+          resourceName: request.params?.name || 'Unknown Tool Name',
+          eventType: MCPAnalyticsEventType.mcpInitialize,
+          parameters: buildCapturedMcpParameters(request),
+          timestamp: new Date(),
+          redactionFn: data.options.redactSensitiveInformation,
+        }
+
+        const resolvedProperties = await resolveEventProperties(data, request, extra)
+        if (resolvedProperties) {
+          event.properties = resolvedProperties
+        }
+
+        const result = await originalInitializeHandler(request, extra)
+        event.response = result
+        publishEvent(server, event)
+        return result
+      })
+    }
+
+    server.setRequestHandler(
+      CallToolRequestSchema,
+      async (request, extra) => await handleToolCallRequest(server, originalCallToolHandler, request, extra)
+    )
+  } catch (error) {
+    log(`Warning: Failed to setup tool call tracing - ${error}`)
+    throw error
+  }
+}
+
+async function handleToolCallRequest(
+  server: MCPServerLike,
+  originalCallToolHandler: MCPRequestHandler | undefined,
+  request: MCPRequest,
+  extra: MCPRequestExtra
+): Promise<unknown> {
+  const data = getServerTrackingData(server)
+  if (!data) {
+    log(
+      'Warning: PostHog MCP analytics is unable to find server tracking data. Please ensure you have called track(server, options) before using tool calls.'
+    )
+    return await originalCallToolHandler?.(request, extra)
+  }
+
+  const conversation = resolveConversationId(
+    data.options.enableConversationId ?? false,
+    request.params?.arguments,
+    request.params?.name
+  )
+  const downstreamRequest = conversation.conversationId ? cloneRequestWithoutConversationId(request) : request
+
+  const toolName = request.params?.name
+  const event: UnredactedEvent = {
+    sessionId: getServerSessionId(server, extra),
+    conversationId: conversation.conversationId,
+    resourceName: toolName || 'Unknown Tool Name',
+    parameters: buildCapturedMcpParameters(downstreamRequest),
+    eventType: MCPAnalyticsEventType.mcpToolsCall,
+    timestamp: new Date(),
+    toolDescription: toolName ? data.toolDescriptions.get(toolName) : undefined,
+    redactionFn: data.options.redactSensitiveInformation,
+  }
+
+  try {
+    await handleIdentify(server, data, request, extra)
+    await applyResolvedMetadata(event, data, request, extra)
+    setEventIntent(event, await resolveToolCallIntent(data, request, extra))
+
+    const result = await executeToolCall(server, originalCallToolHandler, downstreamRequest, extra, event)
+    if (isToolResultError(result)) {
+      event.isError = true
+      event.error = captureException(result)
+    } else {
+      event.isError = false
+    }
+
+    let finalResult = result
+    if (conversation.minted) {
+      if (canInjectConversationIdPromptBack(result)) {
+        finalResult = injectConversationIdPromptBack(result, conversation.conversationId)
+      } else {
+        // Agent never received the minted id → clear so the event is not
+        // an orphan in analytics.
+        event.conversationId = undefined
+      }
+    }
+
+    event.response = finalResult
+    event.duration = getEventDuration(event)
+    publishEvent(server, event)
+    return finalResult
+  } catch (error) {
+    event.isError = true
+    event.error = captureException(error)
+    if (conversation.minted) {
+      event.conversationId = undefined
+    }
+    event.duration = getEventDuration(event)
+    publishEvent(server, event)
+    throw error
+  }
+}
+
+async function executeToolCall(
+  server: MCPServerLike,
+  originalCallToolHandler: MCPRequestHandler | undefined,
+  request: MCPRequest,
+  extra: MCPRequestExtra,
+  event: UnredactedEvent
+): Promise<unknown> {
+  if (request.params?.name === GET_MORE_TOOLS_NAME) {
+    const context = getContextArgument(request) || ''
+    setExplicitContextIntent(event, context)
+    return handleReportMissing({ context })
+  }
+
+  if (originalCallToolHandler) {
+    return await originalCallToolHandler(request, extra)
+  }
+
+  event.isError = true
+  event.error = {
+    message: `Tool call handler not found for ${request.params?.name || 'unknown'}`,
+  }
+  event.duration = getEventDuration(event) || undefined
+  publishEvent(server, event)
+  throw new Error(`Unknown tool: ${request.params?.name || 'unknown'}`)
+}
+
+async function applyResolvedMetadata(
+  event: UnredactedEvent,
+  data: NonNullable<ReturnType<typeof getServerTrackingData>>,
+  request: MCPRequest,
+  extra: MCPRequestExtra
+): Promise<void> {
+  const resolvedProperties = await resolveEventProperties(data, request, extra)
+  if (resolvedProperties) {
+    event.properties = resolvedProperties
+  }
+}
+
+function getContextArgument(request: MCPRequest): string | undefined {
+  const context = request.params?.arguments?.context
+  return typeof context === 'string' ? context : undefined
+}
+
+function getEventDuration(event: UnredactedEvent): number {
+  return event.timestamp ? Date.now() - event.timestamp.getTime() : 0
+}
+
+export function cacheToolDescriptions(cache: Map<string, string>, tools: ListToolsResult['tools'] | undefined): void {
+  if (!tools) {
+    return
+  }
+  for (const tool of tools) {
+    if (tool?.name && typeof tool.description === 'string') {
+      cache.set(tool.name, tool.description)
+    }
+  }
+}

--- a/packages/mcp/src/modules/truncation.ts
+++ b/packages/mcp/src/modules/truncation.ts
@@ -1,0 +1,434 @@
+import type { ErrorData, Event, StackFrame, UnredactedEvent } from '../types'
+
+// --- Constants ---
+export const MAX_DEPTH = 10
+export const MAX_BREADTH = 100
+export const MAX_STRING_LENGTH = 32_768 // 32KB
+export const MAX_EVENT_BYTES = 102_400 // 100KB
+
+// --- Field-level limit constants ---
+const MAX_USER_INTENT_LENGTH = 2048
+const MAX_ERROR_MESSAGE_LENGTH = 2048
+const MAX_RESOURCE_NAME_LENGTH = 256
+const MAX_METADATA_LENGTH = 256
+const MAX_STACK_FRAMES = 50
+const MAX_CONTENT_TEXT_LENGTH = 32_768
+
+// --- Truncation markers ---
+const TRUNCATION_SUFFIX = '...'
+
+type MutableEvent = Partial<Event | UnredactedEvent> & Record<string, unknown>
+type MutableRecord = Record<string, unknown>
+
+/**
+ * Recursively normalizes a value, handling:
+ * - String truncation (> MAX_STRING_LENGTH)
+ * - Non-serializable values (functions, symbols, undefined, BigInt, NaN, Infinity)
+ * - Date objects -> ISO string
+ * - Circular reference detection
+ * - Depth limiting
+ * - Breadth limiting
+ */
+export function normalize(
+  input: unknown,
+  depth: number = MAX_DEPTH,
+  maxBreadth: number = MAX_BREADTH,
+  maxStringLength: number = MAX_STRING_LENGTH
+): unknown {
+  const memo = new WeakSet<object>()
+  return visit(input, depth, maxBreadth, maxStringLength, memo)
+}
+
+function visit(
+  value: unknown,
+  remainingDepth: number,
+  maxBreadth: number,
+  maxStringLength: number,
+  memo: WeakSet<object>
+): unknown {
+  // null
+  if (value === null) {
+    return null
+  }
+
+  // undefined
+  if (value === undefined) {
+    return '[undefined]'
+  }
+
+  // boolean
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  // number (including NaN, Infinity)
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) {
+      return '[NaN]'
+    }
+    if (!Number.isFinite(value)) {
+      return value > 0 ? '[Infinity]' : '[-Infinity]'
+    }
+    return value
+  }
+
+  // bigint
+  if (typeof value === 'bigint') {
+    return `[BigInt: ${value}]`
+  }
+
+  // string
+  if (typeof value === 'string') {
+    if (value.length > maxStringLength) {
+      return value.slice(0, maxStringLength) + TRUNCATION_SUFFIX
+    }
+    return value
+  }
+
+  // symbol
+  if (typeof value === 'symbol') {
+    const desc = value.description
+    return desc ? `[Symbol(${desc})]` : '[Symbol()]'
+  }
+
+  // function
+  if (typeof value === 'function') {
+    const name = value.name || '<anonymous>'
+    return `[Function: ${name}]`
+  }
+
+  // Date
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? '[Invalid Date]' : value.toISOString()
+  }
+
+  // Objects and arrays from here — need depth/breadth/circular checks
+  if (typeof value === 'object') {
+    // Circular reference detection
+    if (memo.has(value)) {
+      return '[Circular ~]'
+    }
+
+    // Depth limit
+    if (remainingDepth <= 0) {
+      return Array.isArray(value) ? '[Array]' : '[Object]'
+    }
+
+    memo.add(value)
+
+    let result: unknown
+    if (Array.isArray(value)) {
+      result = visitArray(value, remainingDepth - 1, maxBreadth, maxStringLength, memo)
+    } else {
+      result = visitObject(value as Record<string, unknown>, remainingDepth - 1, maxBreadth, maxStringLength, memo)
+    }
+
+    memo.delete(value)
+    return result
+  }
+
+  // Fallback: coerce to string
+  return String(value)
+}
+
+function visitArray(
+  arr: unknown[],
+  remainingDepth: number,
+  maxBreadth: number,
+  maxStringLength: number,
+  memo: WeakSet<object>
+): unknown[] {
+  const result: unknown[] = []
+  for (let i = 0; i < arr.length; i++) {
+    if (i >= maxBreadth) {
+      result.push('[MaxProperties ~]')
+      break
+    }
+    result.push(visit(arr[i], remainingDepth, maxBreadth, maxStringLength, memo))
+  }
+  return result
+}
+
+function visitObject(
+  obj: Record<string, unknown>,
+  remainingDepth: number,
+  maxBreadth: number,
+  maxStringLength: number,
+  memo: WeakSet<object>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  const keys = Object.keys(obj)
+  let count = 0
+
+  for (const key of keys) {
+    if (count >= maxBreadth) {
+      result['...'] = '[MaxProperties ~]'
+      break
+    }
+    // Skip undefined values — matches JSON.stringify behavior (omits undefined properties)
+    if (obj[key] === undefined) {
+      continue
+    }
+    result[key] = visit(obj[key], remainingDepth, maxBreadth, maxStringLength, memo)
+    count++
+  }
+
+  return result
+}
+
+// --- Field-level truncation helpers ---
+
+function truncateString(str: string | undefined, maxLength: number): string | undefined {
+  if (str == null) {
+    return str
+  }
+  if (str.length <= maxLength) {
+    return str
+  }
+  return str.slice(0, maxLength) + TRUNCATION_SUFFIX
+}
+
+function truncateStackFrames(frames: StackFrame[] | undefined): StackFrame[] | undefined {
+  if (!frames || frames.length <= MAX_STACK_FRAMES) {
+    return frames
+  }
+  const half = Math.floor(MAX_STACK_FRAMES / 2)
+  return [...frames.slice(0, half), ...frames.slice(-half)]
+}
+
+function truncateResponseContent(response: unknown): unknown {
+  if (response == null || typeof response !== 'object') {
+    return response
+  }
+  const result: MutableRecord = { ...(response as MutableRecord) }
+  if (Array.isArray(result.content)) {
+    result.content = result.content.map((block: unknown) => {
+      if (
+        block != null &&
+        typeof block === 'object' &&
+        'type' in block &&
+        'text' in block &&
+        block?.type === 'text' &&
+        typeof block.text === 'string' &&
+        block.text.length > MAX_CONTENT_TEXT_LENGTH
+      ) {
+        return {
+          ...(block as MutableRecord),
+          text: block.text.slice(0, MAX_CONTENT_TEXT_LENGTH) + TRUNCATION_SUFFIX,
+        }
+      }
+      return block
+    })
+  }
+  return result
+}
+
+/**
+ * Calculates the UTF-8 byte size of a JSON-serialized value.
+ */
+const textEncoder = new TextEncoder()
+
+function jsonByteSize(value: unknown): number {
+  return textEncoder.encode(JSON.stringify(value)).length
+}
+
+/**
+ * Finds and truncates the largest string values in an object to fit within a byte budget.
+ * Last-resort mechanism when depth reduction alone isn't enough.
+ * Iterates until the result fits or no further reduction is possible.
+ */
+function truncateLargestFields<T>(obj: T, maxBytes: number): T {
+  const result = structuredClone(obj)
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const currentSize = jsonByteSize(result)
+    if (currentSize <= maxBytes) {
+      return result
+    }
+
+    const excess = currentSize - maxBytes
+
+    // Find all string values and their sizes, sorted largest first
+    const stringPaths: Array<{ path: string[]; length: number }> = []
+    collectStringPaths(result, [], stringPaths)
+    stringPaths.sort((a, b) => b.length - a.length)
+
+    if (stringPaths.length === 0) {
+      break // no strings left to truncate
+    }
+
+    // Distribute the reduction across the largest strings
+    let remaining = excess + 200 // buffer for JSON overhead from added "..." suffixes
+    let truncated = false
+
+    for (const { path, length } of stringPaths) {
+      if (remaining <= 0) {
+        break
+      }
+      const reduction = Math.min(remaining, Math.floor(length * 0.5))
+      if (reduction < 10) {
+        continue // not worth truncating tiny strings
+      }
+      const newLength = length - reduction
+      const currentValue = getNestedValue(result, path)
+      if (typeof currentValue !== 'string') {
+        continue
+      }
+      setNestedValue(result, path, currentValue.slice(0, newLength) + TRUNCATION_SUFFIX)
+      remaining -= reduction
+      truncated = true
+    }
+
+    if (!truncated) {
+      break // no progress possible
+    }
+  }
+
+  return result
+}
+
+function collectStringPaths(
+  obj: unknown,
+  currentPath: string[],
+  results: Array<{ path: string[]; length: number }>
+): void {
+  if (typeof obj === 'string' && obj.length > 100) {
+    results.push({ path: [...currentPath], length: obj.length })
+    return
+  }
+  if (Array.isArray(obj)) {
+    for (const [i, item] of obj.entries()) {
+      collectStringPaths(item, [...currentPath, String(i)], results)
+    }
+    return
+  }
+  if (obj != null && typeof obj === 'object') {
+    for (const [key, value] of Object.entries(obj)) {
+      collectStringPaths(value, [...currentPath, key], results)
+    }
+  }
+}
+
+function getNestedValue(obj: unknown, path: string[]): unknown {
+  let current: unknown = obj
+  for (const key of path) {
+    if (current == null || typeof current !== 'object') {
+      return
+    }
+    current = (current as MutableRecord)[key]
+  }
+  return current
+}
+
+function setNestedValue(obj: unknown, path: string[], value: unknown): void {
+  let current: unknown = obj
+  for (let i = 0; i < path.length - 1; i++) {
+    if (current == null || typeof current !== 'object') {
+      return
+    }
+    current = (current as MutableRecord)[path[i]]
+  }
+  const finalKey = path.at(-1)
+  if (finalKey !== undefined && current != null && typeof current === 'object') {
+    ;(current as MutableRecord)[finalKey] = value
+  }
+}
+
+/**
+ * Ensures an event fits within MAX_EVENT_BYTES by progressively reducing
+ * normalization depth, then truncating largest string fields as a last resort.
+ */
+function truncateToSize(event: MutableEvent): MutableEvent {
+  // Check if already within budget
+  if (jsonByteSize(event) <= MAX_EVENT_BYTES) {
+    return event
+  }
+
+  // Progressive depth reduction
+  for (let depth = MAX_DEPTH - 1; depth >= 1; depth--) {
+    const reduced: MutableEvent = { ...event }
+    if (reduced.parameters != null) {
+      reduced.parameters = normalize(reduced.parameters, depth)
+    }
+    if (reduced.response != null) {
+      reduced.response = normalize(reduced.response, depth)
+    }
+    if (reduced.identifyActorData != null) {
+      reduced.identifyActorData = normalize(reduced.identifyActorData, depth) as Event['identifyActorData']
+    }
+    if (reduced.error != null) {
+      reduced.error = normalize(reduced.error, depth) as Event['error']
+    }
+
+    if (jsonByteSize(reduced) <= MAX_EVENT_BYTES) {
+      return reduced
+    }
+  }
+
+  // Last resort: truncate largest string fields
+  const minimal: MutableEvent = { ...event }
+  if (minimal.parameters != null) {
+    minimal.parameters = normalize(minimal.parameters, 1)
+  }
+  if (minimal.response != null) {
+    minimal.response = normalize(minimal.response, 1)
+  }
+  if (minimal.identifyActorData != null) {
+    minimal.identifyActorData = normalize(minimal.identifyActorData, 1) as Event['identifyActorData']
+  }
+  if (minimal.error != null) {
+    minimal.error = normalize(minimal.error, 1) as Event['error']
+  }
+
+  return truncateLargestFields(minimal, MAX_EVENT_BYTES)
+}
+
+/**
+ * Applies layered truncation to an event:
+ * 1. Field-level string limits (userIntent, resourceName, metadata fields, error.message)
+ * 2. Error frame limiting (first 25 + last 25 if > 50)
+ * 3. Response content text limits (32KB per text block)
+ * 4. Recursive normalization on user-controlled fields
+ * 5. Size-targeted truncation (progressive depth reduction + last-resort string truncation)
+ */
+export function truncateEvent<T extends Event | UnredactedEvent>(event: T): T {
+  const result: MutableEvent = { ...event }
+
+  // Layer 1: Field-level string limits
+  result.userIntent = truncateString(result.userIntent, MAX_USER_INTENT_LENGTH)
+  result.resourceName = truncateString(result.resourceName, MAX_RESOURCE_NAME_LENGTH)
+  result.serverName = truncateString(result.serverName, MAX_METADATA_LENGTH)
+  result.serverVersion = truncateString(result.serverVersion, MAX_METADATA_LENGTH)
+  result.clientName = truncateString(result.clientName, MAX_METADATA_LENGTH)
+  result.clientVersion = truncateString(result.clientVersion, MAX_METADATA_LENGTH)
+
+  // Error field limits
+  if (result.error != null && typeof result.error === 'object') {
+    const error = { ...(result.error as Partial<ErrorData>) }
+    error.message = truncateString(error.message, MAX_ERROR_MESSAGE_LENGTH)
+    if (error.frames !== undefined) {
+      error.frames = truncateStackFrames(error.frames)
+    }
+    result.error = error as ErrorData
+  }
+
+  // Response content text limits
+  result.response = truncateResponseContent(result.response)
+
+  // Layer 2: Recursive normalization on user-controlled fields
+  if (result.parameters != null) {
+    result.parameters = normalize(result.parameters)
+  }
+  if (result.response != null) {
+    result.response = normalize(result.response)
+  }
+  if (result.identifyActorData != null) {
+    result.identifyActorData = normalize(result.identifyActorData) as Event['identifyActorData']
+  }
+  if (result.error != null) {
+    result.error = normalize(result.error) as Event['error']
+  }
+
+  // Layer 3: Size-targeted normalization
+  return truncateToSize(result) as T
+}

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -1,0 +1,240 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import type { MCPAnalyticsEventType } from './modules/event-types'
+import type { PostHogMCP, PostHogMCPOptions } from './modules/client'
+import type { LoggerFn } from './modules/logger'
+
+export type JsonRecord = Record<string, unknown>
+
+export interface MCPRequestParamsLike {
+  arguments?: JsonRecord
+  name?: string
+  [key: string]: unknown
+}
+
+export interface MCPRequestLike {
+  id?: number | string
+  jsonrpc?: string
+  method?: string
+  params?: MCPRequestParamsLike
+  [key: string]: unknown
+}
+
+export interface MCPAnalyticsOptions {
+  /**
+   * PostHog project API key (`phc_...`). Optional only when a `client` is passed.
+   */
+  apiKey?: string | null
+  /**
+   * Override the PostHog ingestion host. Defaults to `https://us.i.posthog.com`.
+   */
+  host?: string
+  /**
+   * PostHog client transport options forwarded to the underlying `@posthog/core` instance.
+   * Use this to tune batching, retries, or supply a custom `fetch`.
+   */
+  clientOptions?: PostHogMCPOptions
+  /**
+   * Use an existing PostHog client instead of letting the SDK create one. Most apps don't
+   * need this — pass it when you want to share one PostHog instance across instrumentation.
+   */
+  client?: PostHogMCP
+  /**
+   * Optional STDIO-safe log sink for SDK-internal warnings. Receives single string messages.
+   * Defaults to a no-op since MCP STDIO transports cannot use console.
+   */
+  logger?: LoggerFn
+  /** Enable the `get_more_tools` virtual tool so agents can report missing functionality. */
+  reportMissing?: boolean
+  /** Emit a parallel `$ai_span` event per tool call so MCP activity appears in PostHog LLM analytics. */
+  enableAITracing?: boolean
+  /** Enables the `conversation_id` tool parameter + prompt-back loop. */
+  enableConversationId?: boolean
+  /** Master switch for auto-captured events. Defaults to `true`. */
+  enableTracing?: boolean
+  /** Inject a required `context` parameter on every tool to capture user intent. */
+  context?: boolean | MCPAnalyticsContextOptions
+  /**
+   * Identify the calling user. Returning a non-null value sets `distinct_id` and `$set`
+   * on subsequent events for the session. Object form is treated as a static identity.
+   */
+  identify?:
+    | ((request: MCPRequestLike, extra?: CompatibleRequestHandlerExtra) => Promise<UserIdentity | null>)
+    | UserIdentity
+    | null
+  /**
+   * Called when a tool is invoked without an explicit `context` argument. Return a short
+   * intent string to record as `$mcp_intent` with `$mcp_intent_source = "inferred"`.
+   */
+  intentFallback?: (
+    request: MCPRequestLike,
+    extra?: CompatibleRequestHandlerExtra
+  ) => MaybePromise<string | null | undefined>
+  /**
+   * Async string redactor applied to every user-controlled string field before capture.
+   * Protected fields (session id, server name, etc.) are skipped.
+   */
+  redactSensitiveInformation?: RedactFunction
+  /**
+   * Attach extra event properties on every auto-captured event. Spread into the PostHog
+   * event properties as-is — values must be JSON-serializable.
+   */
+  eventProperties?: (
+    request: MCPRequestLike,
+    extra?: CompatibleRequestHandlerExtra
+  ) => JsonRecord | null | Promise<JsonRecord | null>
+}
+
+export interface MCPAnalyticsContextOptions {
+  description?: string
+}
+
+export type MaybePromise<T> = T | Promise<T>
+export type MCPAnalyticsIntentSource = 'context_parameter' | 'inferred'
+
+export type ToolCallback =
+  | ((args: unknown, extra: CompatibleRequestHandlerExtra) => CallToolResult | Promise<CallToolResult>)
+  | ((extra: CompatibleRequestHandlerExtra) => CallToolResult | Promise<CallToolResult>)
+
+// RegisteredTool type that supports both MCP SDK 1.23- (callback) and 1.24+ (handler)
+export type RegisteredTool = {
+  description?: string
+  inputSchema?: unknown
+  update?: (...args: unknown[]) => unknown
+} & ({ callback: ToolCallback; handler?: never } | { handler: ToolCallback; callback?: never })
+
+export type RedactFunction = (text: string) => Promise<string>
+
+export interface Event {
+  actorId?: string
+  clientName?: string
+  clientVersion?: string
+  conversationId?: string
+  duration?: number
+  error?: ErrorData | null
+  eventId?: string
+  eventType: MCPAnalyticsEventType
+  id: string
+  identifyActorData?: JsonRecord
+  identifyActorGivenId?: string
+  identifyActorName?: string
+  identifyData?: JsonRecord
+  ipAddress?: string
+  isError?: boolean
+  listedToolNames?: string[]
+  parameters?: unknown
+  properties?: JsonRecord | null
+  resourceName?: string
+  response?: unknown
+  sdkLanguage?: string
+  sdkVersion?: string
+  serverName?: string
+  serverVersion?: string
+  sessionId: string
+  timestamp: Date
+  toolDescription?: string
+  userIntent?: string
+  userIntentSource?: MCPAnalyticsIntentSource
+}
+
+export interface UnredactedEvent extends Partial<Event> {
+  redactionFn?: RedactFunction
+}
+
+export interface CompatibleRequestHandlerExtra {
+  headers?: Record<string, string | string[]>
+  sessionId?: string
+  [key: string]: unknown
+}
+
+export interface ServerClientInfoLike {
+  name?: string
+  version?: string
+}
+
+export interface HighLevelMCPServerLike {
+  _registeredTools: { [name: string]: RegisteredTool }
+  registerTool?(name: string, config: { description?: string; inputSchema?: unknown }, handler: ToolCallback): void
+  server: MCPServerLike
+  tool?(name: string, cb: ToolCallback): void
+  tool?(name: string, paramsSchema: unknown, cb: ToolCallback): void
+  tool?(name: string, description: string, paramsSchema: unknown, cb: ToolCallback): void
+}
+
+export interface MCPServerLike {
+  _requestHandlers: Map<string, (request: MCPRequestLike, extra?: CompatibleRequestHandlerExtra) => Promise<unknown>>
+  _serverInfo?: ServerClientInfoLike
+  getClientVersion(): ServerClientInfoLike | undefined
+  setRequestHandler(
+    schema: unknown,
+    handler: (request: MCPRequestLike, extra?: CompatibleRequestHandlerExtra) => Promise<unknown>
+  ): void
+}
+
+export interface UserIdentity {
+  userData?: JsonRecord
+  userId: string
+  userName?: string
+}
+
+export interface SessionInfo {
+  clientName?: string
+  clientVersion?: string
+  identifyActorData?: JsonRecord
+  identifyActorGivenId?: string
+  identifyActorName?: string
+  ipAddress?: string
+  sdkLanguage?: string
+  sdkVersion?: string
+  serverName?: string
+  serverVersion?: string
+}
+
+export interface MCPAnalyticsData {
+  client: PostHogMCP | undefined
+  identifiedSessions: Map<string, UserIdentity>
+  lastActivity: Date
+  lastMcpSessionId?: string
+  options: MCPAnalyticsOptions
+  sessionId: string
+  sessionInfo: SessionInfo
+  sessionSource: 'generated' | 'mcp'
+  toolDescriptions: Map<string, string>
+}
+
+export interface StackFrame {
+  abs_path?: string
+  colno?: number
+  context_line?: string
+  filename: string
+  function: string
+  in_app: boolean
+  lineno?: number
+}
+
+export interface ChainedErrorData {
+  frames?: StackFrame[]
+  message: string
+  stack?: string
+  type?: string
+}
+
+export interface ErrorData {
+  chained_errors?: ChainedErrorData[]
+  frames?: StackFrame[]
+  message: string
+  platform?: string
+  stack?: string
+  type?: string
+  [key: string]: unknown
+}
+
+export interface CustomEventData {
+  duration?: number
+  error?: unknown
+  isError?: boolean
+  message?: string
+  parameters?: unknown
+  properties?: JsonRecord
+  resourceName?: string
+  response?: unknown
+}

--- a/packages/mcp/src/version.ts
+++ b/packages/mcp/src/version.ts
@@ -1,0 +1,1 @@
+export const version = '0.1.0'

--- a/packages/mcp/tsconfig.build.json
+++ b/packages/mcp/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["./src/**/*"],
+  "exclude": ["./src/__tests__/**/*", "./src/**/*.spec.ts"]
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@posthog-tooling/tsconfig-base",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true,
+    "lib": ["ES2023"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["./src/**/*", "rslib.config.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,6 +565,40 @@ importers:
         specifier: 'catalog:'
         version: 29.7.0(@types/node@24.10.13)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
 
+  packages/mcp:
+    dependencies:
+      '@posthog/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@babel/preset-env':
+        specifier: 'catalog:'
+        version: 7.28.5(@babel/core@7.28.5)
+      '@babel/preset-typescript':
+        specifier: 'catalog:'
+        version: 7.28.5(@babel/core@7.28.5)
+      '@modelcontextprotocol/sdk':
+        specifier: ~1.24.2
+        version: 1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@posthog-tooling/tsconfig-base':
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig-base
+      '@rslib/core':
+        specifier: 'catalog:'
+        version: 0.10.6(@microsoft/api-extractor@7.55.1(@types/node@20.19.9))(typescript@5.9.3)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.9
+      jest:
+        specifier: 'catalog:'
+        version: 29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3))
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+
   packages/next:
     dependencies:
       '@posthog/core':
@@ -4084,6 +4118,16 @@ packages:
   '@miherlosev/esm@3.2.26':
     resolution: {integrity: sha512-TaW4jTGVE1/ln2VGFChnheMh589QCAZy1MVnLvjjSzZ4pEAa4WYAWPwFkDVZbSdPQdLfZy7LuTyZjWRkhX9/Gg==}
     engines: {node: '>=6'}
+
+  '@modelcontextprotocol/sdk@1.24.3':
+    resolution: {integrity: sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -8796,6 +8840,12 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express-rate-limit@8.3.2:
     resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
@@ -15607,6 +15657,9 @@ packages:
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.1.13:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
 
@@ -19218,6 +19271,27 @@ snapshots:
 
   '@miherlosev/esm@3.2.26': {}
 
+  '@modelcontextprotocol/sdk@1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      jose: 6.2.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
     dependencies:
       '@hono/node-server': 1.19.12(hono@4.12.11)
@@ -22319,7 +22393,6 @@ snapshots:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
-    optional: true
 
   acorn-globals@6.0.0:
     dependencies:
@@ -22376,9 +22449,9 @@ snapshots:
     optionalDependencies:
       ajv: 8.13.0
 
-  ajv-formats@2.1.1(ajv@8.13.0):
+  ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.13.0
+      ajv: 8.18.0
 
   ajv-formats@3.0.1(ajv@8.13.0):
     optionalDependencies:
@@ -22387,11 +22460,10 @@ snapshots:
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
-    optional: true
 
-  ajv-keywords@5.1.0(ajv@8.13.0):
+  ajv-keywords@5.1.0(ajv@8.18.0):
     dependencies:
-      ajv: 8.13.0
+      ajv: 8.18.0
       fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
@@ -22421,7 +22493,6 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-    optional: true
 
   alien-signals@0.4.14: {}
 
@@ -23017,7 +23088,6 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   boolbase@1.0.0: {}
 
@@ -23607,8 +23677,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  content-disposition@1.0.1:
-    optional: true
+  content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
 
@@ -23635,8 +23704,7 @@ snapshots:
 
   cookie-signature@1.0.7: {}
 
-  cookie-signature@1.2.2:
-    optional: true
+  cookie-signature@1.2.2: {}
 
   cookie@0.4.2: {}
 
@@ -23664,7 +23732,6 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
-    optional: true
 
   corser@2.0.1: {}
 
@@ -25146,13 +25213,11 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.0.6:
-    optional: true
+  eventsource-parser@3.0.6: {}
 
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
-    optional: true
 
   exec-async@2.2.0: {}
 
@@ -25372,6 +25437,10 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
+  express-rate-limit@7.5.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
@@ -25429,7 +25498,7 @@ snapshots:
       etag: 1.8.1
       finalhandler: 2.1.1
       fresh: 2.0.0
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       merge-descriptors: 2.0.0
       mime-types: 3.0.2
       on-finished: 2.4.1
@@ -25441,12 +25510,11 @@ snapshots:
       router: 2.2.0
       send: 1.2.0
       serve-static: 2.2.0
-      statuses: 2.0.1
+      statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   exsolve@1.0.7: {}
 
@@ -25526,8 +25594,7 @@ snapshots:
 
   fast-npm-meta@0.4.7: {}
 
-  fast-uri@3.1.0:
-    optional: true
+  fast-uri@3.1.0: {}
 
   fast-xml-builder@1.1.4:
     dependencies:
@@ -25669,7 +25736,6 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   find-babel-config@1.2.2:
     dependencies:
@@ -26812,8 +26878,7 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
-  is-promise@4.0.0:
-    optional: true
+  is-promise@4.0.0: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -28171,8 +28236,7 @@ snapshots:
 
   join-component@1.1.0: {}
 
-  jose@6.2.2:
-    optional: true
+  jose@6.2.2: {}
 
   js-levenshtein@1.1.6: {}
 
@@ -28816,8 +28880,7 @@ snapshots:
 
   media-typer@0.3.0: {}
 
-  media-typer@1.1.0:
-    optional: true
+  media-typer@1.1.0: {}
 
   memoize-one@5.2.1: {}
 
@@ -28825,8 +28888,7 @@ snapshots:
 
   merge-descriptors@1.0.3: {}
 
-  merge-descriptors@2.0.0:
-    optional: true
+  merge-descriptors@2.0.0: {}
 
   merge-options@3.0.4:
     dependencies:
@@ -29550,8 +29612,7 @@ snapshots:
 
   negotiator@0.6.4: {}
 
-  negotiator@1.0.0:
-    optional: true
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -30388,8 +30449,7 @@ snapshots:
 
   path-to-regexp@6.2.1: {}
 
-  path-to-regexp@8.4.2:
-    optional: true
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -30445,8 +30505,7 @@ snapshots:
     dependencies:
       pngjs: 6.0.0
 
-  pkce-challenge@5.0.1:
-    optional: true
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@3.0.0:
     dependencies:
@@ -31257,7 +31316,6 @@ snapshots:
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
-    optional: true
 
   qs@6.5.3: {}
 
@@ -31310,7 +31368,6 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.0
       unpipe: 1.0.0
-    optional: true
 
   rc9@2.1.2:
     dependencies:
@@ -31854,7 +31911,6 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   rrweb-cssom@0.6.0: {}
 
@@ -32001,9 +32057,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.13.0
-      ajv-formats: 2.1.1(ajv@8.13.0)
-      ajv-keywords: 5.1.0(ajv@8.13.0)
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv-keywords: 5.1.0(ajv@8.18.0)
 
   scslre@0.3.0:
     dependencies:
@@ -33542,7 +33598,6 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
-    optional: true
 
   type-level-regexp@0.1.17: {}
 
@@ -34785,11 +34840,17 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
   zod-to-json-schema@3.25.2(zod@4.1.13):
     dependencies:
       zod: 4.1.13
     optional: true
 
   zod@3.23.8: {}
+
+  zod@3.25.76: {}
 
   zod@4.1.13: {}


### PR DESCRIPTION
## Summary

- Ports the previous standalone `@posthog/mcp` SDK into this monorepo, rebuilt on top of `@posthog/core` instead of `posthog-node`.
- Aligns the SDK with posthog-js conventions: `$`-prefixed event names, rslib build, jest tests, root eslint + per-package prettier (no-semi, single-quote, 2-space).
- Initial monorepo release as `0.1.0` (clean break — there were no users of the 0.0.x line, per Lucas).

## What changed vs the standalone 0.0.x

**Runtime / API**
- Drops the `posthog-node` runtime dependency. Introduces `PostHogMCP`, a small `PostHogCoreStateless` subclass that owns the redact → sanitize → truncate → fan-out → `captureStateless` pipeline.
- Drops the bring-your-own-client surface (`posthogClient` / `posthogOptions` / the `PostHogCaptureClient` duck-type). Replaced with `client?: PostHogMCP` and `clientOptions?: PostHogMCPOptions`.
- Drops the `eventTags` callback and tag validation. All customer metadata now flows through `eventProperties` (free-form JSON, spread flat into properties).
- Every PostHog-owned event name now starts with `$`:
  - `mcp_tool_call` → `$mcp_tool_call`
  - `mcp_custom` → `$mcp_custom`
  - `posthog_identify` → `$identify`
  - (full list in `docs/ARCHITECTURE.md`)
- Removes the SDK-managed `~/posthog-mcp-analytics.log` file. Replaced with optional `logger?: (msg: string) => void` callback; no-op by default so STDIO transports stay clean.
- Drops `node:crypto`: session/event ids use `uuidv7` from `@posthog/core`; deterministic ids use FNV-1a so it works in edge runtimes.
- Drops `createRequire(import.meta.url)` in `exceptions.ts` in favor of a guarded CJS-require fallback.
- Deletes the unused vendored `thirdparty/ksuid/`.

**Tooling**
- `tsdown` → `rslib` (file-by-file ESM + CJS + `.d.ts`, matches `posthog-node`).
- `vitest` → `jest` with `@babel/preset-env` + `@babel/preset-typescript`.
- `biome` / `ultracite` → root `.eslintrc.cjs` override with per-package `.prettierrc` (2-space, no-semi, single-quote, printWidth 120).

**Monorepo wiring**
- `packages/mcp/**` added to the no-console/relaxed override block in the root `.eslintrc.cjs`.
- `@posthog/mcp` added to the publish matrix in `.github/workflows/release.yml`.
- `.changeset/posthog-mcp-initial.md` describes the `0.1.0` minor.
- `docs/ARCHITECTURE.md` documents wire-up, pipeline, event/property catalogs, HogQL queries, intent resolution, file map, and migration notes from 0.0.x.

## Test plan

- [x] `pnpm --filter=@posthog/mcp build` — emits ESM + CJS + `.d.ts` cleanly (~153 kB CJS, ~103 kB ESM).
- [x] `pnpm --filter=@posthog/mcp test:unit` — **387 passing, 1 skipped, 0 failing** across 28 jest test files.
- [x] `pnpm --filter=@posthog/mcp lint` — clean.
- [x] `pnpm lint` (all 26 monorepo packages) — clean.
- [ ] CI passes on this PR (`library-ci.yml`, `changeset-hygiene`, etc.).
- [ ] Optionally: smoke-test against the actual PostHog MCP server before merging.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*