### PR TITLE
chore: add package tarball CI job

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -303,6 +303,20 @@ jobs:
       - name: Lint playground files
         run: pnpm lint:playground
 
+  package:
+    name: Package tarballs
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+        with:
+          build: false
+
+      - name: Build package tarballs
+        run: pnpm package
+
   write-mangled-property-names:
     name: Write mangled property names
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Problem

CI did not currently validate that package tarballs can be generated as part of the main library workflow. This can let packaging regressions slip through until release or local packaging checks.

## Changes

Adds a dedicated `package` job to `.github/workflows/library-ci.yml` that checks out the repository, sets up the workspace without building first, and runs `pnpm package` to build SDK tarballs.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
