### PR TITLE
ci: run generate-references on PRs

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -295,3 +295,21 @@ jobs:
           WRITE_MANGLED_PROPERTIES: 1
 
       - run: git diff --exit-code # fail if e.g. the mangled properties list has changed, see rollup.config.js
+
+  generate-references:
+    # Runs the same api-extractor pipeline the release workflow uses to bump
+    # versions, so type-extraction breakages (e.g. unresolved DOM globals in
+    # `@posthog/core` types when extracted from a non-DOM tsconfig) surface
+    # on the PR instead of blocking the release.
+    name: Generate references
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup environment
+        uses: ./.github/actions/setup
+        with:
+          build: false
+      - name: Generate references
+        run: pnpm generate-references


### PR DESCRIPTION
## Problem

The release workflow's `Bump versions and commit to main` step runs `pnpm bump && pnpm generate-references`. If `generate-references` (which runs `api-extractor` over `posthog-js`, `posthog-node`, and `posthog-react-native`) fails, the release is blocked — but the failure isn't visible until release time.

PR #3681 introduced a type-extraction breakage (`@posthog/core` leaked DOM globals into its public type surface; api-extractor couldn't follow them when analysing `posthog-react-native`'s non-DOM tsconfig). The release ran, the bump step failed, and #3693 had to chase it down after the fact. Running the same command on the PR would have caught it pre-merge.

## Changes

Add a `generate-references` job to `library-ci.yml`. Same machine class as the other PR jobs; uses the shared setup action; runs the existing root-level `pnpm generate-references` script (which fans out to `posthog-js`, `posthog-node`, `posthog-react-native` via turbo). The job's only purpose is to fail when api-extractor errors — no commits, no artifacts, no special tokens.

Local runtime: ~9s end-to-end.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

(CI-only change — no library version bump.)

## Checklist

- [x] Tests for new code (the job itself is the check)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran \`pnpm changeset\` to generate a changeset file (n/a — CI-only)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*