### PR TITLE
fix: unify capture exception

### DIFF
--- a/.changeset/red-apes-brush.md
+++ b/.changeset/red-apes-brush.md
@@ -1,0 +1,7 @@
+---
+'posthog-react-native': patch
+'@posthog/core': patch
+'posthog-node': patch
+---
+
+unify captureException in posthog core

--- a/examples/example-expo-53/pnpm-lock.yaml
+++ b/examples/example-expo-53/pnpm-lock.yaml
@@ -867,12 +867,12 @@ packages:
     engines: {node: '>=14'}
 
   '@posthog/core@file:../../target/posthog-core.tgz':
-    resolution: {integrity: sha512-XeeSqo/UNA8itbVs9qlseZMA/Z3MWtkQZ7nb+N/fTeeltNtBZCfL0Tt7tgnZ9+932nh/+cT7J205mPyCn/JC7g==, tarball: file:../../target/posthog-core.tgz}
-    version: 1.27.7
+    resolution: {integrity: sha512-quPW3CiWHvlntgoePEFedqhBAw8+OJSTjADf6QinTyGnvlLvsDk9QR1mQeEuz+SCrC5mVTD9Bwa4uUUu8Kgchg==, tarball: file:../../target/posthog-core.tgz}
+    version: 1.29.12
 
   '@posthog/types@file:../../target/posthog-types.tgz':
