### PR TITLE
fix: logs-opt-out

### DIFF
--- a/.changeset/logs-respect-opt-out.md
+++ b/.changeset/logs-respect-opt-out.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+logs: the console-log integration now respects `opt_out_capturing()` — it checks `is_capturing()` before emitting, so log events stop on opt-out (and resume on opt-in).

--- a/packages/browser/src/__tests__/entrypoints/logs.test.ts
+++ b/packages/browser/src/__tests__/entrypoints/logs.test.ts
@@ -73,6 +73,7 @@ describe('logs entrypoint', () => {
                 })),
             },
             get_distinct_id: jest.fn(() => 'user-123'),
+            is_capturing: jest.fn(() => true),
         } as unknown as PostHog
 
         // Mock assignableWindow
@@ -577,6 +578,62 @@ describe('logs entrypoint', () => {
                     }),
                 })
             )
+        })
+    })
+
+    describe('consent / opt-out handling', () => {
+        beforeEach(() => {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            require('../../entrypoints/logs')
+        })
+
+        it('should not emit logs when capturing is opted out', () => {
+            const originalConsoleLog = assignableWindow.console.log as jest.Mock
+            ;(mockPostHog.is_capturing as jest.Mock).mockReturnValue(false)
+
+            const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
+            initializeLogs(mockPostHog)
+
+            assignableWindow.console.log('should not be captured')
+
+            expect(mockEmit).not.toHaveBeenCalled()
+            // the original console method must still be called so local output isn't suppressed
+            expect(originalConsoleLog).toHaveBeenCalledWith('should not be captured')
+        })
+
+        it('should resume emitting once capturing is opted back in', () => {
+            const isCapturing = mockPostHog.is_capturing as jest.Mock
+            isCapturing.mockReturnValue(false)
+
+            const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
+            initializeLogs(mockPostHog)
+
+            assignableWindow.console.log('while opted out')
+            expect(mockEmit).not.toHaveBeenCalled()
+
+            isCapturing.mockReturnValue(true)
+            assignableWindow.console.log('after opt back in')
+
+            expect(mockEmit).toHaveBeenCalledTimes(1)
+            expect(mockEmit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: '"after opt back in"',
+                })
+            )
+        })
+
+        it('should check capturing status on every log, not just at init', () => {
+            const isCapturing = mockPostHog.is_capturing as jest.Mock
+
+            const initializeLogs = assignableWindow.__PosthogExtensions__.logs.initializeLogs
+            initializeLogs(mockPostHog)
+
+            assignableWindow.console.log('captured')
+            expect(mockEmit).toHaveBeenCalledTimes(1)
+
+            isCapturing.mockReturnValue(false)
+            assignableWindow.console.log('not captured')
+            expect(mockEmit).toHaveBeenCalledTimes(1)
         })
     })
 

--- a/packages/browser/src/__tests__/extensions/logs.test.ts
+++ b/packages/browser/src/__tests__/extensions/logs.test.ts
@@ -81,6 +81,7 @@ describe('logs entrypoint', () => {
                 })),
             },
             get_distinct_id: jest.fn(() => 'user-123'),
+            is_capturing: jest.fn(() => true),
         } as unknown as PostHog
 
         // Mock assignableWindow

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -354,22 +354,24 @@ const initializeLogs = (posthog: PostHog) => {
             (originalConsoleLog: any) =>
             (...args: any[]) => {
                 if (args.length > 0) {
-                    const { body, truncated } = stringifyArgsSafely(args, LOG_BODY_SIZE_LIMIT)
-                    const logAttributes = {
-                        ...attributes,
-                        ...(truncated ? { body_truncated: 'true' } : {}),
+                    if (posthog.is_captuing() {
+                        const { body, truncated } = stringifyArgsSafely(args, LOG_BODY_SIZE_LIMIT)
+                        const logAttributes = {
+                            ...attributes,
+                            ...(truncated ? { body_truncated: 'true' } : {}),
+                        }
+                        logger.emit({
+                            severityText: SEVERITY_MAP[level],
+                            body: body,
+                            attributes: {
+                                'log.source': `console.${level}`,
+                                distinct_id: posthog.get_distinct_id(),
+                                'location.href': assignableWindow.location.href,
+                                ...logAttributes,
+                                ...(isObject(args[0]) ? flattenObject(args[0]) : {}),
+                            },
+                        })
                     }
-                    logger.emit({
-                        severityText: SEVERITY_MAP[level],
-                        body: body,
-                        attributes: {
-                            'log.source': `console.${level}`,
-                            distinct_id: posthog.get_distinct_id(),
-                            'location.href': assignableWindow.location.href,
-                            ...logAttributes,
-                            ...(isObject(args[0]) ? flattenObject(args[0]) : {}),
-                        },
-                    })
                     originalConsoleLog.apply(assignableWindow.console, args)
                 }
             }

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -353,27 +353,32 @@ const initializeLogs = (posthog: PostHog) => {
         const logWrapper =
             (originalConsoleLog: any) =>
             (...args: any[]) => {
-                if (args.length > 0) {
-                    if (posthog.is_capturing()) {
-                        const { body, truncated } = stringifyArgsSafely(args, LOG_BODY_SIZE_LIMIT)
-                        const logAttributes = {
-                            ...attributes,
-                            ...(truncated ? { body_truncated: 'true' } : {}),
-                        }
-                        logger.emit({
-                            severityText: SEVERITY_MAP[level],
-                            body: body,
-                            attributes: {
-                                'log.source': `console.${level}`,
-                                distinct_id: posthog.get_distinct_id(),
-                                'location.href': assignableWindow.location.href,
-                                ...logAttributes,
-                                ...(isObject(args[0]) ? flattenObject(args[0]) : {}),
-                            },
-                        })
-                    }
-                    originalConsoleLog.apply(assignableWindow.console, args)
+                if (args.length === 0) {
+                    return
                 }
+
+                if (!posthog.is_capturing()) {
+                    originalConsoleLog.apply(assignableWindow.console, args)
+                    return
+                }
+
+                const { body, truncated } = stringifyArgsSafely(args, LOG_BODY_SIZE_LIMIT)
+                const logAttributes = {
+                    ...attributes,
+                    ...(truncated ? { body_truncated: 'true' } : {}),
+                }
+                logger.emit({
+                    severityText: SEVERITY_MAP[level],
+                    body: body,
+                    attributes: {
+                        'log.source': `console.${level}`,
+                        distinct_id: posthog.get_distinct_id(),
+                        'location.href': assignableWindow.location.href,
+                        ...logAttributes,
+                        ...(isObject(args[0]) ? flattenObject(args[0]) : {}),
+                    },
+                })
+                originalConsoleLog.apply(assignableWindow.console, args)
             }
 
         const originalConsoleLog = assignableWindow.console[level]

--- a/packages/browser/src/entrypoints/logs.ts
+++ b/packages/browser/src/entrypoints/logs.ts
@@ -354,7 +354,7 @@ const initializeLogs = (posthog: PostHog) => {
             (originalConsoleLog: any) =>
             (...args: any[]) => {
                 if (args.length > 0) {
-                    if (posthog.is_captuing() {
+                    if (posthog.is_capturing()) {
                         const { body, truncated } = stringifyArgsSafely(args, LOG_BODY_SIZE_LIMIT)
                         const logAttributes = {
                             ...attributes,


### PR DESCRIPTION
opt out of capturing for logs

## Problem

opt out doesn't abide logs

## Changes

added a check to logs 

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [x] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
