### PR TITLE
fix(replay): capture resting scroll offset on scrollend

### DIFF
--- a/.changeset/record-scrollend-resting-offset.md
+++ b/.changeset/record-scrollend-resting-offset.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/rrweb': patch
+---
+
+record: capture the resting scroll offset on `scrollend`. A scroll applied before its target is scrollable (e.g. scroll-snap-revealed sheets/modals whose content mounts the same frame, like Silk sheets) clamps to 0, so the throttled `scroll` samples miss the final snapped position and the element is recorded as scrolled to 0 — leaving the revealed content out of view on replay regardless of seeking. We now also listen for `scrollend` (where supported) and emit the settled offset, so the true resting position lands in the recording. `posthog-js` is bumped too so the rebuilt bundle containing the fix is published.

--- a/packages/rrweb/rrweb/src/record/observer.ts
+++ b/packages/rrweb/rrweb/src/record/observer.ts
@@ -318,36 +318,44 @@ export function initScrollObserver({
   observerParam,
   'scrollCb' | 'doc' | 'mirror' | 'blockClass' | 'blockSelector' | 'sampling'
 >): listenerHandler {
+  const emitScrollPosition = (evt: Event) => {
+    const target = getEventTarget(evt);
+    if (!target || isBlocked(target as Node, blockClass, blockSelector, true)) {
+      return;
+    }
+    const id = mirror.getId(target as Node);
+    if (target === doc && doc.defaultView) {
+      const scrollLeftTop = getWindowScroll(doc.defaultView);
+      scrollCb({
+        id,
+        x: scrollLeftTop.left,
+        y: scrollLeftTop.top,
+      });
+    } else {
+      scrollCb({
+        id,
+        x: (target as HTMLElement).scrollLeft,
+        y: (target as HTMLElement).scrollTop,
+      });
+    }
+  };
   const updatePosition = callbackWrapper(
     throttle<UIEvent>(
-      callbackWrapper((evt) => {
-        const target = getEventTarget(evt);
-        if (
-          !target ||
-          isBlocked(target as Node, blockClass, blockSelector, true)
-        ) {
-          return;
-        }
-        const id = mirror.getId(target as Node);
-        if (target === doc && doc.defaultView) {
-          const scrollLeftTop = getWindowScroll(doc.defaultView);
-          scrollCb({
-            id,
-            x: scrollLeftTop.left,
-            y: scrollLeftTop.top,
-          });
-        } else {
-          scrollCb({
-            id,
-            x: (target as HTMLElement).scrollLeft,
-            y: (target as HTMLElement).scrollTop,
-          });
-        }
-      }),
+      callbackWrapper(emitScrollPosition),
       sampling.scroll || 100,
     ),
   );
-  return on('scroll', updatePosition, doc);
+  const handlers: listenerHandler[] = [on('scroll', updatePosition, doc)];
+  // Also capture the resting offset once scrolling settles. A scroll applied
+  // before its target is scrollable (e.g. scroll-snap-revealed sheets/modals
+  // whose content mounts the same frame, like Silk sheets) clamps to 0, so the
+  // throttled `scroll` samples miss the final snapped position. `scrollend`
+  // fires after the browser finishes snapping/animating, yielding the true
+  // resting offset that replay needs.
+  if ('onscrollend' in doc) {
+    handlers.push(on('scrollend', callbackWrapper(emitScrollPosition), doc));
+  }
+  return () => handlers.forEach((h) => h());
 }
 
 function initViewportResizeObserver(

--- a/packages/rrweb/rrweb/test/record.test.ts
+++ b/packages/rrweb/rrweb/test/record.test.ts
@@ -250,6 +250,50 @@ describe('record', function (this: ISuite) {
     await assertSnapshot(ctx.events);
   });
 
+  it('should record the resting scroll offset on scrollend', async () => {
+    // Mirrors scroll-snap-revealed sheets/modals (e.g. Silk): the reveal scroll
+    // settles via a native scrollend without a `scroll` event the throttled
+    // observer captures, so the snapped offset is otherwise lost and the content
+    // replays scrolled to 0. We scroll the element BEFORE recording starts (and
+    // drain that scroll event) so the only signal during recording is the
+    // scrollend, which must still capture the resting offset.
+    await ctx.page.evaluate(() => {
+      const container = document.createElement('div');
+      container.setAttribute(
+        'style',
+        'overflow: auto; height: 100px; width: 100px;',
+      );
+      const tall = document.createElement('div');
+      tall.setAttribute('style', 'height: 3000px; width: 50px;');
+      container.appendChild(tall);
+      document.body.appendChild(container);
+      container.scrollTop = 745;
+      (window as unknown as { __container: HTMLElement }).__container =
+        container;
+    });
+    await waitForRAF(ctx.page);
+
+    await ctx.page.evaluate(() => {
+      const { record } = (window as unknown as IWindow).rrweb;
+      record({
+        emit: (window as unknown as IWindow).emit,
+      });
+      const c = (window as unknown as { __container: HTMLElement }).__container;
+      c.dispatchEvent(new Event('scrollend'));
+    });
+    await waitForRAF(ctx.page);
+
+    const scrollEvents = ctx.events.filter(
+      (e) =>
+        e.type === EventType.IncrementalSnapshot &&
+        e.data.source === IncrementalSource.Scroll,
+    );
+    expect(scrollEvents.length).toBeGreaterThan(0);
+    expect(scrollEvents.some((e) => (e.data as { y: number }).y === 745)).toBe(
+      true,
+    );
+  });
+
   it('should record selection event', async () => {
     await ctx.page.evaluate(() => {
       const { record } = (window as unknown as IWindow).rrweb;


### PR DESCRIPTION
## Problem

Scroll-snap-revealed sheets/modals (e.g. [Silk](https://silkhq.co/) sheets) reveal their content by scrolling a snap container to a resting offset. When the revealing scroll is applied *before* the target becomes scrollable — the new content mounts the same frame — the scroll clamps to `0`. rrweb's scroll observer only listens to the throttled `scroll` event, so it samples that clamped `0` (or misses the snap entirely) and never captures the final snapped offset. The element gets recorded as scrolled to `0`, so on replay the revealed content sits out of view and the user sees an empty/grey overlay — regardless of seeking.

This is the capture-side counterpart to #3736, which fixed the replay-side scroll clamping on fast-forward catch-up. That fix can't help here because the correct offset never made it into the recording in the first place.

Repro: a real recording of a Silk-based detail sheet opening at the 0:26 mark replays as a grey overlay; the snap container's resting `scrollTop` (~745px) is absent from the event stream. Manually setting that offset in the replay iframe reveals the sheet correctly, confirming the missing data is the resting scroll position.

## Changes

- `initScrollObserver` now also subscribes to `scrollend` (where supported) and emits the settled scroll offset. `scrollend` fires after the browser finishes snapping/animating, so we capture the true resting position even when the throttled `scroll` samples missed it.
- Extracted the shared emit logic into `emitScrollPosition` so both `scroll` and `scrollend` reuse it; the observer now returns a teardown that removes both listeners.
- Added a `record` integration test that scrolls an element before recording starts (and drains that `scroll` event) so `scrollend` is the only signal — asserting the resting offset still lands in the recording.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

(also `@posthog/rrweb`)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms (feature-detected via `'onscrollend' in doc`)
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

Made with [Cursor](https://cursor.com)