### PR TITLE
fix: drop events whose token property is removed by before_send (#3438)

### DIFF
--- a/.changeset/before-send-token.md
+++ b/.changeset/before-send-token.md
@@ -1,5 +1,6 @@
 ---
-"posthog-js": patch
+'@posthog/core': patch
+'posthog-js': patch
 ---
 
-Re-assert the `token` property if a `before_send` hook removes it, so events are no longer silently rejected by ingest with a 401.
+Drop the event and log a warning when a `before_send` hook removes the `token` property, instead of silently sending an event that ingest rejects with a 401.

--- a/.changeset/before-send-token.md
+++ b/.changeset/before-send-token.md
@@ -1,0 +1,5 @@
+---
+"posthog-js": patch
+---
+
+Re-assert the `token` property if a `before_send` hook removes it, so events are no longer silently rejected by ingest with a 401.

--- a/packages/browser/src/__tests__/posthog-core.beforeSend.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.beforeSend.test.ts
@@ -174,4 +174,31 @@ describe('posthog core - before send', () => {
             `Event '${randomUnsafeEditableEvent}' was rejected in beforeSend function. This can cause unexpected behavior.`
         )
     })
+
+    it('re-asserts the token property if a beforeSend function strips it', () => {
+        // Regression test for #3438: the project api_key is sent on
+        // properties.token, so a generic token/PII scrubber that drops it would
+        // otherwise make every event 401 with "submitted without an api_key".
+        const posthog = posthogWith({
+            before_send: (cr) => {
+                if (cr.properties) {
+                    for (const key of Object.keys(cr.properties)) {
+                        if (/token/i.test(key)) {
+                            delete cr.properties[key]
+                        }
+                    }
+                }
+                return cr
+            },
+        })
+        ;(posthog._send_request as jest.Mock).mockClear()
+
+        const capturedData = posthog.capture(eventName, {}, {})
+
+        expect(capturedData).toHaveProperty(['properties', 'token'], 'testtoken')
+        expect(posthog._send_request).toHaveBeenCalled()
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+            `Event '${eventName}' is missing its 'token' property after beforeSend (it may have been removed by a token or PII scrubber); re-adding it so the event can be ingested.`
+        )
+    })
 })

--- a/packages/browser/src/__tests__/posthog-core.beforeSend.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.beforeSend.test.ts
@@ -175,10 +175,11 @@ describe('posthog core - before send', () => {
         )
     })
 
