### PR TITLE
chore: deprecate eager replay load flag

### DIFF
--- a/.changeset/few-lazy-replays.md
+++ b/.changeset/few-lazy-replays.md
@@ -1,0 +1,6 @@
+---
+"@posthog/types": patch
+"posthog-js": patch
+---
+
+Deprecate `__preview_eager_load_replay` as a no-op now that session replay lazy loading is the default.

--- a/packages/browser/playwright/mocked/session-recording/lazy-session-recording-sampling.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/lazy-session-recording-sampling.spec.ts
@@ -11,7 +11,6 @@ const startOptions = {
         },
         capturePerformance: true,
         autocapture_opt_out: true,
-        __preview_eager_load_replay: false,
     },
     url: './playground/cypress/index.html',
 }

--- a/packages/browser/playwright/mocked/session-recording/lazy-session-recording.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/lazy-session-recording.spec.ts
@@ -86,7 +86,6 @@ const startOptions = {
         },
         capturePerformance: true,
         autocapture_opt_out: true,
-        __preview_eager_load_replay: false,
     },
     url: './playground/cypress/index.html',
 }

--- a/packages/browser/playwright/mocked/session-recording/session-linking.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-linking.spec.ts
@@ -12,7 +12,6 @@ const startOptions = {
         },
         capturePerformance: true,
         autocapture_opt_out: true,
-        __preview_eager_load_replay: false,
     },
     url: './playground/cypress/index.html',
 }

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -290,9 +290,6 @@ export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     // Used for internal testing
     _onCapture: __NOOP,
 
-    // make the default be lazy loading replay
-    __preview_eager_load_replay: false,
-
     ...defaultsThatVaryByConfig(defaults),
 })
 

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1722,10 +1722,7 @@ export interface PostHogConfig {
     __preview_flags_v2?: boolean
 
     /**
-     * PREVIEW - MAY CHANGE WITHOUT WARNING - ONLY USE WHEN TALKING TO POSTHOG SUPPORT
-     * Enables deprecated eager loading of session recording code, not just rrweb and network plugin
-     * we are switching the default to lazy loading because the bundle will ultimately be 18% smaller then
-     * keeping this around for a few days in case there are unexpected consequences that testing did not uncover
+     * @deprecated This option is a no-op. Session replay is lazy-loaded by default.
      * */
     __preview_eager_load_replay?: boolean
 


### PR DESCRIPTION
## Problem

`__preview_eager_load_replay` was still documented as a preview option and used in a few replay tests, even though session replay lazy loading is already the default.

## Changes

- Mark `__preview_eager_load_replay` as deprecated and document it as a no-op.
- Remove the default config assignment for the flag.
- Remove test usage of the flag from mocked session recording Playwright specs.
- Add a changeset for `posthog-js` and `@posthog/types`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
