### PR TITLE
chore: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,17 @@ pnpm turbo --filter=<package-name> test:unit -- --verbose
 pnpm turbo --filter=<package-name> test:unit -- -u
 ```
 
+## Cursor Cloud specific instructions
+
+- **Node version**: The `.nvmrc` specifies Node 24. Run `nvm use` to activate it. Ensure `corepack enable` has been run so that `pnpm` resolves to the version in `packageManager` field of `package.json`.
+- **Build order matters**: Always run `pnpm build` before running playground/example projects, as they depend on built artifacts from workspace packages.
+- **Playground projects are independent workspaces**: They have their own `pnpm-lock.yaml` and `node_modules`. Run `pnpm install` inside the playground directory after generating tarballs. The `.pnpmfile.cjs` in `playground/` rewrites PostHog package references to local tarballs.
+- **Tarball workflow**: Use `pnpm package` (root) to generate tarballs in `./target/`, then `pnpm install` in the playground/example project to pick them up. Use `pnpm package:watch` for continuous development.
+- **Ignored build scripts warning**: After `pnpm install`, you'll see warnings about ignored build scripts (e.g., `@parcel/watcher`, `esbuild`, `msw`). These are safe to ignore — the binaries are pre-downloaded and don't need postinstall scripts to function.
+- **Unit tests are fast**: `pnpm turbo --filter=<package> test:unit` runs in seconds for most packages. Use `pnpm test:unit` for all packages.
+- **No external services required**: This is a library-only codebase. Unit tests and builds don't need databases, Docker, or a PostHog server. The SDK intentionally fails gracefully when its configured host is unreachable.
+- **Next.js playground**: To start it, run `pnpm install` in `playground/nextjs/` (ensure tarballs exist in `./target/` first), then `pnpm dev`. It starts on port 3000.
+
 ## Additional Resources
 
 - [PostHog Documentation](https://posthog.com/docs)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious development environment caveats for future cloud agents, including:

- Node version activation via nvm
- Build order dependencies for playground projects
- Tarball workflow for local development
- Ignored build scripts (safe to skip)
- No external services required for unit tests
- Next.js playground startup instructions

[PostHog React playground running at localhost:3000](https://cursor.com/agents/bc-e8133183-a4be-42db-933d-2e96f838f535/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplayground_nextjs_running.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8133183-a4be-42db-933d-2e96f838f535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8133183-a4be-42db-933d-2e96f838f535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

