### PR TITLE
fix(react-native): make Android sourcemap upload configuration-cache compatible

### DIFF
--- a/.changeset/rn-gradle-configuration-cache.md
+++ b/.changeset/rn-gradle-configuration-cache.md
@@ -2,4 +2,4 @@
 "posthog-react-native": patch
 ---
 
-fix(react-native): make the Android Hermes sourcemap upload tasks compatible with Gradle's configuration cache by resolving the posthog-cli path and arguments at configuration time, so the task actions no longer call script-level methods or access `project` at execution time.
+fix(react-native): make the Android Hermes sourcemap upload tasks compatible with Gradle's configuration cache.

--- a/.changeset/rn-gradle-configuration-cache.md
+++ b/.changeset/rn-gradle-configuration-cache.md
@@ -1,0 +1,5 @@
+---
+"posthog-react-native": patch
+---
+
+fix(react-native): make the Android Hermes sourcemap upload tasks compatible with Gradle's configuration cache by resolving the posthog-cli path and arguments at configuration time, so the task actions no longer call script-level methods or access `project` at execution time.

--- a/packages/react-native/tooling/posthog.gradle
+++ b/packages/react-native/tooling/posthog.gradle
@@ -5,6 +5,8 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
+import org.gradle.api.logging.Logging
+
 interface InjectedExecOps {
     @Inject //@javax.inject.Inject
     ExecOperations getExecOps()
@@ -90,43 +92,47 @@ plugins.withId('com.android.application') {
 
                         def injected = project.objects.newInstance(InjectedExecOps)
 
-                        // Resolve the CLI path, arguments and OS prefix at configuration time and
-                        // capture them as plain serializable state (String/List). The doFirst/doLast
-                        // actions must not call the script-level resolvePostHogCliPackagePath() nor
-                        // read `project` at execution time: with Gradle's configuration cache enabled
-                        // the task actions are serialized and lose the apply-from script's owner
-                        // chain, which breaks method resolution ("Could not find method
-                        // resolvePostHogCliPackagePath() ... on object of type
-                        // DefaultExecAction_Decorated") and disallows `Task.project` access.
-                        def cliPackage = resolvePostHogCliPackagePath(reactRoot)
+                        // Resolve the posthog-cli path at execution time, not during
+                        // configuration. The resolver starts node/npm via Groovy's `.execute()`,
+                        // and Gradle's configuration cache forbids starting external processes at
+                        // configuration time. Resolution lives in the static
+                        // PostHogCli.resolveCliPackagePath() so these serialized task actions can
+                        // call it without relying on the apply-from script's owner chain — a
+                        // script-level method fails under the configuration cache with "Could not
+                        // find method ... on object of type DefaultExecAction_Decorated". rootDir
+                        // is captured as plain serializable state; `Task.project` must not be read
+                        // at execution time, so logging uses the task's own `logger`.
+                        def rootDirFile = rootDir
                         def osCompatibility = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c', 'node'] : []
 
-                        def cloneArgs = [cliPackage]
-                        cloneArgs.addAll(["hermes", "clone",
-                            "--minified-map-path", packagerSourcemapOutput, // The path to a sourcemap
-                            "--composed-map-path", sourcemapOutput          // The path of the composed source map
-                        ])
-                        cloneArgs.addAll(extraArgs)
-                        logger.info("posthog-cli clone arguments: ${cloneArgs}")
-
-                        def uploadArgs = [cliPackage]
-                        uploadArgs.addAll(["hermes", "upload",
-                            "--directory", sourcemapOutput.getParent()      // The path to a sourcemap that should be uploaded.
-                        ])
-                        uploadArgs.addAll(extraArgs)
-                        logger.info("posthog-cli upload arguments: ${uploadArgs}")
-
                         doFirst {
+                            def cliPackage = PostHogCli.resolveCliPackagePath(rootDirFile, reactRoot)
+                            def args = [cliPackage]
+                            args.addAll(["hermes", "clone",
+                                "--minified-map-path", packagerSourcemapOutput, // The path to a sourcemap
+                                "--composed-map-path", sourcemapOutput          // The path of the composed source map
+                            ])
+                            args.addAll(extraArgs)
+                            logger.info("posthog-cli clone arguments: ${args}")
+
                             injected.execOps.exec {
                                 workingDir reactRoot
-                                commandLine(*osCompatibility, *cloneArgs)
+                                commandLine(*osCompatibility, *args)
                             }
                         }
 
                         doLast {
+                            def cliPackage = PostHogCli.resolveCliPackagePath(rootDirFile, reactRoot)
+                            def args = [cliPackage]
+                            args.addAll(["hermes", "upload",
+                                "--directory", sourcemapOutput.getParent()      // The path to a sourcemap that should be uploaded.
+                            ])
+                            args.addAll(extraArgs)
+                            logger.info("posthog-cli upload arguments: ${args}")
+
                             injected.execOps.exec {
                                 workingDir reactRoot
-                                commandLine(*osCompatibility, *uploadArgs)
+                                commandLine(*osCompatibility, *args)
                             }
                         }
 
@@ -167,65 +173,74 @@ plugins.withId('com.android.application') {
     }
 }
 
-def resolvePostHogCliPackagePath(reactRoot) {
-    // First, try to find @posthog/cli folder from require.resolve
-    try {
-        def resolvedPath = new File(["node", "--print", "require.resolve('@posthog/cli/package.json')"].execute(null, rootDir).text.trim()).getParentFile()
-        if (resolvedPath != null && resolvedPath.exists()) {
-            def runPostHogCliFile = new File(resolvedPath, "run-posthog-cli.js")
+// Static so the serialized sourcemap-upload task actions can call it under the
+// Gradle configuration cache. It starts node/npm, so it must run at execution
+// time — starting external processes at configuration time is rejected by the
+// configuration cache. Uses its own logger (not `project.logger`) and takes
+// rootDir as a parameter so it never touches `Task.project` at execution time.
+abstract class PostHogCli {
+    static String resolveCliPackagePath(File rootDir, reactRoot) {
+        def logger = Logging.getLogger(PostHogCli)
+
+        // First, try to find @posthog/cli folder from require.resolve
+        try {
+            def resolvedPath = new File(["node", "--print", "require.resolve('@posthog/cli/package.json')"].execute(null, rootDir).text.trim()).getParentFile()
+            if (resolvedPath != null && resolvedPath.exists()) {
+                def runPostHogCliFile = new File(resolvedPath, "run-posthog-cli.js")
+                if (runPostHogCliFile.exists()) {
+                    logger.info("resolved posthog-cli dynamically: `${runPostHogCliFile.getAbsolutePath()}`")
+                    return runPostHogCliFile.getAbsolutePath()
+                }
+            }
+        } catch (Throwable ignored) {}
+
+        // Second, check if @posthog/cli exists in $reactRoot/node_modules
+        def nodeModulesPath = new File("$reactRoot/node_modules/@posthog/cli")
+        if (nodeModulesPath.exists()) {
+            def runPostHogCliFile = new File(nodeModulesPath, "run-posthog-cli.js")
             if (runPostHogCliFile.exists()) {
-                project.logger.info("resolved posthog-cli dynamically: `${runPostHogCliFile.getAbsolutePath()}`")
+                logger.info("resolved posthog-cli hard-coded path (yarn or npm): `${runPostHogCliFile.getAbsolutePath()}`")
                 return runPostHogCliFile.getAbsolutePath()
             }
         }
-    } catch (Throwable ignored) {}
 
-    // Second, check if @posthog/cli exists in $reactRoot/node_modules
-    def nodeModulesPath = new File("$reactRoot/node_modules/@posthog/cli")
-    if (nodeModulesPath.exists()) {
-        def runPostHogCliFile = new File(nodeModulesPath, "run-posthog-cli.js")
-        if (runPostHogCliFile.exists()) {
-            project.logger.info("resolved posthog-cli hard-coded path (yarn or npm): `${runPostHogCliFile.getAbsolutePath()}`")
-            return runPostHogCliFile.getAbsolutePath()
+        // Third, check for pnpm installation with node_modules/.bin/posthog-cli
+        def pnpmBinPath = new File("$reactRoot/node_modules/.bin/posthog-cli")
+        if (pnpmBinPath.exists()) {
+            logger.info("resolved posthog-cli hard-coded path (pnpm): `${pnpmBinPath.getAbsolutePath()}`")
+            return pnpmBinPath.getAbsolutePath()
         }
+
+        // Fourth, check using npm root for local installation
+        try {
+            def npmRoot = ["npm", "root"].execute(null, rootDir).text.trim()
+            def npmPostHogCliPath = new File(npmRoot, "@posthog/cli")
+            if (npmPostHogCliPath.exists()) {
+                def runPostHogCliFile = new File(npmPostHogCliPath, "run-posthog-cli.js")
+                if (runPostHogCliFile.exists()) {
+                    logger.info("resolved posthog-cli via npm root: `${runPostHogCliFile.getAbsolutePath()}`")
+                    return runPostHogCliFile.getAbsolutePath()
+                }
+            }
+        } catch (Throwable ignored) {}
+
+        // Fifth, check for global npm installation of @posthog/cli
+        try {
+            def globalPrefix = ["npm", "prefix", "-g"].execute().text.trim()
+            def globalPostHogCliPath = new File(globalPrefix, "lib/node_modules/@posthog/cli")
+            if (globalPostHogCliPath.exists()) {
+                def runPostHogCliFile = new File(globalPostHogCliPath, "run-posthog-cli.js")
+                if (runPostHogCliFile.exists()) {
+                    logger.info("resolved posthog-cli from global npm installation: `${runPostHogCliFile.getAbsolutePath()}`")
+                    return runPostHogCliFile.getAbsolutePath()
+                }
+            }
+        } catch (Throwable ignored) {}
+
+        // Finally, fallback to global install
+        logger.info("falling back to global posthog-cli")
+        return "posthog-cli"
     }
-
-    // Third, check for pnpm installation with node_modules/.bin/posthog-cli
-    def pnpmBinPath = new File("$reactRoot/node_modules/.bin/posthog-cli")
-    if (pnpmBinPath.exists()) {
-        project.logger.info("resolved posthog-cli hard-coded path (pnpm): `${pnpmBinPath.getAbsolutePath()}`")
-        return pnpmBinPath.getAbsolutePath()
-    }
-
-    // Fourth, check using npm root for local installation
-    try {
-        def npmRoot = ["npm", "root"].execute(null, rootDir).text.trim()
-        def npmPostHogCliPath = new File(npmRoot, "@posthog/cli")
-        if (npmPostHogCliPath.exists()) {
-            def runPostHogCliFile = new File(npmPostHogCliPath, "run-posthog-cli.js")
-            if (runPostHogCliFile.exists()) {
-                project.logger.info("resolved posthog-cli via npm root: `${runPostHogCliFile.getAbsolutePath()}`")
-                return runPostHogCliFile.getAbsolutePath()
-            }
-        }
-    } catch (Throwable ignored) {}
-
-    // Fifth, check for global npm installation of @posthog/cli
-    try {
-        def globalPrefix = ["npm", "prefix", "-g"].execute().text.trim()
-        def globalPostHogCliPath = new File(globalPrefix, "lib/node_modules/@posthog/cli")
-        if (globalPostHogCliPath.exists()) {
-            def runPostHogCliFile = new File(globalPostHogCliPath, "run-posthog-cli.js")
-            if (runPostHogCliFile.exists()) {
-                project.logger.info("resolved posthog-cli from global npm installation: `${runPostHogCliFile.getAbsolutePath()}`")
-                return runPostHogCliFile.getAbsolutePath()
-            }
-        }
-    } catch (Throwable ignored) {}
-
-    // Finally, fallback to global install
-    project.logger.info("falling back to global posthog-cli")
-    return "posthog-cli"
 }
 
 def resolvePostHogReactNativeSDKPath(reactRoot) {

--- a/packages/react-native/tooling/posthog.gradle
+++ b/packages/react-native/tooling/posthog.gradle
@@ -89,45 +89,44 @@ plugins.withId('com.android.application') {
                         }
 
                         def injected = project.objects.newInstance(InjectedExecOps)
+
+                        // Resolve the CLI path, arguments and OS prefix at configuration time and
+                        // capture them as plain serializable state (String/List). The doFirst/doLast
+                        // actions must not call the script-level resolvePostHogCliPackagePath() nor
+                        // read `project` at execution time: with Gradle's configuration cache enabled
+                        // the task actions are serialized and lose the apply-from script's owner
+                        // chain, which breaks method resolution ("Could not find method
+                        // resolvePostHogCliPackagePath() ... on object of type
+                        // DefaultExecAction_Decorated") and disallows `Task.project` access.
+                        def cliPackage = resolvePostHogCliPackagePath(reactRoot)
+                        def osCompatibility = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c', 'node'] : []
+
+                        def cloneArgs = [cliPackage]
+                        cloneArgs.addAll(["hermes", "clone",
+                            "--minified-map-path", packagerSourcemapOutput, // The path to a sourcemap
+                            "--composed-map-path", sourcemapOutput          // The path of the composed source map
+                        ])
+                        cloneArgs.addAll(extraArgs)
+                        logger.info("posthog-cli clone arguments: ${cloneArgs}")
+
+                        def uploadArgs = [cliPackage]
+                        uploadArgs.addAll(["hermes", "upload",
+                            "--directory", sourcemapOutput.getParent()      // The path to a sourcemap that should be uploaded.
+                        ])
+                        uploadArgs.addAll(extraArgs)
+                        logger.info("posthog-cli upload arguments: ${uploadArgs}")
+
                         doFirst {
                             injected.execOps.exec {
                                 workingDir reactRoot
-
-                                def cliPackage = resolvePostHogCliPackagePath(reactRoot)
-                                def args = [cliPackage]
-
-                                args.addAll(["hermes", "clone",
-                                    "--minified-map-path", packagerSourcemapOutput, // The path to a sourcemap
-                                    "--composed-map-path", sourcemapOutput          // The path of the composed source map
-                                ])
-
-                                args.addAll(extraArgs)
-
-                                project.logger.info("posthog-cli clone arguments: ${args}")
-                                def osCompatibility = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c', 'node'] : []
-
-                                commandLine(*osCompatibility, *args)
+                                commandLine(*osCompatibility, *cloneArgs)
                             }
                         }
 
                         doLast {
                             injected.execOps.exec {
                                 workingDir reactRoot
-
-                                def cliPackage = resolvePostHogCliPackagePath(reactRoot)
-                                def args = [cliPackage]
-
-                                def sourcemapDir = sourcemapOutput.getParent()
-                                args.addAll(["hermes", "upload",
-                                    "--directory", sourcemapDir        // The path to a sourcemap that should be uploaded.
-                                ])
-
-                                args.addAll(extraArgs)
-
-                                project.logger.info("posthog-cli upload arguments: ${args}")
-                                def osCompatibility = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c', 'node'] : []
-
-                                commandLine(*osCompatibility, *args)
+                                commandLine(*osCompatibility, *uploadArgs)
                             }
                         }
 


### PR DESCRIPTION
Resolve the posthog-cli path at execution time so the Android Hermes sourcemap upload task actions work with Gradle's configuration cache. Resolution is a static `PostHogCli.resolveCliPackagePath()` (callable from the serialized task actions) that uses its own logger, so the actions never call a script-level method or read `project` at execution time. The process-based resolver stays at execution time because the configuration cache rejects external processes started during configuration.

## How this was tested

A standalone Gradle project (no Android SDK) mirroring the task shape, run with `--configuration-cache` on Gradle 8.14.

**Shipped shape** — script-level method + `project` inside the serialized action:

```groovy
doFirst {
    injected.execOps.exec {
        def cliPackage = resolvePostHogCliPackagePath(reactRoot) // script-level method
        project.logger.info("...")                               // Task.project at execution time
        commandLine(*osCompatibility, *args)
    }
}
```

```
> Could not find method resolvePostHogCliPackagePath() ... on object of type
  org.gradle.process.internal.DefaultExecAction_Decorated.
```

**Resolving at configuration time is also rejected** — the resolver starts node/npm:

```
> Starting an external process during configuration time is unsupported.
  Configuration cache entry discarded with 1 problem.
```

**Fixed shape** — execution-time resolution via a static class:

```groovy
abstract class PostHogCli {
    static String resolveCliPackagePath(File rootDir, reactRoot) { /* node/npm + fs lookup */ }
}

doFirst {
    def cliPackage = PostHogCli.resolveCliPackagePath(rootDirFile, reactRoot)
    def args = [cliPackage] + extraArgs
    logger.info("...")
    injected.execOps.exec { commandLine(*osCompatibility, *args) }
}
```

```
> Task :phUpload
BUILD SUCCESSFUL
Configuration cache entry stored.   // and "reused" on a second run
```
