### PR TITLE
fix(persistence): skip save() when serialized props are unchanged

### DIFF
--- a/.changeset/persist-skip-unchanged.md
+++ b/.changeset/persist-skip-unchanged.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(persistence): skip the storage write when the serialized props are unchanged. Callers spam `save()` after every property change, and many of those changes leave the serialized payload identical (e.g. resetting a value to its current value). Writing identical bytes to localStorage still fires a cross-tab `storage` event in every same-origin tab, where Chrome allocates the payload buffer in mojo IPC even though no listener reacts. Now `save()` compares the serialized payload against the last successful write and bails out when nothing changed.

--- a/packages/browser/src/__tests__/posthog-persistence.test.ts
+++ b/packages/browser/src/__tests__/posthog-persistence.test.ts
@@ -352,6 +352,73 @@ describe('persistence', () => {
             }
             expect(library.properties()).toEqual({})
         })
+
+        describe('no-op write rejection in save()', () => {
+            // save() short-circuits if the serialized props are unchanged
+            // since the last successful write. cookieStore and localStore
+            // are shared singletons; the spy may carry calls from setup
+            // (library.clear() removes both subdomain variants, which
+            // cookieStore._remove implements as two _set calls). We
+            // mockClear() after the setup write to isolate the assertion.
+
+            it('skips storage writes when props are unchanged', () => {
+                library.register({ distinct_id: 'hi' })
+                const storageSetSpy = jest.spyOn(library['_storage'], '_set')
+                storageSetSpy.mockClear()
+
+                library.save()
+                library.save()
+                library.save()
+
+                expect(storageSetSpy).not.toHaveBeenCalled()
+            })
+
+            it('writes when a value changes', () => {
+                library.register({ distinct_id: 'hi' })
+                const storageSetSpy = jest.spyOn(library['_storage'], '_set')
+                storageSetSpy.mockClear()
+
+                library.register({ distinct_id: 'bye' })
+                expect(storageSetSpy).toHaveBeenCalledTimes(1)
+            })
+
+            it('writes again after a remove() resets the cache', () => {
+                library.register({ distinct_id: 'hi' })
+                const storageSetSpy = jest.spyOn(library['_storage'], '_set')
+
+                // Without remove(), the save below would be deduped.
+                library.remove()
+                storageSetSpy.mockClear()
+                library.save()
+
+                expect(storageSetSpy).toHaveBeenCalledTimes(1)
+            })
+
+            it('writes through after remove() even if props are unchanged', () => {
+                library.register({ distinct_id: 'hi' })
+                library.remove()
+                const storageSetSpy = jest.spyOn(library['_storage'], '_set')
+                storageSetSpy.mockClear()
+
+                // save() with unchanged props would normally be a no-op.
+                // After remove(), the cache was cleared, so this must
+                // write through — there is nothing in storage right now.
+                library.save()
+                expect(storageSetSpy).toHaveBeenCalled()
+            })
+
+            it('treats equivalent props (same JSON) as no-op even with new object identity', () => {
+                library.register({ distinct_id: 'hi', tags: ['a', 'b'] })
+                const storageSetSpy = jest.spyOn(library['_storage'], '_set')
+                storageSetSpy.mockClear()
+
+                // Force a save() with no real change. register() guards
+                // against this via `!==`, so call save() directly.
+                library.save()
+
+                expect(storageSetSpy).not.toHaveBeenCalled()
+            })
+        })
     })
 
     describe('localStorage+cookie', () => {
@@ -609,9 +676,10 @@ describe('posthog instance persistence', () => {
         const createdStore = (posthog.persistence as any)._storage
         const localPlusCookieSpy = jest.spyOn(createdStore, '_set')
 
-        // Trigger a save to verify storage is called
+        // Trigger a save to verify storage is called. We force a real
+        // state change because save() now no-ops identical writes.
         if (posthog.persistence) {
-            posthog.persistence.save()
+            posthog.persistence.register({ verify_write: 'yes' })
         }
 
         const sessionCalls = sessionSpy.mock.calls.filter(([key]) => key !== '__support__')

--- a/packages/browser/src/__tests__/posthog-persistence.test.ts
+++ b/packages/browser/src/__tests__/posthog-persistence.test.ts
@@ -418,6 +418,58 @@ describe('persistence', () => {
 
                 expect(storageSetSpy).not.toHaveBeenCalled()
             })
+
+            it.each([
+                {
+                    label: 'expire_days change',
+                    mutate: (lib: PostHogPersistence) => ((lib as any)._expire_days = 90),
+                },
+                {
+                    label: 'cross_subdomain change',
+                    mutate: (lib: PostHogPersistence) => ((lib as any)._cross_subdomain = true),
+                },
+                {
+                    label: 'secure change',
+                    mutate: (lib: PostHogPersistence) => ((lib as any)._secure = true),
+                },
+            ])('writes through when $label invalidates the storage args, even with unchanged props', ({ mutate }) => {
+                // The no-op fingerprint must cover all four arguments to
+                // `_storage._set` — serialized props plus expire_days,
+                // cross_subdomain, secure. Otherwise a customer who calls
+                // `posthog.set_config({ cookie_expiration: 90 })` would
+                // mutate `_expire_days` but the no-op check (which only
+                // saw props) would short-circuit, and the cookie keeps
+                // its old `Expires` header until some other prop changes.
+                library.register({ distinct_id: 'hi' })
+                const storageSetSpy = jest.spyOn(library['_storage'], '_set')
+                storageSetSpy.mockClear()
+
+                mutate(library)
+                library.save()
+
+                expect(storageSetSpy).toHaveBeenCalledTimes(1)
+            })
+
+            it.each([
+                { label: 'BigInt', value: BigInt(1234567890123) },
+                {
+                    label: 'circular reference',
+                    value: (() => {
+                        const o: any = {}
+                        o.self = o
+                        return o
+                    })(),
+                },
+            ])('does not throw on $label values that JSON.stringify rejects', ({ value }) => {
+                // Pre-existing behaviour: unserializable values like BigInt
+                // and circular references were caught by the storage layer's
+                // own try/catch and logged/dropped. The no-op fingerprint
+                // calls JSON.stringify too, but we mustn't propagate the
+                // exception out of save() — application code that registered
+                // such values would crash.
+                library.register({ ok: 'value', weird: value })
+                expect(() => library.save()).not.toThrow()
+            })
         })
     })
 

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -208,18 +208,33 @@ export class PostHogPersistence {
             return
         }
 