-    resolution: {integrity: sha512-67d/J6sJY2YFuM57v61jrvwk31nea//DR4scLzu5f1GdJuBafCoRx4DcMNF+wgO5+95g8vDGA/DNcZdLELBCvQ==, tarball: file:../../target/posthog-types.tgz}
-    version: 1.372.3
+    resolution: {integrity: sha512-RILFzuWlEiTjJ2NsyQckUjmYTSl6QJtSELniYltBURPZ9aRRcTpoJEDp8WrRiiBN2+J8KRU4j76chCvsZmDToQ==, tarball: file:../../target/posthog-types.tgz}
+    version: 1.376.3
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -3140,8 +3140,8 @@ packages:
       react-native: '*'
 
   posthog-react-native@file:../../target/posthog-react-native.tgz:
-    resolution: {integrity: sha512-XvkNZkDbnsz/hzV2emgIdMsWATiazRBGC4MjEVgpcYXY3dTRT91Oh2OChZpwSE7gnPEMssHiQbnjhUW9qIBRBQ==, tarball: file:../../target/posthog-react-native.tgz}
-    version: 4.43.10
+    resolution: {integrity: sha512-F/IwIPXnSB774erZGOYPAyECp14q/7se5A1ANrQeRrMliy1uBiLUpEovlBK3Pi2IXSEfTu4LPI2da2nyd1ss0g==, tarball: file:../../target/posthog-react-native.tgz}
+    version: 4.46.1
     peerDependencies:
       '@react-native-async-storage/async-storage': '>=1.0.0'
       '@react-navigation/native': '>= 5.0.0'
@@ -3149,7 +3149,7 @@ packages:
       expo-device: '>= 4.0.0'
       expo-file-system: '>= 13.0.0'
       expo-localization: '>= 11.0.0'
-      posthog-react-native-session-replay: '>= 1.5.6'
+      posthog-react-native-session-replay: '>= 1.6.0'
       react-native-device-info: '>= 10.0.0'
       react-native-localize: '>= 3.0.0'
       react-native-navigation: '>= 6.0.0'

--- a/examples/example-node/pnpm-lock.yaml
+++ b/examples/example-node/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-51V53DYAleXHgPrntlBZSmeS8lOCPoT1zhKZkbvcJZs=
+pnpmfileChecksum: sha256-yVJZ6vhbVglHX96LCyXF5k3CRZo/MEv/K0owx+7kTTo=
 
 importers:
 
@@ -106,8 +106,12 @@ packages:
     engines: {node: '>= 8'}
 
   '@posthog/core@file:../../target/posthog-core.tgz':
-    resolution: {integrity: sha512-KoEq+q0wuyI36rYRnR05L73SJF/uNlWUT4c4dpyb7/ruU5WZwx7jvFB/mHuhWrKx9aEDVtNpuEj8k3Ng/oe9rg==, tarball: file:../../target/posthog-core.tgz}
-    version: 1.6.0
+    resolution: {integrity: sha512-quPW3CiWHvlntgoePEFedqhBAw8+OJSTjADf6QinTyGnvlLvsDk9QR1mQeEuz+SCrC5mVTD9Bwa4uUUu8Kgchg==, tarball: file:../../target/posthog-core.tgz}
+    version: 1.29.12
+
+  '@posthog/types@file:../../target/posthog-types.tgz':
+    resolution: {integrity: sha512-RILFzuWlEiTjJ2NsyQckUjmYTSl6QJtSELniYltBURPZ9aRRcTpoJEDp8WrRiiBN2+J8KRU4j76chCvsZmDToQ==, tarball: file:../../target/posthog-types.tgz}
+    version: 1.376.3
 
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
@@ -623,9 +627,14 @@ packages:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   posthog-node@file:../../target/posthog-node.tgz:
-    resolution: {integrity: sha512-ppOeec7hEfjCfmPQ8nNyUG13WDxkc/HsnKeaH5sTRL31CDOw8q7B9Uu38b+duY4EmATWjtMD5kgOgGz2XA2J9w==, tarball: file:../../target/posthog-node.tgz}
-    version: 5.14.0
-    engines: {node: '>=20'}
+    resolution: {integrity: sha512-DL70tro6poCO4qzZ6HI3q5dSmE0bxiiyunfljTm5jbwy8uhQ64eLXhRmZHArrHrtKfqrdHPV60Bq1jnMGtYHMw==, tarball: file:../../target/posthog-node.tgz}
+    version: 5.35.5
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -881,7 +890,9 @@ snapshots:
 
   '@posthog/core@file:../../target/posthog-core.tgz':
     dependencies:
-      cross-spawn: 7.0.6
+      '@posthog/types': file:../../target/posthog-types.tgz
+
+  '@posthog/types@file:../../target/posthog-types.tgz': {}
 
   '@tsconfig/node10@1.0.11': {}
 

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -175,6 +175,8 @@ export abstract class PostHogCoreStateless {
   /**
    * Returns the builder used by `captureException` to coerce arbitrary inputs into a
    * structured `$exception_list` (with parsed stack frames).
+   *
+   * @internal Exposed for cross-package use within this SDK; not part of the stable public API.
    */
   getErrorPropertiesBuilder(): ErrorPropertiesBuilder {
     if (!this._errorPropertiesBuilder) {

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -35,6 +35,14 @@ import {
   createLogger,
 } from './utils'
 import { uuidv7 } from './vendor/uuidv7'
+import {
+  ErrorPropertiesBuilder,
+  ErrorCoercer,
+  ObjectCoercer,
+  StringCoercer,
+  PrimitiveCoercer,
+  createDefaultStackParser,
+} from './error-tracking'
 
 class PostHogFetchHttpError extends Error {
   name = 'PostHogFetchHttpError'
@@ -78,7 +86,7 @@ export async function logFlushError(err: any): Promise<void> {
     let text = ''
     try {
       text = await err.text
-    } catch {}
+    } catch { }
 
     console.error(`Error while flushing PostHog: message=${err.message}, response body=${text}`, err)
   } else {
@@ -162,6 +170,33 @@ export abstract class PostHogCoreStateless {
   protected _isInitialized: boolean = false
   protected _remoteConfigResponsePromise?: Promise<PostHogRemoteConfig | undefined>
   protected _logger: Logger
+  private _errorPropertiesBuilder?: ErrorPropertiesBuilder
+
+  /**
+   * Returns the builder used by `captureException` to coerce arbitrary inputs into a
+   * structured `$exception_list` (with parsed stack frames).
+   */
+  getErrorPropertiesBuilder(): ErrorPropertiesBuilder {
+    if (!this._errorPropertiesBuilder) {
+      this._errorPropertiesBuilder = this.createErrorPropertiesBuilder()
+    }
+    return this._errorPropertiesBuilder
+  }
+
+  /**
+   * Override in subclasses to plug in platform-specific stack parsers (e.g. node, hermes),
+   * additional coercers (DOMException, ErrorEvent, PromiseRejectionEvent), or async frame
+   * modifiers (source maps, context lines).
+   *
+   * The default is intentionally JS-runtime-agnostic — no DOM-typed coercers — so any SDK
+   * that just extends core gets parsed stack frames out of the box.
+   */
+  protected createErrorPropertiesBuilder(): ErrorPropertiesBuilder {
+    return new ErrorPropertiesBuilder(
+      [new ErrorCoercer(), new ObjectCoercer(), new StringCoercer(), new PrimitiveCoercer()],
+      createDefaultStackParser()
+    )
+  }
 
   // Abstract methods to be overridden by implementations
   abstract fetch(url: string, options: PostHogFetchOptions): Promise<PostHogFetchResponse>
@@ -611,10 +646,10 @@ export abstract class PostHogCoreStateless {
     disableGeoip?: boolean
   ): Promise<
     | {
-        response: FeatureFlagDetail | undefined
-        requestId: string | undefined
-        evaluatedAt: number | undefined
-      }
+      response: FeatureFlagDetail | undefined
+      requestId: string | undefined
+      evaluatedAt: number | undefined
+    }
     | undefined
   > {
     await this._initPromise
@@ -1013,7 +1048,7 @@ export abstract class PostHogCoreStateless {
       // Consume the response body to prevent cross-request promise warnings
       // in runtimes like Cloudflare Workers that enforce body consumption.
       // See: https://github.com/PostHog/posthog-js/issues/3173
-      await response.body?.cancel()?.catch(() => {})
+      await response.body?.cancel()?.catch(() => { })
     } catch (err) {
       this._events.emit('error', err)
     }
@@ -1196,7 +1231,7 @@ export abstract class PostHogCoreStateless {
         // Consume the response body to prevent cross-request promise warnings
         // in runtimes like Cloudflare Workers that enforce body consumption.
         // See: https://github.com/PostHog/posthog-js/issues/3173
-        await response.body?.cancel()?.catch(() => {})
+        await response.body?.cancel()?.catch(() => { })
       } catch (err) {
         if (isPostHogFetchContentTooLargeError(err) && batchMessages.length > 1) {
           // if we get a 413 error, we want to reduce the batch size and try again

--- a/packages/core/src/posthog-core-stateless.ts
+++ b/packages/core/src/posthog-core-stateless.ts
@@ -86,7 +86,7 @@ export async function logFlushError(err: any): Promise<void> {
     let text = ''
     try {
       text = await err.text
-    } catch { }
+    } catch {}
 
     console.error(`Error while flushing PostHog: message=${err.message}, response body=${text}`, err)
   } else {
@@ -646,10 +646,10 @@ export abstract class PostHogCoreStateless {
     disableGeoip?: boolean
   ): Promise<
     | {
-      response: FeatureFlagDetail | undefined
-      requestId: string | undefined
-      evaluatedAt: number | undefined
-    }
+        response: FeatureFlagDetail | undefined
+        requestId: string | undefined
+        evaluatedAt: number | undefined
+      }
     | undefined
   > {
     await this._initPromise
@@ -1048,7 +1048,7 @@ export abstract class PostHogCoreStateless {
       // Consume the response body to prevent cross-request promise warnings
       // in runtimes like Cloudflare Workers that enforce body consumption.
       // See: https://github.com/PostHog/posthog-js/issues/3173
-      await response.body?.cancel()?.catch(() => { })
+      await response.body?.cancel()?.catch(() => {})
     } catch (err) {
       this._events.emit('error', err)
     }
@@ -1231,7 +1231,7 @@ export abstract class PostHogCoreStateless {
         // Consume the response body to prevent cross-request promise warnings
         // in runtimes like Cloudflare Workers that enforce body consumption.
         // See: https://github.com/PostHog/posthog-js/issues/3173
-        await response.body?.cancel()?.catch(() => { })
+        await response.body?.cancel()?.catch(() => {})
       } catch (err) {
         if (isPostHogFetchContentTooLargeError(err) && batchMessages.length > 1) {
           // if we get a 413 error, we want to reduce the batch size and try again

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -35,7 +35,8 @@ import {
 import { Compression, FeatureFlagError, PostHogPersistedProperty } from './types'
 import { maybeAdd, PostHogCoreStateless, QuotaLimitedFeature } from './posthog-core-stateless'
 import { uuidv7 } from './vendor/uuidv7'
-import { isEmptyObject, isNullish, isPlainError, getPersonPropertiesHash, isObject } from './utils'
+import { isEmptyObject, isNullish, getPersonPropertiesHash, isObject } from './utils'
+import { EventHint } from './error-tracking'
 
 // Stores the parameters for a pending feature flags reload request
 interface FlagsAsyncOptions {
@@ -1169,23 +1170,13 @@ export abstract class PostHogCore extends PostHogCoreStateless {
    * @param {Object} [additionalProperties] Any additional properties to add to the error event
    * @returns {CaptureResult} The result of the capture
    */
-  captureException(error: unknown, additionalProperties?: PostHogEventProperties): void {
-    const properties: { [key: string]: any } = {
-      $exception_level: 'error',
-      $exception_list: [
-        {
-          type: isPlainError(error) ? error.name : 'Error',
-          value: isPlainError(error) ? error.message : error,
-          mechanism: {
-            handled: true,
-            synthetic: false,
-          },
-        },
-      ],
-      ...additionalProperties,
-    }
-
-    this.capture('$exception', properties, { _originatedFromCaptureException: true })
+  captureException(error: unknown, additionalProperties?: PostHogEventProperties, hint?: EventHint): void {
+    const exceptionProperties = this.getErrorPropertiesBuilder().buildFromUnknown(error, hint)
+    this.capture(
+      '$exception',
+      { ...exceptionProperties, ...additionalProperties } as unknown as PostHogEventProperties,
+      { _originatedFromCaptureException: true }
+    )
   }
 
   /**

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -1171,12 +1171,16 @@ export abstract class PostHogCore extends PostHogCoreStateless {
    * @returns {CaptureResult} The result of the capture
    */
   captureException(error: unknown, additionalProperties?: PostHogEventProperties, hint?: EventHint): void {
-    const exceptionProperties = this.getErrorPropertiesBuilder().buildFromUnknown(error, hint)
-    this.capture(
-      '$exception',
-      { ...exceptionProperties, ...additionalProperties } as unknown as PostHogEventProperties,
-      { _originatedFromCaptureException: true }
-    )
+    try {
+      const exceptionProperties = this.getErrorPropertiesBuilder().buildFromUnknown(error, hint)
+      this.capture(
+        '$exception',
+        { ...exceptionProperties, ...additionalProperties } as unknown as PostHogEventProperties,
+        { _originatedFromCaptureException: true }
+      )
+    } catch (e) {
+      this._logger.error('Error while capturing $exception:', e)
+    }
   }
 
   /**

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -2298,9 +2298,13 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     if (!ErrorTracking.isPreviouslyCapturedError(error)) {
       const syntheticException = new Error('PostHog syntheticException')
       this.addPendingPromise(
-        ErrorTracking.buildEventMessage(error, { syntheticException }, distinctId, additionalProperties).then((msg) =>
-          this.capture({ ...msg, uuid, flags })
-        )
+        ErrorTracking.buildEventMessage(
+          this.getErrorPropertiesBuilder(),
+          error,
+          { syntheticException },
+          distinctId,
+          additionalProperties
+        ).then((msg) => this.capture({ ...msg, uuid, flags }))
       )
     }
   }
@@ -2350,9 +2354,13 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
     if (!ErrorTracking.isPreviouslyCapturedError(error)) {
       const syntheticException = new Error('PostHog syntheticException')
       return this.addPendingPromise(
-        ErrorTracking.buildEventMessage(error, { syntheticException }, distinctId, additionalProperties).then((msg) =>
-          this.captureImmediate({ ...msg, flags })
-        )
+        ErrorTracking.buildEventMessage(
+          this.getErrorPropertiesBuilder(),
+          error,
+          { syntheticException },
+          distinctId,
+          additionalProperties
+        ).then((msg) => this.captureImmediate({ ...msg, flags }))
       )
     }
   }

--- a/packages/node/src/entrypoints/index.edge.ts
+++ b/packages/node/src/entrypoints/index.edge.ts
@@ -1,19 +1,7 @@
 export * from '../exports'
 
-import ErrorTracking from '../extensions/error-tracking'
 import { PostHogBackendClient } from '../client'
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
-
-ErrorTracking.errorPropertiesBuilder = new CoreErrorTracking.ErrorPropertiesBuilder(
-  [
-    new CoreErrorTracking.EventCoercer(),
-    new CoreErrorTracking.ErrorCoercer(),
-    new CoreErrorTracking.ObjectCoercer(),
-    new CoreErrorTracking.StringCoercer(),
-    new CoreErrorTracking.PrimitiveCoercer(),
-  ],
-  CoreErrorTracking.createStackParser('node:javascript', CoreErrorTracking.nodeStackLineParser)
-)
 
 export class PostHog extends PostHogBackendClient {
   getLibraryId(): string {
@@ -22,5 +10,18 @@ export class PostHog extends PostHogBackendClient {
 
   protected initializeContext(): undefined {
     return undefined
+  }
+
+  protected override createErrorPropertiesBuilder(): CoreErrorTracking.ErrorPropertiesBuilder {
+    return new CoreErrorTracking.ErrorPropertiesBuilder(
+      [
+        new CoreErrorTracking.EventCoercer(),
+        new CoreErrorTracking.ErrorCoercer(),
+        new CoreErrorTracking.ObjectCoercer(),
+        new CoreErrorTracking.StringCoercer(),
+        new CoreErrorTracking.PrimitiveCoercer(),
+      ],
+      CoreErrorTracking.createStackParser('node:javascript', CoreErrorTracking.nodeStackLineParser)
+    )
   }
 }

--- a/packages/node/src/entrypoints/index.node.ts
+++ b/packages/node/src/entrypoints/index.node.ts
@@ -3,23 +3,10 @@ export * from '../exports'
 import { createModulerModifier } from '../extensions/error-tracking/modifiers/module.node'
 import { addSourceContext } from '../extensions/error-tracking/modifiers/context-lines.node'
 import { createRelativePathModifier } from '../extensions/error-tracking/modifiers/relative-path.node'
-import ErrorTracking from '../extensions/error-tracking'
 
 import { PostHogBackendClient } from '../client'
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { PostHogContext } from '../extensions/context/context'
-
-ErrorTracking.errorPropertiesBuilder = new CoreErrorTracking.ErrorPropertiesBuilder(
-  [
-    new CoreErrorTracking.EventCoercer(),
-    new CoreErrorTracking.ErrorCoercer(),
-    new CoreErrorTracking.ObjectCoercer(),
-    new CoreErrorTracking.StringCoercer(),
-    new CoreErrorTracking.PrimitiveCoercer(),
-  ],
-  CoreErrorTracking.createStackParser('node:javascript', CoreErrorTracking.nodeStackLineParser),
-  [createModulerModifier(), addSourceContext, createRelativePathModifier()]
-)
 
 export class PostHog extends PostHogBackendClient {
   getLibraryId(): string {
@@ -28,5 +15,19 @@ export class PostHog extends PostHogBackendClient {
 
   protected initializeContext(): PostHogContext {
     return new PostHogContext()
+  }
+
+  protected override createErrorPropertiesBuilder(): CoreErrorTracking.ErrorPropertiesBuilder {
+    return new CoreErrorTracking.ErrorPropertiesBuilder(
+      [
+        new CoreErrorTracking.EventCoercer(),
+        new CoreErrorTracking.ErrorCoercer(),
+        new CoreErrorTracking.ObjectCoercer(),
+        new CoreErrorTracking.StringCoercer(),
+        new CoreErrorTracking.PrimitiveCoercer(),
+      ],
+      CoreErrorTracking.createStackParser('node:javascript', CoreErrorTracking.nodeStackLineParser),
+      [createModulerModifier(), addSourceContext, createRelativePathModifier()]
+    )
   }
 }

--- a/packages/node/src/extensions/error-tracking/index.ts
+++ b/packages/node/src/extensions/error-tracking/index.ts
@@ -14,8 +14,6 @@ export default class ErrorTracking {
   private _rateLimiter: BucketedRateLimiter<string>
   private _logger: Logger
 
-  static errorPropertiesBuilder: CoreErrorTracking.ErrorPropertiesBuilder
-
   constructor(client: PostHogBackendClient, options: PostHogOptions, _logger: Logger) {
     this.client = client
     this._exceptionAutocaptureEnabled = options.enableExceptionAutocapture || false
@@ -39,6 +37,7 @@ export default class ErrorTracking {
   }
 
   static async buildEventMessage(
+    builder: CoreErrorTracking.ErrorPropertiesBuilder,
     error: unknown,
     hint: CoreErrorTracking.EventHint,
     distinctId?: string,
@@ -46,10 +45,8 @@ export default class ErrorTracking {
   ): Promise<EventMessage> {
     const properties: EventMessage['properties'] = { ...additionalProperties }
 
-    const exceptionProperties = this.errorPropertiesBuilder.buildFromUnknown(error, hint)
-    exceptionProperties.$exception_list = await this.errorPropertiesBuilder.modifyFrames(
-      exceptionProperties.$exception_list
-    )
+    const exceptionProperties = builder.buildFromUnknown(error, hint)
+    exceptionProperties.$exception_list = await builder.modifyFrames(exceptionProperties.$exception_list)
 
     return {
       event: '$exception',
@@ -75,7 +72,11 @@ export default class ErrorTracking {
     this.client.addPendingPromise(
       (async () => {
         if (!ErrorTracking.isPreviouslyCapturedError(exception)) {
-          const eventMessage = await ErrorTracking.buildEventMessage(exception, hint)
+          const eventMessage = await ErrorTracking.buildEventMessage(
+            this.client.getErrorPropertiesBuilder(),
+            exception,
+            hint
+          )
           const exceptionProperties = eventMessage.properties
           const exceptionType = exceptionProperties?.$exception_list[0]?.type ?? 'Exception'
           const isRateLimited = this._rateLimiter.consumeRateLimit(exceptionType)

--- a/packages/node/src/extensions/express.ts
+++ b/packages/node/src/extensions/express.ts
@@ -90,7 +90,13 @@ function posthogErrorHandler(posthog: PostHogBackendClient): ExpressErrorMiddlew
     }
 
     posthog.addPendingPromise(
-      ErrorTracking.buildEventMessage(error, hint, contextData.distinctId, additionalProperties).then((msg) => {
+      ErrorTracking.buildEventMessage(
+        posthog.getErrorPropertiesBuilder(),
+        error,
+        hint,
+        contextData.distinctId,
+        additionalProperties
+      ).then((msg) => {
         posthog.capture(msg)
       })
     )

--- a/packages/react-native/src/error-tracking/index.ts
+++ b/packages/react-native/src/error-tracking/index.ts
@@ -1,13 +1,7 @@
 import type { PostHog } from '../posthog-rn'
-import {
-  JsonType,
-  Logger,
-  PostHogEventProperties,
-  ErrorTracking as CoreErrorTracking,
-  isPostHogFetchNetworkError,
-} from '@posthog/core'
+import { JsonType, Logger, ErrorTracking as CoreErrorTracking, isPostHogFetchNetworkError } from '@posthog/core'
 import { trackConsole, trackUncaughtExceptions, trackUnhandledRejections } from './utils'
-import { getRemoteConfigBool, isHermes } from '../utils'
+import { getRemoteConfigBool } from '../utils'
 
 type LogLevel = 'debug' | 'log' | 'info' | 'warn' | 'error'
 
@@ -36,7 +30,6 @@ interface ResolvedErrorTrackingOptions {
 }
 
 export class ErrorTracking {
-  private errorPropertiesBuilder: CoreErrorTracking.ErrorPropertiesBuilder
   private logger: Logger
   private options: ResolvedErrorTrackingOptions
 
@@ -53,21 +46,6 @@ export class ErrorTracking {
     options: ErrorTrackingOptions = {},
     logger: Logger
   ) {
-    this.errorPropertiesBuilder = new CoreErrorTracking.ErrorPropertiesBuilder(
-      [
-        new CoreErrorTracking.PromiseRejectionEventCoercer(),
-        new CoreErrorTracking.ErrorCoercer(),
-        new CoreErrorTracking.ErrorEventCoercer(),
-        new CoreErrorTracking.ObjectCoercer(),
-        new CoreErrorTracking.StringCoercer(),
-        new CoreErrorTracking.PrimitiveCoercer(),
-      ],
-      CoreErrorTracking.createStackParser(
-        isHermes() ? 'hermes' : 'web:javascript',
-        CoreErrorTracking.chromeStackLineParser,
-        CoreErrorTracking.geckoStackLineParser
-      )
-    )
     this.logger = logger.createLogger('[ErrorTracking]')
     this.options = this.resolveOptions(options)
     this.autocapture(this.options.autocapture)
@@ -90,18 +68,6 @@ export class ErrorTracking {
     this.logger.info(
       `Error tracking autocapture ${this._autocaptureEnabled ? 'enabled' : 'disabled'} by remote config.`
     )
-  }
-
-  captureException(input: unknown, additionalProperties: PostHogEventProperties, hint: CoreErrorTracking.EventHint) {
-    try {
-      const properties = this.errorPropertiesBuilder.buildFromUnknown(input, hint)
-      return this.instance.capture('$exception', {
-        ...properties,
-        ...additionalProperties,
-      } as unknown as PostHogEventProperties)
-    } catch (error) {
-      this.logger.error('An error occurred while capturing an $exception event:', error)
-    }
   }
 
   private resolveOptions(options: ErrorTrackingOptions): ResolvedErrorTrackingOptions {
@@ -157,7 +123,7 @@ export class ErrorTracking {
         additionalProperties['$exception_level'] = 'fatal' as CoreErrorTracking.SeverityLevel
       }
 
-      this.captureException(error, additionalProperties, hint)
+      this.instance.captureException(error, additionalProperties, hint)
 
       if (isFatal) {
         void this.instance.flush().catch(() => {
@@ -190,7 +156,7 @@ export class ErrorTracking {
           handled: false,
         },
       }
-      this.captureException(error, {}, hint)
+      this.instance.captureException(error, {}, hint)
     }
 
     try {
@@ -217,7 +183,7 @@ export class ErrorTracking {
       const additionalProperties = {
         $exception_level: level as CoreErrorTracking.SeverityLevel,
       }
-      this.captureException(error, additionalProperties, hint)
+      this.instance.captureException(error, additionalProperties, hint)
     }
 
     try {

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -21,6 +21,7 @@ import {
   maybeAdd,
   patchFetchForTracingHeaders,
   FeatureFlagValue,
+  ErrorTracking as CoreErrorTracking,
 } from '@posthog/core'
 import {
   PostHogRNStorage,
@@ -38,7 +39,7 @@ import {
   PostHogCustomStorage,
   PostHogSessionReplayConfig,
 } from './types'
-import { getRemoteConfigBool, getRemoteConfigNumber, isValidSampleRate } from './utils'
+import { getRemoteConfigBool, getRemoteConfigNumber, isHermes, isValidSampleRate } from './utils'
 import { withReactNativeNavigation } from './frameworks/wix-navigation'
 import { OptionalReactNativeSessionReplay } from './optional/OptionalSessionReplay'
 import { ErrorTracking, ErrorTrackingOptions } from './error-tracking'
@@ -1587,15 +1588,34 @@ export class PostHog extends PostHogCore {
    * @param {Object} [additionalProperties] Any additional properties to add to the error event
    * @returns {void}
    */
-  captureException(error: Error | unknown, additionalProperties: PostHogEventProperties = {}): void {
-    const syntheticException = new Error('Synthetic Error')
-    this._errorTracking.captureException(error, additionalProperties, {
-      mechanism: {
-        handled: true,
-        type: 'generic',
-      },
-      syntheticException,
-    })
+  captureException(
+    error: Error | unknown,
+    additionalProperties: PostHogEventProperties = {},
+    hint?: CoreErrorTracking.EventHint
+  ): void {
+    const resolvedHint: CoreErrorTracking.EventHint = hint ?? {
+      mechanism: { handled: true, type: 'generic' },
+      syntheticException: new Error('Synthetic Error'),
+    }
+    super.captureException(error, additionalProperties, resolvedHint)
+  }
+
+  protected override createErrorPropertiesBuilder(): CoreErrorTracking.ErrorPropertiesBuilder {
+    return new CoreErrorTracking.ErrorPropertiesBuilder(
+      [
+        new CoreErrorTracking.PromiseRejectionEventCoercer(),
+        new CoreErrorTracking.ErrorCoercer(),
+        new CoreErrorTracking.ErrorEventCoercer(),
+        new CoreErrorTracking.ObjectCoercer(),
+        new CoreErrorTracking.StringCoercer(),
+        new CoreErrorTracking.PrimitiveCoercer(),
+      ],
+      CoreErrorTracking.createStackParser(
+        isHermes() ? 'hermes' : 'web:javascript',
+        CoreErrorTracking.chromeStackLineParser,
+        CoreErrorTracking.geckoStackLineParser
+      )
+    )
   }
 
   initReactNativeNavigation(options: PostHogAutocaptureOptions): boolean {

--- a/packages/react-native/test/error-tracking-internal-errors.spec.ts
+++ b/packages/react-native/test/error-tracking-internal-errors.spec.ts
@@ -40,7 +40,7 @@ describe('ErrorTracking filters PostHog internal network errors', () => {
 
     handler(new Error('network'), false)
 
-    expect(mockPostHog.capture).not.toHaveBeenCalled()
+    expect(mockPostHog.captureException).not.toHaveBeenCalled()
   })
 
   it('does not capture a network error from the unhandled rejection handler', () => {
@@ -50,7 +50,7 @@ describe('ErrorTracking filters PostHog internal network errors', () => {
 
     handler(new Error('network'))
 
-    expect(mockPostHog.capture).not.toHaveBeenCalled()
+    expect(mockPostHog.captureException).not.toHaveBeenCalled()
   })
 
   it('still captures ordinary application errors from the uncaught exception handler', () => {
@@ -59,7 +59,7 @@ describe('ErrorTracking filters PostHog internal network errors', () => {
 
     handler(new Error('boom'), false)
 
-    expect(mockPostHog.capture).toHaveBeenCalledTimes(1)
+    expect(mockPostHog.captureException).toHaveBeenCalledTimes(1)
   })
 
   it('does not filter the console handler (console is left untouched)', () => {
@@ -69,6 +69,6 @@ describe('ErrorTracking filters PostHog internal network errors', () => {
 
     consoleHandler(new Error('network'), false)
 
-    expect(mockPostHog.capture).toHaveBeenCalledTimes(1)
+    expect(mockPostHog.captureException).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/react-native/test/error-tracking-remote-config.spec.ts
+++ b/packages/react-native/test/error-tracking-remote-config.spec.ts
@@ -32,14 +32,14 @@ describe('ErrorTracking remote config', () => {
 
       // Should capture before remote config
       handler(new Error('test'), false)
-      expect(mockPostHog.capture).toHaveBeenCalledTimes(1)
+      expect(mockPostHog.captureException).toHaveBeenCalledTimes(1)
 
-      mockPostHog.capture.mockClear()
+      mockPostHog.captureException.mockClear()
 
       // undefined should not change anything
       et.onRemoteConfig(undefined)
       handler(new Error('test2'), false)
-      expect(mockPostHog.capture).toHaveBeenCalledTimes(1)
+      expect(mockPostHog.captureException).toHaveBeenCalledTimes(1)
     })
 
     it('does not change state when errorTracking is null', () => {
@@ -48,7 +48,7 @@ describe('ErrorTracking remote config', () => {
 
       et.onRemoteConfig(null as any)
       handler(new Error('test'), false)
-      expect(mockPostHog.capture).toHaveBeenCalledTimes(1)
+      expect(mockPostHog.captureException).toHaveBeenCalledTimes(1)
     })
 
     it('disables autocapture when errorTracking is false', () => {
@@ -57,7 +57,7 @@ describe('ErrorTracking remote config', () => {
 
       et.onRemoteConfig(false)
       handler(new Error('test'), false)
-      expect(mockPostHog.capture).not.toHaveBeenCalled()
+      expect(mockPostHog.captureException).not.toHaveBeenCalled()
     })
 
     it('enables autocapture when errorTracking is true', () => {
@@ -67,12 +67,12 @@ describe('ErrorTracking remote config', () => {
       // First disable
       et.onRemoteConfig(false)
       handler(new Error('test'), false)
-      expect(mockPostHog.capture).not.toHaveBeenCalled()
+      expect(mockPostHog.captureException).not.toHaveBeenCalled()
 
       // Then re-enable
       et.onRemoteConfig(true)
       handler(new Error('test2'), false)
-      expect(mockPostHog.capture).toHaveBeenCalledTimes(1)
+      expect(mockPostHog.captureException).toHaveBeenCalledTimes(1)
     })
 
     it('enables autocapture when errorTracking map has autocaptureExceptions=true', () => {
@@ -81,7 +81,7 @@ describe('ErrorTracking remote config', () => {
 
       et.onRemoteConfig({ autocaptureExceptions: true })
       handler(new Error('test'), false)
-      expect(mockPostHog.capture).toHaveBeenCalledTimes(1)
+      expect(mockPostHog.captureException).toHaveBeenCalledTimes(1)
     })
 
     it('disables autocapture when errorTracking map has autocaptureExceptions=false', () => {
@@ -90,7 +90,7 @@ describe('ErrorTracking remote config', () => {
 
       et.onRemoteConfig({ autocaptureExceptions: false })
       handler(new Error('test'), false)
-      expect(mockPostHog.capture).not.toHaveBeenCalled()
+      expect(mockPostHog.captureException).not.toHaveBeenCalled()
     })
 
     it('disables autocapture when errorTracking map is missing autocaptureExceptions key', () => {
@@ -99,7 +99,7 @@ describe('ErrorTracking remote config', () => {
 
       et.onRemoteConfig({ otherKey: 'value' })
       handler(new Error('test'), false)
-      expect(mockPostHog.capture).not.toHaveBeenCalled()
+      expect(mockPostHog.captureException).not.toHaveBeenCalled()
     })
 
     it('gates unhandled rejection handler on remote config', () => {
@@ -108,13 +108,13 @@ describe('ErrorTracking remote config', () => {
 
       // Enabled by default
       handler(new Error('test'))
-      expect(mockPostHog.capture).toHaveBeenCalledTimes(1)
-      mockPostHog.capture.mockClear()
+      expect(mockPostHog.captureException).toHaveBeenCalledTimes(1)
+      mockPostHog.captureException.mockClear()
 
       // Disable via remote config
       et.onRemoteConfig(false)
       handler(new Error('test2'))
-      expect(mockPostHog.capture).not.toHaveBeenCalled()
+      expect(mockPostHog.captureException).not.toHaveBeenCalled()
     })
 
     it('gates console handler on remote config', () => {
@@ -126,13 +126,13 @@ describe('ErrorTracking remote config', () => {
 
       // Enabled by default
       consoleHandler(new Error('test'), false)
-      expect(mockPostHog.capture).toHaveBeenCalledTimes(1)
-      mockPostHog.capture.mockClear()
+      expect(mockPostHog.captureException).toHaveBeenCalledTimes(1)
+      mockPostHog.captureException.mockClear()
 
       // Disable via remote config
       et.onRemoteConfig(false)
       consoleHandler(new Error('test2'), false)
-      expect(mockPostHog.capture).not.toHaveBeenCalled()
+      expect(mockPostHog.captureException).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/react-native/test/test-utils.ts
+++ b/packages/react-native/test/test-utils.ts
@@ -4,6 +4,7 @@ export const wait = async (t: number): Promise<void> => {
 
 export const createMockPostHog = (): any => ({
   capture: jest.fn(),
+  captureException: jest.fn(),
   flush: jest.fn(() => Promise.resolve()),
 })
 


### PR DESCRIPTION
## Problem

core package has wrong implementation of `captureException()`

## Changes

- core package now exposes base version of `captureException()`. You can call it and it will work,
- it now also exposes error properties builder so classes which inherit it can override it,
- adjusted RN to correctly override it,
- adjusted node to correctly override it,

Tested node, looks good:
<img width="1215" height="563" alt="image" src="https://github.com/user-attachments/assets/e729953f-fbf1-4426-8fe6-ba2aae105c27" />

Tested RN, looks good:
<img width="1455" height="683" alt="image" src="https://github.com/user-attachments/assets/b073c4de-1896-4f99-be8d-fd308276596d" />


## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
