### PR TITLE
ci: guard dismiss-alerts step against missing SARIF file

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -109,8 +109,21 @@ jobs:
     # default branch — see https://github.com/advanced-security/dismiss-alerts
     # ("dismissal status of an alert is a global property") — and only for
     # languages that opted in via `matrix.query`.
-    - name: Dismiss alerts
+    # Only runs when the SARIF file was actually written by the analyze step.
+    # The file can be absent when the CodeQL analysis is cancelled or the
+    # runner exits early, which would otherwise fail this non-critical step.
+    - name: Check SARIF file exists
+      id: sarif-check
       if: github.ref == 'refs/heads/main' && matrix.query != ''
+      run: |
+        if [ -f "sarif-results/${{ matrix.language }}.sarif" ]; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Dismiss alerts
+      if: github.ref == 'refs/heads/main' && matrix.query != '' && steps.sarif-check.outputs.exists == 'true'
       uses: advanced-security/dismiss-alerts@046d6b48d2e43cf563f96f67332c47c432eff83e # v2.0.2
       with:
         sarif-id: ${{ steps.analyze.outputs.sarif-id }}


### PR DESCRIPTION
## Summary

context: https://posthog.slack.com/archives/C0A3UEVDDNF/p1779784082225089

- Adds a `Check SARIF file exists` step before `Dismiss alerts` that sets an output flag
- `Dismiss alerts` only runs when the flag is `true`, preventing failures when the SARIF file wasn't written (cancelled run, early runner exit, etc.)
- Fixes recurring CI failures seen on multiple runs where `sarif-results/javascript-typescript.sarif` was absent

## Test plan
- [ ] Verify the CodeQL workflow passes on this PR
- [ ] Verify `Dismiss alerts` is skipped gracefully if the analyze step doesn't produce a SARIF file