### PR TITLE
fix(cookieless): enable request queue when opting out in on_reject mode

### DIFF
--- a/.changeset/fix-cookieless-queue-not-enabled-on-reject.md
+++ b/.changeset/fix-cookieless-queue-not-enabled-on-reject.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(cookieless): enable request queue when opting out in `on_reject` mode. When using `cookieless_mode: "on_reject"`, calling `opt_out_capturing()` correctly switched the SDK into cookieless capturing but never enabled the `RequestQueue` — so batched events were enqueued but never flushed over the network. At init time the queue was not started because consent was `PENDING` and `is_capturing()` returned `false`; `opt_out_capturing()` is the first moment capturing becomes active but was missing the `_start_queue_if_opted_in()` call that `opt_in_capturing()` already had.

--- a/packages/browser/src/__tests__/cookieless.test.ts
+++ b/packages/browser/src/__tests__/cookieless.test.ts
@@ -405,7 +405,9 @@ describe('cookieless', () => {
             jest.advanceTimersByTime(5000) // flush the batch queue
             expect(mockedFetch).toBeCalledTimes(3) // flags + pageview + custom event
             expect(JSON.parse(mockedFetch.mock.calls[2][1].body)[0].event).toEqual('custom event')
-            expect(JSON.parse(mockedFetch.mock.calls[2][1].body)[0].properties.distinct_id).toEqual('$posthog_cookieless')
+            expect(JSON.parse(mockedFetch.mock.calls[2][1].body)[0].properties.distinct_id).toEqual(
+                '$posthog_cookieless'
+            )
         })
     })
 })

--- a/packages/browser/src/__tests__/cookieless.test.ts
+++ b/packages/browser/src/__tests__/cookieless.test.ts
@@ -382,5 +382,30 @@ describe('cookieless', () => {
             expect(mockedFetch).toBeCalledTimes(4) // flags + opt in + pageview + custom event
             expect(JSON.parse(mockedFetch.mock.calls[3][1].body)[0].event).toEqual('custom event')
         })
+
+        it('should start the request queue when opting out (cookieless transport regression #3680)', async () => {
+            // Regression: after opt_out_capturing() in on_reject mode the SDK switches to cookieless
+            // capturing, but the RequestQueue was never enabled — so batched events were enqueued
+            // but never flushed over the network.
+            jest.useFakeTimers()
+            const { posthog } = await setup({
+                cookieless_mode: 'on_reject',
+                request_batching: true,
+            })
+            jest.advanceTimersByTime(10)
+            expect(mockedFetch).toBeCalledTimes(1) // flags only — queue is paused, no events yet
+
+            posthog.opt_out_capturing()
+            // opt_out triggers an initial $pageview in cookieless mode — it should be sent immediately (non-batched)
+            expect(mockedFetch).toBeCalledTimes(2) // flags + pageview
+            expect(JSON.parse(mockedFetch.mock.calls[1][1].body).event).toEqual('$pageview')
+            expect(JSON.parse(mockedFetch.mock.calls[1][1].body).properties.distinct_id).toEqual('$posthog_cookieless')
+
+            posthog.capture('custom event')
+            jest.advanceTimersByTime(5000) // flush the batch queue
+            expect(mockedFetch).toBeCalledTimes(3) // flags + pageview + custom event
+            expect(JSON.parse(mockedFetch.mock.calls[2][1].body)[0].event).toEqual('custom event')
+            expect(JSON.parse(mockedFetch.mock.calls[2][1].body)[0].properties.distinct_id).toEqual('$posthog_cookieless')
+        })
     })
 })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -3693,6 +3693,9 @@ export class PostHog implements PostHogInterface {
             this.sessionManager = undefined
             this.sessionPropsManager = undefined
             this._captureInitialPageview()
+            // At init time, consent was PENDING so is_capturing() was false and _start_queue_if_opted_in() was a no-op.
+            // Now that rejection has been recorded, capturing is active — enable the queue so batched events are flushed.
+            this._start_queue_if_opted_in()
         }
     }
 


### PR DESCRIPTION
Fixes #3680

## Problem

When using `cookieless_mode: "on_reject"` with the documented consent pattern, calling `posthog.opt_out_capturing()` correctly switches the SDK into cookieless capturing — but events captured afterwards are never sent over the network. `posthog.is_capturing()` returns `true`, `before_send` fires, debug logs show the event — but no HTTP request is made.

**Root cause:** The `RequestQueue` starts paused and is only enabled by `_start_queue_if_opted_in()`, which calls `_requestQueue.enable()` only when `is_capturing()` returns `true`. At init time with `cookieless_mode: "on_reject"` and no stored consent (`PENDING`), `is_capturing()` returns `false` — so `_start_queue_if_opted_in()` in `_loaded()` / `_dom_loaded()` is a no-op and the queue stays paused.

When the user later calls `opt_out_capturing()`, consent is set to `DENIED` and the SDK enters cookieless capturing. `is_capturing()` now returns `true` (rejected consent = active cookieless capturing in `on_reject` mode), but `opt_out_capturing()` never called `_start_queue_if_opted_in()`. The queue stays paused indefinitely, so batched events are enqueued but never flushed. `opt_in_capturing()` already has this call (line 3630) — `opt_out_capturing()` was simply missing the equivalent.

## Changes

Added `_start_queue_if_opted_in()` at the end of the `COOKIELESS_ON_REJECT` block in `opt_out_capturing()`, mirroring the existing call in `opt_in_capturing()`. One-line fix.

Added a regression test `"should start the request queue when opting out (cookieless transport regression #3680)"` in `cookieless.test.ts`, alongside the existing "should restart the request queue when opting in" test. The test uses `request_batching: true` and intercepts `fetch` directly rather than `before_send` — because `before_send` fires before the queue and would have masked the bug. It confirms the flags request, the cookieless `$pageview`, and a subsequent `capture()` all produce real network calls with `distinct_id: '$posthog_cookieless'`. The test fails before this fix and passes after. All existing cookieless tests continue to pass.

Added a changeset for a `posthog-js` patch bump.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file