### PR TITLE
feat: conversation ticket numbers

### DIFF
--- a/.changeset/conversations-ticket-number.md
+++ b/.changeset/conversations-ticket-number.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': minor
+---
+
+Surface the human-readable ticket number in the conversations/support API. `Ticket`, `SendMessageResponse`, and `GetMessagesResponse` now include an optional `ticket_number`, and a new `posthog.conversations.getCurrentTicketNumber()` returns it for the active ticket (persisted across reloads). Use this instead of the ticket UUID when displaying a reference users can quote externally.

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-api.test.ts
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-api.test.ts
@@ -47,6 +47,7 @@ describe('Conversations API Methods', () => {
             restoreFromToken: jest.fn(),
             restoreFromUrlToken: jest.fn(),
             getCurrentTicketId: jest.fn(),
+            getCurrentTicketNumber: jest.fn(),
             getWidgetSessionId: jest.fn(),
         } as unknown as ConversationsManager
 
@@ -133,6 +134,13 @@ describe('Conversations API Methods', () => {
 
         it('should return null from getCurrentTicketId when conversations not available', () => {
             const result = conversations.getCurrentTicketId()
+
+            expect(result).toBeNull()
+            expect(consoleWarnSpy).not.toHaveBeenCalled() // Safe method, no warning
+        })
+
+        it('should return null from getCurrentTicketNumber when conversations not available', () => {
+            const result = conversations.getCurrentTicketNumber()
 
             expect(result).toBeNull()
             expect(consoleWarnSpy).not.toHaveBeenCalled() // Safe method, no warning
@@ -542,6 +550,26 @@ describe('Conversations API Methods', () => {
 
                 expect(result).toBeNull()
                 expect(mockManager.getCurrentTicketId).toHaveBeenCalled()
+            })
+        })
+
+        describe('getCurrentTicketNumber', () => {
+            it('should return current ticket number when available', () => {
+                ;(mockManager.getCurrentTicketNumber as jest.Mock).mockReturnValue(1234)
+
+                const result = conversations.getCurrentTicketNumber()
+
+                expect(result).toBe(1234)
+                expect(mockManager.getCurrentTicketNumber).toHaveBeenCalled()
+            })
+
+            it('should return null when ticket number is not known', () => {
+                ;(mockManager.getCurrentTicketNumber as jest.Mock).mockReturnValue(null)
+
+                const result = conversations.getCurrentTicketNumber()
+
+                expect(result).toBeNull()
+                expect(mockManager.getCurrentTicketNumber).toHaveBeenCalled()
             })
         })
 

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-identity-manager.test.tsx
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-identity-manager.test.tsx
@@ -9,15 +9,19 @@ jest.mock('../../../extensions/conversations/external/persistence', () => {
     return {
         ConversationsPersistence: jest.fn().mockImplementation(() => {
             let storedTicketId: string | null = null
+            let storedTicketNumber: number | null = null
             return {
                 getOrCreateWidgetSessionId: jest.fn().mockReturnValue('test-widget-session-id'),
                 setWidgetSessionId: jest.fn(),
                 loadTicketId: jest.fn(() => storedTicketId),
-                saveTicketId: jest.fn((ticketId: string) => {
+                loadTicketNumber: jest.fn(() => storedTicketNumber),
+                saveTicketId: jest.fn((ticketId: string, ticketNumber?: number | null) => {
                     storedTicketId = ticketId
+                    storedTicketNumber = ticketNumber ?? null
                 }),
                 clearTicketId: jest.fn(() => {
                     storedTicketId = null
+                    storedTicketNumber = null
                 }),
                 loadWidgetState: jest.fn().mockReturnValue('closed'),
                 saveWidgetState: jest.fn(),
@@ -26,6 +30,7 @@ jest.mock('../../../extensions/conversations/external/persistence', () => {
                 clearWidgetSessionId: jest.fn(),
                 clearAll: jest.fn(() => {
                     storedTicketId = null
+                    storedTicketNumber = null
                 }),
             }
         }),

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-identity.test.ts
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-identity.test.ts
@@ -35,6 +35,7 @@ describe('Conversations Identity Verification', () => {
             restoreFromToken: jest.fn(),
             restoreFromUrlToken: jest.fn(),
             getCurrentTicketId: jest.fn(),
+            getCurrentTicketNumber: jest.fn(),
             getWidgetSessionId: jest.fn(),
             setIdentity: jest.fn(),
             clearIdentity: jest.fn(),

--- a/packages/browser/src/__tests__/extensions/conversations/conversations-manager.test.tsx
+++ b/packages/browser/src/__tests__/extensions/conversations/conversations-manager.test.tsx
@@ -16,15 +16,19 @@ jest.mock('../../../extensions/conversations/external/persistence', () => {
     return {
         ConversationsPersistence: jest.fn().mockImplementation(() => {
             let storedTicketId: string | null = null
+            let storedTicketNumber: number | null = null
             return {
                 getOrCreateWidgetSessionId: jest.fn().mockReturnValue('test-widget-session-id'),
                 setWidgetSessionId: jest.fn(),
                 loadTicketId: jest.fn(() => storedTicketId),
-                saveTicketId: jest.fn((ticketId: string) => {
+                loadTicketNumber: jest.fn(() => storedTicketNumber),
+                saveTicketId: jest.fn((ticketId: string, ticketNumber?: number | null) => {
                     storedTicketId = ticketId
+                    storedTicketNumber = ticketNumber ?? null
                 }),
                 clearTicketId: jest.fn(() => {
                     storedTicketId = null
+                    storedTicketNumber = null
                 }),
                 loadWidgetState: jest.fn().mockReturnValue('closed'),
                 saveWidgetState: jest.fn(),
@@ -33,6 +37,7 @@ jest.mock('../../../extensions/conversations/external/persistence', () => {
                 clearWidgetSessionId: jest.fn(),
                 clearAll: jest.fn(() => {
                     storedTicketId = null
+                    storedTicketNumber = null
                 }),
             }
         }),
@@ -66,6 +71,7 @@ describe('ConversationsManager', () => {
 
     const createMockSendMessageResponse = (): SendMessageResponse => ({
         ticket_id: 'ticket-123',
+        ticket_number: 4567,
         message_id: 'msg-456',
         ticket_status: 'open',
         created_at: '2023-01-01T00:00:00Z',
@@ -527,6 +533,16 @@ describe('ConversationsManager', () => {
             })
 
             expect(manager['_currentTicketId']).toBe('ticket-123')
+        })
+
+        it('should expose the human-readable ticket number after sending first message', async () => {
+            expect(manager.getCurrentTicketNumber()).toBeNull()
+
+            await act(async () => {
+                await manager.sendMessage('Hello!')
+            })
+
+            expect(manager.getCurrentTicketNumber()).toBe(4567)
         })
 
         it('should include ticket ID in subsequent messages', async () => {

--- a/packages/browser/src/extensions/conversations/external/index.tsx
+++ b/packages/browser/src/extensions/conversations/external/index.tsx
@@ -46,6 +46,7 @@ export class ConversationsManager implements ConversationsManagerInterface {
     private _widgetRef: ConversationsWidget | null = null
     private _containerElement: HTMLDivElement | null = null
     private _currentTicketId: string | null = null
+    private _currentTicketNumber: number | null = null
     private _pollIntervalId: number | null = null
     private _lastMessageTimestamp: string | null = null
     private _isPollingMessages: boolean = false
@@ -190,9 +191,11 @@ export class ConversationsManager implements ConversationsManagerInterface {
                     // This happens when: 1) No ticket existed, or 2) User forced new ticket creation
                     if (isNewTicket && data.ticket_id) {
                         this._currentTicketId = data.ticket_id
-                        this._persistence.saveTicketId(data.ticket_id)
+                        this._currentTicketNumber = data.ticket_number ?? null
+                        this._persistence.saveTicketId(data.ticket_id, data.ticket_number)
                         logger.info('New ticket created', {
                             ticketId: data.ticket_id,
+                            ticketNumber: data.ticket_number,
                             forced: newTicket === true,
                         })
                     }
@@ -220,6 +223,8 @@ export class ConversationsManager implements ConversationsManagerInterface {
     private _switchToTicketIfNeeded(ticketId: string | undefined): void {
         if (ticketId && ticketId !== this._currentTicketId) {
             this._currentTicketId = ticketId
+            // The ticket number for the new ticket is unknown until we fetch it
+            this._currentTicketNumber = null
             this._persistence.saveTicketId(ticketId)
             // Reset last message timestamp when switching tickets
             this._lastMessageTimestamp = null
@@ -286,6 +291,13 @@ export class ConversationsManager implements ConversationsManagerInterface {
                     }
 
                     const data = response.json as GetMessagesResponse
+
+                    // Keep the cached/persisted ticket number in sync for the active ticket
+                    if (data.ticket_id === this._currentTicketId && isNumber(data.ticket_number)) {
+                        this._currentTicketNumber = data.ticket_number
+                        this._persistence.saveTicketId(data.ticket_id, data.ticket_number)
+                    }
+
                     resolve(data)
                 },
             })
@@ -399,7 +411,11 @@ export class ConversationsManager implements ConversationsManagerInterface {
 
         // Load any existing ticket ID from localStorage
         this._currentTicketId = this._persistence.loadTicketId()
-        logger.info('Loaded ticket ID from storage', { ticketId: this._currentTicketId })
+        this._currentTicketNumber = this._persistence.loadTicketNumber()
+        logger.info('Loaded ticket ID from storage', {
+            ticketId: this._currentTicketId,
+            ticketNumber: this._currentTicketNumber,
+        })
 
         // Track conversations API loaded (separate from widget loaded)
         this._posthog.capture('$conversations_loaded', {
@@ -492,12 +508,15 @@ export class ConversationsManager implements ConversationsManagerInterface {
 
         if (data.migrated_ticket_ids?.length) {
             this._currentTicketId = data.migrated_ticket_ids[0]
+            // Number is unknown for migrated tickets; it gets refreshed on the next fetch
+            this._currentTicketNumber = null
             this._persistence.saveTicketId(this._currentTicketId)
             // Poll straight away so messages and ticket list are fresh
             void this._pollMessages()
             void this._pollTickets()
         } else {
             this._currentTicketId = null
+            this._currentTicketNumber = null
             this._persistence.clearTicketId()
         }
 
@@ -880,6 +899,7 @@ export class ConversationsManager implements ConversationsManagerInterface {
 
         // Clear current ticket
         this._currentTicketId = null
+        this._currentTicketNumber = null
         this._persistence.clearTicketId()
 
         // Reset timestamp
@@ -951,19 +971,22 @@ export class ConversationsManager implements ConversationsManagerInterface {
 
         if (tickets.length >= 2) {
             this._currentTicketId = null
+            this._currentTicketNumber = null
             return 'tickets'
         }
 
         // Single resolved ticket: show list so user can start a new conversation instead of writing to it
         if (tickets.length === 1 && tickets[0].status === 'resolved') {
             this._currentTicketId = null
+            this._currentTicketNumber = null
             this._persistence.clearTicketId()
             return 'tickets'
         }
 
         if (tickets.length === 1) {
             this._currentTicketId = tickets[0].id
-            this._persistence.saveTicketId(tickets[0].id)
+            this._currentTicketNumber = tickets[0].ticket_number ?? null
+            this._persistence.saveTicketId(tickets[0].id, tickets[0].ticket_number)
         }
 
         return 'messages'
@@ -1205,6 +1228,16 @@ export class ConversationsManager implements ConversationsManagerInterface {
     }
 
     /**
+     * Get the human-readable ticket number for the current active ticket.
+     * Returns null if no conversation has been started yet, or if the number
+     * is not yet known (e.g. a backend that doesn't return it, or before the
+     * first message/fetch on a restored ticket).
+     */
+    getCurrentTicketNumber(): number | null {
+        return this._currentTicketNumber
+    }
+
+    /**
      * Get the widget session ID (persistent browser identifier)
      * This ID is used for access control and stays the same across page loads
      */
@@ -1235,6 +1268,7 @@ export class ConversationsManager implements ConversationsManagerInterface {
 
     private _resetConversationState(): void {
         this._currentTicketId = null
+        this._currentTicketNumber = null
         this._persistence.clearTicketId()
         this._lastMessageTimestamp = null
         this._widgetRef?.clearMessages(true)
@@ -1300,6 +1334,7 @@ export class ConversationsManager implements ConversationsManagerInterface {
 
         // Reset local state
         this._currentTicketId = null
+        this._currentTicketNumber = null
         this._lastMessageTimestamp = null
         this._unreadCount = 0
 

--- a/packages/browser/src/extensions/conversations/external/persistence.ts
+++ b/packages/browser/src/extensions/conversations/external/persistence.ts
@@ -9,12 +9,14 @@ import { UserProvidedTraits } from '../../../posthog-conversations-types'
 import { createLogger } from '../../../utils/logger'
 import { window } from '../../../utils/globals'
 import { uuidv7 } from '../../../uuidv7'
+import { isNumber } from '@posthog/core'
 
 const logger = createLogger('[ConversationsPersistence]')
 
 interface ConversationsStorageData {
     widgetSessionId?: string
     ticketId?: string | null
+    ticketNumber?: number | null
     widgetState?: 'open' | 'closed'
     userTraits?: UserProvidedTraits | null
 }
@@ -93,19 +95,25 @@ export class ConversationsPersistence {
         }
     }
 
-    saveTicketId(ticketId: string): void {
+    saveTicketId(ticketId: string, ticketNumber?: number | null): void {
         const data = this._read() || {}
-        this._write({ ...data, ticketId })
+        this._write({ ...data, ticketId, ticketNumber: ticketNumber ?? null })
     }
 
     loadTicketId(): string | null {
         return this._read()?.ticketId || null
     }
 
+    loadTicketNumber(): number | null {
+        const ticketNumber = this._read()?.ticketNumber
+        return isNumber(ticketNumber) ? ticketNumber : null
+    }
+
     clearTicketId(): void {
         const data = this._read()
         if (data) {
             delete data.ticketId
+            delete data.ticketNumber
             this._write(data)
         }
     }

--- a/packages/browser/src/extensions/conversations/posthog-conversations.ts
+++ b/packages/browser/src/extensions/conversations/posthog-conversations.ts
@@ -365,6 +365,30 @@ export class PostHogConversations implements Extension {
     }
 
     /**
+     * Get the human-readable ticket number for the current active ticket.
+     *
+     * Unlike the ticket ID (a UUID), this is the short, sequential number that
+     * users can quote externally — the same number shown in the PostHog support
+     * UI. Use it to display a reference in your own widget.
+     *
+     * Returns null if no conversation has been started, if conversations aren't
+     * available yet, or if the number isn't known yet (e.g. a backend that
+     * doesn't return it, or a restored ticket before its first fetch).
+     *
+     * @returns Ticket number or null
+     * @note Safe to call before conversations are available, will return null
+     *
+     * @example
+     * const ticketNumber = posthog.conversations.getCurrentTicketNumber()
+     * if (ticketNumber) {
+     *   console.log(`Your reference number is #${ticketNumber}`)
+     * }
+     */
+    getCurrentTicketNumber(): number | null {
+        return this._conversationsManager?.getCurrentTicketNumber() ?? null
+    }
+
+    /**
      * Get the widget session ID (persistent browser identifier)
      * This ID is used for access control and stays the same across page loads
      * Returns null if conversations not available yet

--- a/packages/browser/src/posthog-conversations-types.ts
+++ b/packages/browser/src/posthog-conversations-types.ts
@@ -166,9 +166,17 @@ export type TicketStatus = 'new' | 'open' | 'pending' | 'on_hold' | 'resolved'
  */
 export interface Ticket {
     /**
-     * Unique identifier for the ticket
+     * Unique identifier for the ticket (UUID)
      */
     id: string
+
+    /**
+     * Human-readable, sequential ticket number.
+     * Use this when displaying a reference users can quote externally
+     * (the same number shown in the PostHog support UI). May be absent
+     * on older backends that don't yet return it.
+     */
+    ticket_number?: number
 
     /**
      * Current status of the ticket
@@ -216,9 +224,17 @@ export type ConversationsWidgetState = 'open' | 'closed'
  */
 export interface SendMessageResponse {
     /**
-     * ID of the ticket this message belongs to
+     * ID of the ticket this message belongs to (UUID)
      */
     ticket_id: string
+
+    /**
+     * Human-readable, sequential ticket number.
+     * Use this when displaying a reference users can quote externally
+     * (the same number shown in the PostHog support UI). May be absent
+     * on older backends that don't yet return it.
+     */
+    ticket_number?: number
 
     /**
      * ID of the newly created message
@@ -247,9 +263,17 @@ export interface SendMessageResponse {
  */
 export interface GetMessagesResponse {
     /**
-     * ID of the ticket
+     * ID of the ticket (UUID)
      */
     ticket_id: string
+
+    /**
+     * Human-readable, sequential ticket number.
+     * Use this when displaying a reference users can quote externally
+     * (the same number shown in the PostHog support UI). May be absent
+     * on older backends that don't yet return it.
+     */
+    ticket_number?: number
 
     /**
      * Current status of the ticket

--- a/packages/browser/src/utils/globals.ts
+++ b/packages/browser/src/utils/globals.ts
@@ -222,6 +222,7 @@ export interface LazyLoadedConversationsInterface {
     restoreFromToken: (restoreToken: string) => Promise<RestoreFromTokenResponse>
     restoreFromUrlToken: () => Promise<RestoreFromTokenResponse | null>
     getCurrentTicketId: () => string | null
+    getCurrentTicketNumber: () => number | null
     getWidgetSessionId: () => string
 }
 


### PR DESCRIPTION
## Problem
https://posthoghelp.zendesk.com/agent/tickets/59701 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/60860)

The conversations SDK only exposed the ticket UUID, which isn't human-readable and shares a common prefix which isn't great UX for users referencing a ticket externally.

## Changes

Added ticket_number to the Ticket, SendMessageResponse, and GetMessagesResponse types.
Added posthog.conversations.getCurrentTicketNumber(), mirroring getCurrentTicketId() — tracked in memory, persisted to localStorage, and reloaded on init so it survives page reloads.
Keeps the cached number in sync across send/fetch/switch/restore/identity-change/reset, the same points the ticket ID is managed.
Backend must include ticket_number in the widget API responses for this to populate (SDK side is ready).

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [X] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [X] Tests for new code
- [X] Accounted for the impact of any changes across different platforms
- [X] Accounted for backwards compatibility of any changes (no breaking changes!)
- [X] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [X] Ran `pnpm changeset` to generate a changeset file


