### PR TITLE
fix(react-native): keep session replay active across identify/reset

### DIFF
--- a/.changeset/core-flags-emit-after-replay-cache.md
+++ b/.changeset/core-flags-emit-after-replay-cache.md
@@ -1,0 +1,5 @@
+---
+'@posthog/core': patch
+---
+
+fix: persist the session replay config from a `/flags` response before emitting the `featureflags` event, so listeners (e.g. React Native session replay linked-flag re-evaluation) read a recording config consistent with the new flag values. This only reorders two adjacent synchronous writes in the stateful core client (used by `posthog-react-native` and `@posthog/web`); the event payload is unchanged, and `posthog-node` and the browser `posthog-js` package do not use this code path.

--- a/.changeset/rn-session-replay-rearm.md
+++ b/.changeset/rn-session-replay-rearm.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+fix: keep session replay active across `identify()`/`reset()`. The project-level remote config (session replay, error tracking, capture performance) and survey definitions are now preserved across `reset()` instead of being cleared, and replay is re-evaluated whenever feature flags load/reload. A linked flag that becomes active for the identified user now starts (or resumes) recording without an app restart, and a linked flag that turns off pauses recording instead of leaving a gated-off user recorded until restart. Previously replay activation was only evaluated once at startup and the cached config was wiped on `reset()`. The user-specific survey state (which surveys were seen, last-seen date) is still cleared on `reset()`. This now mirrors the native iOS SDK, which keeps the project-level config across an identity change and gates replay on the linked flag once flags have loaded.

--- a/packages/core/src/posthog-core.ts
+++ b/packages/core/src/posthog-core.ts
@@ -802,6 +802,10 @@ export abstract class PostHogCore extends PostHogCoreStateless {
               flags: { ...currentFlagDetails?.flags, ...filteredFlags },
             }
           }
