### PR TITLE
feat(node): add convex export condition

### DIFF
--- a/.changeset/blue-masks-end.md
+++ b/.changeset/blue-masks-end.md
@@ -1,0 +1,5 @@
+---
+'posthog-node': minor
+---
+
+Add a `convex` export condition so `posthog-node` resolves to the edge-compatible build when bundled for the Convex runtime.

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -87,6 +87,11 @@
         "require": "./dist/entrypoints/index.edge.js",
         "default": "./dist/entrypoints/index.edge.js"
       },
+      "convex": {
+        "import": "./dist/entrypoints/index.edge.mjs",
+        "require": "./dist/entrypoints/index.edge.js",
+        "default": "./dist/entrypoints/index.edge.js"
+      },
       "import": "./dist/entrypoints/index.node.mjs",
       "require": "./dist/entrypoints/index.node.js"
     },


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Convex runtime imports for node, so posthog-node can only run in node functions. This means every posthog message/error report has to go through a separate isolate call when coming from a Convex function that doesn't include a 'use node' directive.

## Changes

<!-- What is changed and what information would be useful to a reviewer? -->
Adds a `"convex"` package.json export so the convex runtime pulls in the correct bundle.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [x] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [n/a] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
