### PR TITLE
docs: clarify posthog-js CDN release flow

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,8 +19,18 @@ When a PR containing a changeset is merged to `main`, the release workflow will 
 
 # for posthog-js browser sdk
 
-When we run post-merge actions for the browser SDK we publish to NPM
+When we run post-merge actions for the browser SDK, the release workflow publishes the package to npm and uploads the browser bundles to S3 for the CDN.
 
-But then we automagically open a PR against the main PostHog repo. We don't update the CDN with the new version until that PR merges. So if it fails you can end up with html snippet users on version N and npm install on version N+1
+The CDN upload happens in `.github/workflows/release.yml` via the `upload-s3` job. For a new stable `posthog-js` version it uploads:
 
-PostHoggers can join the [#alerts-posthog-js channel in slack](https://posthog.slack.com/archives/C07HTMN9X47) which gets notified when those PRs fail
+- immutable versioned assets under `/static/<version>/`
+- mutable major-version aliases under `/static/<major>/`
+- top-level compatibility aliases under `/static/`
+
+Prerelease versions only get immutable versioned assets.
+
+The workflow still opens an automatic PR against the main `PostHog/posthog` repo to bump its `posthog-js` dependency, but that PR is no longer what uploads the browser SDK assets to the CDN. When that PR merges, the main app image is rebuilt with the new `posthog-js` dependency and app-bundled/disk-fallback static assets. If the PR fails or is delayed, the main app dependency update is blocked, but snippet/CDN users are not kept on the old version for that reason.
+
+A mismatch can still happen if npm publish succeeds but the S3/CDN upload fails: npm users may get version N+1 while CDN/snippet users remain on version N or see incomplete CDN assets until the failed upload is retried. The release workflow sends a partial-release Slack warning for this case.
+
+PostHoggers can join the [#alerts-posthog-js channel in Slack](https://posthog.slack.com/archives/C07HTMN9X47), which gets notified about release workflow failures.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,8 +29,6 @@ The CDN upload happens in `.github/workflows/release.yml` via the `upload-s3` jo
 
 Prerelease versions only get immutable versioned assets.
 
-The workflow still opens an automatic PR against the main `PostHog/posthog` repo to bump its `posthog-js` dependency, but that PR is no longer what uploads the browser SDK assets to the CDN. When that PR merges, the main app image is rebuilt with the new `posthog-js` dependency and app-bundled/disk-fallback static assets. If the PR fails or is delayed, the main app dependency update is blocked, but snippet/CDN users are not kept on the old version for that reason.
-
 A mismatch can still happen if npm publish succeeds but the S3/CDN upload fails: npm users may get version N+1 while CDN/snippet users remain on version N or see incomplete CDN assets until the failed upload is retried. The release workflow sends a partial-release Slack warning for this case.
 
 PostHoggers can join the [#alerts-posthog-js channel in Slack](https://posthog.slack.com/archives/C07HTMN9X47), which gets notified about release workflow failures.


### PR DESCRIPTION
## Problem

The browser SDK release notes still described an older flow where the automatic `PostHog/posthog` dependency PR gated CDN updates. That no longer matches the release workflow.

## Changes

- Document that `.github/workflows/release.yml` uploads browser bundles to S3/CDN via `upload-s3`.
- Clarify which CDN paths are uploaded for stable and prerelease versions.
- Keep the npm-vs-CDN mismatch warning for the case where npm publish succeeds but S3/CDN upload fails.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
