### PR TITLE
feat(ai): expose `token` in PostHogTraceExporter and deprecate `apiKey`

### DIFF
--- a/.changeset/grumpy-heads-accept.md
+++ b/.changeset/grumpy-heads-accept.md
@@ -1,0 +1,7 @@
+---
+'@posthog/ai': patch
+---
+
+Expose `token` in addition to `apiKey` for `PostHogTraceExporter`
+
+We're moving towards a place where we're calling this `token` everywhere. Let's release this as a patch version because it's a tiny change and we still support the old usage. This might be dropped in the next packages/ai major version.

--- a/.changeset/grumpy-heads-accept.md
+++ b/.changeset/grumpy-heads-accept.md
@@ -2,6 +2,6 @@
 '@posthog/ai': patch
 ---
 
-Expose `token` in addition to `apiKey` for `PostHogTraceExporter`
+Expose `projectToken` in addition to `apiKey` for `PostHogTraceExporter`
 
-We're moving towards a place where we're calling this `token` everywhere. Let's release this as a patch version because it's a tiny change and we still support the old usage. This might be dropped in the next packages/ai major version.
+We're moving towards a place where we're calling this `projectToken` everywhere. Let's release this as a patch version because it's a tiny change and we still support the old usage. This might be dropped in the next packages/ai major version.

