### PR TITLE
fix(surveys): avoid native StyleSheet.create at import time

### DIFF
--- a/.changeset/surveys-import-side-effects.md
+++ b/.changeset/surveys-import-side-effects.md
@@ -1,0 +1,5 @@
+---
+"posthog-react-native": patch
+---
+
+Fix `posthog-react-native` throwing `Cannot read properties of undefined (reading 'create')` at import time in analytics-only setups and Jest `testEnvironment: node` runs without the React Native preset. The surveys UI is reachable from the package entrypoint and no longer evaluates native `StyleSheet` APIs while loading. (#3740)

--- a/packages/react-native/src/surveys/components/BottomSection.tsx
+++ b/packages/react-native/src/surveys/components/BottomSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Linking, Text, TouchableOpacity, View } from 'react-native'
 
+import { createSafeStyleSheet } from '../safeStyleSheet'
 import { SurveyAppearanceTheme } from '../surveys-utils'
 
 export function BottomSection({
@@ -48,7 +49,7 @@ export function BottomSection({
   )
 }
 
-const styles = StyleSheet.create({
+const styles = createSafeStyleSheet({
   bottomSection: {
     padding: 10,
   },

--- a/packages/react-native/src/surveys/components/Cancel.tsx
+++ b/packages/react-native/src/surveys/components/Cancel.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { StyleSheet, TouchableOpacity } from 'react-native'
+import { TouchableOpacity } from 'react-native'
 import { CancelSVG } from '../icons'
 
+import { createSafeStyleSheet } from '../safeStyleSheet'
 import { SurveyAppearanceTheme } from '../surveys-utils'
 
 export function Cancel({
@@ -18,7 +19,7 @@ export function Cancel({
   )
 }
 
-const styles = StyleSheet.create({
+const styles = createSafeStyleSheet({
   cancelBtnWrapper: {
     width: 40,
     height: 40,

--- a/packages/react-native/src/surveys/components/ConfirmationMessage.tsx
+++ b/packages/react-native/src/surveys/components/ConfirmationMessage.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { StyleSheet, Text, View, ViewStyle } from 'react-native'
+import { Text, View, ViewStyle } from 'react-native'
 
+import { createSafeStyleSheet } from '../safeStyleSheet'
 import {
   defaultDescriptionOpacity,
   getContrastingTextColor,
@@ -49,7 +50,7 @@ export function ConfirmationMessage({
   )
 }
 
-const styles = StyleSheet.create({
+const styles = createSafeStyleSheet({
   thankYouMessageContainer: {
     padding: 10,
   },

--- a/packages/react-native/src/surveys/components/QuestionHeader.tsx
+++ b/packages/react-native/src/surveys/components/QuestionHeader.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { StyleSheet, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
 
 import { SurveyQuestionDescriptionContentType } from '@posthog/core'
+import { createSafeStyleSheet } from '../safeStyleSheet'
 import {
   defaultDescriptionOpacity,
   getContrastingTextColor,
@@ -35,7 +36,7 @@ export function QuestionHeader({
   )
 }
 
-const styles = StyleSheet.create({
+const styles = createSafeStyleSheet({
   container: {
     padding: 10,
   },

--- a/packages/react-native/src/surveys/components/QuestionTypes.tsx
+++ b/packages/react-native/src/surveys/components/QuestionTypes.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useMemo, useState } from 'react'
-import { Pressable, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native'
+import { Pressable, ScrollView, Text, TextInput, TouchableOpacity, View } from 'react-native'
 
+import { createSafeStyleSheet } from '../safeStyleSheet'
 import {
   CheckSVG,
   DissatisfiedEmoji,
@@ -54,7 +55,7 @@ function QuestionLayout({ children, footer }: { children: ReactNode; footer: Rea
   )
 }
 
-const questionLayoutStyles = StyleSheet.create({
+const questionLayoutStyles = createSafeStyleSheet({
   container: {
     flexShrink: 1,
   },
@@ -427,7 +428,7 @@ function getScaleNumbers(scale: number): number[] {
   }
 }
 
-const styles = StyleSheet.create({
+const styles = createSafeStyleSheet({
   textInputContainer: {
     padding: 10,
   },

--- a/packages/react-native/src/surveys/components/SurveyModal.tsx
+++ b/packages/react-native/src/surveys/components/SurveyModal.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { Keyboard, KeyboardAvoidingView, Modal, Platform, StyleSheet, View, useWindowDimensions } from 'react-native'
+import { Keyboard, KeyboardAvoidingView, Modal, Platform, View, useWindowDimensions } from 'react-native'
 
 import { Cancel } from './Cancel'
 import { ConfirmationMessage } from './ConfirmationMessage'
+import { createSafeStyleSheet } from '../safeStyleSheet'
 import { SurveyAppearanceTheme, resolveSurveyAlignment } from '../surveys-utils'
 import { Survey, type SurveyResponses } from '@posthog/core'
 import { useOptionalSafeAreaInsets } from '../../optional/OptionalReactNativeSafeArea'
@@ -146,7 +147,7 @@ export function SurveyModal(props: SurveyModalProps): JSX.Element | null {
   )
 }
 
-const styles = StyleSheet.create({
+const styles = createSafeStyleSheet({
   fill: {
     flex: 1,
   },

--- a/packages/react-native/src/surveys/icons.tsx
+++ b/packages/react-native/src/surveys/icons.tsx
@@ -1,8 +1,9 @@
 import React, { JSX } from 'react'
-import { StyleSheet, Text } from 'react-native'
+import { Text } from 'react-native'
 import type { SvgProps } from 'react-native-svg'
 
 import { OptionalReactNativeSvg } from '../optional/OptionalReactNativeSvg'
+import { createSafeStyleSheet } from './safeStyleSheet'
 
 const Svg = OptionalReactNativeSvg?.Svg as React.ComponentType<SvgProps> | undefined
 const Path = OptionalReactNativeSvg?.Path as React.ComponentType<Record<string, unknown>> | undefined
@@ -194,7 +195,7 @@ export const CancelSVG = (props: SvgProps): JSX.Element =>
     },
   })
 
-const styles = StyleSheet.create({
+const styles = createSafeStyleSheet({
   fallbackIcon: {
     textAlign: 'center',
   },

--- a/packages/react-native/src/surveys/safeStyleSheet.ts
+++ b/packages/react-native/src/surveys/safeStyleSheet.ts
@@ -1,0 +1,11 @@
+import { StyleSheet } from 'react-native'
+
+/**
+ * `StyleSheet.create` that returns the raw style map when the React Native
+ * `StyleSheet` runtime is unavailable (e.g. Jest `testEnvironment: node` without
+ * the RN preset), instead of throwing at import.
+ * See https://github.com/PostHog/posthog-js/issues/3740.
+ */
+export const createSafeStyleSheet = <T extends StyleSheet.NamedStyles<T>>(styles: T): T => {
+  return typeof StyleSheet?.create === 'function' ? StyleSheet.create(styles) : styles
+}

--- a/packages/react-native/test/safeStyleSheet.spec.ts
+++ b/packages/react-native/test/safeStyleSheet.spec.ts
@@ -15,6 +15,9 @@ describe('createSafeStyleSheet', () => {
 
     expect(createSpy).toHaveBeenCalledWith(input)
     expect(result).toBe(sentinel)
+    // clearMocks resets call counts but not the implementation; restore so the
+    // sentinel return doesn't leak into other tests in this file.
+    createSpy.mockRestore()
   })
 
   it('falls back to the raw style map when StyleSheet is unavailable', () => {

--- a/packages/react-native/test/safeStyleSheet.spec.ts
+++ b/packages/react-native/test/safeStyleSheet.spec.ts
@@ -1,0 +1,30 @@
+import { StyleSheet } from 'react-native'
+
+import { createSafeStyleSheet } from '../src/surveys/safeStyleSheet'
+
+describe('createSafeStyleSheet', () => {
+  it('delegates to StyleSheet.create when the React Native runtime is present', () => {
+    // jest-expo's StyleSheet.create is an identity passthrough, so a returned value
+    // could come from delegation or the fallback. Mock a distinct sentinel so the
+    // delegation path is observable: a result of `sentinel` can only come from create.
+    const sentinel = { container: { padding: 10 } }
+    const createSpy = jest.spyOn(StyleSheet, 'create').mockReturnValue(sentinel as never)
+    const input = { container: { padding: 10 } }
+
+    const result = createSafeStyleSheet(input)
+
+    expect(createSpy).toHaveBeenCalledWith(input)
+    expect(result).toBe(sentinel)
+  })
+
+  it('falls back to the raw style map when StyleSheet is unavailable', () => {
+    jest.isolateModules(() => {
+      jest.doMock('react-native', () => ({ StyleSheet: undefined }))
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- isolated require exercises the no-runtime branch
+      const { createSafeStyleSheet: createWithoutRuntime } = require('../src/surveys/safeStyleSheet')
+      const input = { container: { padding: 10 } }
+
+      expect(createWithoutRuntime(input)).toBe(input)
+    })
+  })
+})

--- a/packages/react-native/test/surveys-import-side-effects.spec.ts
+++ b/packages/react-native/test/surveys-import-side-effects.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for https://github.com/PostHog/posthog-js/issues/3740
+ *
+ * The surveys UI is reachable from the package entrypoint, so its modules are
+ * evaluated on import. Where `StyleSheet` is undefined (Jest `testEnvironment: node`
+ * without the RN preset), a top-level `StyleSheet.create(...)` throws at import.
+ * Loading these modules must not call native-only APIs.
+ */
+describe('surveys import side effects (#3740)', () => {
+  const surveyModulesWithStyles = [
+    '../src/surveys/icons',
+    '../src/surveys/components/Cancel',
+    '../src/surveys/components/ConfirmationMessage',
+    '../src/surveys/components/BottomSection',
+    '../src/surveys/components/QuestionTypes',
+    '../src/surveys/components/SurveyModal',
+    '../src/surveys/components/QuestionHeader',
+  ]
+
+  it.each(surveyModulesWithStyles)('imports %s without calling native StyleSheet.create', (modulePath) => {
+    jest.isolateModules(() => {
+      // Simulate a runtime where react-native resolves but StyleSheet is unavailable
+      // (e.g. Jest `testEnvironment: node` without the React Native preset).
+      jest.doMock('react-native', () => ({ StyleSheet: undefined }))
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- dynamic require is required to test import-time side effects under an isolated module registry
+      expect(() => require(modulePath)).not.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
## Problem

Importing `posthog-react-native` for **analytics-only** use throws at import time when `react-native`'s `StyleSheet` is unavailable — e.g. in apps that don't install the optional `react-native-svg` peer, or in Jest `testEnvironment: node` runs without the React Native preset:

```
TypeError: Cannot read properties of undefined (reading 'create')
  at dist/surveys/icons.js
  at dist/index.js          ← package entrypoint
```

The package entrypoint does `export * from './surveys'`, which eagerly evaluates the surveys UI tree. Several survey modules call `StyleSheet.create(...)` at module scope, so just `import PostHog from 'posthog-react-native'` dereferences `StyleSheet.create` — and crashes when `StyleSheet` is undefined, before any analytics call. ([#3740](https://github.com/PostHog/posthog-js/issues/3740))

Note: the earlier #3485 only guarded the `react-native-svg` require; it does not cover this `StyleSheet.create` path, which is the actual crash here.

## Changes

- New `createSafeStyleSheet` helper that delegates to `StyleSheet.create` when the RN runtime is present and returns the raw style map otherwise (only when nothing renders), so the surveys modules are safe to evaluate at import. This matches the repo's existing "tolerate missing native runtime" convention in `src/optional/`. It lives in `surveys/` rather than `optional/` because it guards an undefined *member* of an always-present module, not a missing module.
- Routed all top-level `StyleSheet.create` calls in the surveys tree (`icons` + 6 components) through it.
- Tests: a regression spec that imports every survey module with `StyleSheet` undefined and asserts no throw, plus a unit spec covering both the delegate and fallback paths.

In a real RN runtime, behavior is unchanged — `StyleSheet.create` is still called and styles render identically.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-react-native

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
