### PR TITLE
test(node): drain promise queue in captureException context tests

### DIFF
--- a/packages/node/src/__tests__/context.spec.ts
+++ b/packages/node/src/__tests__/context.spec.ts
@@ -488,9 +488,11 @@ describe('PostHog Context', () => {
       const run = () => posthog.captureException(new Error('test error'), explicitDistinctId)
       contextDistinctId ? posthog.withContext({ distinctId: contextDistinctId }, run) : run()
 
-      // captureException uses addPendingPromise with an async buildEventMessage,
-      // so we need extra microtask cycles to let the promise chain resolve before flushing
-      await waitForPromises()
+      // captureException uses addPendingPromise around an async buildEventMessage that
+      // performs fs I/O for source-context lines. A fixed setTimeout-based wait races
+      // that I/O on slow CI runners. Drain the promise queue deterministically so the
+      // build → capture → flush chain has fully resolved before we assert.
+      await (posthog as any).promiseQueue.join()
       await waitForFlush()
 
       const events = getLastBatchEvents()


### PR DESCRIPTION
## Problem

The `captureException $label` parameterised cases in `packages/node/src/__tests__/context.spec.ts` (added in #3681) are flaky on CI. The "no distinctId and no context → personless" variant failed on PR #3693 with `Received has value: undefined` — `getLastBatchEvents()` returned nothing because the network mock had no calls yet. Same code, same branch, passed in the previous CI run and failed in the next.

Root cause: `captureException` enqueues an async chain `buildEventMessage(...).then(capture(...))`, where `buildEventMessage` performs `modifyFrames`, which in posthog-node runs the `addSourceContext` modifier — that does fs reads for the source files referenced in the stack. The test waited for that chain to resolve with a fixed `setTimeout(10)`-style helper (`waitForPromises` + `waitForFlush`). On a busy CI runner the fs reads can exceed that budget, so the assertions race the chain.

## Changes

Replace the time-based wait with a deterministic drain of the client's pending-promise queue (`promiseQueue.join()`) before the flush wait. Behavior under test is unchanged — we just stop racing the I/O.

Verified:
- Failing case (and the other two parameterised cases) pass locally.
- Full `posthog-node` test suite passes: 583 tests, 19 suites.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

(Test-only change — no library version bump.)

## Checklist

- [x] Tests for new code (this is a test-stability fix)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran \`pnpm changeset\` to generate a changeset file (n/a — test-only)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*