### PR TITLE
chore: exclude examples from Dependabot and add reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,14 +31,13 @@ updates:
       exclude-paths:
           - 'examples/**'
           - 'playground/**'
+          - 'compliance/**'
       ignore:
           - dependency-name: '*'
             update-types: ['version-update:semver-major']
       open-pull-requests-limit: 1
       reviewers:
           - 'PostHog/team-llm-analytics'
-      assignees:
-          - 'PostHog/team-client-libraries'
 
     - package-ecosystem: 'npm'
       commit-message:
@@ -55,6 +54,7 @@ updates:
       exclude-paths:
           - 'examples/**'
           - 'playground/**'
+          - 'compliance/**'
       ignore:
           - dependency-name: '@anthropic-ai/sdk'
           - dependency-name: '@google/genai'
@@ -66,6 +66,4 @@ updates:
             update-types: ['version-update:semver-major']
       open-pull-requests-limit: 1
       reviewers:
-          - 'PostHog/team-client-libraries'
-      assignees:
           - 'PostHog/team-client-libraries'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,44 @@ updates:
           - dependency-name: '@ai-sdk/provider'
           - dependency-name: '@langchain/core'
           - dependency-name: 'langchain'
+      exclude-paths:
+          - 'examples/**'
+          - 'playground/**'
       ignore:
           - dependency-name: '*'
             update-types: ['version-update:semver-major']
       open-pull-requests-limit: 1
+      reviewers:
+          - 'PostHog/team-llm-analytics'
+      assignees:
+          - 'PostHog/team-client-libraries'
+
+    - package-ecosystem: 'npm'
+      commit-message:
+          prefix: 'chore'
+      labels:
+          - dependencies
+          - release
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'monday'
+          time: '10:00'
+          timezone: 'UTC'
+      exclude-paths:
+          - 'examples/**'
+          - 'playground/**'
+      ignore:
+          - dependency-name: '@anthropic-ai/sdk'
+          - dependency-name: '@google/genai'
+          - dependency-name: 'openai'
+          - dependency-name: '@ai-sdk/provider'
+          - dependency-name: '@langchain/core'
+          - dependency-name: 'langchain'
+          - dependency-name: '*'
+            update-types: ['version-update:semver-major']
+      open-pull-requests-limit: 1
+      reviewers:
+          - 'PostHog/team-client-libraries'
+      assignees:
+          - 'PostHog/team-client-libraries'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,33 +37,4 @@ updates:
             update-types: ['version-update:semver-major']
       open-pull-requests-limit: 1
       reviewers:
-          - 'PostHog/team-llm-analytics'
-
-    - package-ecosystem: 'npm'
-      commit-message:
-          prefix: 'chore'
-      labels:
-          - dependencies
-          - release
-      directory: '/'
-      schedule:
-          interval: 'weekly'
-          day: 'monday'
-          time: '10:00'
-          timezone: 'UTC'
-      exclude-paths:
-          - 'examples/**'
-          - 'playground/**'
-          - 'compliance/**'
-      ignore:
-          - dependency-name: '@anthropic-ai/sdk'
-          - dependency-name: '@google/genai'
-          - dependency-name: 'openai'
-          - dependency-name: '@ai-sdk/provider'
-          - dependency-name: '@langchain/core'
-          - dependency-name: 'langchain'
-          - dependency-name: '*'
-            update-types: ['version-update:semver-major']
-      open-pull-requests-limit: 1
-      reviewers:
           - 'PostHog/team-client-libraries'

--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,3 @@ CLAUDE.md
 
 # Ignore Ralph's local configuration directory
 .ralph/
-.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ CLAUDE.md
 
 # Ignore Ralph's local configuration directory
 .ralph/
+.worktrees/


### PR DESCRIPTION
## Problem

Dependabot was opening weekly PRs that only touched lockfiles inside `examples/example-ai-*/` (27 directories) and `playground/`. These are demo/sample apps, not shipped SDK code, so bumping their lockfiles provides minimal value and creates noise. Additionally, none of these PRs had reviewers or assignees configured, so they were going unnoticed.

Examples: #3657, #3656, #3612, #3567, #3565, #3554 — all only touching `examples/` lockfiles, piling up unreviewed.

## Changes

### `exclude-paths`
Added `examples/**` and `playground/**` to `exclude-paths`. Dependabot will no longer scan or open PRs for dependency files under those directories.

### Two update blocks
Split the single npm block into two to route PRs to the correct team:

**Block 1 — AI providers** (`@anthropic-ai/sdk`, `@google/genai`, `openai`, `@ai-sdk/provider`, `@langchain/core`, `langchain`)
- Grouped into a single PR via the existing `ai-providers` group
- Reviewer: `@PostHog/team-llm-analytics` | Assignee: `@PostHog/team-client-libraries`
- Max 1 open PR

**Block 2 — All other packages**
- Ignores AI packages above to avoid overlap with block 1
- Reviewer: `@PostHog/team-client-libraries` | Assignee: `@PostHog/team-client-libraries`
- Max 1 open PR

Both blocks continue to exclude `examples/**` and `playground/**`, and ignore semver-major updates.

> **Note:** The 6 currently open Dependabot PRs (#3554, #3565, #3567, #3612, #3656, #3657) will need to be manually closed — this change only prevents new ones from being created.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file