### PR TITLE
fix(ai): wrap the Azure OpenAI responses API so responses.create is tracked (#2946)

### DIFF
--- a/.changeset/azure-responses-wrapping.md
+++ b/.changeset/azure-responses-wrapping.md
@@ -1,0 +1,5 @@
+---
+"@posthog/ai": patch
+---
+
+Wrap the Azure OpenAI `responses` API in `PostHogAzureOpenAI` so `responses.create` calls are tracked, matching the non-Azure `PostHogOpenAI` client.

--- a/packages/ai/src/openai/azure.ts
+++ b/packages/ai/src/openai/azure.ts
@@ -40,6 +40,7 @@ type RequestOptions = Record<string, any>
 export class PostHogAzureOpenAI extends AzureOpenAI {
   private readonly phClient: PostHog
   public chat: WrappedChat
+  public responses: WrappedResponses
   public embeddings: WrappedEmbeddings
 
   constructor(config: MonitoringOpenAIConfig) {
@@ -47,6 +48,7 @@ export class PostHogAzureOpenAI extends AzureOpenAI {
     super(openAIConfig)
     this.phClient = posthog
     this.chat = new WrappedChat(this, this.phClient)
+    this.responses = new WrappedResponses(this, this.phClient)
     this.embeddings = new WrappedEmbeddings(this, this.phClient)
   }
 }

--- a/packages/ai/tests/azure-openai.test.ts
+++ b/packages/ai/tests/azure-openai.test.ts
@@ -252,6 +252,12 @@ describe('PostHogAzureOpenAI - Embeddings test suite', () => {
     expect(properties['$ai_provider']).toBe('azure')
     expect(properties['$ai_model']).toBe('gpt-4')
     expect(properties['$ai_completion_id']).toBe('resp_test-response-id')
+    expect(properties['$ai_input']).toEqual([{ role: 'user', content: 'Hello' }])
+    expect(properties['$ai_output_choices']).toEqual(mockAzureResponsesResult.output)
+    expect(properties['$ai_input_tokens']).toBe(20)
+    expect(properties['$ai_output_tokens']).toBe(10)
+    expect(properties['$ai_http_status']).toBe(200)
+    expect(typeof properties['$ai_latency']).toBe('number')
     expect(properties['foo']).toBe('bar')
   })
 

--- a/packages/ai/tests/azure-openai.test.ts
+++ b/packages/ai/tests/azure-openai.test.ts
@@ -212,6 +212,49 @@ describe('PostHogAzureOpenAI - Embeddings test suite', () => {
     })
   })
 
+  conditionalTest('responses create is wrapped and captures a generation', async () => {
+    // Regression test for #2946: PostHogAzureOpenAI must wrap `responses` so that
+    // responses.create(...) is tracked, like the non-Azure PostHogOpenAI client.
+    const mockAzureResponsesResult = {
+      id: 'resp_test-response-id',
+      _request_id: 'req_test-responses-create',
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello from Azure Responses!' }],
+        },
+      ],
+      usage: {
+        input_tokens: 20,
+        output_tokens: 10,
+        total_tokens: 30,
+      },
+    }
+
+    const ResponsesMock: any = openaiModule.Responses
+    ResponsesMock.prototype.create = jest.fn().mockResolvedValue(mockAzureResponsesResult)
+
+    await client.responses.create({
+      model: 'gpt-4',
+      input: 'Hello',
+      posthogDistinctId: 'test-id',
+      posthogProperties: { foo: 'bar' },
+    } as any)
+
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+
+    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    const { distinctId, event, properties } = captureArgs[0]
+
+    expect(distinctId).toBe('test-id')
+    expect(event).toBe('$ai_generation')
+    expect(properties['$ai_provider']).toBe('azure')
+    expect(properties['$ai_model']).toBe('gpt-4')
+    expect(properties['$ai_completion_id']).toBe('resp_test-response-id')
+    expect(properties['foo']).toBe('bar')
+  })
+
   conditionalTest('groups', async () => {
     const mockAzureChatResponse = {
       id: 'test-response-id',


### PR DESCRIPTION
## Problem

Fixes #2946.

`PostHogAzureOpenAI` wires `chat` and `embeddings` in its constructor but never instantiates `WrappedResponses`, even though the class is defined in the same file. As a result, `azureClient.responses.create(...)` falls through to the unwrapped base `AzureOpenAI` SDK and **no `$ai_generation` event is captured** — unlike the non-Azure `PostHogOpenAI` client, which does wrap `responses`.

## Changes

- Declare `public responses: WrappedResponses` and instantiate it in the `PostHogAzureOpenAI` constructor, mirroring the non-Azure `PostHogOpenAI` client in `index.ts`.
- Add a regression test asserting `responses.create(...)` on the Azure client captures an `$ai_generation` event (`$ai_provider: 'azure'`).
- Add a changeset (`@posthog/ai` patch).

Verified locally: `eslint`, `prettier --check`, and `pnpm test:unit azure-openai` (18/18) all pass; the new test fails without the fix and passes with it.

## Release info Sub-libraries affected

### Libraries affected

- [x] @posthog/ai

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
