### PR TITLE
feat(ai): warn when AI wrapper is pointed at the PostHog AI Gateway

### DIFF
--- a/.changeset/warn-ai-gateway-double-capture.md
+++ b/.changeset/warn-ai-gateway-double-capture.md
@@ -1,0 +1,5 @@
+---
+"@posthog/ai": minor
+---
+
+feat: warn when the AI wrapper's `base_url` points at the PostHog AI Gateway. The gateway emits its own `$ai_generation`, so routing the wrapper through it double-captures (and, for billable products, double-bills) every call. The warning logs on every routed call; the wrapper's event is left untouched, since it carries data the gateway never sees (groups, custom properties, trace hierarchy).

--- a/.changeset/warn-ai-gateway-double-capture.md
+++ b/.changeset/warn-ai-gateway-double-capture.md
@@ -2,4 +2,4 @@
 "@posthog/ai": minor
 ---
 
-feat: warn when the AI wrapper's `base_url` points at the PostHog AI Gateway. The gateway emits its own `$ai_generation`, so routing the wrapper through it double-captures (and, for billable products, double-bills) every call. The warning logs on every routed call; the wrapper's event is left untouched, since it carries data the gateway never sees (groups, custom properties, trace hierarchy).
+feat: warn when a `base_url` points at the PostHog AI Gateway. The gateway emits its own `$ai_generation`, so routing through it double-captures (and, for billable products, double-bills) every call. Detection covers the provider wrappers (OpenAI, Azure, Anthropic, Gemini, Vercel), LangChain, OpenAI Agents, direct `captureAiGeneration` callers, and the OTel exporter/processor (via the span's `server.address` / `url.full`). The warning logs on every routed call; the event is left untouched, since it carries data the gateway never sees (groups, custom properties, trace hierarchy).

--- a/packages/ai/src/captureAiGeneration.ts
+++ b/packages/ai/src/captureAiGeneration.ts
@@ -5,6 +5,7 @@ import { version } from '../package.json'
 import type { TokenUsage } from './types'
 import { stringifyError } from './serializeError'
 import { AIEvent, CostOverride, getTokensSource, sanitizeValues, withPrivacyMode } from './utils'
+import { warnIfPostHogAiGateway } from './gatewayWarning'
 
 /**
  * Options for `captureAiGeneration`. Mirrors the `$ai_generation` event shape
@@ -95,6 +96,8 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
   if (!client.capture) {
     return
   }
+
+  warnIfPostHogAiGateway(options.baseURL)
 
   const traceId = options.traceId ?? uuidv4()
   const eventType = options.eventType ?? AIEvent.Generation

--- a/packages/ai/src/gatewayWarning.ts
+++ b/packages/ai/src/gatewayWarning.ts
@@ -1,7 +1,7 @@
-// Warn (once) when a wrapper's base_url points at the PostHog AI Gateway: the
-// gateway emits its own $ai_generation, so each call would be captured (and, for
-// billable products, billed) twice. We only warn — the wrapper's event carries
-// data the gateway never sees (groups, custom properties, trace hierarchy).
+// Warn when a wrapper's base_url points at the PostHog AI Gateway: the gateway
+// emits its own $ai_generation, so each call would be captured (and, for billable
+// products, billed) twice. We only warn — the wrapper's event carries data the
+// gateway never sees (groups, custom properties, trace hierarchy).
 
 // Keep in sync with the gateway's deployed hosts (see services/llm-gateway in the
 // main repo). gateway.us.posthog.com is live today; the rest are listed ahead of
@@ -35,22 +35,15 @@ export const isPostHogAiGatewayUrl = (baseURL: string | undefined | null): boole
   return host !== undefined && POSTHOG_AI_GATEWAY_HOSTS.includes(host)
 }
 
-let hasWarned = false
-
-// Safe to call on every generation: short-circuits after the first warning.
+// Warns on every gateway call by design: the misconfiguration is impossible to
+// miss that way, and a doubled bill is worse than noisy logs.
 export const warnIfPostHogAiGateway = (baseURL: string | undefined | null): void => {
-  if (hasWarned || !isPostHogAiGatewayUrl(baseURL)) {
+  if (!isPostHogAiGatewayUrl(baseURL)) {
     return
   }
-  hasWarned = true
   console.warn(
     '[PostHog] The PostHog AI wrapper is pointed at the PostHog AI Gateway. ' +
       'Both capture $ai_generation, so every call is double-counted and double-billed. ' +
       `Use one or the other — see ${GATEWAY_DOCS_URL}.`
   )
-}
-
-/** Test-only: reset the once-per-process warning latch. */
-export const resetGatewayWarningForTesting = (): void => {
-  hasWarned = false
 }

--- a/packages/ai/src/gatewayWarning.ts
+++ b/packages/ai/src/gatewayWarning.ts
@@ -47,3 +47,22 @@ export const warnIfPostHogAiGateway = (baseURL: string | undefined | null): void
       `Use one or the other — see ${GATEWAY_DOCS_URL}.`
   )
 }
