### PR TITLE
feat: emit $is_server property on captured events

### DIFF
--- a/.changeset/is-server-property.md
+++ b/.changeset/is-server-property.md
@@ -1,5 +1,5 @@
 ---
-"posthog-node": patch
+"posthog-node": minor
 ---
 
 Add a configurable `$is_server` event property (default `true`) so PostHog can identify server-side events. Set `isServer: false` when using the SDK as a client/CLI so the device OS is attributed normally.

--- a/.changeset/is-server-property.md
+++ b/.changeset/is-server-property.md
@@ -2,4 +2,4 @@
 "posthog-node": patch
 ---
 
-Emit `$is_server` property on captured events so PostHog can identify server-side events.
+Add a configurable `$is_server` event property (default `true`) so PostHog can identify server-side events. Set `isServer: false` when using the SDK as a client/CLI so the device OS is attributed normally.

--- a/.changeset/is-server-property.md
+++ b/.changeset/is-server-property.md
@@ -1,0 +1,5 @@
+---
+"posthog-node": patch
+---
+
+Emit `$is_server` property on captured events so PostHog can identify server-side events.

--- a/packages/node/src/__tests__/extensions/sentry-integration.spec.ts
+++ b/packages/node/src/__tests__/extensions/sentry-integration.spec.ts
@@ -149,6 +149,7 @@ describe('PostHogSentryIntegration', () => {
           $lib: 'posthog-node',
           $lib_version: '1.2.3',
           $geoip_disable: true,
+          $is_server: true,
         },
         type: 'capture',
         library: 'posthog-node',

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -127,6 +127,34 @@ describe('PostHog Node.js', () => {
       )
     })
 
+    it('should not include $is_server when isServer is false (client/CLI usage)', async () => {
+      const cliClient = new PostHog('TEST_API_KEY', {
+        host: 'http://example.com',
+        fetchRetryCount: 0,
+        disableCompression: true,
+        isServer: false,
+      })
+
+      try {
+        cliClient.capture({ distinctId: '123', event: 'test-event', properties: { foo: 'bar' } })
+
+        await waitForFlushTimer()
+
+        const batchEvents = getLastBatchEvents()
+        expect(batchEvents?.[0]).toEqual(
+          expect.objectContaining({
+            event: 'test-event',
+            properties: expect.objectContaining({
+              $lib: 'posthog-node',
+            }),
+          })
+        )
+        expect(batchEvents?.[0]?.properties).not.toHaveProperty('$is_server')
+      } finally {
+        await cliClient.shutdown()
+      }
+    })
+
     it('shouldnt muddy subsequent capture calls', async () => {
       expect(mockedFetch).toHaveBeenCalledTimes(0)
       posthog.capture({ distinctId: '123', event: 'test-event', properties: { foo: 'bar' }, groups: { org: 123 } })

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -98,6 +98,7 @@ describe('PostHog Node.js', () => {
             $geoip_disable: true,
             $lib: 'posthog-node',
             $lib_version: '1.2.3',
+            $is_server: true,
           },
           uuid: expect.any(String),
           timestamp: expect.any(String),
@@ -106,6 +107,24 @@ describe('PostHog Node.js', () => {
           library_version: '1.2.3',
         },
       ])
+    })
+
+    it('should include $is_server: true on captured events (server-side SDK)', async () => {
+      expect(mockedFetch).toHaveBeenCalledTimes(0)
+      posthog.capture({ distinctId: '123', event: 'test-event', properties: { foo: 'bar' } })
+
+      await waitForFlushTimer()
+
+      const batchEvents = getLastBatchEvents()
+      expect(batchEvents?.[0]).toEqual(
+        expect.objectContaining({
+          event: 'test-event',
+          properties: expect.objectContaining({
+            $lib: 'posthog-node',
+            $is_server: true,
+          }),
+        })
+      )
     })
 
     it('shouldnt muddy subsequent capture calls', async () => {

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -109,24 +109,6 @@ describe('PostHog Node.js', () => {
       ])
     })
 
