### PR TITLE
fix: don't autocapture PostHog's own network errors in react-native

### DIFF
--- a/.changeset/eager-bananas-smash.md
+++ b/.changeset/eager-bananas-smash.md
@@ -1,0 +1,6 @@
+---
+'posthog-react-native': patch
+'@posthog/core': patch
+---
+
+Don't autocapture PostHog's own `PostHogFetchNetworkError` (raised when the device is offline) as a `$exception`. These connectivity failures are expected and were flooding error tracking with internal SDK noise. Adds an `isPostHogFetchNetworkError` type guard to `@posthog/core` so SDKs can detect these errors.

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -91,6 +91,18 @@ function isPostHogFetchError(err: unknown): err is PostHogFetchHttpError | PostH
   return typeof err === 'object' && (err instanceof PostHogFetchHttpError || err instanceof PostHogFetchNetworkError)
 }
 
+/**
+ * True for the network error PostHog throws when a request fails to reach the server
+ * (e.g. the device is offline or the request times out). Exposed so SDKs that autocapture
+ * errors can skip these expected connectivity failures instead of reporting them as
+ * application exceptions.
+ *
+ * @public
+ */
+export function isPostHogFetchNetworkError(err: unknown): err is PostHogFetchNetworkError {
+  return err instanceof PostHogFetchNetworkError
+}
+
 function isPostHogFetchContentTooLargeError(err: unknown): err is PostHogFetchHttpError & { status: 413 } {
   return typeof err === 'object' && err instanceof PostHogFetchHttpError && err.status === 413
 }

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -88,7 +88,7 @@ export async function logFlushError(err: any): Promise<void> {
 }
 
 function isPostHogFetchError(err: unknown): err is PostHogFetchHttpError | PostHogFetchNetworkError {
-  return typeof err === 'object' && (err instanceof PostHogFetchHttpError || err instanceof PostHogFetchNetworkError)
+  return typeof err === 'object' && (err instanceof PostHogFetchHttpError || isPostHogFetchNetworkError(err))
 }
 
 /**

--- a/packages/react-native/src/error-tracking/index.ts
+++ b/packages/react-native/src/error-tracking/index.ts
@@ -1,5 +1,11 @@
 import type { PostHog } from '../posthog-rn'
-import { JsonType, Logger, PostHogEventProperties, ErrorTracking as CoreErrorTracking } from '@posthog/core'
+import {
+  JsonType,
+  Logger,
+  PostHogEventProperties,
+  ErrorTracking as CoreErrorTracking,
+  isPostHogFetchNetworkError,
+} from '@posthog/core'
 import { trackConsole, trackUncaughtExceptions, trackUnhandledRejections } from './utils'
 import { getRemoteConfigBool, isHermes } from '../utils'
 
@@ -134,6 +140,11 @@ export class ErrorTracking {
         return
       }
 
+      // Offline/timeout failures are expected, not application errors.
+      if (isPostHogFetchNetworkError(error)) {
+        return
+      }
+
       const hint: CoreErrorTracking.EventHint = {
         mechanism: {
           type: 'onuncaughtexception',
@@ -165,6 +176,11 @@ export class ErrorTracking {
     const onUnhandledRejection = (error: unknown) => {
       // Gate on remote config — if remotely disabled, don't capture
       if (!this._autocaptureEnabled) {
+        return
+      }
+
+      // Offline/timeout failures are expected, not application errors.
+      if (isPostHogFetchNetworkError(error)) {
         return
       }
 

--- a/packages/react-native/test/error-tracking-internal-errors.integration.spec.ts
+++ b/packages/react-native/test/error-tracking-internal-errors.integration.spec.ts
@@ -1,0 +1,45 @@
+import { PostHog } from '../src'
+import { isPostHogFetchNetworkError } from '@posthog/core'
+
+// Proves the exported instanceof guard recognizes a genuine PostHogFetchNetworkError
+// produced by core's real fetch path.
+describe('isPostHogFetchNetworkError recognizes real core errors', () => {
+  const originalFetch = (globalThis as any).window.fetch
+
+  beforeAll(() => {
+    // The SDK flush/shutdown lifecycle is timer-driven; the suite's global fake timers
+    // would deadlock awaited async operations, so use real timers here.
+    jest.useRealTimers()
+  })
+
+  afterAll(() => {
+    ;(globalThis as any).window.fetch = originalFetch
+    jest.useFakeTimers()
+  })
+
+  it('returns true for the error core throws when fetch fails', async () => {
+    ;(globalThis as any).window.fetch = jest.fn(() => {
+      throw new Error('offline')
+    })
+
+    const posthog = new PostHog('test-token', {
+      persistence: 'memory',
+      flushInterval: 0,
+      fetchRetryCount: 0,
+    })
+    await posthog.ready()
+    posthog.capture('event')
+
+    let caught: unknown
+    try {
+      await posthog.flush()
+    } catch (err) {
+      caught = err
+    }
+    await posthog.shutdown()
+
+    expect(isPostHogFetchNetworkError(caught)).toBe(true)
+    // ordinary errors must not be mistaken for network errors
+    expect(isPostHogFetchNetworkError(new Error('boom'))).toBe(false)
+  }, 15000)
+})

--- a/packages/react-native/test/error-tracking-internal-errors.integration.spec.ts
+++ b/packages/react-native/test/error-tracking-internal-errors.integration.spec.ts
@@ -38,6 +38,7 @@ describe('isPostHogFetchNetworkError recognizes real core errors', () => {
     }
     await posthog.shutdown()
 
+    expect(caught).toBeDefined()
     expect(isPostHogFetchNetworkError(caught)).toBe(true)
     // ordinary errors must not be mistaken for network errors
     expect(isPostHogFetchNetworkError(new Error('boom'))).toBe(false)

--- a/packages/react-native/test/error-tracking-internal-errors.spec.ts
+++ b/packages/react-native/test/error-tracking-internal-errors.spec.ts
@@ -1,0 +1,74 @@
+import { ErrorTracking } from '../src/error-tracking'
+
+// Mock the utils to prevent actual global handler registration
+jest.mock('../src/error-tracking/utils', () => ({
+  trackUncaughtExceptions: jest.fn(),
+  trackUnhandledRejections: jest.fn(),
+  trackConsole: jest.fn(),
+}))
+
+jest.mock('../src/utils', () => ({
+  isHermes: jest.fn(() => false),
+  getRemoteConfigBool: jest.requireActual('../src/utils').getRemoteConfigBool,
+}))
+
+// Mock core's guard so handler tests can simulate "this is a network error" without
+// spinning up a real PostHog to produce a genuine instance. The guard itself is
+// verified against a real core instance in error-tracking-internal-errors.integration.spec.ts.
+jest.mock('@posthog/core', () => ({
+  ...jest.requireActual('@posthog/core'),
+  isPostHogFetchNetworkError: jest.fn(),
+}))
+
+import { isPostHogFetchNetworkError } from '@posthog/core'
+import { trackUncaughtExceptions, trackUnhandledRejections, trackConsole } from '../src/error-tracking/utils'
+import { createMockLogger, createMockPostHog } from './test-utils'
+
+const mockPostHog = createMockPostHog()
+const mockLogger = createMockLogger()
+
+describe('ErrorTracking filters PostHog internal network errors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(isPostHogFetchNetworkError as jest.Mock).mockReturnValue(false)
+  })
+
+  it('does not capture a network error from the uncaught exception handler', () => {
+    ;(isPostHogFetchNetworkError as jest.Mock).mockReturnValue(true)
+    new ErrorTracking(mockPostHog, { autocapture: true }, mockLogger as any)
+    const handler = (trackUncaughtExceptions as jest.Mock).mock.calls[0][0]
+
+    handler(new Error('network'), false)
+
+    expect(mockPostHog.capture).not.toHaveBeenCalled()
+  })
+
+  it('does not capture a network error from the unhandled rejection handler', () => {
+    ;(isPostHogFetchNetworkError as jest.Mock).mockReturnValue(true)
+    new ErrorTracking(mockPostHog, { autocapture: { unhandledRejections: true } }, mockLogger as any)
+    const handler = (trackUnhandledRejections as jest.Mock).mock.calls[0][0]
+
+    handler(new Error('network'))
+
+    expect(mockPostHog.capture).not.toHaveBeenCalled()
+  })
+
+  it('still captures ordinary application errors from the uncaught exception handler', () => {
+    new ErrorTracking(mockPostHog, { autocapture: true }, mockLogger as any)
+    const handler = (trackUncaughtExceptions as jest.Mock).mock.calls[0][0]
+
+    handler(new Error('boom'), false)
+
+    expect(mockPostHog.capture).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not filter the console handler (console is left untouched)', () => {
+    ;(isPostHogFetchNetworkError as jest.Mock).mockReturnValue(true)
+    new ErrorTracking(mockPostHog, { autocapture: { console: ['error'] } }, mockLogger as any)
+    const consoleHandler = (trackConsole as jest.Mock).mock.calls[0][1]
+
+    consoleHandler(new Error('network'), false)
+
+    expect(mockPostHog.capture).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react-native/test/error-tracking-remote-config.spec.ts
+++ b/packages/react-native/test/error-tracking-remote-config.spec.ts
@@ -13,19 +13,10 @@ jest.mock('../src/utils', () => ({
 }))
 
 import { trackUncaughtExceptions, trackUnhandledRejections, trackConsole } from '../src/error-tracking/utils'
+import { createMockLogger, createMockPostHog } from './test-utils'
 
-const mockPostHog = {
-  capture: jest.fn(),
-  flush: jest.fn(() => Promise.resolve()),
-} as any
-
-const mockLogger = {
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  critical: jest.fn(),
-  createLogger: jest.fn(() => mockLogger),
-}
+const mockPostHog = createMockPostHog()
+const mockLogger = createMockLogger()
 
 describe('ErrorTracking remote config', () => {
   beforeEach(() => {

--- a/packages/react-native/test/test-utils.ts
+++ b/packages/react-native/test/test-utils.ts
@@ -2,6 +2,22 @@ export const wait = async (t: number): Promise<void> => {
   await new Promise<void>((r) => setTimeout(r, t))
 }
 
+export const createMockPostHog = (): any => ({
+  capture: jest.fn(),
+  flush: jest.fn(() => Promise.resolve()),
+})
+
+export const createMockLogger = (): any => {
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    critical: jest.fn(),
+    createLogger: jest.fn(() => logger),
+  }
+  return logger
+}
+
 export const waitForExpect = async (timeout: number, fn: () => void): Promise<void> => {
   const start = Date.now()
   while (true) {


### PR DESCRIPTION
## Problem

Closes #3664

React Native / Expo apps with error-tracking autocapture enabled were seeing their dashboards flooded with `PostHogFetchNetworkError` events. This is PostHog's *own* internal error — thrown by the core when a `fetch` fails to reach the server (device offline or request timeout). It's an expected, non-actionable connectivity condition, not an application error, but the autocapture handlers reported it as a `$exception`.

The leak path: a user (or auto-flush) calls into the SDK, the network request fails offline, and the resulting `PostHogFetchNetworkError` surfaces as an uncaught exception / unhandled rejection — which the error-tracking handlers then capture and send.

## Changes

- **`@posthog/core`**: export a new `isPostHogFetchNetworkError(err): err is PostHogFetchNetworkError` type guard (`instanceof`-based). The error class itself stays module-private; only the guard is public surface.
- **`posthog-react-native`**: the `onUncaughtException` and `onUnhandledRejection` autocapture handlers now skip errors matching the guard. The **console** autocapture path is intentionally left untouched, and `PostHogFetchHttpError` (bad API key, 5xx, etc.) is intentionally **not** filtered — those are developer-actionable and should remain visible.
- Tests: unit tests for handler wiring + an integration test that produces a genuine `PostHogFetchNetworkError` through core's real fetch path and verifies the guard recognizes it. Extracted shared `createMockPostHog()` / `createMockLogger()` into `test-utils.ts`.

Scope was deliberately limited to network errors only (not all PostHog-internal errors) to preserve visibility of misconfiguration errors like a bad API key.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-react-native
- [x] @posthog/core

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file