### PR TITLE
feat(persistence): optional `persistence_save_debounce_ms` to coalesce saves

### DIFF
--- a/.changeset/persist-save-debounce.md
+++ b/.changeset/persist-save-debounce.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/types': minor
+---
+
+feat(persistence): add `persistence_save_debounce_ms` config option to coalesce rapid storage saves into a single write. Setting a positive value debounces writes to localStorage/cookie by that window; the in-memory `props` object still updates synchronously so within-tab reads see the latest values immediately, and pending writes flush on `beforeunload` and `pagehide` so no state is lost on tab close. Cross-tab `storage` events are reduced proportionally to the debounce window. Defaults to `0` (no debouncing) for backwards compatibility. On pages that capture many events per second, `250` is a reasonable starting point. The new `2026-05-30` config default opts into `persistence_save_debounce_ms: 250` automatically.

--- a/packages/browser/src/__tests__/config.test.ts
+++ b/packages/browser/src/__tests__/config.test.ts
@@ -26,6 +26,18 @@ describe('config', () => {
             expect(posthog.config.rageclick).toStrictEqual({ content_ignorelist: true })
         })
 
+        it.each([
+            ['unset', undefined, 0],
+            ['2025-05-24', '2025-05-24' as const, 0],
+            ['2025-11-30', '2025-11-30' as const, 0],
+            ['2026-01-30', '2026-01-30' as const, 0],
+            ['2026-05-30', '2026-05-30' as const, 250],
+        ])('persistence_save_debounce_ms with defaults %s', (_label, defaults, expected) => {
+            const posthog = new PostHog()
+            posthog._init('test-token', defaults ? { defaults } : undefined)
+            expect(posthog.config.persistence_save_debounce_ms).toBe(expected)
+        })
+
         it('should preserve other default config values when setting defaults', () => {
             const posthog1 = new PostHog()
             posthog1._init('test-token')
@@ -35,7 +47,6 @@ describe('config', () => {
             posthog2._init('test-token', { defaults: '2025-05-24' })
             const config2 = posthog2.config
 
-            // Check that all other config values remain the same
             const allKeys = new Set([...Object.keys(config1), ...Object.keys(config2)])
             allKeys.forEach((key) => {
                 if (!['capture_pageview', 'defaults'].includes(key)) {

--- a/packages/browser/src/__tests__/persistence-key-policy.test.ts
+++ b/packages/browser/src/__tests__/persistence-key-policy.test.ts
@@ -378,6 +378,7 @@ const collectPostHogPersistenceMutationBoundaryIssues = (): string[] => {
         'set_event_timer',
         'remove_event_timer',
         'set_property',
+        'refreshKey',
     ])
 
     const visit = (node: ts.Node) => {

--- a/packages/browser/src/__tests__/posthog-persistence.test.ts
+++ b/packages/browser/src/__tests__/posthog-persistence.test.ts
@@ -472,6 +472,52 @@ describe('persistence', () => {
             })
         })
 
+        describe('refreshKey', () => {
+            // Pulls a single key from on-disk storage into in-memory props
+            // without a whole-blob flush() (which would clobber a sibling's
+            // write) or load() (which would discard pending in-memory writes).
+            let parseSpy: jest.SpyInstance
+
+            afterEach(() => {
+                parseSpy?.mockRestore()
+            })
+
+            it('pulls a single key from storage and leaves other in-memory props untouched', () => {
+                library.register({ distinct_id: 'mine', other: 'in-memory-only' })
+
+                // Simulate a sibling having written a different value for one key.
+                const onDisk = { ...library.props, distinct_id: 'from-sibling' }
+                parseSpy = jest.spyOn(library['_storage'], '_parse').mockReturnValue(onDisk)
+
+                library.refreshKey('distinct_id')
+
+                expect(library.props.distinct_id).toBe('from-sibling')
+                expect(library.props.other).toBe('in-memory-only')
+            })
+
+            it('does not write to storage', () => {
+                library.register({ distinct_id: 'mine' })
+                parseSpy = jest.spyOn(library['_storage'], '_parse').mockReturnValue({ distinct_id: 'from-sibling' })
+                const storageSetSpy = jest.spyOn(library['_storage'], '_set')
+                storageSetSpy.mockClear()
+
+                library.refreshKey('distinct_id')
+
+                expect(storageSetSpy).not.toHaveBeenCalled()
+                storageSetSpy.mockRestore()
+            })
+
+            it('deletes the in-memory key when storage no longer has it', () => {
+                library.register({ distinct_id: 'mine', keep: 'me' })
+                parseSpy = jest.spyOn(library['_storage'], '_parse').mockReturnValue({ keep: 'me' })
+
+                library.refreshKey('distinct_id')
+
+                expect(library.props.distinct_id).toBeUndefined()
+                expect(library.props.keep).toBe('me')
+            })
+        })
+
         describe('save debounce', () => {
             // `persistence_save_debounce_ms` coalesces rapid save() calls
             // into a single write per window. The default is 0 (immediate).

--- a/packages/browser/src/__tests__/posthog-persistence.test.ts
+++ b/packages/browser/src/__tests__/posthog-persistence.test.ts
@@ -471,6 +471,162 @@ describe('persistence', () => {
                 expect(() => library.save()).not.toThrow()
             })
         })
+
+        describe('save debounce', () => {
+            // `persistence_save_debounce_ms` coalesces rapid save() calls
+            // into a single write per window. The default is 0 (immediate).
+            beforeEach(() => {
+                jest.useFakeTimers()
+            })
+
+            afterEach(() => {
+                jest.runOnlyPendingTimers()
+                jest.useRealTimers()
+            })
+
+            it('writes immediately when debounce is 0 (default)', () => {
+                const config = makePostHogConfig('test-debounce-off', persistenceMode)
+                const debounced = new PostHogPersistence(config)
+                const spy = jest.spyOn(debounced['_storage'], '_set')
+                spy.mockClear()
+
+                debounced.register({ distinct_id: 'a' })
+                debounced.register({ distinct_id: 'b' })
+
+                expect(spy).toHaveBeenCalledTimes(2)
+                debounced.clear()
+            })
+
+            it('coalesces multiple saves within the debounce window into one write', () => {
+                const config = {
+                    ...makePostHogConfig('test-debounce-on', persistenceMode),
+                    persistence_save_debounce_ms: 250,
+                }
+                const debounced = new PostHogPersistence(config)
+                const spy = jest.spyOn(debounced['_storage'], '_set')
+                spy.mockClear()
+
+                debounced.register({ a: '1' })
+                debounced.register({ b: '2' })
+                debounced.register({ c: '3' })
+
+                expect(spy).not.toHaveBeenCalled()
+
+                jest.advanceTimersByTime(250)
+
+                expect(spy).toHaveBeenCalledTimes(1)
+                expect(debounced.props).toMatchObject({ a: '1', b: '2', c: '3' })
+                debounced.clear()
+            })
+
+            it('in-memory props update synchronously even before the debounced write lands', () => {
+                const config = {
+                    ...makePostHogConfig('test-debounce-sync', persistenceMode),
+                    persistence_save_debounce_ms: 250,
+                }
+                const debounced = new PostHogPersistence(config)
+
+                debounced.register({ distinct_id: 'live' })
+                expect(debounced.props.distinct_id).toBe('live')
+                debounced.clear()
+            })
+
+            it('flush() writes pending state immediately', () => {
+                const config = {
+                    ...makePostHogConfig('test-debounce-flush', persistenceMode),
+                    persistence_save_debounce_ms: 250,
+                }
+                const debounced = new PostHogPersistence(config)
+                const spy = jest.spyOn(debounced['_storage'], '_set')
+                spy.mockClear()
+
+                debounced.register({ distinct_id: 'before-flush' })
+                expect(spy).not.toHaveBeenCalled()
+
+                debounced.flush()
+                expect(spy).toHaveBeenCalledTimes(1)
+
+                jest.advanceTimersByTime(1000)
+                expect(spy).toHaveBeenCalledTimes(1)
+                debounced.clear()
+            })
+
+            it('remove() cancels any pending debounced write', () => {
+                const config = {
+                    ...makePostHogConfig('test-debounce-remove', persistenceMode),
+                    persistence_save_debounce_ms: 250,
+                }
+                const debounced = new PostHogPersistence(config)
+                const setSpy = jest.spyOn(debounced['_storage'], '_set')
+                const removeSpy = jest.spyOn(debounced['_storage'], '_remove')
+
+                debounced.register({ distinct_id: 'doomed' })
+                setSpy.mockClear()
+                removeSpy.mockClear()
+
+                debounced.remove()
+                jest.advanceTimersByTime(1000)
+
+                expect(setSpy).not.toHaveBeenCalled()
+                expect(removeSpy).toHaveBeenCalled()
+            })
+
+            it('flush() does NOT resurrect storage after remove() (the reset bug)', () => {
+                // Sequence: posthog.reset() → clear() → remove() cancels
+                // the timer, clears _lastSavedSerialized, deletes storage.
+                // Then the unload listener fires flush(). Without the
+                // pending-timer guard, flush() would call _writeNow() with
+                // props={}, mismatch against undefined _lastSavedSerialized,
+                // and resurrect the storage entry that remove() just
+                // deleted. The guard means flush() is a no-op once there
+                // is no pending timer.
+                const config = {
+                    ...makePostHogConfig('test-flush-after-remove', persistenceMode),
+                    persistence_save_debounce_ms: 250,
+                }
+                const debounced = new PostHogPersistence(config)
+                debounced.register({ distinct_id: 'before-reset' })
+
+                // Simulate reset
+                debounced.clear()
+
+                const setSpy = jest.spyOn(debounced['_storage'], '_set')
+                setSpy.mockClear()
+
+                // Simulate the unload listener firing after reset
+                debounced.flush()
+
+                expect(setSpy).not.toHaveBeenCalled()
+            })
+
+            it('writes through on flush() when debounce is enabled at runtime via set_config (late-enable)', () => {
+                // Customer constructs PostHog with debounce=0 (no listener
+                // would be installed under the old logic), then later does
+                // `posthog.set_config({ persistence_save_debounce_ms: 250 })`.
+                // The mutable config is read every save() via _saveDebounceMs(),
+                // so save() correctly starts debouncing. But we must ALSO
+                // have installed unload listeners at construction so the
+                // pending write isn't lost on page close.
+                const config: any = makePostHogConfig('test-late-debounce', persistenceMode)
+                const debounced = new PostHogPersistence(config)
+                const spy = jest.spyOn(debounced['_storage'], '_set')
+
+                // Enable debounce after construction.
+                config.persistence_save_debounce_ms = 250
+                spy.mockClear()
+
+                debounced.register({ distinct_id: 'late' })
+
+                // The debounced write is pending — not in storage yet.
+                expect(spy).not.toHaveBeenCalled()
+
+                // Simulate the unload listener firing.
+                debounced.flush()
+
+                expect(spy).toHaveBeenCalledTimes(1)
+                debounced.clear()
+            })
+        })
     })
 
     describe('localStorage+cookie', () => {

--- a/packages/browser/src/__tests__/sessionid.test.ts
+++ b/packages/browser/src/__tests__/sessionid.test.ts
@@ -52,6 +52,7 @@ describe('Session ID manager', () => {
                 Object.assign(persistence.props, props)
             }),
             load: jest.fn(),
+            flush: jest.fn(),
             _disabled: false,
         }
         ;(sessionStore._is_supported as jest.Mock).mockReturnValue(true)
@@ -550,6 +551,29 @@ describe('Session ID manager', () => {
             expect(persistence.register).toHaveBeenCalledWith({
                 [SESSION_ID]: [1_004_000, 'sessionA', 1_000_000],
             })
+        })
+
+        it('flush calls persistence.flush before load and after register so debounced writes are not lost', () => {
+            // With persistence_save_debounce_ms > 0, persistence batches saves.
+            // Calling load() without flushing first would clobber pending
+            // debounced writes; not flushing after register() would leave
+            // our SESSION_ID write waiting on a debounce timer that never
+            // fires before the page closes.
+            const order: string[] = []
+            ;(persistence.flush as jest.Mock).mockImplementation(() => order.push('flush'))
+            ;(persistence.load as jest.Mock).mockImplementation(() => order.push('load'))
+            ;(persistence.register as jest.Mock).mockImplementation((props) => {
+                Object.assign(persistence.props, props)
+                order.push('register')
+            })
+
+            const sessionIdManager = sessionIdMgr(persistence)
+            sessionIdManager['_setSessionId']('sessionA', 1_000_000, 1_000_000)
+            sessionIdManager['_setSessionId']('sessionA', 1_004_000, 1_000_000) // throttled
+            order.length = 0
+
+            sessionIdManager['_flushPendingActivityTimestamp']()
+            expect(order).toEqual(['flush', 'load', 'register', 'flush'])
         })
     })
 

--- a/packages/browser/src/__tests__/sessionid.test.ts
+++ b/packages/browser/src/__tests__/sessionid.test.ts
@@ -53,6 +53,7 @@ describe('Session ID manager', () => {
             }),
             load: jest.fn(),
             flush: jest.fn(),
+            refreshKey: jest.fn(),
             _disabled: false,
         }
         ;(sessionStore._is_supported as jest.Mock).mockReturnValue(true)
@@ -541,6 +542,36 @@ describe('Session ID manager', () => {
             expect(persistence.props[SESSION_ID]).toEqual([2_000_000, 'sessionB', 2_000_000])
         })
 
+        it('flush does not clobber a cross-tab rotation when debounce is enabled', () => {
+            // The debounce>0 regression: a leading whole-blob flush() would
+            // write our stale SESSION_ID over the sibling's rotation before
+            // we read it, defeating the mismatch guard. Per-key refresh reads
+            // SESSION_ID without writing, so the sibling's rotation survives.
+            config.persistence_save_debounce_ms = 250
+            try {
+                const sessionIdManager = sessionIdMgr(persistence)
+                sessionIdManager['_setSessionId']('sessionA', 1_000_000, 1_000_000)
+                sessionIdManager['_setSessionId']('sessionA', 1_004_000, 1_000_000) // throttled
+                ;(persistence.register as jest.Mock).mockClear()
+
+                // Sibling rotated to sessionB in storage; refreshKey pulls it in.
+                ;(persistence.refreshKey as jest.Mock).mockImplementation(() => {
+                    persistence.props[SESSION_ID] = [2_000_000, 'sessionB', 2_000_000]
+                })
+
+                sessionIdManager['_flushPendingActivityTimestamp']()
+
+                // Guard skips before any write: refreshKey read the sibling
+                // rotation, and we never flushed our stale blob.
+                expect(persistence.refreshKey).toHaveBeenCalledWith(SESSION_ID)
+                expect(persistence.flush).not.toHaveBeenCalled()
+                expect(persistence.register).not.toHaveBeenCalled()
+                expect(persistence.props[SESSION_ID]).toEqual([2_000_000, 'sessionB', 2_000_000])
+            } finally {
+                delete config.persistence_save_debounce_ms
+            }
+        })
+
         it('flush proceeds when persisted session still matches the tab', () => {
             const sessionIdManager = sessionIdMgr(persistence)
             sessionIdManager['_setSessionId']('sessionA', 1_000_000, 1_000_000)
@@ -553,15 +584,41 @@ describe('Session ID manager', () => {
             })
         })
 
-        it('flush calls persistence.flush before load and after register so debounced writes are not lost', () => {
-            // With persistence_save_debounce_ms > 0, persistence batches saves.
-            // Calling load() without flushing first would clobber pending
-            // debounced writes; not flushing after register() would leave
-            // our SESSION_ID write waiting on a debounce timer that never
-            // fires before the page closes.
+        it('flush refreshes SESSION_ID from storage, registers, then forces the debounced write (hardened path)', () => {
+            // With persistence_save_debounce_ms > 0, a whole-blob flush()
+            // would clobber a sibling SESSION_ID write before we read it.
+            // Per-key refresh reads only SESSION_ID and writes nothing, so
+            // neither side is clobbered. The trailing flush() forces the
+            // SESSION_ID register past the debounce.
+            config.persistence_save_debounce_ms = 250
+            try {
+                const order: string[] = []
+                ;(persistence.flush as jest.Mock).mockImplementation(() => order.push('flush'))
+                ;(persistence.refreshKey as jest.Mock).mockImplementation(() => order.push('refreshKey'))
+                ;(persistence.register as jest.Mock).mockImplementation((props) => {
+                    Object.assign(persistence.props, props)
+                    order.push('register')
+                })
+
+                const sessionIdManager = sessionIdMgr(persistence)
+                sessionIdManager['_setSessionId']('sessionA', 1_000_000, 1_000_000)
+                sessionIdManager['_setSessionId']('sessionA', 1_004_000, 1_000_000) // throttled
+                order.length = 0
+
+                sessionIdManager['_flushPendingActivityTimestamp']()
+                expect(order).toEqual(['refreshKey', 'register', 'flush'])
+            } finally {
+                delete config.persistence_save_debounce_ms
+            }
+        })
+
+        it('flush uses legacy flush+load when debounce is disabled', () => {
+            // With debounce off, flush() is a no-op (no pending timer) so it
+            // cannot clobber storage, and load() picks up sibling writes.
             const order: string[] = []
             ;(persistence.flush as jest.Mock).mockImplementation(() => order.push('flush'))
             ;(persistence.load as jest.Mock).mockImplementation(() => order.push('load'))
+            ;(persistence.refreshKey as jest.Mock).mockImplementation(() => order.push('refreshKey'))
             ;(persistence.register as jest.Mock).mockImplementation((props) => {
                 Object.assign(persistence.props, props)
                 order.push('register')

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -187,12 +187,14 @@ const defaultsThatVaryByConfig = (
     | 'session_recording'
     | 'external_scripts_inject_target'
     | 'internal_or_test_user_hostname'
+    | 'persistence_save_debounce_ms'
 > => ({
     rageclick: defaults && defaults >= '2025-11-30' ? { content_ignorelist: true } : true,
     capture_pageview: defaults && defaults >= '2025-05-24' ? 'history_change' : true,
     session_recording: defaults && defaults >= '2025-11-30' ? { strictMinimumDuration: true } : {},
     external_scripts_inject_target: defaults && defaults >= '2026-01-30' ? 'head' : 'body',
     internal_or_test_user_hostname: defaults && defaults >= '2026-01-30' ? /^(localhost|127\.0\.0\.1)$/ : undefined,
+    persistence_save_debounce_ms: defaults && defaults >= '2026-05-30' ? 250 : 0,
 })
 
 // NOTE: Remember to update `types.ts` when changing a default value
@@ -222,7 +224,6 @@ export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     upgrade: false,
     disable_session_recording: false,
     disable_persistence: false,
-    persistence_save_debounce_ms: 0,
     disable_web_experiments: true, // disabled in beta.
     disable_surveys: false,
     disable_surveys_automatic_display: false,

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -222,6 +222,7 @@ export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     upgrade: false,
     disable_session_recording: false,
     disable_persistence: false,
+    persistence_save_debounce_ms: 0,
     disable_web_experiments: true, // disabled in beta.
     disable_surveys: false,
     disable_surveys_automatic_display: false,

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -225,6 +225,28 @@ export class PostHogPersistence {
     }
 
     /**
+     * Refresh a single key from on-disk storage into `this.props` without
+     * touching the rest. Used by `SessionIdManager` on the cross-tab idle
+     * path so we can pick up a sibling tab's SESSION_ID write without
+     * either:
+     *  - flushing our own (potentially stale) whole-props blob to storage
+     *    via `flush()`, which would clobber the sibling's write, or
+     *  - replacing all of `props` via `load()`, which would discard any
+     *    in-memory writes that haven't yet been debounced to storage.
+     */
+    refreshKey(prop: string): void {
+        if (this._disabled) {
+            return
+        }
+        const entry = this._storage._parse(this._name)
+        if (entry && prop in entry) {
+            this._setProp(prop, entry[prop])
+        } else {
+            this._deleteProp(prop)
+        }
+    }
+
+    /**
      * NOTE: Saving frequently causes issues with Recordings and Consent Management Platform (CMP) tools which
      * observe cookie changes, and modify their UI, often causing infinite loops.
      * As such callers of this should ideally check that the data has changed beforehand

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -1,8 +1,9 @@
 /* eslint camelcase: "off" */
 
-import { each, extend, stripEmptyProperties } from './utils'
+import { each, extend, stripEmptyProperties, addEventListener } from './utils'
 import { cookieStore, createLocalPlusCookieStore, localStore, memoryStore, sessionStore } from './storage'
 import { PersistentStore, PostHogConfig, Properties } from './types'
+import { window } from './utils/globals'
 import {
     ENABLED_FEATURE_FLAGS,
     EVENT_TIMERS_KEY,
@@ -13,7 +14,7 @@ import {
 } from './constants'
 import { getPersistenceKeyPolicy } from './persistence-key-policy'
 
-import { isUndefined } from '@posthog/core'
+import { isNumber, isUndefined } from '@posthog/core'
 import {
     getCampaignParams,
     getInitialPersonPropsFromInfo,
@@ -71,10 +72,17 @@ export class PostHogPersistence {
     private _default_expiry: number | undefined
     private _cross_subdomain: boolean | undefined
     // Serialized snapshot of `props` from the most recent successful write.
-    // Used by `save()` to skip writes that would produce an identical
+    // Used by `_writeNow()` to skip writes that would produce an identical
     // payload. Cleared whenever we explicitly remove the storage entry, so
     // a save after remove always lands.
     private _lastSavedSerialized: string | undefined
+    // Optional debounce: when `persistence_save_debounce_ms` is > 0, rapid
+    // calls to `save()` are coalesced into one write at the end of the
+    // window. The in-memory `props` is always updated synchronously, so
+    // in-tab reads see the latest values regardless. Pending writes are
+    // flushed on `beforeunload` and `pagehide` so no state is lost on
+    // tab close.
+    private _pendingSaveTimer: ReturnType<typeof setTimeout> | undefined
 
     /**
      * @param {PostHogConfig} config initial PostHog configuration
@@ -92,6 +100,24 @@ export class PostHogPersistence {
         }
         this.update_config(config, config, isDisabled)
         this.save()
+
+        // Install unload flush listeners unconditionally. They are a no-op
+        // when no debounced write is pending (see `flush()`), so it is safe
+        // to install even when `persistence_save_debounce_ms` is 0 at
+        // construction. Crucially this also handles `posthog.set_config({
+        // persistence_save_debounce_ms: 250 })` enabling debounce later —
+        // we'd otherwise miss the listener install and lose pending writes
+        // on close.
+        if (window) {
+            const flush = (): void => this.flush()
+            addEventListener(window, 'beforeunload', flush as EventListener, { capture: false })
+            addEventListener(window, 'pagehide', flush as EventListener, { capture: false })
+        }
+    }
+
+    private _saveDebounceMs(): number {
+        const value = this._config?.persistence_save_debounce_ms
+        return isNumber(value) && value > 0 ? value : 0
     }
 
     /**
@@ -208,6 +234,45 @@ export class PostHogPersistence {
             return
         }
 
+        const debounce = this._saveDebounceMs()
+        if (debounce <= 0) {
+            this._writeNow()
+            return
+        }
+        // Coalesce: if a flush is already scheduled, the latest `props`
+        // will be picked up when the timer fires. Otherwise schedule one.
+        if (!isUndefined(this._pendingSaveTimer)) {
+            return
+        }
+        this._pendingSaveTimer = setTimeout(() => {
+            this._pendingSaveTimer = undefined
+            this._writeNow()
+        }, debounce)
+    }
+
+    /**
+     * Force any pending debounced save to land in storage immediately.
+     * No-op when there is no pending timer — crucially, this means the
+     * `beforeunload` / `pagehide` listeners installed in the constructor
+     * cannot accidentally resurrect a storage entry that `remove()` or
+     * `clear()` just deleted. Without this guard, the listener would
+     * call `_writeNow()` and write the in-memory `props` (now `{}`) back
+     * to storage, breaking `posthog.reset()` / opt-out flows.
+     */
+    flush(): void {
+        if (isUndefined(this._pendingSaveTimer)) {
+            return
+        }
+        clearTimeout(this._pendingSaveTimer)
+        this._pendingSaveTimer = undefined
+        this._writeNow()
+    }
+
+    private _writeNow(): void {
+        if (this._disabled) {
+            return
+        }
+
         // No-op rejection: skip the write when none of the arguments to
         // `_storage._set` have changed since the last successful write.
         // Callers spam `save()` after every property change, and many of
@@ -247,6 +312,12 @@ export class PostHogPersistence {
     }
 
     remove(): void {
+        // Cancel any pending debounced write — the storage entry is going
+        // away so there is nothing useful to flush.
+        if (!isUndefined(this._pendingSaveTimer)) {
+            clearTimeout(this._pendingSaveTimer)
+            this._pendingSaveTimer = undefined
+        }
         // remove both domain and subdomain cookies
         this._storage._remove(this._name, false)
         this._storage._remove(this._name, true)

--- a/packages/browser/src/sessionid.ts
+++ b/packages/browser/src/sessionid.ts
@@ -216,6 +216,10 @@ export class SessionIdManager {
             return
         }
 
+        // Push any pending debounced writes (persistence_save_debounce_ms > 0)
+        // to storage first — otherwise load() would clobber them in memory.
+        this._persistence.flush()
+
         // A sibling tab may have rotated the session — refresh and skip the
         // flush if storage no longer matches our cached id/start, otherwise
         // we would clobber the new session with stale values.
@@ -229,6 +233,9 @@ export class SessionIdManager {
         this._persistence.register({
             [SESSION_ID]: [this._sessionActivityTimestamp, this._sessionId ?? null, this._sessionStartTimestamp],
         })
+        // Force the write past the debounce — destroy / unload paths cannot
+        // wait for a deferred timer that will never fire.
+        this._persistence.flush()
     }
 
     // `max` because either view can be ahead: the throttle holds in-memory

--- a/packages/browser/src/sessionid.ts
+++ b/packages/browser/src/sessionid.ts
@@ -206,6 +206,17 @@ export class SessionIdManager {
         })
     }
 
+    // Gates the per-key cross-tab refresh path. When persistence is in
+    // debounced-write mode, our pending in-memory writes plus a sibling's
+    // recent on-disk writes are both at risk if we do a whole-blob
+    // `flush() + load()` cycle. Per-key refresh avoids both clobbers. The
+    // dated default (>= 2026-05-30) enables debounce, so the new behaviour
+    // and the bug surface roll out together.
+    private _useCrossTabRefreshHardening(): boolean {
+        const debounce = this._config?.persistence_save_debounce_ms
+        return isPositiveNumber(debounce) && debounce > 0
+    }
+
     // Called from destroy / beforeunload so a tab close inside the throttle
     // window doesn't leave the persisted activity timestamp stale.
     private _flushPendingActivityTimestamp(): void {
@@ -216,14 +227,19 @@ export class SessionIdManager {
             return
         }
 
-        // Push any pending debounced writes (persistence_save_debounce_ms > 0)
-        // to storage first — otherwise load() would clobber them in memory.
-        this._persistence.flush()
-
-        // A sibling tab may have rotated the session — refresh and skip the
-        // flush if storage no longer matches our cached id/start, otherwise
-        // we would clobber the new session with stale values.
-        this._persistence.load()
+        if (this._useCrossTabRefreshHardening()) {
+            // Pull only the SESSION_ID slot from storage to see whether a
+            // sibling tab has rotated the session. We must NOT flush our
+            // whole props blob first — it would clobber the sibling's
+            // SESSION_ID write before we get to read it.
+            this._persistence.refreshKey(SESSION_ID)
+        } else {
+            // Legacy path for callers with debounce disabled. `flush()` is
+            // a no-op when there's no pending timer, and `load()` does a
+            // whole-blob refresh that picks up sibling SESSION_ID writes.
+            this._persistence.flush()
+            this._persistence.load()
+        }
         const [, persistedSessionId, persistedStart] = this._getSessionId()
         if (persistedSessionId !== this._sessionId || persistedStart !== this._sessionStartTimestamp) {
             return

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -406,6 +406,7 @@
         "_pauseRecording",
         "_pendingCompressionEvents",
         "_pendingRemoteConfig",
+        "_pendingSaveTimer",
         "_pendingTourTimeouts",
         "_perfConfig",
         "_persistFlagsOnSessionListener",
@@ -503,6 +504,7 @@
         "_runBeforeSend",
         "_sampleRate",
         "_samplingSessionListener",
+        "_saveDebounceMs",
         "_saveSessionState",
         "_scheduleFlush",
         "_scheduleFullSnapshot",
@@ -633,6 +635,7 @@
         "_windowId",
         "_windowIdGenerator",
         "_window_id_storage_key",
-        "_write"
+        "_write",
+        "_writeNow"
     ]
 }

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -623,6 +623,7 @@
         "_urlTriggerMatching",
         "_urlTriggerStatus",
         "_urlTriggers",
+        "_useCrossTabRefreshHardening",
         "_validateEmail",
         "_validateIdentifyId",
         "_validateSampleRate",

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -155,6 +155,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "false",
     "true"
   ],
+  "persistence_save_debounce_ms": [
+    "undefined",
+    "number"
+  ],
   "disable_surveys": [
     "false",
     "true"

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -327,6 +327,7 @@ exports[`config snapshot for PostHogConfig 1`] = `
   ],
   "properties_string_max_length": "number",
   "defaults": [
+    "\\"2026-05-30\\"",
     "\\"2026-01-30\\"",
     "\\"2025-11-30\\"",
     "\\"2025-05-24\\"",

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -896,6 +896,26 @@ export interface PostHogConfig {
     disable_cookie?: boolean
 
     /**
+     * Coalesce rapid `Persistence.save()` calls into a single write.
+     *
+     * Set to a positive number (milliseconds) to debounce writes to localStorage / cookie
+     * by that window. The in-memory `props` object is always updated synchronously so
+     * within-tab reads see the latest values immediately. Cross-tab `storage` events
+     * (which carry the full persistence value as a payload) are reduced proportionally
+     * to the debounce window.
+     *
+     * Pending writes are flushed on `beforeunload` and `pagehide` so no state is lost
+     * on tab close. The cross-tab visibility delay is bounded by the configured window.
+     *
+     * Defaults to `0` (no debouncing, write synchronously) for backwards compatibility.
+     * On pages that capture many events per second, `250` is a reasonable starting point
+     * to reduce localStorage write pressure and cross-tab IPC traffic.
+     *
+     * @default 0
+     */
+    persistence_save_debounce_ms?: number
+
+    /**
      * Determines whether PostHog should disable all surveys functionality.
      *
      * @default false

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -327,7 +327,7 @@ export interface HeatmapConfig {
     flush_interval_milliseconds: number
 }
 
-export type ConfigDefaults = '2026-01-30' | '2025-11-30' | '2025-05-24' | 'unset'
+export type ConfigDefaults = '2026-05-30' | '2026-01-30' | '2025-11-30' | '2025-05-24' | 'unset'
 
 export type ExternalIntegrationKind = 'intercom' | 'crispChat'
 
@@ -909,7 +909,8 @@ export interface PostHogConfig {
      *
      * Defaults to `0` (no debouncing, write synchronously) for backwards compatibility.
      * On pages that capture many events per second, `250` is a reasonable starting point
-     * to reduce localStorage write pressure and cross-tab IPC traffic.
+     * to reduce localStorage write pressure and cross-tab IPC traffic. The `2026-05-30`
+     * config default opts into `250` automatically.
      *
      * @default 0
      */


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

there is an open P2 bug in chromium that local storage writes cause a memory leak https://issues.chromium.org/issues/394823902

we write to local storage a lot  
the PH memory leak in https://github.com/PostHog/posthog/issues/32479 is fiendish to replicate in a test

## Changes

let's write to local storage less since it can't hurt...

let's debounce writes. we write super frequently sometimes and can afford to wait a little

<!-- What is changed and what information would be useful to a reviewer? -->

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [ ] Accounted for the impact of any changes across different platforms
- [ ] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->