### PR TITLE
chore: clarify error tracking comments

### DIFF
--- a/packages/browser/src/extensions/replay/rrweb-plugins/patch.ts
+++ b/packages/browser/src/extensions/replay/rrweb-plugins/patch.ts
@@ -42,7 +42,7 @@ export function patch(
         return () => {
             //
         }
-        // This can throw if multiple fill happens on a global object like XMLHttpRequest
-        // Fixes https://github.com/getsentry/sentry-javascript/issues/2043
+        // This can throw when multiple instrumentation layers try to wrap the same global object,
+        // such as XMLHttpRequest, and redefine the same non-configurable wrapper marker.
     }
 }

--- a/packages/core/src/error-tracking/coercers/promise-rejection-event.ts
+++ b/packages/core/src/error-tracking/coercers/promise-rejection-event.ts
@@ -59,8 +59,9 @@ export class PromiseRejectionEventCoercer implements ErrorTrackingCoercer<Reject
       // something, somewhere, (likely a browser extension) effectively casts PromiseRejectionEvents
       // to CustomEvents, moving the `promise` and `reason` attributes of the PRE into
       // the CustomEvent's `detail` attribute, since they're not part of CustomEvent's spec
-      // see https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent and
-      // https://github.com/getsentry/sentry-javascript/issues/2380
+      // Unwrap `detail.reason` so extension errors are reported as the original Error instead of
+      // a generic CustomEvent with keys like currentTarget, detail, isTrusted, and target.
+      // see https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent
       if ('detail' in error && error.detail != null && typeof error.detail === 'object' && 'reason' in error.detail) {
         return error.detail.reason
       }

--- a/packages/core/src/error-tracking/parsers/chrome.ts
+++ b/packages/core/src/error-tracking/parsers/chrome.ts
@@ -18,8 +18,8 @@ const chromeRegex =
 const chromeEvalRegex = /\((\S*)(?::(\d+))(?::(\d+))\)/
 
 // Chromium based browsers: Chrome, Brave, new Opera, new Edge
-// We cannot call this variable `chrome` because it can conflict with global `chrome` variable in certain environments
-// See: https://github.com/getsentry/sentry-javascript/issues/6880
+// We cannot call this variable `chrome` because it can conflict with the global `chrome` variable
+// exposed in some browser environments, causing `Identifier 'chrome' has already been declared`.
 export const chromeStackLineParser: StackLineParser = (line, platform) => {
   // If the stack line has no function name, we need to parse it differently
   const noFnParts = chromeRegexNoFnName.exec(line) as null | [string, string, string, string]

--- a/packages/core/src/error-tracking/parsers/index.ts
+++ b/packages/core/src/error-tracking/parsers/index.ts
@@ -74,18 +74,16 @@ export function createStackParser(platform: Platform, ...parsers: StackLineParse
       const line = lines[i] as string
       // Ignore lines over 1kb as they are unlikely to be stack frames.
       // Many of the regular expressions use backtracking which results in run time that increases exponentially with
-      // input size. Huge strings can result in hangs/Denial of Service:
-      // https://github.com/getsentry/sentry-javascript/issues/2286
+      // input size. Huge strings can result in long hangs or Denial of Service when parsing stack traces.
       if (line.length > 1024) {
         continue
       }
 
-      // https://github.com/getsentry/sentry-javascript/issues/5459
-      // Remove webpack (error: *) wrappers
+      // Remove webpack (error: *) wrappers so the trailing wrapper parenthesis is not parsed as part of the URL.
       const cleanedLine = WEBPACK_ERROR_REGEXP.test(line) ? line.replace(WEBPACK_ERROR_REGEXP, '$1') : line
 
-      // https://github.com/getsentry/sentry-javascript/issues/7813
-      // Skip Error: lines
+      // Skip Error: lines, including DOMException pseudo-frames such as
+      // `Error: Blocked a frame with origin ... from accessing a cross-origin frame.`
       if (cleanedLine.match(/\S*Error: /)) {
         continue
       }

--- a/packages/core/src/error-tracking/parsers/node.ts
+++ b/packages/core/src/error-tracking/parsers/node.ts
@@ -103,8 +103,8 @@ function filenameIsInApp(filename: string, isNative: boolean = false): boolean {
       !filename.match(/^[a-zA-Z]([a-zA-Z0-9.\-+])*:\/\//)) // Schema from: https://stackoverflow.com/a/3641782
 
   // in_app is all that's not an internal Node function or a module within node_modules
-  // note that isNative appears to return true even for node core libraries
-  // see https://github.com/getsentry/raven-node/issues/176
+  // note that isNative appears to return true even for node core libraries, which should be
+  // treated as internal frames for cleaner stack traces.
 
   return !isInternal && filename !== undefined && !filename.includes('node_modules/')
 }

--- a/packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts
+++ b/packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts
@@ -106,7 +106,7 @@ function getContextLinesFromFile(path: string, ranges: ReadlineRange[], output: 
 
     // We need to explicitly destroy the stream to prevent memory leaks,
     // removing the listeners on the readline interface is not enough.
-    // See: https://github.com/nodejs/node/issues/9002 and https://github.com/getsentry/sentry-javascript/issues/14892
+    // Otherwise, repeated exception captures can keep opening the same files without closing them.
     function destroyStreamAndResolve(): void {
       stream.destroy()
       resolve()

--- a/packages/rrweb/utils/src/index.ts
+++ b/packages/rrweb/utils/src/index.ts
@@ -279,8 +279,8 @@ export function patch(
     return () => {
       //
     };
-    // This can throw if multiple fill happens on a global object like XMLHttpRequest
-    // Fixes https://github.com/getsentry/sentry-javascript/issues/2043
+    // This can throw when multiple instrumentation layers try to wrap the same global object,
+    // such as XMLHttpRequest, and redefine the same non-configurable wrapper marker.
   }
 }
 

--- a/packages/rrweb/utils/src/index.ts
+++ b/packages/rrweb/utils/src/index.ts
@@ -1,3 +1,6 @@
+// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
+// Licensed under the MIT License
+
 type PrototypeOwner = Node | ShadowRoot | MutationObserver | Element;
 type TypeofPrototypeOwner =
   | typeof Node

--- a/packages/web/src/patch.ts
+++ b/packages/web/src/patch.ts
@@ -44,7 +44,7 @@ export function patch(
     return () => {
       //
     }
-    // This can throw if multiple fill happens on a global object like XMLHttpRequest
-    // Fixes https://github.com/getsentry/sentry-javascript/issues/2043
+    // This can throw when multiple instrumentation layers try to wrap the same global object,
+    // such as XMLHttpRequest, and redefine the same non-configurable wrapper marker.
   }
 }


### PR DESCRIPTION
## Problem

Comments in error tracking and patching code referenced upstream Sentry issues directly, which made the rationale less self-contained for reviewers and maintainers. The rrweb utils-derived code also needed explicit Sentry MIT license attribution alongside the local comment updates.

## Changes

Clarifies inline comments across browser, web lite, rrweb utils, core error tracking, and node error tracking code so the behavior and edge cases are described directly in the code without relying on external issue links.

Adds Sentry MIT license attribution to `packages/rrweb/utils/src/index.ts`.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
