### PR TITLE
chore: add Sentry attribution comments

### DIFF
--- a/packages/core/src/error-tracking/coercers/object-coercer.ts
+++ b/packages/core/src/error-tracking/coercers/object-coercer.ts
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+// Licensed under the MIT License
+
 import { isEmptyString, isError, isEvent, isString } from '@/utils'
 import { CoercingContext, ErrorTrackingCoercer, ExceptionLike, SeverityLevel, severityLevels } from '../types'
 import { extractExceptionKeysForMessage } from './utils'

--- a/packages/core/src/error-tracking/coercers/promise-rejection-event.ts
+++ b/packages/core/src/error-tracking/coercers/promise-rejection-event.ts
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+// Licensed under the MIT License
+
 import { isBuiltin, isEvent, isPrimitive } from '@/utils'
 import { CoercingContext, ErrorTrackingCoercer, ExceptionLike } from '../types'
 

--- a/packages/core/src/error-tracking/coercers/utils.ts
+++ b/packages/core/src/error-tracking/coercers/utils.ts
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+// Licensed under the MIT License
+
 export function truncate(str: string, max: number = 0): string {
   if (typeof str !== 'string' || max === 0) {
     return str

--- a/packages/core/src/error-tracking/parsers/base.ts
+++ b/packages/core/src/error-tracking/parsers/base.ts
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+// Licensed under the MIT License
+
 import { isUndefined } from '@/utils'
 import { StackFrame } from '../types'
 

--- a/packages/core/src/error-tracking/parsers/chrome.ts
+++ b/packages/core/src/error-tracking/parsers/chrome.ts
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+// Licensed under the MIT License
+
 // This regex matches frames that have no function name (ie. are at the top level of a module).
 // For example "at http://localhost:5000//script.js:1:126"
 

--- a/packages/core/src/error-tracking/parsers/gecko.ts
+++ b/packages/core/src/error-tracking/parsers/gecko.ts
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+// Licensed under the MIT License
+
 // gecko regex: `(?:bundle|\d+\.js)`: `bundle` is for react native, `\d+\.js` also but specifically for ram bundles because it
 // generates filenames without a prefix like `file://` the filenames in the stacktrace are just 42.js
 

--- a/packages/core/src/error-tracking/parsers/node.ts
+++ b/packages/core/src/error-tracking/parsers/node.ts
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+// Licensed under the MIT License
+
 import { Platform, StackLineParser } from '../types'
 import { UNKNOWN_FUNCTION } from './base'
 

--- a/packages/core/src/error-tracking/parsers/opera.ts
+++ b/packages/core/src/error-tracking/parsers/opera.ts
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+// Licensed under the MIT License
+
 import { StackLineParser } from '../types'
 import { createFrame, UNKNOWN_FUNCTION } from './base'
 

--- a/packages/core/src/error-tracking/parsers/safari.ts
+++ b/packages/core/src/error-tracking/parsers/safari.ts
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+// Licensed under the MIT License
+
 import { UNKNOWN_FUNCTION } from './base'
 
 /**

--- a/packages/core/src/error-tracking/parsers/winjs.ts
+++ b/packages/core/src/error-tracking/parsers/winjs.ts
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+// Licensed under the MIT License
+
 import { StackLineParser } from '../types'
 import { createFrame, UNKNOWN_FUNCTION } from './base'
 


### PR DESCRIPTION
## Problem

Error tracking coercer and parser files include code derived from Sentry's JavaScript SDK and should clearly document that attribution in source.

## Changes

Added MIT license attribution comments to the affected error tracking coercer and stack parser source files under `packages/core/src/error-tracking`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