+          // Store the recording config before setKnownFeatureFlagDetails, which synchronously
+          // emits 'featureflags' — listeners (e.g. RN session replay re-evaluation) read this
+          // config and must see the version matching the new flag values.
+          this.cacheSessionReplay('flags', res)
           this.setKnownFeatureFlagDetails({
             flags: newFeatureFlagDetails.flags,
             requestId: res.requestId,
@@ -811,7 +815,6 @@ export abstract class PostHogCore extends PostHogCoreStateless {
           })
           // Mark that we hit the /flags endpoint so we can capture this in the $feature_flag_called event
           this.setPersistedProperty(PostHogPersistedProperty.FlagsEndpointWasHit, true)
-          this.cacheSessionReplay('flags', res)
 
           this.maybeNotifyRemoteConfig(triggerOnRemoteConfig, res)
         }

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -1393,15 +1393,20 @@ export class PostHog extends PostHogCore {
    * @param resumeCurrent - Whether to resume recording of current session (true) or start a new session (false). Defaults to true.
    */
   async startSessionRecording(resumeCurrent: boolean = true): Promise<void> {
+    await this._startSessionRecording(resumeCurrent)
+  }
+
+  // Same as startSessionRecording, but reports success so callers can react to failures.
+  private async _startSessionRecording(resumeCurrent: boolean): Promise<boolean> {
     await this._initPromise
 
     if (this.isDisabled) {
-      return
+      return false
     }
 
     if (!OptionalReactNativePlugin) {
       // Web/macOS - silently return
-      return
+      return false
     }
 
     try {
@@ -1410,7 +1415,7 @@ export class PostHog extends PostHogCore {
         this._logger.warn(
           'startRecording is not available. Please update @posthog/react-native-plugin or posthog-react-native-session-replay.'
         )
-        return
+        return false
       }
 
       // If only error tracking is active, add replay to the existing native instance
@@ -1420,7 +1425,7 @@ export class PostHog extends PostHogCore {
         const initialized = await this.initializeNativePlugin(this._sessionReplayOptions, undefined, true)
         if (!initialized) {
           this._logger.error('Failed to initialize native session replay SDK.')
-          return
+          return false
         }
       }
 
@@ -1435,8 +1440,10 @@ export class PostHog extends PostHogCore {
 
       await OptionalReactNativePlugin.startRecording(resumeCurrent)
       this._logger.info(`Session recording ${resumeCurrent ? 'resumed' : 'started'}.`)
+      return true
     } catch (e) {
       this._logger.error(`Failed to start session recording: ${e}`)
+      return false
     }
   }
 
@@ -2239,7 +2246,11 @@ export class PostHog extends PostHogCore {
         }
       } else {
         // Native recorder is initialized but was paused when the linked flag turned off; resume it.
-        await this.startSessionRecording(true)
+        const resumed = await this._startSessionRecording(true)
+        if (!resumed) {
+          // Roll back so the next flags reload retries instead of early-returning forever.
+          this._sessionReplayRecordingActive = false
+        }
       }
     } else {
       this._logger.info('Session replay disabled.')

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -2228,10 +2228,15 @@ export class PostHog extends PostHogCore {
         // Already recording — nothing to do.
         return
       }
+      // Set before the await as a re-entry guard for concurrent flags emits.
       this._sessionReplayRecordingActive = true
 
       if (!this._sessionReplayNativeInitialized) {
-        await this.initializeNativePlugin(options, remoteConfig, true)
+        const initialized = await this.initializeNativePlugin(options, remoteConfig, true)
+        if (!initialized) {
+          // Roll back so the next flags reload retries instead of early-returning forever.
+          this._sessionReplayRecordingActive = false
+        }
       } else {
         // Native recorder is initialized but was paused when the linked flag turned off; resume it.
         await this.startSessionRecording(true)

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -189,6 +189,8 @@ export class PostHog extends PostHogCore {
   private _enableSessionReplay?: boolean
   private _sessionReplayNativeInitialized: boolean = false
   private _nativeErrorTrackingInitialized: boolean = false
+  // Last applied recording state; the native bridge is only crossed on a change.
+  private _sessionReplayRecordingActive?: boolean
   private _sessionReplayOptions?: PostHogOptions
   private _disableSurveys: boolean
   private _disableRemoteConfig: boolean
@@ -472,6 +474,14 @@ export class PostHog extends PostHogCore {
 
       void this.startSessionReplay(options, cachedRemoteConfig ?? undefined)
 
+      // Re-evaluate session replay on every flags load/reload so the linked flag
+      // gates recording without an app restart.
+      if (options?.enableSessionReplay) {
+        this.onFeatureFlags(() => {
+          void this._evaluateAndStartSessionReplay()
+        })
+      }
+
       if (options?.addTracingHeaders && options.addTracingHeaders.length > 0) {
         patchFetchForTracingHeaders(this, options.addTracingHeaders)
       }
@@ -666,6 +676,12 @@ export class PostHog extends PostHogCore {
    * (`PostHogPersistedProperty.LogsQueue`) are always preserved regardless of
    * what is passed in `propertiesToKeep`, to ensure in-flight data is not lost.
    *
+   * The project-level remote config (`PostHogPersistedProperty.RemoteConfig`,
+   * `PostHogPersistedProperty.SessionReplay`, `PostHogPersistedProperty.Surveys`) is also
+   * always preserved — it is not user data — so session replay and surveys keep working
+   * after an identity change. The user-specific survey state (`SurveysSeen`,
+   * `SurveyLastSeenDate`) is still cleared.
+   *
    * {@label Identification}
    *
    * @example
@@ -701,7 +717,15 @@ export class PostHog extends PostHogCore {
       PostHogPersistedProperty.DeviceId,
     ]
 
-    super.reset(effectivePropertiesToKeep)
+    // RemoteConfig, SessionReplay, and Surveys are project-level config, not user data:
+    // always preserve them so replay can re-arm against the new user's flags. The
+    // user-specific survey state (SurveysSeen, SurveyLastSeenDate) is still cleared.
+    super.reset([
+      PostHogPersistedProperty.RemoteConfig,
+      PostHogPersistedProperty.SessionReplay,
+      PostHogPersistedProperty.Surveys,
+      ...effectivePropertiesToKeep,
+    ])
 
     if (this._setDefaultPersonProperties) {
       // Reset reloads flags asyncrhonously, but doesn't wait for it.
@@ -2119,12 +2143,38 @@ export class PostHog extends PostHogCore {
     this._enableSessionReplay = options?.enableSessionReplay
     this._sessionReplayOptions = options
 
+    await this._evaluateAndStartSessionReplay(cachedRemoteConfig)
+  }
+
+  /**
+   * Decides whether session replay should be recording (replay enabled AND the linked
+   * flag, if any, on for the current user) and arms or pauses the native recorder to match.
+   *
+   * Runs at startup and on every feature flags load/reload (identify(), reset(),
+   * reloadFeatureFlags()), so recording starts, resumes, or pauses on identity changes
+   * without an app restart. `_sessionReplayRecordingActive` dedups repeated answers, and
+   * the init guards prevent double-starts. When replay is off, the native plugin is still
+   * initialized for native error tracking (both share one native instance).
+   *
+   * Pausing requires a real "flag off": core keeps the previous flag values across
+   * quota-limited/failed reloads, so a transient error never pauses a recording. Right
+   * after reset() the flags are genuinely unknown and pausing is the intended outcome.
+   */
+  private async _evaluateAndStartSessionReplay(
+    cachedRemoteConfig?: Omit<PostHogRemoteConfig, 'surveys'>
+  ): Promise<void> {
+    const options = this._sessionReplayOptions
     const enableNativeErrorTracking = this._isAutocaptureNativeErrors(options)
+    // On the re-arm path (flags reloaded after identify/reset) cachedRemoteConfig
+    // isn't passed in, so fall back to the persisted remote config for capture gating.
+    const remoteConfig =
+      cachedRemoteConfig ??
+      this.getPersistedProperty<Omit<PostHogRemoteConfig, 'surveys'>>(PostHogPersistedProperty.RemoteConfig)
 
     if (!this._isEnableSessionReplay()) {
       this._logger.info('Session replay is not enabled.')
       if (enableNativeErrorTracking) {
-        await this.initializeNativePlugin(options, cachedRemoteConfig, false)
+        await this.initializeNativePlugin(options, remoteConfig, false)
       }
       return
     }
@@ -2174,11 +2224,31 @@ export class PostHog extends PostHogCore {
     }
 
     if (recordingActive) {
-      await this.initializeNativePlugin(options, cachedRemoteConfig, true)
+      if (this._sessionReplayRecordingActive === true) {
+        // Already recording — nothing to do.
+        return
+      }
+      this._sessionReplayRecordingActive = true
+
+      if (!this._sessionReplayNativeInitialized) {
+        await this.initializeNativePlugin(options, remoteConfig, true)
+      } else {
+        // Native recorder is initialized but was paused when the linked flag turned off; resume it.
+        await this.startSessionRecording(true)
+      }
     } else {
       this._logger.info('Session replay disabled.')
+
+      const wasRecording = this._sessionReplayRecordingActive === true
+      this._sessionReplayRecordingActive = false
+
+      if (wasRecording) {
+        // Linked flag turned off — pause the native recorder so a gated-off user isn't recorded.
+        await this.stopSessionRecording()
+      }
+
       if (enableNativeErrorTracking) {
-        await this.initializeNativePlugin(options, cachedRemoteConfig, false)
+        await this.initializeNativePlugin(options, remoteConfig, false)
       }
     }
   }

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -1463,15 +1463,20 @@ export class PostHog extends PostHogCore {
    * @public
    */
   async stopSessionRecording(): Promise<void> {
+    await this._stopSessionRecording()
+  }
+
+  // Same as stopSessionRecording, but reports success so callers can react to failures.
+  private async _stopSessionRecording(): Promise<boolean> {
     await this._initPromise
 
     if (this.isDisabled) {
-      return
+      return false
     }
 
     if (!OptionalReactNativePlugin) {
       // Web/macOS - silently return
-      return
+      return false
     }
 
     try {
@@ -1480,14 +1485,15 @@ export class PostHog extends PostHogCore {
         this._logger.warn(
           'stopRecording is not available. Please update @posthog/react-native-plugin or posthog-react-native-session-replay.'
         )
-        return
+        return false
       }
 
       await OptionalReactNativePlugin.stopRecording()
-      // this._enableSessionReplay = false
       this._logger.info('Session recording stopped.')
+      return true
     } catch (e) {
       this._logger.error(`Failed to stop session recording: ${e}`)
+      return false
     }
   }
 
@@ -2255,12 +2261,15 @@ export class PostHog extends PostHogCore {
     } else {
       this._logger.info('Session replay disabled.')
 
-      const wasRecording = this._sessionReplayRecordingActive === true
-      this._sessionReplayRecordingActive = false
-
-      if (wasRecording) {
+      if (this._sessionReplayRecordingActive === true) {
         // Linked flag turned off — pause the native recorder so a gated-off user isn't recorded.
-        await this.stopSessionRecording()
+        // Only clear the flag on success; a failed stop stays "recording" so the next reload retries.
+        const stopped = await this._stopSessionRecording()
+        if (stopped) {
+          this._sessionReplayRecordingActive = false
+        }
+      } else {
+        this._sessionReplayRecordingActive = false
       }
 
       if (enableNativeErrorTracking) {

--- a/packages/react-native/src/posthog-rn.ts
+++ b/packages/react-native/src/posthog-rn.ts
@@ -191,6 +191,8 @@ export class PostHog extends PostHogCore {
   private _nativeErrorTrackingInitialized: boolean = false
   // Last applied recording state; the native bridge is only crossed on a change.
   private _sessionReplayRecordingActive?: boolean
+  // Serializes re-arm evaluations so concurrent flags reloads don't interleave.
+  private _sessionReplayEvalChain: Promise<void> = Promise.resolve()
   private _sessionReplayOptions?: PostHogOptions
   private _disableSurveys: boolean
   private _disableRemoteConfig: boolean
@@ -2172,8 +2174,17 @@ export class PostHog extends PostHogCore {
    * Pausing requires a real "flag off": core keeps the previous flag values across
    * quota-limited/failed reloads, so a transient error never pauses a recording. Right
    * after reset() the flags are genuinely unknown and pausing is the intended outcome.
+   *
+   * Evaluations are serialized so concurrent flags reloads run one at a time.
    */
-  private async _evaluateAndStartSessionReplay(
+  private _evaluateAndStartSessionReplay(cachedRemoteConfig?: Omit<PostHogRemoteConfig, 'surveys'>): Promise<void> {
+    this._sessionReplayEvalChain = this._sessionReplayEvalChain
+      .catch(() => {})
+      .then(() => this._evaluateAndStartSessionReplayInternal(cachedRemoteConfig))
+    return this._sessionReplayEvalChain
+  }
+
+  private async _evaluateAndStartSessionReplayInternal(
     cachedRemoteConfig?: Omit<PostHogRemoteConfig, 'surveys'>
   ): Promise<void> {
     const options = this._sessionReplayOptions
@@ -2241,33 +2252,18 @@ export class PostHog extends PostHogCore {
         // Already recording — nothing to do.
         return
       }
-      // Set before the await as a re-entry guard for concurrent flags emits.
-      this._sessionReplayRecordingActive = true
-
-      if (!this._sessionReplayNativeInitialized) {
-        const initialized = await this.initializeNativePlugin(options, remoteConfig, true)
-        if (!initialized) {
-          // Roll back so the next flags reload retries instead of early-returning forever.
-          this._sessionReplayRecordingActive = false
-        }
-      } else {
-        // Native recorder is initialized but was paused when the linked flag turned off; resume it.
-        const resumed = await this._startSessionRecording(true)
-        if (!resumed) {
-          // Roll back so the next flags reload retries instead of early-returning forever.
-          this._sessionReplayRecordingActive = false
-        }
-      }
+      // Record the actual outcome; on failure it stays false so the next reload retries.
+      // (Already initialized means replay was paused by an earlier flag-off, so resume it.)
+      this._sessionReplayRecordingActive = this._sessionReplayNativeInitialized
+        ? await this._startSessionRecording(true)
+        : await this.initializeNativePlugin(options, remoteConfig, true)
     } else {
       this._logger.info('Session replay disabled.')
 
       if (this._sessionReplayRecordingActive === true) {
-        // Linked flag turned off — pause the native recorder so a gated-off user isn't recorded.
-        // Only clear the flag on success; a failed stop stays "recording" so the next reload retries.
-        const stopped = await this._stopSessionRecording()
-        if (stopped) {
-          this._sessionReplayRecordingActive = false
-        }
+        // Linked flag turned off — pause so a gated-off user isn't recorded. Keep the flag
+        // set if the native stop fails, so the next reload retries instead of giving up.
+        this._sessionReplayRecordingActive = !(await this._stopSessionRecording())
       } else {
         this._sessionReplayRecordingActive = false
       }

--- a/packages/react-native/test/native-error-tracking.spec.ts
+++ b/packages/react-native/test/native-error-tracking.spec.ts
@@ -203,4 +203,49 @@ describe('native error tracking', () => {
 
     await posthog.shutdown()
   })
+
+  it('pauses and resumes recording across linked-flag changes without re-running setup() when error tracking is on', async () => {
+    // Controllable /flags response: the linked flag starts true, flips later.
+    let recFlagValue = true
+    ;(globalThis as any).window.fetch = jest.fn(async (url: unknown) => {
+      const res = String(url).includes('flags')
+        ? {
+            featureFlags: { 'rec-flag': recFlagValue },
+            sessionRecording: { linkedFlag: 'rec-flag', endpoint: '/s/' },
+          }
+        : { status: 'ok' }
+      return { status: 200, json: () => Promise.resolve(res) }
+    })
+
+    const { PostHog } = await import('../src/posthog-rn')
+    const posthog = new PostHog('test-token', {
+      persistence: 'memory',
+      flushInterval: 0,
+      enableSessionReplay: true,
+      errorTracking: { autocapture: { nativeCrashes: true } },
+    })
+
+    await posthog.ready()
+
+    // Linked flag is on: replay + error tracking arm in a single setup().
+    await waitForExpect(2000, () => {
+      expect(mockPlugin.setup).toHaveBeenCalledTimes(1)
+    })
+    expect(mockPlugin.setup.mock.calls[0][2].errorTracking.nativeAutocapture).toBe(true)
+
+    // Linked flag turns off -> recording pauses; error tracking keeps the native
+    // instance, so setup() must not run again.
+    recFlagValue = false
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(mockPlugin.stopRecording).toHaveBeenCalledTimes(1))
+    expect(mockPlugin.setup).toHaveBeenCalledTimes(1)
+
+    // Linked flag flips back on -> recording resumes on the existing instance.
+    recFlagValue = true
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(mockPlugin.startRecording).toHaveBeenCalledTimes(1))
+    expect(mockPlugin.setup).toHaveBeenCalledTimes(1)
+
+    await posthog.shutdown()
+  })
 })

--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1016,6 +1016,29 @@ describe('PostHog React Native', () => {
         expect(cachedProps === undefined || Object.keys(cachedProps).length === 0).toBe(true)
       })
 
+      it('keeps project-level remote config across reset() but clears user-specific survey state', () => {
+        // Project-level config (not user data) — should survive an identity change so session replay
+        // re-arms and surveys stay available without an app restart.
+        posthog.setPersistedProperty(PostHogPersistedProperty.RemoteConfig, { capturePerformance: true } as any)
+        posthog.setPersistedProperty(PostHogPersistedProperty.SessionReplay, { linkedFlag: 'replay-flag' } as any)
+        posthog.setPersistedProperty(PostHogPersistedProperty.Surveys, [{ id: 'survey-1' }] as any)
+        // User-specific survey state — should be cleared so the new user starts fresh.
+        posthog.setPersistedProperty(PostHogPersistedProperty.SurveysSeen, { 'survey-1': true } as any)
+        posthog.setPersistedProperty(PostHogPersistedProperty.SurveyLastSeenDate, '2026-01-01' as any)
+
+        posthog.reset()
+
+        expect(posthog.getPersistedProperty(PostHogPersistedProperty.RemoteConfig)).toEqual({
+          capturePerformance: true,
+        })
+        expect(posthog.getPersistedProperty(PostHogPersistedProperty.SessionReplay)).toEqual({
+          linkedFlag: 'replay-flag',
+        })
+        expect(posthog.getPersistedProperty(PostHogPersistedProperty.Surveys)).toEqual([{ id: 'survey-1' }])
+        expect(posthog.getPersistedProperty(PostHogPersistedProperty.SurveysSeen)).toBeFalsy()
+        expect(posthog.getPersistedProperty(PostHogPersistedProperty.SurveyLastSeenDate)).toBeFalsy()
+      })
+
       it('should cache properties from $set when provided', async () => {
         posthog.identify('user-123', {
           $set: { email: 'test@example.com', plan: 'premium' },

--- a/packages/react-native/test/session-replay-rearm.spec.ts
+++ b/packages/react-native/test/session-replay-rearm.spec.ts
@@ -245,4 +245,63 @@ describe('PostHog RN session replay re-arm after flags reload', () => {
     // Without the rollback the failed attempt would suppress every later attempt.
     await waitForExpect(2000, () => expect(replay.start).toHaveBeenCalledTimes(2))
   })
+
+  it('does not stop again on a later reload once the flag is already off', async () => {
+    currentSessionRecording = { linkedFlag: 'replay-flag', endpoint: '/s/' }
+    currentFlags = { 'replay-flag': true }
+
+    posthog = newPostHog()
+    await posthog.ready()
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.start).toHaveBeenCalledTimes(1))
+    replay.isEnabled.mockImplementation(async () => true)
+
+    // Flag off -> one pause.
+    currentFlags = { 'replay-flag': false }
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.stopRecording).toHaveBeenCalledTimes(1))
+
+    // Still off on subsequent reloads -> already paused, must not stop again.
+    await posthog.reloadFeatureFlagsAsync()
+    await posthog.reloadFeatureFlagsAsync()
+    await wait(50)
+    expect(replay.stopRecording).toHaveBeenCalledTimes(1)
+  })
+
+  it('serializes overlapping reloads so an off->on pair ends recording, not stuck off', async () => {
+    currentSessionRecording = { linkedFlag: 'replay-flag', endpoint: '/s/' }
+    currentFlags = { 'replay-flag': true }
+
+    posthog = newPostHog()
+    await posthog.ready()
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.start).toHaveBeenCalledTimes(1))
+    replay.isEnabled.mockImplementation(async () => true)
+
+    // Hold the native stop open so the next evaluation runs while the pause is in flight.
+    let releaseStop: () => void = () => {}
+    replay.stopRecording.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseStop = resolve
+        })
+    )
+
+    // Flag off: the pause evaluation reaches the (held) native stop.
+    currentFlags = { 'replay-flag': false }
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.stopRecording).toHaveBeenCalledTimes(1))
+
+    // Flag back on while the stop is still blocked. The resume evaluation is queued behind
+    // the in-flight pause (serialized), so it has not resumed yet.
+    currentFlags = { 'replay-flag': true }
+    await posthog.reloadFeatureFlagsAsync()
+    await wait(20)
+    expect(replay.startRecording).not.toHaveBeenCalled()
+
+    // Once the stop completes, the queued resume runs and recording ends on (not stuck off).
+    releaseStop()
+    await waitForExpect(2000, () => expect(replay.startRecording).toHaveBeenCalledTimes(1))
+    expect(replay.start).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/react-native/test/session-replay-rearm.spec.ts
+++ b/packages/react-native/test/session-replay-rearm.spec.ts
@@ -184,6 +184,32 @@ describe('PostHog RN session replay re-arm after flags reload', () => {
     expect(replay.start).toHaveBeenCalledTimes(1)
   })
 
+  it('retries resume on the next flags reload when startRecording fails', async () => {
+    currentSessionRecording = { linkedFlag: 'replay-flag', endpoint: '/s/' }
+    currentFlags = { 'replay-flag': true }
+
+    posthog = newPostHog()
+    await posthog.ready()
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.start).toHaveBeenCalledTimes(1))
+    replay.isEnabled.mockImplementation(async () => true)
+
+    // Pause via flag off.
+    currentFlags = { 'replay-flag': false }
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.stopRecording).toHaveBeenCalledTimes(1))
+
+    // Flag back on, but the native resume call fails once -> must roll back.
+    replay.startRecording.mockRejectedValueOnce(new Error('native resume failed'))
+    currentFlags = { 'replay-flag': true }
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.startRecording).toHaveBeenCalledTimes(1))
+
+    // Next reload retries the resume instead of early-returning.
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.startRecording).toHaveBeenCalledTimes(2))
+  })
+
   it('retries native init on the next flags reload when the first attempt fails', async () => {
     currentSessionRecording = { endpoint: '/s/' } // no linkedFlag => recording active
 

--- a/packages/react-native/test/session-replay-rearm.spec.ts
+++ b/packages/react-native/test/session-replay-rearm.spec.ts
@@ -210,6 +210,28 @@ describe('PostHog RN session replay re-arm after flags reload', () => {
     await waitForExpect(2000, () => expect(replay.startRecording).toHaveBeenCalledTimes(2))
   })
 
+  it('retries pause on the next flags reload when stopRecording fails', async () => {
+    currentSessionRecording = { linkedFlag: 'replay-flag', endpoint: '/s/' }
+    currentFlags = { 'replay-flag': true }
+
+    posthog = newPostHog()
+    await posthog.ready()
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.start).toHaveBeenCalledTimes(1))
+    replay.isEnabled.mockImplementation(async () => true)
+
+    // Flag turns off, but the native stop call fails once -> recording state must NOT clear.
+    replay.stopRecording.mockRejectedValueOnce(new Error('native stop failed'))
+    currentFlags = { 'replay-flag': false }
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.stopRecording).toHaveBeenCalledTimes(1))
+
+    // Flag still off on the next reload: since the stop failed, the pause is retried
+    // instead of being treated as already-paused.
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.stopRecording).toHaveBeenCalledTimes(2))
+  })
+
   it('retries native init on the next flags reload when the first attempt fails', async () => {
     currentSessionRecording = { endpoint: '/s/' } // no linkedFlag => recording active
 

--- a/packages/react-native/test/session-replay-rearm.spec.ts
+++ b/packages/react-native/test/session-replay-rearm.spec.ts
@@ -49,8 +49,11 @@ describe('PostHog RN session replay re-arm after flags reload', () => {
     replay.startSession.mockClear()
     replay.endSession.mockClear()
     replay.startRecording.mockClear()
+    replay.stopRecording.mockClear()
+    replay.identify.mockClear()
     replay.isEnabled.mockClear()
     replay.isEnabled.mockImplementation(async () => false)
+    replay.start.mockImplementation(async () => {})
 
     currentFlags = {}
     currentSessionRecording = {}
@@ -179,5 +182,19 @@ describe('PostHog RN session replay re-arm after flags reload', () => {
     await posthog.reloadFeatureFlagsAsync()
     await waitForExpect(2000, () => expect(replay.startRecording).toHaveBeenCalledTimes(1))
     expect(replay.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries native init on the next flags reload when the first attempt fails', async () => {
+    currentSessionRecording = { endpoint: '/s/' } // no linkedFlag => recording active
+
+    // First native start throws -> init fails and the armed state must roll back.
+    replay.start.mockRejectedValueOnce(new Error('native start failed'))
+
+    posthog = newPostHog()
+    await posthog.ready()
+
+    // The bootstrap arm fails and rolls back; the flags load re-arms and retries.
+    // Without the rollback the failed attempt would suppress every later attempt.
+    await waitForExpect(2000, () => expect(replay.start).toHaveBeenCalledTimes(2))
   })
 })

--- a/packages/react-native/test/session-replay-rearm.spec.ts
+++ b/packages/react-native/test/session-replay-rearm.spec.ts
@@ -1,0 +1,183 @@
+import { PostHog, PostHogCustomStorage, PostHogPersistedProperty } from '../src'
+import { OptionalReactNativePlugin } from '../src/optional/OptionalPlugin'
+import { Linking, AppState } from 'react-native'
+import { waitForExpect, wait } from './test-utils'
+
+// Mock the native plugin bridge so we can assert which native calls happen. No `setup`
+// key, so the SDK takes the legacy start() path (same surface as the standalone
+// posthog-react-native-session-replay package).
+// NOTE: the factory must be self-contained (jest hoists it above any const), so we
+// build the jest.fn()s inline and reach them through the imported module handle below.
+jest.mock('../src/optional/OptionalPlugin', () => ({
+  OptionalReactNativePlugin: {
+    start: jest.fn(async () => {}),
+    startSession: jest.fn(async () => {}),
+    endSession: jest.fn(async () => {}),
+    isEnabled: jest.fn(async () => false),
+    identify: jest.fn(async () => {}),
+    startRecording: jest.fn(async () => {}),
+    stopRecording: jest.fn(async () => {}),
+  },
+}))
+
+const replay = OptionalReactNativePlugin as unknown as {
+  start: jest.Mock
+  startSession: jest.Mock
+  endSession: jest.Mock
+  isEnabled: jest.Mock
+  identify: jest.Mock
+  startRecording: jest.Mock
+  stopRecording: jest.Mock
+}
+
+Linking.getInitialURL = jest.fn(() => Promise.resolve(null))
+AppState.addEventListener = jest.fn()
+
+describe('PostHog RN session replay re-arm after flags reload', () => {
+  jest.useRealTimers()
+
+  let posthog: PostHog
+  let cache: any = {}
+  let mockStorage: PostHogCustomStorage
+
+  // Controls what the mocked /flags response returns.
+  let currentFlags: Record<string, any> = {}
+  let currentSessionRecording: any = {}
+
+  beforeEach(() => {
+    replay.start.mockClear()
+    replay.startSession.mockClear()
+    replay.endSession.mockClear()
+    replay.startRecording.mockClear()
+    replay.isEnabled.mockClear()
+    replay.isEnabled.mockImplementation(async () => false)
+
+    currentFlags = {}
+    currentSessionRecording = {}
+    ;(globalThis as any).window.fetch = jest.fn(async (url: string) => {
+      let res: any = { status: 'ok' }
+      if (url.includes('flags')) {
+        res = {
+          featureFlags: currentFlags,
+          sessionRecording: currentSessionRecording,
+        }
+      }
+      return { status: 200, json: () => Promise.resolve(res) }
+    })
+
+    cache = {}
+    mockStorage = {
+      getItem: async (key) => cache[key] || null,
+      setItem: async (key, value) => {
+        cache[key] = value
+      },
+    }
+  })
+
+  afterEach(async () => {
+    await posthog.shutdown()
+  })
+
+  const newPostHog = (): PostHog =>
+    new PostHog('test-token', {
+      customStorage: mockStorage,
+      enableSessionReplay: true,
+      flushInterval: 0,
+    })
+
+  it('common case: replay with no linked flag starts at bootstrap and is not double-started on identify', async () => {
+    currentSessionRecording = { endpoint: '/s/' } // no linkedFlag => active
+    posthog = newPostHog()
+    await posthog.ready()
+
+    // Native recording starts once at bootstrap.
+    await waitForExpect(2000, () => expect(replay.start).toHaveBeenCalledTimes(1))
+
+    // Native is now enabled; the subsequent identify path should rotate, not re-init.
+    replay.isEnabled.mockImplementation(async () => true)
+
+    posthog.identify('user-1')
+    await posthog.reloadFeatureFlagsAsync()
+
+    // Should not start a second native session (no double-init).
+    await new Promise((r) => setTimeout(r, 50))
+    expect(replay.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('warm start: linked-flag off -> on after identify re-arms recording (matches native auto re-arm)', async () => {
+    // Phase 1 (first launch): cache the linkedFlag recording config and a FALSE flag value,
+    // so the next launch evaluates the linked flag from cache at bootstrap.
+    currentSessionRecording = { linkedFlag: 'replay-flag', endpoint: '/s/' }
+    currentFlags = { 'replay-flag': false }
+    const warmup = newPostHog()
+    await warmup.ready()
+    await warmup.reloadFeatureFlagsAsync()
+    await wait(50)
+    await warmup.shutdown()
+    replay.start.mockClear()
+
+    // Phase 2 (next launch): bootstrap respects the cached linked flag (false) -> no recording.
+    posthog = newPostHog()
+    await posthog.ready()
+    await wait(50)
+    expect(replay.start).not.toHaveBeenCalled()
+
+    // User logs in; the linked flag now evaluates TRUE on the next flags reload.
+    currentFlags = { 'replay-flag': true }
+    posthog.identify('user-1')
+    await posthog.reloadFeatureFlagsAsync()
+
+    // The linked flag now evaluates true on reload, so replay re-arms and native start is called.
+    await waitForExpect(2000, () => expect(replay.start).toHaveBeenCalledTimes(1))
+  })
+
+  it('reset() keeps the project-level recording config (not user data) so replay survives an identity change', async () => {
+    currentSessionRecording = { linkedFlag: 'replay-flag', endpoint: '/s/' }
+    currentFlags = { 'replay-flag': true }
+
+    posthog = newPostHog()
+    await posthog.ready()
+    await posthog.reloadFeatureFlagsAsync()
+
+    // Armed for the first user, and the project-level recording config is cached.
+    await waitForExpect(2000, () => expect(replay.start).toHaveBeenCalledTimes(1))
+    expect(posthog.getPersistedProperty(PostHogPersistedProperty.RemoteConfig)).toBeTruthy()
+
+    // Native is now enabled; the post-reset reload should re-evaluate, not start a second session.
+    replay.isEnabled.mockImplementation(async () => true)
+
+    // User logs out. reset() keeps the recording config (project-level, not user data) so it stays
+    // available for the next user's flags to be re-evaluated against. The /flags reload after reset()
+    // does not carry the remote config, so only the cache makes it available before the next launch.
+    posthog.reset()
+    await posthog.reloadFeatureFlagsAsync()
+    await wait(50)
+
+    expect(posthog.getPersistedProperty(PostHogPersistedProperty.RemoteConfig)).toBeTruthy()
+    expect(replay.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('pauses recording when the linked flag turns off and resumes when it turns back on', async () => {
+    currentSessionRecording = { linkedFlag: 'replay-flag', endpoint: '/s/' }
+    currentFlags = { 'replay-flag': true }
+
+    posthog = newPostHog()
+    await posthog.ready()
+    await posthog.reloadFeatureFlagsAsync()
+
+    // Linked flag is active -> recording starts.
+    await waitForExpect(2000, () => expect(replay.start).toHaveBeenCalledTimes(1))
+    replay.isEnabled.mockImplementation(async () => true)
+
+    // Linked flag turns off (e.g. the identified user is outside the rollout) -> recording pauses.
+    currentFlags = { 'replay-flag': false }
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.stopRecording).toHaveBeenCalledTimes(1))
+
+    // Linked flag turns back on -> recording resumes without starting a second native session.
+    currentFlags = { 'replay-flag': true }
+    await posthog.reloadFeatureFlagsAsync()
+    await waitForExpect(2000, () => expect(replay.startRecording).toHaveBeenCalledTimes(1))
+    expect(replay.start).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Problem

After an in-session `identify()` or `reset()`, session replay could stop recording (or keep recording the wrong user) until the app was restarted:

- `reset()` wiped the cached remote config and recording config along with user data, so replay had nothing to re-evaluate against after a logout/login.
- The linked recording flag was only evaluated once at startup. A flag that became active for the identified user never started recording, and a flag that turned off never stopped it.

iOS and Android fixed this in PostHog/posthog-ios#630 and PostHog/posthog-android#547. This brings React Native to parity. The web SDK already preserves its recording config across `reset()` the same way.

## Changes

- `reset()` now keeps `RemoteConfig`, `SessionReplay`, and `Surveys` persisted properties. These hold project-level settings (recording config, error tracking, capture performance, survey definitions), not user data. User-specific state — distinct id, person properties, flags, which surveys were seen — is still cleared. (Android clears survey definitions today and will align in a follow-up.)
- Session replay is re-evaluated whenever feature flags load or reload (`identify()`, `reset()`, `reloadFeatureFlags()`): recording starts or resumes when the linked flag is on for the current user, and pauses when it's off. Transitions are tracked so repeated reloads with the same answer don't cross the native bridge. Pausing only happens on a real flag-off — quota-limited/failed reloads keep the previous flag values, so a network blip can't kill a recording.
- `@posthog/core`: the recording config from a `/flags` response is now persisted *before* the `featureflags` event fires, so listeners evaluate the linked flag against config that matches the new flag values. This only reorders two adjacent synchronous writes; `posthog-node` and browser `posthog-js` don't use this code path.

Verified on a physical Pixel 4 against a live project: recording starts when the linked flag is on, stops mid-session when it turns off, resumes when it comes back, survives `reset()`, and a stale cached flag at cold start is corrected by the first `/flags` response — all without app restarts.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file