### PR TITLE
fix(replay): keep canvas recording alive across iframe/shadow teardown

### DIFF
--- a/.changeset/rrweb-canvas-manager-refcount.md
+++ b/.changeset/rrweb-canvas-manager-refcount.md
@@ -1,0 +1,5 @@
+---
+'@posthog/rrweb': patch
+---
+
+canvas recording: reference-count CanvasManager teardown so it survives secondary-root cleanup. A single CanvasManager is shared by the main document and every iframe / shadow-root observer; previously tearing down any one of those (e.g. an iframe unloading, or a framework unmounting a subtree rrweb was observing) unpatched `HTMLCanvasElement.prototype.getContext` and cancelled the FPS loop for the whole page, silently stopping canvas recording while the session stayed active. The manager now only tears down once the last consumer releases.

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -224,9 +224,7 @@ export default class MutationBuffer {
       // just a type trick, the runtime result is correct
       this[key] = options[key] as never;
     });
-    // Register this buffer as a consumer of the shared CanvasManager so its (global) canvas
-    // observers are only torn down once every root that references it has been reset. Balanced
-    // by the canvasManager.reset() call in this.reset().
+    // Balanced by releaseCanvasManager() in reset().
     this.canvasManager.acquire();
   }
 
@@ -261,11 +259,8 @@ export default class MutationBuffer {
     this.releaseCanvasManager();
   }
 
