### PR TITLE
fix(replay): re-apply scroll after fast-forward catch-up

### DIFF
--- a/.changeset/replay-scroll-reapply-on-fastforward.md
+++ b/.changeset/replay-scroll-reapply-on-fastforward.md
@@ -1,5 +1,6 @@
 ---
+'posthog-js': patch
 '@posthog/rrweb': patch
 ---
 
-replay: re-apply scroll positions after fast-forward/seek. Scrolls applied mid-catch-up could clamp to 0 when the target wasn't scrollable yet (e.g. scroll-revealed sheets/modals whose content sits below the fold), leaving the content scrolled out of view on replay. The last scroll per node is now re-applied in the flush stage once layout has settled.
+replay: re-apply scroll positions after fast-forward/seek. Scrolls applied mid-catch-up could clamp to 0 when the target wasn't scrollable yet (e.g. scroll-revealed sheets/modals whose content sits below the fold), leaving the content scrolled out of view on replay. The last scroll per node is now re-applied in the flush stage once layout has settled. `posthog-js` is bumped too so the rebuilt bundle containing the fix is published.

--- a/.changeset/replay-scroll-reapply-on-fastforward.md
+++ b/.changeset/replay-scroll-reapply-on-fastforward.md
@@ -1,0 +1,5 @@
+---
+'@posthog/rrweb': patch
+---
+
+replay: re-apply scroll positions after fast-forward/seek. Scrolls applied mid-catch-up could clamp to 0 when the target wasn't scrollable yet (e.g. scroll-revealed sheets/modals whose content sits below the fold), leaving the content scrolled out of view on replay. The last scroll per node is now re-applied in the flush stage once layout has settled.

