### PR TITLE
feat(ai): populate $ai_base_url on Vercel and OpenAI Agents paths

### DIFF
--- a/.changeset/ai-base-url-dedup.md
+++ b/.changeset/ai-base-url-dedup.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': minor
+---
+
+feat: populate `$ai_base_url` on the Vercel and OpenAI Agents instrumentation paths so gateway-routed `$ai_generation` events can be deduped on ingestion. The Vercel middleware recovers the base URL from the provider's internal `config` (`config.baseURL`, or the `config.url({ path })` closure used by `@ai-sdk/openai` / `openai-compatible`) instead of hardcoding an empty string. The OpenAI Agents processor emits it from `model_config.base_url` when the SDK exposes it (best-effort; the SDK omits it for Responses calls and for chat calls with model settings).

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -458,6 +458,9 @@ export class PostHogTracingProcessor implements TracingProcessor {
     const properties: Record<string, any> = {
       ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
       $ai_model: spanData.model,
+      // Best-effort: Agents SDK only sets model_config.base_url for chat-completions
+      // calls with no model settings; Responses and normal chat calls omit it, so ''.
+      $ai_base_url: typeof modelConfig.base_url === 'string' ? modelConfig.base_url : '',
       $ai_model_parameters: Object.keys(modelParams).length > 0 ? modelParams : null,
       $ai_input: this._prepareCapturedValue(normalizeInputRoles(spanData.input)),
       $ai_output_choices: this._prepareCapturedValue(spanData.output),
@@ -517,6 +520,7 @@ export class PostHogTracingProcessor implements TracingProcessor {
     // Extract model from response
     const model = response?.model as string | undefined
 
+    // No $ai_base_url: ResponseSpanData carries no base URL, so dedup can't see these.
     const properties: Record<string, any> = {
       ...this._baseProperties(traceId, spanId, parentId, latency, groupId, errorProperties),
       $ai_model: model,

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -24,7 +24,7 @@ import {
 } from '../utils'
 import { captureAiGeneration } from '../captureAiGeneration'
 import { redactBase64DataUrl } from '../sanitization'
-import { isString } from '../typeGuards'
+import { isObject, isString } from '../typeGuards'
 
 // Union types for dual version support
 type LanguageModel = LanguageModelV2 | LanguageModelV3
@@ -292,19 +292,17 @@ const extractProvider = (model: LanguageModel): string => {
  */
 const extractBaseURL = (model: LanguageModel): string => {
   try {
-    const config = (model as unknown as { config?: Record<string, unknown> }).config
-    if (!config) {
+    const config = (model as { config?: unknown }).config
+    if (!isObject(config)) {
       return ''
     }
-    if (typeof config.baseURL === 'string') {
+    if (isString(config.baseURL)) {
       return config.baseURL
     }
-    if (typeof config.url === 'function') {
-      const url = (config.url as (opts: { path: string; modelId: string }) => unknown)({
-        path: '',
-        modelId: model.modelId,
-      })
-      return typeof url === 'string' ? url : ''
+    const urlFn = config.url
+    if (typeof urlFn === 'function') {
+      const url = urlFn({ path: '', modelId: model.modelId })
+      return isString(url) ? url : ''
     }
   } catch {
     // Unknown config shape or url() threw.

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -283,6 +283,35 @@ const extractProvider = (model: LanguageModel): string => {
   return providerName
 }
 
+/**
+ * Recover the base URL so gateway calls self-identify via `$ai_base_url` (dedup
+ * keys on it). The spec exposes none, so we read the off-spec provider `config`:
+ * `@ai-sdk/anthropic` keeps a `config.baseURL` string; `@ai-sdk/openai`/
+ * `openai-compatible` bury it in a `config.url({ path })` closure. Unknown shapes
+ * degrade to `''` — those providers (or a custom `fetch`) stay invisible to dedup.
+ */
+const extractBaseURL = (model: LanguageModel): string => {
+  try {
+    const config = (model as unknown as { config?: Record<string, unknown> }).config
+    if (!config) {
+      return ''
+    }
+    if (typeof config.baseURL === 'string') {
+      return config.baseURL
+    }
+    if (typeof config.url === 'function') {
+      const url = (config.url as (opts: { path: string; modelId: string }) => unknown)({
+        path: '',
+        modelId: model.modelId,
+      })
+      return typeof url === 'string' ? url : ''
+    }
+  } catch {
+    // Unknown config shape or url() threw.
+  }
+  return ''
+}
+
 // Extract web search count from provider metadata (works for both V2 and V3)
 const extractWebSearchCount = (providerMetadata: unknown, usage: any): number => {
   // Try Anthropic-specific extraction
@@ -481,13 +510,13 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
           ...mapVercelParams(params),
         }
         const availableTools = extractAvailableToolCalls('vercel', params)
+        const baseURL = extractBaseURL(model)
 
         try {
           const result = await model.doGenerate(params as any)
           const modelId =
             mergedOptions.posthogModelOverride ?? (result.response?.modelId ? result.response.modelId : model.modelId)
           const provider = mergedOptions.posthogProviderOverride ?? extractProvider(model)
-          const baseURL = '' // cannot currently get baseURL from vercel
           // result.content is undefined when the model returns only tool calls with no text output
           const content = mapVercelOutput((result.content ?? []) as LanguageModelContent[])
           const latency = (Date.now() - startTime) / 1000
@@ -562,7 +591,7 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
             input: mergedOptions.posthogPrivacyMode ? '' : mapVercelPrompt(params.prompt as LanguageModelPrompt),
             output: [],
             latency: 0,
-            baseURL: '',
+            baseURL,
             modelParameters: getModelParams(mergedParams as any),
             usage: {
               inputTokens: 0,
@@ -601,7 +630,7 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
         const modelId = mergedOptions.posthogModelOverride ?? model.modelId
         const provider = mergedOptions.posthogProviderOverride ?? extractProvider(model)
         const availableTools = extractAvailableToolCalls('vercel', params)
-        const baseURL = '' // cannot currently get baseURL from vercel
+        const baseURL = extractBaseURL(model)
 
         // Map to track in-progress tool calls
         const toolCallsInProgress = new Map<
@@ -766,7 +795,7 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
             input: mergedOptions.posthogPrivacyMode ? '' : mapVercelPrompt(params.prompt as LanguageModelPrompt),
             output: [],
             latency: 0,
-            baseURL: '',
+            baseURL,
             modelParameters: getModelParams(mergedParams as any),
             usage: {
               inputTokens: 0,

--- a/packages/ai/tests/anthropic.test.ts
+++ b/packages/ai/tests/anthropic.test.ts
@@ -1,5 +1,5 @@
 import { PostHog } from 'posthog-node'
-import PostHogAnthropic from '../src/anthropic'
+import PostHogAnthropic, { WrappedMessages } from '../src/anthropic'
 import AnthropicOriginal from '@anthropic-ai/sdk'
 import { version } from '../package.json'
 
@@ -1142,5 +1142,25 @@ describe('PostHogAnthropic', () => {
         webSearchCount: 4,
       })
     })
+  })
+})
+
+// No API key: drive the wrapper with a fake parent to assert $ai_base_url carries its base URL.
+describe('PostHogAnthropic - $ai_base_url', () => {
+  it('emits the wrapped client base URL', async () => {
+    const ph = new (PostHog as any)()
+    ;(AnthropicOriginal.Messages.prototype.create as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue(createMockResponse({ content: 'hi' }))
+
+    const wrapped = new WrappedMessages({ baseURL: 'https://gateway.posthog.com/anthropic' } as any, ph as any)
+    await wrapped.create({
+      model: 'claude-3-opus-20240229',
+      max_tokens: 16,
+      messages: [{ role: 'user', content: 'hi' }],
+    } as any)
+
+    const { properties } = (ph.capture as jest.Mock).mock.calls[0][0]
+    expect(properties['$ai_base_url']).toBe('https://gateway.posthog.com/anthropic')
   })
 })

--- a/packages/ai/tests/openai-agents.test.ts
+++ b/packages/ai/tests/openai-agents.test.ts
@@ -243,7 +243,7 @@ describe('PostHogTracingProcessor', () => {
           input: [{ role: 'user', content: 'Hello' }],
           output: [{ role: 'assistant', content: 'Hi there!' }],
           model: 'gpt-4o',
-          model_config: { temperature: 0.7, max_tokens: 100 },
+          model_config: { temperature: 0.7, max_tokens: 100, base_url: 'https://gateway.posthog.com/v1' },
           usage: { input_tokens: 10, output_tokens: 20 },
         },
       })
@@ -254,6 +254,7 @@ describe('PostHogTracingProcessor', () => {
       const call = mockClient.capture.mock.calls[0][0]
 
       expect(call.event).toBe('$ai_generation')
+      expect(call.properties.$ai_base_url).toBe('https://gateway.posthog.com/v1')
       expect(call.properties.$ai_trace_id).toBe('trace_123456789')
       expect(call.properties.$ai_span_id).toBe('span_987654321')
       expect(call.properties.$ai_provider).toBe('openai')
@@ -265,6 +266,17 @@ describe('PostHogTracingProcessor', () => {
       expect(call.properties.$ai_input).toEqual([{ role: 'user', content: 'Hello' }])
       expect(call.properties.$ai_output_choices).toEqual([{ role: 'assistant', content: 'Hi there!' }])
       expect(call.properties.$ai_model_parameters).toEqual({ temperature: 0.7, max_tokens: 100 })
+    })
+
+    it('defaults $ai_base_url to empty when model_config has no base_url', async () => {
+      const span = createMockSpan({
+        spanData: { type: 'generation', model: 'gpt-4o', model_config: { temperature: 0.7 } },
+      })
+
+      await processor.onSpanStart(span as any)
+      await processor.onSpanEnd(span as any)
+
+      expect(mockClient.capture.mock.calls[0][0].properties.$ai_base_url).toBe('')
     })
 
     it('handles no usage data with zero defaults', async () => {

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -1,5 +1,5 @@
 import { PostHog } from 'posthog-node'
-import PostHogOpenAI from '../src/openai'
+import PostHogOpenAI, { WrappedCompletions } from '../src/openai'
 import openaiModule from 'openai'
 import type { ChatCompletion, ChatCompletionChunk } from 'openai/resources/chat/completions'
 import type { ParsedResponse } from 'openai/resources/responses/responses'
@@ -1911,5 +1911,34 @@ describe('PostHogOpenAI - Jest test suite', () => {
     const posthogParams = Object.keys(actualParams).filter((key) => key.startsWith('posthog'))
     expect(posthogParams).toEqual([])
     ;(ChatMock.Completions as any).prototype.create = originalCreate
+  })
+})
+
+// No API key: drive the wrapper with a fake parent to assert $ai_base_url carries its base URL.
+describe('PostHogOpenAI - $ai_base_url', () => {
+  it('emits the wrapped client base URL', async () => {
+    const ph = new (PostHog as any)()
+    const ChatMock: any = openaiModule.Chat
+    ;(ChatMock.Completions as any).prototype.create = jest.fn().mockResolvedValue({
+      id: 'chatcmpl-x',
+      model: 'gpt-4',
+      object: 'chat.completion',
+      created: 0,
+      choices: [
+        {
+          index: 0,
+          finish_reason: 'stop',
+          message: { role: 'assistant', content: 'hi', refusal: null },
+          logprobs: null,
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    })
+
+    const wrapped = new WrappedCompletions({ baseURL: 'https://gateway.posthog.com/v1' } as any, ph as any)
+    await wrapped.create({ model: 'gpt-4', messages: [{ role: 'user', content: 'hi' }] } as any)
+
+    const { properties } = (ph.capture as jest.Mock).mock.calls[0][0]
+    expect(properties['$ai_base_url']).toBe('https://gateway.posthog.com/v1')
   })
 })

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -1176,8 +1176,11 @@ describe('Vercel AI SDK - Dual Version Support', () => {
       expect(props['$ai_base_url']).toBe('https://gateway.posthog.com/anthropic')
     })
 
-    it('falls back to an empty string when config is absent or unrecognized', async () => {
+    it('falls back to an empty string when config is absent', async () => {
       expect((await runGenerate(undefined))['$ai_base_url']).toBe('')
+    })
+
+    it('falls back to an empty string when config shape is unrecognized', async () => {
       expect((await runGenerate({ somethingElse: true }))['$ai_base_url']).toBe('')
     })
 

--- a/packages/ai/tests/vercel.test.ts
+++ b/packages/ai/tests/vercel.test.ts
@@ -1140,4 +1140,76 @@ describe('Vercel AI SDK - Dual Version Support', () => {
       expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('base URL extraction ($ai_base_url)', () => {
+    const runGenerate = async (config: unknown): Promise<Record<string, any>> => {
+      const baseModel = {
+        specificationVersion: 'v2' as const,
+        provider: 'openai',
+        modelId: 'gpt-4o',
+        supportedUrls: {},
+        config,
+        doGenerate: jest.fn().mockResolvedValue({
+          content: [{ type: 'text', text: 'hi' }],
+          usage: { inputTokens: 1, outputTokens: 1 },
+          response: { modelId: 'gpt-4o' },
+          providerMetadata: {},
+          finishReason: 'stop' as const,
+          warnings: [],
+        }),
+        doStream: jest.fn(),
+      } as any
+
+      const model = withTracing(baseModel, mockPostHogClient, { posthogDistinctId: 'test-user' })
+      await model.doGenerate({ prompt: [] } as any)
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      return captureCall[0].properties
+    }
+
+    it('recovers the base URL from a config.url closure (@ai-sdk/openai style)', async () => {
+      const props = await runGenerate({ url: ({ path }: { path: string }) => `https://gateway.posthog.com/v1${path}` })
+      expect(props['$ai_base_url']).toBe('https://gateway.posthog.com/v1')
+    })
+
+    it('recovers the base URL from a config.baseURL string (@ai-sdk/anthropic style)', async () => {
+      const props = await runGenerate({ baseURL: 'https://gateway.posthog.com/anthropic' })
+      expect(props['$ai_base_url']).toBe('https://gateway.posthog.com/anthropic')
+    })
+
+    it('falls back to an empty string when config is absent or unrecognized', async () => {
+      expect((await runGenerate(undefined))['$ai_base_url']).toBe('')
+      expect((await runGenerate({ somethingElse: true }))['$ai_base_url']).toBe('')
+    })
+
+    it('falls back to an empty string when config.url throws', async () => {
+      const props = await runGenerate({
+        url: () => {
+          throw new Error('internal shape changed')
+        },
+      })
+      expect(props['$ai_base_url']).toBe('')
+    })
+
+    it('recovers the base URL on the streaming path too', async () => {
+      const streamParts: LanguageModelV3StreamPart[] = [
+        { type: 'text-delta', id: 'text-1', delta: 'hi' },
+        { type: 'finish', usage: v3TokenUsage(1, 1), finishReason: { unified: 'stop' as const, raw: undefined } },
+      ]
+      const baseModel = createMockStreamingModel('v3', streamParts) as any
+      baseModel.config = { baseURL: 'https://gateway.posthog.com/v1' }
+
+      const model = withTracing(baseModel, mockPostHogClient, { posthogDistinctId: 'test-user' })
+      const result = await model.doStream({
+        prompt: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'hi' }] }],
+      })
+      const reader = result.stream.getReader()
+      while (!(await reader.read()).done) {
+        // drain
+      }
+      await flushPromises()
+
+      const [captureCall] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      expect(captureCall[0].properties['$ai_base_url']).toBe('https://gateway.posthog.com/v1')
+    })
+  })
 })


### PR DESCRIPTION
## Problem

Ingestion dedups gateway-routed `$ai_generation` events by checking whether `$ai_base_url` is a PostHog gateway host. The Vercel and OpenAI Agents paths never set it, so gateway calls instrumented through them couldn't be detected.

## Changes

- Vercel: recover the base URL from the provider's internal `config` (the `config.url({ path })` closure or `config.baseURL`), replacing the hardcoded `''`. Verified against the real published `@ai-sdk` providers.
- OpenAI Agents: emit it from `model_config.base_url` when the SDK exposes it. Best-effort, since the SDK omits it for Responses calls and chat calls with model settings.
- OTel already maps `server.address` to `$ai_base_url` server-side, so no SDK change there.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*