### PR TITLE
chore: skip secret workflows for forked PRs

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
     call-flags-project:
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: PostHog/.github/.github/workflows/flags-project-board.yml@d8b55d05dc5150f05c24542a6397ff3ecfbfb56d
         with:
             pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   changeset:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   browsers:
     name: Test on ${{ matrix.tests.name }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-22.04
 
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,7 +407,7 @@ jobs:
                   if-no-files-found: error
 
     build-toolbar:
-        # Build the toolbar bundle from posthog/posthog@master once per region.
+        # Build the toolbar bundle from posthog/posthog's default branch once per region.
         # Each region gets its own `TOOLBAR_PUBLIC_PATH`, so asset URLs baked
         # into the JS and CSS (and the runtime CSS loader in ToolbarApp.tsx)
         # point at the region-local CDN for the SDK version being released.
@@ -441,7 +441,6 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   repository: PostHog/posthog
-                  ref: master
                   fetch-depth: 1
 
             - name: Install pnpm
@@ -512,7 +511,7 @@ jobs:
 
             # Assert the cross-repo contract: the `TOOLBAR_PUBLIC_PATH` env
             # var we passed in must actually appear in the bundle. If
-            # posthog/posthog@master doesn't yet honour TOOLBAR_PUBLIC_PATH
+            # posthog/posthog's default branch doesn't yet honour TOOLBAR_PUBLIC_PATH
             # (e.g. the matching PR hasn't landed or was reverted), esbuild
             # silently falls back to its hardcoded default `publicPath` and
             # we'd otherwise ship a bundle pointing at the wrong CDN.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,7 +407,7 @@ jobs:
                   if-no-files-found: error
 
     build-toolbar:
-        # Build the toolbar bundle from posthog/posthog's default branch once per region.
+        # Build the toolbar bundle from posthog/posthog@master once per region.
         # Each region gets its own `TOOLBAR_PUBLIC_PATH`, so asset URLs baked
         # into the JS and CSS (and the runtime CSS loader in ToolbarApp.tsx)
         # point at the region-local CDN for the SDK version being released.
@@ -441,6 +441,7 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   repository: PostHog/posthog
+                  ref: master
                   fetch-depth: 1
 
             - name: Install pnpm
@@ -511,7 +512,7 @@ jobs:
 
             # Assert the cross-repo contract: the `TOOLBAR_PUBLIC_PATH` env
             # var we passed in must actually appear in the bundle. If
-            # posthog/posthog's default branch doesn't yet honour TOOLBAR_PUBLIC_PATH
+            # posthog/posthog@master doesn't yet honour TOOLBAR_PUBLIC_PATH
             # (e.g. the matching PR hasn't landed or was reverted), esbuild
             # silently falls back to its hardcoded default `publicPath` and
             # we'd otherwise ship a bundle pointing at the wrong CDN.

--- a/.github/workflows/sdk-compliance-tests-browser.yml
+++ b/.github/workflows/sdk-compliance-tests-browser.yml
@@ -2,14 +2,14 @@ name: Browser SDK Compliance Tests
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
     paths:
       - 'packages/browser/**'
       - 'packages/core/**'
       - 'compliance/browser/**'
       - '.github/workflows/sdk-compliance-tests-browser.yml'
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
     paths:
       - 'packages/browser/**'
       - 'packages/core/**'

--- a/.github/workflows/sdk-compliance-tests-node.yml
+++ b/.github/workflows/sdk-compliance-tests-node.yml
@@ -2,14 +2,14 @@ name: Node SDK Compliance Tests
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
     paths:
       - 'packages/node/**'
       - 'packages/core/**'
       - 'compliance/node/**'
       - '.github/workflows/sdk-compliance-tests-node.yml'
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
     paths:
       - 'packages/node/**'
       - 'packages/core/**'

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   browsers:
     name: Test on ${{ matrix.name }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-22.04
 
     strategy:


### PR DESCRIPTION
## Problem

Pull request workflows that depend on repository secrets still start for forked contributor PRs, even though those contributors do not have access to the required secrets. Some SDK compliance workflow branch filters also still referenced `master`, which is no longer used for this repository.

## Changes

- Skip PR jobs that require non-default secrets when the PR comes from a fork.
- Apply the skip to Playwright integration, TestCafe, Dependabot changeset automation, and the feature flags project board workflow.
- Remove `master` from SDK compliance workflow branch filters.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
