### PR TITLE
chore(react-native-plugin): revert failed 2.0.0 release

### DIFF
--- a/.changeset/posthog-react-native-plugin-initial-release.md
+++ b/.changeset/posthog-react-native-plugin-initial-release.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react-native-plugin': major
+---
+
+First release under the new name `@posthog/react-native-plugin`, picking up from `posthog-react-native-session-replay@1.6.0`. Alongside the existing session replay support, the plugin now enables native error tracking — iOS and Android crash autocapture via the underlying PostHog mobile SDKs. It will be consumed by future versions of `posthog-react-native`.

--- a/packages/react-native-plugin/CHANGELOG.md
+++ b/packages/react-native-plugin/CHANGELOG.md
@@ -1,8 +1,1 @@
 # @posthog/react-native-plugin
-
-## 2.0.0
-
-### Major Changes
-
-- [#3779](https://github.com/PostHog/posthog-js/pull/3779) [`bdd6ec5`](https://github.com/PostHog/posthog-js/commit/bdd6ec59efb3a30e30743583d059c28c5593d0ba) Thanks [@ioannisj](https://github.com/ioannisj)! - First release under the new name `@posthog/react-native-plugin`, picking up from `posthog-react-native-session-replay@1.6.0`. Alongside the existing session replay support, the plugin now enables native error tracking — iOS and Android crash autocapture via the underlying PostHog mobile SDKs. It will be consumed by future versions of `posthog-react-native`.
-  (2026-06-09)

--- a/packages/react-native-plugin/package.json
+++ b/packages/react-native-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posthog/react-native-plugin",
-  "version": "2.0.0",
+  "version": "1.6.0",
   "description": "PostHog React Native plugin for iOS and Android integrations",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
## Problem

The `@posthog/react-native-plugin@2.0.0` release failed to publish, leaving `main` version-bumped (`13fc20cc`: `2.0.0`, changeset consumed) with nothing on npm:

- **First attempt:** `404` from npm — trusted publishing was misconfigured (since fixed).
- **Re-running the same commit:** Sigstore `409` (`TLOG_CREATE_ENTRY_ERROR`) — the first attempt had already written a provenance entry to the transparency log, so re-publishing the identical `2.0.0` build from the same commit is rejected as a duplicate.

A clean publish needs a fresh build commit.

## Changes

Revert the failed version-bump `13fc20cc` — restores the changeset, drops `package.json` back to `1.6.0`, and removes the premature `2.0.0` CHANGELOG entry.

On merge, the restored changeset re-triggers the release, which version-bumps `1.6.0 → 2.0.0` **from a new commit** → fresh provenance → publishes `@posthog/react-native-plugin@2.0.0` (trusted publishing is now correctly configured).

Reverts `13fc20cc`. Follows up #3779.

## Release info

### Libraries affected

- [x] @posthog/react-native-plugin

## Checklist

- [x] Changeset restored (`@posthog/react-native-plugin`, major)
