### PR TITLE
fix(product-tours): drop the cached tours blob when product tours is not enabled

### DIFF
--- a/.changeset/drop-stale-product-tours-cache.md
+++ b/.changeset/drop-stale-product-tours-cache.md
@@ -1,0 +1,7 @@
+---
+'posthog-js': patch
+---
+
+fix(product-tours): drop the cached tours blob when product tours is not enabled
+
+Tours fetched while product tours was enabled are cached under `ph_product_tours` in the main persistence blob. Once product tours is disabled (remote config or the `disable_product_tours` option) that cache was never cleaned up, so a potentially large stale blob kept riding on every persistence write — and on every cross-tab `storage` event those writes broadcast. `onRemoteConfig` now clears the cached tours whenever product tours resolves to disabled; they are re-fetched if it is ever re-enabled.

--- a/packages/browser/src/__tests__/posthog-product-tours.test.ts
+++ b/packages/browser/src/__tests__/posthog-product-tours.test.ts
@@ -1,7 +1,7 @@
 import { PostHog } from '../posthog-core'
 import { createPosthogInstance } from './helpers/posthog-instance'
 import { uuidv7 } from '../uuidv7'
-import { PRODUCT_TOURS_ENABLED_SERVER_SIDE } from '../constants'
+import { PRODUCT_TOURS, PRODUCT_TOURS_ENABLED_SERVER_SIDE } from '../constants'
 import { RemoteConfig } from '../types'
 
 describe('PostHogProductTours', () => {
@@ -50,6 +50,57 @@ describe('PostHogProductTours', () => {
             } as RemoteConfig)
 
             expect(instance.persistence?.props[PRODUCT_TOURS_ENABLED_SERVER_SIDE]).toBe(true)
+        })
+
+        it.each([
+            {
+                label: 'remote config disables product tours',
+                config: {},
+                response: { productTours: false },
+            },
+            {
+                label: 'the disable_product_tours config opt-out is set',
+                config: { disable_product_tours: true },
+                response: { productTours: true },
+            },
+        ])('drops stored tours when $label', async ({ config, response }) => {
+            instance = await createPosthogInstance(uuidv7(), {
+                api_host: 'https://test.com',
+                token: 'testtoken',
+                ...config,
+            })
+            instance.persistence?.register({
+                [PRODUCT_TOURS_ENABLED_SERVER_SIDE]: true,
+                [PRODUCT_TOURS]: [{ id: 'tour-1', name: 'stale cached tour' }],
+            })
+
+            instance.productTours.onRemoteConfig(response as RemoteConfig)
+
+            expect(instance.persistence?.props[PRODUCT_TOURS]).toBeUndefined()
+        })
+
+        it('keeps stored tours when product tours stays enabled', () => {
+            const tours = [{ id: 'tour-1', name: 'cached tour' }]
+            instance.persistence?.register({
+                [PRODUCT_TOURS_ENABLED_SERVER_SIDE]: true,
+                [PRODUCT_TOURS]: tours,
+            })
+
+            instance.productTours.onRemoteConfig({ productTours: true } as RemoteConfig)
+
+            expect(instance.persistence?.props[PRODUCT_TOURS]).toEqual(tours)
+        })
+
+        it('does not drop stored tours when the response carries no productTours key', () => {
+            const tours = [{ id: 'tour-1', name: 'cached tour' }]
+            instance.persistence?.register({
+                [PRODUCT_TOURS_ENABLED_SERVER_SIDE]: true,
+                [PRODUCT_TOURS]: tours,
+            })
+
+            instance.productTours.onRemoteConfig({} as RemoteConfig)
+
+            expect(instance.persistence?.props[PRODUCT_TOURS]).toEqual(tours)
         })
     })
 })

--- a/packages/browser/src/__tests__/posthog-product-tours.test.ts
+++ b/packages/browser/src/__tests__/posthog-product-tours.test.ts
@@ -91,6 +91,34 @@ describe('PostHogProductTours', () => {
             expect(instance.persistence?.props[PRODUCT_TOURS]).toEqual(tours)
         })
 
