### PR TITLE
feat(autocapture): accept remote rage click sensitivity tuning

### DIFF
--- a/.changeset/rageclick-remote-config-tuning.md
+++ b/.changeset/rageclick-remote-config-tuning.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+Accept rage click detector sensitivity (`threshold_px`, `timeout_ms`, `click_count`) from the `/array/{token}/config` remote config response and merge it onto the running detector. Per-field client config (`posthog.init({ rageclick: { ... } })`) takes precedence over remote values, and `posthog.init({ rageclick: false })` is never re-enabled by the server. Backend delivery of these tunables isn't shipped yet — this is the SDK-side wiring.

--- a/packages/browser/src/__tests__/autocapture.test.ts
+++ b/packages/browser/src/__tests__/autocapture.test.ts
@@ -566,6 +566,153 @@ describe('Autocapture system', () => {
             )
         })
 
+        describe('when rageclick sensitivity is delivered via remote config', () => {
+            const fireClicks = (
+                target: Autocapture,
+                el: Element,
+                clicks: { clientX: number; clientY: number; timestamp: number }[]
+            ) => {
+                for (const click of clicks) {
+                    const fakeEvent = makeMouseEvent({
+                        target: el,
+                        clientX: click.clientX,
+                        clientY: click.clientY,
+                    })
+                    Object.defineProperty(fakeEvent, 'timeStamp', { value: click.timestamp })
+                    Object.setPrototypeOf(fakeEvent, MouseEvent.prototype)
+                    target['_captureEvent'](fakeEvent)
+                }
+            }
+
+            // Three clicks tightly clustered in space and time. Under defaults (3 / 30px / 1000ms)
+            // this is a rage click; under a stricter remote config it should not be.
+            const tightCluster = [
+                { clientX: 5, clientY: 5, timestamp: 0 },
+                { clientX: 5, clientY: 5, timestamp: 100 },
+                { clientX: 5, clientY: 5, timestamp: 200 },
+            ]
+
+            it('applies remote rageclick tunables when no client-side object config is set', async () => {
+                // Customer pushes a stricter `click_count: 5` from the PostHog UI.
+                autocapture.onRemoteConfig({ rageclick: { click_count: 5 } } as FlagsResponse)
+
+                const el = document.createElement('button')
+                document.body.appendChild(el)
+                fireClicks(autocapture, el, tightCluster)
+
+                expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual([
+                    '$autocapture',
+                    '$autocapture',
+                    '$autocapture',
+                ])
+
+                document.body.removeChild(el)
+            })
+
+            it('client-side object config takes precedence over remote per-field', async () => {
+                // Local pins click_count = 2; remote tries to relax it to 5. Local wins.
+                const customPosthog = await createPosthogInstance(uuidv7(), {
+                    api_host: 'https://test.com',
+                    token: 'testtoken',
+                    autocapture: true,
+                    before_send: beforeSendMock,
+                    rageclick: { click_count: 2 },
+                })
+
+                if (isUndefined(customPosthog.autocapture)) {
+                    throw new Error('helping TS by confirming this is created by now')
+                }
+                const customAutocapture = customPosthog.autocapture
+                customAutocapture.onRemoteConfig({ rageclick: { click_count: 5 } } as FlagsResponse)
+
+                const el = document.createElement('button')
+                document.body.appendChild(el)
+                fireClicks(customAutocapture, el, [
+                    { clientX: 5, clientY: 5, timestamp: 0 },
+                    { clientX: 5, clientY: 5, timestamp: 100 },
+                ])
+
+                expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual([
+                    '$autocapture',
+                    '$rageclick',
+                    '$autocapture',
+                ])
+
+                document.body.removeChild(el)
+            })
+
+            it('remote fills in fields the client did not pin', async () => {
+                // Local pins threshold_px only; remote provides a stricter click_count.
+                const customPosthog = await createPosthogInstance(uuidv7(), {
+                    api_host: 'https://test.com',
+                    token: 'testtoken',
+                    autocapture: true,
+                    before_send: beforeSendMock,
+                    rageclick: { threshold_px: 50 },
+                })
+
+                if (isUndefined(customPosthog.autocapture)) {
+                    throw new Error('helping TS by confirming this is created by now')
+                }
+                const customAutocapture = customPosthog.autocapture
+                customAutocapture.onRemoteConfig({ rageclick: { click_count: 5 } } as FlagsResponse)
+
+                const el = document.createElement('button')
+                document.body.appendChild(el)
+                // 3 clicks within 50px (local threshold), but click_count remote-set to 5 → no rage click.
+                fireClicks(customAutocapture, el, tightCluster)
+
+                expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual([
+                    '$autocapture',
+                    '$autocapture',
+                    '$autocapture',
+                ])
+
+                document.body.removeChild(el)
+            })
+
+            it('remote config does not re-enable a locally disabled detector', async () => {
+                const customPosthog = await createPosthogInstance(uuidv7(), {
+                    api_host: 'https://test.com',
+                    token: 'testtoken',
+                    autocapture: true,
+                    before_send: beforeSendMock,
+                    rageclick: false,
+                })
+
+                if (isUndefined(customPosthog.autocapture)) {
+                    throw new Error('helping TS by confirming this is created by now')
+                }
+                const customAutocapture = customPosthog.autocapture
+                customAutocapture.onRemoteConfig({
+                    rageclick: { click_count: 2 },
+                } as FlagsResponse)
+
+                const el = document.createElement('button')
+                document.body.appendChild(el)
+                fireClicks(customAutocapture, el, [
+                    { clientX: 5, clientY: 5, timestamp: 0 },
+                    { clientX: 5, clientY: 5, timestamp: 100 },
+                    { clientX: 5, clientY: 5, timestamp: 200 },
+                ])
+
+                expect(beforeSendMock.mock.calls.map((args) => args[0].event)).toEqual([
+                    '$autocapture',
+                    '$autocapture',
+                    '$autocapture',
+                ])
+
+                document.body.removeChild(el)
+            })
+
+            it('absent rageclick on the remote config leaves detector untouched', () => {
+                const updateConfigSpy = jest.spyOn(autocapture.rageclicks, 'updateConfig')
+                autocapture.onRemoteConfig({} as FlagsResponse)
+                expect(updateConfigSpy).not.toHaveBeenCalled()
+                updateConfigSpy.mockRestore()
+            })
+        })
+
         describe('clipboard autocapture', () => {
             let elTarget: HTMLDivElement
 

--- a/packages/browser/src/__tests__/extensions/rageclick.test.ts
+++ b/packages/browser/src/__tests__/extensions/rageclick.test.ts
@@ -128,4 +128,42 @@ describe('RageClick()', () => {
             expect(result).toBe(false)
         })
     })
