### PR TITLE
fix(record): port rrweb 2.0.1 WebKit MutationObserver fix

### DIFF
--- a/.changeset/rrweb-webkit-monkey-patch-mutationobserver.md
+++ b/.changeset/rrweb-webkit-monkey-patch-mutationobserver.md
@@ -4,4 +4,4 @@
 '@posthog/rrweb-utils': patch
 ---
 
-record: fix broken MutationObserver in WebKit/Safari when a 3rd-party library has monkey-patched the page. To dodge a tainted `MutationObserver`, rrweb grabs a pristine constructor from a throwaway iframe. WebKit tears down a detached iframe's `ScriptExecutionContext`, so the observer built from it silently stopped delivering mutations once the iframe was removed (webkit.org/b/179224) — no DOM changes were recorded on affected Safari pages. On Safari the untainted-prototype iframe is now kept attached (hidden, `rr-block`-tagged so it isn't serialized) and torn down via a cleanup wired through `initMutationObserver`'s teardown. Ported from upstream rrweb 2.0.1 (rrweb-io/rrweb#1854).
+record: fix MutationObserver recording on Safari when frameworks monkey-patch built-ins. Keep the untainted-prototype iframe attached on Safari and remove it on recorder teardown. Ported from upstream rrweb 2.0.1 (rrweb-io/rrweb#1854).

--- a/.changeset/rrweb-webkit-monkey-patch-mutationobserver.md
+++ b/.changeset/rrweb-webkit-monkey-patch-mutationobserver.md
@@ -1,0 +1,7 @@
+---
+'posthog-js': patch
+'@posthog/rrweb': patch
+'@posthog/rrweb-utils': patch
+---
+
+record: fix broken MutationObserver in WebKit/Safari when a 3rd-party library has monkey-patched the page. To dodge a tainted `MutationObserver`, rrweb grabs a pristine constructor from a throwaway iframe. WebKit tears down a detached iframe's `ScriptExecutionContext`, so the observer built from it silently stopped delivering mutations once the iframe was removed (webkit.org/b/179224) — no DOM changes were recorded on affected Safari pages. On Safari the untainted-prototype iframe is now kept attached (hidden, `rr-block`-tagged so it isn't serialized) and torn down via a cleanup wired through `initMutationObserver`'s teardown. Ported from upstream rrweb 2.0.1 (rrweb-io/rrweb#1854).

