### PR TITLE
chore(release): re-enable @posthog/mcp publish + initial release

### DIFF
--- a/.changeset/mcp-initial-release.md
+++ b/.changeset/mcp-initial-release.md
@@ -1,0 +1,5 @@
+---
+'@posthog/mcp': patch
+---
+
+First release of `@posthog/mcp` from the posthog-js monorepo. Instrument an MCP server with a single `instrument(server, posthog)` call to auto-capture tool calls, tool listings, initialize, identity, and exceptions to PostHog. BYO `posthog-node` client; `beforeSend` hook; `identify({ distinctId, properties, groups })`; `$mcp_missing_capability`; anonymous sessions sent with `$process_person_profile: false`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,6 +220,7 @@ jobs:
                     - name: '@posthog/react'
                     - name: '@posthog/ai'
                     - name: '@posthog/convex'
+                    - name: '@posthog/mcp'
                     - name: '@posthog/next'
                     - name: '@posthog/nextjs-config'
                     - name: '@posthog/nuxt'


### PR DESCRIPTION
## What
- Re-adds `@posthog/mcp` to the publish matrix in `release.yml` (removed in #3707 to mute failing releases).
- Adds an initial-release changeset so merging this triggers the first successful publish (`0.1.15` → `0.1.16`).

## Why it was failing
`@posthog/mcp` was already published `0.0.0`–`0.0.9` from the old `mcp-analytics` repo. Its npm **OIDC trusted publisher** still pointed at that repo, so publishes from posthog-js's `release.yml` were rejected. #3707 then removed it from the matrix to stop the noise, while the version-bump job kept cascading the version (dependency bumps from `@posthog/core`/`posthog-node`) up to `0.1.15` — hence repo at `0.1.15`, npm frozen at `0.0.9`.

## Prerequisite (done)
The npm trusted publisher for `@posthog/mcp` has been repointed to `PostHog/posthog-js` + `release.yml`. So the publish should now succeed.

## On merge
`release.yml` → Slack approval (`#approvals-client-libraries`) → version-bump (`0.1.16`) → publish to npm.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*