### PR TITLE
chore: deprecate preview request configs

### DIFF
--- a/.changeset/deprecate-preview-request-configs.md
+++ b/.changeset/deprecate-preview-request-configs.md
@@ -1,0 +1,6 @@
+---
+"@posthog/types": patch
+"posthog-js": patch
+---
+
+Deprecate `__preview_disable_beacon` and `__preview_disable_xhr_credentials` in favor of `disable_beacon` and `disable_xhr_credentials`.

--- a/.changeset/deprecate-preview-request-configs.md
+++ b/.changeset/deprecate-preview-request-configs.md
@@ -3,4 +3,4 @@
 "posthog-js": patch
 ---
 
-Deprecate `__preview_disable_beacon` and `__preview_disable_xhr_credentials` in favor of `disable_beacon` and `disable_xhr_credentials`.
+Deprecate `__preview_disable_beacon` in favor of `disable_beacon` and mark `__preview_disable_xhr_credentials` as a no-op.

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -62,25 +62,19 @@ describe('posthog core', () => {
     })
 
     describe('configRenames()', () => {
-        it('maps deprecated preview beacon option to the stable config name', () => {
-            expect(
-                configRenames({
-                    __preview_disable_beacon: true,
-                })
-            ).toMatchObject({
-                disable_beacon: true,
-            })
-        })
-
-        it('prioritizes stable beacon option name over deprecated preview name', () => {
-            expect(
-                configRenames({
-                    disable_beacon: false,
-                    __preview_disable_beacon: true,
-                })
-            ).toMatchObject({
-                disable_beacon: false,
-            })
+        it.each([
+            [
+                'maps deprecated preview beacon option to the stable config name',
+                { __preview_disable_beacon: true },
+                { disable_beacon: true },
+            ],
+            [
+                'prioritizes stable beacon option name over deprecated preview name',
+                { disable_beacon: false, __preview_disable_beacon: true },
+                { disable_beacon: false },
+            ],
+        ] as [string, Partial<PostHogConfig>, Partial<PostHogConfig>][])('%s', (_description, input, expected) => {
+            expect(configRenames(input)).toMatchObject(expected)
         })
     })
 

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -7,7 +7,7 @@ import { isUndefined } from '@posthog/core'
 import { ENABLE_PERSON_PROCESSING, SESSION_RECORDING_REMOTE_CONFIG, USER_STATE } from '../constants'
 import { createPosthogInstance, defaultPostHog } from './helpers/posthog-instance'
 import { PostHogConfig, RemoteConfig } from '../types'
-import { PostHog } from '../posthog-core'
+import { configRenames, PostHog } from '../posthog-core'
 import { PostHogPersistence } from '../posthog-persistence'
 import { SessionIdManager } from '../sessionid'
 import { RequestQueue } from '../request-queue'
@@ -59,6 +59,34 @@ describe('posthog core', () => {
 
     afterEach(() => {
         jest.useRealTimers()
+    })
+
+    describe('configRenames()', () => {
+        it('maps deprecated preview request options to stable config names', () => {
+            expect(
+                configRenames({
+                    __preview_disable_beacon: true,
+                    __preview_disable_xhr_credentials: true,
+                })
+            ).toMatchObject({
+                disable_beacon: true,
+                disable_xhr_credentials: true,
+            })
+        })
+
+        it('prioritizes stable request option names over deprecated preview names', () => {
+            expect(
+                configRenames({
+                    disable_beacon: false,
+                    __preview_disable_beacon: true,
+                    disable_xhr_credentials: false,
+                    __preview_disable_xhr_credentials: true,
+                })
+            ).toMatchObject({
+                disable_beacon: false,
+                disable_xhr_credentials: false,
+            })
+        })
     })
 
     describe('capture()', () => {

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -62,29 +62,24 @@ describe('posthog core', () => {
     })
 
     describe('configRenames()', () => {
-        it('maps deprecated preview request options to stable config names', () => {
+        it('maps deprecated preview beacon option to the stable config name', () => {
             expect(
                 configRenames({
                     __preview_disable_beacon: true,
-                    __preview_disable_xhr_credentials: true,
                 })
             ).toMatchObject({
                 disable_beacon: true,
-                disable_xhr_credentials: true,
             })
         })
 
-        it('prioritizes stable request option names over deprecated preview names', () => {
+        it('prioritizes stable beacon option name over deprecated preview name', () => {
             expect(
                 configRenames({
                     disable_beacon: false,
                     __preview_disable_beacon: true,
-                    disable_xhr_credentials: false,
-                    __preview_disable_xhr_credentials: true,
                 })
             ).toMatchObject({
                 disable_beacon: false,
-                disable_xhr_credentials: false,
             })
         })
     })

--- a/packages/browser/src/__tests__/request.test.ts
+++ b/packages/browser/src/__tests__/request.test.ts
@@ -129,13 +129,9 @@ describe('request', () => {
             })
         })
 
-        it('respects disableXHRCredentials=true', () => {
-            request(createRequest({ disableXHRCredentials: true }))
+        it('does not set XHR credentials', () => {
+            request(createRequest())
             expect(mockedXHR.withCredentials).toBe(false)
-        })
-        it('respects disableXHRCredentials=false', () => {
-            request(createRequest({ disableXHRCredentials: false }))
-            expect(mockedXHR.withCredentials).toBe(true)
         })
     })
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -299,7 +299,6 @@ const CONFIG_RENAMES: [keyof PostHogConfig, keyof PostHogConfig][] = [
     ['cookie_name', 'persistence_name'],
     ['disable_cookie', 'disable_persistence'],
     ['__preview_disable_beacon', 'disable_beacon'],
-    ['__preview_disable_xhr_credentials', 'disable_xhr_credentials'],
     ['store_google', 'save_campaign_params'],
     ['verbose', 'debug'],
 ]
@@ -1057,9 +1056,6 @@ export class PostHog implements PostHogInterface {
             ...options.headers,
         }
         options.compression = options.compression === 'best-available' ? this.compression : options.compression
-        options.disableXHRCredentials = isUndefined(this.config.disable_xhr_credentials)
-            ? this.config.__preview_disable_xhr_credentials
-            : this.config.disable_xhr_credentials
         const disableBeacon = isUndefined(this.config.disable_beacon)
             ? this.config.__preview_disable_beacon
             : this.config.disable_beacon

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -298,6 +298,8 @@ const CONFIG_RENAMES: [keyof PostHogConfig, keyof PostHogConfig][] = [
     ['xhr_headers', 'request_headers'],
     ['cookie_name', 'persistence_name'],
     ['disable_cookie', 'disable_persistence'],
+    ['__preview_disable_beacon', 'disable_beacon'],
+    ['__preview_disable_xhr_credentials', 'disable_xhr_credentials'],
     ['store_google', 'save_campaign_params'],
     ['verbose', 'debug'],
 ]
@@ -1055,8 +1057,13 @@ export class PostHog implements PostHogInterface {
             ...options.headers,
         }
         options.compression = options.compression === 'best-available' ? this.compression : options.compression
-        options.disableXHRCredentials = this.config.__preview_disable_xhr_credentials
-        if (this.config.__preview_disable_beacon) {
+        options.disableXHRCredentials = isUndefined(this.config.disable_xhr_credentials)
+            ? this.config.__preview_disable_xhr_credentials
+            : this.config.disable_xhr_credentials
+        const disableBeacon = isUndefined(this.config.disable_beacon)
+            ? this.config.__preview_disable_beacon
+            : this.config.disable_beacon
+        if (disableBeacon) {
             options.disableTransport = ['sendBeacon']
         }
 

--- a/packages/browser/src/request.ts
+++ b/packages/browser/src/request.ts
@@ -207,11 +207,6 @@ const xhr = (options: RequestWithOptions) => {
     if (options.timeout) {
         req.timeout = options.timeout
     }
-    if (!options.disableXHRCredentials) {
-        // send the ph_optout cookie
-        // withCredentials cannot be modified until after calling .open on Android and Mobile Safari
-        req.withCredentials = true
-    }
     req.onreadystatechange = () => {
         // XMLHttpRequest.DONE == 4, except in safari 4
         if (req.readyState === 4) {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -194,7 +194,6 @@ export interface RequestWithOptions {
     timeout?: number
     noRetries?: boolean
     disableTransport?: ('XHR' | 'fetch' | 'sendBeacon')[]
-    disableXHRCredentials?: boolean
     compression?: Compression | 'best-available'
     fetchOptions?: {
         cache?: RequestInit['cache']

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -761,11 +761,6 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "false",
     "true"
   ],
-  "disable_xhr_credentials": [
-    "undefined",
-    "false",
-    "true"
-  ],
   "__preview_disable_beacon": [
     "undefined",
     "false",

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -756,6 +756,16 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "false",
     "true"
   ],
+  "disable_beacon": [
+    "undefined",
+    "false",
+    "true"
+  ],
+  "disable_xhr_credentials": [
+    "undefined",
+    "false",
+    "true"
+  ],
   "__preview_disable_beacon": [
     "undefined",
     "false",

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1733,17 +1733,12 @@ export interface PostHogConfig {
     disable_beacon?: boolean
 
     /**
-     * Disables sending credentials when using XHR requests.
-     */
-    disable_xhr_credentials?: boolean
-
-    /**
      * @deprecated Use `disable_beacon` instead.
      */
     __preview_disable_beacon?: boolean
 
     /**
-     * @deprecated Use `disable_xhr_credentials` instead.
+     * @deprecated This option is a no-op. The browser SDK no longer sets `XMLHttpRequest.withCredentials`.
      */
     __preview_disable_xhr_credentials?: boolean
 

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -1728,12 +1728,22 @@ export interface PostHogConfig {
 
     /**
      * Prevents posthog-js from using the `navigator.sendBeacon` API to send events.
-     * Enabling this option may hurt the reliability of sending $pageleave events
+     * Enabling this option may hurt the reliability of sending $pageleave events.
+     */
+    disable_beacon?: boolean
+
+    /**
+     * Disables sending credentials when using XHR requests.
+     */
+    disable_xhr_credentials?: boolean
+
+    /**
+     * @deprecated Use `disable_beacon` instead.
      */
     __preview_disable_beacon?: boolean
 
     /**
-     * Disables sending credentials when using XHR requests.
+     * @deprecated Use `disable_xhr_credentials` instead.
      */
     __preview_disable_xhr_credentials?: boolean
 


### PR DESCRIPTION
## Problem

The browser SDK has two request-related config options that were still marked as preview: `__preview_disable_beacon` and `__preview_disable_xhr_credentials`. `disable_beacon` should now have a stable config name, while the XHR credentials option should be retired because the SDK should no longer set `XMLHttpRequest.withCredentials`.

## Changes

- Added stable `disable_beacon` config option.
- Deprecated `__preview_disable_beacon` in favor of `disable_beacon`.
- Deprecated `__preview_disable_xhr_credentials` as a no-op.
- Removed setting `req.withCredentials = true` from XHR requests.
- Removed the proposed `disable_xhr_credentials` config option.
- Updated type snapshots and tests for config rename/XHR credentials behavior.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

