### PR TITLE
fix(replay): forward (url, init) instead of new Request on Safari

### DIFF
--- a/packages/browser/playwright/mocked/tracing-headers.spec.ts
+++ b/packages/browser/playwright/mocked/tracing-headers.spec.ts
@@ -88,4 +88,49 @@ test.describe('tracing headers', () => {
             expect(headers['x-posthog-window-id']).toBeUndefined()
         })
     }
+
+    // Safari refuses stream uploads. The fetch wrapper used to construct `new Request(url, init)`
+    // and forward that Request — which upgraded a string body to a ReadableStream and triggered
+    // `NotSupportedError: ReadableStream uploading is not supported` on Safari/webkit.
+    test('POST with string body succeeds on webkit and preserves the body', async ({ page, context, browserName }) => {
+        test.skip(browserName !== 'webkit', 'Safari-only regression: stream-upload rejection only happens on webkit')
+
+        let capturedHeaders: Record<string, string> = {}
+        let capturedBody: string | undefined
+
+        page.on('request', (request) => {
+            if (request.url().includes('example.com')) {
+                capturedHeaders = request.headers()
+                capturedBody = request.postData() ?? undefined
+            }
+        })
+
+        await context.route('**/example.com/**', (route) => {
+            route.fulfill({ status: 200, contentType: 'text/plain', body: 'ok' })
+        })
+
+        await start(baseOptions, page, context)
+
+        await page.waitForFunction(() => {
+            const win = window as any
+            return win.__PosthogExtensions__?.tracingHeadersPatchFns && win.posthog
+        })
+
+        const result = await page.evaluate(async () => {
+            try {
+                const response = await fetch('https://example.com/api/test', {
+                    method: 'POST',
+                    body: JSON.stringify({ a: 1 }),
+                })
+                return { ok: response.ok, error: null }
+            } catch (err) {
+                return { ok: false, error: (err as Error).message }
+            }
+        })
+
+        expect(result.error).toBeNull()
+        expect(result.ok).toBe(true)
+        expect(capturedBody).toBe(JSON.stringify({ a: 1 }))
+        expect(capturedHeaders['x-posthog-distinct-id']).toBeTruthy()
+    })
 })

