### PR TITLE
fix(browser): harden tracing fetch wrapper

### DIFF
--- a/packages/browser/src/__tests__/extensions/replay/rrweb-plugins/patch.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/rrweb-plugins/patch.test.ts
@@ -7,9 +7,40 @@ const fakeWindow = {
 // JS-DOM doesn't have fetch and its fake XHR doesn't work with our patch,
 // so we can't test them directly
 describe('patch', () => {
+    const originalFakeFetch = fakeWindow.fakeFetch
+
+    afterEach(() => {
+        fakeWindow.fakeFetch = originalFakeFetch
+    })
+
     it('marks a function as wrapped', () => {
         patch(fakeWindow, 'fakeFetch', () => () => {})
         // eslint-disable-next-line compat/compat
         expect((fakeWindow.fakeFetch as any).__posthog_wrapped__).toBe(true)
+    })
+
+    it('does not clobber a newer wrapper when restoring an older patch', () => {
+        const original = fakeWindow.fakeFetch
+        const firstRestore = patch(fakeWindow, 'fakeFetch', (firstOriginal) => {
+            return function firstWrapper() {
+                return firstOriginal()
+            }
+        })
+        const firstWrapper = fakeWindow.fakeFetch
+        const secondRestore = patch(fakeWindow, 'fakeFetch', (secondOriginal) => {
+            return function secondWrapper() {
+                return secondOriginal()
+            }
+        })
+        const secondWrapper = fakeWindow.fakeFetch
+
+        firstRestore()
+        expect(fakeWindow.fakeFetch).toBe(secondWrapper)
+
+        secondRestore()
+        expect(fakeWindow.fakeFetch).toBe(firstWrapper)
+
+        firstRestore()
+        expect(fakeWindow.fakeFetch).toBe(original)
     })
 })

--- a/packages/browser/src/__tests__/tracing-headers.test.ts
+++ b/packages/browser/src/__tests__/tracing-headers.test.ts
@@ -1,98 +1,223 @@
 import { COOKIELESS_SENTINEL_VALUE } from '../constants'
 import patchFns from '../entrypoints/tracing-headers'
 
-class TestHeaders {
-    private _headers: Record<string, string> = {}
-
-    set(name: string, value: string): void {
-        this._headers[name.toLowerCase()] = value
-    }
-
-    get(name: string): string | null {
-        return this._headers[name.toLowerCase()] ?? null
-    }
-}
-
 class TestRequest {
+    body?: BodyInit | null
+    headers: Headers
+    method: string
     url: string
-    headers = new TestHeaders()
 
-    constructor(url: string | URL) {
-        this.url = url.toString()
+    constructor(input: string | URL | TestRequest, init?: RequestInit) {
+        const inputRequest = input instanceof TestRequest ? input : undefined
+        this.url = inputRequest ? inputRequest.url : input.toString()
+        this.headers = new Headers(init?.headers ?? inputRequest?.headers)
+        this.method = init?.method ?? inputRequest?.method ?? 'GET'
+        this.body = init?.body ?? inputRequest?.body ?? null
+    }
+
+    clone(): TestRequest {
+        return new TestRequest(this)
+    }
+
+    text(): Promise<string> {
+        return Promise.resolve(this.body?.toString() ?? '')
+    }
+
+    get [Symbol.toStringTag](): string {
+        return 'Request'
     }
 }
 
 describe('tracing headers', () => {
     const originalRequest = globalThis.Request
     let restoreXHRPatch: (() => void) | undefined
-
-    beforeAll(() => {
-        const globalAny = globalThis as any
-        globalAny.Request = TestRequest
-    })
-
-    afterAll(() => {
-        const globalAny = globalThis as any
-        globalAny.Request = originalRequest
-    })
-
-    afterEach(() => {
-        restoreXHRPatch?.()
-        restoreXHRPatch = undefined
-        jest.restoreAllMocks()
-    })
+    let restoreFetchPatch: (() => void) | undefined
+    const originalWindowFetch = window.fetch
 
     const sessionManager = {
         checkAndGetSessionAndWindowId: jest.fn(() => ({ sessionId: 'session-id', windowId: 'window-id' })),
     }
 
-    test.each([
-        {
-            name: 'adds tracing headers to matching XHR requests',
-            url: 'https://example.com/path',
-            distinctId: 'distinct-id',
-            expectedHeaders: [
-                ['X-POSTHOG-SESSION-ID', 'session-id'],
-                ['X-POSTHOG-WINDOW-ID', 'window-id'],
-                ['X-POSTHOG-DISTINCT-ID', 'distinct-id'],
-            ],
-            absentHeaders: [],
-        },
-        {
-            name: 'does not add tracing headers to non-matching XHR requests',
-            url: 'https://other.example/path',
-            distinctId: 'distinct-id',
-            expectedHeaders: [],
-            absentHeaders: [
-                ['X-POSTHOG-SESSION-ID', 'session-id'],
-                ['X-POSTHOG-WINDOW-ID', 'window-id'],
-                ['X-POSTHOG-DISTINCT-ID', 'distinct-id'],
-            ],
-        },
-        {
-            name: 'does not add the distinct ID header to XHR requests when cookieless mode is active',
-            url: 'https://example.com/path',
-            distinctId: COOKIELESS_SENTINEL_VALUE,
-            expectedHeaders: [
-                ['X-POSTHOG-SESSION-ID', 'session-id'],
-                ['X-POSTHOG-WINDOW-ID', 'window-id'],
-            ],
-            absentHeaders: [['X-POSTHOG-DISTINCT-ID', 'distinct-id']],
-        },
-    ])('$name', ({ url, distinctId, expectedHeaders, absentHeaders }) => {
-        const setRequestHeaderSpy = jest
-            .spyOn(XMLHttpRequest.prototype, 'setRequestHeader')
-            .mockImplementation(() => {})
-        restoreXHRPatch = patchFns._patchXHR(['example.com'], distinctId, sessionManager as any)
-
-        const xhr = new XMLHttpRequest()
-        xhr.open('GET', url)
-
-        expectedHeaders.forEach(([header, value]) => {
-            expect(setRequestHeaderSpy).toHaveBeenCalledWith(header, value)
+    const setWindowFetch = (fetchImpl: typeof fetch | undefined): void => {
+        Object.defineProperty(window, 'fetch', {
+            configurable: true,
+            value: fetchImpl,
+            writable: true,
         })
-        absentHeaders.forEach(([header, value]) => {
-            expect(setRequestHeaderSpy).not.toHaveBeenCalledWith(header, value)
+    }
+
+    beforeAll(() => {
+        ;(globalThis as any).Request = TestRequest
+    })
+
+    afterAll(() => {
+        ;(globalThis as any).Request = originalRequest
+    })
+
+    afterEach(() => {
+        restoreXHRPatch?.()
+        restoreXHRPatch = undefined
+        restoreFetchPatch?.()
+        restoreFetchPatch = undefined
+        setWindowFetch(originalWindowFetch)
+        jest.restoreAllMocks()
+        sessionManager.checkAndGetSessionAndWindowId.mockClear()
+    })
+
+    describe('fetch', () => {
+        it('adds tracing headers without spreading init or mutating caller headers', async () => {
+            const originalFetch = jest.fn(() => Promise.resolve({} as Response)) as jest.MockedFunction<typeof fetch>
+            setWindowFetch(originalFetch)
+            restoreFetchPatch = patchFns._patchFetch(['example.com'], 'distinct-id', sessionManager as any)
+
+            const callerHeaders = new Headers({ 'x-original': 'original-header-value' })
+            const controller = new AbortController()
+            const initPrototype = {}
+            Object.defineProperty(initPrototype, 'method', { get: () => 'POST' })
+            Object.defineProperty(initPrototype, 'body', { get: () => 'request-body' })
+            Object.defineProperty(initPrototype, 'duplex', { get: () => 'half' })
+
+            const init = Object.create(initPrototype)
+            Object.defineProperty(init, 'headers', { configurable: true, value: callerHeaders })
+            Object.defineProperty(init, 'credentials', { configurable: true, value: 'include' })
+            Object.defineProperty(init, 'signal', { configurable: true, value: controller.signal })
+
+            await window.fetch('https://example.com/path', init)
+
+            expect(originalFetch).toHaveBeenCalledTimes(1)
+            const [input, downstreamInit] = originalFetch.mock.calls[0]
+            expect(input).toBe('https://example.com/path')
+            expect(downstreamInit).not.toBe(init)
+            expect((downstreamInit as RequestInit).method).toBe('POST')
+            expect((downstreamInit as RequestInit).body).toBe('request-body')
+            expect((downstreamInit as RequestInit).credentials).toBe('include')
+            expect((downstreamInit as RequestInit).signal).toBe(controller.signal)
+            expect((downstreamInit as RequestInit & { duplex?: string }).duplex).toBe('half')
+
+            // Downstream wrappers that still spread init should retain the effective RequestInit fields.
+            const spreadInit = { ...(downstreamInit as RequestInit & { duplex?: string }) }
+            expect(spreadInit.method).toBe('POST')
+            expect(spreadInit.body).toBe('request-body')
+            expect(spreadInit.credentials).toBe('include')
+            expect(spreadInit.signal).toBe(controller.signal)
+            expect(spreadInit.duplex).toBe('half')
+
+            const headers = new Headers(downstreamInit?.headers)
+            expect(headers.get('x-original')).toBe('original-header-value')
+            expect(headers.get('X-POSTHOG-SESSION-ID')).toBe('session-id')
+            expect(headers.get('X-POSTHOG-WINDOW-ID')).toBe('window-id')
+            expect(headers.get('X-POSTHOG-DISTINCT-ID')).toBe('distinct-id')
+            expect(callerHeaders.get('X-POSTHOG-SESSION-ID')).toBeNull()
+            expect(callerHeaders.get('X-POSTHOG-WINDOW-ID')).toBeNull()
+            expect(callerHeaders.get('X-POSTHOG-DISTINCT-ID')).toBeNull()
+        })
+
+        it('delegates unchanged when the hostname does not match', async () => {
+            const originalFetch = jest.fn(() => Promise.resolve({} as Response)) as jest.MockedFunction<typeof fetch>
+            setWindowFetch(originalFetch)
+            restoreFetchPatch = patchFns._patchFetch(['example.com'], 'distinct-id', sessionManager as any)
+
+            const init = { method: 'POST', headers: { 'x-original': 'value' }, body: 'request-body' }
+            await window.fetch('https://other.example/path', init)
+
+            expect(originalFetch).toHaveBeenCalledWith('https://other.example/path', init)
+            expect(sessionManager.checkAndGetSessionAndWindowId).not.toHaveBeenCalled()
+        })
+
+        it('preserves Request input semantics and init overrides', async () => {
+            const originalFetch = jest.fn(() => Promise.resolve({} as Response)) as jest.MockedFunction<typeof fetch>
+            setWindowFetch(originalFetch)
+            restoreFetchPatch = patchFns._patchFetch(['example.com'], 'distinct-id', sessionManager as any)
+
+            const request = new Request('https://example.com/path', {
+                body: 'request-body',
+                headers: { 'x-request': 'request-header' },
+                method: 'POST',
+            })
+            await window.fetch(request, {
+                body: 'override-body',
+                headers: { 'x-init': 'init-header' },
+                method: 'PUT',
+            })
+
+            expect(originalFetch).toHaveBeenCalledTimes(1)
+            const [input, init] = originalFetch.mock.calls[0]
+            expect(input).toBeInstanceOf(Request)
+            expect(init).toBeUndefined()
+
+            const downstreamRequest = input as Request
+            expect(downstreamRequest).not.toBe(request)
+            expect(downstreamRequest.method).toBe('PUT')
+            expect(downstreamRequest.headers.get('x-request')).toBeNull()
+            expect(downstreamRequest.headers.get('x-init')).toBe('init-header')
+            expect(downstreamRequest.headers.get('X-POSTHOG-SESSION-ID')).toBe('session-id')
+            expect(downstreamRequest.headers.get('X-POSTHOG-WINDOW-ID')).toBe('window-id')
+            expect(downstreamRequest.headers.get('X-POSTHOG-DISTINCT-ID')).toBe('distinct-id')
+            await expect(downstreamRequest.clone().text()).resolves.toBe('override-body')
+        })
+
+        it('propagates synchronous downstream fetch errors without retrying', () => {
+            const error = new Error('sync fetch failure')
+            const originalFetch = jest.fn(() => {
+                throw error
+            }) as jest.MockedFunction<typeof fetch>
+            setWindowFetch(originalFetch)
+            restoreFetchPatch = patchFns._patchFetch(['example.com'], 'distinct-id', sessionManager as any)
+
+            expect(() => window.fetch('https://example.com/path')).toThrow(error)
+            expect(originalFetch).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('xhr', () => {
+        test.each([
+            {
+                name: 'adds tracing headers to matching XHR requests',
+                url: 'https://example.com/path',
+                distinctId: 'distinct-id',
+                expectedHeaders: [
+                    ['X-POSTHOG-SESSION-ID', 'session-id'],
+                    ['X-POSTHOG-WINDOW-ID', 'window-id'],
+                    ['X-POSTHOG-DISTINCT-ID', 'distinct-id'],
+                ],
+                absentHeaders: [],
+            },
+            {
+                name: 'does not add tracing headers to non-matching XHR requests',
+                url: 'https://other.example/path',
+                distinctId: 'distinct-id',
+                expectedHeaders: [],
+                absentHeaders: [
+                    ['X-POSTHOG-SESSION-ID', 'session-id'],
+                    ['X-POSTHOG-WINDOW-ID', 'window-id'],
+                    ['X-POSTHOG-DISTINCT-ID', 'distinct-id'],
+                ],
+            },
+            {
+                name: 'does not add the distinct ID header to XHR requests when cookieless mode is active',
+                url: 'https://example.com/path',
+                distinctId: COOKIELESS_SENTINEL_VALUE,
+                expectedHeaders: [
+                    ['X-POSTHOG-SESSION-ID', 'session-id'],
+                    ['X-POSTHOG-WINDOW-ID', 'window-id'],
+                ],
+                absentHeaders: [['X-POSTHOG-DISTINCT-ID', 'distinct-id']],
+            },
+        ])('$name', ({ url, distinctId, expectedHeaders, absentHeaders }) => {
+            const setRequestHeaderSpy = jest
+                .spyOn(XMLHttpRequest.prototype, 'setRequestHeader')
+                .mockImplementation(() => {})
+            restoreXHRPatch = patchFns._patchXHR(['example.com'], distinctId, sessionManager as any)
+
+            const xhr = new XMLHttpRequest()
+            xhr.open('GET', url)
+
+            expectedHeaders.forEach(([header, value]) => {
+                expect(setRequestHeaderSpy).toHaveBeenCalledWith(header, value)
+            })
+            absentHeaders.forEach(([header, value]) => {
+                expect(setRequestHeaderSpy).not.toHaveBeenCalledWith(header, value)
+            })
         })
     })
 })

--- a/packages/browser/src/entrypoints/tracing-headers.ts
+++ b/packages/browser/src/entrypoints/tracing-headers.ts
@@ -2,12 +2,123 @@ import { SessionIdManager } from '../sessionid'
 import { patch } from '../extensions/replay/rrweb-plugins/patch'
 import { assignableWindow, window } from '../utils/globals'
 import { COOKIELESS_SENTINEL_VALUE } from '../constants'
-import { isArray } from '@posthog/core'
+import { isArray, isFunction, isNull, isUndefined } from '@posthog/core'
 
 const SESSION_ID_HEADER = 'X-POSTHOG-SESSION-ID'
 const WINDOW_ID_HEADER = 'X-POSTHOG-WINDOW-ID'
 const DISTINCT_ID_HEADER = 'X-POSTHOG-DISTINCT-ID'
 const TRACING_HEADERS = [SESSION_ID_HEADER, WINDOW_ID_HEADER, DISTINCT_ID_HEADER]
+const REQUEST_INIT_KEYS = [
+    'attributionReporting',
+    'body',
+    'browsingTopics',
+    'cache',
+    'credentials',
+    'dispatcher',
+    'duplex',
+    'integrity',
+    'keepalive',
+    'method',
+    'mode',
+    'priority',
+    'redirect',
+    'referrer',
+    'referrerPolicy',
+    'signal',
+    'window',
+]
+
+const hasOwnProperty = (value: object, property: PropertyKey): boolean =>
+    Object.prototype.hasOwnProperty.call(value, property)
+
+const isObjectLike = (value: unknown): value is object =>
+    (typeof value === 'object' && !isNull(value)) || isFunction(value)
+
+const isRequest = (value: unknown): value is Request =>
+    typeof Request !== 'undefined' &&
+    (value instanceof Request || Object.prototype.toString.call(value) === '[object Request]')
+
+const getRequestUrl = (url: URL | RequestInfo): string | undefined => {
+    try {
+        if (isRequest(url)) {
+            return url.url
+        }
+
+        // eslint-disable-next-line compat/compat
+        return new URL(url instanceof URL ? url.toString() : String(url), window?.location?.href).toString()
+    } catch {
+        return undefined
+    }
+}
+
+// RequestInit is a WebIDL dictionary: native fetch reads known keys via property access, including inherited
+// and non-enumerable properties. Avoid `{ ...init, headers }`, which can drop body/signal/duplex/etc. Instead,
+// overlay only `headers` while forwarding every other lookup to the caller's original init object.
+const createFetchInitWithHeaders = (init: RequestInit | undefined, headers: Headers): RequestInit | undefined => {
+    if (isUndefined(init) || isNull(init)) {
+        return { headers }
+    }
+    if (!isObjectLike(init)) {
+        return undefined
+    }
+
+    const originalInit = init as RequestInit & Record<PropertyKey, unknown>
+
+    if (typeof Proxy === 'undefined' || typeof Reflect === 'undefined') {
+        // Older browsers without Proxy still get an inherited overlay, which preserves native fetch property lookup.
+        const initWithHeaders = Object.create(originalInit) as RequestInit
+        Object.defineProperty(initWithHeaders, 'headers', {
+            configurable: true,
+            enumerable: true,
+            value: headers,
+            writable: true,
+        })
+        return initWithHeaders
+    }
+
+    const target = { headers } as RequestInit & Record<PropertyKey, unknown>
+
+    return new Proxy(target, {
+        get(target, property) {
+            if (hasOwnProperty(target, property)) {
+                return Reflect.get(target, property)
+            }
+            return Reflect.get(originalInit, property, originalInit)
+        },
+        has(target, property) {
+            return hasOwnProperty(target, property) || property in originalInit
+        },
+        ownKeys(target) {
+            const keys = new Set<string | symbol>(Reflect.ownKeys(target))
+            Reflect.ownKeys(originalInit).forEach((key) => keys.add(key))
+            REQUEST_INIT_KEYS.forEach((key) => {
+                if (key in originalInit) {
+                    keys.add(key)
+                }
+            })
+            return Array.from(keys)
+        },
+        getOwnPropertyDescriptor(target, property) {
+            const targetDescriptor = Reflect.getOwnPropertyDescriptor(target, property)
+            if (targetDescriptor) {
+                return targetDescriptor
+            }
+            if (typeof property === 'string' && REQUEST_INIT_KEYS.includes(property) && property in originalInit) {
+                return {
+                    configurable: true,
+                    enumerable: true,
+                    get: () => Reflect.get(originalInit, property, originalInit),
+                }
+            }
+
+            const descriptor = Reflect.getOwnPropertyDescriptor(originalInit, property)
+            return descriptor ? { ...descriptor, configurable: true } : undefined
+        },
+        getPrototypeOf() {
+            return Object.getPrototypeOf(originalInit)
+        },
+    }) as RequestInit
+}
 
 const addTracingHeaders = (
     hostnames: string[],
@@ -15,7 +126,7 @@ const addTracingHeaders = (
     sessionManager: SessionIdManager | undefined,
     url: string,
     headers: Headers
-) => {
+): boolean => {
     let reqHostname: string
     try {
         // we don't need to support IE11 here
@@ -23,45 +134,65 @@ const addTracingHeaders = (
         reqHostname = new URL(url).hostname
     } catch {
         // If the URL is invalid, we skip adding tracing headers
-        return
+        return false
     }
     if (isArray(hostnames) && !hostnames.includes(reqHostname)) {
         // Skip if the hostname is not in the list (also skip if hostnames is not an array,
         // because in the earliest version of this __add_tracing_headers was a bool)
-        return
+        return false
     }
 
+    let hasAddedHeaders = false
     if (sessionManager) {
         const { sessionId, windowId } = sessionManager.checkAndGetSessionAndWindowId(true)
         headers.set(SESSION_ID_HEADER, sessionId)
         headers.set(WINDOW_ID_HEADER, windowId)
+        hasAddedHeaders = true
     }
     if (distinctId !== COOKIELESS_SENTINEL_VALUE) {
         headers.set(DISTINCT_ID_HEADER, distinctId)
+        hasAddedHeaders = true
     }
+    return hasAddedHeaders
 }
+
+type FetchArgs = [URL | RequestInfo] | [URL | RequestInfo, RequestInit | undefined]
 
 const patchFetch = (hostnames: string[], distinctId: string, sessionManager?: SessionIdManager): (() => void) => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     return patch(window, 'fetch', (originalFetch: typeof fetch) => {
-        return async function (url: URL | RequestInfo, init?: RequestInit | undefined) {
-            // check IE earlier than this, we only initialize if Request is present
-            // eslint-disable-next-line compat/compat
-            const req = new Request(url, init)
+        return function (this: unknown, url: URL | RequestInfo, init?: RequestInit | undefined) {
+            const originalArgs = (arguments.length > 1 ? [url, init] : [url]) as FetchArgs
+            let fetchArgs = originalArgs
 
-            // Use the Request object for URL parsing only. For fetch(url, init), do not pass this internally-created
-            // Request downstream: it exposes request.body as a ReadableStream, and wrappers that forward that body can
-            // trigger Safari's "ReadableStream uploading is not supported" error.
-            if (url instanceof Request) {
-                addTracingHeaders(hostnames, distinctId, sessionManager, req.url, req.headers)
-                return originalFetch(req)
+            try {
+                const requestUrl = getRequestUrl(url)
+                if (requestUrl) {
+                    if (isRequest(url)) {
+                        // For fetch(Request, init), construct a new Request so init overrides are applied and the
+                        // caller's Request is not mutated. For fetch(url, init), avoid this because it exposes string
+                        // bodies as ReadableStreams to downstream wrappers in Safari.
+                        // eslint-disable-next-line compat/compat
+                        const req = new Request(url, init)
+                        if (addTracingHeaders(hostnames, distinctId, sessionManager, req.url, req.headers)) {
+                            fetchArgs = [req]
+                        }
+                    } else {
+                        const headers = new Headers(isObjectLike(init) ? init.headers : undefined)
+                        if (addTracingHeaders(hostnames, distinctId, sessionManager, requestUrl, headers)) {
+                            const initWithHeaders = createFetchInitWithHeaders(init, headers)
+                            if (initWithHeaders) {
+                                fetchArgs = [url, initWithHeaders]
+                            }
+                        }
+                    }
+                }
+            } catch {
+                fetchArgs = originalArgs
             }
 
-            const headers = new Headers(init?.headers)
-            addTracingHeaders(hostnames, distinctId, sessionManager, req.url, headers)
-
-            return originalFetch(url, { ...(init || {}), headers })
+            return originalFetch.apply(this, fetchArgs)
         }
     })
 }
@@ -86,19 +217,22 @@ const patchXHR = (hostnames: string[], distinctId: string, sessionManager?: Sess
                 // @ts-ignore
                 const xhr = this as XMLHttpRequest
 
-                // check IE earlier than this, we only initialize if Request is present
-                // eslint-disable-next-line compat/compat
-                const req = new Request(url)
                 const headers = new Headers()
+                const requestUrl = getRequestUrl(url)
+                if (requestUrl) {
+                    addTracingHeaders(hostnames, distinctId, sessionManager, requestUrl, headers)
+                }
 
-                addTracingHeaders(hostnames, distinctId, sessionManager, req.url, headers)
-
-                const result = originalOpen.call(xhr, method, req.url, async, username, password)
+                const result = originalOpen.call(xhr, method, url, async, username, password)
 
                 TRACING_HEADERS.forEach((header) => {
                     const value = headers.get(header)
                     if (value) {
-                        xhr.setRequestHeader(header, value)
+                        try {
+                            xhr.setRequestHeader(header, value)
+                        } catch {
+                            // Do not let tracing header injection break the host app's XHR.
+                        }
                     }
                 })
 

--- a/packages/browser/src/extensions/replay/rrweb-plugins/patch.ts
+++ b/packages/browser/src/extensions/replay/rrweb-plugins/patch.ts
@@ -34,7 +34,9 @@ export function patch(
         source[name] = wrapped
 
         return () => {
-            source[name] = original
+            if (source[name] === wrapped) {
+                source[name] = original
+            }
         }
     } catch {
         return () => {

--- a/packages/browser/src/extensions/tracing-headers.ts
+++ b/packages/browser/src/extensions/tracing-headers.ts
@@ -20,6 +20,7 @@ export class TracingHeaders implements Extension {
         if (assignableWindow.__PosthogExtensions__?.tracingHeadersPatchFns) {
             // already loaded
             cb()
+            return
         }
 
         assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(this._instance, 'tracing-headers', (err) => {
@@ -49,14 +50,14 @@ export class TracingHeaders implements Extension {
     private _startCapturing = () => {
         const hostnames = this._getConfiguredHostnames() || []
         if (isUndefined(this._restoreXHRPatch)) {
-            assignableWindow.__PosthogExtensions__?.tracingHeadersPatchFns?._patchXHR(
+            this._restoreXHRPatch = assignableWindow.__PosthogExtensions__?.tracingHeadersPatchFns?._patchXHR(
                 hostnames,
                 this._instance.get_distinct_id(),
                 this._instance.sessionManager
             )
         }
         if (isUndefined(this._restoreFetchPatch)) {
-            assignableWindow.__PosthogExtensions__?.tracingHeadersPatchFns?._patchFetch(
+            this._restoreFetchPatch = assignableWindow.__PosthogExtensions__?.tracingHeadersPatchFns?._patchFetch(
                 hostnames,
                 this._instance.get_distinct_id(),
                 this._instance.sessionManager


### PR DESCRIPTION
## Problem

PR #3706 avoids Safari's `ReadableStream uploading is not supported` error by no longer forwarding an internally-created `Request` for `fetch(url, init)` calls. That is the right direction, but the first implementation still rebuilt `init` with object spread (`{ ...(init || {}), headers }`).

That is safer for Safari streams, but not fully safe for host apps: `RequestInit` is a WebIDL dictionary, so native `fetch` reads known fields via property lookup. Object spread only copies own enumerable properties and can drop inherited, non-enumerable, or accessor-backed values such as `body`, `signal`, `duplex`, `credentials`, etc.

## Changes

This stacks on top of `fix/safari-fetch-readable-stream-wrapper` and hardens the wrapper so it preserves host-app fetch semantics more closely:

- For `fetch(url, init)`, keep passing URL + init shape downstream instead of an internally-created `Request`, preserving the Safari fix.
- Overlay only the tracing `headers` field instead of spreading/copying all of `init`.
  - The overlay forwards other property lookups to the original `init`, so inherited/non-enumerable/accessor RequestInit fields still reach native fetch and downstream wrappers.
  - Comments in `tracing-headers.ts` call out why this is safer than object spread.
- For `fetch(Request, init)`, keep using `new Request(request, init)` so native init override semantics are preserved without mutating the caller's `Request`.
- Delegate with the original args when no tracing headers are added or instrumentation fails.
- Make tracing-header lifecycle safer by storing restore callbacks and avoiding duplicate script-load callbacks.
- Make the shared patch restore safer so an older restore cannot clobber a newer wrapper.
- Add regression tests for:
  - non-plain `RequestInit` preservation,
  - caller `Headers` immutability,
  - unchanged delegation for non-matching hosts,
  - `Request` input + init overrides,
  - synchronous downstream fetch errors,
  - stacked patch restore behavior.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

No new changeset in this stacked PR because the base Safari fix PR already includes the patch changeset.

## Validation

- `pnpm --dir packages/browser exec eslint src/entrypoints/tracing-headers.ts src/extensions/tracing-headers.ts src/extensions/replay/rrweb-plugins/patch.ts src/__tests__/tracing-headers.test.ts src/__tests__/extensions/replay/rrweb-plugins/patch.test.ts`
- `pnpm --dir packages/browser exec jest src/__tests__/tracing-headers.test.ts src/__tests__/extensions/replay/rrweb-plugins/patch.test.ts --runInBand`
- `pnpm --dir packages/browser exec playwright test playwright/mocked/fetch-post-body.spec.ts --project webkit`

Note: `pnpm --dir packages/browser typecheck` currently fails on unrelated existing `src/utils/event-utils.ts` errors around `BrowserDetectionHints` / browser detection args.
