### PR TITLE
feat(ai): redact multimodal content from OTel spans

### DIFF
--- a/.changeset/ai-otel-multimodal-redaction.md
+++ b/.changeset/ai-otel-multimodal-redaction.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': minor
+---
+
+Redact base64/binary multimodal content from AI spans in the OTel `PostHogSpanProcessor` and `PostHogTraceExporter` before export, matching the redaction already applied by the direct provider wrappers. Content is redacted by value (data URLs and large base64 blobs) across span attributes and span events, so it works regardless of which GenAI semantic convention produced the span.

--- a/packages/ai/src/otel/exporter.ts
+++ b/packages/ai/src/otel/exporter.ts
@@ -2,6 +2,7 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
 import { ExportResultCode } from '@opentelemetry/core'
 
+import { redactSpan } from './redact'
 import { isAISpan } from './spans'
 
 const DEFAULT_OTEL_HOST = 'https://us.i.posthog.com'
@@ -105,6 +106,6 @@ export class PostHogTraceExporter extends OTLPTraceExporter {
       resultCallback({ code: ExportResultCode.SUCCESS })
       return
     }
-    super.export(aiSpans, resultCallback)
+    super.export(aiSpans.map(redactSpan), resultCallback)
   }
 }

--- a/packages/ai/src/otel/processor.ts
+++ b/packages/ai/src/otel/processor.ts
@@ -2,6 +2,7 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import type { Context } from '@opentelemetry/api'
 import { BatchSpanProcessor, type SpanProcessor, type ReadableSpan, type Span } from '@opentelemetry/sdk-trace-base'
 
+import { redactSpan } from './redact'
 import { isAISpan } from './spans'
 
 const DEFAULT_OTEL_HOST = 'https://us.i.posthog.com'
@@ -106,7 +107,7 @@ export class PostHogSpanProcessor implements SpanProcessor {
 
   onEnd(span: ReadableSpan): void {
     if (isAISpan(span)) {
-      this.inner.onEnd(span)
+      this.inner.onEnd(redactSpan(span))
     }
   }
 

--- a/packages/ai/src/otel/redact.ts
+++ b/packages/ai/src/otel/redact.ts
@@ -1,0 +1,100 @@
+import type { Attributes, AttributeValue } from '@opentelemetry/api'
+import type { ReadableSpan, TimedEvent } from '@opentelemetry/sdk-trace-base'
+
+import { BinaryContentRedactor } from '../sanitization/binary_content_redactor'
+
+const redactor = new BinaryContentRedactor()
+
+export function redactSpan(span: ReadableSpan): ReadableSpan {
+  const attributes = span.attributes ? redactAttributes(span.attributes) : span.attributes
+  const events = span.events ? redactEvents(span.events) : span.events
+  if (attributes === span.attributes && events === span.events) {
+    return span
+  }
+  // Copy rather than mutate: the span is shared across every registered processor/exporter.
+  return Object.create(span, {
+    attributes: { value: attributes, enumerable: true, configurable: true },
+    events: { value: events, enumerable: true, configurable: true },
+  })
+}
+
+function redactAttributes(attributes: Attributes): Attributes {
+  let changed = false
+  const out: Attributes = {}
+  for (const key of Object.keys(attributes)) {
+    const value = attributes[key]
+    const redacted = value === undefined ? value : redactAttributeValue(value)
+    if (redacted !== value) {
+      changed = true
+    }
+    out[key] = redacted
+  }
+  return changed ? out : attributes
+}
+
+function redactEvents(events: TimedEvent[]): TimedEvent[] {
+  let changed = false
+  const out = events.map((event) => {
+    if (!event.attributes) {
+      return event
+    }
+    const attributes = redactAttributes(event.attributes)
+    if (attributes === event.attributes) {
+      return event
+    }
+    changed = true
+    return { ...event, attributes }
+  })
+  return changed ? out : events
+}
+
+function redactAttributeValue(value: AttributeValue): AttributeValue {
+  if (typeof value === 'string') {
+    return redactString(value)
+  }
+  if (isStringArray(value)) {
+    let changed = false
+    const out = value.map((item) => {
+      if (typeof item !== 'string') {
+        return item
+      }
+      const redacted = redactString(item)
+      if (redacted !== item) {
+        changed = true
+      }
+      return redacted
+    })
+    return changed ? out : value
+  }
+  return value
+}
+
+function isStringArray(value: AttributeValue): value is Array<string | null | undefined> {
+  return Array.isArray(value) && value.every((item) => typeof item !== 'number' && typeof item !== 'boolean')
+}
+
+function redactString(value: string): string {
+  const trimmed = value.trimStart()
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    const redacted = redactJson(value)
+    if (redacted !== undefined) {
+      return redacted
+    }
+  }
+  return redactor.redact(value)
+}
+
+function redactJson(value: string): string | undefined {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    return undefined
+  }
+  if (parsed === null || typeof parsed !== 'object') {
+    return undefined
+  }
+  const redactedStr = JSON.stringify(redactor.redact(parsed))
+  // Preserve the original string (and its formatting) when nothing was redacted.
+  return redactedStr === JSON.stringify(parsed) ? value : redactedStr
+}

