### PR TITLE
fix(browser): reload flags after resetting person properties

### DIFF
--- a/.changeset/fresh-flags-reset.md
+++ b/.changeset/fresh-flags-reset.md
@@ -1,0 +1,6 @@
+---
+"posthog-js": patch
+"@posthog/types": patch
+---
+
+Reload feature flags by default when resetting person properties for flags.

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -2030,7 +2030,7 @@ describe('featureflags', () => {
             expect(instance._send_request).not.toHaveBeenCalled()
         })
 
-        it('resetPersonProperties resets all properties', () => {
+        it('resetPersonProperties resets all properties and reloads flags by default', () => {
             featureFlags.setPersonPropertiesForFlags({ a: 'b', c: 'd' }, false)
             featureFlags.setPersonPropertiesForFlags({ x: 'y', c: 'e' }, false)
             jest.runAllTimers()
@@ -2038,8 +2038,9 @@ describe('featureflags', () => {
             expect(instance.persistence.props.$stored_person_properties).toEqual({ a: 'b', c: 'e', x: 'y' })
 
             featureFlags.resetPersonPropertiesForFlags()
-            featureFlags.reloadFeatureFlags()
             jest.runAllTimers()
+
+            expect(instance.persistence.props.$stored_person_properties).toEqual(undefined)
 
             // check the request did not send person properties
             expect(instance._send_request.mock.calls[0][0].data).toEqual({
@@ -2053,8 +2054,38 @@ describe('featureflags', () => {
             })
         })
 
-        it('set_once properties skip keys that already exist in the cache', () => {
+        it('doesnt reload flags when resetting person properties if explicitly asked not to', () => {
+            featureFlags.setPersonPropertiesForFlags({ a: 'b', c: 'd' }, false)
+            jest.runAllTimers()
+
+            expect(instance.persistence.props.$stored_person_properties).toEqual({ a: 'b', c: 'd' })
+
+            featureFlags.resetPersonPropertiesForFlags(false)
+            jest.runAllTimers()
+
+            expect(instance.persistence.props.$stored_person_properties).toEqual(undefined)
+            expect(instance._send_request).not.toHaveBeenCalled()
+        })
+
+        it('coalesces the default reset reload with an explicit reloadFeatureFlags call', () => {
+            featureFlags.setPersonPropertiesForFlags({ a: 'b', c: 'd' }, false)
+            jest.runAllTimers()
+
+            expect(instance.persistence.props.$stored_person_properties).toEqual({ a: 'b', c: 'd' })
+
             featureFlags.resetPersonPropertiesForFlags()
+            featureFlags.reloadFeatureFlags()
+            jest.runAllTimers()
+
+            // this ensures backwards compatibility with users who would previously call
+            // resetPersonPropertiesForFlags followed by reloadFeatureFlags. we will still
+            // guarantee a single /flags request.
+            expect(instance._send_request).toHaveBeenCalledTimes(1)
+            expect(instance._send_request.mock.calls[0][0].data.person_properties).toEqual({})
+        })
+
+        it('set_once properties skip keys that already exist in the cache', () => {
+            featureFlags.resetPersonPropertiesForFlags(false)
             featureFlags.setPersonPropertiesForFlags({ $set_once: { first_date: '2025-01-01', plan: 'free' } }, false)
 
             expect(instance.persistence.props.$stored_person_properties).toEqual({
@@ -2076,7 +2107,7 @@ describe('featureflags', () => {
         })
 
         it('set properties overwrite existing keys even when set_once does not', () => {
-            featureFlags.resetPersonPropertiesForFlags()
+            featureFlags.resetPersonPropertiesForFlags(false)
             featureFlags.setPersonPropertiesForFlags({ $set_once: { first_date: '2025-01-01' } }, false)
 
             expect(instance.persistence.props.$stored_person_properties).toEqual({
@@ -2095,7 +2126,7 @@ describe('featureflags', () => {
         })
 
         it('set_once properties are included in /flags request', () => {
-            featureFlags.resetPersonPropertiesForFlags()
+            featureFlags.resetPersonPropertiesForFlags(false)
             featureFlags.setPersonPropertiesForFlags(
                 { $set: { plan: 'pro' }, $set_once: { first_date: '2025-01-01' } },
                 false
@@ -2120,7 +2151,7 @@ describe('featureflags', () => {
             })
 
             // Clean up to avoid leaking into subsequent tests
-            featureFlags.resetPersonPropertiesForFlags()
+            featureFlags.resetPersonPropertiesForFlags(false)
         })
 
         it('on providing groupProperties updates properties successively', () => {

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -1237,25 +1237,22 @@ describe('posthog core', () => {
             posthog.reloadFeatureFlags = jest.fn()
         })
 
-        it('resets person properties for flags and reloads by default', () => {
-            posthog.setPersonPropertiesForFlags({ plan: 'pro' }, false)
+        it.each([
+            [undefined, 1],
+            [false, 0],
+        ] as const)(
+            'resets person properties for flags (reloadFeatureFlags=%s)',
+            (reloadFeatureFlags, expectedCalls) => {
+                posthog.setPersonPropertiesForFlags({ plan: 'pro' }, false)
 
-            expect(posthog.persistence!.props['$stored_person_properties']).toEqual({ plan: 'pro' })
+                expect(posthog.persistence!.props['$stored_person_properties']).toEqual({ plan: 'pro' })
 
-            posthog.resetPersonPropertiesForFlags()
+                posthog.resetPersonPropertiesForFlags(reloadFeatureFlags)
 
-            expect(posthog.persistence!.props['$stored_person_properties']).toEqual(undefined)
-            expect(posthog.reloadFeatureFlags).toHaveBeenCalledTimes(1)
-        })
-
-        it('resets person properties for flags without reloading if requested', () => {
-            posthog.setPersonPropertiesForFlags({ plan: 'pro' }, false)
-
-            posthog.resetPersonPropertiesForFlags(false)
-
-            expect(posthog.persistence!.props['$stored_person_properties']).toEqual(undefined)
-            expect(posthog.reloadFeatureFlags).not.toHaveBeenCalled()
-        })
+                expect(posthog.persistence!.props['$stored_person_properties']).toEqual(undefined)
+                expect(posthog.reloadFeatureFlags).toHaveBeenCalledTimes(expectedCalls)
+            }
+        )
     })
 
     describe('group()', () => {

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -1222,6 +1222,42 @@ describe('posthog core', () => {
         })
     })
 
+    describe('person properties for flags', () => {
+        let posthog: PostHog
+
+        beforeEach(() => {
+            posthog = defaultPostHog().init(
+                'testtoken',
+                {
+                    persistence: 'memory',
+                },
+                uuidv7()
+            )!
+            posthog.persistence!.clear()
+            posthog.reloadFeatureFlags = jest.fn()
+        })
+
+        it('resets person properties for flags and reloads by default', () => {
+            posthog.setPersonPropertiesForFlags({ plan: 'pro' }, false)
+
+            expect(posthog.persistence!.props['$stored_person_properties']).toEqual({ plan: 'pro' })
+
+            posthog.resetPersonPropertiesForFlags()
+
+            expect(posthog.persistence!.props['$stored_person_properties']).toEqual(undefined)
+            expect(posthog.reloadFeatureFlags).toHaveBeenCalledTimes(1)
+        })
+
+        it('resets person properties for flags without reloading if requested', () => {
+            posthog.setPersonPropertiesForFlags({ plan: 'pro' }, false)
+
+            posthog.resetPersonPropertiesForFlags(false)
+
+            expect(posthog.persistence!.props['$stored_person_properties']).toEqual(undefined)
+            expect(posthog.reloadFeatureFlags).not.toHaveBeenCalled()
+        })
+    })
+
     describe('group()', () => {
         let posthog: PostHog
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -2675,9 +2675,17 @@ export class PostHog implements PostHogInterface {
      * ```js
      * posthog.resetPersonPropertiesForFlags()
      * ```
+     *
+     * @example
+     * ```js
+     * // Reset properties without reloading
+     * posthog.resetPersonPropertiesForFlags(false)
+     * ```
+     *
+     * @param {Boolean} [reloadFeatureFlags=true] Whether to reload feature flags.
      */
-    resetPersonPropertiesForFlags(): void {
-        this.featureFlags?.resetPersonPropertiesForFlags()
+    resetPersonPropertiesForFlags(reloadFeatureFlags = true): void {
+        this.featureFlags?.resetPersonPropertiesForFlags(reloadFeatureFlags)
     }
 
     /**

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -1249,8 +1249,12 @@ export class PostHogFeatureFlags implements Extension {
         }
     }
 
-    resetPersonPropertiesForFlags(): void {
+    resetPersonPropertiesForFlags(reloadFeatureFlags = true): void {
         this._instance.unregister(STORED_PERSON_PROPERTIES_KEY)
+
+        if (reloadFeatureFlags) {
+            this._instance.reloadFeatureFlags()
+        }
     }
 
     /**

--- a/packages/types/src/posthog.ts
+++ b/packages/types/src/posthog.ts
@@ -351,8 +351,10 @@ export interface PostHog {
 
     /**
      * Reset person properties used for feature flag evaluation.
+     *
+     * @param reloadFeatureFlags - Whether to reload feature flags after resetting
      */
-    resetPersonPropertiesForFlags(): void
+    resetPersonPropertiesForFlags(reloadFeatureFlags?: boolean): void
 
     /**
      * Set group properties to be used for feature flag evaluation.


### PR DESCRIPTION
## Problem

`resetPersonPropertiesForFlags()` cleared cached person-property overrides but left feature flags evaluated with the old override values until a later reload. This made the reset easy to miss in apps that expected immediate flag re-evaluation, and deviated from iOS/Android behavior.

## Changes

- Added an optional `reloadFeatureFlags` boolean to `resetPersonPropertiesForFlags`, matching `setPersonPropertiesForFlags` / `setGroupPropertiesForFlags`.
- Defaulted `reloadFeatureFlags` to `true` so reset immediately refreshes flags.
- Supported `resetPersonPropertiesForFlags(false)` for callers that want to clear overrides without reloading.
- Added tests for the browser public method, feature-flags implementation, opt-out behavior, and debounced coalescing when callers also invoke `reloadFeatureFlags()`.
- Updated `@posthog/types` to expose the optional argument.

Validation:
- `pnpm --filter posthog-js exec jest src/__tests__/featureflags.test.ts src/__tests__/posthog-core-also.test.ts --runInBand`
- `pnpm --filter posthog-js exec eslint src/posthog-featureflags.ts src/posthog-core.ts src/__tests__/featureflags.test.ts src/__tests__/posthog-core-also.test.ts`
- `pnpm --filter @posthog/types exec eslint src/posthog.ts`
- `pnpm --filter @posthog/types build`

Note: `pnpm --filter posthog-js typecheck` currently fails on pre-existing `__preview_cookie_wins_on_conflict` config typing errors unrelated to this PR.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