+
+    describe('updateConfig (used by remote config)', () => {
+        it('applies new thresholds and resets in-flight click history', () => {
+            instance = new RageClick(true)
+            // Two clicks under the default 3-click threshold; not yet a rage click.
+            instance.isRageClick(0, 0, 10)
+            instance.isRageClick(5, 5, 20)
+
+            instance.updateConfig({ click_count: 5 })
+
+            // Without the buffer reset, the two previous clicks plus three more would
+            // trigger; with the reset we need a full 5 clicks under the new config.
+            expect(instance.isRageClick(5, 5, 30)).toBe(false)
+            expect(instance.isRageClick(5, 5, 40)).toBe(false)
+            expect(instance.isRageClick(5, 5, 50)).toBe(false)
+            expect(instance.isRageClick(5, 5, 60)).toBe(false)
+            expect(instance.isRageClick(5, 5, 70)).toBe(true)
+        })
+
+        it('falls back to defaults when fields are omitted', () => {
+            instance = new RageClick({ threshold_px: 1, timeout_ms: 1, click_count: 2 })
+            instance.updateConfig({})
+
+            // Three clicks within default 30px / 1000ms triggers default rage click.
+            expect(instance.isRageClick(0, 0, 0)).toBe(false)
+            expect(instance.isRageClick(0, 0, 100)).toBe(false)
+            expect(instance.isRageClick(0, 0, 200)).toBe(true)
+        })
+
+        it('disables detection when called with false', () => {
+            instance = new RageClick(true)
+            instance.updateConfig(false)
+
+            expect(instance.isRageClick(0, 0, 0)).toBe(false)
+            expect(instance.isRageClick(0, 0, 100)).toBe(false)
+            expect(instance.isRageClick(0, 0, 200)).toBe(false)
+        })
+    })
 })

--- a/packages/browser/src/autocapture.ts
+++ b/packages/browser/src/autocapture.ts
@@ -17,7 +17,7 @@ import {
 } from './autocapture-utils'
 
 import RageClick from './extensions/rageclick'
-import { AutocaptureConfig, EventName, Properties, RemoteConfig } from './types'
+import { AutocaptureConfig, EventName, Properties, RageclickConfig, RemoteConfig } from './types'
 import { PostHog } from './posthog-core'
 import { AUTOCAPTURE_DISABLED_SERVER_SIDE } from './constants'
 
@@ -316,6 +316,10 @@ export class Autocapture implements Extension {
             this._elementsChainAsString = response.elementsChainAsString
         }
 
+        if (response.rageclick) {
+            this._applyRemoteRageclickConfig(response.rageclick)
+        }
+
         // NOTE: Unlike other extensions (heatmaps, web-vitals, etc.), we intentionally
         // DO NOT guard against missing autocapture_opt_out key here. Autocapture uses
         // a "wait for server, then enable unless explicitly opted out" model:
