### PR TITLE
chore: add Sentry attribution comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -219,8 +219,8 @@ limitations under the License.
 
 ---
 
-Some files in this codebase contain code from getsentry/sentry-javascript or getsentry/sentry-react-native by Software, Inc. dba Sentry.
-In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases. 
+Some files in this codebase contain code from getsentry/sentry-javascript.
+In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
 
 MIT License
 
@@ -232,6 +232,33 @@ the Software without restriction, including without limitation the rights to
 use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 of the Software, and to permit persons to whom the Software is furnished to do
 so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+Some files in this codebase contain code from getsentry/sentry-react-native.
+In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Sentry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/packages/browser/src/extensions/replay/external/network-plugin.ts
+++ b/packages/browser/src/extensions/replay/external/network-plugin.ts
@@ -1,3 +1,7 @@
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
+
 /// <reference lib="dom" />
 
 // rrweb/network@1 code starts

--- a/packages/browser/src/extensions/replay/rrweb-plugins/patch.ts
+++ b/packages/browser/src/extensions/replay/rrweb-plugins/patch.ts
@@ -1,6 +1,9 @@
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
+
 // import { patch } from 'rrweb/typings/utils'
 // copied from https://github.com/rrweb-io/rrweb/blob/8aea5b00a4dfe5a6f59bd2ae72bb624f45e51e81/packages/rrweb/src/utils.ts#L129
