### PR TITLE
fix: Guard remaining survey localStorage accesses against SecurityError (#3588)

### DIFF
--- a/.changeset/surveys-localstorage-iframe-guard.md
+++ b/.changeset/surveys-localstorage-iframe-guard.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Surveys: guard the remaining unprotected `localStorage` accesses (`reset()` and the `lastSeenSurveyDate` write) so a `SecurityError` in cross-origin iframes is swallowed instead of bubbling up to user monitoring.

--- a/packages/browser/src/__tests__/posthog-surveys.test.ts
+++ b/packages/browser/src/__tests__/posthog-surveys.test.ts
@@ -151,6 +151,18 @@ describe('posthog-surveys', () => {
             localStorage.clear()
         })
 
+        describe('reset', () => {
+            it('does not throw when localStorage access throws (e.g. cross-origin iframe)', () => {
+                const removeItemSpy = jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+                    throw new Error('storage unavailable')
+                })
+
+                expect(() => surveys.reset()).not.toThrow()
+
+                removeItemSpy.mockRestore()
+            })
+        })
+
         describe('canRenderSurvey', () => {
             it('should return false if surveys are not loaded', () => {
                 const result = surveys.canRenderSurvey(survey.id)

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -1055,7 +1055,11 @@ export function usePopupVisibility(
                     sessionRecordingUrl: posthog.get_session_replay_url?.(),
                 })
             }
-            localStorage.setItem('lastSeenSurveyDate', new Date().toISOString())
+            try {
+                localStorage.setItem('lastSeenSurveyDate', new Date().toISOString())
+            } catch {
+                // localStorage is not always available (e.g. in cross-origin iframes).
+            }
         }
 
         addEventListener(window, 'PHSurveyClosed', handleSurveyClosed as EventListener)

--- a/packages/browser/src/posthog-surveys.ts
+++ b/packages/browser/src/posthog-surveys.ts
@@ -73,16 +73,20 @@ export class PostHogSurveys implements Extension {
     }
 
     reset(): void {
-        localStorage.removeItem('lastSeenSurveyDate')
-        const surveyKeys = []
-        for (let i = 0; i < localStorage.length; i++) {
-            const key = localStorage.key(i)
-            if (key?.startsWith(SURVEY_SEEN_PREFIX) || key?.startsWith(SURVEY_IN_PROGRESS_PREFIX)) {
-                surveyKeys.push(key)
+        try {
+            localStorage.removeItem('lastSeenSurveyDate')
+            const surveyKeys = []
+            for (let i = 0; i < localStorage.length; i++) {
+                const key = localStorage.key(i)
+                if (key?.startsWith(SURVEY_SEEN_PREFIX) || key?.startsWith(SURVEY_IN_PROGRESS_PREFIX)) {
+                    surveyKeys.push(key)
+                }
             }
-        }
 
-        surveyKeys.forEach((key) => localStorage.removeItem(key))
+            surveyKeys.forEach((key) => localStorage.removeItem(key))
+        } catch {
+            // localStorage is not always available (e.g. in cross-origin iframes); resetting survey state is best-effort.
+        }
     }
 
     loadIfEnabled() {


### PR DESCRIPTION
## Changes

Fixes #3588: surveys throw an uncaught `SecurityError` when `localStorage` is unavailable (most commonly in cross-origin iframes), which floods users' error monitoring (PostHog, Sentry, etc.).

Most survey storage access is already wrapped in `try/catch` (e.g. `surveys-extension-utils.tsx`), but two spots were still unprotected and are the remaining source of the reported errors:

- `PostHogSurveys.reset()` in `packages/browser/src/posthog-surveys.ts` — `localStorage.removeItem` / `.length` / `.key(i)`.
- The `lastSeenSurveyDate` write in the `PHSurveySent` handler in `packages/browser/src/extensions/surveys.tsx`.

Both are now wrapped in `try/catch`, matching the existing best-effort idiom used elsewhere in the survey code (`// localStorage not available`). Survey reset and the last-seen-date write are non-critical, so swallowing the error is correct here.

## Tests

Added a regression test in `posthog-surveys.test.ts` that mocks `Storage.prototype.removeItem` to throw and asserts `reset()` no longer throws. It fails on `main` and passes with this change.

### Verification (run locally)
- `jest src/__tests__/posthog-surveys.test.ts` — 41 pass (regression-proven against revert).
- `jest src/__tests__/extensions/surveys.test.ts` — 68 pass (no regressions).
- `tsc --noEmit` clean, `eslint` clean, `prettier --check` clean.

## Checklist
- [x] Added a changeset (`patch`).
- [x] Added a test that reproduces the bug and verifies the fix.
- [x] Followed the existing storage-guarding pattern in the survey code.

👋 Hi, I use PostHog and hit this while running surveys in an embedded context. Happy to extend the same guard to any other unprotected survey storage access if you'd like.