--- a/examples/example-convex/convex/aiSdk/openTelemetry.ts
+++ b/examples/example-convex/convex/aiSdk/openTelemetry.ts
@@ -20,7 +20,7 @@ const provider = new BasicTracerProvider({
     spanProcessors: [
         new SimpleSpanProcessor(
             new PostHogTraceExporter({
-                token: process.env.POSTHOG_PROJECT_TOKEN!,
+                projectToken: process.env.POSTHOG_PROJECT_TOKEN!,
                 host: process.env.POSTHOG_HOST,
             })
         ),

--- a/examples/example-convex/convex/aiSdk/openTelemetry.ts
+++ b/examples/example-convex/convex/aiSdk/openTelemetry.ts
@@ -20,7 +20,7 @@ const provider = new BasicTracerProvider({
     spanProcessors: [
         new SimpleSpanProcessor(
             new PostHogTraceExporter({
-                apiKey: process.env.POSTHOG_PROJECT_TOKEN!,
+                token: process.env.POSTHOG_PROJECT_TOKEN!,
                 host: process.env.POSTHOG_HOST,
             })
         ),

--- a/examples/example-convex/convex/convexAgent/openTelemetry.ts
+++ b/examples/example-convex/convex/convexAgent/openTelemetry.ts
@@ -21,7 +21,7 @@ const provider = new BasicTracerProvider({
     spanProcessors: [
         new SimpleSpanProcessor(
             new PostHogTraceExporter({
-                token: process.env.POSTHOG_PROJECT_TOKEN!,
+                projectToken: process.env.POSTHOG_PROJECT_TOKEN!,
                 host: process.env.POSTHOG_HOST,
             })
         ),

--- a/examples/example-convex/convex/convexAgent/openTelemetry.ts
+++ b/examples/example-convex/convex/convexAgent/openTelemetry.ts
@@ -21,7 +21,7 @@ const provider = new BasicTracerProvider({
     spanProcessors: [
         new SimpleSpanProcessor(
             new PostHogTraceExporter({
-                apiKey: process.env.POSTHOG_PROJECT_TOKEN!,
+                token: process.env.POSTHOG_PROJECT_TOKEN!,
                 host: process.env.POSTHOG_HOST,
             })
         ),

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -125,7 +125,7 @@ import { registerOTel } from '@vercel/otel'
 registerOTel({
   serviceName: 'my-app',
   traceExporter: new PostHogTraceExporter({
-    token: '<YOUR_PROJECT_TOKEN>',
+    projectToken: '<YOUR_PROJECT_TOKEN>',
     host: 'https://us.i.posthog.com', // optional, defaults to https://us.i.posthog.com
   }),
 })

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -125,7 +125,7 @@ import { registerOTel } from '@vercel/otel'
 registerOTel({
   serviceName: 'my-app',
   traceExporter: new PostHogTraceExporter({
-    apiKey: '<YOUR_PROJECT_API_KEY>',
+    token: '<YOUR_PROJECT_TOKEN>',
     host: 'https://us.i.posthog.com', // optional, defaults to https://us.i.posthog.com
   }),
 })

--- a/packages/ai/src/otel/exporter.ts
+++ b/packages/ai/src/otel/exporter.ts
@@ -15,24 +15,32 @@ function normalizeHost(value?: unknown): string {
   return normalizedValue || DEFAULT_OTEL_HOST
 }
 
-export interface PostHogTraceExporterOptions {
-  /**
-   * Your PostHog project API token.
-   */
-  projectToken?: string
-
-  /**
-   * Your PostHog project API key.
-   *
-   * @deprecated Use `projectToken` instead
-   */
-  apiKey?: string
-
-  /**
-   * PostHog host URL. Defaults to `https://us.i.posthog.com`.
-   */
-  host?: string
-}
+/**
+ * Options for the PostHogTraceExporter. You must obligatorily provide `projectToken`. You can also
+ * optionally override the `host` URL. `host` defaults to `https://us.i.posthog.com`.
+ *
+ * @example
+ * ```ts
+ * import { PostHogTraceExporter } from '@posthog/ai/otel'
+ *
+ * new PostHogTraceExporter({ projectToken: 'phc_...' })
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { PostHogTraceExporter } from '@posthog/ai/otel'
+ *
+ * new PostHogTraceExporter({ projectToken: 'phc_...', host: 'https://eu.i.posthog.com' })
+ * ```
+ */
+export type PostHogTraceExporterOptions =
+  | { projectToken: string; apiKey?: never; host?: string }
+  | {
+      /** @deprecated Use `projectToken` instead */
+      apiKey: string
+      projectToken?: never
+      host?: string
+    }
 
 /**
  * An OpenTelemetry `TraceExporter` that sends AI traces to PostHog's OTLP
@@ -48,6 +56,9 @@ export interface PostHogTraceExporterOptions {
  * plug PostHog into an existing processor chain. Otherwise prefer
  * {@link PostHogSpanProcessor}, which is self-contained.
  *
+ * You must obligatorily provide `projectToken`. You can also
+ * optionally override the `host` URL.
+ *
  * @example
  * ```ts
  * import { PostHogTraceExporter } from '@posthog/ai/otel'
@@ -61,7 +72,7 @@ export interface PostHogTraceExporterOptions {
  */
 export class PostHogTraceExporter extends OTLPTraceExporter {
   constructor(options: PostHogTraceExporterOptions) {
-    const token = normalizeToken(options.projectToken || options.apiKey)
+    const token = 'projectToken' in options ? normalizeToken(options.projectToken) : normalizeToken(options.apiKey)
     if (!token) {
       throw new Error('PostHogTraceExporter requires a projectToken')
     }

--- a/packages/ai/src/otel/exporter.ts
+++ b/packages/ai/src/otel/exporter.ts
@@ -6,7 +6,7 @@ import { isAISpan } from './spans'
 
 const DEFAULT_OTEL_HOST = 'https://us.i.posthog.com'
 
-function normalizeApiKey(value?: unknown): string {
+function normalizeToken(value?: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
@@ -17,9 +17,16 @@ function normalizeHost(value?: unknown): string {
 
 export interface PostHogTraceExporterOptions {
   /**
-   * Your PostHog project API key.
+   * Your PostHog project API token.
    */
-  apiKey: string
+  token?: string
+
+  /**
+   * Your PostHog project API key.
+   *
+   * @deprecated Use `token` instead
+   */
+  apiKey?: string
 
   /**
    * PostHog host URL. Defaults to `https://us.i.posthog.com`.
@@ -48,21 +55,22 @@ export interface PostHogTraceExporterOptions {
  *
  * registerOTel({
  *   serviceName: 'my-app',
- *   traceExporter: new PostHogTraceExporter({ apiKey: 'phc_...' }),
+ *   traceExporter: new PostHogTraceExporter({ token: 'phc_...' }),
  * })
  * ```
  */
 export class PostHogTraceExporter extends OTLPTraceExporter {
   constructor(options: PostHogTraceExporterOptions) {
-    const apiKey = normalizeApiKey(options.apiKey)
-    if (!apiKey) {
-      throw new Error('PostHogTraceExporter requires an apiKey')
+    const token = normalizeToken(options.token || options.apiKey)
+    if (!token) {
+      throw new Error('PostHogTraceExporter requires a token')
     }
+
     const host = new URL(normalizeHost(options.host)).origin
     super({
       url: `${host}/i/v0/ai/otel`,
       headers: {
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${token}`,
       },
     })
   }

--- a/packages/ai/src/otel/exporter.ts
+++ b/packages/ai/src/otel/exporter.ts
@@ -19,12 +19,12 @@ export interface PostHogTraceExporterOptions {
   /**
    * Your PostHog project API token.
    */
-  token?: string
+  projectToken?: string
 
   /**
    * Your PostHog project API key.
    *
-   * @deprecated Use `token` instead
+   * @deprecated Use `projectToken` instead
    */
   apiKey?: string
 
@@ -55,15 +55,15 @@ export interface PostHogTraceExporterOptions {
  *
  * registerOTel({
  *   serviceName: 'my-app',
- *   traceExporter: new PostHogTraceExporter({ token: 'phc_...' }),
+ *   traceExporter: new PostHogTraceExporter({ projectToken: 'phc_...' }),
  * })
  * ```
  */
 export class PostHogTraceExporter extends OTLPTraceExporter {
   constructor(options: PostHogTraceExporterOptions) {
-    const token = normalizeToken(options.token || options.apiKey)
+    const token = normalizeToken(options.projectToken || options.apiKey)
     if (!token) {
-      throw new Error('PostHogTraceExporter requires a token')
+      throw new Error('PostHogTraceExporter requires a projectToken')
     }
 
     const host = new URL(normalizeHost(options.host)).origin

--- a/packages/ai/tests/otel.test.ts
+++ b/packages/ai/tests/otel.test.ts
@@ -89,8 +89,8 @@ describe('PostHogTraceExporter', () => {
   })
 
   it('throws when token is missing', () => {
-    expect(() => new PostHogTraceExporter({ token: '' })).toThrow('PostHogTraceExporter requires an token')
-    expect(() => new PostHogTraceExporter({ token: '  \n\t ' })).toThrow('PostHogTraceExporter requires an token')
+    expect(() => new PostHogTraceExporter({ token: '' })).toThrow('PostHogTraceExporter requires a token')
+    expect(() => new PostHogTraceExporter({ token: '  \n\t ' })).toThrow('PostHogTraceExporter requires a token')
   })
 
   it('inherits shutdown from OTLPTraceExporter', async () => {

--- a/packages/ai/tests/otel.test.ts
+++ b/packages/ai/tests/otel.test.ts
@@ -36,41 +36,41 @@ describe('PostHogTraceExporter', () => {
   it.each([
     {
       name: 'default host',
-      token: 'phc_test123',
+      projectToken: 'phc_test123',
       host: undefined,
       expectedUrl: 'https://us.i.posthog.com/i/v0/ai/otel',
       expectedToken: 'phc_test123',
     },
     {
       name: 'custom host',
-      token: 'phc_test456',
+      projectToken: 'phc_test456',
       host: 'https://eu.i.posthog.com',
       expectedUrl: 'https://eu.i.posthog.com/i/v0/ai/otel',
       expectedToken: 'phc_test456',
     },
     {
       name: 'trailing slash',
-      token: 'phc_test789',
+      projectToken: 'phc_test789',
       host: 'https://custom.posthog.com/',
       expectedUrl: 'https://custom.posthog.com/i/v0/ai/otel',
       expectedToken: 'phc_test789',
     },
     {
       name: 'multiple trailing slashes',
-      token: 'phc_test000',
+      projectToken: 'phc_test000',
       host: 'https://custom.posthog.com///',
       expectedUrl: 'https://custom.posthog.com/i/v0/ai/otel',
       expectedToken: 'phc_test000',
     },
     {
       name: 'trimmed whitespace-sensitive values',
-      token: '  phc_test999\t ',
+      projectToken: '  phc_test999\t ',
       host: '  https://custom.posthog.com/\n',
       expectedUrl: 'https://custom.posthog.com/i/v0/ai/otel',
       expectedToken: 'phc_test999',
     },
-  ])('configures the OTLP exporter correctly with $name', ({ token, host, expectedUrl, expectedToken }) => {
-    new PostHogTraceExporter({ token, host })
+  ])('configures the OTLP exporter correctly with $name', ({ projectToken, host, expectedUrl, expectedToken }) => {
+    new PostHogTraceExporter({ projectToken, host })
 
     expect(OTLPTraceExporter).toHaveBeenCalledWith({
       url: expectedUrl,
@@ -88,19 +88,21 @@ describe('PostHogTraceExporter', () => {
     })
   })
 
-  it('throws when token is missing', () => {
-    expect(() => new PostHogTraceExporter({ token: '' })).toThrow('PostHogTraceExporter requires a token')
-    expect(() => new PostHogTraceExporter({ token: '  \n\t ' })).toThrow('PostHogTraceExporter requires a token')
+  it('throws when projectToken is missing', () => {
+    expect(() => new PostHogTraceExporter({ projectToken: '' })).toThrow('PostHogTraceExporter requires a projectToken')
+    expect(() => new PostHogTraceExporter({ projectToken: '  \n\t ' })).toThrow(
+      'PostHogTraceExporter requires a projectToken'
+    )
   })
 
   it('inherits shutdown from OTLPTraceExporter', async () => {
-    const exporter = new PostHogTraceExporter({ token: DEFAULT_TOKEN })
+    const exporter = new PostHogTraceExporter({ projectToken: DEFAULT_TOKEN })
     await exporter.shutdown()
     expect(getSuperShutdown()).toHaveBeenCalled()
   })
 
   it('inherits forceFlush from OTLPTraceExporter', async () => {
-    const exporter = new PostHogTraceExporter({ token: DEFAULT_TOKEN })
+    const exporter = new PostHogTraceExporter({ projectToken: DEFAULT_TOKEN })
     await exporter.forceFlush()
     expect(getSuperForceFlush()).toHaveBeenCalled()
   })
@@ -112,7 +114,7 @@ describe('PostHogTraceExporter AI span filtering', () => {
   })
 
   it('exports only AI spans', () => {
-    const exporter = new PostHogTraceExporter({ token: DEFAULT_TOKEN })
+    const exporter = new PostHogTraceExporter({ projectToken: DEFAULT_TOKEN })
     const callback = jest.fn()
 
     exporter.export([makeSpan('gen_ai.chat'), makeSpan('http.request'), makeSpan('llm.completion')], callback)
@@ -124,7 +126,7 @@ describe('PostHogTraceExporter AI span filtering', () => {
   })
 
   it('calls back with success immediately when no AI spans are present', () => {
-    const exporter = new PostHogTraceExporter({ token: DEFAULT_TOKEN })
+    const exporter = new PostHogTraceExporter({ projectToken: DEFAULT_TOKEN })
     const callback = jest.fn()
 
     exporter.export([makeSpan('http.request'), makeSpan('db.query')], callback)
@@ -134,7 +136,7 @@ describe('PostHogTraceExporter AI span filtering', () => {
   })
 
   it('detects AI spans by attribute keys', () => {
-    const exporter = new PostHogTraceExporter({ token: DEFAULT_TOKEN })
+    const exporter = new PostHogTraceExporter({ projectToken: DEFAULT_TOKEN })
     const callback = jest.fn()
 
     exporter.export([makeSpan('some.operation', { 'gen_ai.model': 'gpt-4' }), makeSpan('other.operation')], callback)

--- a/packages/ai/tests/otel.test.ts
+++ b/packages/ai/tests/otel.test.ts
@@ -10,6 +10,8 @@ jest.mock('@opentelemetry/exporter-trace-otlp-http', () => {
   return { OTLPTraceExporter: MockExporter }
 })
 
+const DEFAULT_TOKEN = 'phc_test'
+
 function makeSpan(name: string, attributes: Record<string, unknown> = {}): ReadableSpan {
   return { name, attributes } as unknown as ReadableSpan
 }
@@ -34,63 +36,71 @@ describe('PostHogTraceExporter', () => {
   it.each([
     {
       name: 'default host',
-      apiKey: 'phc_test123',
+      token: 'phc_test123',
       host: undefined,
       expectedUrl: 'https://us.i.posthog.com/i/v0/ai/otel',
-      expectedApiKey: 'phc_test123',
+      expectedToken: 'phc_test123',
     },
     {
       name: 'custom host',
-      apiKey: 'phc_test456',
+      token: 'phc_test456',
       host: 'https://eu.i.posthog.com',
       expectedUrl: 'https://eu.i.posthog.com/i/v0/ai/otel',
-      expectedApiKey: 'phc_test456',
+      expectedToken: 'phc_test456',
     },
     {
       name: 'trailing slash',
-      apiKey: 'phc_test789',
+      token: 'phc_test789',
       host: 'https://custom.posthog.com/',
       expectedUrl: 'https://custom.posthog.com/i/v0/ai/otel',
-      expectedApiKey: 'phc_test789',
+      expectedToken: 'phc_test789',
     },
     {
       name: 'multiple trailing slashes',
-      apiKey: 'phc_test000',
+      token: 'phc_test000',
       host: 'https://custom.posthog.com///',
       expectedUrl: 'https://custom.posthog.com/i/v0/ai/otel',
-      expectedApiKey: 'phc_test000',
+      expectedToken: 'phc_test000',
     },
     {
       name: 'trimmed whitespace-sensitive values',
-      apiKey: '  phc_test999\t ',
+      token: '  phc_test999\t ',
       host: '  https://custom.posthog.com/\n',
       expectedUrl: 'https://custom.posthog.com/i/v0/ai/otel',
-      expectedApiKey: 'phc_test999',
+      expectedToken: 'phc_test999',
     },
-  ])('configures the OTLP exporter correctly with $name', ({ apiKey, host, expectedUrl, expectedApiKey }) => {
-    new PostHogTraceExporter({ apiKey, host })
+  ])('configures the OTLP exporter correctly with $name', ({ token, host, expectedUrl, expectedToken }) => {
+    new PostHogTraceExporter({ token, host })
 
     expect(OTLPTraceExporter).toHaveBeenCalledWith({
       url: expectedUrl,
       headers: {
-        Authorization: `Bearer ${expectedApiKey}`,
+        Authorization: `Bearer ${expectedToken}`,
       },
     })
   })
 
-  it('throws when apiKey is missing', () => {
-    expect(() => new PostHogTraceExporter({ apiKey: '' })).toThrow('PostHogTraceExporter requires an apiKey')
-    expect(() => new PostHogTraceExporter({ apiKey: '  \n\t ' })).toThrow('PostHogTraceExporter requires an apiKey')
+  it('accepts deprecated apiKey', () => {
+    new PostHogTraceExporter({ apiKey: DEFAULT_TOKEN })
+    expect(OTLPTraceExporter).toHaveBeenCalledWith({
+      url: 'https://us.i.posthog.com/i/v0/ai/otel',
+      headers: { Authorization: `Bearer ${DEFAULT_TOKEN}` },
+    })
+  })
+
+  it('throws when token is missing', () => {
+    expect(() => new PostHogTraceExporter({ token: '' })).toThrow('PostHogTraceExporter requires an token')
+    expect(() => new PostHogTraceExporter({ token: '  \n\t ' })).toThrow('PostHogTraceExporter requires an token')
   })
 
   it('inherits shutdown from OTLPTraceExporter', async () => {
-    const exporter = new PostHogTraceExporter({ apiKey: 'phc_test' })
+    const exporter = new PostHogTraceExporter({ token: DEFAULT_TOKEN })
     await exporter.shutdown()
     expect(getSuperShutdown()).toHaveBeenCalled()
   })
 
   it('inherits forceFlush from OTLPTraceExporter', async () => {
-    const exporter = new PostHogTraceExporter({ apiKey: 'phc_test' })
+    const exporter = new PostHogTraceExporter({ token: DEFAULT_TOKEN })
     await exporter.forceFlush()
     expect(getSuperForceFlush()).toHaveBeenCalled()
   })
@@ -102,7 +112,7 @@ describe('PostHogTraceExporter AI span filtering', () => {
   })
 
   it('exports only AI spans', () => {
-    const exporter = new PostHogTraceExporter({ apiKey: 'phc_test' })
+    const exporter = new PostHogTraceExporter({ token: DEFAULT_TOKEN })
     const callback = jest.fn()
 
     exporter.export([makeSpan('gen_ai.chat'), makeSpan('http.request'), makeSpan('llm.completion')], callback)
@@ -114,7 +124,7 @@ describe('PostHogTraceExporter AI span filtering', () => {
   })
 
   it('calls back with success immediately when no AI spans are present', () => {
-    const exporter = new PostHogTraceExporter({ apiKey: 'phc_test' })
+    const exporter = new PostHogTraceExporter({ token: DEFAULT_TOKEN })
     const callback = jest.fn()
 
     exporter.export([makeSpan('http.request'), makeSpan('db.query')], callback)
@@ -124,7 +134,7 @@ describe('PostHogTraceExporter AI span filtering', () => {
   })
 
   it('detects AI spans by attribute keys', () => {
-    const exporter = new PostHogTraceExporter({ apiKey: 'phc_test' })
+    const exporter = new PostHogTraceExporter({ token: DEFAULT_TOKEN })
     const callback = jest.fn()
 
     exporter.export([makeSpan('some.operation', { 'gen_ai.model': 'gpt-4' }), makeSpan('other.operation')], callback)


### PR DESCRIPTION
This update introduces a new `token` parameter for the PostHogTraceExporter, aligning with our goal of standardizing terminology. The `apiKey` parameter is still supported but marked as deprecated. Adjustments have been made across examples and tests to reflect this change, ensuring backward compatibility while encouraging the use of `token` moving forward.