### PR TITLE
chore: make release version bump pull main before release and fail if main is durty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,9 @@ jobs:
                   fetch-depth: 0
                   token: ${{ steps.releaser.outputs.token }}
 
+            - name: Update to latest main before generating release artifacts
+              run: git pull --ff-only origin main
+
             - name: Setup environment
               uses: ./.github/actions/setup
               with:
@@ -122,8 +125,13 @@ jobs:
                   echo "version=$VERSION" >> "$GITHUB_OUTPUT"
                   echo "Resolved posthog-js version: $VERSION"
 
-            - name: Update to latest main before committing
-              run: git pull --ff-only --autostash origin main
+            - name: Ensure main did not advance during release artifact generation
+              run: |
+                  git fetch origin main
+                  if [ "$(git rev-parse HEAD)" != "$(git rev-parse FETCH_HEAD)" ]; then
+                    echo "::error::main advanced while generating release artifacts. Re-run the workflow so versions and changelogs include the latest changesets."
+                    exit 1
+                  fi
 
             - name: Commit version bump and lockfile
               id: commit-version-bump

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,9 @@ jobs:
                   echo "version=$VERSION" >> "$GITHUB_OUTPUT"
                   echo "Resolved posthog-js version: $VERSION"
 
+            - name: Update to latest main before committing
+              run: git pull --ff-only --autostash origin main
+
             - name: Commit version bump and lockfile
               id: commit-version-bump
               uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20


### PR DESCRIPTION
## Problem

The release workflow can fail if `main` advances while the approved version-bump job is generating package versions, changelogs, references, and lockfile updates. This happened in https://github.com/PostHog/posthog-js/actions/runs/27272295505/attempts/1, where `planetscale/ghcommit-action` refused to commit because `main` no longer pointed at the workflow's starting SHA.

## Changes

Before committing the generated version bump, update the checkout to the latest `main` and fail if dirty before release

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
