### PR TITLE
fix(react-native): preserve property types for flag evaluation

### DIFF
--- a/.changeset/typed-flag-properties-rn.md
+++ b/.changeset/typed-flag-properties-rn.md
@@ -1,0 +1,6 @@
+---
+'posthog-react-native': patch
+'@posthog/core': patch
+---
+
+fix(react-native): preserve non-string property types (booleans, arrays, numbers, objects) when caching person and group properties for feature flag evaluation. Previously these were force-coerced to strings via `String(value)`, causing flag conditions using boolean equality or array `contains` to fail on device while the PostHog UI still evaluated correctly.

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -535,11 +535,11 @@ export abstract class PostHogCore extends PostHogCoreStateless {
     })
   }
 
-  setGroupPropertiesForFlags(properties: { [type: string]: Record<string, string> }): void {
+  setGroupPropertiesForFlags(properties: { [type: string]: Record<string, JsonType> }): void {
     this.wrap(() => {
       // Get persisted group properties
       const existingProperties =
-        this.getPersistedProperty<Record<string, Record<string, string>>>(PostHogPersistedProperty.GroupProperties) ||
+        this.getPersistedProperty<Record<string, Record<string, JsonType>>>(PostHogPersistedProperty.GroupProperties) ||
         {}
 
       if (Object.keys(existingProperties).length !== 0) {

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -701,7 +701,7 @@ export class PostHog extends PostHogCore {
    * @param reloadFeatureFlags Whether to reload feature flags after setting the properties. Defaults to true.
    */
   private _setDefaultPersonPropertiesForFlags(reloadFeatureFlags = true): void {
-    const defaultProps: Record<string, string> = {}
+    const defaultProps: Record<string, JsonType> = {}
     const relevantKeys = [
       '$app_version',
       '$app_build',
@@ -714,16 +714,16 @@ export class PostHog extends PostHogCore {
     relevantKeys.forEach((key) => {
       const value = this._appProperties[key]
       if (value !== null && value !== undefined) {
-        defaultProps[key] = String(value)
+        defaultProps[key] = value
       }
     })
 
     const commonProps = this.getCommonEventProperties()
     if (commonProps.$lib) {
-      defaultProps.$lib = String(commonProps.$lib)
+      defaultProps.$lib = commonProps.$lib as JsonType
     }
     if (commonProps.$lib_version) {
-      defaultProps.$lib_version = String(commonProps.$lib_version)
+      defaultProps.$lib_version = commonProps.$lib_version as JsonType
     }
 
     if (Object.keys(defaultProps).length > 0) {
@@ -1041,11 +1041,11 @@ export class PostHog extends PostHogCore {
 
     // Automatically cache group properties for feature flag evaluation
     if (properties && Object.keys(properties).length > 0) {
-      const propsToCache: Record<string, string> = {}
+      const propsToCache: Record<string, JsonType> = {}
       Object.keys(properties).forEach((key) => {
         const value = properties[key]
         if (value !== null && value !== undefined) {
-          propsToCache[key] = String(value)
+          propsToCache[key] = value as JsonType
         }
       })
       if (Object.keys(propsToCache).length > 0) {
@@ -1188,7 +1188,7 @@ export class PostHog extends PostHogCore {
    * @param properties The group properties to set for flag evaluation
    * @param reloadFeatureFlags Whether to reload feature flags after setting the properties. Defaults to true.
    */
-  setGroupPropertiesForFlags(properties: Record<string, Record<string, string>>, reloadFeatureFlags = true): void {
+  setGroupPropertiesForFlags(properties: Record<string, Record<string, JsonType>>, reloadFeatureFlags = true): void {
     super.setGroupPropertiesForFlags(properties)
 
     if (reloadFeatureFlags) {
@@ -1513,20 +1513,20 @@ export class PostHog extends PostHogCore {
 
     // Automatically cache person properties for feature flag evaluation
 
-    const propsToCache: Record<string, string> = {}
+    const propsToCache: Record<string, JsonType> = {}
     if (userProps) {
       Object.entries(userProps).forEach(([key, value]) => {
         if (value !== null && value !== undefined) {
-          propsToCache[key] = String(value)
+          propsToCache[key] = value as JsonType
         }
       })
     }
 
-    const propsOnceToCache: Record<string, string> = {}
+    const propsOnceToCache: Record<string, JsonType> = {}
     if (userPropsOnce && typeof userPropsOnce === 'object') {
       Object.entries(userPropsOnce as Record<string, unknown>).forEach(([key, value]) => {
         if (value !== null && value !== undefined) {
-          propsOnceToCache[key] = String(value)
+          propsOnceToCache[key] = value as JsonType
         }
       })
     }

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -720,10 +720,10 @@ export class PostHog extends PostHogCore {
 
     const commonProps = this.getCommonEventProperties()
     if (commonProps.$lib) {
-      defaultProps.$lib = commonProps.$lib as JsonType
+      defaultProps.$lib = commonProps.$lib
     }
     if (commonProps.$lib_version) {
-      defaultProps.$lib_version = commonProps.$lib_version as JsonType
+      defaultProps.$lib_version = commonProps.$lib_version
     }
 
     if (Object.keys(defaultProps).length > 0) {
@@ -1045,7 +1045,7 @@ export class PostHog extends PostHogCore {
       Object.keys(properties).forEach((key) => {
         const value = properties[key]
         if (value !== null && value !== undefined) {
-          propsToCache[key] = value as JsonType
+          propsToCache[key] = value
         }
       })
       if (Object.keys(propsToCache).length > 0) {
@@ -1514,19 +1514,19 @@ export class PostHog extends PostHogCore {
     // Automatically cache person properties for feature flag evaluation
 
     const propsToCache: Record<string, JsonType> = {}
-    if (userProps) {
+    if (userProps && typeof userProps === 'object' && !Array.isArray(userProps)) {
       Object.entries(userProps).forEach(([key, value]) => {
         if (value !== null && value !== undefined) {
-          propsToCache[key] = value as JsonType
+          propsToCache[key] = value
         }
       })
     }
 
     const propsOnceToCache: Record<string, JsonType> = {}
-    if (userPropsOnce && typeof userPropsOnce === 'object') {
-      Object.entries(userPropsOnce as Record<string, unknown>).forEach(([key, value]) => {
+    if (userPropsOnce && typeof userPropsOnce === 'object' && !Array.isArray(userPropsOnce)) {
+      Object.entries(userPropsOnce).forEach(([key, value]) => {
         if (value !== null && value !== undefined) {
-          propsOnceToCache[key] = value as JsonType
+          propsOnceToCache[key] = value
         }
       })
     }

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -838,6 +838,33 @@ describe('PostHog React Native', () => {
         expect(cachedProps).toEqual({ email: 'test@example.com', plan: 'premium' })
       })
 
+      it('should preserve non-string types (boolean, array, number, object) in person properties', async () => {
+        posthog.identify('user-123', {
+          $set: {
+            hasApprovedSubscription: true,
+            user_categories: ['wl'],
+            score: 7,
+            nested: { x: 1, deep: ['a', 'b'] },
+          },
+          $set_once: {
+            initial_signup_completed: false,
+            signup_steps: ['email', 'plan'],
+          },
+        })
+
+        const cachedProps = posthog.getPersistedProperty(PostHogPersistedProperty.PersonProperties)
+        expect(cachedProps).toEqual({
+          hasApprovedSubscription: true,
+          user_categories: ['wl'],
+          score: 7,
+          nested: { x: 1, deep: ['a', 'b'] },
+          initial_signup_completed: false,
+          signup_steps: ['email', 'plan'],
+        })
+        expect(cachedProps.hasApprovedSubscription).not.toBe('true')
+        expect(cachedProps.user_categories).not.toBe('wl')
+      })
+
       it('should cache $set_once properties with set-once semantics', async () => {
         posthog.identify('user-123', {
           $set: { email: 'test@example.com' },
@@ -931,7 +958,7 @@ describe('PostHog React Native', () => {
         posthog.group('company', 'acme-inc', { name: 'Acme Inc', employees: 50 })
 
         const cachedProps = posthog.getPersistedProperty(PostHogPersistedProperty.GroupProperties)
-        expect(cachedProps).toEqual({ company: { name: 'Acme Inc', employees: '50' } })
+        expect(cachedProps).toEqual({ company: { name: 'Acme Inc', employees: 50 } })
       })
 
       it('should merge group properties from multiple group() calls', async () => {
@@ -939,7 +966,28 @@ describe('PostHog React Native', () => {
         posthog.group('company', 'acme-inc', { employees: 50 })
 
         const cachedProps = posthog.getPersistedProperty(PostHogPersistedProperty.GroupProperties)
-        expect(cachedProps).toEqual({ company: { name: 'Acme Inc', employees: '50' } })
+        expect(cachedProps).toEqual({ company: { name: 'Acme Inc', employees: 50 } })
+      })
+
+      it('should preserve non-string types (boolean, array, number, object) for group properties', async () => {
+        posthog.group('company', 'acme-inc', {
+          plan_active: true,
+          seats: 10,
+          tags: ['enterprise', 'beta'],
+          metadata: { region: 'us', tier: 1 },
+        })
+
+        const cachedProps = posthog.getPersistedProperty(PostHogPersistedProperty.GroupProperties)
+        expect(cachedProps).toEqual({
+          company: {
+            plan_active: true,
+            seats: 10,
+            tags: ['enterprise', 'beta'],
+            metadata: { region: 'us', tier: 1 },
+          },
+        })
+        expect(cachedProps.company.plan_active).not.toBe('true')
+        expect(cachedProps.company.tags).not.toBe('enterprise,beta')
       })
 
       it('should handle multiple group types', async () => {

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -2,7 +2,17 @@ import { PostHog, PostHogCustomStorage, PostHogPersistedProperty } from '../src'
 import { Linking, AppState, AppStateStatus } from 'react-native'
 import { waitForExpect } from './test-utils'
 import { PostHogRNStorage, createEventsStorage } from '../src/storage'
-import { FeatureFlagError } from '@posthog/core'
+import { FeatureFlagError, JsonType } from '@posthog/core'
+
+const typePreservationCases: Array<{ name: string; value: JsonType; buggyString: string }> = [
+  { name: 'boolean true', value: true, buggyString: 'true' },
+  { name: 'boolean false', value: false, buggyString: 'false' },
+  { name: 'number', value: 7, buggyString: '7' },
+  { name: 'zero', value: 0, buggyString: '0' },
+  { name: 'array of strings', value: ['wl', 'beta'], buggyString: 'wl,beta' },
+  { name: 'empty array', value: [], buggyString: '' },
+  { name: 'nested object', value: { x: 1, deep: ['a', 'b'] }, buggyString: '[object Object]' },
+]
 
 Linking.getInitialURL = jest.fn(() => Promise.resolve(null))
 AppState.addEventListener = jest.fn()
@@ -838,32 +848,31 @@ describe('PostHog React Native', () => {
         expect(cachedProps).toEqual({ email: 'test@example.com', plan: 'premium' })
       })
 
-      it('should preserve non-string types (boolean, array, number, object) in person properties', async () => {
-        posthog.identify('user-123', {
-          $set: {
-            hasApprovedSubscription: true,
-            user_categories: ['wl'],
-            score: 7,
-            nested: { x: 1, deep: ['a', 'b'] },
-          },
-          $set_once: {
-            initial_signup_completed: false,
-            signup_steps: ['email', 'plan'],
-          },
-        })
+      it.each(typePreservationCases)(
+        'preserves $name in $set person properties (no String() coercion)',
+        ({ value, buggyString }) => {
+          posthog.identify('user-123', { $set: { prop: value } })
 
-        const cachedProps = posthog.getPersistedProperty(PostHogPersistedProperty.PersonProperties)
-        expect(cachedProps).toEqual({
-          hasApprovedSubscription: true,
-          user_categories: ['wl'],
-          score: 7,
-          nested: { x: 1, deep: ['a', 'b'] },
-          initial_signup_completed: false,
-          signup_steps: ['email', 'plan'],
-        })
-        expect(cachedProps.hasApprovedSubscription).not.toBe('true')
-        expect(cachedProps.user_categories).not.toBe('wl')
-      })
+          const cachedProps = posthog.getPersistedProperty<Record<string, JsonType>>(
+            PostHogPersistedProperty.PersonProperties
+          )
+          expect(cachedProps?.prop).toEqual(value)
+          expect(cachedProps?.prop).not.toBe(buggyString)
+        }
+      )
+
+      it.each(typePreservationCases)(
+        'preserves $name in $set_once person properties (no String() coercion)',
+        ({ value, buggyString }) => {
+          posthog.identify('user-123', { $set_once: { prop: value } })
+
+          const cachedProps = posthog.getPersistedProperty<Record<string, JsonType>>(
+            PostHogPersistedProperty.PersonProperties
+          )
+          expect(cachedProps?.prop).toEqual(value)
+          expect(cachedProps?.prop).not.toBe(buggyString)
+        }
+      )
 
       it('should cache $set_once properties with set-once semantics', async () => {
         posthog.identify('user-123', {
@@ -969,26 +978,18 @@ describe('PostHog React Native', () => {
         expect(cachedProps).toEqual({ company: { name: 'Acme Inc', employees: 50 } })
       })
 
-      it('should preserve non-string types (boolean, array, number, object) for group properties', async () => {
-        posthog.group('company', 'acme-inc', {
-          plan_active: true,
-          seats: 10,
-          tags: ['enterprise', 'beta'],
-          metadata: { region: 'us', tier: 1 },
-        })
+      it.each(typePreservationCases)(
+        'preserves $name in group properties (no String() coercion)',
+        ({ value, buggyString }) => {
+          posthog.group('company', 'acme-inc', { prop: value })
 
-        const cachedProps = posthog.getPersistedProperty(PostHogPersistedProperty.GroupProperties)
-        expect(cachedProps).toEqual({
-          company: {
-            plan_active: true,
-            seats: 10,
-            tags: ['enterprise', 'beta'],
-            metadata: { region: 'us', tier: 1 },
-          },
-        })
-        expect(cachedProps.company.plan_active).not.toBe('true')
-        expect(cachedProps.company.tags).not.toBe('enterprise,beta')
-      })
+          const cachedProps = posthog.getPersistedProperty<Record<string, Record<string, JsonType>>>(
+            PostHogPersistedProperty.GroupProperties
+          )
+          expect(cachedProps?.company.prop).toEqual(value)
+          expect(cachedProps?.company.prop).not.toBe(buggyString)
+        }
+      )
 
       it('should handle multiple group types', async () => {
         posthog.group('company', 'acme-inc', { name: 'Acme Inc' })


### PR DESCRIPTION
## Summary

- After PR #2564, `posthog-react-native` (4.43.x) started attaching cached person/group properties to every `/flags` request — but the RN call sites coerced every value via `String(value)`. Booleans became `"true"`, arrays became `"wl"`, nested objects became `"[object Object]"`. Flag conditions using boolean equality or array `contains` then failed on device while the PostHog UI still evaluated correctly against the properly-typed stored profile, producing a device-vs-UI split for the same user / flag / moment after upgrading 4.10.5 → 4.43.x.
- The fix drops the `String()` coercion at the three internal call sites (`identify()`, `group()`, `_setDefaultPersonPropertiesForFlags()`) and widens the accumulator types to `Record<string, JsonType>`. Core's `setPersonPropertiesForFlags` already accepted `JsonType`; this PR also widens core's `setGroupPropertiesForFlags` to match.
- Web SDK already preserved types end-to-end, which is exactly why UI eval and device eval diverged.

## Workaround for customers blocked on a release

```ts
PostHog.init({ ..., setDefaultPersonProperties: false })
```

Reverts `/flags` payload behavior to pre-4.10.5 (empty `person_properties`); server resolves flags from the correctly-typed stored profile.

## Test plan

- [x] New unit tests in `packages/react-native/test/posthog.spec.ts` assert booleans, arrays, numbers, and nested objects survive through `identify($set / $set_once)` and `group()`, with explicit regression guards (`.not.toBe('true')`, `.not.toBe('wl')`).
- [x] Verified the new tests **fail** against the pre-fix source (failure output shows the exact bug shape: `hasApprovedSubscription: "true"`, `user_categories: "wl"`, `tags: "enterprise,beta"`, `metadata: "[object Object]"`).
- [x] Verified the new tests **pass** with the fix.
- [x] Updated two pre-existing tests that asserted the buggy coercion (`employees: '50'` → `employees: 50`).
- [x] `pnpm -F posthog-react-native build` clean, `pnpm -F posthog-react-native lint` clean.
- [x] Full test suites green: RN 335/335, core 587/587, node 583/583.
- [ ] Manual repro on a sample RN app pinned to this build against a staging project with a flag that uses boolean equality + array `contains` — confirm `/flags` payload `person_properties` contains `true` (boolean) and `["wl"]` (array), and the SDK now returns the same variant the PostHog UI returns.