### PR TITLE
fix(react-native): preserve Expo iOS bundle script wrapper

### DIFF
--- a/.changeset/fix-rn-expo-xcode-backtick.md
+++ b/.changeset/fix-rn-expo-xcode-backtick.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Fix the Expo iOS source map upload config plugin so backtick-wrapped `react-native-xcode.sh` commands are preserved when wrapping the bundle phase with `posthog-xcode.sh`.

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -53,14 +53,17 @@ export function modifyExistingXcodeBuildScript(script: BuildPhase): void {
 const POSTHOG_REACT_NATIVE_XCODE_PATH =
   "`\"$NODE_BINARY\" --print \"require('path').join(require('path').dirname(require.resolve('posthog-react-native')), '..', 'tooling', 'posthog-xcode.sh')\"`"
 
+const REACT_NATIVE_XCODE_LINE =
+  /^([ \t]*)(?![A-Za-z_][A-Za-z0-9_]*=)(?:\/bin\/sh\s+)?([^\n]*(?:packager|scripts)\/react-native-xcode\.sh\b[^\n]*)$/m
+
 export function addPostHogWithBundledScriptsToBundleShellScript(script: string): string {
-  // Capture only the RN script path (group 1), stripping any leading shell/interpreter
-  // token (e.g. "/bin/sh") that may prefix it in Expo SDK 53+ bundle phase scripts.
-  // Without this, $1 inside posthog-xcode.sh resolves to "/bin/sh" instead of the
-  // react-native-xcode.sh path, silently breaking the PACKAGER_SOURCEMAP_FILE patch.
+  // Capture the full RN script invocation. Expo uses a backtick-wrapped
+  // node --print command, so matching only up to react-native-xcode.sh cuts the
+  // command substitution in half and leaves the generated shell invalid.
   return script.replace(
-    /^(?:.*\s)?((?:[^\s]*(?:packager|scripts)\/react-native-xcode\.sh)\s*(?:\'\\\")?)/m,
-    (_match: string, rnPath: string) => `/bin/sh ${POSTHOG_REACT_NATIVE_XCODE_PATH} ${rnPath}`
+    REACT_NATIVE_XCODE_LINE,
+    (_match: string, indent: string, rnCommand: string) =>
+      `${indent}/bin/sh ${POSTHOG_REACT_NATIVE_XCODE_PATH} ${rnCommand}`
   )
 }
 

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from 'child_process'
+
 import {
   addPostHogWithBundledScriptsToBundleShellScript,
   disableUserScriptSandboxing,
@@ -64,6 +66,12 @@ const extractArg1 = (wrappedLine: string): string => {
   return afterPosthog.trim().split(/\s+/)[0]
 }
 
+const expectValidShellSyntax = (script: string): void => {
+  const result = spawnSync('/bin/sh', ['-n'], { input: script, encoding: 'utf8' })
+  expect(result.stderr).toBe('')
+  expect(result.status).toBe(0)
+}
+
 describe('addPostHogWithBundledScriptsToBundleShellScript', () => {
   it('wraps the react-native-xcode.sh invocation with posthog-xcode.sh', () => {
     const original = '"../node_modules/react-native/scripts/react-native-xcode.sh"'
@@ -98,6 +106,20 @@ describe('addPostHogWithBundledScriptsToBundleShellScript', () => {
     expect(arg1).toContain('react-native-xcode.sh')
     expect(arg1).not.toBe('/bin/sh')
   })
+
+  it('preserves the full Expo backtick command when wrapping react-native-xcode.sh', () => {
+    const original =
+      "`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`"
+
+    const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original)
+
+    expect(wrapped).toContain('posthog-xcode.sh')
+    expect(wrapped).toContain(
+      "`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`"
+    )
+    expect(wrapped).not.toContain("` '/scripts/react-native-xcode.sh'\"`")
+    expectValidShellSyntax(wrapped)
+  })
 })
 
 describe('modifyExistingXcodeBuildScript', () => {
@@ -106,6 +128,27 @@ describe('modifyExistingXcodeBuildScript', () => {
     modifyExistingXcodeBuildScript(script)
     const parsed = JSON.parse(script.shellScript)
     expect(parsed).toContain('posthog-xcode.sh')
+  })
+
+  it('wraps Expo backtick bundle phase shellScript without creating invalid shell syntax', () => {
+    const expoBundleScript = [
+      'if [[ -z "$CLI_PATH" ]]; then',
+      '  export CLI_PATH="$("$NODE_BINARY" --print "require.resolve(\'@expo/cli\')")"',
+      'fi',
+      '',
+      "`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`",
+      '',
+    ].join('\n')
+    const script = { shellScript: JSON.stringify(expoBundleScript) }
+
+    modifyExistingXcodeBuildScript(script)
+
+    const parsed = JSON.parse(script.shellScript)
+    expect(parsed).toContain('posthog-xcode.sh')
+    expect(parsed).toContain(
+      "`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`"
+    )
+    expectValidShellSyntax(parsed)
   })
 
   it('is idempotent — re-running does not double-wrap', () => {


### PR DESCRIPTION
## Summary

- fix the Expo iOS config plugin wrapper to preserve the full backtick-wrapped React Native Xcode script invocation
- keep the previous leading `/bin/sh` handling so `posthog-xcode.sh` still receives the React Native script path
- add regression coverage that validates the generated shell with `/bin/sh -n`

## Test Plan

- `pnpm --filter=@posthog/core build`
- `pnpm --filter=posthog-react-native build`
- `pnpm --filter=posthog-react-native lint`
- `pnpm --filter=posthog-react-native exec jest -c jest.config.js expoconfig.spec.ts --watchman=false --runInBand`
- `pnpm --filter=posthog-react-native exec jest -c jest.config.js --watchman=false --runInBand`