--- a/packages/rrweb/rrweb/src/record/observer.ts
+++ b/packages/rrweb/rrweb/src/record/observer.ts
@@ -81,12 +81,17 @@ function getEventTarget(event: Event | NonStandardEvent): EventTarget | null {
 export function initMutationObserver(
   options: MutationBufferParam,
   rootEl: Node,
-): { observer: MutationObserver; buffer: MutationBuffer } {
+): {
+  observer: MutationObserver;
+  buffer: MutationBuffer;
+  iframeCleanup: () => void;
+} {
   const mutationBuffer = new MutationBuffer();
   mutationBuffers.push(mutationBuffer);
   // see mutation.ts for details
   mutationBuffer.init(options);
-  const observer = new (mutationObserverCtor() as new (
+  const [ObserverCtor, iframeCleanup] = mutationObserverCtor();
+  const observer = new (ObserverCtor as new (
     callback: MutationCallback,
   ) => MutationObserver)(
     callbackWrapper(mutationBuffer.processMutations.bind(mutationBuffer)),
@@ -99,7 +104,7 @@ export function initMutationObserver(
     childList: true,
     subtree: true,
   });
-  return { observer, buffer: mutationBuffer };
+  return { observer, buffer: mutationBuffer, iframeCleanup };
 }
 
 function initMoveObserver({
@@ -1333,10 +1338,13 @@ export function initObservers(
   mergeHooks(o, hooks);
   let mutationObserver: MutationObserver | undefined;
   let mutationBuffer: MutationBuffer | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  let cleanupMutationIframe: () => void = () => {};
   if (o.recordDOM) {
     const result = initMutationObserver(o, o.doc);
     mutationObserver = result.observer;
     mutationBuffer = result.buffer;
+    cleanupMutationIframe = result.iframeCleanup;
   }
   const mousemoveHandler = initMoveObserver(o);
   const mouseInteractionHandler = initMouseInteractionObserver(o);
@@ -1388,6 +1396,7 @@ export function initObservers(
       }
     }
     mutationObserver?.disconnect();
+    cleanupMutationIframe();
     mousemoveHandler();
     mouseInteractionHandler();
     scrollHandler();

--- a/packages/rrweb/rrweb/src/record/observer.ts
+++ b/packages/rrweb/rrweb/src/record/observer.ts
@@ -52,7 +52,10 @@ import type {
 } from '@posthog/rrweb-types';
 import MutationBuffer from './mutation';
 import { callbackWrapper } from './error-handler';
-import dom, { mutationObserverCtor } from '@posthog/rrweb-utils';
+import dom, {
+  cleanupUntaintedIframe,
+  mutationObserverCtor,
+} from '@posthog/rrweb-utils';
 
 export const mutationBuffers: MutationBuffer[] = [];
 
@@ -81,17 +84,12 @@ function getEventTarget(event: Event | NonStandardEvent): EventTarget | null {
 export function initMutationObserver(
   options: MutationBufferParam,
   rootEl: Node,
-): {
-  observer: MutationObserver;
-  buffer: MutationBuffer;
-  iframeCleanup: () => void;
-} {
+): { observer: MutationObserver; buffer: MutationBuffer } {
   const mutationBuffer = new MutationBuffer();
   mutationBuffers.push(mutationBuffer);
   // see mutation.ts for details
   mutationBuffer.init(options);
-  const [ObserverCtor, iframeCleanup] = mutationObserverCtor();
-  const observer = new (ObserverCtor as new (
+  const observer = new (mutationObserverCtor() as new (
     callback: MutationCallback,
   ) => MutationObserver)(
     callbackWrapper(mutationBuffer.processMutations.bind(mutationBuffer)),
@@ -104,7 +102,7 @@ export function initMutationObserver(
     childList: true,
     subtree: true,
   });
-  return { observer, buffer: mutationBuffer, iframeCleanup };
+  return { observer, buffer: mutationBuffer };
 }
 
 function initMoveObserver({
@@ -1338,13 +1336,10 @@ export function initObservers(
   mergeHooks(o, hooks);
   let mutationObserver: MutationObserver | undefined;
   let mutationBuffer: MutationBuffer | undefined;
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  let cleanupMutationIframe: () => void = () => {};
   if (o.recordDOM) {
     const result = initMutationObserver(o, o.doc);
     mutationObserver = result.observer;
     mutationBuffer = result.buffer;
-    cleanupMutationIframe = result.iframeCleanup;
   }
   const mousemoveHandler = initMoveObserver(o);
   const mouseInteractionHandler = initMouseInteractionObserver(o);
@@ -1396,7 +1391,7 @@ export function initObservers(
       }
     }
     mutationObserver?.disconnect();
-    cleanupMutationIframe();
+    cleanupUntaintedIframe();
     mousemoveHandler();
     mouseInteractionHandler();
     scrollHandler();

--- a/packages/rrweb/rrweb/test/html/monkey-patched-mutation.html
+++ b/packages/rrweb/rrweb/test/html/monkey-patched-mutation.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Monkey-patched MutationObserver</title>
+    <script>
+      MutationObserver = class {
+        constructor() {
+          throw new Error('MutationObserver was hijacked by framework');
+        }
+      };
+    </script>
+  </head>
+  <body>
+    <ul id="list">
+      <li>a</li>
+    </ul>
+  </body>
+</html>

--- a/packages/rrweb/rrweb/test/record/monkey-patched-mutation.test.ts
+++ b/packages/rrweb/rrweb/test/record/monkey-patched-mutation.test.ts
@@ -1,0 +1,104 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  EventType,
+  IncrementalSource,
+  eventWithTime,
+} from '@posthog/rrweb-types';
+import {
+  getServerURL,
+  launchPuppeteer,
+  startServer,
+  waitForRAF,
+} from '../utils';
+import type { Server } from 'http';
+import type * as puppeteer from 'puppeteer';
+
+describe('monkey-patched MutationObserver', () => {
+  vi.setConfig({ testTimeout: 30_000 });
+
+  let server: Server;
+  let serverURL: string;
+  let browser: puppeteer.Browser;
+  let code: string;
+
+  beforeAll(async () => {
+    server = await startServer();
+    serverURL = getServerURL(server);
+    browser = await launchPuppeteer();
+    code = fs.readFileSync(
+      path.resolve(__dirname, '../../dist/rrweb.umd.cjs'),
+      'utf-8',
+    );
+  });
+
+  afterAll(async () => {
+    await browser.close();
+    await server.close();
+  });
+
+  it('records DOM mutations when MutationObserver is monkey-patched', async () => {
+    const page = await browser.newPage();
+    await page.goto(`${serverURL}/html/monkey-patched-mutation.html`, {
+      waitUntil: 'load',
+    });
+    await waitForRAF(page);
+
+    const patchActive = await page.evaluate(() => {
+      try {
+        new MutationObserver(() => {});
+        return false;
+      } catch (e) {
+        return (e as Error).message.includes('hijacked');
+      }
+    });
+    expect(patchActive).toBe(true);
+
+    await page.evaluate((bundle) => {
+      eval(bundle);
+      (window as Window & { __rrwebEvents: eventWithTime[] }).__rrwebEvents =
+        [];
+      (
+        window as Window & { __rrwebStop: () => void }
+      ).__rrwebStop = (
+        window as Window & {
+          rrweb: { record: (options: { emit: (e: eventWithTime) => void }) => () => void };
+        }
+      ).rrweb.record({
+        emit: (e) => {
+          (
+            window as Window & { __rrwebEvents: eventWithTime[] }
+          ).__rrwebEvents.push(e);
+        },
+      });
+    }, code);
+    await waitForRAF(page);
+
+    await page.evaluate(() => {
+      const li = document.createElement('li');
+      li.textContent = 'b';
+      document.getElementById('list')?.appendChild(li);
+    });
+    await waitForRAF(page);
+    await waitForRAF(page);
+
+    const events = (await page.evaluate(() =>
+      JSON.parse(
+        JSON.stringify(
+          (window as Window & { __rrwebEvents: eventWithTime[] })
+            .__rrwebEvents,
+        ),
+      ),
+    )) as eventWithTime[];
+
+    const mutationEvents = events.filter(
+      (e) =>
+        e.type === EventType.IncrementalSnapshot &&
+        (e.data as { source: number }).source === IncrementalSource.Mutation,
+    );
+
+    expect(mutationEvents.length).toBeGreaterThan(0);
+    await page.close();
+  });
+});

--- a/packages/rrweb/rrweb/test/record/safari-mutation-observer-hardening.test.ts
+++ b/packages/rrweb/rrweb/test/record/safari-mutation-observer-hardening.test.ts
@@ -1,0 +1,202 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  EventType,
+  IncrementalSource,
+  eventWithTime,
+} from '@posthog/rrweb-types';
+import {
+  getServerURL,
+  launchPuppeteer,
+  startServer,
+  waitForRAF,
+} from '../utils';
+import type { Server } from 'http';
+import type * as puppeteer from 'puppeteer';
+
+describe('monkey-patched MutationObserver hardening', () => {
+  vi.setConfig({ testTimeout: 45_000 });
+
+  let server: Server;
+  let serverURL: string;
+  let browser: puppeteer.Browser;
+  let code: string;
+
+  beforeAll(async () => {
+    server = await startServer();
+    serverURL = getServerURL(server);
+    browser = await launchPuppeteer();
+    code = fs.readFileSync(
+      path.resolve(__dirname, '../../dist/rrweb.umd.cjs'),
+      'utf-8',
+    );
+  });
+
+  afterAll(async () => {
+    await browser.close();
+    await server.close();
+  });
+
+  async function startRecording(page: puppeteer.Page, resetEvents = true) {
+    await page.evaluate(
+      (bundle, shouldReset) => {
+        eval(bundle);
+        const w = window as Window & { __rrwebEvents: eventWithTime[] };
+        if (shouldReset || !w.__rrwebEvents) {
+          w.__rrwebEvents = [];
+        }
+      (
+        window as Window & { __rrwebStop: (() => void) | undefined }
+      ).__rrwebStop = (
+        window as Window & {
+          rrweb: {
+            record: (options: {
+              emit: (e: eventWithTime) => void;
+            }) => () => void;
+          };
+        }
+      ).rrweb.record({
+        emit: (e) => {
+          (
+            window as Window & { __rrwebEvents: eventWithTime[] }
+          ).__rrwebEvents.push(e);
+        },
+      });
+      },
+      code,
+      resetEvents,
+    );
+    await waitForRAF(page);
+  }
+
+  function mutationEvents(events: eventWithTime[]) {
+    return events.filter(
+      (e) =>
+        e.type === EventType.IncrementalSnapshot &&
+        (e.data as { source: number }).source === IncrementalSource.Mutation,
+    );
+  }
+
+  it('records mutations across stop/start cycles', async () => {
+    const page = await browser.newPage();
+    await page.goto(`${serverURL}/html/monkey-patched-mutation.html`, {
+      waitUntil: 'load',
+    });
+    await waitForRAF(page);
+
+    await startRecording(page);
+    await page.evaluate(() => {
+      const li = document.createElement('li');
+      li.textContent = 'first-session';
+      document.getElementById('list')?.appendChild(li);
+    });
+    await waitForRAF(page);
+    await page.evaluate(() => {
+      (window as Window & { __rrwebStop: () => void }).__rrwebStop();
+      (window as Window & { __rrwebStop: undefined }).__rrwebStop = undefined;
+    });
+    await waitForRAF(page);
+
+    await startRecording(page, false);
+    await page.evaluate(() => {
+      const li = document.createElement('li');
+      li.textContent = 'second-session';
+      document.getElementById('list')?.appendChild(li);
+    });
+    await waitForRAF(page);
+    await waitForRAF(page);
+
+    const events = (await page.evaluate(() =>
+      JSON.parse(
+        JSON.stringify(
+          (window as Window & { __rrwebEvents: eventWithTime[] })
+            .__rrwebEvents,
+        ),
+      ),
+    )) as eventWithTime[];
+
+    const mutations = mutationEvents(events);
+    expect(mutations.length).toBeGreaterThanOrEqual(2);
+
+    const texts = JSON.stringify(mutations);
+    expect(texts).toContain('first-session');
+    expect(texts).toContain('second-session');
+    await page.close();
+  });
+
+  it('does not leak untainted iframes after recording stops', async () => {
+    const page = await browser.newPage();
+    await page.goto(`${serverURL}/html/monkey-patched-mutation.html`, {
+      waitUntil: 'load',
+    });
+    await waitForRAF(page);
+
+    await startRecording(page);
+    await page.evaluate(() => {
+      const li = document.createElement('li');
+      li.textContent = 'cleanup-check';
+      document.getElementById('list')?.appendChild(li);
+    });
+    await waitForRAF(page);
+
+    const iframeCountDuringRecord = await page.evaluate(
+      () =>
+        document.querySelectorAll(
+          'iframe[__rrwebUntaintedMutationObserver]',
+        ).length,
+    );
+
+    await page.evaluate(() => {
+      (window as Window & { __rrwebStop: () => void }).__rrwebStop();
+    });
+    await waitForRAF(page);
+
+    const iframeCountAfterStop = await page.evaluate(
+      () =>
+        document.querySelectorAll(
+          'iframe[__rrwebUntaintedMutationObserver]',
+        ).length,
+    );
+
+    // Chromium removes the helper iframe immediately; attribute only exists on Safari.
+    expect(iframeCountDuringRecord).toBeGreaterThanOrEqual(0);
+    expect(iframeCountAfterStop).toBe(0);
+    await page.close();
+  });
+
+  it('records attribute and child-list mutations when monkey-patched', async () => {
+    const page = await browser.newPage();
+    await page.goto(`${serverURL}/html/monkey-patched-mutation.html`, {
+      waitUntil: 'load',
+    });
+    await waitForRAF(page);
+    await startRecording(page);
+
+    await page.evaluate(() => {
+      const root = document.getElementById('list')!;
+      root.setAttribute('data-test', 'mutated');
+      const li = document.createElement('li');
+      li.textContent = 'child-list';
+      root.appendChild(li);
+      root.firstElementChild?.remove();
+    });
+    await waitForRAF(page);
+    await waitForRAF(page);
+
+    const events = (await page.evaluate(() =>
+      JSON.parse(
+        JSON.stringify(
+          (window as Window & { __rrwebEvents: eventWithTime[] })
+            .__rrwebEvents,
+        ),
+      ),
+    )) as eventWithTime[];
+
+    expect(mutationEvents(events).length).toBeGreaterThan(0);
+    const serialized = JSON.stringify(events);
+    expect(serialized).toContain('child-list');
+    expect(serialized).toContain('data-test');
+    await page.close();
+  });
+});

--- a/packages/rrweb/rrweb/test/record/untainted-mutation-observer.test.ts
+++ b/packages/rrweb/rrweb/test/record/untainted-mutation-observer.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const safariUA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Safari/605.1.15';
+const chromeUA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36';
+
+class HijackedMutationObserver {
+  constructor(_callback: MutationCallback) {}
+  observe() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+async function loadUtils(userAgent: string) {
+  vi.resetModules();
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    url: 'http://localhost',
+  });
+  const { window } = dom;
+  vi.stubGlobal('window', window);
+  vi.stubGlobal('document', window.document);
+  vi.stubGlobal('navigator', { userAgent });
+  vi.stubGlobal(
+    'MutationObserver',
+    HijackedMutationObserver as unknown as typeof MutationObserver,
+  );
+
+  return import('@posthog/rrweb-utils');
+}
+
+describe('untainted MutationObserver iframe', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('keeps the iframe attached on Safari', async () => {
+    const utils = await loadUtils(safariUA);
+    utils.mutationObserverCtor();
+
+    const iframe = document.querySelector('iframe.rr-block');
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute('__rrwebUntaintedMutationObserver')).toBe('');
+
+    utils.cleanupUntaintedIframe();
+    expect(document.querySelector('iframe')).toBeNull();
+  });
+
+  it('removes the iframe immediately on non-Safari browsers', async () => {
+    const utils = await loadUtils(chromeUA);
+    utils.mutationObserverCtor();
+
+    expect(document.querySelector('iframe')).toBeNull();
+    utils.cleanupUntaintedIframe();
+  });
+});

--- a/packages/rrweb/utils/src/index.ts
+++ b/packages/rrweb/utils/src/index.ts
@@ -111,38 +111,43 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
 
   const iframeEl = document.createElement('iframe');
   iframeEl.style.display = 'none';
-  // WebKit/Safari tears down a detached iframe's ScriptExecutionContext, which
-  // silently breaks a MutationObserver constructed from it (webkit.org/b/179224).
-  // On Safari we keep the iframe attached and expose a cleanup via mutationObserverCtor.
-  let keepIframeAttached = false;
   try {
     document.body.appendChild(iframeEl);
     const win = iframeEl.contentWindow;
-    if (!win) return candidate.prototype as BasePrototypeCache[T];
+    if (!win) {
+      iframeEl.remove();
+      return candidate.prototype as BasePrototypeCache[T];
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     const untaintedObject = (win as any)[key]
       .prototype as BasePrototypeCache[T];
 
-    if (!untaintedObject) return defaultPrototype;
+    if (!untaintedObject) {
+      iframeEl.remove();
+      return defaultPrototype;
+    }
 
     const ua = navigator.userAgent;
     if (ua.includes('Safari') && !ua.includes('Chrome')) {
-      keepIframeAttached = true;
-      // rr-block prevents rrweb from serializing this iframe in later snapshots
       iframeEl.classList.add('rr-block');
       iframeEl.setAttribute('__rrwebUntaintedMutationObserver', '');
       untaintedBaseIframeCleanup[key] = () => iframeEl.remove();
+    } else {
+      iframeEl.remove();
     }
 
     return (untaintedBasePrototype[key] = untaintedObject);
   } catch {
     return defaultPrototype;
-  } finally {
-    if (!keepIframeAttached && iframeEl.parentNode) {
-      document.body.removeChild(iframeEl);
-    }
   }
+}
+
+export function cleanupUntaintedIframe(
+  key: keyof BasePrototypeCache = 'MutationObserver',
+): void {
+  untaintedBaseIframeCleanup[key]?.();
+  delete untaintedBaseIframeCleanup[key];
 }
 
 const untaintedAccessorCache: Record<
@@ -258,17 +263,8 @@ export function querySelectorAll(
   return getUntaintedMethod('Element', n, 'querySelectorAll')(selectors);
 }
 
-export function mutationObserverCtor(): [
-  (typeof MutationObserver)['prototype']['constructor'],
-  () => void,
-] {
-  return [
-    getUntaintedPrototype('MutationObserver').constructor,
-    untaintedBaseIframeCleanup['MutationObserver'] ??
-      (() => {
-        /* no-op; a cleanup function is only needed in Safari browsers */
-      }),
-  ];
+export function mutationObserverCtor(): (typeof MutationObserver)['prototype']['constructor'] {
+  return getUntaintedPrototype('MutationObserver').constructor;
 }
 
 // copy from https://github.com/getsentry/sentry-javascript/blob/b2109071975af8bf0316d3b5b38f519bdaf5dc15/packages/utils/src/object.ts

--- a/packages/rrweb/utils/src/index.ts
+++ b/packages/rrweb/utils/src/index.ts
@@ -31,6 +31,9 @@ const testableMethods = {
 } as const;
 
 const untaintedBasePrototype: Partial<BasePrototypeCache> = {};
+const untaintedBaseIframeCleanup: Partial<
+  Record<keyof BasePrototypeCache, () => void>
+> = {};
 
 type WindowWithZone = typeof globalThis & {
   Zone?: {
@@ -107,6 +110,11 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
   }
 
   const iframeEl = document.createElement('iframe');
+  iframeEl.style.display = 'none';
+  // WebKit/Safari tears down a detached iframe's ScriptExecutionContext, which
+  // silently breaks a MutationObserver constructed from it (webkit.org/b/179224).
+  // On Safari we keep the iframe attached and expose a cleanup via mutationObserverCtor.
+  let keepIframeAttached = false;
   try {
     document.body.appendChild(iframeEl);
     const win = iframeEl.contentWindow;
@@ -118,11 +126,20 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
 
     if (!untaintedObject) return defaultPrototype;
 
+    const ua = navigator.userAgent;
+    if (ua.includes('Safari') && !ua.includes('Chrome')) {
+      keepIframeAttached = true;
+      // rr-block prevents rrweb from serializing this iframe in later snapshots
+      iframeEl.classList.add('rr-block');
+      iframeEl.setAttribute('__rrwebUntaintedMutationObserver', '');
+      untaintedBaseIframeCleanup[key] = () => iframeEl.remove();
+    }
+
     return (untaintedBasePrototype[key] = untaintedObject);
   } catch {
     return defaultPrototype;
   } finally {
-    if (iframeEl.parentNode) {
+    if (!keepIframeAttached && iframeEl.parentNode) {
       document.body.removeChild(iframeEl);
     }
   }
@@ -241,8 +258,17 @@ export function querySelectorAll(
   return getUntaintedMethod('Element', n, 'querySelectorAll')(selectors);
 }
 
-export function mutationObserverCtor(): (typeof MutationObserver)['prototype']['constructor'] {
-  return getUntaintedPrototype('MutationObserver').constructor;
+export function mutationObserverCtor(): [
+  (typeof MutationObserver)['prototype']['constructor'],
+  () => void,
+] {
+  return [
+    getUntaintedPrototype('MutationObserver').constructor,
+    untaintedBaseIframeCleanup['MutationObserver'] ??
+      (() => {
+        /* no-op; a cleanup function is only needed in Safari browsers */
+      }),
+  ];
 }
 
 // copy from https://github.com/getsentry/sentry-javascript/blob/b2109071975af8bf0316d3b5b38f519bdaf5dc15/packages/utils/src/object.ts


### PR DESCRIPTION
## Problem

I reviewed upstream rrweb's releases (`rrweb-io/rrweb`) against our vendored fork (`packages/rrweb/*`, `@posthog/rrweb`). The fork's upstream baseline is **`rrweb@2.0.0-alpha.18`**; upstream has since cut **`2.0.0`** and **`2.0.1`**.

The headline of `2.0.0` is a packaging/dist restructure (split plugin packages, new `@rrweb/browser-client`, new file extensions) that **we already do our own incompatible way** (our `@posthog/rrweb-*` workspace split + property mangling + custom vite build), so adopting it would fight our build. Stripping out docs/CI/`browser-client` noise, the **only functional code change** upstream landed after our baseline is the `2.0.1` WebKit fix.

That fix matters: on **WebKit/Safari**, when a 3rd-party library has monkey-patched the page, rrweb grabs a pristine `MutationObserver` constructor from a throwaway iframe to avoid the tainted one. WebKit tears down a **detached** iframe's `ScriptExecutionContext`, so the observer built from it silently stops delivering mutations once we remove the iframe ([webkit.org/b/179224](https://bugs.webkit.org/show_bug.cgi?id=179224)) — i.e. **no DOM mutations get recorded** on affected Safari pages.

## Changes

Ported [rrweb-io/rrweb#1854](https://github.com/rrweb-io/rrweb/pull/1854), reconciled against our diverged fork:

- `@posthog/rrweb-utils` (`getUntaintedPrototype`): on Safari, keep the untainted-prototype iframe **attached** (hidden via `display:none`, tagged `rr-block` + `__rrwebUntaintedMutationObserver` so it isn't serialized into snapshots) instead of removing it. `mutationObserverCtor()` now returns `[ctor, cleanup]`.
- `@posthog/rrweb` (`initMutationObserver` / `initObservers`): thread the `iframeCleanup` through and invoke it on observer teardown so we don't leak the iframe.
- Non-Safari behavior is unchanged (iframe still removed immediately; cleanup is a no-op).

Adapted to our fork's shape: our `initMutationObserver` returns an object (`{ observer, buffer }`) rather than upstream's tuple, so `shadow-dom-manager` needs no change (it just ignores the extra `iframeCleanup` field). Deliberately **not** porting the upstream WebKit Docker/CI test harness (`Dockerfile.webkit-test`, `vitest.config.webkit.ts`) — that's a separate CI infrastructure decision.

Typecheck + eslint clean on both packages.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

(Changeset bumps `posthog-js`, `@posthog/rrweb`, `@posthog/rrweb-utils` as patch.)

## Checklist

- [ ] Tests for new code — source-only port; the upstream regression test needs a WebKit CI runner we don't have wired up. Open to adding a Chromium-safe variant if wanted.
- [x] Accounted for the impact of any changes across different platforms — Safari-gated; non-Safari path byte-for-byte equivalent.
- [x] Accounted for backwards compatibility — `mutationObserverCtor` signature changed but it has a single internal caller; no external `dom.mutationObserver(` consumers.
- [x] Took care not to unnecessarily increase the bundle size — a few lines, Safari-gated.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

Scope was deliberately narrowed from "sync all rrweb updates": a literal full merge of `alpha.18 → 2.0.1` (65 commits) would drag in upstream's 2.0.0 packaging restructure which conflicts with our custom build/mangling. The genuine functional delta since our baseline is just the `2.0.1` WebKit MutationObserver fix, which this PR ports.

Made with [Cursor](https://cursor.com)