### PR TITLE
fix(persistence): stop per-request metadata rewriting split-storage entries on every load

### DIFF
--- a/.changeset/volatile-group-metadata.md
+++ b/.changeset/volatile-group-metadata.md
@@ -1,0 +1,7 @@
+---
+'posthog-js': patch
+---
+
+fix(persistence): stop per-request metadata rewriting the split-storage entries on every load
+
+`$feature_flag_evaluated_at`, `$feature_flag_request_id`, and `$surveys_loaded_at` change on every `/flags` (or `/surveys`) load even when the flag and survey content is unchanged. With `split_storage` enabled that made the multi-hundred-KB `__flags` / `__surveys` localStorage entries dirty on every SPA navigation, re-broadcasting the full payload to every open same-origin tab via cross-tab `storage` events — the exact pressure the split exists to remove. These keys are now marked volatile: a value-only change neither dirties the group nor alters its fingerprint, so the write is skipped and the freshest value rides along on the next real content write. Adding or deleting a volatile key still writes through (presence is fingerprinted, the moving value is not), and the in-memory value is always current — only the on-disk copy may lag until the next content change.

--- a/packages/browser/src/__tests__/posthog-persistence.test.ts
+++ b/packages/browser/src/__tests__/posthog-persistence.test.ts
@@ -1162,6 +1162,83 @@ describe('flag and survey storage split', () => {
         })
     })
 