--- a/packages/rrweb/rrweb/src/replay/index.ts
+++ b/packages/rrweb/rrweb/src/replay/index.ts
@@ -167,10 +167,8 @@ export class Replayer {
   // In the fast-forward mode, only the last selection data needs to be applied.
   private lastSelectionData: selectionData | null = null;
 
-  // In the fast-forward mode, scrolls applied mid-batch can clamp to 0 because the target's
-  // scrollable content isn't laid out yet (e.g. scroll-revealed sheets/modals whose content
-  // is positioned below the fold). Keep the last scroll per node and re-apply it once the
-  // catch-up has finished and layout has settled, in the flush stage.
+  // Last scroll per node during fast-forward. A scroll applied before its target is scrollable
+  // clamps to 0, so it's re-applied in the flush stage once layout has settled.
   private lastScrollMap: Map<number, scrollData> = new Map();
 
   // In the fast-forward mode using VirtualDom optimization, all stylesheetRule, and styleDeclaration events on constructed StyleSheets will be delayed to get applied until the flush stage.
@@ -344,8 +342,7 @@ export class Replayer {
         this.lastSelectionData = null;
       }
 
-      // Re-apply the last scroll per node now that all mutations are flushed and layout has
-      // settled, so scrolls that clamped mid-fast-forward (target not yet scrollable) land.
+      // Re-apply scrolls that clamped mid-fast-forward, now that layout has settled.
       if (this.lastScrollMap.size) {
         this.lastScrollMap.forEach((d) => {
           this.applyScroll(d, true);
@@ -1343,8 +1340,7 @@ export class Replayer {
         if (d.id === -1) {
           break;
         }
-        // Re-applied after the catch-up flush (covers both the virtual-dom and direct paths),
-        // so a scroll that clamps mid-fast-forward because the target isn't scrollable yet lands.
+        // Recorded for the flush-stage re-apply (covers both fast-forward paths).
         if (isSync) {
           this.lastScrollMap.set(d.id, d);
         }

--- a/packages/rrweb/rrweb/src/replay/index.ts
+++ b/packages/rrweb/rrweb/src/replay/index.ts
@@ -167,6 +167,12 @@ export class Replayer {
   // In the fast-forward mode, only the last selection data needs to be applied.
   private lastSelectionData: selectionData | null = null;
 
+  // In the fast-forward mode, scrolls applied mid-batch can clamp to 0 because the target's
+  // scrollable content isn't laid out yet (e.g. scroll-revealed sheets/modals whose content
+  // is positioned below the fold). Keep the last scroll per node and re-apply it once the
+  // catch-up has finished and layout has settled, in the flush stage.
+  private lastScrollMap: Map<number, scrollData> = new Map();
+
   // In the fast-forward mode using VirtualDom optimization, all stylesheetRule, and styleDeclaration events on constructed StyleSheets will be delayed to get applied until the flush stage.
   private constructedStyleMutations: (
     | styleSheetRuleData
@@ -337,6 +343,15 @@ export class Replayer {
         this.applySelection(this.lastSelectionData);
         this.lastSelectionData = null;
       }
+
+      // Re-apply the last scroll per node now that all mutations are flushed and layout has
+      // settled, so scrolls that clamped mid-fast-forward (target not yet scrollable) land.
+      if (this.lastScrollMap.size) {
+        this.lastScrollMap.forEach((d) => {
+          this.applyScroll(d, true);
+        });
+        this.lastScrollMap.clear();
+      }
     };
     this.addEmitterHandler(ReplayerEvents.Flush, flushHandler);
 
@@ -345,6 +360,7 @@ export class Replayer {
       this.mirror.reset();
       this.styleMirror.reset();
       this.mediaManager.reset();
+      this.lastScrollMap.clear();
     };
     this.addEmitterHandler(ReplayerEvents.PlayBack, playBackHandler);
 
@@ -1326,6 +1342,11 @@ export class Replayer {
          */
         if (d.id === -1) {
           break;
+        }
+        // Re-applied after the catch-up flush (covers both the virtual-dom and direct paths),
+        // so a scroll that clamps mid-fast-forward because the target isn't scrollable yet lands.
+        if (isSync) {
+          this.lastScrollMap.set(d.id, d);
         }
         if (this.usingVirtualDom) {
           const target = this.virtualDom.mirror.getNode(d.id) as RRElement;

--- a/packages/rrweb/rrweb/test/events/scroll-revealed-by-late-style.ts
+++ b/packages/rrweb/rrweb/test/events/scroll-revealed-by-late-style.ts
@@ -1,0 +1,103 @@
+import { EventType, IncrementalSource } from '@posthog/rrweb-types';
+import type { eventWithTime } from '@posthog/rrweb-types';
+
+const now = Date.now();
+
+// Reproduces a scroll that clamps to 0 mid-fast-forward because the target only becomes
+// scrollable once a stylesheet (applied after the DOM diff in the flush stage) gives its
+// content height. Mirrors scroll-revealed sheets/modals whose content sits below the fold.
+const events: eventWithTime[] = [
+  { type: EventType.DomContentLoaded, data: {}, timestamp: now },
+  { type: EventType.Load, data: {}, timestamp: now + 100 },
+  {
+    type: EventType.Meta,
+    data: { href: 'http://localhost', width: 1200, height: 500 },
+    timestamp: now + 100,
+  },
+  {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        id: 1,
+        type: 0,
+        childNodes: [
+          { type: 1, name: 'html', publicId: '', systemId: '', id: 2 },
+          {
+            id: 3,
+            type: 2,
+            tagName: 'html',
+            attributes: {},
+            childNodes: [
+              { id: 4, type: 2, tagName: 'head', attributes: {}, childNodes: [] },
+              {
+                id: 7,
+                type: 2,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [
+                  {
+                    id: 8,
+                    type: 2,
+                    tagName: 'div',
+                    attributes: {
+                      id: 'container',
+                      style:
+                        'overflow: auto; height: 100px; width: 100px; display: block;',
+                    },
+                    childNodes: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      initialOffset: { left: 0, top: 0 },
+    },
+    timestamp: now + 100,
+  },
+  // Add the (initially zero-height) content. This triggers the virtual-dom fast-forward path.
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Mutation,
+      texts: [],
+      attributes: [],
+      removes: [],
+      adds: [
+        {
+          parentId: 8,
+          nextId: null,
+          node: {
+            id: 9,
+            type: 2,
+            tagName: 'div',
+            attributes: { id: 'tall' },
+            childNodes: [],
+          },
+        },
+      ],
+    },
+    timestamp: now + 500,
+  },
+  // Scroll the container. At apply time #tall has no height yet, so this clamps to 0.
+  {
+    type: EventType.IncrementalSnapshot,
+    data: { source: IncrementalSource.Scroll, id: 8, x: 0, y: 800 },
+    timestamp: now + 1000,
+  },
+  // Adopted stylesheet gives #tall its height, making the container scrollable. Applied after
+  // the DOM diff in the flush stage, i.e. after the scroll above was already applied.
+  {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.AdoptedStyleSheet,
+      id: 1,
+      styleIds: [1],
+      styles: [{ rules: [{ rule: '#tall { display: block; height: 2000px; }' }], styleId: 1 }],
+    },
+    timestamp: now + 1500,
+  },
+];
+
+export default events;

--- a/packages/rrweb/rrweb/test/events/scroll-revealed-by-late-style.ts
+++ b/packages/rrweb/rrweb/test/events/scroll-revealed-by-late-style.ts
@@ -3,9 +3,8 @@ import type { eventWithTime } from '@posthog/rrweb-types';
 
 const now = Date.now();
 
-// Reproduces a scroll that clamps to 0 mid-fast-forward because the target only becomes
-// scrollable once a stylesheet (applied after the DOM diff in the flush stage) gives its
-// content height. Mirrors scroll-revealed sheets/modals whose content sits below the fold.
+// Scroll that clamps to 0 mid-fast-forward: the target only becomes scrollable via a stylesheet
+// applied after the scroll. Mirrors scroll-revealed sheets/modals whose content sits below the fold.
 const events: eventWithTime[] = [
   { type: EventType.DomContentLoaded, data: {}, timestamp: now },
   { type: EventType.Load, data: {}, timestamp: now + 100 },

--- a/packages/rrweb/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/rrweb/test/replayer.test.ts
@@ -14,6 +14,7 @@ import styleSheetRuleEvents from './events/style-sheet-rule-events';
 import orderingEvents from './events/ordering';
 import scrollEvents from './events/scroll';
 import scrollWithParentStylesEvents from './events/scroll-with-parent-styles';
+import scrollRevealedByLateStyleEvents from './events/scroll-revealed-by-late-style';
 import inputEvents from './events/input';
 import iframeEvents from './events/iframe';
 import selectionEvents from './events/selection';
@@ -457,6 +458,25 @@ describe('replayer', function () {
           (element as HTMLIFrameElement)!.contentWindow!.scrollY,
       ),
     ).toEqual(0);
+  });
+
+  it('re-applies a scroll that clamps mid-fast-forward once the target becomes scrollable', async () => {
+    await page.evaluate(`
+      events = ${JSON.stringify(scrollRevealedByLateStyleEvents)};
+      const { Replayer } = rrweb;
+      var replayer = new Replayer(events,{showDebug:true});
+      replayer.pause(2000);
+    `);
+    const iframe = await page.$('iframe');
+    const contentDocument = await iframe!.contentFrame()!;
+    // The container only becomes scrollable via a stylesheet applied after the scroll, so without
+    // the flush-stage re-apply the scroll would be stuck at 0.
+    expect(
+      await contentDocument!.$eval(
+        '#container',
+        (element: Element) => element.scrollTop,
+      ),
+    ).toEqual(800);
   });
 
   it('can fast forward input events', async () => {


### PR DESCRIPTION
## Problem

Some apps reveal modals/sheets by **scrolling an internal track** rather than with transform/opacity — the sheet content is laid out below the fold and scrolled into view (e.g. the Silk sheet library). The recording captures the reveal scroll correctly, but on **seek/scrub** the sheet shows up as an empty "black rectangle": the backdrop scrim renders while the content stays scrolled out of view.

Root cause: during fast-forward catch-up, a scroll can be applied to its target *before* that target is scrollable (its content height comes from mutations/stylesheets applied later in the same flush). Setting `scrollTop` on a not-yet-scrollable element clamps to `0`, and the scroll is never re-applied — so the resting scroll offset is lost. It works during linear real-time playback (layout has time to settle between the add and the scroll), which is why it looked intermittent.

## Changes

- Keep the last scroll per node during fast-forward and re-apply it in the flush stage, once all mutations are flushed and layout has settled. Re-applying after the catch-up lands the offset that previously clamped to `0`.
- Recorded before the virtual-dom branch so it covers both the virtual-dom and direct fast-forward paths.
- Added a replayer regression test (`scroll-revealed-by-late-style`) where the target only becomes scrollable via a stylesheet applied after the scroll — fails without the fix (`0`), passes with it (`800`).

No behavior change for real-time playback, no API change, off no flags.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)
- [x] @posthog/rrweb

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

Diagnosed from a real customer recording: the sheet's full DOM and the reveal scroll (track → `scrollTop 1006`) were both present in the export, but on seek the track stayed at `0`, leaving the content below the fold. Reproduced in an rrweb replayer harness, confirmed the fix renders the modal on seek, and verified all existing replayer tests still pass.

Made with [Cursor](https://cursor.com)