### PR TITLE
ci: add fork-safe placeholders for required checks

### DIFF
--- a/.github/workflows/bundled-size.yaml
+++ b/.github/workflows/bundled-size.yaml
@@ -27,7 +27,12 @@ jobs:
           name: bundle-stats-array.html
           path: packages/browser/bundle-stats-array.html
 
+      - name: Skip PR comments for fork PR
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: echo "Skipping bundled-size PR comments for fork PRs because GitHub tokens are read-only."
+
       - name: Find artifact link comment if it exists
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # pin v4.0.0
         id: fc
         with:
@@ -36,6 +41,7 @@ jobs:
           body-includes: Download bundle size visualization
 
       - name: Create or update artifact link comment
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # pin v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -45,6 +51,7 @@ jobs:
           edit-mode: replace
 
       - uses: preactjs/compressed-size-action@946a292cd35bd1088e0d7eb92b69d1a8d5b5d76a # pin v2.8.0
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           compression: "none"
           strip-hash: '-(\w{8})\.'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,6 @@ concurrency:
 jobs:
   browsers:
     name: Test on ${{ matrix.tests.name }}
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -40,30 +39,37 @@ jobs:
             install: "chromium"
 
     steps:
+      - name: Skip fork PR
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: echo "Skipping ${{ matrix.tests.name }} integration tests for fork PRs because required secrets are unavailable."
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           build: false
 
       - uses: ./.github/actions/is-affected
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         id: is-affected
         with:
           package-name: posthog-js
 
       - name: Build packages
-        if: ${{ steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
         run: pnpm build
 
       - name: Install Playwright Browsers
-        if: ${{ steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
         run: pnpm exec playwright install ${{ matrix.tests.install }} --with-deps --only-shell
         working-directory: packages/browser
 
       - name: Run ${{ matrix.tests.name }} test
-        if: ${{ steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
         timeout-minutes: 30
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -145,7 +145,7 @@ jobs:
           fi
 
       - name: Find existing compat comment
-        if: steps.process-results.outputs.has_failures == 'true'
+        if: ${{ steps.process-results.outputs.has_failures == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
@@ -154,7 +154,7 @@ jobs:
           body-includes: '<!-- compat-test-results -->'
 
       - name: Create or update compat comment
-        if: steps.process-results.outputs.has_failures == 'true'
+        if: ${{ steps.process-results.outputs.has_failures == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -201,7 +201,7 @@ jobs:
             </details>
 
       - name: Delete compat comment if tests pass
-        if: steps.process-results.outputs.has_failures == 'false' && steps.is-affected.outputs.is-affected == 'true'
+        if: ${{ steps.process-results.outputs.has_failures == 'false' && steps.is-affected.outputs.is-affected == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-passing-comment
         with:
@@ -210,7 +210,7 @@ jobs:
           body-includes: '<!-- compat-test-results -->'
 
       - name: Remove outdated comment
-        if: steps.find-passing-comment.outputs.comment-id != ''
+        if: ${{ steps.find-passing-comment.outputs.comment-id != '' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           COMMENT_ID: ${{ steps.find-passing-comment.outputs.comment-id }}

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -33,8 +33,12 @@ jobs:
               env:
                   RAW_BODY: ${{ github.event.pull_request.body || '' }}
 
+            - name: Skip shame comment for fork PR
+              if: ${{ steps.is-shame-worthy.outputs.is-shame-worthy == 'true' && github.event.pull_request.head.repo.full_name != github.repository }}
+              run: echo "Skipping no-description PR comment for fork PR because GitHub tokens are read-only."
+
             - name: Shame if PR has no description
-              if: steps.is-shame-worthy.outputs.is-shame-worthy == 'true'
+              if: ${{ steps.is-shame-worthy.outputs.is-shame-worthy == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -19,7 +19,6 @@ concurrency:
 jobs:
   browsers:
     name: Test on ${{ matrix.name }}
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -31,29 +30,36 @@ jobs:
             name: IE11
 
     steps:
+      - name: Skip fork PR
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: echo "Skipping ${{ matrix.name }} TestCafe tests for fork PRs because required BrowserStack/PostHog secrets are unavailable."
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           build: false
 
       - uses: ./.github/actions/is-affected
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         id: is-affected
         with:
           package-name: posthog-js
 
       - name: Build packages
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
         run: pnpm build
 
       - name: Serve static files
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
         run: python -m http.server 8080 &
 
       - name: Run ${{ matrix.name }} test
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
         timeout-minutes: 10
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -64,7 +70,7 @@ jobs:
         working-directory: packages/browser
 
       - name: Check ${{ matrix.name }} events
-        if: steps.is-affected.outputs.is-affected == 'true'
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
         timeout-minutes: 30
         run: pnpm check-testcafe-results
         working-directory: packages/browser

--- a/.github/workflows/validate-versioning.yml
+++ b/.github/workflows/validate-versioning.yml
@@ -100,7 +100,7 @@ jobs:
           fi
       
       - name: Remove outdated comments
-        if: always()
+        if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           NO_CHANGESETS: ${{ steps.check-major.outputs.no_changesets }}
@@ -171,7 +171,7 @@ jobs:
             }
       
       - name: Comment on PR
-        if: failure() && steps.check-major.outputs.major_bump_found == 'true'
+        if: ${{ failure() && steps.check-major.outputs.major_bump_found == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           MAJOR_FILES: ${{ steps.check-major.outputs.major_files }}
@@ -234,7 +234,7 @@ jobs:
             }
       
       - name: Comment about PR title and changeset mismatch
-        if: failure() && steps.check-major.outputs.title_mismatch_found == 'true'
+        if: ${{ failure() && steps.check-major.outputs.title_mismatch_found == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           TITLE_MISMATCH_FILES: ${{ steps.check-major.outputs.title_mismatch_files }}
@@ -291,7 +291,7 @@ jobs:
             }
 
       - name: Comment about missing changeset
-        if: always() && steps.check-major.outputs.no_changesets == 'true'
+        if: ${{ always() && steps.check-major.outputs.no_changesets == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Forked contributor PRs can get stuck with required checks showing “Waiting for status to be reported”. Some required browser checks were skipped at the job level for fork PRs, so GitHub never created the exact required status contexts. Some PR-commenting steps can also fail on fork PRs because the default token is read-only.

## Changes

- Make Playwright browser matrix checks and the IE11 TestCafe check materialize for fork PRs with a passing placeholder step.
- Keep the real browser/TestCafe steps restricted to same-repository PRs where required secrets are available.
- Guard PR comment creation/update/deletion in bundled-size, backward compatibility, versioning, and new-PR workflows so fork PRs do not fail with `Resource not accessible by integration`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
