### PR TITLE
chore(ai): update span processor test token option

### DIFF
--- a/packages/ai/tests/processor.test.ts
+++ b/packages/ai/tests/processor.test.ts
@@ -159,7 +159,7 @@ describe('PostHogSpanProcessor AI span filtering', () => {
 
   it('redacts multimodal content before forwarding', () => {
     const inner = mockProcessor()
-    const processor = new PostHogSpanProcessor({ apiKey: 'phc_test', _spanProcessor: inner })
+    const processor = new PostHogSpanProcessor({ projectToken: 'phc_test', _spanProcessor: inner })
 
     processor.onEnd(makeSpan('gen_ai.chat', { 'gen_ai.prompt': 'data:image/png;base64,iVBORw0KGgo' }))
 


### PR DESCRIPTION
## Problem

The release build is failing because one `@posthog/ai` test still constructs `PostHogSpanProcessor` with the removed `apiKey` option. `@posthog/ai@8` intentionally renamed this OTel option to `projectToken`, so Rollup's TypeScript build fails while type-checking tests.

## Changes

- Update the remaining `PostHogSpanProcessor` test caller to use `projectToken`.
- Verified locally:
  - `pnpm --filter @posthog/ai build`
  - `pnpm --filter @posthog/ai test:unit -- processor.test.ts`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

Test-only release build fix; no changeset needed.