-  /**
-   * Releases this buffer's reference to the shared CanvasManager exactly once, even if reset()
-   * runs multiple times (the iframe pagehide + stop paths can both fire). Kept separate from
-   * reset() so shadow-root teardown can release without recursing back into shadowDomManager.reset().
-   */
+  // Releases at most once even if reset() runs twice (iframe pagehide + stop). Separate from
+  // reset() so shadow-root teardown can release without re-entering shadowDomManager.reset().
   public releaseCanvasManager() {
     if (this.canvasManagerReleased) {
       return;

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -193,6 +193,7 @@ export default class MutationBuffer {
   private canvasManager: observerParam['canvasManager'];
   private processedNodeManager: observerParam['processedNodeManager'];
   private unattachedDoc: HTMLDocument;
+  private canvasManagerReleased = false;
 
   public init(options: MutationBufferParam) {
     (
@@ -223,6 +224,10 @@ export default class MutationBuffer {
       // just a type trick, the runtime result is correct
       this[key] = options[key] as never;
     });
+    // Register this buffer as a consumer of the shared CanvasManager so its (global) canvas
+    // observers are only torn down once every root that references it has been reset. Balanced
+    // by the canvasManager.reset() call in this.reset().
+    this.canvasManager.acquire();
   }
 
   public freeze() {
@@ -253,6 +258,19 @@ export default class MutationBuffer {
 
   public reset() {
     this.shadowDomManager.reset();
+    this.releaseCanvasManager();
+  }
+
+  /**
+   * Releases this buffer's reference to the shared CanvasManager exactly once, even if reset()
+   * runs multiple times (the iframe pagehide + stop paths can both fire). Kept separate from
+   * reset() so shadow-root teardown can release without recursing back into shadowDomManager.reset().
+   */
+  public releaseCanvasManager() {
+    if (this.canvasManagerReleased) {
+      return;
+    }
+    this.canvasManagerReleased = true;
     this.canvasManager.reset();
   }
 

--- a/packages/rrweb/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -39,13 +39,8 @@ export class CanvasManager {
   private refCount = 0;
   private torndown = false;
 
-  /**
-   * A single CanvasManager is shared by the main document and every iframe / shadow-root
-   * observer (see record/index.ts). Each consumer registers itself so we can reference-count
-   * teardown: the getContext patch and FPS loop are global, so tearing them down when only one
-   * root is cleaned up (e.g. an iframe unloads, or a framework unmounts a subtree rrweb was
-   * observing) would silently stop canvas recording for the whole page.
-   */
+  // Shared by the main document and every iframe/shadow-root observer, so reference-count
+  // teardown: a single root cleaning up must not unpatch getContext / stop the FPS loop globally.
   public acquire() {
     this.refCount += 1;
   }
@@ -54,7 +49,6 @@ export class CanvasManager {
     if (this.refCount > 0) {
       this.refCount -= 1;
     }
-    // Only the last consumer to release actually tears the observers down.
     if (this.refCount > 0) {
       return;
     }

--- a/packages/rrweb/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -36,8 +36,36 @@ export class CanvasManager {
   private locked = false;
   private rafIdTimestamp: number | null = null;
   private rafIdFlush: number | null = null;
+  private refCount = 0;
+  private torndown = false;
+
+  /**
+   * A single CanvasManager is shared by the main document and every iframe / shadow-root
+   * observer (see record/index.ts). Each consumer registers itself so we can reference-count
+   * teardown: the getContext patch and FPS loop are global, so tearing them down when only one
+   * root is cleaned up (e.g. an iframe unloads, or a framework unmounts a subtree rrweb was
+   * observing) would silently stop canvas recording for the whole page.
+   */
+  public acquire() {
+    this.refCount += 1;
+  }
 
   public reset() {
+    if (this.refCount > 0) {
+      this.refCount -= 1;
+    }
+    // Only the last consumer to release actually tears the observers down.
+    if (this.refCount > 0) {
+      return;
+    }
+    this.teardown();
+  }
+
+  private teardown() {
+    if (this.torndown) {
+      return;
+    }
+    this.torndown = true;
     this.pendingCanvasMutations.clear();
     this.resetObservers && this.resetObservers();
     if (this.rafIdTimestamp !== null) {

--- a/packages/rrweb/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/rrweb/src/record/shadow-dom-manager.ts
@@ -67,9 +67,7 @@ export class ShadowDomManager {
     this.restoreHandlers.push(() => {
       observer.disconnect();
       buffer.destroy();
-      // Release this shadow root's reference to the shared CanvasManager so the reference count
-      // stays balanced. We can't call buffer.reset() here because that re-enters this manager's
-      // reset() (we're often invoked from it), so release the canvas reference directly.
+      // Release the canvas ref directly; buffer.reset() would re-enter shadowDomManager.reset().
       buffer.releaseCanvasManager();
       const index = mutationBuffers.indexOf(buffer);
       if (index !== -1) {

--- a/packages/rrweb/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/rrweb/src/record/shadow-dom-manager.ts
@@ -67,6 +67,10 @@ export class ShadowDomManager {
     this.restoreHandlers.push(() => {
       observer.disconnect();
       buffer.destroy();
+      // Release this shadow root's reference to the shared CanvasManager so the reference count
+      // stays balanced. We can't call buffer.reset() here because that re-enters this manager's
+      // reset() (we're often invoked from it), so release the canvas reference directly.
+      buffer.releaseCanvasManager();
       const index = mutationBuffers.indexOf(buffer);
       if (index !== -1) {
         mutationBuffers.splice(index, 1);

--- a/packages/rrweb/rrweb/test/record/canvas-manager.test.ts
+++ b/packages/rrweb/rrweb/test/record/canvas-manager.test.ts
@@ -279,11 +279,7 @@ describe('CanvasManager FPS observer', () => {
   });
 });
 
-// Regression coverage for the bug where tearing down a single iframe / shadow-root observer
-// would unpatch HTMLCanvasElement.prototype.getContext and cancel the FPS loop for the WHOLE
-// page, silently stopping canvas recording while the session stayed active. The CanvasManager is
-// shared across the main document and every secondary root, so its teardown is reference-counted:
-// it only happens once the last consumer releases.
+// A single root tearing down must not stop canvas recording for the whole page.
 describe('CanvasManager reference-counted teardown', () => {
   const makeManager = (): {
     manager: CanvasManager;

--- a/packages/rrweb/rrweb/test/record/canvas-manager.test.ts
+++ b/packages/rrweb/rrweb/test/record/canvas-manager.test.ts
@@ -300,11 +300,21 @@ describe('CanvasManager reference-counted teardown', () => {
     return { manager, resetObservers };
   };
 
-  it('tears down once a single consumer releases', () => {
+  it.each([
+    ['one acquire, one reset', (m: CanvasManager) => m.reset()],
+    [
+      'extra resets are clamped',
+      (m: CanvasManager) => {
+        m.reset();
+        m.reset();
+        m.reset();
+      },
+    ],
+  ])('tears down exactly once: %s', (_label, releaseAll) => {
     const { manager, resetObservers } = makeManager();
     manager.acquire();
 
-    manager.reset();
+    releaseAll(manager);
 
     expect(resetObservers).toHaveBeenCalledTimes(1);
   });
@@ -319,17 +329,6 @@ describe('CanvasManager reference-counted teardown', () => {
     expect(resetObservers).not.toHaveBeenCalled();
 
     manager.reset(); // last consumer (main document) released
-
-    expect(resetObservers).toHaveBeenCalledTimes(1);
-  });
-
-  it('only tears down once even if reset is called more than there were consumers', () => {
-    const { manager, resetObservers } = makeManager();
-    manager.acquire();
-
-    manager.reset();
-    manager.reset();
-    manager.reset();
 
     expect(resetObservers).toHaveBeenCalledTimes(1);
   });

--- a/packages/rrweb/rrweb/test/record/canvas-manager.test.ts
+++ b/packages/rrweb/rrweb/test/record/canvas-manager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createMirror } from '@posthog/rrweb-snapshot';
 import { CanvasManager } from '../../src/record/observers/canvas/canvas-manager';
+import MutationBuffer from '../../src/record/mutation';
 
 vi.mock('../../src/record/observers/canvas/canvas', () => ({
   default: () => () => {},
@@ -275,5 +276,106 @@ describe('CanvasManager FPS observer', () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(vi.mocked(createImageBitmap)).toHaveBeenCalled();
+  });
+});
+
+// Regression coverage for the bug where tearing down a single iframe / shadow-root observer
+// would unpatch HTMLCanvasElement.prototype.getContext and cancel the FPS loop for the WHOLE
+// page, silently stopping canvas recording while the session stayed active. The CanvasManager is
+// shared across the main document and every secondary root, so its teardown is reference-counted:
+// it only happens once the last consumer releases.
+describe('CanvasManager reference-counted teardown', () => {
+  const makeManager = (): {
+    manager: CanvasManager;
+    resetObservers: ReturnType<typeof vi.fn>;
+  } => {
+    const manager = new CanvasManager({
+      recordCanvas: false, // skip real observer setup; we inject a spy below
+      mutationCb: vi.fn(),
+      win: {} as never,
+      blockClass: 'rr-block',
+      blockSelector: null,
+      mirror: {} as never,
+      dataURLOptions: {},
+    });
+    const resetObservers = vi.fn();
+    (manager as unknown as { resetObservers: () => void }).resetObservers =
+      resetObservers;
+    return { manager, resetObservers };
+  };
+
+  it('tears down once a single consumer releases', () => {
+    const { manager, resetObservers } = makeManager();
+    manager.acquire();
+
+    manager.reset();
+
+    expect(resetObservers).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not tear down while other consumers are still attached', () => {
+    const { manager, resetObservers } = makeManager();
+    manager.acquire(); // main document
+    manager.acquire(); // e.g. an iframe / shadow root
+
+    manager.reset(); // secondary root torn down
+
+    expect(resetObservers).not.toHaveBeenCalled();
+
+    manager.reset(); // last consumer (main document) released
+
+    expect(resetObservers).toHaveBeenCalledTimes(1);
+  });
+
+  it('only tears down once even if reset is called more than there were consumers', () => {
+    const { manager, resetObservers } = makeManager();
+    manager.acquire();
+
+    manager.reset();
+    manager.reset();
+    manager.reset();
+
+    expect(resetObservers).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('MutationBuffer canvas reference balance', () => {
+  const makeBuffer = (): {
+    buffer: MutationBuffer;
+    canvasManager: {
+      acquire: ReturnType<typeof vi.fn>;
+      reset: ReturnType<typeof vi.fn>;
+    };
+    shadowDomManager: { reset: ReturnType<typeof vi.fn> };
+  } => {
+    const canvasManager = { acquire: vi.fn(), reset: vi.fn() };
+    const shadowDomManager = { reset: vi.fn() };
+    const buffer = new MutationBuffer();
+    buffer.init({ canvasManager, shadowDomManager } as never);
+    return { buffer, canvasManager, shadowDomManager };
+  };
+
+  it('acquires the canvas manager exactly once on init', () => {
+    const { canvasManager } = makeBuffer();
+
+    expect(canvasManager.acquire).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the canvas manager only once even if reset runs multiple times', () => {
+    const { buffer, canvasManager } = makeBuffer();
+
+    buffer.reset();
+    buffer.reset();
+
+    expect(canvasManager.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('releaseCanvasManager is idempotent with reset', () => {
+    const { buffer, canvasManager } = makeBuffer();
+
+    buffer.releaseCanvasManager();
+    buffer.reset();
+
+    expect(canvasManager.reset).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/rrweb/rrweb/test/record/shadow-dom-manager.test.ts
+++ b/packages/rrweb/rrweb/test/record/shadow-dom-manager.test.ts
@@ -43,6 +43,7 @@ describe('ShadowDomManager', () => {
           adoptStyleSheets: vi.fn(),
         } as any,
         canvasManager: {
+          acquire: vi.fn(),
           reset: vi.fn(),
           lock: vi.fn(),
           unlock: vi.fn(),


### PR DESCRIPTION
## Problem

Customers recording canvas-heavy React SPAs (Konva / Three.js / `@react-three/fiber`) report that canvas areas are **completely blank in replay** whenever the canvas route is reached via SPA navigation, while a hard refresh onto the same route records fine. `sessionRecording.status` stays `active` and `recordCanvas` stays `true` the whole time — the canvas just stops being captured.

Root cause: a single `CanvasManager` instance is shared by the main document and every iframe / shadow-root observer (it's constructed once in `record/index.ts` and passed to all observers). `MutationBuffer.reset()` calls the **global** `canvasManager.reset()`, which unpatches `HTMLCanvasElement.prototype.getContext` and cancels the FPS `requestAnimationFrame` loop. So when *any* secondary root observer is torn down — an iframe unloading, or (as in the report) a framework like React unmounting a subtree that rrweb was observing during a commit — canvas capture dies for the **entire page**, even though the main document's observer should still be running.

This matches the customer-captured stack trace exactly: React fiber commit → `initObservers` cleanup → `MutationBuffer.reset` → `CanvasManager.reset` → `resetObservers` → `getContext` restorer, with no posthog frame in between (the public `stopRecording` API is never called).

## Changes

Reference-count `CanvasManager` teardown so it survives secondary-root cleanup and only actually tears down once the **last** consumer releases:

- `CanvasManager` gains `acquire()` and an internal `refCount`. `reset()` now decrements and only runs the real teardown (`resetObservers()` + cancelling the rAF loops) when the count reaches zero. A `torndown` guard keeps the final teardown idempotent.
- `MutationBuffer.init()` acquires the shared manager; `MutationBuffer.reset()` releases it via a new `releaseCanvasManager()` that releases **at most once per buffer** (the iframe pagehide + stop paths can both invoke a buffer's cleanup, which would otherwise double-decrement).
- `ShadowDomManager` releases its per-shadow-root buffer's reference on teardown via `releaseCanvasManager()` directly — it can't call `buffer.reset()` there because that re-enters `shadowDomManager.reset()`.

The main-document buffer holds a reference for the entire recording (acquired at start, released only on stop), so the count never hits zero mid-session and the observers stay alive across iframe/shadow churn. On full stop every buffer releases and the manager tears down exactly once.

Added regression tests in `canvas-manager.test.ts` (ref-counted teardown + per-buffer release balance) and updated the shadow-dom-manager test mock with `acquire`.

> Note: affects the `@posthog/rrweb` package (canvas recorder), consumed by posthog-js. Changeset included.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web) — via the bundled `@posthog/rrweb` canvas recorder
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

Made with [Cursor](https://cursor.com)