### PR TITLE
fix(logs): move OpenTelemetry deps to devDependencies

### DIFF
--- a/.changeset/otel-logs-deps-to-dev.md
+++ b/.changeset/otel-logs-deps-to-dev.md
@@ -1,0 +1,7 @@
+---
+'posthog-js': patch
+---
+
+Move the OpenTelemetry logs dependencies to `devDependencies`. They are only used to build the CDN-served `logs` extension chunk, which inlines them, so consumers no longer install the transitive `protobufjs` (whose `eval("require")` tripped `unsafe-eval` Content Security Policies).
+
+If you imported `@opentelemetry/*` directly while relying on it being hoisted from `posthog-js`, add it to your own dependencies.

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -58,11 +58,6 @@
         "rrweb-plugin-console-record/package.json"
     ],
     "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/api-logs": "^0.208.0",
-        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
-        "@opentelemetry/resources": "^2.2.0",
-        "@opentelemetry/sdk-logs": "^0.208.0",
         "@posthog/core": "workspace:*",
         "@posthog/types": "workspace:*",
         "core-js": "^3.38.1",
@@ -82,6 +77,11 @@
         "@babel/preset-typescript": "catalog:",
         "@jest/globals": "^29.7.0",
         "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
         "@playwright/test": "^1.52.0",
         "@posthog-tooling/rollup-utils": "workspace:*",
         "@posthog/rrweb": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,21 +270,6 @@ importers:
 
   packages/browser:
     dependencies:
-      '@opentelemetry/api':
-        specifier: ^1.9.0
-        version: 1.9.0
-      '@opentelemetry/api-logs':
-        specifier: ^0.208.0
-        version: 0.208.0
-      '@opentelemetry/exporter-logs-otlp-http':
-        specifier: ^0.208.0
-        version: 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources':
-        specifier: ^2.2.0
-        version: 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs':
-        specifier: ^0.208.0
-        version: 0.208.0(@opentelemetry/api@1.9.0)
       '@posthog/core':
         specifier: workspace:*
         version: link:../core
@@ -337,6 +322,21 @@ importers:
       '@jridgewell/sourcemap-codec':
         specifier: ^1.5.5
         version: 1.5.5
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      '@opentelemetry/api-logs':
+        specifier: ^0.208.0
+        version: 0.208.0
+      '@opentelemetry/exporter-logs-otlp-http':
+        specifier: ^0.208.0
+        version: 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^2.2.0
+        version: 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.208.0
+        version: 0.208.0(@opentelemetry/api@1.9.0)
       '@playwright/test':
         specifier: ^1.52.0
         version: 1.52.0


### PR DESCRIPTION
## Problem

Closes #3714. `posthog-js` declared the OpenTelemetry logs packages as production `dependencies`, so `npm install posthog-js` pulled in `protobufjs` transitively (via `@opentelemetry/exporter-logs-otlp-http → @opentelemetry/otlp-transformer`). `protobufjs`'s `@protobufjs/inquire` uses `eval("require")`, which violates `unsafe-eval` Content Security Policies in the browser — even for teams that never use PostHog's browser logging.

## Changes

Moved the five `@opentelemetry/*` packages from `dependencies` to `devDependencies`. They are only used to build the `logs` extension entrypoint, which Rollup inlines into the self-contained `dist/logs.js` chunk served from the CDN — consumers never resolve them directly (same pattern as `@posthog/rrweb` for session replay). This removes `protobufjs` from the production install entirely.

Verified locally: `pnpm why protobufjs --prod --filter posthog-js` is now empty, the dev tree still resolves it (so the build is unaffected), and `dist/logs.js` rebuilds byte-identical with OpenTelemetry inlined and zero external imports.

Revives #3224, which made the same change but was auto-closed for inactivity.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