+
+// OTel spans don't pass through captureAiGeneration, so detect the gateway from
+// the span's host/URL attributes instead. These follow the GenAI / HTTP semantic
+// conventions: `server.address` is a bare host, `url.full` a full URL, both of
+// which isPostHogAiGatewayUrl accepts.
+const OTEL_GATEWAY_URL_ATTRIBUTES = ['server.address', 'url.full'] as const
+
+export const warnIfPostHogAiGatewayOtelAttributes = (attributes: Record<string, unknown> | undefined): void => {
+  if (!attributes) {
+    return
+  }
+  for (const key of OTEL_GATEWAY_URL_ATTRIBUTES) {
+    const value = attributes[key]
+    if (typeof value === 'string' && isPostHogAiGatewayUrl(value)) {
+      warnIfPostHogAiGateway(value)
+      return
+    }
+  }
+}

--- a/packages/ai/src/gatewayWarning.ts
+++ b/packages/ai/src/gatewayWarning.ts
@@ -1,26 +1,11 @@
-/**
- * Detects when an `@posthog/ai` wrapper is pointed at the PostHog AI Gateway and
- * warns once, because that configuration double-captures every generation.
- *
- * The PostHog AI Gateway emits its own `$ai_generation` for every call it routes.
- * If a developer points a wrapper's `base_url` at the gateway, each call is
- * captured twice — once by the wrapper, once by the gateway — and, for billable
- * products, billed twice. We only warn: the wrapper's event carries data the
- * gateway never sees (groups, custom properties, trace hierarchy), so dropping it
- * would lose information. The fix is to pick one or the other.
- */
+// Warn (once) when a wrapper's base_url points at the PostHog AI Gateway: the
+// gateway emits its own $ai_generation, so each call would be captured (and, for
+// billable products, billed) twice. We only warn — the wrapper's event carries
+// data the gateway never sees (groups, custom properties, trace hierarchy).
 