--- a/packages/ai/tests/otel.test.ts
+++ b/packages/ai/tests/otel.test.ts
@@ -166,4 +166,14 @@ describe('PostHogTraceExporter AI span filtering', () => {
 
     expect(getSuperExport()).toHaveBeenCalledWith([expect.objectContaining({ name: 'some.operation' })], callback)
   })
+
+  it('redacts multimodal content before exporting', () => {
+    const exporter = new PostHogTraceExporter({ projectToken: DEFAULT_TOKEN })
+    const callback = jest.fn()
+
+    exporter.export([makeSpan('gen_ai.chat', { 'gen_ai.prompt': 'data:image/png;base64,iVBORw0KGgo' })], callback)
+
+    const exported = getSuperExport().mock.calls[0][0] as ReadableSpan[]
+    expect(exported[0].attributes['gen_ai.prompt']).toBe('[base64 image/png redacted]')
+  })
 })

--- a/packages/ai/tests/otel_redact.test.ts
+++ b/packages/ai/tests/otel_redact.test.ts
@@ -1,0 +1,101 @@
+import type { ReadableSpan, TimedEvent } from '@opentelemetry/sdk-trace-base'
+import type { Attributes } from '@opentelemetry/api'
+
+import { redactSpan } from '../src/otel/redact'
+
+const DATA_URL = 'data:image/png;base64,iVBORw0KGgo'
+const REDACTED_PNG = '[base64 image/png redacted]'
+const LARGE_B64 = 'A'.repeat(2000)
+const REDACTED_GENERIC = '[base64 redacted]'
+
+function makeSpan(attributes: Attributes = {}, events: TimedEvent[] = []): ReadableSpan {
+  return {
+    name: 'gen_ai.chat',
+    attributes,
+    events,
+    spanContext: () => ({ traceId: 't', spanId: 's', traceFlags: 1 }),
+  } as unknown as ReadableSpan
+}
+
+describe('redactSpan', () => {
+  it.each([
+    [
+      'a bare data URL (OpenInference flattened leaf)',
+      'llm.input_messages.0.message.contents.0.message_content.image.image.url',
+      DATA_URL,
+      REDACTED_PNG,
+    ],
+    ['long raw base64 with no context via the weak threshold', 'traceloop.entity.input', LARGE_B64, REDACTED_GENERIC],
+    [
+      'data URLs inside a string-array attribute',
+      'gen_ai.prompt.images',
+      [DATA_URL, 'just text'],
+      [REDACTED_PNG, 'just text'],
+    ],
+  ])('redacts %s', (_desc, key, input, expected) => {
+    const out = redactSpan(makeSpan({ [key]: input }))
+
+    expect(out.attributes[key]).toEqual(expected)
+  })
+
+  it('redacts data URLs nested inside a JSON-blob attribute (gen_ai.input.messages)', () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what is this?' },
+          { type: 'image', image_url: DATA_URL },
+        ],
+      },
+    ]
+    const span = makeSpan({ 'gen_ai.input.messages': JSON.stringify(messages) })
+
+    const out = redactSpan(span)
+
+    const parsed = JSON.parse(out.attributes['gen_ai.input.messages'] as string)
+    expect(parsed[0].content[1].image_url).toBe(REDACTED_PNG)
+    expect(parsed[0].content[0].text).toBe('what is this?')
+  })
+
+  it('redacts content carried in span events (gen_ai.content.prompt)', () => {
+    const span = makeSpan({}, [
+      { name: 'gen_ai.content.prompt', time: [0, 0], attributes: { 'gen_ai.prompt': DATA_URL } },
+    ])
+
+    const out = redactSpan(span)
+
+    expect(out.events[0].attributes!['gen_ai.prompt']).toBe(REDACTED_PNG)
+  })
+
+  it('does not mutate the original span', () => {
+    const attributes = { 'gen_ai.prompt': DATA_URL }
+    const span = makeSpan(attributes)
+
+    redactSpan(span)
+
+    expect(span.attributes['gen_ai.prompt']).toBe(DATA_URL)
+    expect(attributes['gen_ai.prompt']).toBe(DATA_URL)
+  })
+
+  it('returns the same span instance when nothing is redacted', () => {
+    const span = makeSpan({ 'gen_ai.model': 'gpt-4', 'gen_ai.usage.input_tokens': 12 })
+
+    expect(redactSpan(span)).toBe(span)
+  })
+
+  it('preserves prototype methods on the redacted copy', () => {
+    const span = makeSpan({ 'gen_ai.prompt': DATA_URL })
+
+    const out = redactSpan(span)
+
+    expect(out.spanContext()).toEqual({ traceId: 't', spanId: 's', traceFlags: 1 })
+    expect(out.name).toBe('gen_ai.chat')
+  })
+
+  it('preserves the original string when JSON has no binary content', () => {
+    const json = JSON.stringify({ role: 'user', content: 'hello' })
+    const span = makeSpan({ 'gen_ai.input.messages': json })
+
+    expect(redactSpan(span)).toBe(span)
+  })
+})