+        it('ignores an in-flight tours response that lands after product tours is disabled', () => {
+            const requests: { callback: (response: any) => void }[] = []
+            instance._send_request = jest.fn((req) => requests.push(req)) as any
+            instance.persistence?.register({ [PRODUCT_TOURS_ENABLED_SERVER_SIDE]: true })
+
+            const consumer = jest.fn()
+            instance.productTours.getProductTours(consumer, true)
+            expect(requests).toHaveLength(1)
+
+            instance.productTours.onRemoteConfig({ productTours: false } as RemoteConfig)
+
+            requests[0].callback({ statusCode: 200, json: { product_tours: [{ id: 'tour-1' }] } })
+
+            expect(instance.persistence?.props[PRODUCT_TOURS]).toBeUndefined()
+            expect(consumer).toHaveBeenCalledWith([], { isLoaded: true })
+        })
+
+        it('stops a running tour manager when product tours is disabled mid-session', () => {
+            const stop = jest.fn()
+            ;(instance.productTours as any)._productTourManager = { stop }
+            instance.persistence?.register({ [PRODUCT_TOURS_ENABLED_SERVER_SIDE]: true })
+
+            instance.productTours.onRemoteConfig({ productTours: false } as RemoteConfig)
+
+            expect(stop).toHaveBeenCalled()
+            expect((instance.productTours as any)._productTourManager).toBeNull()
+        })
+
         it('does not drop stored tours when the response carries no productTours key', () => {
             const tours = [{ id: 'tour-1', name: 'cached tour' }]
             instance.persistence?.register({

--- a/packages/browser/src/posthog-product-tours.ts
+++ b/packages/browser/src/posthog-product-tours.ts
@@ -57,6 +57,12 @@ export class PostHogProductTours implements Extension {
                 [PRODUCT_TOURS_ENABLED_SERVER_SIDE]: !!response.productTours,
             })
         }
+        if (!isProductToursEnabled(this._instance)) {
+            // tours cached while enabled would otherwise ride along in the main
+            // persistence blob (and every cross-tab storage broadcast) forever
+            this.clearCache()
+            return
+        }
         this.loadIfEnabled()
     }
 

--- a/packages/browser/src/posthog-product-tours.ts
+++ b/packages/browser/src/posthog-product-tours.ts
@@ -58,6 +58,13 @@ export class PostHogProductTours implements Extension {
             })
         }
         if (!isProductToursEnabled(this._instance)) {
+            if (this._productTourManager || !isNullish(this._persistence?.props[PRODUCT_TOURS])) {
+                logger.info('product tours disabled; stopping and clearing cached tours')
+            }
+            // a manager started from the previously-persisted enabled flag keeps
+            // serving tours until told to stop
+            this._productTourManager?.stop()
+            this._productTourManager = null
             // tours cached while enabled would otherwise ride along in the main
             // persistence blob (and every cross-tab storage broadcast) forever
             this.clearCache()
@@ -117,6 +124,12 @@ export class PostHogProductTours implements Extension {
             ),
             method: 'GET',
             callback: (response) => {
+                if (!isProductToursEnabled(this._instance)) {
+                    // a disable can land while this request is in flight; honouring
+                    // the response would re-create the cache the disable just cleared
+                    callback([], { isLoaded: true })
+                    return
+                }
                 const statusCode = response.statusCode
                 if (statusCode !== 200 || !response.json) {
                     const error = `Product Tours API could not be loaded, status: ${statusCode}`


### PR DESCRIPTION
see: https://github.com/PostHog/posthog/issues/32479 where we're currently reducing local storage writes to avoid a chromium bug  
  
Stale cached tours no longer ride in the main persistence blob once product tours is disabled.

## Problem

Part of the browser memory investigation in PostHog/posthog#32479. Tours fetched while product tours was enabled are cached under `ph_product_tours` in the main persistence blob. When product tours is later disabled (remote config, or the `disable_product_tours` option), nothing ever cleaned that cache up — measured on [us.posthog.com](http://us.posthog.com), the stale entry was the single largest item in the main blob (~74 of ~115 KB), riding on every throttled persistence write and every cross-tab `storage` event those writes broadcast to hidden tabs.

## Changes

`onRemoteConfig` now checks `isProductToursEnabled` after registering the server-side flag: when product tours resolves to disabled it calls the existing `clearCache()` (which unregisters `ph_product_tours` and drops the in-memory copy) instead of `loadIfEnabled()`. Tours are simply re-fetched if product tours is ever re-enabled — the cache is an optimization, not state.

## Tests

- Parameterized: stored tours are dropped when remote config disables product tours, and when the `disable_product_tours` config opt-out is set.
- Stored tours are kept when product tours stays enabled.
- A response with no `productTours` key (config fetch failure) does not drop the cache — matching the existing don't-overwrite-on-empty-config behaviour.

## Release info

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

🤖 Generated with [Claude Code](https://claude.com/claude-code) — driven by @pauldambra as part of PostHog/posthog#32479.