-        // No-op rejection: skip the write if `props` serialize to the same
-        // string we wrote last time. Callers spam `save()` after every
-        // property change, and many of those changes leave the serialized
-        // payload unchanged (e.g. resetting a value to its current value).
-        // Writing identical bytes to localStorage still fires a `storage`
-        // event in every other same-origin tab, where Chrome allocates the
-        // payload buffer in mojo IPC even though no listener reacts.
-        const serialized = JSON.stringify(this.props)
-        if (serialized === this._lastSavedSerialized) {
-            return
+        // No-op rejection: skip the write when none of the arguments to
+        // `_storage._set` have changed since the last successful write.
+        // Callers spam `save()` after every property change, and many of
+        // those changes leave the storage payload unchanged. Writing
+        // identical bytes to localStorage still fires a cross-tab `storage`
+        // event where Chrome allocates the payload buffer in mojo IPC even
+        // though no listener reacts.
+        //
+        // The fingerprint covers all four meaningful inputs to `_storage._set`:
+        // serialized props, expire_days, cross_subdomain, secure. For
+        // localStorage / sessionStorage the last three are ignored by the
+        // storage backend so including them just costs a redundant write
+        // when cookie options change on a non-cookie store — rare and cheap.
+        //
+        // JSON.stringify can throw on BigInt / circular refs. We let the
+        // underlying storage layer keep its existing try/catch behaviour
+        // (log and drop) by falling through on serialization errors.
+        try {
+            const fingerprint =
+                JSON.stringify(this.props) + '|' + this._expire_days + '|' + this._cross_subdomain + '|' + this._secure
+            if (fingerprint === this._lastSavedSerialized) {
+                return
+            }
+            this._lastSavedSerialized = fingerprint
+        } catch {
+            // fall through to storage._set, which handles the error itself
         }
-        this._lastSavedSerialized = serialized
 
         this._storage._set(
             this._name,

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -70,6 +70,11 @@ export class PostHogPersistence {
     private _expire_days: number | undefined
     private _default_expiry: number | undefined
     private _cross_subdomain: boolean | undefined
+    // Serialized snapshot of `props` from the most recent successful write.
+    // Used by `save()` to skip writes that would produce an identical
+    // payload. Cleared whenever we explicitly remove the storage entry, so
+    // a save after remove always lands.
+    private _lastSavedSerialized: string | undefined
 
     /**
      * @param {PostHogConfig} config initial PostHog configuration
@@ -202,6 +207,20 @@ export class PostHogPersistence {
         if (this._disabled) {
             return
         }
+
+        // No-op rejection: skip the write if `props` serialize to the same
+        // string we wrote last time. Callers spam `save()` after every
+        // property change, and many of those changes leave the serialized
+        // payload unchanged (e.g. resetting a value to its current value).
+        // Writing identical bytes to localStorage still fires a `storage`
+        // event in every other same-origin tab, where Chrome allocates the
+        // payload buffer in mojo IPC even though no listener reacts.
+        const serialized = JSON.stringify(this.props)
+        if (serialized === this._lastSavedSerialized) {
+            return
+        }
+        this._lastSavedSerialized = serialized
+
         this._storage._set(
             this._name,
             this.props,
@@ -216,6 +235,8 @@ export class PostHogPersistence {
         // remove both domain and subdomain cookies
         this._storage._remove(this._name, false)
         this._storage._remove(this._name, true)
+        // Storage entry is gone — any future save() must write through.
+        this._lastSavedSerialized = undefined
     }
 
     // removes the storage entry and deletes all loaded data

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -313,6 +313,7 @@
         "_lastPathname",
         "_lastPersistedActivityTimestamp",
         "_lastRemoteConfig",
+        "_lastSavedSerialized",
         "_lastSelectionChanged",
         "_lastVisibilityChange",
         "_lazyLoadAndStart",


### PR DESCRIPTION
## Problem

<!---->

there is an open P2 bug in chromium that local storage writes cause a memory leak https://issues.chromium.org/issues/394823902

we write to local storage a lot  
the PH memory leak in https://github.com/PostHog/posthog/issues/32479 is fiendish to replicate in a test

## Changes

let's write to local storage less since it can't hurt...

second, let's not write duplicates... it's a no-op

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->