### PR TITLE
docs: remove alpha comments from captured network request

### DIFF
--- a/packages/types/src/session-recording.ts
+++ b/packages/types/src/session-recording.ts
@@ -81,9 +81,7 @@ type Writable<T> = { -readonly [P in keyof T]: T[P] }
 //     readonly entryType: string;
 //     readonly name: string;
 //     readonly startTime: DOMHighResTimeStamp;
-// NB: properties below here are ALPHA, don't rely on them, they may change without notice
 export type CapturedNetworkRequest = Writable<Omit<PerformanceEntry, 'toJSON'>> & {
-    // properties below here are ALPHA, don't rely on them, they may change without notice
     method?: string
     initiatorType?: InitiatorType
     status?: number


### PR DESCRIPTION
## Problem

`CapturedNetworkRequest` properties are public API now, but the type still had comments warning that the properties were ALPHA and might change without notice.

## Changes

Removed the outdated ALPHA warning comments from `CapturedNetworkRequest` in `packages/types/src/session-recording.ts`.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