--- a/packages/ai/tests/processor.test.ts
+++ b/packages/ai/tests/processor.test.ts
@@ -156,4 +156,14 @@ describe('PostHogSpanProcessor AI span filtering', () => {
 
     expect(inner.onEnd).toHaveBeenCalledTimes(1)
   })
+
+  it('redacts multimodal content before forwarding', () => {
+    const inner = mockProcessor()
+    const processor = new PostHogSpanProcessor({ apiKey: 'phc_test', _spanProcessor: inner })
+
+    processor.onEnd(makeSpan('gen_ai.chat', { 'gen_ai.prompt': 'data:image/png;base64,iVBORw0KGgo' }))
+
+    const forwarded = inner.onEnd.mock.calls[0][0] as ReadableSpan
+    expect(forwarded.attributes['gen_ai.prompt']).toBe('[base64 image/png redacted]')
+  })
 })


### PR DESCRIPTION
## Problem

The `@posthog/ai` direct provider wrappers (OpenAI, Anthropic, Gemini, LangChain, Vercel) already strip base64/binary multimodal content out of `$ai_input`/`$ai_output` before sending it to PostHog, the OTel path does not.

## Changes

Adds a span redaction pass that reuses the existing `BinaryContentRedactor`, so OTel behaves consistently with the direct-SDK wrappers.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

Built with Claude Code. The design followed prior art from OTel: `ReadableSpan` is read-only in `onEnd` by design ([spec #2990](https://github.com/open-telemetry/opentelemetry-specification/issues/2990)), and the community consensus for non-mutating transforms is a custom `SpanProcessor` plus an `Object.create`-based shallow copy ([opentelemetry-js #2817](https://github.com/open-telemetry/opentelemetry-js/discussions/2817)) — chosen over a `Proxy` for readability and over in-place mutation because the span is shared across processors. Redaction is value-based rather than keyed on a field allowlist specifically because the GenAI conventions are fragmented and still moving (`gen_ai.input.messages` superseding the deprecated `gen_ai.prompt`/`gen_ai.completion`, OpenInference flattened leaves, Traceloop blobs).
