### PR TITLE
chore: split library CI jobs

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     name: Unit tests

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -80,6 +80,9 @@ jobs:
     name: Backward compatibility tests
     runs-on: depot-ubuntu-latest-8
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -22,6 +22,15 @@ jobs:
 
       - run: pnpm test:unit
 
+  edge-runtime:
+    name: Node edge runtime tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+
       - name: Node edge runtime tests
         run: pnpm --filter=posthog-node test:edge-compat
 
@@ -265,7 +274,7 @@ jobs:
           if-no-files-found: ignore
 
   lint:
-    name: Lint
+    name: Lint packages
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -275,6 +284,16 @@ jobs:
           build: false
       - name: Lint all packages
         run: pnpm lint
+
+  lint-playground:
+    name: Lint playground
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup environment
+        uses: ./.github/actions/setup
+        with:
+          build: false
       - name: Lint playground files
         run: pnpm lint:playground
 


### PR DESCRIPTION
## Problem

The library CI workflow had edge runtime and playground lint steps grouped under existing jobs, which made the job names and execution boundaries less clear. GitHub Advanced Security also flagged that the workflow should explicitly limit `GITHUB_TOKEN` permissions while preserving the extra scope needed by jobs that update PR comments.

## Changes

- Add top-level read-only workflow permissions with `permissions: contents: read`.
- Grant the `compat` job `pull-requests: write` so it can create, update, and delete backward compatibility result comments.
- Split Node edge runtime tests into their own `edge-runtime` job with checkout and environment setup.
- Rename the package lint job to `Lint packages`.
- Split playground linting into a dedicated `lint-playground` job with its own setup.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
