### PR TITLE
fix(react-native): fix posthog-xcode.sh receiving /bin/sh as $1 in Expo bundle phase

### DIFF
--- a/.changeset/fix-rn-expo-xcode-sh-arg1.md
+++ b/.changeset/fix-rn-expo-xcode-sh-arg1.md
@@ -1,0 +1,5 @@
+---
+"posthog-react-native": patch
+---
+
+fix(ios): iOS Release builds with Expo config plugin fail when bundle phase uses a /bin/sh prefix, causing posthog-xcode.sh to receive /bin/sh as $1 instead of the react-native-xcode.sh path. The PACKAGER_SOURCEMAP_FILE preservation patch was silently skipped, leading to posthog-cli failing with "Failed to load minified map". Fixes #3682.

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -54,10 +54,13 @@ const POSTHOG_REACT_NATIVE_XCODE_PATH =
   "`\"$NODE_BINARY\" --print \"require('path').join(require('path').dirname(require.resolve('posthog-react-native')), '..', 'tooling', 'posthog-xcode.sh')\"`"
 
 export function addPostHogWithBundledScriptsToBundleShellScript(script: string): string {
+  // Capture only the RN script path (group 1), stripping any leading shell/interpreter
+  // token (e.g. "/bin/sh") that may prefix it in Expo SDK 53+ bundle phase scripts.
+  // Without this, $1 inside posthog-xcode.sh resolves to "/bin/sh" instead of the
+  // react-native-xcode.sh path, silently breaking the PACKAGER_SOURCEMAP_FILE patch.
   return script.replace(
-    /^.*?(packager|scripts)\/react-native-xcode\.sh\s*(\\'\\\\")?/m,
-    // eslint-disable-next-line no-useless-escape
-    (match: string) => `/bin/sh ${POSTHOG_REACT_NATIVE_XCODE_PATH} ${match}`
+    /^(?:.*\s)?((?:[^\s]*(?:packager|scripts)\/react-native-xcode\.sh)\s*(?:\'\\\")?)/m,
+    (_match: string, rnPath: string) => `/bin/sh ${POSTHOG_REACT_NATIVE_XCODE_PATH} ${rnPath}`
   )
 }
 

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -52,6 +52,18 @@ describe('disableUserScriptSandboxing', () => {
   })
 })
 
+// Extracts the argument that would become $1 inside posthog-xcode.sh when
+// the wrapped line is executed by the shell. The shell runs:
+//   /bin/sh <posthog-xcode.sh-path> <...rest>
+// so $1 is the token immediately after the posthog-xcode.sh path.
+const extractArg1 = (wrappedLine: string): string => {
+  // The line looks like: /bin/sh `<node eval>` <arg1> ...
+  // Split on the backtick-delimited posthog-xcode.sh path expression, then
+  // take the first whitespace-separated token from whatever follows it.
+  const afterPosthog = wrappedLine.split(/`[^`]+`/)[1] ?? ''
+  return afterPosthog.trim().split(/\s+/)[0]
+}
+
 describe('addPostHogWithBundledScriptsToBundleShellScript', () => {
   it('wraps the react-native-xcode.sh invocation with posthog-xcode.sh', () => {
     const original = '"../node_modules/react-native/scripts/react-native-xcode.sh"'
@@ -67,6 +79,33 @@ describe('addPostHogWithBundledScriptsToBundleShellScript', () => {
     const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
     expect(wrapped).toContain('posthog-xcode.sh')
     expect(wrapped).toContain('packager/react-native-xcode.sh')
+  })
+
+  // Regression tests for issue #3682:
+  // When the Expo bundle phase already contains a /bin/sh prefix (common in
+  // Expo SDK 53+ and plain RN projects), posthog-xcode.sh receives /bin/sh as
+  // $1, which makes the REACT_NATIVE_XCODE variable resolve to /bin/sh instead
+  // of react-native-xcode.sh, silently breaking the PACKAGER_SOURCEMAP_FILE patch.
+
+  it('arg1 passed to posthog-xcode.sh is react-native-xcode.sh path, not /bin/sh — simple path (no shell prefix)', () => {
+    // Typical Expo bundle phase: just the bare path, no /bin/sh prefix.
+    const original = '../node_modules/react-native/scripts/react-native-xcode.sh'
+    const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
+    const arg1 = extractArg1(wrapped)
+    // $1 must point at the RN script, not at an interpreter
+    expect(arg1).toContain('react-native-xcode.sh')
+    expect(arg1).not.toBe('/bin/sh')
+  })
+
+  it('arg1 passed to posthog-xcode.sh is react-native-xcode.sh path, not /bin/sh — shell-prefixed command (Expo SDK 53+ / plain RN)', () => {
+    // This is the format that triggers issue #3682:
+    // the bundle phase already starts with "/bin/sh", so after wrapping,
+    // $1 inside posthog-xcode.sh becomes "/bin/sh" instead of the RN script path.
+    const original = '/bin/sh "$PODS_ROOT/../.."/node_modules/react-native/scripts/react-native-xcode.sh'
+    const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
+    const arg1 = extractArg1(wrapped)
+    expect(arg1).toContain('react-native-xcode.sh')
+    expect(arg1).not.toBe('/bin/sh')
   })
 })
 

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -92,15 +92,12 @@ describe('addPostHogWithBundledScriptsToBundleShellScript', () => {
       'shell-prefixed command (Expo SDK 53+ / plain RN)',
       '/bin/sh "$PODS_ROOT/../.."/node_modules/react-native/scripts/react-native-xcode.sh',
     ],
-  ])(
-    'arg1 passed to posthog-xcode.sh is react-native-xcode.sh path, not /bin/sh — %s',
-    (_desc, original) => {
-      const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
-      const arg1 = extractArg1(wrapped)
-      expect(arg1).toContain('react-native-xcode.sh')
-      expect(arg1).not.toBe('/bin/sh')
-    }
-  )
+  ])('arg1 passed to posthog-xcode.sh is react-native-xcode.sh path, not /bin/sh — %s', (_desc, original) => {
+    const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
+    const arg1 = extractArg1(wrapped)
+    expect(arg1).toContain('react-native-xcode.sh')
+    expect(arg1).not.toBe('/bin/sh')
+  })
 })
 
 describe('modifyExistingXcodeBuildScript', () => {

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -86,27 +86,21 @@ describe('addPostHogWithBundledScriptsToBundleShellScript', () => {
   // Expo SDK 53+ and plain RN projects), posthog-xcode.sh receives /bin/sh as
   // $1, which makes the REACT_NATIVE_XCODE variable resolve to /bin/sh instead
   // of react-native-xcode.sh, silently breaking the PACKAGER_SOURCEMAP_FILE patch.
-
-  it('arg1 passed to posthog-xcode.sh is react-native-xcode.sh path, not /bin/sh — simple path (no shell prefix)', () => {
-    // Typical Expo bundle phase: just the bare path, no /bin/sh prefix.
-    const original = '../node_modules/react-native/scripts/react-native-xcode.sh'
-    const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
-    const arg1 = extractArg1(wrapped)
-    // $1 must point at the RN script, not at an interpreter
-    expect(arg1).toContain('react-native-xcode.sh')
-    expect(arg1).not.toBe('/bin/sh')
-  })
-
-  it('arg1 passed to posthog-xcode.sh is react-native-xcode.sh path, not /bin/sh — shell-prefixed command (Expo SDK 53+ / plain RN)', () => {
-    // This is the format that triggers issue #3682:
-    // the bundle phase already starts with "/bin/sh", so after wrapping,
-    // $1 inside posthog-xcode.sh becomes "/bin/sh" instead of the RN script path.
-    const original = '/bin/sh "$PODS_ROOT/../.."/node_modules/react-native/scripts/react-native-xcode.sh'
-    const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
-    const arg1 = extractArg1(wrapped)
-    expect(arg1).toContain('react-native-xcode.sh')
-    expect(arg1).not.toBe('/bin/sh')
-  })
+  it.each([
+    ['simple path (no shell prefix)', '../node_modules/react-native/scripts/react-native-xcode.sh'],
+    [
+      'shell-prefixed command (Expo SDK 53+ / plain RN)',
+      '/bin/sh "$PODS_ROOT/../.."/node_modules/react-native/scripts/react-native-xcode.sh',
+    ],
+  ])(
+    'arg1 passed to posthog-xcode.sh is react-native-xcode.sh path, not /bin/sh — %s',
+    (_desc, original) => {
+      const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
+      const arg1 = extractArg1(wrapped)
+      expect(arg1).toContain('react-native-xcode.sh')
+      expect(arg1).not.toBe('/bin/sh')
+    }
+  )
 })
 
 describe('modifyExistingXcodeBuildScript', () => {

--- a/packages/react-native/test/posthog-xcode-parse.spec.ts
+++ b/packages/react-native/test/posthog-xcode-parse.spec.ts
@@ -7,6 +7,9 @@ import * as path from 'path'
  * to parse a git remote URL into {host, owner/repo}. Rather than re-declare
  * the regexes here (and risk drift), we extract them at test runtime from the
  * shell script itself — so the tests cannot diverge from the source.
+ *
+ * Also contains regression tests for issue #3682: posthog-xcode.sh was
+ * resolving REACT_NATIVE_XCODE to /bin/sh when invoked by the Expo plugin.
  */
 
 const SCRIPT_PATH = path.resolve(__dirname, '..', 'tooling', 'posthog-xcode.sh')
@@ -64,5 +67,51 @@ describe('posthog-xcode.sh remote URL parsing', () => {
   it('constructs the expected remote_url for self-hosted', () => {
     const { host, repo } = parse('git@git.corp.internal:team/repo.git')
     expect(`https://${host}/${repo}.git`).toBe('https://git.corp.internal/team/repo.git')
+  })
+})
+
+// Regression tests for issue #3682:
+// The Expo plugin wraps the bundle phase as:
+//   /bin/sh posthog-xcode.sh /bin/sh react-native-xcode.sh ...
+// making $1 = /bin/sh inside posthog-xcode.sh.  REACT_NATIVE_XCODE then
+// resolves to /bin/sh (a binary), so the grep/sed patch against it silently
+// no-ops and the packager sourcemap is deleted before posthog-cli reads it.
+describe('posthog-xcode.sh REACT_NATIVE_XCODE resolution', () => {
+  const scriptContents = fs.readFileSync(SCRIPT_PATH, 'utf8')
+
+  // Extract the REACT_NATIVE_XCODE_DEFAULT + resolution block from the script
+  // so the tests track the actual source and cannot silently diverge from it.
+  const extractAssignmentBlock = (): string => {
+    // Match from REACT_NATIVE_XCODE_DEFAULT=... through the closing `fi` of
+    // the if/else guard (or a plain assignment if the structure changes again).
+    const match = scriptContents.match(
+      /REACT_NATIVE_XCODE_DEFAULT="[^"]+"[\s\S]+?(?:fi|REACT_NATIVE_XCODE="\$\{[^}]+\}")/
+    )
+    if (!match) throw new Error('Could not locate REACT_NATIVE_XCODE assignment in posthog-xcode.sh')
+    return match[0]
+  }
+
+  const resolveReactNativeXcode = (arg1: string): string => {
+    const block = extractAssignmentBlock()
+    // Run the extracted shell fragment with $1 set to the provided value and
+    // print the resulting REACT_NATIVE_XCODE variable.
+    const script = `${block}\nprintf '%s' "$REACT_NATIVE_XCODE"`
+    const escaped = arg1.replace(/'/g, `'\\''`)
+    return execSync(`/bin/bash -c 'set -- '"'"'${escaped}'"'"'; ${script}'`).toString()
+  }
+
+  it('resolves to react-native-xcode.sh when $1 is the RN script path (no shell prefix)', () => {
+    const rnScript = '../node_modules/react-native/scripts/react-native-xcode.sh'
+    const result = resolveReactNativeXcode(rnScript)
+    expect(result).toBe(rnScript)
+    expect(result).not.toBe('/bin/sh')
+  })
+
+  it('does NOT resolve to /bin/sh when $1 is /bin/sh (issue #3682 — Expo shell-prefixed bundle phase)', () => {
+    // This is the broken state: the Expo plugin passes /bin/sh as $1.
+    // The test currently FAILS (documents the bug). Once the fix is applied it must PASS.
+    const result = resolveReactNativeXcode('/bin/sh')
+    expect(result).not.toBe('/bin/sh')
+    expect(result).toContain('react-native-xcode.sh')
   })
 })

--- a/packages/react-native/test/posthog-xcode-parse.spec.ts
+++ b/packages/react-native/test/posthog-xcode-parse.spec.ts
@@ -100,17 +100,11 @@ describe('posthog-xcode.sh REACT_NATIVE_XCODE resolution', () => {
     return execSync(`/bin/bash -c 'set -- '"'"'${escaped}'"'"'; ${script}'`).toString()
   }
 
-  it('resolves to react-native-xcode.sh when $1 is the RN script path (no shell prefix)', () => {
-    const rnScript = '../node_modules/react-native/scripts/react-native-xcode.sh'
-    const result = resolveReactNativeXcode(rnScript)
-    expect(result).toBe(rnScript)
-    expect(result).not.toBe('/bin/sh')
-  })
-
-  it('does NOT resolve to /bin/sh when $1 is /bin/sh (issue #3682 — Expo shell-prefixed bundle phase)', () => {
-    // This is the broken state: the Expo plugin passes /bin/sh as $1.
-    // The test currently FAILS (documents the bug). Once the fix is applied it must PASS.
-    const result = resolveReactNativeXcode('/bin/sh')
+  it.each([
+    ['RN script path', '../node_modules/react-native/scripts/react-native-xcode.sh'],
+    ['/bin/sh (issue #3682 — Expo shell-prefixed bundle phase)', '/bin/sh'],
+  ])('REACT_NATIVE_XCODE resolves to react-native-xcode.sh path when $1 is %s', (_desc, arg1) => {
+    const result = resolveReactNativeXcode(arg1)
     expect(result).not.toBe('/bin/sh')
     expect(result).toContain('react-native-xcode.sh')
   })

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -13,7 +13,13 @@ export PATH="/usr/bin:/usr/local/bin:/opt/homebrew/bin:$HOME/.cargo/bin:$HOME/.l
 # WITH_ENVIRONMENT is executed by React Native
 
 REACT_NATIVE_XCODE_DEFAULT="../node_modules/react-native/scripts/react-native-xcode.sh"
-REACT_NATIVE_XCODE="${1:-$REACT_NATIVE_XCODE_DEFAULT}"
+# Accept $1 only when it actually points at a shell script; guard against the
+# Expo plugin previously passing "/bin/sh" as $1 (issue #3682).
+if [[ "${1:-}" == *.sh ]]; then
+  REACT_NATIVE_XCODE="$1"
+else
+  REACT_NATIVE_XCODE="$REACT_NATIVE_XCODE_DEFAULT"
+fi
 
 # Check if DERIVED_FILE_DIR exists, defined by Xcode
 if [ ! -d "$DERIVED_FILE_DIR" ]; then


### PR DESCRIPTION
## Problem

Closes #3682

iOS Release builds using the Expo config plugin (`posthog-react-native/expo`) fail on Hermes + RN ≥ 0.81 with:

```
ERROR posthog_cli::commands: msg="Oops! Failed to load minified map at '...main.jsbundle.map': No such file or directory (os error 2)"
```

When the Expo bundle phase already starts with `/bin/sh`, the plugin wraps it as:

```sh
/bin/sh posthog-xcode.sh /bin/sh react-native-xcode.sh ...
```

So `$1` inside `posthog-xcode.sh` resolves to `/bin/sh` instead of `react-native-xcode.sh`. The `grep`/`sed` patch that preserves `PACKAGER_SOURCEMAP_FILE` silently no-ops (grepping a binary), RN deletes the packager map, and `posthog-cli hermes clone` hard-fails trying to read it.

## Changes

**`src/tooling/expoconfig.ts`** — updated the regex in `addPostHogWithBundledScriptsToBundleShellScript` to capture only the RN script path (stripping any leading `/bin/sh` prefix) before passing it as `$1` to `posthog-xcode.sh`.

**`tooling/posthog-xcode.sh`** — added a `*.sh` guard on `REACT_NATIVE_XCODE`: if `$1` is not a `.sh` path, fall back to `$REACT_NATIVE_XCODE_DEFAULT`. Defence-in-depth against future caller variations.

**`test/expoconfig.spec.ts`** + **`test/posthog-xcode-parse.spec.ts`** — regression tests written first to reproduce the bug, now passing with the fix.

## How this is tested

The regression tests were written _before_ the fix to confirm they reproduced the bug, then the fix was applied:

- `expoconfig.spec.ts` — two new tests assert that the first positional argument (`$1`) passed to `posthog-xcode.sh` is the `react-native-xcode.sh` path for both the bare-path and `/bin/sh`-prefixed bundle phase formats. The second test failed before the fix and passes after.
- `posthog-xcode-parse.spec.ts` — a shell-level test extracts the `REACT_NATIVE_XCODE` assignment block directly from the script source and runs it via `bash -c` with `/bin/sh` as `$1`, asserting the resolved value is not `/bin/sh`. This failed before the fix and passes after.

All 337 tests pass.

## Why we didn't implement Option 2 from the issue

The issue suggested skipping `PACKAGER_SOURCEMAP_FILE` entirely and uploading `SOURCEMAP_FILE` directly. However, `posthog-cli hermes clone` requires `--minified-map-path` (the packager map) as an input — it copies `chunk_id` and `release_id` metadata from the pre-Hermes JS source map into the final composed map. Without it, the clone step has nothing to read from. Eliminating this dependency would require a `posthog-cli` change to derive chunk metadata from `SOURCEMAP_FILE` directly, which is a separate future improvement.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file