### PR TITLE
feat: detect Google Search App as its own browser

### DIFF
--- a/.changeset/detect-google-search-app.md
+++ b/.changeset/detect-google-search-app.md
@@ -5,3 +5,5 @@
 ---
 
 Detect the Google Search App (GSA) as its own `$browser` value (`Google Search App`) via the cross-platform `GSA/` UA marker, instead of reporting the embedded webview as Mobile Safari (iOS) or Chrome (Android). Gated behind the new `detect_google_search_app` config option, which the `2026-05-30` config defaults opt into automatically — left off otherwise to keep existing browser attribution backwards-compatible.
+
+Note: `$browser_version` for `Google Search App` is not comparable across platforms — iOS yields a version like `284.0` (from `GSA/284.0.564099828`) while Android yields a version like `14.21` (from `GSA/14.21.20.28.arm64`), since Google maintains separate versioning schemes for the two apps. Avoid building cross-platform version dashboards on `$browser_version` for this browser.

--- a/.changeset/detect-google-search-app.md
+++ b/.changeset/detect-google-search-app.md
@@ -1,0 +1,7 @@
+---
+'posthog-js': minor
+'@posthog/core': minor
+'@posthog/types': minor
+---
+
+Detect the Google Search App (GSA) as its own `$browser` value (`Google Search App`) via the cross-platform `GSA/` UA marker, instead of reporting the embedded webview as Mobile Safari (iOS) or Chrome (Android). Gated behind the new `detect_google_search_app` config option, which the `2026-05-30` config defaults opt into automatically — left off otherwise to keep existing browser attribution backwards-compatible.

--- a/packages/browser/src/__tests__/config.test.ts
+++ b/packages/browser/src/__tests__/config.test.ts
@@ -85,6 +85,18 @@ describe('config', () => {
             expect(posthog.config.split_storage).toBe(expected)
         })
 
+        it.each([
+            ['unset', undefined, false],
+            ['2025-05-24', '2025-05-24' as const, false],
+            ['2025-11-30', '2025-11-30' as const, false],
+            ['2026-01-30', '2026-01-30' as const, false],
+            ['2026-05-30', '2026-05-30' as const, true],
+        ])('detect_google_search_app with defaults %s', (_label, defaults, expected) => {
+            const posthog = new PostHog()
+            posthog._init('test-token', defaults ? { defaults } : undefined)
+            expect(posthog.config.detect_google_search_app).toBe(expected)
+        })
+
         it('should preserve other default config values when setting defaults', () => {
             const posthog1 = new PostHog()
             posthog1._init('test-token')

--- a/packages/browser/src/__tests__/utils/user-agent-utils.test.ts
+++ b/packages/browser/src/__tests__/utils/user-agent-utils.test.ts
@@ -416,6 +416,51 @@ describe('user-agent-utils', () => {
             })
         })
 
