### PR TITLE
fix(replay): don't apply late-added past events onto the current DOM

### DIFF
--- a/.changeset/replayer-late-addevent-corruption.md
+++ b/.changeset/replayer-late-addevent-corruption.md
@@ -1,0 +1,6 @@
+---
+'@posthog/rrweb': patch
+'posthog-js': patch
+---
+
+replayer: stop corrupting recordings when events are added behind the playhead. `addEvent()` used to apply any event older than the playback baseline synchronously onto the current DOM — correct for live-mode catch-up, but wrong for on-demand playback where snapshot chunks can finish loading after the user has seeked ahead. Applying those past mutations onto a DOM at a different position made their `removes` fail mirror lookups, and `applyMutation` then deleted the failed entries from the event objects themselves, so every later seek rebuilt from corrupted data (DOM nodes accumulating, e.g. duplicated text) and exports serialized the stripped events. Past events are now only applied synchronously in live mode (otherwise they are just inserted for the next seek to pick up), and `applyMutation` filters removes into a local copy instead of mutating the event data.

--- a/packages/rrweb/rrweb/src/replay/index.ts
+++ b/packages/rrweb/rrweb/src/replay/index.ts
@@ -659,7 +659,13 @@ export class Replayer {
       this.mouse.classList.add('touch-device');
     }
     void Promise.resolve().then(() =>
-      this.service.send({ type: 'ADD_EVENT', payload: { event } }),
+      this.service.send({
+        type: 'ADD_EVENT',
+        payload: {
+          event,
+          applyPastEventSynchronously: this.config.liveMode,
+        },
+      }),
     );
   }
 
