### PR TITLE
fix(replay): fix idle session rotation race condition

### DIFF
--- a/.changeset/fix-replay-idle-rotation-snapshot.md
+++ b/.changeset/fix-replay-idle-rotation-snapshot.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(replay): take a fresh full snapshot after session ID rotates via `forcedIdleReset`. Previously, when the session manager's idle enforcement timer rotated the session id, the recorder tore down rrweb and set `_isIdle = 'unknown'` before the new session id was observed. Neither restart path then fired (the `_onSessionIdCallback` guard only restarted when `_isIdle === true`, and `_updateWindowAndSessionIds` could not run with rrweb stopped), so the new session received only incremental mutations until a later snapshot — leaving the player stuck on "Buffering". The restart guard now also fires when rrweb isn't running.

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1260,6 +1260,44 @@ describe('Lazy SessionRecording', () => {
                 const recorderSessionId = sessionRecording['_lazyLoadedSessionRecording']['_sessionId']
                 expect(recorderSessionId).toEqual(rotatedSessionId)
             })
+
+            it('restarts recorder when session rotates via forcedIdleReset', () => {
+                // After forcedIdleReset, _isIdle is 'unknown' and rrweb is stopped; the
+                // session-id callback must still restart so the new session gets a full snapshot.
+                const firstActivityTimestamp = startingTimestamp + 100
+                const idleTriggerTimestamp = startingTimestamp + RECORDING_IDLE_THRESHOLD_MS + 1000
+
+                emitActiveEvent(firstActivityTimestamp)
+                const firstSessionId = sessionRecording['_lazyLoadedSessionRecording']['_sessionId']
+
+                const recordMock = assignableWindow.__PosthogExtensions__.rrweb.record as Mock
+                expect(recordMock).toHaveBeenCalledTimes(1)
+
+                emitInactiveEvent(idleTriggerTimestamp, true)
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_isIdle']).toEqual(true)
+
+                sessionIdGeneratorMock.mockClear()
+                const rotatedSessionId = 'forced-idle-rotated-session-id'
+                sessionIdGeneratorMock.mockImplementation(() => rotatedSessionId)
+                sessionManager.resetSessionId()
+                sessionManager['_eventEmitter'].emit('forcedIdleReset', { idleSessionId: firstSessionId })
+
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_isIdle']).toEqual('unknown')
+                expect(sessionRecording['_lazyLoadedSessionRecording']['isStarted']).toEqual(false)
+
+                const rotationTimestamp = idleTriggerTimestamp + 1000
+                jest.useFakeTimers().setSystemTime(new Date(rotationTimestamp))
+                const { sessionId: newSessionId } = sessionManager.checkAndGetSessionAndWindowId(
+                    false,
+                    rotationTimestamp
+                )
+                expect(newSessionId).toEqual(rotatedSessionId)
+                expect(newSessionId).not.toEqual(firstSessionId)
+
+                expect(recordMock).toHaveBeenCalledTimes(2)
+                expect(sessionRecording['_lazyLoadedSessionRecording']['_sessionId']).toEqual(rotatedSessionId)
+                expect(sessionRecording['_lazyLoadedSessionRecording']['isStarted']).toEqual(true)
+            })
         })
 
         describe('scheduled full snapshots', () => {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -1099,10 +1099,9 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         this._clearConditionalRecordingPersistence()
 
-        // When idle, _updateWindowAndSessionIds bails early and won't pick up the
-        // session change, so we restart here. Otherwise it handles the restart after
-        // this callback returns.
-        if (this._isIdle === true) {
+        // When rrweb isn't running _updateWindowAndSessionIds can't drive the restart,
+        // so we restart here. Otherwise it handles the restart after this callback returns.
+        if (this._isIdle === true || !this.isStarted) {
             this._isIdle = 'unknown'
             this.stop()
             this.start('session_id_changed')


### PR DESCRIPTION
## Problem

A customer reported a session replay stuck on "Buffering" for ~5 minutes. Investigating the recording showed the session ID had rotated due to an inactivity gap right before recording resumed, and the first DOM full snapshot landed under the OLD session ID. The new session received only incremental mutations until the next periodic snapshot fired, so rrweb had nothing to paint onto and the player sat spinning.

Root cause: a hole in the `forcedIdleReset` path in `lazy-loaded-session-recorder.ts`.

Two paths normally re-snapshot on session rotation:
- **Path A** — `_onSessionIdCallback` restarts rrweb when `_isIdle === true`
- **Path B** — `_updateWindowAndSessionIds` (driven by `onRRwebEmit`) restarts rrweb on session change for non-idle rotations

When the session manager's idle enforcement timer fires `forcedIdleReset`, the listener sets `_isIdle = 'unknown'` and calls `stop()` BEFORE the new session id is observed. When `_onSessionIdCallback` subsequently fires for the rotated id:
- `_isIdle` is `'unknown'`, not `true` → Path A's guard misses
- rrweb is already torn down → Path B can never fire (no events to emit)

The recorder ends up running under the new session id with no rrweb instance and no full snapshot, until something else restarts recording.

## Changes

- `_onSessionIdCallback`: extend the restart guard to also fire when rrweb isn't running (`!this.isStarted`). `stop()` is safe to call when already stopped, and the `isStarted` getter already exists at line 867.
- Add a regression test that simulates the `forcedIdleReset` path and asserts `rrweb.record` is called a second time after the rotation.

Diff is tiny — one boolean condition + one test. No new abstractions.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran \`pnpm changeset\` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*