### PR TITLE
fix(surveys): drop :has(.survey-question:empty) that crashes WebKit

### DIFF
--- a/.changeset/surveys-webkit-has-empty-crash.md
+++ b/.changeset/surveys-webkit-has-empty-crash.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(surveys): stop the survey CSS from using `:has(.survey-question:empty)`, which crashes some WebKit builds during text-node style invalidation while a survey renders. The empty-header margin tweak now keys off a JS-set `question-header--empty` class and a sibling selector instead.

--- a/packages/browser/src/__tests__/extensions/surveys/question-header.test.tsx
+++ b/packages/browser/src/__tests__/extensions/surveys/question-header.test.tsx
@@ -1,0 +1,36 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/preact'
+import { QuestionHeader } from '../../../extensions/surveys/components/QuestionHeader'
+import { SurveyQuestionType } from '../../../posthog-surveys-types'
+
+// The question-header--empty class replaces a :has(.survey-question:empty) CSS rule that
+// crashes some WebKit builds. Keep it driven from JS so the crashing selector never returns.
+describe('QuestionHeader', () => {
+    it.each([
+        ['empty question and no description', '', undefined, true],
+        ['question text present', 'What is your favorite color?', undefined, false],
+        ['no question but a description', '', 'A description', false],
+        ['both question and description present', 'A question', 'A description', false],
+    ])('%s', (_label, question, description, expectEmpty) => {
+        const { container } = render(
+            <QuestionHeader
+                question={{
+                    type: SurveyQuestionType.Open,
+                    question: question as string,
+                    description: description as string | undefined,
+                    descriptionContentType: 'text',
+                }}
+                forceDisableHtml={false}
+            />
+        )
+
+        const header = container.querySelector('.question-header')
+        expect(header).not.toBeNull()
+        if (expectEmpty) {
+            expect(header).toHaveClass('question-header--empty')
+        } else {
+            expect(header).not.toHaveClass('question-header--empty')
+        }
+    })
+})

--- a/packages/browser/src/extensions/surveys/components/QuestionHeader.tsx
+++ b/packages/browser/src/extensions/surveys/components/QuestionHeader.tsx
@@ -14,8 +14,11 @@ export function QuestionHeader({
     htmlFor?: string
 }) {
     const TitleComponent = question.type === SurveyQuestionType.Open ? 'label' : 'h3'
+    // Flag an empty header in JS rather than via :has(.survey-question:empty) in CSS,
+    // which crashes some WebKit builds during text-node style invalidation.
+    const isHeaderEmpty = !question.question && !question.description
     return (
-        <div class="question-header">
+        <div class={isHeaderEmpty ? 'question-header question-header--empty' : 'question-header'}>
             <TitleComponent className="survey-question" htmlFor={htmlFor}>
                 {question.question}
             </TitleComponent>

--- a/packages/browser/src/extensions/surveys/survey.css
+++ b/packages/browser/src/extensions/surveys/survey.css
@@ -286,10 +286,12 @@
 }
 
 .survey-box {
-    /* Adjust margin if question/description is empty */
-    &:has(.survey-question:empty):not(:has(.survey-question-description)) {
-        & .multiple-choice-options,
-        & textarea {
+    /* Adjust margin when the question header is empty (no title or description).
+       Keyed off a JS-set class rather than :has(.survey-question:empty), which
+       crashes some WebKit builds during text-node style invalidation. */
+    & .question-header--empty {
+        & ~ .multiple-choice-options,
+        & ~ textarea {
             margin-top: 0;
         }
     }


### PR DESCRIPTION
## Problem

Rendering a survey crashes the browser's web content process on some WebKit builds. The survey CSS uses `.survey-box:has(.survey-question:empty):not(:has(.survey-question-description))`, and WebKit re-evaluates that `:has()` rule whenever the question's text node is updated during render. On affected builds that style invalidation dereferences a bad pointer and the renderer dies (`EXC_BAD_ACCESS` / `SIGSEGV` in `WebCore::SelectorChecker::matchHasArgumentSelector` via `Style::ChildChangeInvalidation::invalidateForHasBeforeMutation`).

The rule itself only does anything in a degenerate case (a question with no title and no description), but its mere presence makes any question-text update crash the renderer on those builds.

Engine notes: reproduced deterministically on the WebKit bundled with Playwright 1.60.0 (this is what breaks the Storybook visual-regression job on webkit). Shipping Safari 26.5 is not affected, but other WebKit builds carrying the buggy `:has()` invalidation are, and survey respondents would be the ones hitting it.

## Changes

Drop `:has(.survey-question:empty)` from the survey CSS. Emptiness is now flagged with a `question-header--empty` class set in `QuestionHeader`, and the margin adjustment uses a plain sibling selector. With no `:has()`, the buggy invalidation path is never taken.

The rendered `className` is unchanged for normal (non-empty) headers, so there is no visual change outside the empty-header edge case.

Verification:
- Controlled WebKit repro (identical DOM and the same in-place text-mutation loop, differing only in the CSS rule): the old `:has()` rule crashes the renderer within ~100ms; the new selector survives.
- New unit test `question-header.test.tsx` for the class toggling, verified red against the old always-`question-header` markup.
- `pnpm test:unit:surveys`: 417/417 pass.
- `pnpm typecheck`: clean.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
