### PR TITLE
ci: bump flags-board pin to skip Dependabot PRs

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     call-flags-project:
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@d8b55d05dc5150f05c24542a6397ff3ecfbfb56d
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@69336b569d22687f8982eea6ff7d450a885cda05
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}


### PR DESCRIPTION
Bumps the `flags-project-board.yml` pin to `69336b569d22687f8982eea6ff7d450a885cda05` to pick up [PostHog/.github#52](https://github.com/PostHog/.github/pull/52) (merged), which skips the feature flags project board for Dependabot PRs.

The board's GitHub App token step hard-fails in Dependabot's restricted secret context (`The 'client-id'... must be set to a non-empty string`), so the `call-*-project-board` check has been red on every dependency-bump PR. This one-line pin bump is the only change needed to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