--- a/packages/browser/src/__tests__/extensions/replay/external/fetch-wrapper-invariants.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/external/fetch-wrapper-invariants.test.ts
@@ -172,7 +172,7 @@ describe('fetch wrapper', () => {
     })
 
     describe('downstream wrapper compatibility', () => {
-        it('downstream receives Request object as first argument', async () => {
+        it('downstream receives the caller input verbatim', async () => {
             let receivedInput: RequestInfo | URL | undefined
             const { wrappedFetch, cleanup } = setupWrappedFetch(async (input: RequestInfo | URL) => {
                 receivedInput = input
@@ -182,10 +182,10 @@ describe('fetch wrapper', () => {
             await wrappedFetch('https://example.com/api', { method: 'POST' })
             cleanup()
 
-            expect(receivedInput).toBeInstanceOf(Request)
+            expect(receivedInput).toBe('https://example.com/api')
         })
 
-        it('downstream receives undefined as second argument (init not passed)', async () => {
+        it('downstream receives the caller init verbatim', async () => {
             let receivedInit: RequestInit | undefined
             const { wrappedFetch, cleanup } = setupWrappedFetch(
                 async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -197,19 +197,45 @@ describe('fetch wrapper', () => {
             await wrappedFetch('https://example.com/api', { method: 'POST', body: 'test' })
             cleanup()
 
-            expect(receivedInit).toBeUndefined()
+            expect(receivedInit?.method).toBe('POST')
+            expect(receivedInit?.body).toBe('test')
+        })
+
+        // On Safari, constructing `new Request(url, { body: '<string>' })` upgrades the body to a
+        // ReadableStream; forwarding that Request to native fetch then raises
+        // `NotSupportedError: ReadableStream uploading is not supported`. The wrapper must keep
+        // string bodies as strings all the way through to the downstream fetch.
+        it('forwards string body as a string, not a stream', async () => {
+            let receivedBody: BodyInit | null | undefined
+            const { wrappedFetch, cleanup } = setupWrappedFetch(
+                async (_input: RequestInfo | URL, init?: RequestInit) => {
+                    receivedBody = init?.body
+                    return new Response('ok')
+                }
+            )
+
+            await wrappedFetch('https://example.com/api', { method: 'POST', body: '{"a":1}' })
+            cleanup()
+
+            expect(typeof receivedBody).toBe('string')
+            expect(receivedBody).toBe('{"a":1}')
         })
 
         it.each([
-            ['method', { method: 'PUT' } as RequestInit, (req: Request) => req.method, 'PUT'],
-            ['headers', { headers: { 'X-Custom': 'value' } }, (req: Request) => req.headers.get('X-Custom'), 'value'],
-            ['url', {}, (req: Request) => req.url, 'https://example.com/api'],
-        ])('downstream can read %s from Request object', async (_name, init, getter, expected) => {
+            ['method', { method: 'PUT' } as RequestInit, 'PUT'],
+            ['headers', { headers: { 'X-Custom': 'value' } }, 'value'],
+            ['url', {}, 'https://example.com/api'],
+        ])('downstream can reconstruct %s into a Request', async (name, init, expected) => {
             let captured: string | null | undefined
-            const { wrappedFetch, cleanup } = setupWrappedFetch(async (input: RequestInfo | URL) => {
-                captured = getter(input as Request)
-                return new Response('ok')
-            })
+            const { wrappedFetch, cleanup } = setupWrappedFetch(
+                async (input: RequestInfo | URL, downstreamInit?: RequestInit) => {
+                    const req = input instanceof Request ? input : new Request(input, downstreamInit)
+                    if (name === 'method') captured = req.method
+                    else if (name === 'headers') captured = req.headers.get('X-Custom')
+                    else captured = req.url
+                    return new Response('ok')
+                }
+            )
 
             await wrappedFetch('https://example.com/api', init)
             cleanup()
@@ -241,8 +267,8 @@ describe('fetch wrapper', () => {
         expect(headerBoundary).toContain(bodyBoundary)
     })
 
-    // TODO: Fix https://github.com/PostHog/posthog-js/issues/1326
-    it.skip('passes init to downstream wrappers', async () => {
+    // Regression test for https://github.com/PostHog/posthog-js/issues/1326
+    it('passes init to downstream wrappers', async () => {
         let capturedInit: RequestInit | undefined
         const { wrappedFetch, cleanup } = setupWrappedFetch(async (_input: RequestInfo | URL, init?: RequestInit) => {
             capturedInit = init
@@ -302,10 +328,12 @@ describe('fetch wrapper', () => {
 
         it.each(cases)('via %s: preserves %s on downstream Request', async (_label, name, value, invoke) => {
             let downstream: Request | undefined
-            const { wrappedFetch, cleanup } = setupWrappedFetch(async (input: RequestInfo | URL) => {
-                downstream = input as Request
-                return new Response('ok')
-            })
+            const { wrappedFetch, cleanup } = setupWrappedFetch(
+                async (input: RequestInfo | URL, init?: RequestInit) => {
+                    downstream = input instanceof Request ? input : new Request(input, init)
+                    return new Response('ok')
+                }
+            )
 
             await invoke(wrappedFetch, name, value)
             cleanup()
@@ -320,10 +348,12 @@ describe('fetch wrapper', () => {
     describe('does not strip ordinary headers from the actual outgoing request', () => {
         it.each(unaffectedHeaderCases)('preserves %s on downstream Request', async (name, value) => {
             let downstream: Request | undefined
-            const { wrappedFetch, cleanup } = setupWrappedFetch(async (input: RequestInfo | URL) => {
-                downstream = input as Request
-                return new Response('ok')
-            })
+            const { wrappedFetch, cleanup } = setupWrappedFetch(
+                async (input: RequestInfo | URL, init?: RequestInit) => {
+                    downstream = input instanceof Request ? input : new Request(input, init)
+                    return new Response('ok')
+                }
+            )
 
             await wrappedFetch('https://example.com/api/internal/surveys', {
                 method: 'POST',

--- a/packages/browser/src/entrypoints/tracing-headers.ts
+++ b/packages/browser/src/entrypoints/tracing-headers.ts
@@ -51,7 +51,15 @@ const patchFetch = (hostnames: string[], distinctId: string, sessionManager?: Se
 
             addTracingHeaders(hostnames, distinctId, sessionManager, req)
 
-            return originalFetch(req)
+            // For non-Request callers, forward (url, init) with the tracing headers merged in:
+            // on Safari, forwarding a Request whose body was a string triggers
+            // `NotSupportedError: ReadableStream uploading is not supported`. For Request callers,
+            // forwarding `req` is unavoidable (the caller already chose a Request body).
+            // eslint-disable-next-line compat/compat
+            if (url instanceof Request) {
+                return originalFetch(req)
+            }
+            return originalFetch(url, { ...init, headers: req.headers })
         }
     })
 }

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -588,7 +588,14 @@ function initFetchObserver(
                 }
 
                 start = win.performance.now()
-                res = await originalFetch(req)
+                // For (url, init) callers, forward (url, init) instead of the reconstructed `req`:
+                // on Safari, forwarding a Request whose body was a string triggers
+                // `NotSupportedError: ReadableStream uploading is not supported`. For Request-input
+                // callers, forwarding `req` is unavoidable and required: constructing the local
+                // `req` above consumed the caller's Request body, so `req` is now the only usable
+                // copy. `req` already incorporates any `init` overrides, so we don't re-pass init.
+                // eslint-disable-next-line compat/compat
+                res = url instanceof Request ? await originalFetch(req) : await originalFetch(url, init)
                 end = win.performance.now()
 
                 const responseHeaders: Headers = {}


### PR DESCRIPTION
## Summary

- Safari refuses stream uploads. Both fetch wrappers (session-replay network plugin and tracing-headers) reconstructed `new Request(url, init)` from `(url, init)` and forwarded the `Request` to native fetch. Per the Fetch spec, constructing a Request with a string body stores it as a `ReadableStream`; forwarding that Request makes Safari throw `NotSupportedError: ReadableStream uploading is not supported`.
- Fix: forward the caller's `(url, init)` for non-Request inputs so the string body stays a string. Keep forwarding `req` when the caller passed a `Request` directly (constructing the local `req` consumed the caller's body, so `req` is the only usable copy, and the caller already chose a Request body).
- Affects any Safari user with `__add_tracing_headers` or `session_recording.recordBody` enabled; Chrome/Firefox unaffected. Both options are off by default.

## Test plan

- [x] Browser unit tests pass (99 affected, including un-skipped issue #1326 contract)
- [x] Webkit Playwright pass: `tracing-headers.spec.ts` (5, including new POST-with-string-body Safari regression)
- [x] Webkit Playwright pass: `csrf-headers-preserved.spec.ts` (9, including double-wrap)
- [x] Webkit Playwright pass: `session-recording-network-recorder.spec.ts` (4)
- [ ] Manual repro in Safari: PostHog init with `__add_tracing_headers` and `session_recording: { recordBody: true }`, then `await fetch('/anything', { method: 'POST', body: JSON.stringify({a:1}) })` — should succeed (throws `NotSupportedError` before the fix)
- [ ] Confirm Chrome behaviour unchanged
- [ ] Confirm session-replay body capture still records the request body
- [ ] Confirm tracing headers still added on outgoing requests for listed domains

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*