### PR TITLE
feat(react): optional defaultValue for useFeatureFlagEnabled

### DIFF
--- a/.changeset/use-feature-flag-enabled-default-value.md
+++ b/.changeset/use-feature-flag-enabled-default-value.md
@@ -1,0 +1,5 @@
+---
+"@posthog/react": minor
+---
+
+Add an optional `defaultValue` argument to `useFeatureFlagEnabled`. When supplied, the hook returns that value instead of `undefined` while flags are loading or when the flag is absent, and the return type narrows to `boolean`. Omitting the argument keeps the existing `boolean | undefined` behavior.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -83,6 +83,13 @@ function MyComponent() {
 }
 ```
 
+By default the hook returns `boolean | undefined`, where `undefined` means the flags haven't loaded yet or the flag is absent. Pass a `defaultValue` to use instead of `undefined` in those cases — the return type then narrows to `boolean`:
+
+```tsx
+// false until proven enabled
+const isEnabled = useFeatureFlagEnabled('new-feature', false)
+```
+
 #### useFeatureFlagVariantKey
 
 Get the variant key for a multivariate feature flag.

--- a/packages/react/src/hooks/__tests__/featureFlags.test.tsx
+++ b/packages/react/src/hooks/__tests__/featureFlags.test.tsx
@@ -115,6 +115,70 @@ describe('feature flag hooks', () => {
         expect(result.current).toEqual(expected)
     })
 
+    describe('useFeatureFlagEnabled defaultValue', () => {
+        // A client whose flags have loaded but where isFeatureEnabled returns undefined,
+        // i.e. the flag is absent from the payload. The default beforeEach mock coerces
+        // every result with `!!`, so it can never produce the undefined we need here.
+        function renderWithUnknownFlag() {
+            const client = {
+                isFeatureEnabled: () => undefined,
+                onFeatureFlags: () => () => {},
+                featureFlags: {
+                    hasLoadedFlags: true,
+                } as unknown as PostHog['featureFlags'],
+            } as unknown as PostHog
+
+            // eslint-disable-next-line react/display-name
+            return ({ children }: { children: React.ReactNode }) => (
+                <PostHogProvider client={client}>{children}</PostHogProvider>
+            )
+        }
+
+        it('returns the default value while the flag value is unknown', () => {
+            const { result } = renderHook(() => useFeatureFlagEnabled('missing', false), {
+                wrapper: renderWithUnknownFlag(),
+            })
+            expect(result.current).toBe(false)
+        })
+
+        it('returns undefined for an unknown flag when no default is given', () => {
+            const { result } = renderHook(() => useFeatureFlagEnabled('missing'), {
+                wrapper: renderWithUnknownFlag(),
+            })
+            expect(result.current).toBeUndefined()
+        })
+
+        it('prefers the real flag value over the default', () => {
+            const { result } = renderHook(() => useFeatureFlagEnabled('example_feature_false', true), {
+                wrapper: renderProvider,
+            })
+            expect(result.current).toBe(false)
+        })
+
+        it('applies the default in the bootstrap branch when the flag is absent', () => {
+            const client = {
+                isFeatureEnabled: () => undefined,
+                onFeatureFlags: () => () => {},
+                config: {
+                    bootstrap: {
+                        featureFlags: { other_flag: true },
+                    },
+                },
+                featureFlags: {
+                    hasLoadedFlags: false,
+                } as unknown as PostHog['featureFlags'],
+            } as unknown as PostHog
+
+            // eslint-disable-next-line react/display-name
+            const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+                <PostHogProvider client={client}>{children}</PostHogProvider>
+            )
+
+            const { result } = renderHook(() => useFeatureFlagEnabled('my_flag', false), { wrapper })
+            expect(result.current).toBe(false)
+        })
+    })
+
     describe('useFeatureFlagResult', () => {
         describe('bootstrap fallback', () => {
             function renderWithBootstrap(

--- a/packages/react/src/hooks/__tests__/featureFlags.test.tsx
+++ b/packages/react/src/hooks/__tests__/featureFlags.test.tsx
@@ -134,18 +134,15 @@ describe('feature flag hooks', () => {
             )
         }
 
-        it('returns the default value while the flag value is unknown', () => {
-            const { result } = renderHook(() => useFeatureFlagEnabled('missing', false), {
+        it.each([
+            [false as boolean | undefined, false],
+            [true as boolean | undefined, true],
+            [undefined, undefined],
+        ])('returns %s for an unknown flag when defaultValue is %s', (defaultValue, expected) => {
+            const { result } = renderHook(() => useFeatureFlagEnabled('missing', defaultValue as boolean), {
                 wrapper: renderWithUnknownFlag(),
             })
-            expect(result.current).toBe(false)
-        })
-
-        it('returns undefined for an unknown flag when no default is given', () => {
-            const { result } = renderHook(() => useFeatureFlagEnabled('missing'), {
-                wrapper: renderWithUnknownFlag(),
-            })
-            expect(result.current).toBeUndefined()
+            expect(result.current).toBe(expected)
         })
 
         it('prefers the real flag value over the default', () => {

--- a/packages/react/src/hooks/useFeatureFlagEnabled.ts
+++ b/packages/react/src/hooks/useFeatureFlagEnabled.ts
@@ -2,7 +2,23 @@ import { useContext, useEffect, useState } from 'react'
 import { PostHogContext } from '../context'
 import { isUndefined } from '../utils/type-utils'
 
+/**
+ * Check whether a feature flag is enabled for the current user.
+ *
+ * Returns `undefined` while flags are still loading or when the flag is absent, so callers can
+ * distinguish "not known yet" from "disabled".
+ *
+ * @param flag Key of the feature flag.
+ * @returns Whether the flag is enabled, or `undefined` if not yet loaded or not found.
+ */
 export function useFeatureFlagEnabled(flag: string): boolean | undefined
+/**
+ * Check whether a feature flag is enabled for the current user.
+ *
+ * @param flag Key of the feature flag.
+ * @param defaultValue Returned instead of `undefined` while flags are loading or when the flag is absent.
+ * @returns Whether the flag is enabled, falling back to `defaultValue` when the value is unknown.
+ */
 export function useFeatureFlagEnabled(flag: string, defaultValue: boolean): boolean
 export function useFeatureFlagEnabled(flag: string, defaultValue?: boolean): boolean | undefined {
     const { client, bootstrap } = useContext(PostHogContext)

--- a/packages/react/src/hooks/useFeatureFlagEnabled.ts
+++ b/packages/react/src/hooks/useFeatureFlagEnabled.ts
@@ -2,7 +2,9 @@ import { useContext, useEffect, useState } from 'react'
 import { PostHogContext } from '../context'
 import { isUndefined } from '../utils/type-utils'
 
-export function useFeatureFlagEnabled(flag: string): boolean | undefined {
+export function useFeatureFlagEnabled(flag: string): boolean | undefined
+export function useFeatureFlagEnabled(flag: string, defaultValue: boolean): boolean
+export function useFeatureFlagEnabled(flag: string, defaultValue?: boolean): boolean | undefined {
     const { client, bootstrap } = useContext(PostHogContext)
 
     const [featureEnabled, setFeatureEnabled] = useState<boolean | undefined>(() => client.isFeatureEnabled(flag))
@@ -17,8 +19,9 @@ export function useFeatureFlagEnabled(flag: string): boolean | undefined {
 
     // if the client is not loaded yet, check if we have a bootstrapped value and then true/false it
     if (!client?.featureFlags?.hasLoadedFlags && bootstrap?.featureFlags) {
-        return isUndefined(bootstrapped) ? undefined : !!bootstrapped
+        return isUndefined(bootstrapped) ? defaultValue : !!bootstrapped
     }
 
-    return featureEnabled
+    // while the flag value is unknown (flags not loaded, or the flag is absent), fall back to defaultValue
+    return isUndefined(featureEnabled) ? defaultValue : featureEnabled
 }


### PR DESCRIPTION
## Problem

Closes #3712. `useFeatureFlagEnabled` returns `boolean | undefined`, so every caller has to handle a third state even when the intent is simply "feature off until proven on." That leads to `useFeatureFlagEnabled('flag') ?? false` scattered everywhere, and if it's missed, `undefined` leaks into conditionals and UI state.

## Changes

Added an optional second argument, `defaultValue`, to `useFeatureFlagEnabled`. When supplied, the hook returns it instead of `undefined` while flags are loading or when the flag is absent from the payload; overloads narrow the return type to `boolean` in that case so callers no longer need `?? false`. Omitting the argument is fully backwards compatible — the hook still returns `boolean | undefined` exactly as before.

```ts
useFeatureFlagEnabled('flag')         // boolean | undefined  (unchanged)
useFeatureFlagEnabled('flag', false)  // boolean — false until proven enabled
```

Added tests for: default applied while the value is unknown, `undefined` preserved when no default is given, the real flag value taking precedence over the default, and the default applying in the bootstrap branch.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [x] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
