### PR TITLE
feat(browser): add strict script versioning config

### DIFF
--- a/.changeset/strict-script-versioning.md
+++ b/.changeset/strict-script-versioning.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/types': minor
+---
+
+Promote external dependency script versioning to supported `strict_script_versioning` and `asset_host` config options.

--- a/packages/browser/src/__tests__/config.test.ts
+++ b/packages/browser/src/__tests__/config.test.ts
@@ -108,4 +108,36 @@ describe('config', () => {
             })
         })
     })
+
+    describe('external dependency asset config', () => {
+        it('defaults supported script asset config options', () => {
+            const posthog = new PostHog()
+            posthog._init('test-token')
+
+            expect(posthog.config.strict_script_versioning).toBe(false)
+            expect(posthog.config.asset_host).toBeNull()
+        })
+
+        it('maps the deprecated preview string option to strict_script_versioning and asset_host', () => {
+            const posthog = new PostHog()
+            posthog._init('test-token', {
+                __preview_external_dependency_versioned_paths: 'https://cdn-preview.example.com/',
+            })
+
+            expect(posthog.config.strict_script_versioning).toBe(true)
+            expect(posthog.config.asset_host).toBe('https://cdn-preview.example.com/')
+        })
+
+        it('lets supported options take precedence over the deprecated preview option', () => {
+            const posthog = new PostHog()
+            posthog._init('test-token', {
+                strict_script_versioning: false,
+                asset_host: 'https://cdn.example.com/',
+                __preview_external_dependency_versioned_paths: 'https://cdn-preview.example.com/',
+            })
+
+            expect(posthog.config.strict_script_versioning).toBe(false)
+            expect(posthog.config.asset_host).toBe('https://cdn.example.com/')
+        })
+    })
 })

--- a/packages/browser/src/__tests__/config.test.ts
+++ b/packages/browser/src/__tests__/config.test.ts
@@ -118,6 +118,16 @@ describe('config', () => {
             expect(posthog.config.asset_host).toBeNull()
         })
 
