### PR TITLE
fix(replay): never record or flush snapshots while the sampling decision is missing

### DIFF
--- a/.changeset/replay-sampling-decision-leak.md
+++ b/.changeset/replay-sampling-decision-leak.md
@@ -1,0 +1,7 @@
+---
+'posthog-js': patch
+---
+
+fix(replay): never record or flush snapshots while the sampling decision is missing
+
+When the stored sampling decision was wiped while the recorder was running (e.g. by `posthog.reset()`), the undecided session reported an `active` status and could leak short junk recordings from sessions that then decided not to record. Sampling decisions are now persisted tagged with the session id they were made for (`'!' + sessionId` when sampled out), are re-made on every session id change regardless of config availability, and a buffer is never flushed without a decision when sampling is configured. Because the decision is a deterministic hash of the session id, re-deciding never flips the outcome for the same session. This also stops a stale `false` decision from a previous session being inherited by a new session, which chronically under-recorded returning visitors.

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -2861,7 +2861,7 @@ describe('Lazy SessionRecording', () => {
                 },
                 sampleRate: '0.00',
                 expectedStatus: 'disabled',
-                expectedIsSampled: () => false,
+                expectedIsSampled: () => '!' + sessionId,
                 expectedSampleRate: 0,
             },
             {
@@ -2873,7 +2873,7 @@ describe('Lazy SessionRecording', () => {
                 },
                 sampleRate: '0.00',
                 expectedStatus: 'disabled',
-                expectedIsSampled: () => false,
+                expectedIsSampled: () => '!' + sessionId,
                 expectedSampleRate: 0,
             },
             {
@@ -2970,7 +2970,7 @@ describe('Lazy SessionRecording', () => {
             _emit(createFullSnapshot())
 
             expect(sessionRecording.status).toBe('disabled')
-            expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(false)
+            expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe('!' + sessionId)
             expect(posthog.capture).not.toHaveBeenCalled()
         })
 
@@ -3026,8 +3026,8 @@ describe('Lazy SessionRecording', () => {
             sessionRecording.onRemoteConfig(
                 makeFlagsResponse({ sessionRecording: { endpoint: '/s/', sampleRate: '0.00' } })
             )
-            // then check that a session is sampled (i.e. storage is false not true or null)
-            expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(false)
+            // then check that a session is sampled out (stored tagged with its session id)
+            expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe('!' + sessionId)
             expect(sessionRecording.status).toBe('disabled')
 
             // then turn sample rate to null
@@ -3075,13 +3075,15 @@ describe('Lazy SessionRecording', () => {
 
                 // should be disabled despite legacy true, because 0% sample rate
                 expect(sessionRecording.status).toBe('disabled')
-                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(false)
+                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe('!' + sessionId)
 
                 _emit(createIncrementalSnapshot({ data: { source: 1 } }))
                 expect(posthog.capture).not.toHaveBeenCalled()
             })
 
-            it('re-decides when a legacy false from persistence is stored', () => {
+            it('re-decides when a legacy untagged false is stored', () => {
+                // legacy SDKs stored a bare `false`, which cannot be tied to a session —
+                // it may have been made for a previous session, so it must not be inherited
                 posthog.persistence?.register({
                     [SESSION_RECORDING_IS_SAMPLED]: false,
                 })
@@ -3090,9 +3092,87 @@ describe('Lazy SessionRecording', () => {
                     makeFlagsResponse({ sessionRecording: { endpoint: '/s/', sampleRate: '1.00' } })
                 )
 
+                // at 100% the fresh decision for this session is sampled in,
+                // proving the stale false was not reused
                 expect(sessionRecording.status).toBe('sampled')
                 expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(sessionId)
-                expect(posthog.get_property(SESSION_RECORDING_SAMPLE_RATE)).toBe(1)
+            })
+
+            it('re-decides when the stored decision belongs to a different session', () => {
+                // a sampled-out decision tagged with a previous session id must not
+                // be inherited by a new session (e.g. page load after session expiry)
+                posthog.persistence?.register({
+                    [SESSION_RECORDING_IS_SAMPLED]: '!some-previous-session-id',
+                })
+
+                sessionRecording.onRemoteConfig(
+                    makeFlagsResponse({ sessionRecording: { endpoint: '/s/', sampleRate: '1.00' } })
+                )
+
+                expect(sessionRecording.status).toBe('sampled')
+                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(sessionId)
+            })
+        })
+
+        describe('missing sampling decision (posthog.reset())', () => {
+            // simpleHash('session-a') % 100 === 46 → sampled in at 50%
+            // simpleHash('session-e') % 100 === 50 → sampled out at 50%
+            const SAMPLED_IN_SESSION_ID = 'session-a'
+            const SAMPLED_OUT_SESSION_ID = 'session-e'
+
+            it('re-makes the decision before flushing when the stored decision was wiped', () => {
+                sessionId = SAMPLED_IN_SESSION_ID
+                sessionRecording.onRemoteConfig(
+                    makeFlagsResponse({ sessionRecording: { endpoint: '/s/', sampleRate: '0.50' } })
+                )
+                expect(sessionRecording.status).toBe('sampled')
+
+                _emit(createIncrementalSnapshot({ data: { source: 1 } }))
+
+                // posthog.reset() clears persistence (including the stored decision)
+                // while rrweb keeps emitting
+                posthog.persistence?.unregister(SESSION_RECORDING_IS_SAMPLED)
+
+                sessionRecording['_lazyLoadedSessionRecording']['_flushBuffer']()
+
+                // the decision was re-made (deterministically, same outcome) before sending
+                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(SAMPLED_IN_SESSION_ID)
+                expect(posthog.capture).toHaveBeenCalledWith(
+                    '$snapshot',
+                    expect.objectContaining({ $session_id: SAMPLED_IN_SESSION_ID }),
+                    expect.anything()
+                )
+            })
+
+            it('does not leak snapshots into a new session that is sampled out', () => {
+                sessionId = SAMPLED_IN_SESSION_ID
+                sessionRecording.onRemoteConfig(
+                    makeFlagsResponse({ sessionRecording: { endpoint: '/s/', sampleRate: '0.50' } })
+                )
+                expect(sessionRecording.status).toBe('sampled')
+
+                _emit(createIncrementalSnapshot({ data: { source: 1 } }))
+
+                // posthog.reset() wipes the stored decision and the persisted remote
+                // config is unavailable at session-change time, then rotates the session
+                posthog.persistence?.unregister(SESSION_RECORDING_IS_SAMPLED)
+                posthog.persistence?.unregister(SESSION_RECORDING_REMOTE_CONFIG)
+                sessionManager.resetSessionId()
+                sessionId = SAMPLED_OUT_SESSION_ID
+                ;(posthog.capture as Mock).mockClear()
+
+                _emit(createIncrementalSnapshot({ data: { source: 1 } }))
+
+                // the new session must have a (negative) decision, not record unsampled
+                expect(sessionRecording.status).toBe('disabled')
+                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe('!' + SAMPLED_OUT_SESSION_ID)
+
+                // and nothing is ever sent for the sampled-out session
+                expect(posthog.capture).not.toHaveBeenCalledWith(
+                    '$snapshot',
+                    expect.objectContaining({ $session_id: SAMPLED_OUT_SESSION_ID }),
+                    expect.anything()
+                )
             })
         })
     })

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -3081,11 +3081,15 @@ describe('Lazy SessionRecording', () => {
                 expect(posthog.capture).not.toHaveBeenCalled()
             })
 
-            it('re-decides when a legacy untagged false is stored', () => {
-                // legacy SDKs stored a bare `false`, which cannot be tied to a session —
-                // it may have been made for a previous session, so it must not be inherited
+            it.each([
+                ['a legacy untagged false', false],
+                ["a different session's sampled-out decision", '!some-previous-session-id'],
+                ["a different session's sampled-in decision", 'some-previous-session-id'],
+            ])('re-decides when %s is stored', (_name, storedValue) => {
+                // a decision that cannot be tied to the current session must not be
+                // inherited (e.g. page load after session expiry, or legacy SDK formats)
                 posthog.persistence?.register({
-                    [SESSION_RECORDING_IS_SAMPLED]: false,
+                    [SESSION_RECORDING_IS_SAMPLED]: storedValue,
                 })
 
                 sessionRecording.onRemoteConfig(
@@ -3093,22 +3097,7 @@ describe('Lazy SessionRecording', () => {
                 )
 
                 // at 100% the fresh decision for this session is sampled in,
-                // proving the stale false was not reused
-                expect(sessionRecording.status).toBe('sampled')
-                expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(sessionId)
-            })
-
-            it('re-decides when the stored decision belongs to a different session', () => {
-                // a sampled-out decision tagged with a previous session id must not
-                // be inherited by a new session (e.g. page load after session expiry)
-                posthog.persistence?.register({
-                    [SESSION_RECORDING_IS_SAMPLED]: '!some-previous-session-id',
-                })
-
-                sessionRecording.onRemoteConfig(
-                    makeFlagsResponse({ sessionRecording: { endpoint: '/s/', sampleRate: '1.00' } })
-                )
-
+                // proving the stale value was not reused
                 expect(sessionRecording.status).toBe('sampled')
                 expect(posthog.get_property(SESSION_RECORDING_IS_SAMPLED)).toBe(sessionId)
             })

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -44,7 +44,6 @@ import {
     isNativeAsyncGzipError,
     isNumber,
     isObject,
-    isString,
     isUndefined,
 } from '@posthog/core'
 import {
@@ -81,6 +80,7 @@ import {
     V1RecordingStrategy,
     V2TriggerGroupStrategy,
     RecordingStrategyContext,
+    decodeSamplingDecision,
 } from './recording-strategies'
 
 const BASE_ENDPOINT = '/s/'
@@ -493,14 +493,10 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
     private get _isSampled(): boolean | null {
         const currentValue = this._instance.get_property(SESSION_RECORDING_IS_SAMPLED)
-        // we store the session id when sampled so that we can detect session id changes
-        // and `false` when not sampled
-        // legacy SDKs stored `true` when sampled, but that is not tied to a session id
-        // so we treat it as null (unknown) and will make a fresh decision
-        if (currentValue === true) {
-            return null
-        }
-        return currentValue === false ? false : isString(currentValue) ? currentValue === this.sessionId : null
+        // decisions are stored tagged with the session id they were made for —
+        // anything else (legacy `true`/`false`, another session's decision) decodes
+        // to null (unknown) so that a fresh decision is made for this session
+        return decodeSamplingDecision(currentValue, this.sessionId)
     }
 
     private get _sampleRate(): number | null {
@@ -514,7 +510,6 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
     private _onSessionIdListener: (() => void) | undefined = undefined
     private _onSessionIdleResetForcedListener: (() => void) | undefined = undefined
-    private _samplingSessionListener: (() => void) | undefined = undefined
     private _forceIdleSessionIdListener: (() => void) | undefined = undefined
 
     constructor(private readonly _instance: PostHog) {
@@ -1088,9 +1083,12 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             })
         }
 
-        if (isNumber(this._sampleRate) && isNullish(this._samplingSessionListener)) {
-            this._strategy?.makeSamplingDecisions(sessionId)
-        }
+        // always re-make sampling decisions for the new session — each strategy no-ops
+        // when sampling isn't configured. Guarding on `isNumber(this._sampleRate)` here
+        // would skip V2 trigger-group sampling (no top-level sampleRate) and any session
+        // where the persisted remote config is unavailable, leaving the session with no
+        // decision at all — which reads as ACTIVE and records unsampled.
+        this._strategy?.makeSamplingDecisions(sessionId)
     }
 
     private _teardown() {
@@ -1110,8 +1108,6 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         this._onSessionIdListener = undefined
         this._onSessionIdleResetForcedListener?.()
         this._onSessionIdleResetForcedListener = undefined
-        this._samplingSessionListener?.()
-        this._samplingSessionListener = undefined
         this._forceIdleSessionIdListener?.()
         this._forceIdleSessionIdListener = undefined
 
@@ -1520,6 +1516,17 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
     private _flushBuffer(): SnapshotBuffer {
         this._clearFlushBufferTimer()
+
+        // a buffer must never be flushed while a sampling decision is missing —
+        // e.g. posthog.reset() wipes the stored decision while rrweb keeps emitting,
+        // and an undecided session reads as ACTIVE, so without this it leaks a batch
+        // from a session that then decides not to record. The decision is a
+        // deterministic hash of the session id, so deciding here is idempotent.
+        // The strategy keeps its own copy of the sample rate, so this works even
+        // when the persisted remote config has been wiped.
+        if (this._strategy?.isSamplingConfigured() && isNullish(this._isSampled)) {
+            this._strategy.makeSamplingDecisions(this.sessionId)
+        }
 
         const isBelowMinimumDuration = this._isBelowMinimumDuration()
 

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -493,9 +493,7 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
     private get _isSampled(): boolean | null {
         const currentValue = this._instance.get_property(SESSION_RECORDING_IS_SAMPLED)
-        // decisions are stored tagged with the session id they were made for —
-        // anything else (legacy `true`/`false`, another session's decision) decodes
-        // to null (unknown) so that a fresh decision is made for this session
+        // anything but this session's own tagged decision decodes to null, forcing a fresh decision
         return decodeSamplingDecision(currentValue, this.sessionId)
     }
 
@@ -1083,11 +1081,8 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
             })
         }
 
-        // always re-make sampling decisions for the new session — each strategy no-ops
-        // when sampling isn't configured. Guarding on `isNumber(this._sampleRate)` here
-        // would skip V2 trigger-group sampling (no top-level sampleRate) and any session
-        // where the persisted remote config is unavailable, leaving the session with no
-        // decision at all — which reads as ACTIVE and records unsampled.
+        // always re-decide for the new session — guarding on the persisted config here would skip
+        // V2 trigger groups and post-reset() sessions, leaving them undecided (= ACTIVE, unsampled)
         this._strategy?.makeSamplingDecisions(sessionId)
     }
 
@@ -1517,16 +1512,9 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     private _flushBuffer(): SnapshotBuffer {
         this._clearFlushBufferTimer()
 
-        // a buffer must never be flushed while a sampling decision is missing —
-        // e.g. posthog.reset() wipes the stored decision while rrweb keeps emitting,
-        // and an undecided session reads as ACTIVE, so without this it leaks a batch
-        // from a session that then decides not to record. The decision is a
-        // deterministic hash of the session id, so deciding here is idempotent.
-        // The strategy keeps its own copy of the sample rate, so this works even
-        // when the persisted remote config has been wiped.
-        if (this._strategy?.isSamplingConfigured() && isNullish(this._isSampled)) {
-            this._strategy.makeSamplingDecisions(this.sessionId)
-        }
+        // never flush while a sampling decision is missing (e.g. wiped by posthog.reset()) — an
+        // undecided session reads as ACTIVE and would leak a batch it then decides not to record
+        this._strategy?.ensureSamplingDecision(this.sessionId)
 
         const isBelowMinimumDuration = this._isBelowMinimumDuration()
 

--- a/packages/browser/src/extensions/replay/external/recording-strategies.ts
+++ b/packages/browser/src/extensions/replay/external/recording-strategies.ts
@@ -43,6 +43,33 @@ import { matchTriggerPropertyFilters } from '../../../utils/property-utils'
 const logger = createLogger('[SessionRecording]')
 
 /**
+ * Sampling decisions are persisted tagged with the session id they were made for,
+ * so that a decision can never be inherited by a different session:
+ * - `sessionId` = sampled in for that session
+ * - `'!' + sessionId` = sampled out for that session
+ *
+ * Anything else (legacy `true`/`false`, another session's decision) decodes to
+ * null and the decision is re-made. That is always safe: `sampleOnProperty` is a
+ * deterministic hash of the session id, so re-deciding can never flip the
+ * outcome for the same session.
+ */
+const NOT_SAMPLED_PREFIX = '!'
+
+export function encodeSamplingDecision(sessionId: string, isSampled: boolean): string {
+    return isSampled ? sessionId : NOT_SAMPLED_PREFIX + sessionId
+}
+
+export function decodeSamplingDecision(storedValue: unknown, sessionId: string): boolean | null {
+    if (storedValue === sessionId) {
+        return true
+    }
+    if (storedValue === NOT_SAMPLED_PREFIX + sessionId) {
+        return false
+    }
+    return null
+}
+
+/**
  * Shared context that strategies need to access from the recorder
  */
 export interface RecordingStrategyContext {
@@ -99,6 +126,13 @@ export interface RecordingStrategy {
      * Make sampling decisions for the session
      */
     makeSamplingDecisions(sessionId: string): void
+
+    /**
+     * Whether session-level sampling is configured, read from the strategy's own
+     * copy of the config — reliable even when the persisted remote config has
+     * been wiped (e.g. by posthog.reset())
+     */
+    isSamplingConfigured(): boolean
 
     /**
      * Called after the initial buffer flush (performance optimization hook)
@@ -233,27 +267,22 @@ export class V1RecordingStrategy implements RecordingStrategy {
         const storedValue = this._instance.get_property(SESSION_RECORDING_IS_SAMPLED)
         const storedSampleRate = this._instance.get_property(SESSION_RECORDING_SAMPLE_RATE)
 
-        // Parse stored decision:
-        // - sessionId string = sampled in for that session
-        // - false = legacy sampled out decision without session/rate context (re-decide)
-        // - undefined/null = no decision yet
-        const storedIsSampled = storedValue === sessionId ? true : null
+        // Only a decision stored for this exact session is reusable; anything else
+        // (no decision, another session's decision, legacy formats) is re-decided
+        const storedIsSampled = decodeSamplingDecision(storedValue, sessionId)
 
-        // Make new decision only if:
-        // 1. No stored decision exists (storedIsSampled is null/undefined), OR
-        // 2. Session changed (stored sessionId doesn't match current), OR
-        // 3. Sample rate changed since the stored decision was made
-        //
-        // Older SDK versions only stored the session ID for sampled-in sessions, not the rate. Treat
-        // those sampled-in decisions as needing a fresh decision so lowering sampleRate to 0 takes
-        // effect after a page reload within the same PostHog session.
+        // Re-decide when:
+        // 1. there is no reusable decision for this session (covers another session's
+        //    decision and legacy formats, which decode to null), OR
+        // 2. the sample rate changed since the stored decision was made, OR
+        // 3. the decision predates rate storage — older SDK versions stored only the
+        //    session id for sampled-in sessions, not the rate — so lowering sampleRate
+        //    to 0 takes effect after a page reload within the same PostHog session.
         // An explicit override from a config without sampling stores null as the rate, so only an
         // undefined rate is considered legacy missing-rate state.
-        const sessionChanged = typeof storedValue === 'string' && storedValue !== sessionId
         const sampleRateChanged = isNumber(storedSampleRate) && storedSampleRate !== currentSampleRate
         const sampledInWithoutStoredRate = isUndefined(storedSampleRate) && storedValue === sessionId
-        const makeDecision =
-            sessionChanged || sampleRateChanged || sampledInWithoutStoredRate || !isBoolean(storedIsSampled)
+        const makeDecision = sampleRateChanged || sampledInWithoutStoredRate || !isBoolean(storedIsSampled)
         const shouldSample = makeDecision ? sampleOnProperty(sessionId, currentSampleRate) : storedIsSampled!
 
         if (makeDecision) {
@@ -267,10 +296,14 @@ export class V1RecordingStrategy implements RecordingStrategy {
         }
 
         this._instance.persistence?.register({
-            [SESSION_RECORDING_IS_SAMPLED]: shouldSample ? sessionId : false,
+            [SESSION_RECORDING_IS_SAMPLED]: encodeSamplingDecision(sessionId, shouldSample),
             [SESSION_RECORDING_SAMPLE_RATE]:
                 isNull(storedSampleRate) && storedValue === sessionId ? null : currentSampleRate,
         })
+    }
+
+    isSamplingConfigured(): boolean {
+        return isNumber(this._sampleRate)
     }
 
     onFlushComplete(): void {
@@ -535,6 +568,12 @@ export class V2TriggerGroupStrategy implements RecordingStrategy {
 
         // After all sampling decisions, register which groups are actively recording
         this.updateActiveTriggers(sessionId)
+    }
+
+    isSamplingConfigured(): boolean {
+        // V2 sampling is per trigger group and safe by default — a missing group
+        // decision reads as not sampled, so it can never leak an undecided flush
+        return false
     }
 
     onFlushComplete(): void {

--- a/packages/browser/src/extensions/replay/external/recording-strategies.ts
+++ b/packages/browser/src/extensions/replay/external/recording-strategies.ts
@@ -43,15 +43,9 @@ import { matchTriggerPropertyFilters } from '../../../utils/property-utils'
 const logger = createLogger('[SessionRecording]')
 
 /**
- * Sampling decisions are persisted tagged with the session id they were made for,
- * so that a decision can never be inherited by a different session:
- * - `sessionId` = sampled in for that session
- * - `'!' + sessionId` = sampled out for that session
- *
- * Anything else (legacy `true`/`false`, another session's decision) decodes to
- * null and the decision is re-made. That is always safe: `sampleOnProperty` is a
- * deterministic hash of the session id, so re-deciding can never flip the
- * outcome for the same session.
+ * Decisions are stored as `sessionId` (sampled in) or `'!' + sessionId` (sampled out), so another
+ * session can never inherit them. Anything else (legacy `true`/`false`, another session's decision)
+ * decodes to null and is re-decided — safe, since `sampleOnProperty` is deterministic per session id.
  */
 const NOT_SAMPLED_PREFIX = '!'
 
@@ -128,11 +122,10 @@ export interface RecordingStrategy {
     makeSamplingDecisions(sessionId: string): void
 
     /**
-     * Whether session-level sampling is configured, read from the strategy's own
-     * copy of the config — reliable even when the persisted remote config has
-     * been wiped (e.g. by posthog.reset())
+     * Ensure a sampling decision exists for this session, re-deciding from the strategy's own
+     * config when it is missing (e.g. wiped by posthog.reset()). No-op when sampling isn't configured.
      */
-    isSamplingConfigured(): boolean
+    ensureSamplingDecision(sessionId: string): void
 
     /**
      * Called after the initial buffer flush (performance optimization hook)
@@ -267,19 +260,10 @@ export class V1RecordingStrategy implements RecordingStrategy {
         const storedValue = this._instance.get_property(SESSION_RECORDING_IS_SAMPLED)
         const storedSampleRate = this._instance.get_property(SESSION_RECORDING_SAMPLE_RATE)
 
-        // Only a decision stored for this exact session is reusable; anything else
-        // (no decision, another session's decision, legacy formats) is re-decided
         const storedIsSampled = decodeSamplingDecision(storedValue, sessionId)
 
-        // Re-decide when:
-        // 1. there is no reusable decision for this session (covers another session's
-        //    decision and legacy formats, which decode to null), OR
-        // 2. the sample rate changed since the stored decision was made, OR
-        // 3. the decision predates rate storage — older SDK versions stored only the
-        //    session id for sampled-in sessions, not the rate — so lowering sampleRate
-        //    to 0 takes effect after a page reload within the same PostHog session.
-        // An explicit override from a config without sampling stores null as the rate, so only an
-        // undefined rate is considered legacy missing-rate state.
+        // Re-decide when the rate changed, or a legacy sampled-in decision predates rate storage.
+        // An explicit override stores null as the rate, so only undefined means legacy missing-rate.
         const sampleRateChanged = isNumber(storedSampleRate) && storedSampleRate !== currentSampleRate
         const sampledInWithoutStoredRate = isUndefined(storedSampleRate) && storedValue === sessionId
         const makeDecision = sampleRateChanged || sampledInWithoutStoredRate || !isBoolean(storedIsSampled)
@@ -302,8 +286,14 @@ export class V1RecordingStrategy implements RecordingStrategy {
         })
     }
 
-    isSamplingConfigured(): boolean {
-        return isNumber(this._sampleRate)
+    ensureSamplingDecision(sessionId: string): void {
+        if (!isNumber(this._sampleRate)) {
+            return
+        }
+        const storedValue = this._instance.get_property(SESSION_RECORDING_IS_SAMPLED)
+        if (!isBoolean(decodeSamplingDecision(storedValue, sessionId))) {
+            this.makeSamplingDecisions(sessionId)
+        }
     }
 
     onFlushComplete(): void {
@@ -570,10 +560,10 @@ export class V2TriggerGroupStrategy implements RecordingStrategy {
         this.updateActiveTriggers(sessionId)
     }
 
-    isSamplingConfigured(): boolean {
+    ensureSamplingDecision(sessionId: string): void {
         // V2 sampling is per trigger group and safe by default — a missing group
         // decision reads as not sampled, so it can never leak an undecided flush
-        return false
+        void sessionId
     }
 
     onFlushComplete(): void {

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -513,7 +513,6 @@
         "_rrwebStartAttempted",
         "_runBeforeSend",
         "_sampleRate",
-        "_samplingSessionListener",
         "_saveDebounceMs",
         "_saveSessionState",
         "_scheduleFlush",


### PR DESCRIPTION
## Problem

If the stored sampling decision goes missing while the recorder is running (e.g. `posthog.reset()`), the session reports `active` and the next flush leaks a junk 0-second recording from a session that then decides not to record. And because sampled-out decisions were stored as an untagged `false`, new sessions inherited the previous session's negative decision at page load instead of re-deciding.

## Changes

- Persist sampled-out decisions as `'!' + sessionId`, so a decision is only ever reused by the session it was made for. Re-deciding is safe: `sampleOnProperty` is a deterministic hash of the session id.
- Always re-make sampling decisions on session id change (previously skipped post-`reset()` and for V2 trigger groups).
- Never flush a buffer while a decision is missing — the recorder asks the strategy to `ensureSamplingDecision` first.

Builds on the sample-rate re-decision logic from #3780.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] posthog-react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file