### PR TITLE
chore: make workspace releases explicit

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
     "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
     "changelog": ["@posthog-tooling/changelog", { "repo": "PostHog/posthog-js" }],
     "commit": false,
-    "fixed": [["posthog-js", "@posthog/types"]],
+    "fixed": [],
     "linked": [],
     "access": "restricted",
     "baseBranch": "main",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -41,7 +41,7 @@
     "@types/jest": "catalog:",
     "jest": "catalog:",
     "node-fetch": "^3.3.2",
-    "posthog-node": "workspace:*"
+    "posthog-node": "workspace:^"
   },
   "keywords": [
     "posthog",
@@ -57,7 +57,7 @@
     "node": "^20.20.0 || >=22.22.0"
   },
   "dependencies": {
-    "@posthog/core": "workspace:*",
+    "@posthog/core": "workspace:^",
     "uuid": "^11.1.0",
     "zod": "^4.1.13"
   },

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -58,8 +58,8 @@
         "rrweb-plugin-console-record/package.json"
     ],
     "dependencies": {
-        "@posthog/core": "workspace:*",
-        "@posthog/types": "workspace:*",
+        "@posthog/core": "workspace:^",
+        "@posthog/types": "workspace:^",
         "core-js": "^3.38.1",
         "dompurify": "^3.3.2",
         "fflate": "^0.4.8",

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -62,8 +62,8 @@
   "types": "./dist/client/index.d.ts",
   "module": "./dist/client/index.js",
   "dependencies": {
-    "@posthog/core": "workspace:*",
-    "posthog-node": "workspace:*"
+    "@posthog/core": "workspace:^",
+    "posthog-node": "workspace:^"
   },
   "devDependencies": {
     "@edge-runtime/vm": "^5.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,7 @@
     }
   },
   "dependencies": {
-    "@posthog/types": "workspace:*"
+    "@posthog/types": "workspace:^"
   },
   "devDependencies": {
     "@posthog-tooling/tsconfig-base": "workspace:*",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -38,7 +38,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@posthog/core": "workspace:*"
+    "@posthog/core": "workspace:^"
   },
   "devDependencies": {
     "@babel/preset-env": "catalog:",
@@ -49,7 +49,7 @@
     "@types/jest": "catalog:",
     "@types/node": "^20.0.0",
     "jest": "catalog:",
-    "posthog-node": "workspace:*",
+    "posthog-node": "workspace:^",
     "zod": "^3.25.0"
   },
   "peerDependencies": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -61,10 +61,10 @@
         "package": "pnpm pack --out $PACKAGE_DEST/%s.tgz"
     },
     "dependencies": {
-        "@posthog/core": "workspace:*",
-        "@posthog/react": "workspace:*",
-        "posthog-js": "workspace:*",
-        "posthog-node": "workspace:*",
+        "@posthog/core": "workspace:^",
+        "@posthog/react": "workspace:^",
+        "posthog-js": "workspace:^",
+        "posthog-node": "workspace:^",
         "server-only": "^0.0.1"
     },
     "devDependencies": {

--- a/packages/nextjs-config/package.json
+++ b/packages/nextjs-config/package.json
@@ -44,8 +44,8 @@
   "dependencies": {
     "@posthog/cli": "catalog:",
     "semver": "^7.7.2",
-    "@posthog/plugin-utils": "workspace:*",
-    "@posthog/webpack-plugin": "workspace:*"
+    "@posthog/plugin-utils": "workspace:^",
+    "@posthog/webpack-plugin": "workspace:^"
   },
   "keywords": [
     "posthog",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -38,7 +38,7 @@
   "module": "dist/entrypoints/index.node.mjs",
   "types": "dist/entrypoints/index.node.d.ts",
   "dependencies": {
-    "@posthog/core": "workspace:*"
+    "@posthog/core": "workspace:^"
   },
   "devDependencies": {
     "@edge-runtime/jest-environment": "^4.0.0",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -32,10 +32,10 @@
   "dependencies": {
     "@posthog/cli": "catalog:",
     "@nuxt/kit": ">=3.7.0",
-    "posthog-node": "workspace:*",
-    "@posthog/core": "workspace:*",
-    "@posthog/plugin-utils": "workspace:*",
-    "posthog-js": "workspace:*"
+    "posthog-node": "workspace:^",
+    "@posthog/core": "workspace:^",
+    "@posthog/plugin-utils": "workspace:^",
+    "posthog-js": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -40,8 +40,8 @@
     "generate-references": "pnpm exec api-extractor run --config ./api-extractor.json --local && node scripts/generate-docs.js"
   },
   "dependencies": {
-    "@posthog/core": "workspace:*",
-    "@posthog/types": "workspace:*"
+    "@posthog/core": "workspace:^",
+    "@posthog/types": "workspace:^"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,7 +55,7 @@
         "cross-env": "^7.0.3",
         "jest": "catalog:",
         "jest-environment-jsdom": "catalog:",
-        "posthog-js": "workspace:*",
+        "posthog-js": "workspace:^",
         "react": "catalog:",
         "react-dom": "catalog:",
         "react-test-renderer": "catalog:",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -26,7 +26,7 @@
     ],
     "dependencies": {
         "@posthog/cli": "catalog:",
-        "@posthog/plugin-utils": "workspace:*"
+        "@posthog/plugin-utils": "workspace:^"
     },
     "peerDependencies": {
         "rollup": ">= 4.0.0"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,7 +26,7 @@
     "src"
   ],
   "dependencies": {
-    "@posthog/core": "workspace:*"
+    "@posthog/core": "workspace:^"
   },
   "devDependencies": {
     "@babel/preset-env": "catalog:",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -17,8 +17,8 @@
     "types": "./dist/index.d.ts",
     "dependencies": {
         "@posthog/cli": "catalog:",
-        "@posthog/core": "workspace:*",
-        "@posthog/plugin-utils": "workspace:*"
+        "@posthog/core": "workspace:^",
+        "@posthog/plugin-utils": "workspace:^"
     },
     "files": [
         "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,7 +195,7 @@ importers:
   packages/ai:
     dependencies:
       '@posthog/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       uuid:
         specifier: ^11.1.0
@@ -262,16 +262,16 @@ importers:
         specifier: ^6.25.0
         version: 6.25.0(ws@8.19.0)(zod@4.1.13)
       posthog-node:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../node
 
   packages/browser:
     dependencies:
       '@posthog/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@posthog/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
       core-js:
         specifier: ^3.38.1
@@ -509,10 +509,10 @@ importers:
   packages/convex:
     dependencies:
       '@posthog/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       posthog-node:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../node
     devDependencies:
       '@edge-runtime/vm':
@@ -549,7 +549,7 @@ importers:
   packages/core:
     dependencies:
       '@posthog/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
     devDependencies:
       '@posthog-tooling/tsconfig-base':
@@ -568,7 +568,7 @@ importers:
   packages/mcp:
     dependencies:
       '@posthog/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@babel/preset-env':
@@ -596,7 +596,7 @@ importers:
         specifier: 'catalog:'
         version: 29.7.0(@types/node@20.19.9)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.19.9)(typescript@5.9.3))
       posthog-node:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../node
       zod:
         specifier: ^3.25.0
@@ -605,16 +605,16 @@ importers:
   packages/next:
     dependencies:
       '@posthog/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@posthog/react':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../react
       posthog-js:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../browser
       posthog-node:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../node
       server-only:
         specifier: ^0.0.1
@@ -669,10 +669,10 @@ importers:
         specifier: 'catalog:'
         version: 0.7.21
       '@posthog/plugin-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../plugin-utils
       '@posthog/webpack-plugin':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../webpack-plugin
       semver:
         specifier: ^7.7.2
@@ -709,7 +709,7 @@ importers:
   packages/node:
     dependencies:
       '@posthog/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@edge-runtime/jest-environment':
@@ -746,16 +746,16 @@ importers:
         specifier: 'catalog:'
         version: 0.7.21
       '@posthog/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@posthog/plugin-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../plugin-utils
       posthog-js:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../browser
       posthog-node:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../node
     devDependencies:
       '@nuxt/devtools':
@@ -847,7 +847,7 @@ importers:
         specifier: 'catalog:'
         version: 29.7.0
       posthog-js:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../browser
       react:
         specifier: 'catalog:'
@@ -874,10 +874,10 @@ importers:
   packages/react-native:
     dependencies:
       '@posthog/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@posthog/types':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../types
     devDependencies:
       '@babel/cli':
@@ -1031,7 +1031,7 @@ importers:
         specifier: 'catalog:'
         version: 0.7.21
       '@posthog/plugin-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../plugin-utils
     devDependencies:
       '@posthog-tooling/tsconfig-base':
@@ -1546,7 +1546,7 @@ importers:
   packages/web:
     dependencies:
       '@posthog/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@babel/preset-env':
@@ -1577,10 +1577,10 @@ importers:
         specifier: 'catalog:'
         version: 0.7.21
       '@posthog/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@posthog/plugin-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../plugin-utils
     devDependencies:
       '@posthog-tooling/tsconfig-base':


### PR DESCRIPTION
## Problem

Shared internal package releases were unintentionally cascading into dependent package releases. In particular, a release of `@posthog/core` or `@posthog/types` could cause packages like `posthog-react-native`, `posthog-js`, and others to be versioned/published even when they had no explicit changeset.

## Changes

- Change published runtime workspace dependencies from `workspace:*` to `workspace:^` so patch/minor dependency releases do not automatically bump consumers.
- Remove the fixed release group between `posthog-js` and `@posthog/types`.
- Apply the same approach to remaining published workspace runtime dependencies such as `posthog-node`, `posthog-js`, `@posthog/react`, `@posthog/plugin-utils`, and `@posthog/webpack-plugin`.
- Update `pnpm-lock.yaml` workspace specifiers.

Validation:
- `pnpm install --lockfile-only --frozen-lockfile --config.trust-policy=ignore`
- Verified no published runtime `workspace:*` dependencies remain under `packages/*`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