-// which was copied from https://github.com/getsentry/sentry-javascript/blob/b2109071975af8bf0316d3b5b38f519bdaf5dc15/packages/utils/src/object.ts
 import { isFunction } from '@posthog/core'
 
 export function patch(

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -1,3 +1,7 @@
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
+
 import { PostHog } from './posthog-core'
 import { Survey } from './posthog-surveys-types'
 import { ConversationsRemoteConfig } from './posthog-conversations-types'

--- a/packages/browser/src/utils/prototype-utils.ts
+++ b/packages/browser/src/utils/prototype-utils.ts
@@ -1,6 +1,9 @@
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
+
 /**
- * adapted from https://github.com/getsentry/sentry-javascript/blob/72751dacb88c5b970d8bac15052ee8e09b28fd5d/packages/browser-utils/src/getNativeImplementation.ts#L27
- * and https://github.com/PostHog/rrweb/blob/804380afbb1b9bed70b8792cb5a25d827f5c0cb5/packages/utils/src/index.ts#L31
+ * Also adapted from https://github.com/PostHog/rrweb/blob/804380afbb1b9bed70b8792cb5a25d827f5c0cb5/packages/utils/src/index.ts#L31
  * after a number of performance reports from Angular users
  */
 

--- a/packages/core/src/error-tracking/chunk-ids.ts
+++ b/packages/core/src/error-tracking/chunk-ids.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import type { StackParser } from './types'
 

--- a/packages/core/src/error-tracking/coercers/object-coercer.ts
+++ b/packages/core/src/error-tracking/coercers/object-coercer.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import { isEmptyString, isError, isEvent, isString } from '@/utils'
 import { CoercingContext, ErrorTrackingCoercer, ExceptionLike, SeverityLevel, severityLevels } from '../types'

--- a/packages/core/src/error-tracking/coercers/promise-rejection-event.ts
+++ b/packages/core/src/error-tracking/coercers/promise-rejection-event.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import { isBuiltin, isEvent, isPrimitive } from '@/utils'
 import { CoercingContext, ErrorTrackingCoercer, ExceptionLike } from '../types'

--- a/packages/core/src/error-tracking/coercers/utils.ts
+++ b/packages/core/src/error-tracking/coercers/utils.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 export function truncate(str: string, max: number = 0): string {
   if (typeof str !== 'string' || max === 0) {

--- a/packages/core/src/error-tracking/parsers/base.ts
+++ b/packages/core/src/error-tracking/parsers/base.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import { isUndefined } from '@/utils'
 import { StackFrame } from '../types'

--- a/packages/core/src/error-tracking/parsers/chrome.ts
+++ b/packages/core/src/error-tracking/parsers/chrome.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 // This regex matches frames that have no function name (ie. are at the top level of a module).
 // For example "at http://localhost:5000//script.js:1:126"

--- a/packages/core/src/error-tracking/parsers/gecko.ts
+++ b/packages/core/src/error-tracking/parsers/gecko.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 // gecko regex: `(?:bundle|\d+\.js)`: `bundle` is for react native, `\d+\.js` also but specifically for ram bundles because it
 // generates filenames without a prefix like `file://` the filenames in the stacktrace are just 42.js

--- a/packages/core/src/error-tracking/parsers/index.ts
+++ b/packages/core/src/error-tracking/parsers/index.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 // 💖 open source
 

--- a/packages/core/src/error-tracking/parsers/node.ts
+++ b/packages/core/src/error-tracking/parsers/node.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import { Platform, StackLineParser } from '../types'
 import { UNKNOWN_FUNCTION } from './base'

--- a/packages/core/src/error-tracking/parsers/opera.ts
+++ b/packages/core/src/error-tracking/parsers/opera.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import { StackLineParser } from '../types'
 import { createFrame, UNKNOWN_FUNCTION } from './base'

--- a/packages/core/src/error-tracking/parsers/safari.ts
+++ b/packages/core/src/error-tracking/parsers/safari.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import { UNKNOWN_FUNCTION } from './base'
 

--- a/packages/core/src/error-tracking/parsers/winjs.ts
+++ b/packages/core/src/error-tracking/parsers/winjs.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import { StackLineParser } from '../types'
 import { createFrame, UNKNOWN_FUNCTION } from './base'

--- a/packages/core/src/error-tracking/types.ts
+++ b/packages/core/src/error-tracking/types.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import type { JsonType } from '../types'
 

--- a/packages/core/src/error-tracking/utils.ts
+++ b/packages/core/src/error-tracking/utils.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 /** A simple Least Recently Used map */
 export class ReduceableCache<K, V> {

--- a/packages/node/src/extensions/error-tracking/autocapture.ts
+++ b/packages/node/src/extensions/error-tracking/autocapture.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 

--- a/packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts
+++ b/packages/node/src/extensions/error-tracking/modifiers/context-lines.node.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { createReadStream } from 'node:fs'

--- a/packages/node/src/extensions/error-tracking/modifiers/module.node.ts
+++ b/packages/node/src/extensions/error-tracking/modifiers/module.node.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 import { ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { posix, sep, dirname } from 'path'

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -1,4 +1,6 @@
-// inspired from https://github.com/getsentry/sentry-react-native/blob/c1981913a90fad31d8e98ec4a7dcb35c7af46a04/packages/core/plugin/src/withSentryIOS.ts#L18
+// Portions of this file are derived from getsentry/sentry-react-native
+// Copyright (c) 2017 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-react-native/blob/main/LICENSE.md
 
 const { withAppBuildGradle, withXcodeProject } = require('@expo/config-plugins')
 

--- a/packages/react-native/src/tooling/metroconfig.ts
+++ b/packages/react-native/src/tooling/metroconfig.ts
@@ -1,4 +1,6 @@
-// copied from https://github.com/getsentry/sentry-react-native/blob/73f2455090a375857fe115ed135e524c70324cdd/packages/core/src/js/tools/metroconfig.ts
+// Portions of this file are derived from getsentry/sentry-react-native
+// Copyright (c) 2017 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-react-native/blob/main/LICENSE.md
 
 import type { MetroConfig, MixedOutput, Module, ReadOnlyGraph } from 'metro'
 import { unstableBeforeAssetSerializationDebugIdPlugin } from './posthogMetroSerializer'

--- a/packages/react-native/src/tooling/posthogMetroSerializer.ts
+++ b/packages/react-native/src/tooling/posthogMetroSerializer.ts
@@ -1,4 +1,6 @@
-// copied from https://github.com/getsentry/sentry-react-native/blob/73f2455090a375857fe115ed135e524c70324cdd/packages/core/src/js/tools/sentryMetroSerializer.ts
+// Portions of this file are derived from getsentry/sentry-react-native
+// Copyright (c) 2017 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-react-native/blob/main/LICENSE.md
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type { MixedOutput, Module, ReadOnlyGraph } from 'metro'

--- a/packages/react-native/src/tooling/utils.ts
+++ b/packages/react-native/src/tooling/utils.ts
@@ -1,4 +1,6 @@
-// copied from https://github.com/getsentry/sentry-react-native/blob/14f576eeb6c444281bff03a323b0aed836002cce/packages/core/src/js/tools/utils.ts
+// Portions of this file are derived from getsentry/sentry-react-native
+// Copyright (c) 2017 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-react-native/blob/main/LICENSE.md
 
 import * as crypto from 'crypto'
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# adapted from https://github.com/getsentry/sentry-react-native/blob/e76d0d388228437e82f235546de00f4e748fcbda/packages/core/scripts/sentry-xcode.sh
+# Portions of this file are derived from getsentry/sentry-react-native
+# Copyright (c) 2017 Sentry
+# Licensed under the MIT License: https://github.com/getsentry/sentry-react-native/blob/main/LICENSE.md
 # Bundle React Native code and images
 # PWD=ios
 

--- a/packages/react-native/tooling/posthog.gradle
+++ b/packages/react-native/tooling/posthog.gradle
@@ -1,4 +1,6 @@
-// adapted from https://github.com/getsentry/sentry-react-native/blob/e76d0d388228437e82f235546de00f4e748fcbda/packages/core/sentry.gradle
+// Portions of this file are derived from getsentry/sentry-react-native
+// Copyright (c) 2017 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-react-native/blob/main/LICENSE.md
 
 import org.apache.tools.ant.taskdefs.condition.Os
 

--- a/packages/rrweb/utils/src/index.ts
+++ b/packages/rrweb/utils/src/index.ts
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-javascript by Software, Inc. dba Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
 
 type PrototypeOwner = Node | ShadowRoot | MutationObserver | Element;
 type TypeofPrototypeOwner =

--- a/packages/types/src/session-recording.ts
+++ b/packages/types/src/session-recording.ts
@@ -1,3 +1,7 @@
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
+
 /**
  * Session recording types
  */

--- a/packages/web/src/patch.ts
+++ b/packages/web/src/patch.ts
@@ -1,7 +1,10 @@
+// Portions of this file are derived from getsentry/sentry-javascript
+// Copyright (c) 2012 Functional Software, Inc. dba Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE
+
 // import { patch } from 'rrweb/typings/utils'
 // copied from: https://github.com/PostHog/posthog-js/blob/main/src/extensions/replay/rrweb-plugins/patch.ts
 // which was copied from https://github.com/rrweb-io/rrweb/blob/8aea5b00a4dfe5a6f59bd2ae72bb624f45e51e81/packages/rrweb/src/utils.ts#L129
-// which was copied from https://github.com/getsentry/sentry-javascript/blob/b2109071975af8bf0316d3b5b38f519bdaf5dc15/packages/utils/src/object.ts
 
 // copied from: https://github.com/PostHog/posthog-js/blob/main/react/src/utils/type-utils.ts#L4
 export const isFunction = function (f: any): f is (...args: any[]) => any {


### PR DESCRIPTION
## Problem

We need clear attribution for source files that include code derived from Sentry projects, including the relevant copyright and MIT license references.

## Changes

- Adds Sentry attribution comments and license links to browser, core error-tracking, node error-tracking, React Native tooling, rrweb utility, types, and web patch files.
- Updates the root `LICENSE` with Sentry copyright and MIT license information.
- No runtime behavior changes.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