+    describe('volatile metadata does not dirty the group entries', () => {
+        // $feature_flag_evaluated_at, $feature_flag_request_id, and
+        // $surveys_loaded_at change on every /flags (or /surveys) load even when
+        // the meaningful content is unchanged. Rewriting a multi-hundred-KB group
+        // entry just to refresh them re-broadcasts the payload to every open tab
+        // on each SPA navigation — exactly the cross-tab storage-event pressure
+        // the split exists to remove. A volatile-only change skips the write; the
+        // freshest value rides along on the next content write.
+        it.each([
+            {
+                label: '$feature_flag_evaluated_at',
+                entry: FLAGS,
+                register: { [PERSISTENCE_FEATURE_FLAG_EVALUATED_AT]: 1717200099999 },
+            },
+            {
+                label: '$feature_flag_request_id',
+                entry: FLAGS,
+                register: { [PERSISTENCE_FEATURE_FLAG_REQUEST_ID]: 'req-789' },
+            },
+            {
+                label: '$surveys_loaded_at',
+                entry: SURVEYS_ENTRY,
+                register: { [SURVEYS_LOADED_AT]: 1717200099999 },
+            },
+        ])('registering only a fresh $label does not rewrite the group entry', ({ entry, register }) => {
+            const lib = new PostHogPersistence(makeConfig())
+            lib.register({ ...FLAG_CLUSTER, ...SURVEY_DATA, [SURVEYS_LOADED_AT]: 1717200000000, distinct_id: 'd' })
+
+            const setSpy = jest.spyOn(localStore, '_set')
+            setSpy.mockClear()
+            lib.register(register)
+
+            expect(setSpy.mock.calls.map(([name]) => name)).not.toContain(entry)
+            setSpy.mockRestore()
+        })
+
+        it('a content change writes the group entry with the freshest volatile values riding along', () => {
+            const lib = new PostHogPersistence(makeConfig())
+            lib.register({ ...FLAG_CLUSTER, distinct_id: 'd' })
+
+            lib.register({ [PERSISTENCE_FEATURE_FLAG_EVALUATED_AT]: 1717200099999 })
+            expect(parse(FLAGS)[PERSISTENCE_FEATURE_FLAG_EVALUATED_AT]).toEqual(1717200000000)
+
+            lib.register({ [ENABLED_FEATURE_FLAGS]: { beta: false } })
+            const flagsEntry = parse(FLAGS)
+            expect(flagsEntry[ENABLED_FEATURE_FLAGS]).toEqual({ beta: false })
+            expect(flagsEntry[PERSISTENCE_FEATURE_FLAG_EVALUATED_AT]).toEqual(1717200099999)
+        })
+
+        it('the in-memory value is always the freshest even while disk lags', () => {
+            const lib = new PostHogPersistence(makeConfig())
+            lib.register({ ...FLAG_CLUSTER, distinct_id: 'd' })
+
+            lib.register({ [PERSISTENCE_FEATURE_FLAG_REQUEST_ID]: 'req-789' })
+
+            expect(lib.props[PERSISTENCE_FEATURE_FLAG_REQUEST_ID]).toEqual('req-789')
+            expect(parse(FLAGS)[PERSISTENCE_FEATURE_FLAG_REQUEST_ID]).toEqual('req-123')
+        })
+
+        it('a returning visitor whose loads only refresh volatile values never rewrites the entry', () => {
+            localStorage.setItem(MAIN, JSON.stringify({ distinct_id: 'd' }))
+            localStorage.setItem(FLAGS, JSON.stringify(FLAG_CLUSTER))
+
+            const lib = new PostHogPersistence(makeConfig())
+            const setSpy = jest.spyOn(localStore, '_set')
+            setSpy.mockClear()
+
+            lib.register({
+                [PERSISTENCE_FEATURE_FLAG_EVALUATED_AT]: 1717200099999,
+                [PERSISTENCE_FEATURE_FLAG_REQUEST_ID]: 'req-789',
+            })
+
+            expect(setSpy.mock.calls.map(([name]) => name)).not.toContain(FLAGS)
+            setSpy.mockRestore()
+        })
+    })
+
     describe('per-entry fingerprints decouple the writes', () => {
         it('a main-blob change does not rewrite __flags or __surveys', () => {
             const lib = new PostHogPersistence(makeConfig())
@@ -1186,7 +1263,7 @@ describe('flag and survey storage split', () => {
             const setSpy = jest.spyOn(localStore, '_set')
             setSpy.mockClear()
 
-            lib.register({ [PERSISTENCE_FEATURE_FLAG_REQUEST_ID]: 'req-456' })
+            lib.register({ [ENABLED_FEATURE_FLAGS]: { beta: false, exp: 'test' } })
 
             const names = setSpy.mock.calls.map(([name]) => name)
             expect(names).toContain(FLAGS)
@@ -1264,10 +1341,10 @@ describe('flag and survey storage split', () => {
             const setSpy = jest.spyOn(localStore, '_set')
             setSpy.mockClear()
 
-            lib.register({ [PERSISTENCE_FEATURE_FLAG_REQUEST_ID]: 'req-new' })
+            lib.register({ [ENABLED_FEATURE_FLAGS]: { beta: false, exp: 'control' } })
 
             expect(setSpy.mock.calls.map(([name]) => name)).toContain(FLAGS)
-            expect(parse(FLAGS)[PERSISTENCE_FEATURE_FLAG_REQUEST_ID]).toBe('req-new')
+            expect(parse(FLAGS)[ENABLED_FEATURE_FLAGS]).toEqual({ beta: false, exp: 'control' })
             setSpy.mockRestore()
         })
     })

--- a/packages/browser/src/persistence-key-policy.ts
+++ b/packages/browser/src/persistence-key-policy.ts
@@ -94,6 +94,15 @@ export const PERSISTENCE_STORAGE_GROUPS: readonly PersistenceStorageGroup[] = ['
 interface PersistenceKeyPolicyEntry {
     exposure: PersistenceKeyExposure
     storageGroup?: PersistenceStorageGroup
+    /**
+     * Per-request metadata that changes on every remote load even when the
+     * meaningful content is unchanged. A volatile key never marks its storage
+     * group dirty and is excluded from the group fingerprint, so a
+     * volatile-only change does not rewrite — and cross-tab re-broadcast — a
+     * large group entry. The freshest value rides along on the next content
+     * write; the on-disk copy may lag in-memory until then.
+     */
+    volatile?: boolean
     shouldSkipFromEventProperties?: (value: Property, shouldSkip: () => boolean) => boolean
     transformToEventProperties?: (value: Property) => Properties
 }
@@ -130,13 +139,13 @@ export const PERSISTENCE_KEY_POLICY: Record<string, PersistenceKeyPolicyEntry> =
     [PERSISTENCE_EARLY_ACCESS_FEATURES]: { exposure: 'hidden' },
     [PERSISTENCE_FEATURE_FLAG_DETAILS]: { exposure: 'hidden', storageGroup: 'flags' },
     [PERSISTENCE_FEATURE_FLAG_PAYLOADS]: { exposure: 'event', storageGroup: 'flags' },
-    [PERSISTENCE_FEATURE_FLAG_REQUEST_ID]: { exposure: 'event', storageGroup: 'flags' },
+    [PERSISTENCE_FEATURE_FLAG_REQUEST_ID]: { exposure: 'event', storageGroup: 'flags', volatile: true },
     [PERSISTENCE_OVERRIDE_FEATURE_FLAGS]: { exposure: 'event' },
     [PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS]: { exposure: 'hidden' },
     [STORED_PERSON_PROPERTIES_KEY]: { exposure: 'hidden' },
     [STORED_GROUP_PROPERTIES_KEY]: { exposure: 'hidden' },
     [SURVEYS]: { exposure: 'hidden', storageGroup: 'surveys' },
-    [SURVEYS_LOADED_AT]: { exposure: 'hidden', storageGroup: 'surveys' },
+    [SURVEYS_LOADED_AT]: { exposure: 'hidden', storageGroup: 'surveys', volatile: true },
     [SURVEYS_ACTIVATED]: { exposure: 'event' },
     [PRODUCT_TOURS]: { exposure: 'hidden' },
     [PRODUCT_TOURS_ACTIVATED]: { exposure: 'hidden' },
@@ -147,7 +156,7 @@ export const PERSISTENCE_KEY_POLICY: Record<string, PersistenceKeyPolicyEntry> =
     [FLAG_CALL_REPORTED]: { exposure: 'hidden' },
     [FLAG_CALL_REPORTED_SESSION_ID]: { exposure: 'hidden' },
     [PERSISTENCE_FEATURE_FLAG_ERRORS]: { exposure: 'hidden' },
-    [PERSISTENCE_FEATURE_FLAG_EVALUATED_AT]: { exposure: 'hidden', storageGroup: 'flags' },
+    [PERSISTENCE_FEATURE_FLAG_EVALUATED_AT]: { exposure: 'hidden', storageGroup: 'flags', volatile: true },
     [USER_STATE]: { exposure: 'hidden' },
     [CLIENT_SESSION_PROPS]: { exposure: 'hidden' },
     [CAPTURE_RATE_LIMIT]: { exposure: 'hidden' },

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -22,6 +22,10 @@ import { getPersistenceKeyPolicy, PERSISTENCE_STORAGE_GROUPS, PersistenceStorage
 // signal, so the group entry wins by default (the migrated-forward home).
 const VOLATILE_FINGERPRINT_PLACEHOLDER = '__volatile__'
 
+// Both freshness keys are volatile (their on-disk value lags the last content
+// change). That is safe: when only the stamp moved, both the group entry and the
+// main blob hold identical content, so whichever side wins still produces the
+// same values. A mixed-fleet race at most causes one extra /flags cycle.
 const GROUP_FRESHNESS_KEY: Partial<Record<PersistenceStorageGroup, string>> = {
     flags: PERSISTENCE_FEATURE_FLAG_EVALUATED_AT,
     surveys: SURVEYS_LOADED_AT,

--- a/packages/browser/src/posthog-persistence.ts
+++ b/packages/browser/src/posthog-persistence.ts
@@ -20,6 +20,8 @@ import { getPersistenceKeyPolicy, PERSISTENCE_STORAGE_GROUPS, PersistenceStorage
 // stale orphan (a gate-off / older-SDK tab wrote a fresher payload back to main)
 // and must not win on load. Groups without an entry here have no freshness
 // signal, so the group entry wins by default (the migrated-forward home).
+const VOLATILE_FINGERPRINT_PLACEHOLDER = '__volatile__'
+
 const GROUP_FRESHNESS_KEY: Partial<Record<PersistenceStorageGroup, string>> = {
     flags: PERSISTENCE_FEATURE_FLAG_EVALUATED_AT,
     surveys: SURVEYS_LOADED_AT,
@@ -511,11 +513,18 @@ export class PostHogPersistence {
     // across the cookie-option setters that run during construction, so an
     // unchanged flag entry is neither re-serialized nor re-broadcast.
     private _entryFingerprint(props: Properties, slot: StorageSlot): string {
-        const serialized = JSON.stringify(props)
         if (slot === MAIN_STORAGE_SLOT) {
-            return serialized + '|' + this._expire_days + '|' + this._cross_subdomain + '|' + this._secure
+            return JSON.stringify(props) + '|' + this._expire_days + '|' + this._cross_subdomain + '|' + this._secure
         }
-        return serialized
+        // Volatile keys count by presence only: a write triggered by a real
+        // content change records a fingerprint that stays valid while the
+        // volatile values keep moving between writes, but adding or deleting a
+        // volatile key still changes the fingerprint so the entry writes through.
+        const stable: Properties = {}
+        each(props, (value, key) => {
+            stable[key] = getPersistenceKeyPolicy(key)?.volatile ? VOLATILE_FINGERPRINT_PLACEHOLDER : value
+        })
+        return JSON.stringify(stable)
     }
 
     // No-op rejection: skip the write when nothing that affects this entry has
@@ -856,7 +865,13 @@ export class PostHogPersistence {
 
     private _setProp(prop: string, to: any): void {
         this.props[prop] = to
-        this._markGroupDirty(prop)
+        // A volatile value change never dirties its group — it changes on every
+        // remote load and would otherwise force a rewrite of the large entry per
+        // load. Deletions still dirty (see _deleteProp): presence is part of the
+        // fingerprint, the moving value is not.
+        if (!getPersistenceKeyPolicy(prop)?.volatile) {
+            this._markGroupDirty(prop)
+        }
     }
 
     private _deleteProp(prop: string): void {


### PR DESCRIPTION
further reduce frequency of writes for https://github.com/PostHog/posthog/issues/32479

---

Per-request metadata stamps no longer rewrite the split-storage entries on every load: a volatile-only change skips the write entirely, and the fresh value rides along on the next real content change.

## Problem

`$feature_flag_evaluated_at`, `$feature_flag_request_id`, and `$surveys_loaded_at` are re-stamped on every `/flags` (or `/surveys`) load even when the flag and survey content is byte-identical. With `split_storage` enabled, that makes the `__flags` (often several hundred KB) and `__surveys` entries dirty on every SPA navigation. Each rewrite fires a cross-tab `storage` event whose payload Chromium buffers per hidden same-origin renderer — the exact background-tab memory pressure the storage split exists to remove. Measured on production-realistic multi-tab runs, these always-dirty rewrites are roughly half of the remaining storage-event payload hidden tabs absorb.

## Changes

- `persistence-key-policy.ts`: new `volatile` flag on the key policy, set for the three stamps.
- `posthog-persistence.ts`:
    - `_setProp` skips `_markGroupDirty` for volatile keys, so a value-only change leaves the group clean and the fast path skips the write (no serialize, no `storage` event). Deletions still dirty the group.
    - group fingerprints replace volatile values with a placeholder: a moving value never changes the fingerprint, but adding or deleting the key still writes through, so `unregister` / clears land on disk.
- In-memory props always hold the freshest values; only the on-disk copy lags until the next content write. The load-time freshness comparison (`_groupEntryIsStale`) is unaffected in the cases that matter: when only the stamp moved, both candidate copies hold identical content, so either side winning yields the same values.

## Tests

- Parameterized over all three volatile keys: a volatile-only `register` does not rewrite the group entry (fresh instance and seeded-load returning-visitor cases).
- A content change writes the entry with the freshest volatile values riding along.
- In-memory stays fresh while disk lags.
- Existing suite updated where it used `$feature_flag_request_id` as a "content changed" trigger.
- 649 tests passing across persistence, key-policy, featureflags, sessionid, and cross-tab suites.

## Release info

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

🤖 Generated with [Claude Code](https://claude.com/claude-code) — driven by @pauldambra as part of PostHog/posthog#32479.