### PR TITLE
chore(ci): capture PR age metrics to PostHog on merge

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -1,0 +1,49 @@
+name: Closed PR
+
+on:
+    pull_request:
+        types:
+            - closed
+
+permissions:
+    contents: read
+    pull-requests: read
+
+jobs:
+    report-pr-age:
+        name: Report age of PR
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.merged == true
+        steps:
+            - name: Calculate PR age
+              env:
+                  PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
+                  PR_HREF: ${{ github.event.pull_request._links.commits.href }}
+                  PR_TITLE: ${{ github.event.pull_request.title }}
+              run: |
+                  pr_age=$((($(date '+%s') - $(date -d "$PR_CREATED_AT" '+%s'))))
+                  echo "pr_age=$pr_age" >> $GITHUB_ENV
+
+                  first_commit_message_in_pr=$(curl -s "$PR_HREF" | jq '.[0].commit.message')
+                  echo "first_commit_message_in_pr<<EOF" >> $GITHUB_ENV
+                  echo "$first_commit_message_in_pr" >> $GITHUB_ENV
+                  echo "EOF" >> $GITHUB_ENV
+
+                  if [[ $first_commit_message_in_pr =~ Revert[[:space:]] ]]; then
+                      echo "is_revert=true" >> $GITHUB_ENV
+                  else
+                      echo "is_revert=false" >> $GITHUB_ENV
+                  fi
+
+                  # Escape the PR title for JSON
+                  pr_title_escaped=$(echo "$PR_TITLE" | jq -R .)
+                  echo "pr_title_escaped<<EOF" >> $GITHUB_ENV
+                  echo "$pr_title_escaped" >> $GITHUB_ENV
+                  echo "EOF" >> $GITHUB_ENV
+            - name: Capture PR age to PostHog
+              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+              with:
+                  posthog-token: ${{ secrets.POSTHOG_API_TOKEN }}
+                  event: 'posthog-ci-pr-stats'
+                  properties: '{"prAgeInSeconds": ${{ env.pr_age }}, "isRevert": ${{ env.is_revert }}, "prTitle": ${{ env.pr_title_escaped }}, "prNumber": "${{ github.event.pull_request.number }}"}'


### PR DESCRIPTION
## Problem

We track PR throughput and age-to-merge for `PostHog/posthog` via a `posthog-ci-pr-stats` event (the `posthog-pr-metrics` action in project 2), but `posthog-js` has no equivalent, so its PRs are invisible in that view.

## Changes

Adds `.github/workflows/pr-closed.yml` with a single `report-pr-age` job that, when a PR is **merged** from a branch in this repo, fires a `posthog-ci-pr-stats` event to PostHog project 2 (via the org `POSTHOG_API_TOKEN` secret).

It mirrors the job already running in `PostHog/posthog`. Each event carries `prAgeInSeconds`, `isRevert`, `prTitle`, `prNumber`, plus `repository`/`actor`/`actor_type` metadata added automatically by `posthog-github-action@v1.2.0` — so events from all repos land in the same project and can be split by `repository`.

No library/runtime code changes; CI-only. Forks are excluded (same-repo head check), and the capture step no-ops harmlessly if `POSTHOG_API_TOKEN` isn't scoped to this repo.

## Release info Sub-libraries affected

### Libraries affected

- [ ] None — CI workflow only, no published package affected

## Checklist

- [ ] Tests for new code — n/a (CI workflow)
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size — n/a

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