@@ -1505,7 +1511,10 @@ export class Replayer {
     const mirror = this.usingVirtualDom ? this.virtualDom.mirror : this.mirror;
     type TNode = typeof mirror extends Mirror ? Node : RRNode;
 
-    d.removes = d.removes.filter((mutation) => {
+    // filter into a local copy — never mutate the event data itself, as the
+    // caller's events array must stay intact for later seeks (a rebuild from
+    // an event whose removes were dropped renders accumulated stale nodes)
+    const validRemoves = d.removes.filter((mutation) => {
       // warn of absence from mirror before we start applying each removal
       // as earlier removals could remove a tree that includes a later removal
       if (!mirror.getNode(mutation.id)) {
@@ -1514,7 +1523,7 @@ export class Replayer {
       }
       return true;
     });
-    d.removes.forEach((mutation) => {
+    validRemoves.forEach((mutation) => {
       const target = mirror.getNode(mutation.id);
       if (!target) {
         // no need to warn here, an ancestor may have already been removed

--- a/packages/rrweb/rrweb/src/replay/machine.ts
+++ b/packages/rrweb/rrweb/src/replay/machine.ts
@@ -40,6 +40,14 @@ export type PlayerEvent =
       type: 'ADD_EVENT';
       payload: {
         event: eventWithTime;
+        /**
+         * Whether an event whose timestamp is before the current baseline
+         * may be applied synchronously onto the current DOM. Only safe in
+         * live mode (catch-up on a DOM that is at the stream's tail); in
+         * on-demand playback the current DOM is at an arbitrary position,
+         * so applying a past event there corrupts the rendered state.
+         */
+        applyPastEventSynchronously?: boolean;
       };
     }
   | {
@@ -263,10 +271,15 @@ export function createPlayerService(
             }
 
             const isSync = event.timestamp < baselineTime;
-            const castFn = getCastFn(event, isSync);
             if (isSync) {
-              castFn();
+              // a past event can only be applied onto the current DOM in
+              // live mode; otherwise just insert it — the next seek/play
+              // rebuild will pick it up from the events array
+              if (machineEvent.payload.applyPastEventSynchronously) {
+                getCastFn(event, true)();
+              }
             } else if (timer.isActive()) {
+              const castFn = getCastFn(event, false);
               timer.addAction({
                 doAction: () => {
                   castFn();

--- a/packages/rrweb/rrweb/test/machine.test.ts
+++ b/packages/rrweb/rrweb/test/machine.test.ts
@@ -86,17 +86,26 @@ describe('addEvent', () => {
     return { service, getCastFn };
   };
 
-  it('does not apply a past event onto the current DOM by default', () => {
-    // a chunk loading after the user seeked ahead must not be cast onto a
-    // DOM that is at a different position
-    const { service, getCastFn } = createService();
-    const event = makeMutationEvent(BASELINE - 5000);
+  it.each([
+    { label: 'absent', applyPastEventSynchronously: undefined },
+    { label: 'false', applyPastEventSynchronously: false },
+  ])(
+    'does not apply a past event onto the current DOM when applyPastEventSynchronously is $label',
+    ({ applyPastEventSynchronously }) => {
+      // a chunk loading after the user seeked ahead must not be cast onto a
+      // DOM that is at a different position
+      const { service, getCastFn } = createService();
+      const event = makeMutationEvent(BASELINE - 5000);
 
-    service.send({ type: 'ADD_EVENT', payload: { event } });
+      service.send({
+        type: 'ADD_EVENT',
+        payload: { event, applyPastEventSynchronously },
+      });
 
-    expect(getCastFn).not.toHaveBeenCalled();
-    expect(service.state.context.events).toEqual([event]);
-  });
+      expect(getCastFn).not.toHaveBeenCalled();
+      expect(service.state.context.events).toEqual([event]);
+    },
+  );
 
   it('applies a past event synchronously when explicitly allowed (live mode)', () => {
     const { service, getCastFn } = createService();

--- a/packages/rrweb/rrweb/test/machine.test.ts
+++ b/packages/rrweb/rrweb/test/machine.test.ts
@@ -1,6 +1,11 @@
-import { discardPriorSnapshots } from '../src/replay/machine';
+import {
+  createPlayerService,
+  discardPriorSnapshots,
+} from '../src/replay/machine';
+import { Timer } from '../src/replay/timer';
 import { sampleEvents } from './utils';
-import { EventType } from '@posthog/rrweb-types';
+import { EventType, IncrementalSource } from '@posthog/rrweb-types';
+import type { eventWithTime } from '@posthog/rrweb-types';
 
 const events = sampleEvents.filter(
   (e) => ![EventType.DomContentLoaded, EventType.Load].includes(e.type),
@@ -43,5 +48,80 @@ describe('get last session', () => {
     expect(discardPriorSnapshots(events, events[0].timestamp - 1000)).toEqual(
       events,
     );
+  });
+});
+
+describe('addEvent', () => {
+  const BASELINE = 1_000_000;
+
+  const makeMutationEvent = (timestamp: number): eventWithTime => ({
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Mutation,
+      texts: [],
+      attributes: [],
+      removes: [{ parentId: 1, id: 2 }],
+      adds: [],
+    },
+    timestamp,
+  });
+
+  const createService = () => {
+    const getCastFn = vi.fn(() => vi.fn());
+    const service = createPlayerService(
+      {
+        events: [],
+        timer: new Timer([], { speed: 1 }),
+        timeOffset: 0,
+        baselineTime: BASELINE,
+        lastPlayedEvent: null,
+      },
+      {
+        getCastFn,
+        applyEventsSynchronously: vi.fn(),
+        emitter: { emit: vi.fn(), on: vi.fn(), off: vi.fn() } as any,
+      },
+    );
+    service.start();
+    return { service, getCastFn };
+  };
+
+  it('does not apply a past event onto the current DOM by default', () => {
+    // a block of events loading after the user seeked ahead must not be
+    // cast onto the current DOM — that DOM is at a different position, so
+    // the mutations would target nodes that don't exist there
+    const { service, getCastFn } = createService();
+    const event = makeMutationEvent(BASELINE - 5000);
+
+    service.send({ type: 'ADD_EVENT', payload: { event } });
+
+    expect(getCastFn).not.toHaveBeenCalled();
+    expect(service.state.context.events).toEqual([event]);
+  });
+
+  it('applies a past event synchronously when explicitly allowed (live mode)', () => {
+    const castFn = vi.fn();
+    const { service, getCastFn } = createService();
+    getCastFn.mockReturnValue(castFn);
+    const event = makeMutationEvent(BASELINE - 5000);
+
+    service.send({
+      type: 'ADD_EVENT',
+      payload: { event, applyPastEventSynchronously: true },
+    });
+
+    expect(getCastFn).toHaveBeenCalledWith(event, true);
+    expect(castFn).toHaveBeenCalled();
+    expect(service.state.context.events).toEqual([event]);
+  });
+
+  it('inserts a future event without applying it while the timer is inactive', () => {
+    const { service, getCastFn } = createService();
+    const event = makeMutationEvent(BASELINE + 5000);
+
+    service.send({ type: 'ADD_EVENT', payload: { event } });
+
+    expect(getCastFn).not.toHaveBeenCalled();
+    expect(service.state.context.events).toEqual([event]);
   });
 });

--- a/packages/rrweb/rrweb/test/machine.test.ts
+++ b/packages/rrweb/rrweb/test/machine.test.ts
@@ -87,9 +87,8 @@ describe('addEvent', () => {
   };
 
   it('does not apply a past event onto the current DOM by default', () => {
-    // a block of events loading after the user seeked ahead must not be
-    // cast onto the current DOM — that DOM is at a different position, so
-    // the mutations would target nodes that don't exist there
+    // a chunk loading after the user seeked ahead must not be cast onto a
+    // DOM that is at a different position
     const { service, getCastFn } = createService();
     const event = makeMutationEvent(BASELINE - 5000);
 
@@ -100,9 +99,7 @@ describe('addEvent', () => {
   });
 
   it('applies a past event synchronously when explicitly allowed (live mode)', () => {
-    const castFn = vi.fn();
     const { service, getCastFn } = createService();
-    getCastFn.mockReturnValue(castFn);
     const event = makeMutationEvent(BASELINE - 5000);
 
     service.send({
@@ -111,7 +108,7 @@ describe('addEvent', () => {
     });
 
     expect(getCastFn).toHaveBeenCalledWith(event, true);
-    expect(castFn).toHaveBeenCalled();
+    expect(getCastFn.mock.results[0].value).toHaveBeenCalled();
     expect(service.state.context.events).toEqual([event]);
   });
 


### PR DESCRIPTION
## Problem

Session replays can render duplicated, stacked DOM content (e.g. the same title text repeated 10–20×), and JSON exports of those recordings show mutation events with emptied `removes` arrays — even though the stored recording data is correct and balanced.

Two compounding bugs in the replayer:

1. `Replayer.addEvent()` applies any event whose timestamp is behind the playback baseline **synchronously onto the current DOM** (`isSync → castFn()` in `machine.ts`). That is live-mode catch-up behavior, but it also fires in on-demand playback. Snapshot data is typically loaded in chunks and fed to the replayer via `addEvent` as it arrives, so when a viewer seeks ahead before loading finishes, a late-arriving chunk's mutations are force-applied onto a DOM that is at a completely different position, where their node ids don't resolve.
2. `applyMutation` runs `d.removes = d.removes.filter(node-in-mirror)` — removes that fail the mirror lookup are deleted **from the event object itself**. Combined with (1), this permanently corrupts the in-memory recording: every subsequent seek rebuilds from the stripped events (adds without their paired removes → stale nodes accumulate), and anything serializing the same event objects (e.g. export features) writes out the corruption.

Reproduction (real recording data): construct the replayer without one chunk, seek past it, then `addEvent` the late chunk → 54 remove entries permanently stripped, and every subsequent seek into that region renders up to 26 stacked text nodes on a single span. The same navigation patterns with all data present upfront are clean.

## Changes

- `ADD_EVENT` payload gains `applyPastEventSynchronously`, set from `config.liveMode`. In on-demand playback, past events are now only inserted into the event array (the next seek/play rebuild picks them up) instead of being cast onto the current DOM. Live mode behavior is unchanged.
- `applyMutation` filters removes into a local copy instead of reassigning `d.removes`, so event data is never mutated by playback.
- Unit tests for the machine's `addEvent` behavior (past event default, past event in live mode, future event while paused).

Test status: `machine.test.ts` 7/7 pass; `replayer.test.ts` 33 pass + 5 snapshot failures that are pre-existing on `main` (local Chrome version mismatch).

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file