### PR TITLE
fix(core): stop leaking DOM globals into public type surface

### DIFF
--- a/.changeset/fix-rn-generate-references.md
+++ b/.changeset/fix-rn-generate-references.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+Avoid leaking DOM-only globals (`ErrorEvent`, `PromiseRejectionEvent`, `Event`) into `@posthog/core`'s public type surface by typing the relevant coercers with structural subsets. Fixes `generate-references` failing in `posthog-react-native` whose tsconfig `lib` excludes DOM.

--- a/.changeset/fix-rn-generate-references.md
+++ b/.changeset/fix-rn-generate-references.md
@@ -1,5 +1,0 @@
----
-'@posthog/core': patch
----
-
-Avoid leaking DOM-only globals (`ErrorEvent`, `PromiseRejectionEvent`, `Event`) into `@posthog/core`'s public type surface by typing the relevant coercers with structural subsets. Fixes `generate-references` failing in `posthog-react-native` whose tsconfig `lib` excludes DOM.

--- a/packages/core/src/error-tracking/coercers/error-event-coercer.ts
+++ b/packages/core/src/error-tracking/coercers/error-event-coercer.ts
@@ -1,14 +1,23 @@
 import { CoercingContext, ErrorTrackingCoercer, ExceptionLike } from '../types'
 import { isErrorEvent } from '@/utils'
 
-export class ErrorEventCoercer implements ErrorTrackingCoercer<ErrorEvent> {
+// Structural subset of the DOM `ErrorEvent`. Avoids leaking a DOM-only global
+// into the public type surface so non-DOM consumers (e.g. React Native, whose
+// tsconfig lib excludes DOM) can still consume `@posthog/core` types via tools
+// like api-extractor that resolve symbols transitively.
+interface ErrorEventLike {
+  message: string
+  error?: unknown
+}
+
+export class ErrorEventCoercer implements ErrorTrackingCoercer<ErrorEventLike> {
   constructor() {}
 
-  match(err: unknown): err is ErrorEvent {
-    return isErrorEvent(err) && (err as ErrorEvent).error != undefined
+  match(err: unknown): err is ErrorEventLike {
+    return isErrorEvent(err) && (err as ErrorEventLike).error != undefined
   }
 
-  coerce(err: ErrorEvent, ctx: CoercingContext): ExceptionLike {
+  coerce(err: ErrorEventLike, ctx: CoercingContext): ExceptionLike {
     const exceptionLike = ctx.apply(err.error)
     if (!exceptionLike) {
       return {

--- a/packages/core/src/error-tracking/coercers/promise-rejection-event.ts
+++ b/packages/core/src/error-tracking/coercers/promise-rejection-event.ts
@@ -1,13 +1,21 @@
 import { isBuiltin, isEvent, isPrimitive } from '@/utils'
 import { CoercingContext, ErrorTrackingCoercer, ExceptionLike } from '../types'
 
-type EventWithDetailReason = Event & { detail: { reason: unknown } }
+// Structural subsets of the DOM `PromiseRejectionEvent` / `Event`. Avoids leaking
+// DOM-only globals into the public type surface so non-DOM consumers (e.g. React
+// Native, whose tsconfig lib excludes DOM) can still consume `@posthog/core`
+// types via tools like api-extractor that resolve symbols transitively.
+interface PromiseRejectionEventLike {
+  reason: unknown
+}
+interface EventWithDetailReason {
+  detail: { reason: unknown }
+}
+type RejectionLike = PromiseRejectionEventLike | EventWithDetailReason
 
 // Web only
-export class PromiseRejectionEventCoercer implements ErrorTrackingCoercer<
-  PromiseRejectionEvent | EventWithDetailReason
-> {
-  match(err: unknown): err is PromiseRejectionEvent | EventWithDetailReason {
+export class PromiseRejectionEventCoercer implements ErrorTrackingCoercer<RejectionLike> {
+  match(err: unknown): err is RejectionLike {
     return isBuiltin(err, 'PromiseRejectionEvent') || this.isCustomEventWrappingRejection(err)
   }
 
@@ -16,14 +24,14 @@ export class PromiseRejectionEventCoercer implements ErrorTrackingCoercer<
       return false
     }
     try {
-      const detail = (err as EventWithDetailReason).detail
+      const detail = (err as unknown as EventWithDetailReason).detail
       return detail != null && typeof detail === 'object' && 'reason' in detail
     } catch {
       return false
     }
   }
 
-  coerce(err: PromiseRejectionEvent | EventWithDetailReason, ctx: CoercingContext): ExceptionLike | undefined {
+  coerce(err: RejectionLike, ctx: CoercingContext): ExceptionLike | undefined {
     const reason = this.getUnhandledRejectionReason(err)
     if (isPrimitive(reason)) {
       return {
@@ -37,7 +45,7 @@ export class PromiseRejectionEventCoercer implements ErrorTrackingCoercer<
     }
   }
 
-  private getUnhandledRejectionReason(error: PromiseRejectionEvent | EventWithDetailReason): unknown {
+  private getUnhandledRejectionReason(error: RejectionLike): unknown {
     try {
       // PromiseRejectionEvents store the object of the rejection under 'reason'
       // see https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent


### PR DESCRIPTION
## Problem

The `Bump versions and commit to main` step of the release workflow was failing because `posthog-react-native#generate-references` errored with:

> ERROR: Internal Error: Unable to follow symbol for "ErrorEvent"

After fixing that, the same failure surfaced for `PromiseRejectionEvent`. (Failed run: https://github.com/PostHog/posthog-js/actions/runs/26583417207)

Root cause: PR #3681 (`fix: unify capture exception`) added `createErrorPropertiesBuilder` to `posthog-rn.ts`, which references `CoreErrorTracking.ErrorEventCoercer` / `PromiseRejectionEventCoercer`. Those classes are typed `ErrorTrackingCoercer<ErrorEvent>` / `ErrorTrackingCoercer<PromiseRejectionEvent | EventWithDetailReason>` in `@posthog/core`. The emitted `.d.ts` files therefore reference DOM-only globals (`ErrorEvent`, `PromiseRejectionEvent`, `Event`). When api-extractor analyses the react-native package — whose tsconfig `lib` is `["ESNext"]` and excludes DOM — it cannot resolve those symbols and aborts.

The browser package (`posthog-js`) doesn't hit this because its tsconfig includes DOM. The release-workflow bump step still fails because it runs `generate-references` across all three publishable packages.

## Changes

Replace the DOM-typed generic parameters on `ErrorEventCoercer` and `PromiseRejectionEventCoercer` with structural subsets that capture only the fields actually read at runtime (`message`, `error`, `reason`, `detail.reason`). Runtime behaviour, `match()` semantics, and the public class shapes are unchanged; the emitted `.d.ts` files no longer reference DOM globals, so api-extractor can analyse them in a non-DOM tsconfig.

Verified locally:
- `pnpm exec turbo --filter=posthog-js --filter=posthog-node --filter=posthog-react-native generate-references` now passes for all three packages.
- `@posthog/core` unit tests: 587 passed.
- `posthog-react-native` unit tests: 333 passed.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

(`@posthog/core` patch — pulled in transitively by every dependent SDK on the next release.)

## Checklist

- [x] Tests for new code (covered by existing coercer tests; behaviour unchanged)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran \`pnpm changeset\` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*