### PR TITLE
fix: prevent autocapture extension script reloads

### DIFF
--- a/.changeset/quiet-ducks-breathe.md
+++ b/.changeset/quiet-ducks-breathe.md
@@ -1,0 +1,5 @@
+---
+"posthog-js": patch
+---
+
+Avoid reloading exception and dead-click autocapture external scripts when they are already present.

--- a/packages/browser/src/__tests__/extensions/dead-clicks-autocapture.test.ts
+++ b/packages/browser/src/__tests__/extensions/dead-clicks-autocapture.test.ts
@@ -57,6 +57,16 @@ describe('DeadClicksAutocapture', () => {
         expect(mockLoader).toHaveBeenCalledWith(instance, 'dead-clicks-autocapture', expect.any(Function))
     })
 
+    it('should not call loadExternalDependency if script is already loaded', async () => {
+        const instance = await createPosthogInstance(uuidv7(), { capture_dead_clicks: true })
+        const mockLoader = assignableWindow.__PosthogExtensions__.loadExternalDependency as jest.Mock
+        mockLoader.mockClear()
+
+        instance.deadClicksAutocapture.startIfEnabledOrStop()
+
+        expect(mockLoader).not.toHaveBeenCalled()
+    })
+
     it('should call lazy loaded stop when stopping', async () => {
         const instance = await createPosthogInstance(uuidv7(), {
             api_host: 'https://test.com',

--- a/packages/browser/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
@@ -84,6 +84,15 @@ describe('Exception Observer', () => {
             expect((window?.onunhandledrejection as any).__POSTHOG_INSTRUMENTED__).toBe(true)
         })
 
+        it('does not call loadExternalDependency if script is already loaded', () => {
+            addErrorWrappingFlagToWindow()
+            loadScriptMock.mockClear()
+
+            exceptionObserver.startIfEnabledOrStop()
+
+            expect(loadScriptMock).not.toHaveBeenCalled()
+        })
+
         it('should remove instrument handlers when stopped', () => {
             exceptionObserver['_stopCapturing']()
             expectNoHandlers()

--- a/packages/browser/src/extensions/dead-clicks-autocapture.ts
+++ b/packages/browser/src/extensions/dead-clicks-autocapture.ts
@@ -65,6 +65,7 @@ export class DeadClicksAutocapture implements Extension {
         if (assignableWindow.__PosthogExtensions__?.initDeadClicksAutocapture) {
             // already loaded
             cb()
+            return
         }
         assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(
             this.instance,

--- a/packages/browser/src/extensions/exception-autocapture/index.ts
+++ b/packages/browser/src/extensions/exception-autocapture/index.ts
@@ -76,6 +76,7 @@ export class ExceptionObserver {
         if (assignableWindow.__PosthogExtensions__?.errorWrappingFunctions) {
             // already loaded
             cb()
+            return
         }
 
         assignableWindow.__PosthogExtensions__?.loadExternalDependency?.(


### PR DESCRIPTION
## Problem

On posthog.com, `set_config()` calls after consent updates can restart enabled extension managers. Exception autocapture and dead-click autocapture detected that their lazy-loaded extension code was already present and invoked their start callback, but then continued into `loadExternalDependency()`. This could trigger duplicate network requests for `exception-autocapture.js` and `dead-clicks-autocapture.js`.

## Changes

The fix is pretty straight-forward:
- Return early from exception autocapture's `_loadScript()` when `errorWrappingFunctions` is already loaded.
- Return early from dead-click autocapture's `_loadScript()` when `initDeadClicksAutocapture` is already loaded.
- Added regression tests ensuring neither extension calls `loadExternalDependency()` once its lazy-loaded script is present.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
