### PR TITLE
fix(react-native): surface full Xcode sourcemap upload errors

### DIFF
--- a/.changeset/rn-xcode-cli-error-lines.md
+++ b/.changeset/rn-xcode-cli-error-lines.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Improve Xcode sourcemap upload failure logs so every captured `posthog-cli` line is reported as an Xcode error with the failing Hermes command and exit code.

--- a/packages/react-native/test/posthog-xcode-parse.spec.ts
+++ b/packages/react-native/test/posthog-xcode-parse.spec.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execFileSync, execSync } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 
@@ -29,6 +29,15 @@ const runSed = (sedExpr: string, input: string): string => {
   // Shell-escape the sed expression to pass it through execSync safely.
   const escaped = sedExpr.replace(/'/g, `'\\''`)
   return execSync(`printf %s '${input}' | sed -E '${escaped}'`).toString().trim()
+}
+
+const extractCommandErrorBlock = (): string => {
+  const contents = fs.readFileSync(SCRIPT_PATH, 'utf8')
+  const match = contents.match(/print_prefixed_output\(\) \{[\s\S]+?\n\}\n\nprint_command_error\(\) \{[\s\S]+?\n\}/)
+  if (!match) {
+    throw new Error(`Could not find posthog-cli error formatting helpers in ${SCRIPT_PATH}`)
+  }
+  return match[0]
 }
 
 describe('posthog-xcode.sh remote URL parsing', () => {
@@ -107,5 +116,36 @@ describe('posthog-xcode.sh REACT_NATIVE_XCODE resolution', () => {
     const result = resolveReactNativeXcode(arg1)
     expect(result).not.toBe('/bin/sh')
     expect(result).toContain('react-native-xcode.sh')
+  })
+})
+
+describe('posthog-xcode.sh posthog-cli error formatting', () => {
+  it('uses multiline Xcode error formatting for clone and upload failures', () => {
+    const contents = fs.readFileSync(SCRIPT_PATH, 'utf8')
+
+    expect(contents).toContain('print_command_error "posthog-cli hermes clone" "$CLONE_EXIT_CODE" "$CLI_CLONE_OUTPUT"')
+    expect(contents).toContain(
+      'print_command_error "posthog-cli hermes upload" "$UPLOAD_EXIT_CODE" "$CLI_UPLOAD_OUTPUT"'
+    )
+  })
+
+  it('prefixes every captured posthog-cli failure line as an Xcode error', () => {
+    const helperBlock = extractCommandErrorBlock()
+    const script = `${helperBlock}
+CLI_OUTPUT=$(printf '%s\\n%s\\n%s\\n' \
+  '2026-06-04T20:42:06Z  INFO posthog_cli::utils::auth: Using token from environment' \
+  '2026-06-04T20:42:07Z ERROR posthog_cli::commands: msg="Oops! real failure"' \
+  'Oops! real failure')
+print_command_error "posthog-cli hermes upload" "42" "$CLI_OUTPUT"`
+
+    const output = execFileSync('/bin/bash', ['-c', script]).toString().trim().split('\n')
+
+    expect(output).toEqual([
+      'error: posthog-cli hermes upload failed with exit code 42',
+      'error: posthog-cli hermes upload - 2026-06-04T20:42:06Z  INFO posthog_cli::utils::auth: Using token from environment',
+      'error: posthog-cli hermes upload - 2026-06-04T20:42:07Z ERROR posthog_cli::commands: msg="Oops! real failure"',
+      'error: posthog-cli hermes upload - Oops! real failure',
+    ])
+    expect(output.every((line) => line.startsWith('error: '))).toBe(true)
   })
 })

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -12,6 +12,24 @@ set -x -e
 # (Xcode runs build phases with a minimal PATH)
 export PATH="/usr/bin:/usr/local/bin:/opt/homebrew/bin:$HOME/.cargo/bin:$HOME/.local/bin:$HOME/.posthog:$PATH"
 
+print_prefixed_output() {
+  local prefix="$1"
+  local output="$2"
+
+  if [ -n "$output" ]; then
+    echo "$output" | awk -v prefix="$prefix" '{print prefix $0}'
+  fi
+}
+
+print_command_error() {
+  local command_name="$1"
+  local exit_code="$2"
+  local output="$3"
+
+  echo "error: ${command_name} failed with exit code ${exit_code}"
+  print_prefixed_output "error: ${command_name} - " "$output"
+}
+
 # WITH_ENVIRONMENT is executed by React Native
 
 REACT_NATIVE_XCODE_DEFAULT="../node_modules/react-native/scripts/react-native-xcode.sh"
@@ -174,7 +192,7 @@ CLONE_EXIT_CODE=$?
 if [ $CLONE_EXIT_CODE -eq 0 ]; then
   echo "$CLI_CLONE_OUTPUT" | awk '{print "output: posthog-cli - " $0}'
 else
-  echo "error: posthog-cli - $CLI_CLONE_OUTPUT"
+  print_command_error "posthog-cli hermes clone" "$CLONE_EXIT_CODE" "$CLI_CLONE_OUTPUT"
   exit $CLONE_EXIT_CODE
 fi
 set -x -e
@@ -186,7 +204,7 @@ UPLOAD_EXIT_CODE=$?
 if [ $UPLOAD_EXIT_CODE -eq 0 ]; then
   echo "$CLI_UPLOAD_OUTPUT" | awk '{print "output: posthog-cli - " $0}'
 else
-  echo "error: posthog-cli - $CLI_UPLOAD_OUTPUT"
+  print_command_error "posthog-cli hermes upload" "$UPLOAD_EXIT_CODE" "$CLI_UPLOAD_OUTPUT"
   exit $UPLOAD_EXIT_CODE
 fi
 set -x -e


### PR DESCRIPTION
## Problem

EAS/Fastlane can surface only the first Xcode error line from the React Native sourcemap upload phase. When posthog-cli logs auth first and fails later, users can see only the auth INFO line even though the real CLI failure is lower in the captured output.

https://github.com/expo/eas-cli/blob/543261b68a5a19278a2c2ac9d8b548de2738b595/packages/build-tools/src/buildErrors/userErrorHandlers.ts#L298-L304

## Changes

- Add Xcode error-formatting helpers for posthog-cli clone/upload failures.
- Include the failing Hermes command and exit code on the first error line.
- Prefix every captured CLI output line with an Xcode error marker so log parsers keep the actual failure.
- Add regression coverage for multiline CLI output where auth INFO precedes the real error.

## Tests

- pnpm --filter=posthog-react-native lint
- pnpm --filter=@posthog/types build
- pnpm --filter=@posthog/core build
- pnpm --filter=posthog-react-native build
- pnpm --dir packages/react-native exec jest -c jest.config.js test/posthog-xcode-parse.spec.ts --watchman=false --runInBand --no-cache
- pnpm --dir packages/react-native exec jest -c jest.config.js --watchman=false --runInBand

Regression proof:

- The new focused spec fails against the old single-line posthog-cli error formatting.
- The same focused spec passes with this change.