+        it('maps the deprecated preview boolean option to strict_script_versioning', () => {
+            const posthog = new PostHog()
+            posthog._init('test-token', {
+                __preview_external_dependency_versioned_paths: true,
+            })
+
+            expect(posthog.config.strict_script_versioning).toBe(true)
+            expect(posthog.config.asset_host).toBeNull()
+        })
+
         it('maps the deprecated preview string option to strict_script_versioning and asset_host', () => {
             const posthog = new PostHog()
             posthog._init('test-token', {

--- a/packages/browser/src/__tests__/utils/external-scripts-loader.test.ts
+++ b/packages/browser/src/__tests__/utils/external-scripts-loader.test.ts
@@ -22,6 +22,8 @@ describe('external-scripts-loader', () => {
         const callback = jest.fn()
         beforeEach(() => {
             callback.mockClear()
+            mockPostHog.config.strict_script_versioning = false
+            mockPostHog.config.asset_host = null
             delete mockPostHog.config.__preview_external_dependency_versioned_paths
         })
 
@@ -98,29 +100,35 @@ describe('external-scripts-loader', () => {
 
         it.each([
             [
-                'uses versioned asset paths on the normal asset host when the preview flag is enabled as a boolean',
+                'uses versioned asset paths on the normal asset host when strict_script_versioning is enabled',
                 'https://us.posthog.com',
-                true,
+                { strict_script_versioning: true },
                 'https://us-assets.i.posthog.com/static/1.0.0/recorder.js',
             ],
             [
-                'uses a configured asset host override for versioned asset paths',
+                'uses a configured asset_host override for versioned asset paths',
                 'https://us.posthog.com',
-                'https://cdn-preview.example.com/',
+                { strict_script_versioning: true, asset_host: 'https://cdn-preview.example.com/' },
                 'https://cdn-preview.example.com/static/1.0.0/recorder.js',
             ],
             [
-                'uses the custom asset host from endpointFor when the preview flag is enabled',
+                'uses a configured asset_host override for legacy asset paths',
+                'https://us.posthog.com',
+                { asset_host: 'https://cdn-preview.example.com/' },
+                'https://cdn-preview.example.com/static/recorder.js?v=1.0.0',
+            ],
+            [
+                'uses the custom asset host from endpointFor when strict_script_versioning is enabled',
                 'https://my-proxy.example.com',
-                true,
+                { strict_script_versioning: true },
                 'https://my-proxy.example.com/static/1.0.0/recorder.js',
             ],
-        ])('%s', (_, apiHost, previewFlag, expectedSrc) => {
+        ])('%s', (_, apiHost, configOverrides, expectedSrc) => {
             const posthog = {
                 config: {
                     api_host: apiHost,
                     external_scripts_inject_target: 'body',
-                    __preview_external_dependency_versioned_paths: previewFlag,
+                    ...configOverrides,
                 },
                 version: '1.0.0',
             } as PostHog
@@ -129,6 +137,24 @@ describe('external-scripts-loader', () => {
             assignableWindow.__PosthogExtensions__.loadExternalDependency(posthog, 'recorder', callback)
 
             expect(document!.getElementsByTagName('script')[0].src).toBe(expectedSrc)
+        })
+
+        it('keeps the deprecated preview string behavior as an alias', () => {
+            const posthog = {
+                config: {
+                    api_host: 'https://us.posthog.com',
+                    external_scripts_inject_target: 'body',
+                    __preview_external_dependency_versioned_paths: 'https://cdn-preview.example.com/',
+                },
+                version: '1.0.0',
+            } as PostHog
+            posthog.requestRouter = new RequestRouter(posthog)
+
+            assignableWindow.__PosthogExtensions__.loadExternalDependency(posthog, 'recorder', callback)
+
+            expect(document!.getElementsByTagName('script')[0].src).toBe(
+                'https://cdn-preview.example.com/static/1.0.0/recorder.js'
+            )
         })
 
         it('uses eu-assets on the EU region', () => {

--- a/packages/browser/src/__tests__/utils/external-scripts-loader.test.ts
+++ b/packages/browser/src/__tests__/utils/external-scripts-loader.test.ts
@@ -139,24 +139,6 @@ describe('external-scripts-loader', () => {
             expect(document!.getElementsByTagName('script')[0].src).toBe(expectedSrc)
         })
 
-        it('keeps the deprecated preview string behavior as an alias', () => {
-            const posthog = {
-                config: {
-                    api_host: 'https://us.posthog.com',
-                    external_scripts_inject_target: 'body',
-                    __preview_external_dependency_versioned_paths: 'https://cdn-preview.example.com/',
-                },
-                version: '1.0.0',
-            } as PostHog
-            posthog.requestRouter = new RequestRouter(posthog)
-
-            assignableWindow.__PosthogExtensions__.loadExternalDependency(posthog, 'recorder', callback)
-
-            expect(document!.getElementsByTagName('script')[0].src).toBe(
-                'https://cdn-preview.example.com/static/1.0.0/recorder.js'
-            )
-        })
-
         it('uses eu-assets on the EU region', () => {
             const euPostHog = {
                 config: {

--- a/packages/browser/src/__tests__/utils/request-router.test.ts
+++ b/packages/browser/src/__tests__/utils/request-router.test.ts
@@ -147,14 +147,6 @@ describe('request-router', () => {
                 'https://us-assets.i.posthog.com/array/test-token/config.js'
             )
         })
-
-        it('keeps the deprecated preview string behavior as an asset_host alias', () => {
-            expect(
-                router('https://app.posthog.com', undefined, {
-                    __preview_external_dependency_versioned_paths: 'https://cdn-preview.example.com/',
-                }).endpointFor('assets', '/static/1.370.0/recorder.js')
-            ).toEqual('https://cdn-preview.example.com/static/1.370.0/recorder.js')
-        })
     })
 
     describe('flags_api_host configuration', () => {

--- a/packages/browser/src/__tests__/utils/request-router.test.ts
+++ b/packages/browser/src/__tests__/utils/request-router.test.ts
@@ -86,66 +86,74 @@ describe('request-router', () => {
         expect(router.endpointFor('api')).toEqual('https://eu.i.posthog.com')
     })
 
-    describe('preview versioned asset host routing', () => {
+    describe('asset_host configuration', () => {
         it.each([
             [
-                'keeps exact semver asset paths on the normal US asset host when enabled as a boolean',
+                'keeps exact semver asset paths on the normal US asset host when asset_host is not configured',
                 'https://app.posthog.com',
-                true,
+                undefined,
                 '/static/1.370.0/recorder.js',
                 'https://us-assets.i.posthog.com/static/1.370.0/recorder.js',
             ],
             [
-                'keeps exact semver asset paths on the normal EU asset host when enabled as a boolean',
+                'keeps exact semver asset paths on the normal EU asset host when asset_host is not configured',
                 'https://eu.posthog.com',
-                true,
+                undefined,
                 '/static/1.370.0/recorder.js',
                 'https://eu-assets.i.posthog.com/static/1.370.0/recorder.js',
             ],
             [
-                'accepts a string asset host override for exact semver asset paths',
+                'accepts asset_host for exact semver asset paths',
                 'https://app.posthog.com',
                 'https://cdn-preview.example.com/',
                 '/static/1.370.0/recorder.js',
                 'https://cdn-preview.example.com/static/1.370.0/recorder.js',
             ],
             [
-                'accepts a string asset host override for compatibility asset paths',
+                'accepts asset_host for compatibility asset paths',
                 'https://app.posthog.com',
                 'https://cdn-preview.example.com/',
                 '/static/recorder.js?v=1.370.0',
                 'https://cdn-preview.example.com/static/recorder.js?v=1.370.0',
             ],
             [
-                'lets a string asset host override win even when api_host is custom',
+                'lets asset_host win even when api_host is custom',
                 'https://my-proxy.example.com',
                 'https://cdn-preview.example.com',
                 '/static/1.370.0/recorder.js',
                 'https://cdn-preview.example.com/static/1.370.0/recorder.js',
             ],
             [
-                'keeps custom asset hosts unchanged when enabled as a boolean',
+                'keeps custom asset hosts unchanged when asset_host is not configured',
                 'https://my-proxy.example.com',
-                true,
+                undefined,
                 '/static/1.370.0/recorder.js',
                 'https://my-proxy.example.com/static/1.370.0/recorder.js',
             ],
-        ])('%s', (_, apiHost, override, path, expected) => {
+        ])('%s', (_, apiHost, assetHost, path, expected) => {
             expect(
                 router(apiHost, undefined, {
-                    __preview_external_dependency_versioned_paths: override,
+                    asset_host: assetHost,
                 }).endpointFor('assets', path)
             ).toEqual(expected)
         })
 
-        it('keeps non-static asset paths on the normal asset host even when a preview override is configured', () => {
-            const previewRouter = router('https://app.posthog.com', undefined, {
-                __preview_external_dependency_versioned_paths: 'https://cdn-preview.example.com/',
+        it('keeps non-static asset paths on the normal asset host even when asset_host is configured', () => {
+            const assetHostRouter = router('https://app.posthog.com', undefined, {
+                asset_host: 'https://cdn-preview.example.com/',
             })
 
-            expect(previewRouter.endpointFor('assets', '/array/test-token/config.js')).toEqual(
+            expect(assetHostRouter.endpointFor('assets', '/array/test-token/config.js')).toEqual(
                 'https://us-assets.i.posthog.com/array/test-token/config.js'
             )
+        })
+
+        it('keeps the deprecated preview string behavior as an asset_host alias', () => {
+            expect(
+                router('https://app.posthog.com', undefined, {
+                    __preview_external_dependency_versioned_paths: 'https://cdn-preview.example.com/',
+                }).endpointFor('assets', '/static/1.370.0/recorder.js')
+            ).toEqual('https://cdn-preview.example.com/static/1.370.0/recorder.js')
         })
     })
 

--- a/packages/browser/src/entrypoints/external-scripts-loader.ts
+++ b/packages/browser/src/entrypoints/external-scripts-loader.ts
@@ -1,4 +1,3 @@
-import { isBoolean } from '@posthog/core'
 import type { PostHog } from '../posthog-core'
 import { assignableWindow, document, PostHogExtensionKind } from '../utils/globals'
 import { createLogger } from '../utils/logger'
@@ -100,11 +99,7 @@ assignableWindow.__PosthogExtensions__.loadExternalDependency = (
 
     let url: string
 
-    const strictScriptVersioning = isBoolean(posthog.config.strict_script_versioning)
-        ? posthog.config.strict_script_versioning
-        : !!posthog.config.__preview_external_dependency_versioned_paths
-
-    if (strictScriptVersioning) {
+    if (posthog.config.strict_script_versioning) {
         // posthog.version is baked into the executing array.js bundle, so this points at
         // the exact semver-qualified sibling asset without relying on alias redirects.
         url = posthog.requestRouter.endpointFor('assets', `/static/${posthog.version}/${kind}.js`)

--- a/packages/browser/src/entrypoints/external-scripts-loader.ts
+++ b/packages/browser/src/entrypoints/external-scripts-loader.ts
@@ -99,7 +99,12 @@ assignableWindow.__PosthogExtensions__.loadExternalDependency = (
 
     let url: string
 
-    if (posthog.config.__preview_external_dependency_versioned_paths) {
+    const strictScriptVersioning =
+        typeof posthog.config.strict_script_versioning === 'boolean'
+            ? posthog.config.strict_script_versioning
+            : !!posthog.config.__preview_external_dependency_versioned_paths
+
+    if (strictScriptVersioning) {
         // posthog.version is baked into the executing array.js bundle, so this points at
         // the exact semver-qualified sibling asset without relying on alias redirects.
         url = posthog.requestRouter.endpointFor('assets', `/static/${posthog.version}/${kind}.js`)

--- a/packages/browser/src/entrypoints/external-scripts-loader.ts
+++ b/packages/browser/src/entrypoints/external-scripts-loader.ts
@@ -1,3 +1,4 @@
+import { isBoolean } from '@posthog/core'
 import type { PostHog } from '../posthog-core'
 import { assignableWindow, document, PostHogExtensionKind } from '../utils/globals'
 import { createLogger } from '../utils/logger'
@@ -99,10 +100,9 @@ assignableWindow.__PosthogExtensions__.loadExternalDependency = (
 
     let url: string
 
-    const strictScriptVersioning =
-        typeof posthog.config.strict_script_versioning === 'boolean'
-            ? posthog.config.strict_script_versioning
-            : !!posthog.config.__preview_external_dependency_versioned_paths
+    const strictScriptVersioning = isBoolean(posthog.config.strict_script_versioning)
+        ? posthog.config.strict_script_versioning
+        : !!posthog.config.__preview_external_dependency_versioned_paths
 
     if (strictScriptVersioning) {
         // posthog.version is baked into the executing array.js bundle, so this points at

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -213,6 +213,7 @@ export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     api_host: 'https://us.i.posthog.com',
     flags_api_host: null,
     ui_host: null,
+    asset_host: null,
     token: '',
     autocapture: true,
     cross_subdomain_cookie: isCrossDomainCookie(document?.location),
@@ -240,6 +241,7 @@ export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     disable_conversations: false,
     disable_product_tours: false,
     disable_external_dependency_loading: false,
+    strict_script_versioning: false,
     enable_recording_console_log: undefined, // When undefined, it falls back to the server-side setting
     secure_cookie: window?.location?.protocol === 'https:',
     ip: false,
@@ -314,6 +316,18 @@ export const configRenames = (origConfig: Partial<PostHogConfig>): Partial<PostH
 
     // the original config takes priority over the renames
     const newConfig = extend({}, renames, origConfig)
+
+    // Maintain backwards compatibility for the deprecated preview option while
+    // letting the supported options take precedence when they are provided.
+    const previewExternalDependencyVersionedPaths = origConfig.__preview_external_dependency_versioned_paths
+    if (!isUndefined(previewExternalDependencyVersionedPaths)) {
+        if (isUndefined(origConfig.strict_script_versioning)) {
+            newConfig.strict_script_versioning = !!previewExternalDependencyVersionedPaths
+        }
+        if (isString(previewExternalDependencyVersionedPaths) && isUndefined(origConfig.asset_host)) {
+            newConfig.asset_host = previewExternalDependencyVersionedPaths
+        }
+    }
 
     // merge property_blacklist into property_denylist
     if (isArray(origConfig.property_blacklist)) {

--- a/packages/browser/src/utils/request-router.ts
+++ b/packages/browser/src/utils/request-router.ts
@@ -1,3 +1,4 @@
+import { isUndefined } from '@posthog/core'
 import { PostHog } from '../posthog-core'
 
 /**
@@ -79,10 +80,7 @@ export class RequestRouter {
         }
 
         const legacyOverride = this.instance.config.__preview_external_dependency_versioned_paths
-        const override =
-            this.instance.config.asset_host === undefined && typeof legacyOverride === 'string'
-                ? legacyOverride
-                : this.instance.config.asset_host
+        const override = isUndefined(this.instance.config.asset_host) ? legacyOverride : this.instance.config.asset_host
         if (typeof override !== 'string') {
             return undefined
         }

--- a/packages/browser/src/utils/request-router.ts
+++ b/packages/browser/src/utils/request-router.ts
@@ -1,4 +1,3 @@
-import { isUndefined } from '@posthog/core'
 import { PostHog } from '../posthog-core'
 
 /**
@@ -79,8 +78,7 @@ export class RequestRouter {
             return undefined
         }
 
-        const legacyOverride = this.instance.config.__preview_external_dependency_versioned_paths
-        const override = isUndefined(this.instance.config.asset_host) ? legacyOverride : this.instance.config.asset_host
+        const override = this.instance.config.asset_host
         if (typeof override !== 'string') {
             return undefined
         }

--- a/packages/browser/src/utils/request-router.ts
+++ b/packages/browser/src/utils/request-router.ts
@@ -74,8 +74,16 @@ export class RequestRouter {
     }
 
     private _staticAssetHostOverride(path: string): string | undefined {
-        const override = this.instance.config.__preview_external_dependency_versioned_paths
-        if (typeof override !== 'string' || !staticAssetPath.test(path)) {
+        if (!staticAssetPath.test(path)) {
+            return undefined
+        }
+
+        const legacyOverride = this.instance.config.__preview_external_dependency_versioned_paths
+        const override =
+            this.instance.config.asset_host === undefined && typeof legacyOverride === 'string'
+                ? legacyOverride
+                : this.instance.config.asset_host
+        if (typeof override !== 'string') {
             return undefined
         }
 

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -258,6 +258,14 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "false",
     "true"
   ],
+  "strict_script_versioning": [
+    "false",
+    "true"
+  ],
+  "asset_host": [
+    "null",
+    "string"
+  ],
   "prepare_external_dependency_script": [
     "undefined",
     "(script: HTMLScriptElement) => HTMLScriptElement | null"

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1027,6 +1027,25 @@ export interface PostHogConfig {
     disable_external_dependency_loading: boolean
 
     /**
+     * Determines whether PostHog should load external dependency scripts from
+     * semver-qualified asset paths such as /static/1.370.0/recorder.js instead
+     * of the legacy /static/recorder.js?v=1.370.0 form.
+     *
+     * @default false
+     */
+    strict_script_versioning: boolean
+
+    /**
+     * Optional host override for static assets loaded by PostHog, such as
+     * recorder.js, surveys.js, or toolbar.js. Only applies to /static/* asset
+     * paths; dynamic assets like remote config continue to use the regular
+     * asset host derived from api_host.
+     *
+     * @default null
+     */
+    asset_host: string | null
+
+    /**
      * A function to be called when a script is being loaded.
      * This can be used to modify the script before it is loaded.
      * This is useful for adding a nonce to the script, for example.
@@ -1728,13 +1747,10 @@ export interface PostHogConfig {
     __preview_disable_xhr_credentials?: boolean
 
     /**
-     * PREVIEW - MAY CHANGE WITHOUT WARNING - DO NOT USE IN PRODUCTION
-     * Loads external dependency bundles (for example recorder.js and toolbar.js) from
-     * semver-qualified asset paths such as /static/1.370.0/recorder.js instead of the
-     * legacy /static/recorder.js?v=1.370.0 form.
-     *
-     * When set to a string, that string is treated as an asset host override for any
-     * /static/* asset path while leaving non-static asset paths unchanged.
+     * @deprecated Use {@link strict_script_versioning} and {@link asset_host} instead.
+     * When set to true, this is equivalent to strict_script_versioning: true.
+     * When set to a string, this is equivalent to strict_script_versioning: true
+     * and asset_host set to that string.
      */
     __preview_external_dependency_versioned_paths?: boolean | string
 


### PR DESCRIPTION
## Problem

`__preview_external_dependency_versioned_paths` should be promoted to a supported configuration option, though, it's carrying two behaviors: enabling version-qualified external dependency paths and optionally overriding the static asset host. We need supported, stable config options for both behaviors.

## Changes

- Adds supported `strict_script_versioning: boolean` config to load external dependencies from `/static/{version}/{kind}.js`.
- Adds supported `asset_host: string | null` config to override `/static/*` asset hosts independently.
- Keeps `__preview_external_dependency_versioned_paths` as a deprecated compatibility alias.
- Updates routing/loading tests and the config type snapshot.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

Tests run:

- `pnpm --filter=@posthog/types test:unit`
- `pnpm --filter=posthog-js exec jest src/__tests__/utils/external-scripts-loader.test.ts src/__tests__/utils/request-router.test.ts src/__tests__/config.test.ts`
- `pnpm --filter=posthog-js typecheck`