-/**
- * Hosts served by the PostHog AI Gateway. Detection keys on the URL host so it is
- * robust to the path, scheme, and per-product route prefix (e.g.
- * `gateway.us.posthog.com/v1`, `gateway.us.posthog.com/signals/v1`).
- *
- * Maintained by hand — keep in sync with the gateway's deployed hosts (see
- * `services/llm-gateway` and `posthog/llm/gateway_client.py` in the main PostHog
- * repo). `gateway.us.posthog.com` is the live production host today; the regional
- * and `ai-gateway.*` variants are listed defensively so the warning keeps firing
- * if/when traffic moves to them.
- */
+// Keep in sync with the gateway's deployed hosts (see services/llm-gateway in the
+// main repo). gateway.us.posthog.com is live today; the rest are listed ahead of
+// any traffic moving to them.
 export const POSTHOG_AI_GATEWAY_HOSTS: readonly string[] = [
   'gateway.posthog.com',
   'gateway.us.posthog.com',
@@ -29,12 +14,12 @@ export const POSTHOG_AI_GATEWAY_HOSTS: readonly string[] = [
   'ai-gateway.eu.posthog.com',
 ]
 
-// Live LLM analytics docs. Swap for the dedicated AI Gateway page once it ships.
-const GATEWAY_DOCS_URL = 'https://posthog.com/docs/llm-analytics'
+// Swap for the dedicated AI Gateway page once it ships.
+const GATEWAY_DOCS_URL = 'https://posthog.com/docs/ai-observability'
 
 const extractHost = (baseURL: string): string | undefined => {
   try {
-    // Tolerate bare hosts ("gateway.us.posthog.com/v1") that omit a scheme.
+    // Tolerate bare hosts that omit a scheme, e.g. "gateway.us.posthog.com/v1".
     const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(baseURL)
     return new URL(hasScheme ? baseURL : `https://${baseURL}`).hostname.toLowerCase()
   } catch {
@@ -42,7 +27,6 @@ const extractHost = (baseURL: string): string | undefined => {
   }
 }
 
-/** Whether `baseURL`'s host is a known PostHog AI Gateway host. */
 export const isPostHogAiGatewayUrl = (baseURL: string | undefined | null): boolean => {
   if (!baseURL) {
     return false
@@ -53,11 +37,7 @@ export const isPostHogAiGatewayUrl = (baseURL: string | undefined | null): boole
 
 let hasWarned = false
 
-/**
- * Log a one-time warning when `baseURL` points at the PostHog AI Gateway. Safe to
- * call on every generation: it short-circuits after the first warning and does
- * nothing for non-gateway URLs. Behavior is unchanged beyond the log line.
- */
+// Safe to call on every generation: short-circuits after the first warning.
 export const warnIfPostHogAiGateway = (baseURL: string | undefined | null): void => {
   if (hasWarned || !isPostHogAiGatewayUrl(baseURL)) {
     return

--- a/packages/ai/src/gatewayWarning.ts
+++ b/packages/ai/src/gatewayWarning.ts
@@ -1,0 +1,76 @@
+/**
+ * Detects when an `@posthog/ai` wrapper is pointed at the PostHog AI Gateway and
+ * warns once, because that configuration double-captures every generation.
+ *
+ * The PostHog AI Gateway emits its own `$ai_generation` for every call it routes.
+ * If a developer points a wrapper's `base_url` at the gateway, each call is
+ * captured twice — once by the wrapper, once by the gateway — and, for billable
+ * products, billed twice. We only warn: the wrapper's event carries data the
+ * gateway never sees (groups, custom properties, trace hierarchy), so dropping it
+ * would lose information. The fix is to pick one or the other.
+ */
+
+/**
+ * Hosts served by the PostHog AI Gateway. Detection keys on the URL host so it is
+ * robust to the path, scheme, and per-product route prefix (e.g.
+ * `gateway.us.posthog.com/v1`, `gateway.us.posthog.com/signals/v1`).
+ *
+ * Maintained by hand — keep in sync with the gateway's deployed hosts (see
+ * `services/llm-gateway` and `posthog/llm/gateway_client.py` in the main PostHog
+ * repo). `gateway.us.posthog.com` is the live production host today; the regional
+ * and `ai-gateway.*` variants are listed defensively so the warning keeps firing
+ * if/when traffic moves to them.
+ */
+export const POSTHOG_AI_GATEWAY_HOSTS: readonly string[] = [
+  'gateway.posthog.com',
+  'gateway.us.posthog.com',
+  'gateway.eu.posthog.com',
+  'ai-gateway.us.posthog.com',
+  'ai-gateway.eu.posthog.com',
+]
+
+// Live LLM analytics docs. Swap for the dedicated AI Gateway page once it ships.
+const GATEWAY_DOCS_URL = 'https://posthog.com/docs/llm-analytics'
+
+const extractHost = (baseURL: string): string | undefined => {
+  try {
+    // Tolerate bare hosts ("gateway.us.posthog.com/v1") that omit a scheme.
+    const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(baseURL)
+    return new URL(hasScheme ? baseURL : `https://${baseURL}`).hostname.toLowerCase()
+  } catch {
+    return undefined
+  }
+}
+
+/** Whether `baseURL`'s host is a known PostHog AI Gateway host. */
+export const isPostHogAiGatewayUrl = (baseURL: string | undefined | null): boolean => {
+  if (!baseURL) {
+    return false
+  }
+  const host = extractHost(baseURL)
+  return host !== undefined && POSTHOG_AI_GATEWAY_HOSTS.includes(host)
+}
+
+let hasWarned = false
+
+/**
+ * Log a one-time warning when `baseURL` points at the PostHog AI Gateway. Safe to
+ * call on every generation: it short-circuits after the first warning and does
+ * nothing for non-gateway URLs. Behavior is unchanged beyond the log line.
+ */
+export const warnIfPostHogAiGateway = (baseURL: string | undefined | null): void => {
+  if (hasWarned || !isPostHogAiGatewayUrl(baseURL)) {
+    return
+  }
+  hasWarned = true
+  console.warn(
+    '[PostHog] The PostHog AI wrapper is pointed at the PostHog AI Gateway. ' +
+      'Both capture $ai_generation, so every call is double-counted and double-billed. ' +
+      `Use one or the other — see ${GATEWAY_DOCS_URL}.`
+  )
+}
+
+/** Test-only: reset the once-per-process warning latch. */
+export const resetGatewayWarningForTesting = (): void => {
+  hasWarned = false
+}

--- a/packages/ai/src/langchain/callbacks.ts
+++ b/packages/ai/src/langchain/callbacks.ts
@@ -11,6 +11,7 @@ import { ToolCall } from '@langchain/core/messages/tool'
 import { BaseMessage } from '@langchain/core/messages'
 import { sanitizeLangChain } from '../sanitization'
 import { stringifyError } from '../serializeError'
+import { warnIfPostHogAiGateway } from '../gatewayWarning'
 
 interface SpanMetadata {
   /** Name of the trace/span (e.g. chain name) */
@@ -460,6 +461,7 @@ export class LangChainCallbackHandler extends BaseCallbackHandler {
     parentRunId?: string
   ): void {
     const latency = run.endTime ? (run.endTime - run.startTime) / 1000 : 0
+    warnIfPostHogAiGateway(run.baseUrl)
     const eventProperties: Record<string, any> = {
       $ai_lib: 'posthog-ai',
       $ai_lib_version: version,

--- a/packages/ai/src/openai-agents/processor.ts
+++ b/packages/ai/src/openai-agents/processor.ts
@@ -19,6 +19,7 @@ import type {
 } from '@openai/agents-core'
 import { MAX_OUTPUT_SIZE, truncate, withPrivacyMode } from '../utils'
 import { version } from '../../package.json'
+import { warnIfPostHogAiGateway } from '../gatewayWarning'
 
 /**
  * Normalize OpenAI Responses API input items to include a `role` field.
@@ -453,6 +454,10 @@ export class PostHogTracingProcessor implements TracingProcessor {
       if (param in modelConfig) {
         modelParams[param] = modelConfig[param]
       }
+    }
+
+    if (typeof modelConfig.base_url === 'string') {
+      warnIfPostHogAiGateway(modelConfig.base_url)
     }
 
     const properties: Record<string, any> = {

--- a/packages/ai/src/otel/exporter.ts
+++ b/packages/ai/src/otel/exporter.ts
@@ -4,6 +4,7 @@ import { ExportResultCode } from '@opentelemetry/core'
 
 import { redactSpan } from './redact'
 import { isAISpan } from './spans'
+import { warnIfPostHogAiGatewayOtelAttributes } from '../gatewayWarning'
 
 const DEFAULT_OTEL_HOST = 'https://us.i.posthog.com'
 
@@ -98,6 +99,9 @@ export class PostHogTraceExporter extends OTLPTraceExporter {
     if (aiSpans.length === 0) {
       resultCallback({ code: ExportResultCode.SUCCESS })
       return
+    }
+    for (const span of aiSpans) {
+      warnIfPostHogAiGatewayOtelAttributes(span.attributes)
     }
     super.export(aiSpans.map(redactSpan), resultCallback)
   }

--- a/packages/ai/src/otel/processor.ts
+++ b/packages/ai/src/otel/processor.ts
@@ -4,6 +4,7 @@ import { BatchSpanProcessor, type SpanProcessor, type ReadableSpan, type Span } 
 
 import { redactSpan } from './redact'
 import { isAISpan } from './spans'
+import { warnIfPostHogAiGatewayOtelAttributes } from '../gatewayWarning'
 
 const DEFAULT_OTEL_HOST = 'https://us.i.posthog.com'
 
@@ -108,6 +109,7 @@ export class PostHogSpanProcessor implements SpanProcessor {
 
   onEnd(span: ReadableSpan): void {
     if (isAISpan(span)) {
+      warnIfPostHogAiGatewayOtelAttributes(span.attributes)
       this.inner.onEnd(redactSpan(span))
     }
   }

--- a/packages/ai/tests/gatewayWarning.test.ts
+++ b/packages/ai/tests/gatewayWarning.test.ts
@@ -1,9 +1,4 @@
-import {
-  POSTHOG_AI_GATEWAY_HOSTS,
-  isPostHogAiGatewayUrl,
-  warnIfPostHogAiGateway,
-  resetGatewayWarningForTesting,
-} from '../src/gatewayWarning'
+import { POSTHOG_AI_GATEWAY_HOSTS, isPostHogAiGatewayUrl, warnIfPostHogAiGateway } from '../src/gatewayWarning'
 
 describe('gatewayWarning', () => {
   describe('isPostHogAiGatewayUrl', () => {
@@ -46,7 +41,6 @@ describe('gatewayWarning', () => {
     let warnSpy: jest.SpyInstance
 
     beforeEach(() => {
-      resetGatewayWarningForTesting()
       warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
     })
 
@@ -54,7 +48,7 @@ describe('gatewayWarning', () => {
       warnSpy.mockRestore()
     })
 
-    it('warns once with the double-counting message when pointed at the gateway', () => {
+    it('warns with the double-counting message when pointed at the gateway', () => {
       warnIfPostHogAiGateway('https://gateway.us.posthog.com/v1')
 
       expect(warnSpy).toHaveBeenCalledTimes(1)
@@ -66,14 +60,12 @@ describe('gatewayWarning', () => {
       expect(message).toContain('https://posthog.com/docs/ai-observability')
     })
 
-    it('warns only once across many gateway calls', () => {
+    it('warns on every gateway call so the misconfiguration cannot be missed', () => {
       for (let i = 0; i < 5; i++) {
         warnIfPostHogAiGateway('https://gateway.us.posthog.com/v1')
       }
-      // A second host should not re-trigger the warning either.
-      warnIfPostHogAiGateway('https://gateway.eu.posthog.com/v1')
 
-      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledTimes(5)
     })
 
     it('does not warn for non-gateway base URLs', () => {

--- a/packages/ai/tests/gatewayWarning.test.ts
+++ b/packages/ai/tests/gatewayWarning.test.ts
@@ -1,0 +1,87 @@
+import {
+  POSTHOG_AI_GATEWAY_HOSTS,
+  isPostHogAiGatewayUrl,
+  warnIfPostHogAiGateway,
+  resetGatewayWarningForTesting,
+} from '../src/gatewayWarning'
+
+describe('gatewayWarning', () => {
+  describe('isPostHogAiGatewayUrl', () => {
+    it('detects every maintained gateway host', () => {
+      for (const host of POSTHOG_AI_GATEWAY_HOSTS) {
+        expect(isPostHogAiGatewayUrl(`https://${host}/v1`)).toBe(true)
+      }
+    })
+
+    it('detects the live production host with a per-product route prefix', () => {
+      expect(isPostHogAiGatewayUrl('https://gateway.us.posthog.com/v1')).toBe(true)
+      expect(isPostHogAiGatewayUrl('https://gateway.us.posthog.com/signals/v1')).toBe(true)
+      expect(isPostHogAiGatewayUrl('https://gateway.us.posthog.com/anthropic')).toBe(true)
+    })
+
+    it('matches the host regardless of scheme, casing, or a missing scheme', () => {
+      expect(isPostHogAiGatewayUrl('http://gateway.us.posthog.com/v1')).toBe(true)
+      expect(isPostHogAiGatewayUrl('https://GATEWAY.US.POSTHOG.COM/v1')).toBe(true)
+      expect(isPostHogAiGatewayUrl('gateway.us.posthog.com/v1')).toBe(true)
+    })
+
+    it('does not match non-gateway PostHog hosts or other providers', () => {
+      expect(isPostHogAiGatewayUrl('https://us.i.posthog.com')).toBe(false)
+      expect(isPostHogAiGatewayUrl('https://eu.posthog.com')).toBe(false)
+      expect(isPostHogAiGatewayUrl('https://api.openai.com/v1')).toBe(false)
+      expect(isPostHogAiGatewayUrl('https://api.anthropic.com')).toBe(false)
+      // A look-alike host on a different domain must not match.
+      expect(isPostHogAiGatewayUrl('https://gateway.us.posthog.com.evil.example/v1')).toBe(false)
+    })
+
+    it('does not match empty, missing, or malformed values', () => {
+      expect(isPostHogAiGatewayUrl('')).toBe(false)
+      expect(isPostHogAiGatewayUrl(undefined)).toBe(false)
+      expect(isPostHogAiGatewayUrl(null)).toBe(false)
+      expect(isPostHogAiGatewayUrl('::::not a url')).toBe(false)
+    })
+  })
+
+  describe('warnIfPostHogAiGateway', () => {
+    let warnSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      resetGatewayWarningForTesting()
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => {
+      warnSpy.mockRestore()
+    })
+
+    it('warns once with the double-counting message when pointed at the gateway', () => {
+      warnIfPostHogAiGateway('https://gateway.us.posthog.com/v1')
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const message = warnSpy.mock.calls[0][0]
+      expect(message).toContain('[PostHog]')
+      expect(message).toContain('PostHog AI Gateway')
+      expect(message).toContain('$ai_generation')
+      expect(message).toContain('double-counted and double-billed')
+      expect(message).toContain('https://posthog.com/docs/llm-analytics')
+    })
+
+    it('warns only once across many gateway calls', () => {
+      for (let i = 0; i < 5; i++) {
+        warnIfPostHogAiGateway('https://gateway.us.posthog.com/v1')
+      }
+      // A second host should not re-trigger the warning either.
+      warnIfPostHogAiGateway('https://gateway.eu.posthog.com/v1')
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not warn for non-gateway base URLs', () => {
+      warnIfPostHogAiGateway('https://api.openai.com/v1')
+      warnIfPostHogAiGateway(undefined)
+      warnIfPostHogAiGateway('')
+
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/ai/tests/gatewayWarning.test.ts
+++ b/packages/ai/tests/gatewayWarning.test.ts
@@ -63,7 +63,7 @@ describe('gatewayWarning', () => {
       expect(message).toContain('PostHog AI Gateway')
       expect(message).toContain('$ai_generation')
       expect(message).toContain('double-counted and double-billed')
-      expect(message).toContain('https://posthog.com/docs/llm-analytics')
+      expect(message).toContain('https://posthog.com/docs/ai-observability')
     })
 
     it('warns only once across many gateway calls', () => {

--- a/packages/ai/tests/gatewayWarning.test.ts
+++ b/packages/ai/tests/gatewayWarning.test.ts
@@ -2,38 +2,43 @@ import { POSTHOG_AI_GATEWAY_HOSTS, isPostHogAiGatewayUrl, warnIfPostHogAiGateway
 
 describe('gatewayWarning', () => {
   describe('isPostHogAiGatewayUrl', () => {
-    it('detects every maintained gateway host', () => {
-      for (const host of POSTHOG_AI_GATEWAY_HOSTS) {
-        expect(isPostHogAiGatewayUrl(`https://${host}/v1`)).toBe(true)
-      }
+    it.each(POSTHOG_AI_GATEWAY_HOSTS)('detects gateway host %s', (host) => {
+      expect(isPostHogAiGatewayUrl(`https://${host}/v1`)).toBe(true)
     })
 
-    it('detects the live production host with a per-product route prefix', () => {
-      expect(isPostHogAiGatewayUrl('https://gateway.us.posthog.com/v1')).toBe(true)
-      expect(isPostHogAiGatewayUrl('https://gateway.us.posthog.com/signals/v1')).toBe(true)
-      expect(isPostHogAiGatewayUrl('https://gateway.us.posthog.com/anthropic')).toBe(true)
+    it.each([
+      'https://gateway.us.posthog.com/v1',
+      'https://gateway.us.posthog.com/signals/v1',
+      'https://gateway.us.posthog.com/anthropic',
+    ])('detects the live production host with a route prefix: %s', (url) => {
+      expect(isPostHogAiGatewayUrl(url)).toBe(true)
     })
 
-    it('matches the host regardless of scheme, casing, or a missing scheme', () => {
-      expect(isPostHogAiGatewayUrl('http://gateway.us.posthog.com/v1')).toBe(true)
-      expect(isPostHogAiGatewayUrl('https://GATEWAY.US.POSTHOG.COM/v1')).toBe(true)
-      expect(isPostHogAiGatewayUrl('gateway.us.posthog.com/v1')).toBe(true)
+    it.each([
+      ['http scheme', 'http://gateway.us.posthog.com/v1'],
+      ['uppercase host', 'https://GATEWAY.US.POSTHOG.COM/v1'],
+      ['missing scheme', 'gateway.us.posthog.com/v1'],
+    ])('matches a gateway host with %s', (_label, url) => {
+      expect(isPostHogAiGatewayUrl(url)).toBe(true)
     })
 
-    it('does not match non-gateway PostHog hosts or other providers', () => {
-      expect(isPostHogAiGatewayUrl('https://us.i.posthog.com')).toBe(false)
-      expect(isPostHogAiGatewayUrl('https://eu.posthog.com')).toBe(false)
-      expect(isPostHogAiGatewayUrl('https://api.openai.com/v1')).toBe(false)
-      expect(isPostHogAiGatewayUrl('https://api.anthropic.com')).toBe(false)
-      // A look-alike host on a different domain must not match.
-      expect(isPostHogAiGatewayUrl('https://gateway.us.posthog.com.evil.example/v1')).toBe(false)
+    it.each([
+      ['ingestion host', 'https://us.i.posthog.com'],
+      ['app host', 'https://eu.posthog.com'],
+      ['openai', 'https://api.openai.com/v1'],
+      ['anthropic', 'https://api.anthropic.com'],
+      ['look-alike domain', 'https://gateway.us.posthog.com.evil.example/v1'],
+    ])('does not match non-gateway URL (%s)', (_label, url) => {
+      expect(isPostHogAiGatewayUrl(url)).toBe(false)
     })
 
-    it('does not match empty, missing, or malformed values', () => {
-      expect(isPostHogAiGatewayUrl('')).toBe(false)
-      expect(isPostHogAiGatewayUrl(undefined)).toBe(false)
-      expect(isPostHogAiGatewayUrl(null)).toBe(false)
-      expect(isPostHogAiGatewayUrl('::::not a url')).toBe(false)
+    it.each([
+      ['empty string', ''],
+      ['undefined', undefined],
+      ['null', null],
+      ['malformed', '::::not a url'],
+    ])('does not match %s', (_label, value) => {
+      expect(isPostHogAiGatewayUrl(value)).toBe(false)
     })
   })
 

--- a/packages/ai/tests/gatewayWarning.test.ts
+++ b/packages/ai/tests/gatewayWarning.test.ts
@@ -1,4 +1,9 @@
-import { POSTHOG_AI_GATEWAY_HOSTS, isPostHogAiGatewayUrl, warnIfPostHogAiGateway } from '../src/gatewayWarning'
+import {
+  POSTHOG_AI_GATEWAY_HOSTS,
+  isPostHogAiGatewayUrl,
+  warnIfPostHogAiGateway,
+  warnIfPostHogAiGatewayOtelAttributes,
+} from '../src/gatewayWarning'
 
 describe('gatewayWarning', () => {
   describe('isPostHogAiGatewayUrl', () => {
@@ -77,6 +82,47 @@ describe('gatewayWarning', () => {
       warnIfPostHogAiGateway('https://api.openai.com/v1')
       warnIfPostHogAiGateway(undefined)
       warnIfPostHogAiGateway('')
+
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('warnIfPostHogAiGatewayOtelAttributes', () => {
+    let warnSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => {
+      warnSpy.mockRestore()
+    })
+
+    it.each([
+      ['server.address bare host', { 'server.address': 'gateway.us.posthog.com' }],
+      ['url.full full URL', { 'url.full': 'https://gateway.us.posthog.com/v1/chat/completions' }],
+    ])('warns when a gateway is detected via %s', (_label, attributes) => {
+      warnIfPostHogAiGatewayOtelAttributes(attributes)
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toContain('PostHog AI Gateway')
+    })
+
+    it('warns at most once per span even when several attributes point at the gateway', () => {
+      warnIfPostHogAiGatewayOtelAttributes({
+        'server.address': 'gateway.us.posthog.com',
+        'url.full': 'https://gateway.us.posthog.com/v1',
+      })
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it.each([
+      ['a non-gateway host', { 'server.address': 'api.openai.com', 'url.full': 'https://api.openai.com/v1' }],
+      ['no relevant attributes', { 'gen_ai.model': 'gpt-4o' }],
+      ['undefined attributes', undefined],
+    ])('does not warn for %s', (_label, attributes) => {
+      warnIfPostHogAiGatewayOtelAttributes(attributes)
 
       expect(warnSpy).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
## Problem

The `@posthog/ai` wrapper and the PostHog AI Gateway both emit `$ai_generation`. Point a wrapper's `base_url` at the gateway and every call is captured (and, for billable products, billed) twice, with nothing surfacing the mistake.

## Changes

- `console.warn` on every routed call whose `base_url` resolves to a known gateway host, matched on host so scheme and route prefix don't matter.
- Fires on every call, not once: a single startup line is too easy to scroll past, and the first sign would otherwise be a doubled bill.
- Warns only, never drops the wrapper's event, which carries data the gateway never sees (groups, custom properties, trace hierarchy). Wired through `captureAiGeneration` plus the inline LangChain and OpenAI Agents paths.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file