@@ -331,6 +335,26 @@ export class Autocapture implements Extension {
         // store this in-memory in case persistence is disabled
         this._isDisabledServerSide = !!response['autocapture_opt_out']
         this.startIfEnabled()
+    }
+
+    // Merge remote rage click tuning onto the detector. Client config wins
+    // per-field; `rageclick: false` locally is never overridden by the server.
+    private _applyRemoteRageclickConfig(remote: NonNullable<RemoteConfig['rageclick']>): void {
+        const local = this.instance.config.rageclick
+
+        if (local === false) {
+            return
+        }
+
+        const localObj: RageclickConfig = isObject(local) ? local : {}
+        const merged: RageclickConfig = {
+            ...localObj,
+            threshold_px: localObj.threshold_px ?? remote.threshold_px,
+            timeout_ms: localObj.timeout_ms ?? remote.timeout_ms,
+            click_count: localObj.click_count ?? remote.click_count,
+        }
+
+        this.rageclicks.updateConfig(merged)
     }
 
     public setElementSelectors(selectors: Set<string>): void {

--- a/packages/browser/src/extensions/rageclick.ts
+++ b/packages/browser/src/extensions/rageclick.ts
@@ -18,6 +18,18 @@ export default class RageClick {
     disabled: boolean
 
     constructor(rageclickConfig: RageclickConfig | boolean) {
+        this.clicks = []
+        this.disabled = false
+        this.thresholdPx = DEFAULT_THRESHOLD_PX
+        this.timeoutMs = DEFAULT_TIMEOUT_MS
+        this.clickCount = DEFAULT_CLICK_COUNT
+
+        this.updateConfig(rageclickConfig)
+    }
+
+    // Apply (possibly remote) config and reset the in-flight click buffer so
+    // stale clicks don't fire against the new thresholds.
+    updateConfig(rageclickConfig: RageclickConfig | boolean): void {
         this.disabled = rageclickConfig === false
         const conf = isObject(rageclickConfig) ? rageclickConfig : {}
 

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -276,6 +276,19 @@ export type SessionRecordingRemoteConfig = SessionRecordingCanvasOptions & {
 }
 
 /**
+ * Server-tunable subset of {@link RageclickConfig}. Element/content ignore lists
+ * are client-only since they reference app-specific selectors and copy.
+ */
+export interface RageclickRemoteConfig {
+    /** @see RageclickConfig.threshold_px */
+    threshold_px?: number
+    /** @see RageclickConfig.timeout_ms */
+    timeout_ms?: number
+    /** @see RageclickConfig.click_count */
+    click_count?: number
+}
+
+/**
  * Remote configuration for the PostHog instance
  *
  * All of these settings can be configured directly in your PostHog instance
@@ -394,6 +407,11 @@ export interface RemoteConfig {
      * Whether to capture dead clicks
      */
     captureDeadClicks?: boolean
+
+    /**
+     * Rage click detector sensitivity tuning
+     */
+    rageclick?: RageclickRemoteConfig
 
     /**
      * Indicates if the team has any flags enabled (if not we don't need to load them)


### PR DESCRIPTION
## Problem

`posthog-js` already lets users tune the rage-click detector via `posthog.init({ rageclick: { threshold_px, timeout_ms, click_count } })`, but those values are baked in at SDK initialization time. There's no path to adjust detector sensitivity at the project level without shipping an SDK upgrade and getting customers to redeploy.

## Changes

- Add `RageclickRemoteConfig` (a subset of `RageclickConfig` covering only the three sensitivity knobs) and `RemoteConfig.rageclick?: RageclickRemoteConfig` so the SDK accepts these tunables from the `/array/{token}/config` response. Element/content ignore lists are intentionally not exposed remotely — they reference app-specific selectors and copy.
- Extract the detector's config-application from `RageClick`'s constructor into `RageClick.updateConfig(...)` so it can be re-applied after init. The in-flight click buffer is reset on every update so stale clicks don't fire against new thresholds.
- In `Autocapture.onRemoteConfig`, merge `response.rageclick` onto the live detector via `_applyRemoteRageclickConfig`. Per-field client config wins (a customer can pin one threshold in code and let the others come from the server), and `posthog.init({ rageclick: false })` is never re-enabled by the server.
- New tests in `rageclick.test.ts` covering `updateConfig` behavior, and end-to-end tests in `autocapture.test.ts` covering:
  - custom thresholds passed at init still work,
  - remote config tunables are applied to the live detector,
  - per-field client precedence over remote values,
  - `rageclick: false` locally is never overridden by remote,
  - absent `rageclick` on the remote config leaves the detector untouched.
- Added a `posthog-js: minor` changeset.

**Scope note:** Backend delivery of these tunables isn't shipped yet — this PR is the SDK-side wiring so the server side can land independently. The new `RemoteConfig.rageclick` field is optional and a no-op until the server starts populating it.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## Test plan

- [x] `pnpm exec jest src/__tests__/extensions/rageclick.test.ts src/__tests__/autocapture.test.ts src/__tests__/heatmaps.test.ts src/__tests__/config.test.ts` — 157 passed

Made with [Cursor](https://cursor.com)