### PR TITLE
fix(logs): drop log record when beforeSend hook throws

### DIFF
--- a/.changeset/logs-before-send-throw-drops.md
+++ b/.changeset/logs-before-send-throw-drops.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+fix(logs): when a logs `beforeSend` hook throws, log the error and drop the record (fail closed) instead of continuing the chain and enqueuing it — a buggy redaction hook must not leak an unredacted log record.

--- a/packages/core/src/logs/index.spec.ts
+++ b/packages/core/src/logs/index.spec.ts
@@ -961,9 +961,8 @@ describe('PostHogLogs', () => {
       )
 
     // Cases that share a "captureLog → assert queue body" shape. Bespoke
-    // assertions (logger expectations, throw-doesn't-crash, post-chain
-    // continuation after throw) live in their own `it` blocks below — those
-    // were warping the table when forced into it.
+    // assertions (logger expectations, throw-drops-the-record) live in their
+    // own `it` blocks below — those were warping the table when forced into it.
     type Case = {
       name: string
       beforeSend: PostHogLogsConfig['beforeSend']
@@ -1030,10 +1029,7 @@ describe('PostHogLogs', () => {
       expect(logger.info).toHaveBeenCalledWith('Log was rejected in beforeSend function')
     })
 
-    it('never crashes the caller when a fn throws — the chain continues with the prior result', () => {
-      // Bespoke: needs to verify (a) no throw escapes captureLog, (b) the
-      // chain continues with the previous result so a buggy filter degrades
-      // to a no-op, and (c) the failure is logged. Doesn't fit the table.
+    it('never crashes the caller when a fn throws — drops the record (fail closed) and logs', () => {
       const thrower = jest.fn(() => {
         throw new Error('bad filter')
       })
@@ -1047,7 +1043,8 @@ describe('PostHogLogs', () => {
       )
 
       expect(() => logs.captureLog({ body: 'hi' })).not.toThrow()
-      expect(readQueue(mockInstance)[0].record.body.stringValue).toBe('hi!')
+      expect(readQueue(mockInstance)).toHaveLength(0)
+      expect(after).not.toHaveBeenCalled()
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining('Error in beforeSend function for log:'),
         expect.any(Error)

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -92,9 +92,7 @@ export class PostHogLogs {
    * Runs the configured `beforeSend` hook(s) on a capture record:
    *   - single fn OR array of fns (chain, left-to-right)
    *   - returning `null` drops the record (logged at info)
-   *   - a thrown error is logged and the chain *continues* with the previous
-   *     result — a buggy user filter must never crash the caller's
-   *     `captureLog()` call
+   *   - a thrown error is logged and the record is dropped
    */
   private _runBeforeSend(options: CaptureLogOptions): CaptureLogOptions | null {
     const beforeSend = this._config.beforeSend
@@ -112,9 +110,8 @@ export class PostHogLogs {
         }
         result = next
       } catch (e) {
-        // Swallow the throw — the chain continues with `result` unchanged so
-        // a buggy filter degrades to a no-op rather than crashing the app.
         this._logger.error(`Error in beforeSend function for log:`, e)
+        return null
       }
     }
     return result


### PR DESCRIPTION
## Summary

In the shared `@posthog/core` logs pipeline, when a logs `beforeSend` hook **throws**, the previous behavior was to swallow the error and *continue the chain with the prior result* — meaning the record (possibly a still-unredacted one) would be enqueued and sent.

This changes the behavior to **fail closed**: log the error via the existing logger and **drop the record**. A broken redaction hook must not leak an unredacted log record.

This matches the equivalent change just made in `posthog-flutter`. Affects React Native, which uses this shared core logs path. The browser SDK has no logs `beforeSend`. Analytics-events `beforeSend` and session-replay console capture are untouched.

## Changes
- `packages/core/src/logs/index.ts` — `_runBeforeSend`: on throw, `this._logger.error(...)` then `return null` (drop) instead of continuing.
- Updated the bespoke unit test to assert the record is dropped, downstream fns are not reached, and the error is logged.
- Changeset (`@posthog/core` patch).

## Testing
`jest src/logs/index.spec.ts` — 57 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)