### PR TITLE
fix(convex): register refresh cron unconditionally

### DIFF
--- a/.changeset/convex-refresh-cron-registration.md
+++ b/.changeset/convex-refresh-cron-registration.md
@@ -1,0 +1,7 @@
+---
+'@posthog/convex': patch
+---
+
+Fix the refresh cron not registering when `POSTHOG_PERSONAL_API_KEY` is forwarded from the installing app. Convex only forwards component env vars at runtime, so the previous load-time gate saw an empty value during deploy-time module analysis and silently dropped the cron. The cron now registers unconditionally and gates at runtime, and the default polling interval is now 10 minutes (override with `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS`).
+
+Fixes [#3683](https://github.com/PostHog/posthog-js/issues/3683).

--- a/.changeset/convex-refresh-cron-registration.md
+++ b/.changeset/convex-refresh-cron-registration.md
@@ -2,6 +2,6 @@
 '@posthog/convex': patch
 ---
 
-Fix the refresh cron not registering when `POSTHOG_PERSONAL_API_KEY` is forwarded from the installing app. Convex only forwards component env vars at runtime, so the previous load-time gate saw an empty value during deploy-time module analysis and silently dropped the cron. The cron now registers unconditionally and gates at runtime, and the default polling interval is now 10 minutes (override with `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS`).
+Fix the refresh cron not registering when `POSTHOG_PERSONAL_API_KEY` is forwarded from the installing app. Convex only forwards component env vars at runtime, so the previous load-time gate saw an empty value during deploy-time module analysis and silently dropped the cron. The cron now registers unconditionally and gates at runtime.
 
 Fixes [#3683](https://github.com/PostHog/posthog-js/issues/3683).

--- a/packages/convex/README.md
+++ b/packages/convex/README.md
@@ -41,9 +41,9 @@ const app = defineApp({
     POSTHOG_PROJECT_TOKEN: v.string(),
     // Optional. PostHog host. Defaults to `https://us.i.posthog.com`; use `https://eu.i.posthog.com` for EU Cloud or your self-hosted URL.
     POSTHOG_HOST: v.optional(v.string()),
-    // Optional. A feature flags secure API key (`phs_…`, recommended) or personal API key (`phx_…`). Setting it enables local feature flag evaluation and starts the refresh cron.
+    // Optional. A feature flags secure API key (`phs_…`, recommended) or personal API key (`phx_…`). Setting it enables local feature flag evaluation.
     POSTHOG_PERSONAL_API_KEY: v.optional(v.string()),
-    // Optional. Cron interval (seconds) for refreshing flag definitions. Defaults to 60. Raise it on free-tier dev deployments to reduce function-call usage.
+    // Optional. Cron interval (seconds) for refreshing flag definitions. Defaults to 600 (10 minutes). Lower it for faster flag propagation; raise it to reduce function-call usage further.
     POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS: v.optional(v.string()),
   },
 });
@@ -73,7 +73,7 @@ To enable local feature flag evaluation, also set a [feature flags secure API ke
 npx convex env set POSTHOG_PERSONAL_API_KEY phs_your_feature_flags_secure_api_key
 ```
 
-> Personal API keys (`phx_…`) also still work for local evaluation, but PostHog recommends the project-scoped feature flags secure API key going forward. This env var also gates the component's built-in refresh cron: when it's set the cron is registered at deploy time and refreshes flag definitions once a minute; when it isn't, the cron isn't registered at all so idle dev deployments don't burn function calls. The gate is evaluated at module-load (i.e. deploy) time — `npx convex dev` redeploys automatically when you set the env var, but production deployments need a manual redeploy for the cron to start.
+> Personal API keys (`phx_…`) also still work for local evaluation, but PostHog recommends the project-scoped feature flags secure API key going forward. Setting this env var is what flips on local evaluation — the component's built-in refresh cron starts populating flag definitions on the next tick, no redeploy needed.
 
 Create a `convex/posthog.ts` file to initialize the client. Credentials live on the component, so this file is just for callbacks (identify, beforeSend):
 
@@ -85,10 +85,10 @@ import { components } from "./_generated/api";
 export const posthog = new PostHog(components.posthog);
 ```
 
-That's the whole setup — feature flag methods will start returning live values on the next cron tick. The component refreshes flag definitions every minute when `POSTHOG_PERSONAL_API_KEY` is set. To tune the cadence (e.g. raise it to `300` for a free-tier dev deployment), set `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` and redeploy:
+That's the whole setup — feature flag methods will start returning live values on the next cron tick. The component refreshes flag definitions every 10 minutes by default when `POSTHOG_PERSONAL_API_KEY` is set. To tune the cadence (e.g. drop it to `60` for faster flag propagation in development), set `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` and redeploy:
 
 ```sh
-npx convex env set POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS 300
+npx convex env set POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS 60
 ```
 
 If you call a local-eval method (`getFeatureFlag`, `isFeatureEnabled`, …) without `POSTHOG_PERSONAL_API_KEY` configured, the client throws with a pointer to the remote `evaluateFlag` / `evaluateFlagPayload` / `evaluateAllFlags` methods. While the first cron tick is still in flight (PAK is set but no definitions are cached yet) the local methods return `undefined` so your fallback path keeps working.
@@ -310,7 +310,7 @@ await posthog.capture(ctx, {
 There are also reasons you might *not want* local eval at all, even when it's possible:
 
 - **Low-traffic projects.** PostHog bills each `/flags/definitions` poll as 10 flag-request equivalents. For projects that evaluate fewer flags than that per polling interval, remote evaluation is cheaper.
-- **Need-it-now changes.** Local eval accepts up to one polling interval of staleness (default 1 minute with our cron). For flags that must flip in well under that, you want remote eval.
+- **Need-it-now changes.** Local eval accepts up to one polling interval of staleness (default 10 minutes with our cron, configurable via `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS`). For flags that must flip in well under that, you want remote eval.
 - **No personal API key.** If you don't want to set `POSTHOG_PERSONAL_API_KEY`, the local methods aren't useful — there's nothing for them to read.
 
 For any of those, use the remote-eval methods below instead.

--- a/packages/convex/README.md
+++ b/packages/convex/README.md
@@ -43,7 +43,7 @@ const app = defineApp({
     POSTHOG_HOST: v.optional(v.string()),
     // Optional. A feature flags secure API key (`phs_…`, recommended) or personal API key (`phx_…`). Setting it enables local feature flag evaluation.
     POSTHOG_PERSONAL_API_KEY: v.optional(v.string()),
-    // Optional. Cron interval (seconds) for refreshing flag definitions. Defaults to 600 (10 minutes). Lower it for faster flag propagation; raise it to reduce function-call usage further.
+    // Optional. Cron interval (seconds) for refreshing flag definitions. Defaults to 60. Raise it on free-tier dev deployments to reduce function-call usage.
     POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS: v.optional(v.string()),
   },
 });
@@ -85,10 +85,10 @@ import { components } from "./_generated/api";
 export const posthog = new PostHog(components.posthog);
 ```
 
-That's the whole setup — feature flag methods will start returning live values on the next cron tick. The component refreshes flag definitions every 10 minutes by default when `POSTHOG_PERSONAL_API_KEY` is set. To tune the cadence (e.g. drop it to `60` for faster flag propagation in development), set `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` and redeploy:
+That's the whole setup — feature flag methods will start returning live values on the next cron tick. The component refreshes flag definitions once a minute by default when `POSTHOG_PERSONAL_API_KEY` is set. To tune the cadence (e.g. raise it to `300` for a free-tier dev deployment), set `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` and redeploy:
 
 ```sh
-npx convex env set POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS 60
+npx convex env set POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS 300
 ```
 
 If you call a local-eval method (`getFeatureFlag`, `isFeatureEnabled`, …) without `POSTHOG_PERSONAL_API_KEY` configured, the client throws with a pointer to the remote `evaluateFlag` / `evaluateFlagPayload` / `evaluateAllFlags` methods. While the first cron tick is still in flight (PAK is set but no definitions are cached yet) the local methods return `undefined` so your fallback path keeps working.
@@ -310,7 +310,7 @@ await posthog.capture(ctx, {
 There are also reasons you might *not want* local eval at all, even when it's possible:
 
 - **Low-traffic projects.** PostHog bills each `/flags/definitions` poll as 10 flag-request equivalents. For projects that evaluate fewer flags than that per polling interval, remote evaluation is cheaper.
-- **Need-it-now changes.** Local eval accepts up to one polling interval of staleness (default 10 minutes with our cron, configurable via `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS`). For flags that must flip in well under that, you want remote eval.
+- **Need-it-now changes.** Local eval accepts up to one polling interval of staleness (default 1 minute with our cron). For flags that must flip in well under that, you want remote eval.
 - **No personal API key.** If you don't want to set `POSTHOG_PERSONAL_API_KEY`, the local methods aren't useful — there's nothing for them to read.
 
 For any of those, use the remote-eval methods below instead.

--- a/packages/convex/src/component/crons.test.ts
+++ b/packages/convex/src/component/crons.test.ts
@@ -1,5 +1,39 @@
 import { describe, expect, test, beforeEach, afterEach, jest } from '@jest/globals'
+import type { Crons } from 'convex/server'
 import { DEFAULT_INTERVAL_SECONDS, readPollingIntervalSeconds } from './crons.js'
+
+describe('cron registration', () => {
+  let originalPak: string | undefined
+
+  beforeEach(() => {
+    originalPak = process.env.POSTHOG_PERSONAL_API_KEY
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    if (originalPak === undefined) {
+      delete process.env.POSTHOG_PERSONAL_API_KEY
+    } else {
+      process.env.POSTHOG_PERSONAL_API_KEY = originalPak
+    }
+    jest.resetModules()
+  })
+
+  // Convex forwards component env vars only at runtime, so deploy-time module analysis sees
+  // `process.env.POSTHOG_PERSONAL_API_KEY` empty even when the installing app has set it.
+  // A load-time gate would silently drop the cron — see #3683.
+  test('registers the refresh cron when POSTHOG_PERSONAL_API_KEY is empty at module load', async () => {
+    delete process.env.POSTHOG_PERSONAL_API_KEY
+    const mod = (await import('./crons.js')) as { default: Crons }
+    expect(Object.keys(mod.default.crons)).toContain('Refresh PostHog feature flag definitions')
+  })
+
+  test('registers the refresh cron when POSTHOG_PERSONAL_API_KEY is set at module load', async () => {
+    process.env.POSTHOG_PERSONAL_API_KEY = 'phx_test'
+    const mod = (await import('./crons.js')) as { default: Crons }
+    expect(Object.keys(mod.default.crons)).toContain('Refresh PostHog feature flag definitions')
+  })
+})
 
 describe('readPollingIntervalSeconds', () => {
   let warnSpy: ReturnType<typeof jest.spyOn>

--- a/packages/convex/src/component/crons.test.ts
+++ b/packages/convex/src/component/crons.test.ts
@@ -16,20 +16,20 @@ describe('cron registration', () => {
     } else {
       process.env.POSTHOG_PERSONAL_API_KEY = originalPak
     }
-    jest.resetModules()
   })
 
   // Convex forwards component env vars only at runtime, so deploy-time module analysis sees
   // `process.env.POSTHOG_PERSONAL_API_KEY` empty even when the installing app has set it.
   // A load-time gate would silently drop the cron — see #3683.
-  test('registers the refresh cron when POSTHOG_PERSONAL_API_KEY is empty at module load', async () => {
-    delete process.env.POSTHOG_PERSONAL_API_KEY
-    const mod = (await import('./crons.js')) as { default: Crons }
-    expect(Object.keys(mod.default.crons)).toContain('Refresh PostHog feature flag definitions')
-  })
-
-  test('registers the refresh cron when POSTHOG_PERSONAL_API_KEY is set at module load', async () => {
-    process.env.POSTHOG_PERSONAL_API_KEY = 'phx_test'
+  test.each<[string, string | undefined]>([
+    ['unset', undefined],
+    ['set', 'phx_test'],
+  ])('registers the refresh cron when POSTHOG_PERSONAL_API_KEY is %s at module load', async (_label, pakValue) => {
+    if (pakValue === undefined) {
+      delete process.env.POSTHOG_PERSONAL_API_KEY
+    } else {
+      process.env.POSTHOG_PERSONAL_API_KEY = pakValue
+    }
     const mod = (await import('./crons.js')) as { default: Crons }
     expect(Object.keys(mod.default.crons)).toContain('Refresh PostHog feature flag definitions')
   })

--- a/packages/convex/src/component/crons.ts
+++ b/packages/convex/src/component/crons.ts
@@ -4,15 +4,11 @@ import { env } from './_generated/server.js'
 
 const crons = cronJobs()
 
-export const DEFAULT_INTERVAL_SECONDS = 60
+// Override via `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` for faster propagation.
+export const DEFAULT_INTERVAL_SECONDS = 600
 
-/**
- * Parse the optional `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` env var into a positive integer.
- *
- * Convex component env vars are string-typed, so we coerce here. Invalid values fall back to
- * the default rather than failing the deploy — flags will still refresh on the default cadence
- * and the operator gets a warning to act on. Exported for unit testing.
- */
+// Convex component env vars are string-typed. Invalid values warn and fall back rather than
+// failing the deploy. Exported for unit testing.
 export function readPollingIntervalSeconds(): number {
   const raw = (env.POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS ?? '').trim()
   if (!raw) return DEFAULT_INTERVAL_SECONDS
@@ -27,26 +23,14 @@ export function readPollingIntervalSeconds(): number {
   return parsed
 }
 
-/**
- * The refresh cron is registered only when `POSTHOG_PERSONAL_API_KEY` is configured for the
- * component. Without it, local evaluation can't run, so there's no reason to pay the per-tick
- * resource cost — particularly on idle dev deployments on the free tier.
- *
- * Toggling local evaluation on or off therefore requires redeploying the component, which
- * `npx convex env set` triggers automatically in `npx convex dev`. The cron handler itself also
- * guards against a stale registration where the env var was cleared after deploy.
- */
-// Trim before checking, matching how `readConfig()` in `lib.ts` interprets the env var.
-// `npx convex env set` can leave trailing whitespace; without the trim, a value like `" "` would
-// register the cron but then no-op every tick once `readConfig()` rejects the trimmed-to-empty
-// PAK — wasted function calls, especially painful on free-tier deployments.
-if ((env.POSTHOG_PERSONAL_API_KEY ?? '').trim()) {
-  crons.interval(
-    'Refresh PostHog feature flag definitions',
-    { seconds: readPollingIntervalSeconds() },
-    api.lib.refreshFlagDefinitions,
-    {}
-  )
-}
+// Registered unconditionally — Convex forwards component env vars only at runtime, so a
+// load-time gate on `POSTHOG_PERSONAL_API_KEY` sees an empty value at deploy-time module
+// analysis and silently drops the cron. The handler in `lib.ts` gates at runtime instead.
+crons.interval(
+  'Refresh PostHog feature flag definitions',
+  { seconds: readPollingIntervalSeconds() },
+  api.lib.refreshFlagDefinitions,
+  {}
+)
 
 export default crons

--- a/packages/convex/src/component/crons.ts
+++ b/packages/convex/src/component/crons.ts
@@ -4,8 +4,8 @@ import { env } from './_generated/server.js'
 
 const crons = cronJobs()
 
-// Override via `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS` for faster propagation.
-export const DEFAULT_INTERVAL_SECONDS = 600
+// Override via `POSTHOG_FLAGS_POLLING_INTERVAL_SECONDS`.
+export const DEFAULT_INTERVAL_SECONDS = 60
 
 // Convex component env vars are string-typed. Invalid values warn and fall back rather than
 // failing the deploy. Exported for unit testing.

--- a/packages/convex/src/component/lib.ts
+++ b/packages/convex/src/component/lib.ts
@@ -290,21 +290,14 @@ export const evaluateAllFlags = action({
 
 // --- Feature flag local evaluation ---
 //
-// Flag definitions are fetched on a cron registered inside this component (only when
-// `POSTHOG_PERSONAL_API_KEY` is set — see `crons.ts`) and stored in the `flagDefinitions`
-// table. Clients read them via `getFlagDefinitions` and evaluate flags locally — there is
-// no per-call action for flag evaluation.
+// Flag definitions are fetched on the cron in `crons.ts` and stored in `flagDefinitions`.
+// Clients read them via `getFlagDefinitions` and evaluate flags locally — there is no
+// per-call action for flag evaluation.
 
-/**
- * Returns the cached flag definitions plus whether local evaluation is configured at all.
- *
- * `localEvalConfigured` reflects whether `POSTHOG_PERSONAL_API_KEY` is set on the component —
- * the client uses this to distinguish "you haven't set up local eval" (throw, point the user
- * at the remote `evaluateFlag` methods) from "PAK is set but the cron hasn't fetched yet"
- * (return `undefined` gracefully). `data` is null until the first successful refresh.
- *
- * `data` is a JSON-stringified `FlagDefinitions` object (see `client/feature-flags/types.ts`).
- */
+// `localEvalConfigured` lets the client distinguish "PAK not set" (throw, point at the
+// remote `evaluateFlag` methods) from "PAK set but cron hasn't fetched yet" (return
+// `undefined`). `data` is a JSON-stringified `FlagDefinitions` (see
+// `client/feature-flags/types.ts`), null until the first successful refresh.
 export const getFlagDefinitions = query({
   args: {},
   handler: async (ctx) => {
@@ -355,9 +348,7 @@ export const refreshFlagDefinitions = action({
     const { projectToken, host, personalApiKey } = readConfig()
 
     if (!projectToken || !personalApiKey) {
-      // The cron is conditionally registered on `POSTHOG_PERSONAL_API_KEY`, so reaching this branch
-      // means either env vars were cleared after deploy (cron still scheduled) or the project token wasn't
-      // configured. Return a status rather than throwing so the cron doesn't churn on errors.
+      // The cron registers unconditionally (see `crons.ts`); this is its runtime gate.
       return { status: 'skipped' as const, reason: 'missing-keys' as const }
     }
 


### PR DESCRIPTION
## Problem

Convex only forwards component env vars at runtime, so the load-time gate on `POSTHOG_PERSONAL_API_KEY` in `packages/convex/src/component/crons.ts` saw an empty value during deploy-time module analysis and silently dropped the refresh cron. Local feature flag evaluation never received updates unless the user wired their own cron from the app side. Reported in #3683.

## Changes

Register the cron unconditionally and gate at runtime inside `refreshFlagDefinitions` instead. Default polling interval stays at 60s.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/convex

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran \`pnpm changeset\` to generate a changeset file

## How did you test this code?

Added a parameterised regression test in `packages/convex/src/component/crons.test.ts` that imports the module fresh with `POSTHOG_PERSONAL_API_KEY` both set and unset, asserting the cron is registered either way. Confirmed it fails when the previous `if` gate is reintroduced. Full `pnpm jest --roots=src` passes (98 tests).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*