### PR TITLE
fix: respect capture_pageview on cookieless opt out

### DIFF
--- a/.changeset/quiet-emus-opt-out-pageview.md
+++ b/.changeset/quiet-emus-opt-out-pageview.md
@@ -1,0 +1,5 @@
+---
+"posthog-js": patch
+---
+
+Respect `capture_pageview: false` when opting out in cookieless `on_reject` mode.

--- a/packages/browser/src/__tests__/cookieless.test.ts
+++ b/packages/browser/src/__tests__/cookieless.test.ts
@@ -198,6 +198,28 @@ describe('cookieless', () => {
             expect(posthog.sessionRecording).toBeFalsy()
         })
 
+        it('should not send an initial pageview on opt out when capture_pageview is false', async () => {
+            const { posthog, beforeSendMock } = await setup({
+                cookieless_mode: 'on_reject',
+                capture_pageview: false,
+            })
+            posthog.capture('eventBeforeOptOut') // will be dropped
+            expect(beforeSendMock).toBeCalledTimes(0)
+
+            posthog.opt_out_capturing()
+
+            expect(beforeSendMock).toBeCalledTimes(0)
+
+            posthog.capture('eventAfterOptOut')
+
+            expect(beforeSendMock).toBeCalledTimes(1)
+            const event = beforeSendMock.mock.calls[0][0]
+            expect(event.event).toBe('eventAfterOptOut')
+            expect(event.properties.distinct_id).toEqual('$posthog_cookieless')
+            expect(event.properties.$device_id).toBe(null)
+            expect(event.properties.$cookieless_mode).toEqual(true)
+        })
+
         it('should pick up positive cookie consent on startup and start sending non-cookieless events', async () => {
             const persistenceName = uuidv7()
             const { posthog: previousPosthog } = await setup(

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -3719,7 +3719,9 @@ export class PostHog implements PostHogInterface {
             this.pageViewManager?.destroy()
             this.sessionManager = undefined
             this.sessionPropsManager = undefined
-            this._captureInitialPageview()
+            if (this.config.capture_pageview) {
+                this._captureInitialPageview()
+            }
             // At init time, consent was PENDING so is_capturing() was false and _start_queue_if_opted_in() was a no-op.
             // Now that rejection has been recorded, capturing is active — enable the queue so batched events are flushed.
             this._start_queue_if_opted_in()


### PR DESCRIPTION
## Problem

`posthog.opt_out_capturing()` in `cookieless_mode: 'on_reject'` unconditionally captured an initial `$pageview` after switching into cookieless capture, even when the user configured `capture_pageview: false`.

## Changes

- Guard the cookieless opt-out initial pageview with `this.config.capture_pageview`.
- Add a regression test verifying no `$pageview` is captured on opt-out when `capture_pageview: false`.
- Add a patch changeset for `posthog-js`.

Tested:
- Verified the new regression test fails before the implementation fix.
- `pnpm --filter posthog-js exec jest src/__tests__/cookieless.test.ts --runInBand`

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