-    it('should include $is_server: true on captured events (server-side SDK)', async () => {
-      expect(mockedFetch).toHaveBeenCalledTimes(0)
-      posthog.capture({ distinctId: '123', event: 'test-event', properties: { foo: 'bar' } })
-
-      await waitForFlushTimer()
-
-      const batchEvents = getLastBatchEvents()
-      expect(batchEvents?.[0]).toEqual(
-        expect.objectContaining({
-          event: 'test-event',
-          properties: expect.objectContaining({
-            $lib: 'posthog-node',
-            $is_server: true,
-          }),
-        })
-      )
-    })
-
     it('should not include $is_server when isServer is false (client/CLI usage)', async () => {
       const cliClient = new PostHog('TEST_API_KEY', {
         host: 'http://example.com',

--- a/packages/node/src/__tests__/posthog-node.spec.ts
+++ b/packages/node/src/__tests__/posthog-node.spec.ts
@@ -335,6 +335,7 @@ describe('PostHog Node.js', () => {
         foo: 'bar',
         $lib: 'posthog-node',
         $lib_version: '1.2.3',
+        $is_server: true,
       })
     })
 
@@ -355,6 +356,7 @@ describe('PostHog Node.js', () => {
         foo: 'bar',
         $lib: 'posthog-node',
         $lib_version: '1.2.3',
+        $is_server: true,
       })
 
       client.capture({
@@ -374,6 +376,7 @@ describe('PostHog Node.js', () => {
         $lib: 'posthog-node',
         $lib_version: '1.2.3',
         $geoip_disable: true,
+        $is_server: true,
       })
 
       client.capture({
@@ -393,6 +396,7 @@ describe('PostHog Node.js', () => {
         foo: 'bar',
         $lib: 'posthog-node',
         $lib_version: '1.2.3',
+        $is_server: true,
       })
 
       await client.shutdown()
@@ -1207,6 +1211,7 @@ describe('PostHog Node.js', () => {
         '$feature/feature-variant': 'variant',
         $lib: 'posthog-node',
         $lib_version: '1.2.3',
+        $is_server: true,
       })
 
       // no calls to `/local_evaluation`

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -431,13 +431,22 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
    * react-native clients do not extend `PostHogBackendClient`, so they
    * never receive this property.
    *
-   * @returns The common event properties, including `$is_server: true`.
+   * This is controlled by the `isServer` option, which defaults to `true`.
+   * When `isServer` is `false` (e.g. when using the SDK as a client/CLI), the
+   * `$is_server` property is omitted entirely so the device OS is attributed
+   * normally.
+   *
+   * @returns The common event properties, including `$is_server: true` when
+   * the `isServer` option is enabled.
    */
   protected override getCommonEventProperties(): PostHogEventProperties {
-    return {
-      ...super.getCommonEventProperties(),
-      $is_server: true,
+    const commonProperties = super.getCommonEventProperties()
+
+    if (this.options.isServer ?? true) {
+      commonProperties.$is_server = true
     }
+
+    return commonProperties
   }
 
   /**

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -421,6 +421,26 @@ export abstract class PostHogBackendClient extends PostHogCoreStateless implemen
   }
 
   /**
+   * Returns the common properties attached to every captured event.
+   *
+   * @remarks
+   * Extends the shared core properties (`$lib`, `$lib_version`) with
+   * `$is_server: true` so that events emitted from the server-side SDKs
+   * (posthog-node and posthog-edge, which both extend this class) are
+   * distinguishable from browser and react-native events. Browser and
+   * react-native clients do not extend `PostHogBackendClient`, so they
+   * never receive this property.
+   *
+   * @returns The common event properties, including `$is_server: true`.
+   */
+  protected override getCommonEventProperties(): PostHogEventProperties {
+    return {
+      ...super.getCommonEventProperties(),
+      $is_server: true,
+    }
+  }
+
+  /**
    * Enable the PostHog client (opt-in).
    *
    * @example

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -263,6 +263,23 @@ export type PostHogOptions = Omit<PostHogCoreOptions, 'before_send'> & {
    * @default 500
    */
   waitUntilMaxWaitMs?: number
+  /**
+   * Whether to attach the `$is_server: true` property to every captured event.
+   *
+   * @remarks
+   * Defaults to `true` because this SDK is intended for server-side use, where
+   * the property lets PostHog distinguish server events from browser and
+   * react-native events. Set this to `false` when running the SDK as a
+   * client/CLI so the event is attributed to the device OS normally instead of
+   * being marked as a server event. When `false`, the `$is_server` property is
+   * omitted entirely.
+   *
+   * @default true
+   * @example
+   * // CLI usage: don't mark events as server-side
+   * new PostHog('key', { isServer: false })
+   */
+  isServer?: boolean
 }
 
 export type PostHogFeatureFlag = {


### PR DESCRIPTION
Adds `$is_server: true` to every event captured by this SDK so PostHog ingestion can identify server-side events.