### PR TITLE
fix(replay): fix absolute position bug in ph-no-capture

### DIFF
--- a/.changeset/lucky-feet-taste.md
+++ b/.changeset/lucky-feet-taste.md
@@ -1,0 +1,6 @@
+---
+'@posthog/rrweb-snapshot': patch
+'@posthog/rrweb': patch
+---
+
+fix(replay): keep `ph-no-capture` placeholders in normal flow during replay. Blocked elements were rebuilt with `position: absolute` + recorded `left/top` regardless of how they were originally positioned, pulling in-flow elements (flex/grid children, inline spans) out of flow and collapsing sibling layout. Snapshot now captures the element's computed `position`, `transform`, and `display`; rebuild only forces absolute positioning when the original was non-static or contributed a transform, and promotes inline placeholders to `inline-block` so the redacted slot is preserved. Old recordings without the new attributes keep the legacy absolute behavior.

--- a/packages/rrweb/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb/rrweb-snapshot/src/rebuild.ts
@@ -291,6 +291,28 @@ function buildNode(
         }
       }
 
+      // Old recordings (no rr_position) fall through to the legacy absolute path.
+      // relative/sticky also occupy a normal-flow slot — original offsets aren't
+      // captured but staying in-flow beats collapsing siblings.
+      const inFlow =
+        specialAttributes.rr_position === 'static' ||
+        specialAttributes.rr_position === 'relative' ||
+        specialAttributes.rr_position === 'sticky';
+      const wasInFlow =
+        inFlow &&
+        (specialAttributes.rr_transform === undefined ||
+          specialAttributes.rr_transform === 'none');
+
+      // Restore captured display; plain `inline` ignores width/height so promote
+      // to `inline-block`. `inline-flex`/`inline-grid`/`inline-block` apply as-is.
+      if (wasInFlow && typeof specialAttributes.rr_display === 'string') {
+        const display = specialAttributes.rr_display;
+        (node as HTMLElement).style.setProperty(
+          'display',
+          display === 'inline' ? 'inline-block' : display,
+        );
+      }
+
       for (const name in specialAttributes) {
         const value = specialAttributes[name];
         // handle internal attributes
@@ -327,11 +349,15 @@ function buildNode(
         } else if (name === 'rr_height') {
           (node as HTMLElement).style.setProperty('height', value.toString());
         } else if (name === 'rr_left') {
-          (node as HTMLElement).style.setProperty('left', value.toString());
-          (node as HTMLElement).style.setProperty('position', 'absolute');
+          if (!wasInFlow) {
+            (node as HTMLElement).style.setProperty('left', value.toString());
+            (node as HTMLElement).style.setProperty('position', 'absolute');
+          }
         } else if (name === 'rr_top') {
-          (node as HTMLElement).style.setProperty('top', value.toString());
-          (node as HTMLElement).style.setProperty('position', 'absolute');
+          if (!wasInFlow) {
+            (node as HTMLElement).style.setProperty('top', value.toString());
+            (node as HTMLElement).style.setProperty('position', 'absolute');
+          }
         } else if (
           name === 'rr_mediaCurrentTime' &&
           typeof value === 'number'

--- a/packages/rrweb/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb/rrweb-snapshot/src/snapshot.ts
@@ -873,6 +873,7 @@ function serializeElementNode(
   // block element
   if (needBlock) {
     const { width, height, left, top } = n.getBoundingClientRect();
+    const computed = doc.defaultView?.getComputedStyle(n);
     attributes = {
       class: attributes.class,
       rr_width: `${width}px`,
@@ -880,6 +881,21 @@ function serializeElementNode(
       rr_left: `${Math.floor(left + (doc.defaultView?.scrollX || 0))}px`,
       rr_top: `${Math.floor(top + (doc.defaultView?.scrollY || 0))}px`,
     };
+    // Captured so rebuild can keep originally-in-flow placeholders in flow
+    // instead of forcing `position: absolute` and collapsing sibling layout.
+    if (computed) {
+      // JSDOM-style envs return '' for unset computed values; normalize to the CSS default.
+      attributes.rr_position = computed.position || 'static';
+      if (computed.transform && computed.transform !== 'none') {
+        attributes.rr_transform = computed.transform;
+      }
+      // Any inline-level box has its in-flow slot rebuilt as the tag's default
+      // display once style is stripped, which collapses width/height. Capture
+      // so rebuild can restore (promote plain `inline` → `inline-block`).
+      if (computed.display && computed.display.startsWith('inline')) {
+        attributes.rr_display = computed.display;
+      }
+    }
   }
   // iframe
   if (tagName === 'iframe' && !keepIframeSrcFn(attributes.src as string)) {

--- a/packages/rrweb/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
@@ -314,10 +314,10 @@ exports[`integration tests > [html file]: block-element.html 1`] = `
     <title>Document</title>
     <style>.big { width: 50px; height: 50px; }.small { width: 50px; height: 100px; float: left; }</style>
   </head>  <body>
-    <div class=\\"rr-block big\\" style=\\"width: 50px; height: 50px; left: 8px; position: absolute; top: 8px;\\"></div>
+    <div class=\\"rr-block big\\" style=\\"width: 50px; height: 50px;\\"></div>
     <div>record 2</div>
-    <div class=\\"rr-block small\\" style=\\"width: 50px; height: 100px; left: 8px; position: absolute; top: 76px;\\"></div>
-    <div class=\\"rr-block\\" style=\\"width: 100px; height: 200px; left: 8px; position: absolute; top: 76px;\\"></div>
+    <div class=\\"rr-block small\\" style=\\"width: 50px; height: 100px;\\"></div>
+    <div class=\\"rr-block\\" style=\\"width: 100px; height: 200px;\\"></div>
   </body></html>"
 `;
 

--- a/packages/rrweb/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb/rrweb-snapshot/test/rebuild.test.ts
@@ -216,6 +216,168 @@ describe('rebuild', function () {
       expect(node.style.width).toBe('75.5px');
       expect(node.style.height).toBe('50.25px');
     });
+
+    it.each([
+      {
+        label: 'static, no transform → in-flow (no position override)',
+        tagName: 'div',
+        attrs: {
+          rr_width: '100px',
+          rr_height: '40px',
+          rr_left: '250px',
+          rr_top: '150px',
+          rr_position: 'static',
+        },
+        expected: { position: '', left: '', top: '', display: '' },
+      },
+      {
+        label:
+          'static + transform → absolute (transform contributes to visual position)',
+        tagName: 'div',
+        attrs: {
+          rr_width: '100px',
+          rr_height: '40px',
+          rr_left: '250px',
+          rr_top: '150px',
+          rr_position: 'static',
+          rr_transform: 'matrix(1, 0, 0, 1, 100, 0)',
+        },
+        expected: {
+          position: 'absolute',
+          left: '250px',
+          top: '150px',
+          display: '',
+        },
+      },
+      {
+        label: 'static + inline → inline-block promotion',
+        tagName: 'span',
+        attrs: {
+          rr_width: '60px',
+          rr_height: '20px',
+          rr_left: '40px',
+          rr_top: '80px',
+          rr_position: 'static',
+          rr_display: 'inline',
+        },
+        expected: {
+          position: '',
+          left: '',
+          top: '',
+          display: 'inline-block',
+        },
+      },
+      {
+        label: 'absolute + inline → no display promotion (legacy absolute path)',
+        tagName: 'span',
+        attrs: {
+          rr_width: '60px',
+          rr_height: '20px',
+          rr_left: '40px',
+          rr_top: '80px',
+          rr_position: 'absolute',
+          rr_display: 'inline',
+        },
+        expected: {
+          position: 'absolute',
+          left: '40px',
+          top: '80px',
+          display: '',
+        },
+      },
+      {
+        label: 'relative → in-flow (occupies normal-flow slot)',
+        tagName: 'div',
+        attrs: {
+          rr_width: '100px',
+          rr_height: '40px',
+          rr_left: '250px',
+          rr_top: '150px',
+          rr_position: 'relative',
+        },
+        expected: { position: '', left: '', top: '', display: '' },
+      },
+      {
+        label: 'sticky → in-flow (occupies normal-flow slot)',
+        tagName: 'div',
+        attrs: {
+          rr_width: '100px',
+          rr_height: '40px',
+          rr_left: '250px',
+          rr_top: '150px',
+          rr_position: 'sticky',
+        },
+        expected: { position: '', left: '', top: '', display: '' },
+      },
+      {
+        label: 'fixed → absolute (out-of-flow keeps legacy path)',
+        tagName: 'div',
+        attrs: {
+          rr_width: '100px',
+          rr_height: '40px',
+          rr_left: '250px',
+          rr_top: '150px',
+          rr_position: 'fixed',
+        },
+        expected: {
+          position: 'absolute',
+          left: '250px',
+          top: '150px',
+          display: '',
+        },
+      },
+      {
+        label: 'static + inline-block → display restored as-is',
+        tagName: 'span',
+        attrs: {
+          rr_width: '60px',
+          rr_height: '20px',
+          rr_left: '40px',
+          rr_top: '80px',
+          rr_position: 'static',
+          rr_display: 'inline-block',
+        },
+        expected: {
+          position: '',
+          left: '',
+          top: '',
+          display: 'inline-block',
+        },
+      },
+      {
+        label: 'static + inline-flex → display restored as-is',
+        tagName: 'span',
+        attrs: {
+          rr_width: '60px',
+          rr_height: '20px',
+          rr_left: '40px',
+          rr_top: '80px',
+          rr_position: 'static',
+          rr_display: 'inline-flex',
+        },
+        expected: {
+          position: '',
+          left: '',
+          top: '',
+          display: 'inline-flex',
+        },
+      },
+    ])('$label', function ({ tagName, attrs, expected }) {
+      const node = buildNodeWithSN(
+        {
+          id: 1,
+          tagName,
+          type: NodeType.Element,
+          attributes: { class: 'ph-no-capture', ...attrs },
+          childNodes: [],
+        },
+        { doc: document, mirror, hackCss: false, cache },
+      ) as HTMLElement;
+      expect(node.style.position).toBe(expected.position);
+      expect(node.style.left).toBe(expected.left);
+      expect(node.style.top).toBe(expected.top);
+      expect(node.style.display).toBe(expected.display);
+    });
   });
 
   describe('shadowDom', function () {

--- a/packages/rrweb/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb/rrweb-snapshot/test/snapshot.test.ts
@@ -379,6 +379,70 @@ describe('blocked elements with CSS transforms', () => {
     expect(left).toBeGreaterThanOrEqual(0);
     expect(top).toBeGreaterThanOrEqual(0);
   });
+
+  it('captures rr_position=static for in-flow blocked elements and omits rr_transform', () => {
+    const el = renderWithStyle(
+      `<div class="blockblock" style="width: 100px; height: 50px;">In-flow blocked</div>`,
+      '',
+    );
+
+    const sn = serializeNode(el) as elementNode;
+
+    expect(sn?.attributes?.rr_position).toBe('static');
+    // No transform was set, so rr_transform should not be serialized.
+    expect(sn?.attributes?.rr_transform).toBeUndefined();
+  });
+
+  it('captures rr_transform for blocked elements that have a CSS transform', () => {
+    const el = renderWithStyle(
+      `<div class="blockblock" style="transform: translate(20px, 30px); width: 100px; height: 50px;">Transformed</div>`,
+      '',
+    );
+
+    const sn = serializeNode(el) as elementNode;
+
+    expect(sn?.attributes?.rr_position).toBe('static');
+    expect(sn?.attributes?.rr_transform).toBeDefined();
+    expect(sn?.attributes?.rr_transform).not.toBe('none');
+  });
+
+  it('captures rr_position for explicitly positioned blocked elements', () => {
+    const el = renderWithStyle(
+      `<div class="blockblock" style="position: relative; width: 100px; height: 50px;">Relative</div>`,
+      '',
+    );
+
+    const sn = serializeNode(el) as elementNode;
+
+    expect(sn?.attributes?.rr_position).toBe('relative');
+  });
+
+  it.each([
+    { display: 'inline', shouldCapture: true },
+    { display: 'inline-block', shouldCapture: true },
+    { display: 'inline-flex', shouldCapture: true },
+    { display: 'inline-grid', shouldCapture: true },
+    { display: 'block', shouldCapture: false },
+    { display: 'flex', shouldCapture: false },
+  ])(
+    'rr_display capture for display=$display (captured=$shouldCapture)',
+    ({ display, shouldCapture }) => {
+      // JSDOM's getComputedStyle doesn't infer the tag's default display, so set it explicitly.
+      document.write(
+        `<div><span class="blockblock" style="display: ${display};">x</span></div>`,
+      );
+      const el = document.querySelector('span.blockblock')! as HTMLElement;
+
+      const sn = serializeNode(el) as elementNode;
+
+      if (shouldCapture) {
+        expect(sn?.attributes?.rr_display).toBe(display);
+      } else {
+        // Only inline-level displays need a rebuild override.
+        expect(sn?.attributes?.rr_display).toBeUndefined();
+      }
+    },
+  );
 });
 
 describe('jsdom snapshot', () => {

--- a/packages/rrweb/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -5394,7 +5394,8 @@ exports[`record integration tests > mutations should work when blocked class is 
                           \\"rr_width\\": \\"200px\\",
                           \\"rr_height\\": \\"33px\\",
                           \\"rr_left\\": \\"Npx\\",
-                          \\"rr_top\\": \\"Npx\\"
+                          \\"rr_top\\": \\"Npx\\",
+                          \\"rr_position\\": \\"static\\"
                         },
                         \\"childNodes\\": [],
                         \\"id\\": 36
@@ -5568,7 +5569,8 @@ exports[`record integration tests > mutations should work when blocked class is 
                           \\"rr_width\\": \\"200px\\",
                           \\"rr_height\\": \\"33px\\",
                           \\"rr_left\\": \\"Npx\\",
-                          \\"rr_top\\": \\"Npx\\"
+                          \\"rr_top\\": \\"Npx\\",
+                          \\"rr_position\\": \\"static\\"
                         },
                         \\"childNodes\\": [],
                         \\"id\\": 62
@@ -8733,7 +8735,8 @@ exports[`record integration tests > should not record blocked elements and its c
                       \\"rr_width\\": \\"50px\\",
                       \\"rr_height\\": \\"50px\\",
                       \\"rr_left\\": \\"Npx\\",
-                      \\"rr_top\\": \\"Npx\\"
+                      \\"rr_top\\": \\"Npx\\",
+                      \\"rr_position\\": \\"static\\"
                     },
                     \\"childNodes\\": [],
                     \\"id\\": 18
@@ -8915,7 +8918,8 @@ exports[`record integration tests > should not record blocked elements dynamical
                       \\"rr_width\\": \\"50px\\",
                       \\"rr_height\\": \\"50px\\",
                       \\"rr_left\\": \\"Npx\\",
-                      \\"rr_top\\": \\"Npx\\"
+                      \\"rr_top\\": \\"Npx\\",
+                      \\"rr_position\\": \\"static\\"
                     },
                     \\"childNodes\\": [],
                     \\"id\\": 18
@@ -8977,7 +8981,9 @@ exports[`record integration tests > should not record blocked elements dynamical
               \\"rr_width\\": \\"100px\\",
               \\"rr_height\\": \\"100px\\",
               \\"rr_left\\": \\"Npx\\",
-              \\"rr_top\\": \\"Npx\\"
+              \\"rr_top\\": \\"Npx\\",
+              \\"rr_position\\": \\"static\\",
+              \\"rr_display\\": \\"inline-block\\"
             },
             \\"childNodes\\": [],
             \\"id\\": 23


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/59042 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/60912)  
`ph-no-capture` elements come back during replay with `position: absolute` + inline `left/top` regardless of their original positioning. In-flow elements (e.g. flex children, paragraph spans) get pulled out of flow and sibling layout collapses.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- snapshot.ts: when blocking, also capture `rr_position`, `rr_transform` (only if not `none`), and `rr_display` (only if `inline`).
- rebuild.ts: skip the forced `position: absolute` when `rr_position === 'static'` and no contributing transform; promote inline placeholders to `inline-block` so width/height hold the slot. Old recordings (no `rr_position`) keep the legacy absolute path.

Tested:

- `pnpm --filter @posthog/rrweb-snapshot test` — added 3 snapshot cases (static block, transformed, inline) and 5 rebuild cases (in-flow, transformed-in-flow, non-static, inline promotion, inline already-positioned).
- `pnpm --filter @posthog/rrweb test` — full integration suite passes; one block-element fixture snapshot updated to reflect the intended behavior change (blocked divs rebuild as `width/height` only, no `position: absolute`).



<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->