-    it('re-asserts the token property if a beforeSend function strips it', () => {
+    it('drops the event if a beforeSend function strips a required property like token', () => {
         // Regression test for #3438: the project api_key is sent on
         // properties.token, so a generic token/PII scrubber that drops it would
         // otherwise make every event 401 with "submitted without an api_key".
+        // We drop the event and warn rather than send something ingest will reject.
         const posthog = posthogWith({
             before_send: (cr) => {
                 if (cr.properties) {
@@ -195,10 +196,10 @@ describe('posthog core - before send', () => {
 
         const capturedData = posthog.capture(eventName, {}, {})
 
-        expect(capturedData).toHaveProperty(['properties', 'token'], 'testtoken')
-        expect(posthog._send_request).toHaveBeenCalled()
+        expect(capturedData).toBeUndefined()
+        expect(posthog._send_request).not.toHaveBeenCalled()
         expect(mockLogger.warn).toHaveBeenCalledWith(
-            `Event '${eventName}' is missing its 'token' property after beforeSend (it may have been removed by a token or PII scrubber); re-adding it so the event can be ingested.`
+            `Event '${eventName}' had its 'token' property removed in a beforeSend function. This property is required for ingestion, so the event will be dropped.`
         )
     })
 })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -100,6 +100,7 @@ import {
     isEmptyString,
     isFunction,
     isKnownUnsafeEditableEvent,
+    isKnownUnsafeEditableEventProperty,
     isNullish,
     isNumber,
     isString,
@@ -4073,6 +4074,13 @@ export class PostHog implements PostHogInterface {
             return data
         }
 
+        // Some properties are required for the event to be ingested - e.g. `token`
+        // carries the project api_key, and ingest rejects any event that arrives
+        // without it (a 401). Snapshot which of these were present before the hooks
+        // run, so we can tell if a hook removed one (the names are captured here, so
+        // a hook that mutates `data.properties` in place can't hide the removal).
+        const requiredProperties = Object.keys(data.properties ?? {}).filter(isKnownUnsafeEditableEventProperty)
+
         const fns = isArray(this.config.before_send) ? this.config.before_send : [this.config.before_send]
         let beforeSendResult: CaptureResult | null = data
         for (const fn of fns) {
@@ -4092,15 +4100,18 @@ export class PostHog implements PostHogInterface {
                 )
             }
         }
-        // The project api_key is sent to ingest on `properties.token`. If a beforeSend
-        // hook removed it (e.g. a generic token/PII scrubber matching /token/i), every
-        // event is rejected with a 401. Re-assert it so events keep flowing, and warn
-        // so this isn't a silent footgun.
-        if (beforeSendResult?.properties && isNullish(beforeSendResult.properties['token'])) {
-            beforeSendResult.properties['token'] = this.config.token
-            logger.warn(
-                `Event '${data.event}' is missing its 'token' property after beforeSend (it may have been removed by a token or PII scrubber); re-adding it so the event can be ingested.`
-            )
+        // If a beforeSend hook removed a property the event needs to be ingested
+        // (e.g. a generic token/PII scrubber matching /token/i dropping `token`),
+        // ingest would silently reject every such event with a 401. Drop the event
+        // here and warn instead - we don't restore the property, since the removal
+        // may have been intentional.
+        for (const property of requiredProperties) {
+            if (beforeSendResult.properties && isNullish(beforeSendResult.properties[property])) {
+                logger.warn(
+                    `Event '${data.event}' had its '${property}' property removed in a beforeSend function. This property is required for ingestion, so the event will be dropped.`
+                )
+                return null
+            }
         }
         return beforeSendResult
     }

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -4092,6 +4092,16 @@ export class PostHog implements PostHogInterface {
                 )
             }
         }
+        // The project api_key is sent to ingest on `properties.token`. If a beforeSend
+        // hook removed it (e.g. a generic token/PII scrubber matching /token/i), every
+        // event is rejected with a 401. Re-assert it so events keep flowing, and warn
+        // so this isn't a silent footgun.
+        if (beforeSendResult?.properties && isNullish(beforeSendResult.properties['token'])) {
+            beforeSendResult.properties['token'] = this.config.token
+            logger.warn(
+                `Event '${data.event}' is missing its 'token' property after beforeSend (it may have been removed by a token or PII scrubber); re-adding it so the event can be ingested.`
+            )
+        }
         return beforeSendResult
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -865,6 +865,17 @@ export const knownUnsafeEditableEvent = [
  */
 export type KnownUnsafeEditableEvent = (typeof knownUnsafeEditableEvent)[number]
 
+export const knownUnsafeEditableEventProperty = ['token'] as const
+
+/**
+ * These event properties can be edited by the `before_send` function
+ * but are required for the event to be ingested. For example `token` carries
+ * the project api_key, and ingest rejects any event that arrives without it.
+ *
+ * If a `before_send` function removes one of these, the event is dropped.
+ */
+export type KnownUnsafeEditableEventProperty = (typeof knownUnsafeEditableEventProperty)[number]
+
 /**
  * Represents an event before it's sent to PostHog.
  * This is the interface exposed to the `before_send` hook, matching the web SDK's `CaptureResult`.

--- a/packages/core/src/utils/type-utils.ts
+++ b/packages/core/src/utils/type-utils.ts
@@ -1,4 +1,9 @@
-import { knownUnsafeEditableEvent, KnownUnsafeEditableEvent } from '../types'
+import {
+  knownUnsafeEditableEvent,
+  KnownUnsafeEditableEvent,
+  knownUnsafeEditableEventProperty,
+  KnownUnsafeEditableEventProperty,
+} from '../types'
 import { includes } from './string-utils'
 
 // eslint-disable-next-line posthog-js/no-direct-array-check
@@ -91,6 +96,10 @@ export const isPlainError = (x: unknown): x is Error => {
 
 export const isKnownUnsafeEditableEvent = (x: unknown): x is KnownUnsafeEditableEvent => {
   return includes(knownUnsafeEditableEvent as unknown as string[], x)
+}
+
+export const isKnownUnsafeEditableEventProperty = (x: unknown): x is KnownUnsafeEditableEventProperty => {
+  return includes(knownUnsafeEditableEventProperty as unknown as string[], x)
 }
 
 export function isPrimitive(value: unknown): boolean {


### PR DESCRIPTION
## Problem

Fixes #3438.

The project `api_key` is sent to ingest inside each event as `properties.token` (set in `calculateEventProperties`). User `before_send` hooks run after that. If a hook removes the `token` key — e.g. a generic PII scrubber matching `/token/i`, since the key is named like an app-level `auth_token`/`reset_token` field — the SDK sends a tokenless payload and every event is rejected by ingest with `HTTP 401 event submitted without an api_key`. There is no warning, so it's a silent footgun.

## Changes

Following review feedback from @marandaneto, this **drops the event and logs a warning** when a `before_send` hook removes a required property, rather than restoring it (the removal may be intentional).

Mirroring the existing `knownUnsafeEditableEvent` / `isKnownUnsafeEditableEvent` pattern:

- Adds `knownUnsafeEditableEventProperty` (currently just `['token']`) and an `isKnownUnsafeEditableEventProperty` predicate in `@posthog/core`.
- In `_runBeforeSend`, snapshots which of these required properties were present *before* the hook chain runs (so an in-place mutation can't hide a removal), then after the chain, if such a property is now missing from a still-present `properties` object, logs a warning and drops the event (returns `null`).

Scope note: this only triggers when `properties` still exists but a required key was removed (the reported scrubber case). The pre-existing "no properties after beforeSend" path is left unchanged.

Updates the regression test to assert the event is dropped, and the changeset.

## Release info

### Sub-libraries affected

- [x] posthog-js (web)
