### PR TITLE
fix: load remote config from the api host

### DIFF
--- a/.changeset/eager-routers-align.md
+++ b/.changeset/eager-routers-align.md
@@ -1,0 +1,5 @@
+---
+"posthog-js": patch
+---
+
+Load remote config from the api host instead of the asset host

--- a/packages/browser/src/__tests__/utils/external-scripts-loader.test.ts
+++ b/packages/browser/src/__tests__/utils/external-scripts-loader.test.ts
@@ -200,7 +200,7 @@ describe('external-scripts-loader', () => {
 
             const scripts = document!.getElementsByTagName('script')
             expect(scripts.length).toBe(1)
-            expect(scripts[0].src).toBe('https://us-assets.i.posthog.com/array/test-token/config.js')
+            expect(scripts[0].src).toBe('https://us.i.posthog.com/array/test-token/config.js')
         })
     })
 })

--- a/packages/browser/src/entrypoints/external-scripts-loader.ts
+++ b/packages/browser/src/entrypoints/external-scripts-loader.ts
@@ -92,7 +92,7 @@ assignableWindow.__PosthogExtensions__.loadExternalDependency = (
 ): void => {
     // remote-config always loads from the token-specific path
     if (kind === 'remote-config') {
-        const url = posthog.requestRouter.endpointFor('assets', `/array/${posthog.config.token}/config.js`)
+        const url = posthog.requestRouter.endpointFor('api', `/array/${posthog.config.token}/config.js`)
         loadScript(posthog, url, callback)
         return
     }

--- a/packages/browser/src/remote-config.ts
+++ b/packages/browser/src/remote-config.ts
@@ -33,7 +33,7 @@ export class RemoteConfigLoader {
     private _loadRemoteConfigJSON(cb: (config?: RemoteConfig) => void): void {
         this._instance._send_request({
             method: 'GET',
-            url: this._instance.requestRouter.endpointFor('assets', `/array/${this._instance.config.token}/config`),
+            url: this._instance.requestRouter.endpointFor('api', `/array/${this._instance.config.token}/config`),
             callback: (response) => {
                 cb(response.json as RemoteConfig | undefined)
             },


### PR DESCRIPTION
## Problem

Remote config — both the `/array/<token>/config.js` script and the `/array/<token>/config` JSON fallback — has been routed to the asset host (`us-assets.i.posthog.com` / `eu-assets.i.posthog.com`) since remote config was introduced in #1577 (Dec 2024). Tracing the history, this was inherited rather than deliberate: the remote-config script load was added as a new `kind` in `loadExternalDependency`, which funneled every script URL through a single `endpointFor('assets', …)` call meant for the static lazy bundles, and the JSON fallback then mirrored that host. In the same commit, `/decide` and site apps used the `api` target. Since #2895 made remote config the sole config-loading mechanism, this asset-host routing became load-bearing for every SDK boot.

Remote config is dynamic, token-specific content and should hit the api host like the other dynamic endpoints.

## Changes

- `external-scripts-loader.ts`: the `remote-config` script now loads from `endpointFor('api', '/array/<token>/config.js')`
- `remote-config.ts`: the JSON fallback now uses `endpointFor('api', '/array/<token>/config')`
- Updated the affected URL assertion in `external-scripts-loader.test.ts`

Custom-host setups (reverse proxies, `@posthog/next` middleware) see no behavioral change — the `CUSTOM` region already routed everything to `api_host`. On PostHog Cloud defaults, the config request moves from `<region>-assets.i.posthog.com` to `<region>.i.posthog.com`.

Note for reviewers: `request-router.test.ts` still asserts that `endpointFor('assets', '/array/…')` ignores the `asset_host` override — that's a router-contract test (override applies only to `/static/` paths) and the router itself is unchanged; only the callers moved.

## Infra note (caching difference between the two hosts)

Both hosts CNAME to the same regional ingress ALB, and contour routes `/array/` identically for both (the `static` include): `hypercache-server` at weight 100 (the Django→hypercache cutover shipped in charts #9881, April 2026). Headers are identical either way (`Cache-Control: public, max-age=300`, `Vary: Origin, Referer`). The difference is the Cloudflare layer:

- `us-assets.i` / `eu-assets.i` are **proxied** through Cloudflare, where a host-unscoped `/array/*` cache rule applies a 5-min edge+browser TTL with stale-while-updating.
- `us.i` / `eu.i` are **DNS-only** — no edge cache; requests hit the ALB directly, with only the browser honoring `max-age=300`.

So this change trades Cloudflare edge caching (and up to ~10 min worst-case staleness) for direct origin reads (bounded by the browser's 5-min cache). The repeat-hit volume currently absorbed at Cloudflare PoPs will land on hypercache (autoscaling 2–10 pods at 1 CPU/2Gi per region), which is a purpose-built read path — but its sizing should be sanity-checked against the full config request volume.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