+        describe('detectBrowser Google Search App (GSA)', () => {
+            // GSA embeds a platform webview, so its UA otherwise looks like Mobile
+            // Safari on iOS and Chrome on Android. The `GSA/` marker is the only
+            // cross-platform signal — see the example event linked from PostHog/posthog-js.
+            const gsaIosUA =
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/284.0.564099828 Mobile/15E148 Safari/604.1'
+            const gsaAndroidUA =
+                'Mozilla/5.0 (Linux; Android 13; SM-S908B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36 GSA/14.21.20.28.arm64'
+            const chromeMacOsUA =
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+
+            it('is off by default — iOS GSA is reported as Mobile Safari', () => {
+                expect(detectBrowser(gsaIosUA, 'Apple Computer, Inc.')).toBe('Mobile Safari')
+            })
+
+            it('is off by default — Android GSA is reported as Chrome', () => {
+                expect(detectBrowser(gsaAndroidUA, 'Google Inc.')).toBe('Chrome')
+            })
+
+            it('detects iOS GSA when opted in', () => {
+                expect(detectBrowser(gsaIosUA, 'Apple Computer, Inc.', {}, { detectGoogleSearchApp: true })).toBe(
+                    'Google Search App'
+                )
+            })
+
+            it('detects Android GSA when opted in', () => {
+                expect(detectBrowser(gsaAndroidUA, 'Google Inc.', {}, { detectGoogleSearchApp: true })).toBe(
+                    'Google Search App'
+                )
+            })
+
+            it('reads the GSA version from the UA marker when opted in', () => {
+                expect(
+                    detectBrowserVersion(gsaIosUA, 'Apple Computer, Inc.', {}, { detectGoogleSearchApp: true })
+                ).toBe(284.0)
+                expect(detectBrowserVersion(gsaAndroidUA, 'Google Inc.', {}, { detectGoogleSearchApp: true })).toBe(
+                    14.21
+                )
+            })
+
+            it('does not affect non-GSA traffic when opted in', () => {
+                expect(detectBrowser(chromeMacOsUA, 'Google Inc.', {}, { detectGoogleSearchApp: true })).toBe('Chrome')
+            })
+        })
+
         describe('detectDeviceType with options', () => {
             const desktopUA =
                 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36'

--- a/packages/browser/src/__tests__/utils/user-agent-utils.test.ts
+++ b/packages/browser/src/__tests__/utils/user-agent-utils.test.ts
@@ -427,38 +427,68 @@ describe('user-agent-utils', () => {
             const chromeMacOsUA =
                 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
 
-            it('is off by default — iOS GSA is reported as Mobile Safari', () => {
-                expect(detectBrowser(gsaIosUA, 'Apple Computer, Inc.')).toBe('Mobile Safari')
+            const browserCases: {
+                name: string
+                userAgent: string
+                vendor: string
+                options?: { detectGoogleSearchApp?: boolean }
+                expectedBrowser: string
+            }[] = [
+                // off by default — GSA falls through to the webview it embeds
+                {
+                    name: 'off by default, iOS GSA reads as Mobile Safari',
+                    userAgent: gsaIosUA,
+                    vendor: 'Apple Computer, Inc.',
+                    expectedBrowser: 'Mobile Safari',
+                },
+                {
+                    name: 'off by default, Android GSA reads as Chrome',
+                    userAgent: gsaAndroidUA,
+                    vendor: 'Google Inc.',
+                    expectedBrowser: 'Chrome',
+                },
+                // opted in — GSA surfaces as its own browser on both platforms
+                {
+                    name: 'opted in, detects iOS GSA',
+                    userAgent: gsaIosUA,
+                    vendor: 'Apple Computer, Inc.',
+                    options: { detectGoogleSearchApp: true },
+                    expectedBrowser: 'Google Search App',
+                },
+                {
+                    name: 'opted in, detects Android GSA',
+                    userAgent: gsaAndroidUA,
+                    vendor: 'Google Inc.',
+                    options: { detectGoogleSearchApp: true },
+                    expectedBrowser: 'Google Search App',
+                },
+                // opted in — non-GSA traffic is untouched
+                {
+                    name: 'opted in, leaves non-GSA traffic untouched',
+                    userAgent: chromeMacOsUA,
+                    vendor: 'Google Inc.',
+                    options: { detectGoogleSearchApp: true },
+                    expectedBrowser: 'Chrome',
+                },
+            ]
+
+            it.each(browserCases)('detectBrowser: $name', ({ userAgent, vendor, options, expectedBrowser }) => {
+                expect(detectBrowser(userAgent, vendor, {}, options)).toBe(expectedBrowser)
             })
 
-            it('is off by default — Android GSA is reported as Chrome', () => {
-                expect(detectBrowser(gsaAndroidUA, 'Google Inc.')).toBe('Chrome')
-            })
+            const versionCases: { platform: string; userAgent: string; vendor: string; expectedVersion: number }[] = [
+                { platform: 'iOS', userAgent: gsaIosUA, vendor: 'Apple Computer, Inc.', expectedVersion: 284.0 },
+                { platform: 'Android', userAgent: gsaAndroidUA, vendor: 'Google Inc.', expectedVersion: 14.21 },
+            ]
 
-            it('detects iOS GSA when opted in', () => {
-                expect(detectBrowser(gsaIosUA, 'Apple Computer, Inc.', {}, { detectGoogleSearchApp: true })).toBe(
-                    'Google Search App'
-                )
-            })
-
-            it('detects Android GSA when opted in', () => {
-                expect(detectBrowser(gsaAndroidUA, 'Google Inc.', {}, { detectGoogleSearchApp: true })).toBe(
-                    'Google Search App'
-                )
-            })
-
-            it('reads the GSA version from the UA marker when opted in', () => {
-                expect(
-                    detectBrowserVersion(gsaIosUA, 'Apple Computer, Inc.', {}, { detectGoogleSearchApp: true })
-                ).toBe(284.0)
-                expect(detectBrowserVersion(gsaAndroidUA, 'Google Inc.', {}, { detectGoogleSearchApp: true })).toBe(
-                    14.21
-                )
-            })
-
-            it('does not affect non-GSA traffic when opted in', () => {
-                expect(detectBrowser(chromeMacOsUA, 'Google Inc.', {}, { detectGoogleSearchApp: true })).toBe('Chrome')
-            })
+            it.each(versionCases)(
+                'detectBrowserVersion: reads the GSA version from the $platform UA marker when opted in',
+                ({ userAgent, vendor, expectedVersion }) => {
+                    expect(detectBrowserVersion(userAgent, vendor, {}, { detectGoogleSearchApp: true })).toBe(
+                        expectedVersion
+                    )
+                }
+            )
         })
 
         describe('detectDeviceType with options', () => {

--- a/packages/browser/src/customizations/setAllPersonProfilePropertiesAsPersonPropertiesForFlags.ts
+++ b/packages/browser/src/customizations/setAllPersonProfilePropertiesAsPersonPropertiesForFlags.ts
@@ -14,7 +14,8 @@ export const setAllPersonProfilePropertiesAsPersonPropertiesForFlags = (posthog:
         {},
         getEventProperties(
             posthog.config.mask_personal_data_properties,
-            posthog.config.custom_personal_data_properties
+            posthog.config.custom_personal_data_properties,
+            posthog.config.detect_google_search_app
         ),
         getCampaignParams(
             posthog.config.custom_campaign_params,

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -191,6 +191,7 @@ const defaultsThatVaryByConfig = (
     | 'internal_or_test_user_hostname'
     | 'persistence_save_debounce_ms'
     | 'split_storage'
+    | 'detect_google_search_app'
 > => ({
     rageclick:
         defaults && defaults >= '2026-05-30'
@@ -204,6 +205,7 @@ const defaultsThatVaryByConfig = (
     internal_or_test_user_hostname: defaults && defaults >= '2026-01-30' ? /^(localhost|127\.0\.0\.1)$/ : undefined,
     persistence_save_debounce_ms: defaults && defaults >= '2026-05-30' ? 250 : 0,
     split_storage: !!(defaults && defaults >= '2026-05-30'),
+    detect_google_search_app: !!(defaults && defaults >= '2026-05-30'),
 })
 
 // NOTE: Remember to update `types.ts` when changing a default value
@@ -1453,7 +1455,8 @@ export class PostHog implements PostHogInterface {
 
         const infoProperties = getEventProperties(
             this.config.mask_personal_data_properties,
-            this.config.custom_personal_data_properties
+            this.config.custom_personal_data_properties,
+            this.config.detect_google_search_app
         )
 
         if (this.sessionManager) {

--- a/packages/browser/src/utils/event-utils.ts
+++ b/packages/browser/src/utils/event-utils.ts
@@ -280,7 +280,8 @@ export function getBrowserDetectionHints(): BrowserDetectionHints {
 
 export function getEventProperties(
     maskPersonalDataProperties?: boolean,
-    customPersonalDataProperties?: string[]
+    customPersonalDataProperties?: string[],
+    detectGoogleSearchApp?: boolean
 ): Properties {
     if (!userAgent) {
         return {}
@@ -290,12 +291,13 @@ export function getEventProperties(
         : []
     const [os_name, os_version] = detectOS(userAgent)
     const browserHints = getBrowserDetectionHints()
+    const browserOptions = { detectGoogleSearchApp }
 
     const properties = extend(
         stripEmptyProperties({
             $os: os_name,
             $os_version: os_version,
-            $browser: detectBrowser(userAgent, navigator.vendor, browserHints),
+            $browser: detectBrowser(userAgent, navigator.vendor, browserHints, browserOptions),
             $device: detectDevice(userAgent),
             $device_type: detectDeviceType(userAgent, {
                 // eslint-disable-next-line compat/compat
@@ -313,7 +315,7 @@ export function getEventProperties(
             $host: location?.host,
             $pathname: location?.pathname,
             $raw_user_agent: userAgent.length > 1000 ? userAgent.substring(0, 997) + '...' : userAgent,
-            $browser_version: detectBrowserVersion(userAgent, navigator.vendor, browserHints),
+            $browser_version: detectBrowserVersion(userAgent, navigator.vendor, browserHints, browserOptions),
             $browser_language: getBrowserLanguage(),
             $browser_language_prefix: getBrowserLanguagePrefix(),
             $screen_height: window?.screen.height,

--- a/packages/core/src/utils/user-agent-utils.ts
+++ b/packages/core/src/utils/user-agent-utils.ts
@@ -57,6 +57,7 @@ const DUCKDUCKGO = 'DuckDuckGo'
 const PALE_MOON = 'Pale Moon'
 const WATERFOX = 'Waterfox'
 const BRAVE = 'Brave'
+const GOOGLE_SEARCH_APP = 'Google Search App'
 
 const BROWSER_VERSION_REGEX_SUFFIX = '(\\d+(\\.\\d+)?)'
 const DEFAULT_BROWSER_VERSION_REGEX = new RegExp('Version/' + BROWSER_VERSION_REGEX_SUFFIX)
@@ -78,6 +79,18 @@ function browserFromHints(hints: BrowserDetectionHints | undefined): string | nu
     return BRAVE
   }
   return null
+}
+
+/**
+ * Opt-in tweaks to UA-string detection. These change how existing traffic is
+ * attributed, so the host SDK gates them (behind its `2026-05-30` config
+ * defaults) rather than enabling them unconditionally — turning one on
+ * reattributes browsers that were previously reported as something else.
+ */
+export interface BrowserDetectionOptions {
+  // Surface the Google Search App as its own browser via its `GSA/` UA marker
+  // instead of the underlying webview (Mobile Safari on iOS, Chrome on Android).
+  detectGoogleSearchApp?: boolean
 }
 
 const XBOX_REGEX = new RegExp(XBOX, 'i')
@@ -119,11 +132,14 @@ const safariCheck = (ua: string, vendor?: string) => (vendor && includes(vendor,
  * detect browsers that intentionally do not identify themselves in the UA
  * string. When omitted, only UA-string detection runs — preserving the previous
  * behaviour.
+ *
+ * `options` toggles opt-in UA-detection tweaks (see `BrowserDetectionOptions`).
  */
 export const detectBrowser = function (
   user_agent: string,
   vendor: string | undefined,
-  hints?: BrowserDetectionHints
+  hints?: BrowserDetectionHints,
+  options?: BrowserDetectionOptions
 ): string {
   vendor = vendor || '' // vendor is undefined for at least IE9
 
@@ -133,6 +149,14 @@ export const detectBrowser = function (
   const fromHints = browserFromHints(hints)
   if (fromHints) {
     return fromHints
+  }
+
+  // The Google Search App embeds a platform webview, so its UA otherwise looks
+  // like Mobile Safari (iOS) or Chrome (Android). The `GSA/` marker is present
+  // on every platform, so checking it first lets us attribute GSA consistently
+  // — it must precede the Chrome and Safari branches that would match instead.
+  if (options?.detectGoogleSearchApp && includes(user_agent, 'GSA/')) {
+    return GOOGLE_SEARCH_APP
   }
 
   if (includes(user_agent, ' OPR/') && includes(user_agent, 'Mini')) {
@@ -237,6 +261,7 @@ const versionRegexes: Record<string, RegExp[]> = {
   [DUCKDUCKGO]: [new RegExp('(DuckDuckGo|Ddg)\\/' + BROWSER_VERSION_REGEX_SUFFIX)],
   [PALE_MOON]: [new RegExp('PaleMoon\\/' + BROWSER_VERSION_REGEX_SUFFIX)],
   [WATERFOX]: [new RegExp(WATERFOX + '\\/' + BROWSER_VERSION_REGEX_SUFFIX)],
+  [GOOGLE_SEARCH_APP]: [new RegExp('GSA\\/' + BROWSER_VERSION_REGEX_SUFFIX)],
   [INTERNET_EXPLORER]: [new RegExp('(rv:|MSIE )' + BROWSER_VERSION_REGEX_SUFFIX)],
   Mozilla: [new RegExp('rv:' + BROWSER_VERSION_REGEX_SUFFIX)],
 }
@@ -252,9 +277,10 @@ const versionRegexes: Record<string, RegExp[]> = {
 export const detectBrowserVersion = function (
   userAgent: string,
   vendor: string | undefined,
-  hints?: BrowserDetectionHints
+  hints?: BrowserDetectionHints,
+  options?: BrowserDetectionOptions
 ): number | null {
-  const browser = detectBrowser(userAgent, vendor, hints)
+  const browser = detectBrowser(userAgent, vendor, hints, options)
 
   // Desktop / Android Brave has no parseable UA version, so it returns null
   // below: its `versionRegexes` entry only matches the iOS `Brave/` marker

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -169,6 +169,11 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "false",
     "true"
   ],
+  "detect_google_search_app": [
+    "undefined",
+    "false",
+    "true"
+  ],
   "disable_surveys": [
     "false",
     "true"

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -944,6 +944,20 @@ export interface PostHogConfig {
     split_storage?: boolean
 
     /**
+     * Detect the Google Search App (GSA) as its own `$browser` value instead of
+     * the underlying webview it embeds — Mobile Safari on iOS, Chrome on Android.
+     * Detection keys off the `GSA/` marker present in the UA on every platform.
+     *
+     * Off by default for backwards-compatibility: enabling it reattributes
+     * existing GSA traffic away from Mobile Safari / Chrome, which would
+     * otherwise look like those browsers suddenly losing share. The `2026-05-30`
+     * config default opts in.
+     *
+     * @default false
+     */
+    detect_google_search_app?: boolean
+
+    /**
      * Determines whether PostHog should disable all surveys functionality.
      *
      * @default false


### PR DESCRIPTION
## Problem

A customer exploring their browser breakdowns saw all their Google Search App (GSA) users attributed as **Mobile Safari**. GSA embeds a platform webview, so its UA otherwise looks like Mobile Safari on iOS and Chrome on Android, and there was previously no first-class way to isolate that traffic — `$raw_user_agent` matching on `GSA/` was the only option.

**Why:** the customer wanted to consolidate and identify Google Search App traffic across platforms rather than have it hidden inside Mobile Safari / Chrome.

## Changes

- Detect the Google Search App via the cross-platform `GSA/` UA marker and report it as the `Google Search App` `$browser` value (with a parsed `$browser_version` from the `GSA/<version>` marker).
- Gated behind a new `detect_google_search_app` config option. The `2026-05-30` config defaults opt in automatically; otherwise it stays off so existing browser attribution doesn't silently shift (folks would otherwise see Mobile Safari / Chrome share drop without explanation).

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACMS2BNTU/p1781034868118329?thread_ts=1781034868.118329&cid=C0ACMS2BNTU)*
