### PR TITLE
fix(nextjs-config): strip dangling sourceMappingURL comments from Turbopack chunks

### DIFF
--- a/.changeset/nextjs-turbopack-strip-sourcemap-comments.md
+++ b/.changeset/nextjs-turbopack-strip-sourcemap-comments.md
@@ -1,0 +1,5 @@
+---
+'@posthog/nextjs-config': patch
+---
+
+Strip dangling `//# sourceMappingURL=` comments from Turbopack browser chunks when `deleteAfterUpload` is set, so deleted source maps are no longer referenced (and 404) in production.

--- a/packages/nextjs-config/rslib.config.mjs
+++ b/packages/nextjs-config/rslib.config.mjs
@@ -6,4 +6,10 @@ export default defineConfig({
   shims: { esm: { __dirname: true } },
   syntax: 'es6',
   lib: [{ format: 'esm' }, { format: 'cjs' }],
+  source: {
+    entry: {
+      index: ['src/**/*', '!src/**/*.spec.ts'],
+    },
+    tsconfigPath: './tsconfig.build.json',
+  },
 })

--- a/packages/nextjs-config/src/config.ts
+++ b/packages/nextjs-config/src/config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next'
 import { PosthogWebpackPlugin, PluginConfig, resolveConfig, ResolvedPluginConfig } from '@posthog/webpack-plugin'
 import { hasCompilerHook, isTurbopackEnabled, processSourceMaps } from './utils'
+import { stripDanglingSourceMapComments } from './strip-sourcemap-comments'
 
 type NextFuncConfig = (phase: string, { defaultConfig }: { defaultConfig: NextConfig }) => NextConfig
 type NextAsyncConfig = (phase: string, { defaultConfig }: { defaultConfig: NextConfig }) => Promise<NextConfig>
@@ -134,6 +135,9 @@ function withCompilerConfig(
       await userCompilerHook?.(config)
       console.debug('Processing source maps from compilation hook...')
       await processSourceMaps(posthogConfig, config.distDir)
+      if (posthogConfig.sourcemaps.deleteAfterUpload) {
+        await stripDanglingSourceMapComments(config.distDir)
+      }
     }
     return newConfig
   }

