### PR TITLE
feat(webpack-plugin): default sourcemaps.enabled to true

### DIFF
--- a/.changeset/webpack-plugin-sourcemaps-enabled-default.md
+++ b/.changeset/webpack-plugin-sourcemaps-enabled-default.md
@@ -1,0 +1,5 @@
+---
+"@posthog/webpack-plugin": patch
+---
+
+Default `sourcemaps.enabled` to `true`, matching the other PostHog bundler plugins. Previously it defaulted to `NODE_ENV === 'production'`.

--- a/.changeset/webpack-plugin-sourcemaps-enabled-default.md
+++ b/.changeset/webpack-plugin-sourcemaps-enabled-default.md
@@ -1,5 +1,5 @@
 ---
-"@posthog/webpack-plugin": patch
+"@posthog/webpack-plugin": minor
 ---
 
 Default `sourcemaps.enabled` to `true`, matching the other PostHog bundler plugins. Previously it defaulted to `NODE_ENV === 'production'`.

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -43,7 +43,7 @@ export default {
 | `host`                         | `string`                                             | No       | `https://us.i.posthog.com` | PostHog instance host                       |
 | `logLevel`                     | `'debug' \| 'info' \| 'warn' \| 'error' \| 'silent'` | No       | `'info'`                   | Logging verbosity                           |
 | `cliBinaryPath`                | `string`                                             | No       | Auto-detected              | Path to the PostHog CLI binary              |
-| `sourcemaps.enabled`           | `boolean`                                            | No       | `true` in production       | Enable source map processing                |
+| `sourcemaps.enabled`           | `boolean`                                            | No       | `true`                     | Enable source map processing                |
 | `sourcemaps.releaseName`       | `string`                                             | No       | -                          | Release name for source map grouping        |
 | `sourcemaps.releaseVersion`    | `string`                                             | No       | -                          | Version identifier for the release          |
 | `sourcemaps.deleteAfterUpload` | `boolean`                                            | No       | `true`                     | Delete source maps after upload             |

--- a/packages/webpack-plugin/src/config.ts
+++ b/packages/webpack-plugin/src/config.ts
@@ -12,11 +12,10 @@ export type ResolvedPluginConfig = CoreResolvedPluginConfig
 
 /**
  * Resolve plugin config with webpack-specific defaults.
- * Webpack defaults sourcemaps.enabled to `process.env.NODE_ENV === 'production'`.
+ * Defaults sourcemaps.enabled to `true`, matching the other PostHog bundler plugins.
  */
 export function resolveConfig(options: PluginConfig, resolveOptions?: ResolveConfigOptions): ResolvedPluginConfig {
     return coreResolveConfig(options, {
-        defaultEnabled: process.env.NODE_ENV === 'production',
         cwd: __dirname,
         ...resolveOptions,
     })


### PR DESCRIPTION
Defaults `sourcemaps.enabled` to `true` in the webpack plugin, matching the other PostHog bundler plugins. It was the only one defaulting to `NODE_ENV === 'production'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)