### PR TITLE
fix(replay): keep linkedFlagSeen sticky once the flag has matched

### DIFF
--- a/.changeset/sticky-linked-flag-seen.md
+++ b/.changeset/sticky-linked-flag-seen.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(replay): keep session recording active when a flag reload transiently drops the linked flag. Once `LinkedFlagMatching` has observed the configured linked flag matching for the session, it now stays activated even if a later `onFeatureFlags` callback reports the flag as missing or false. Before this fix, calls to `identify()`, `group()`, or `setPersonPropertiesForFlags()` mid-session triggered a flag reload whose in-flight window could briefly omit the linked flag, flipping the recorder state machine from `active` back to `buffering`. If the user then navigated or closed the tab during that window, `_onBeforeUnload` saw `BUFFERING` and silently discarded the entire local buffer — losing the recording even though the SDK had previously decided to record. The flag listener now only sets `linkedFlagSeen` when the flag actually matches; it never un-sets it within a session. Applies to both the V1 strategy and per-group V2 trigger groups, since both use the same `LinkedFlagMatching` instance.

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -3262,9 +3262,13 @@ describe('Lazy SessionRecording', () => {
             expect(sessionRecording['_lazyLoadedSessionRecording']['_linkedFlagMatching'].linkedFlagSeen).toEqual(true)
             expect(sessionRecording.status).toEqual('active')
 
+            // Sticky: a subsequent flag reload that no longer reports the flag must NOT flip the
+            // status back to buffering. Flag reloads triggered by identify()/group() routinely
+            // produce a transient window where the flag isn't present yet; if we de-activated on
+            // that window, _onBeforeUnload would silently drop the buffer.
             onFeatureFlagsCallback?.(['different', 'keys'], { different: true, keys: true })
-            expect(sessionRecording['_lazyLoadedSessionRecording']['_linkedFlagMatching'].linkedFlagSeen).toEqual(false)
-            expect(sessionRecording.status).toEqual('buffering')
+            expect(sessionRecording['_lazyLoadedSessionRecording']['_linkedFlagMatching'].linkedFlagSeen).toEqual(true)
+            expect(sessionRecording.status).toEqual('active')
         })
 
         it('does not react to flags that are present but false', () => {
@@ -3301,9 +3305,10 @@ describe('Lazy SessionRecording', () => {
             expect(sessionRecording['_lazyLoadedSessionRecording']['_linkedFlagMatching'].linkedFlagSeen).toEqual(true)
             expect(sessionRecording.status).toEqual('active')
 
+            // Sticky once activated for the session — even a different variant on reload keeps recording.
             onFeatureFlagsCallback?.(['the-flag-key'], { 'the-flag-key': 'control' })
-            expect(sessionRecording['_lazyLoadedSessionRecording']['_linkedFlagMatching'].linkedFlagSeen).toEqual(false)
-            expect(sessionRecording.status).toEqual('buffering')
+            expect(sessionRecording['_lazyLoadedSessionRecording']['_linkedFlagMatching'].linkedFlagSeen).toEqual(true)
+            expect(sessionRecording.status).toEqual('active')
         })
 
         it('can handle linked flags with any variants', () => {
@@ -3326,9 +3331,10 @@ describe('Lazy SessionRecording', () => {
             expect(sessionRecording['_lazyLoadedSessionRecording']['_linkedFlagMatching'].linkedFlagSeen).toEqual(true)
             expect(sessionRecording.status).toEqual('active')
 
+            // Sticky once activated for the session — a reload without the flag keeps recording.
             onFeatureFlagsCallback?.(['not-the-flag-key'], { 'not-the-flag-key': 'literally-anything' })
-            expect(sessionRecording['_lazyLoadedSessionRecording']['_linkedFlagMatching'].linkedFlagSeen).toEqual(false)
-            expect(sessionRecording.status).toEqual('buffering')
+            expect(sessionRecording['_lazyLoadedSessionRecording']['_linkedFlagMatching'].linkedFlagSeen).toEqual(true)
+            expect(sessionRecording.status).toEqual('active')
         })
 
         it('can be overriden', () => {
@@ -3344,6 +3350,33 @@ describe('Lazy SessionRecording', () => {
 
             sessionRecording.overrideLinkedFlag()
 
+            expect(sessionRecording['_lazyLoadedSessionRecording']['_linkedFlagMatching'].linkedFlagSeen).toEqual(true)
+            expect(sessionRecording.status).toEqual('active')
+        })
+
+        // Reproduces the Sonia missing-recordings scenario: linked flag matches → SDK records →
+        // app calls identify/group, which triggers a flag reload → reload temporarily reports the
+        // flag as absent → before the next reload arrives, the user navigates → beforeunload runs
+        // while in BUFFERING and silently discards the buffer. The fix makes linkedFlagSeen
+        // sticky so a flicker doesn't drop the recording.
+        it('keeps recording when a flag reload transiently drops the flag', () => {
+            sessionRecording.onRemoteConfig(
+                makeFlagsResponse({ sessionRecording: { endpoint: '/s/', linkedFlag: 'the-flag-key' } })
+            )
+            expect(sessionRecording.status).toEqual('buffering')
+
+            // Initial flag resolution — matches, recording starts
+            onFeatureFlagsCallback?.(['the-flag-key'], { 'the-flag-key': true })
+            expect(sessionRecording.status).toEqual('active')
+
+            // Simulate identify/group triggering a reload that hasn't completed yet —
+            // the previous flag isn't in the result set during the in-flight window.
+            onFeatureFlagsCallback?.([], {})
+            expect(sessionRecording['_lazyLoadedSessionRecording']['_linkedFlagMatching'].linkedFlagSeen).toEqual(true)
+            expect(sessionRecording.status).toEqual('active')
+
+            // Even an explicit false response keeps recording — the user was authorized for this session.
+            onFeatureFlagsCallback?.(['the-flag-key'], { 'the-flag-key': false })
             expect(sessionRecording['_lazyLoadedSessionRecording']['_linkedFlagMatching'].linkedFlagSeen).toEqual(true)
             expect(sessionRecording.status).toEqual('active')
         })

--- a/packages/browser/src/extensions/replay/external/triggerMatching.ts
+++ b/packages/browser/src/extensions/replay/external/triggerMatching.ts
@@ -418,8 +418,15 @@ export class LinkedFlagMatching implements TriggerStatusMatching {
                         linkedFlagMatches = !!variantForFlagKey
                     }
                 }
-                this.linkedFlagSeen = linkedFlagMatches
+                // Sticky: once the flag has matched for this session, keep recording even if
+                // a subsequent flag reload returns false. Reloads happen on identify() / group() /
+                // setPersonPropertiesForFlags(), and the in-flight reload window can briefly
+                // return false (e.g. before group properties have been re-sent to the server).
+                // Without stickiness, the status flips back to BUFFERING and the buffer is
+                // silently discarded on the next page unload — losing the entire recording for
+                // any session that calls identify/group mid-session.
                 if (linkedFlagMatches) {
+                    this.linkedFlagSeen = true
                     onStarted(linkedFlag, linkedVariant)
                 }
             })


### PR DESCRIPTION
## Problem

While investigating a customer's missing session replays, I traced a class of recordings that:

1. Started recording correctly — linked flag matched, `recording_status: active`, snapshots flowing into the local buffer
2. Then flipped to `recording_status: buffering` mid-session
3. Lost the entire buffered recording when the user navigated or closed the tab

The trigger is any operation that causes `posthog.featureFlags` to reload while the recorder is running — `identify()`, `group()`, `setPersonPropertiesForFlags()`, or an explicit `reloadFeatureFlags()`. During the in-flight window, the `onFeatureFlags` callback can fire with the linked flag absent or set to `false` (e.g. before group properties have been re-sent to the server), and `LinkedFlagMatching` flipped `linkedFlagSeen` back to `false` based on that transient value. The recorder state machine moved to `BUFFERING`, and if the user left the page before the next reload restored the flag, `_onBeforeUnload` silently called `_clearBuffer()` on the way out, dropping everything rrweb had captured for the session.

## Changes

`LinkedFlagMatching.onConfig` no longer un-sets `linkedFlagSeen` once it's been set. The boolean is now monotonic per matcher instance: once the configured flag has been observed to match for this session, the matcher stays activated even if a later callback reports the flag as missing or false. Recording continues uninterrupted across the reload window.

This applies to both:
- V1 strategy — the recorder-level `_linkedFlagMatching` instance
- V2 strategy — the per-group `LinkedFlagMatching` inside each `TriggerGroupMatching`

since both code paths share the same class.

Updated three existing test cases in the `linked flags` describe block that asserted the previous "flip back to buffering on flag drop" behavior, since that behavior was the bug. Added a new regression test (`keeps recording when a flag reload transiently drops the flag`) that explicitly walks through the customer-reported sequence: flag matches → reload returns empty variants → explicit `false` response — and asserts the recorder stays `active` the whole way.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