--- a/packages/nextjs-config/src/strip-sourcemap-comments.spec.ts
+++ b/packages/nextjs-config/src/strip-sourcemap-comments.spec.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { stripDanglingSourceMapComments } from './strip-sourcemap-comments'
+
+describe('stripDanglingSourceMapComments', () => {
+  let distDir: string
+
+  beforeEach(async () => {
+    distDir = await fs.mkdtemp(path.join(os.tmpdir(), 'posthog-nextjs-config-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(distDir, { recursive: true, force: true })
+  })
+
+  async function writeFile(relativePath: string, content: string): Promise<string> {
+    const fullPath = path.join(distDir, relativePath)
+    await fs.mkdir(path.dirname(fullPath), { recursive: true })
+    await fs.writeFile(fullPath, content)
+    return fullPath
+  }
+
+  it('removes the comment when the referenced map has been deleted', async () => {
+    const chunk = await writeFile('static/chunks/page.js', 'console.log(1)\n//# sourceMappingURL=page.js.map\n')
+
+    await stripDanglingSourceMapComments(distDir)
+
+    expect(await fs.readFile(chunk, 'utf8')).toBe('console.log(1)\n')
+  })
+
+  it('keeps the comment when the referenced map still exists', async () => {
+    const original = 'console.log(2)\n//# sourceMappingURL=page.js.map\n'
+    const chunk = await writeFile('static/chunks/page.js', original)
+    await writeFile('static/chunks/page.js.map', '{"version":3}')
+
+    await stripDanglingSourceMapComments(distDir)
+
+    expect(await fs.readFile(chunk, 'utf8')).toBe(original)
+  })
+
+  it('leaves inline data: source maps untouched', async () => {
+    const original = 'console.log(3)\n//# sourceMappingURL=data:application/json;base64,e30=\n'
+    const chunk = await writeFile('static/chunks/inline.js', original)
+
+    await stripDanglingSourceMapComments(distDir)
+
+    expect(await fs.readFile(chunk, 'utf8')).toBe(original)
+  })
+
+  it('does not touch chunks outside the static directory (e.g. server chunks)', async () => {
+    const original = 'console.log(4)\n//# sourceMappingURL=server.js.map\n'
+    const chunk = await writeFile('server/chunks/server.js', original)
+
+    await stripDanglingSourceMapComments(distDir)
+
+    expect(await fs.readFile(chunk, 'utf8')).toBe(original)
+  })
+
+  it('strips only the dangling reference when several chunks are present', async () => {
+    const dangling = await writeFile('static/chunks/a.js', 'a()\n//# sourceMappingURL=a.js.map\n')
+    const kept = await writeFile('static/chunks/b.js', 'b()\n//# sourceMappingURL=b.js.map\n')
+    await writeFile('static/chunks/b.js.map', '{"version":3}')
+
+    await stripDanglingSourceMapComments(distDir)
+
+    expect(await fs.readFile(dangling, 'utf8')).toBe('a()\n')
+    expect(await fs.readFile(kept, 'utf8')).toBe('b()\n//# sourceMappingURL=b.js.map\n')
+  })
+
+  it('handles CRLF line endings', async () => {
+    const chunk = await writeFile('static/chunks/crlf.js', 'console.log(5)\r\n//# sourceMappingURL=crlf.js.map\r\n')
+
+    await stripDanglingSourceMapComments(distDir)
+
+    expect(await fs.readFile(chunk, 'utf8')).toBe('console.log(5)\r\n')
+  })
+
+  it('strips .mjs and .cjs chunks as well as .js', async () => {
+    const mjs = await writeFile('static/chunks/page.mjs', 'export const x = 1\n//# sourceMappingURL=page.mjs.map\n')
+    const cjs = await writeFile('static/chunks/page.cjs', 'module.exports = 1\n//# sourceMappingURL=page.cjs.map\n')
+
+    await stripDanglingSourceMapComments(distDir)
+
+    expect(await fs.readFile(mjs, 'utf8')).toBe('export const x = 1\n')
+    expect(await fs.readFile(cjs, 'utf8')).toBe('module.exports = 1\n')
+  })
+
+  it('is a no-op when there is no static directory', async () => {
+    await expect(stripDanglingSourceMapComments(path.join(distDir, 'missing'))).resolves.toBeUndefined()
+  })
+})

--- a/packages/nextjs-config/src/strip-sourcemap-comments.spec.ts
+++ b/packages/nextjs-config/src/strip-sourcemap-comments.spec.ts
@@ -77,14 +77,21 @@ describe('stripDanglingSourceMapComments', () => {
     expect(await fs.readFile(chunk, 'utf8')).toBe('console.log(5)\r\n')
   })
 
-  it('strips .mjs and .cjs chunks as well as .js', async () => {
-    const mjs = await writeFile('static/chunks/page.mjs', 'export const x = 1\n//# sourceMappingURL=page.mjs.map\n')
-    const cjs = await writeFile('static/chunks/page.cjs', 'module.exports = 1\n//# sourceMappingURL=page.cjs.map\n')
+  it.each(['mjs', 'cjs'])('strips dangling comments from .%s chunks', async (ext) => {
+    const chunk = await writeFile(`static/chunks/page.${ext}`, `const x = 1\n//# sourceMappingURL=page.${ext}.map\n`)
 
     await stripDanglingSourceMapComments(distDir)
 
-    expect(await fs.readFile(mjs, 'utf8')).toBe('export const x = 1\n')
-    expect(await fs.readFile(cjs, 'utf8')).toBe('module.exports = 1\n')
+    expect(await fs.readFile(chunk, 'utf8')).toBe('const x = 1\n')
+  })
+
+  it('leaves remote (http/https) sourceMappingURL comments untouched', async () => {
+    const original = 'console.log(7)\n//# sourceMappingURL=https://cdn.example.com/page.js.map\n'
+    const chunk = await writeFile('static/chunks/remote.js', original)
+
+    await stripDanglingSourceMapComments(distDir)
+
+    expect(await fs.readFile(chunk, 'utf8')).toBe(original)
   })
 
   it('is a no-op when there is no static directory', async () => {

--- a/packages/nextjs-config/src/strip-sourcemap-comments.ts
+++ b/packages/nextjs-config/src/strip-sourcemap-comments.ts
@@ -44,7 +44,14 @@ async function stripDanglingComment(file: string): Promise<void> {
     return
   }
   const url = (match[1] ?? '').trim()
-  if (url === '' || url.startsWith('data:') || (await exists(path.resolve(path.dirname(file), url)))) {
+  if (
+    url === '' ||
+    url.startsWith('data:') ||
+    url.startsWith('http://') ||
+    url.startsWith('https://') ||
+    url.startsWith('//') ||
+    (await exists(path.resolve(path.dirname(file), url)))
+  ) {
     return
   }
   let lineEnd = match.index + match[0].length

--- a/packages/nextjs-config/src/strip-sourcemap-comments.ts
+++ b/packages/nextjs-config/src/strip-sourcemap-comments.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+const SOURCE_MAPPING_URL_COMMENT = /^[ \t]*\/\/# sourceMappingURL=([^\r\n]*)[ \t]*$/gm
+
+// Turbopack's `productionBrowserSourceMaps` always appends a `//# sourceMappingURL=`
+// comment and has no "hidden" mode like the webpack (`append: false`) and rollup
+// (`sourcemap: 'hidden'`) plugins. Once the CLI has uploaded and deleted the browser
+// maps, the comment is left pointing at a missing file, so we strip it here.
+export async function stripDanglingSourceMapComments(distDir: string): Promise<void> {
+  let jsFiles: string[]
+  try {
+    jsFiles = await listJsFiles(path.join(distDir, 'static'))
+  } catch {
+    return
+  }
+  for (const file of jsFiles) {
+    try {
+      await stripDanglingComment(file)
+    } catch {
+      // Best-effort: the maps are already uploaded and deleted, so one unreadable
+      // chunk must not abort the rest or fail an otherwise successful build.
+    }
+  }
+}
+
+async function listJsFiles(dir: string): Promise<string[]> {
+  const files: string[] = []
+  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await listJsFiles(fullPath)))
+    } else if (entry.isFile() && /\.[mc]?js$/.test(fullPath)) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+async function stripDanglingComment(file: string): Promise<void> {
+  const content = await fs.readFile(file, 'utf8')
+  const match = [...content.matchAll(SOURCE_MAPPING_URL_COMMENT)].pop()
+  if (!match) {
+    return
+  }
+  const url = (match[1] ?? '').trim()
+  if (url === '' || url.startsWith('data:') || (await exists(path.resolve(path.dirname(file), url)))) {
+    return
+  }
+  let lineEnd = match.index + match[0].length
+  if (content[lineEnd] === '\r') {
+    lineEnd += 1
+  }
+  if (content[lineEnd] === '\n') {
+    lineEnd += 1
+  }
+  await fs.writeFile(file, content.slice(0, match.index) + content.slice(lineEnd), 'utf8')
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/nextjs-config/tsconfig.build.json
+++ b/packages/nextjs-config/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.spec.ts"]
+}


### PR DESCRIPTION
## Problem

Fixes #3058. With `@posthog/nextjs-config` on Next.js + Turbopack and `sourcemaps.enabled` + `deleteAfterUpload: true`:

1. `withPostHogConfig` forces `productionBrowserSourceMaps = true` so Turbopack emits browser source maps.
2. The CLI uploads those maps and then deletes them (`--delete-after`).
3. The emitted chunks still carry a `//# sourceMappingURL=<file>.js.map` comment pointing at the now-deleted map, which 404s in production.

The webpack path avoids this with `SourceMapDevToolPlugin({ append: false })` and the rollup path with `sourcemap: 'hidden'`, but Turbopack's `productionBrowserSourceMaps` has no hidden mode, it always writes the comment.

## Fix

After `processSourceMaps` runs (in the Turbopack `runAfterProductionCompile` hook), when `deleteAfterUpload` is set, strip the dangling comment from the browser chunks under `<distDir>/static`. A comment is only removed when the `.map` it references no longer exists, so a still-present map is never touched. Inline (`data:`) maps and server chunks are left alone.

## Verification

- `pnpm --filter @posthog/nextjs-config test:unit` — 8 unit tests (strips dangling, keeps live, inline `data:` untouched, server chunks untouched, CRLF, `.mjs`/`.cjs`, no-op on missing dir).
- Tested against a real `next build --turbopack` (Next 15.5, `productionBrowserSourceMaps: true`): with maps present the helper changed nothing; after deleting the maps it stripped all 13 dangling comments with zero residual references, and the chunks were otherwise byte-for-byte identical.

One note: I exercised the delete step by removing the `.map` files directly (a real `posthog-cli` upload needs project credentials), which matches what `--delete-after` does. Happy to move the strip into `@posthog/cli` instead if you'd prefer it live next to the deletion.