### PR TITLE
fix: add missing bugs metadata

### DIFF
--- a/.changeset/add-bugs-metadata.md
+++ b/.changeset/add-bugs-metadata.md
@@ -1,0 +1,18 @@
+---
+'posthog-js': patch
+'@posthog/core': patch
+'@posthog/mcp': patch
+'@posthog/next': patch
+'@posthog/nextjs-config': patch
+'posthog-node': patch
+'@posthog/nuxt': patch
+'@posthog/plugin-utils': patch
+'posthog-react-native': patch
+'@posthog/react': patch
+'@posthog/rollup-plugin': patch
+'@posthog/types': patch
+'posthog-js-lite': patch
+'@posthog/webpack-plugin': patch
+---
+
+Add missing bugs metadata to package manifests.

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,9 @@
 {
     "name": "posthog-js",
     "version": "1.386.6",
+    "bugs": {
+        "url": "https://github.com/PostHog/posthog-js/issues"
+    },
     "description": "Posthog-js allows you to automatically capture usage and send events to PostHog.",
     "repository": "https://github.com/PostHog/posthog-js",
     "author": "engineering@posthog.com",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@posthog/core",
   "version": "1.32.3",
+  "bugs": {
+    "url": "https://github.com/PostHog/posthog-js/issues"
+  },
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@posthog/mcp",
   "version": "0.2.0",
+  "bugs": {
+    "url": "https://github.com/PostHog/posthog-js/issues"
+  },
   "description": "PostHog SDK for Model Context Protocol (MCP) servers — tracks tool usage, intent, and identity",
   "repository": {
     "type": "git",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,9 @@
 {
     "name": "@posthog/next",
     "version": "0.4.95",
+    "bugs": {
+        "url": "https://github.com/PostHog/posthog-js/issues"
+    },
     "description": "PostHog integration for Next.js",
     "repository": {
         "type": "git",

--- a/packages/nextjs-config/package.json
+++ b/packages/nextjs-config/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@posthog/nextjs-config",
   "version": "1.9.66",
+  "bugs": {
+    "url": "https://github.com/PostHog/posthog-js/issues"
+  },
   "description": "NextJS configuration helper for Posthog 🦔",
   "repository": {
     "type": "git",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,9 @@
 {
   "name": "posthog-node",
   "version": "5.37.0",
+  "bugs": {
+    "url": "https://github.com/PostHog/posthog-js/issues"
+  },
   "description": "PostHog Node.js integration",
   "repository": {
     "type": "git",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@posthog/nuxt",
   "version": "1.7.75",
+  "bugs": {
+    "url": "https://github.com/PostHog/posthog-js/issues"
+  },
   "description": "Nuxt module for Posthog 🦔",
   "repository": {
     "type": "git",

--- a/packages/plugin-utils/package.json
+++ b/packages/plugin-utils/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@posthog/plugin-utils",
   "version": "1.1.1",
+  "bugs": {
+    "url": "https://github.com/PostHog/posthog-js/issues"
+  },
   "description": "Shared CLI and sourcemap utilities for PostHog build plugins",
   "license": "MIT",
   "repository": {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,9 @@
 {
   "name": "posthog-react-native",
   "version": "4.47.0",
+  "bugs": {
+    "url": "https://github.com/PostHog/posthog-js/issues"
+  },
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,9 @@
 {
     "name": "@posthog/react",
     "version": "1.10.1",
+    "bugs": {
+        "url": "https://github.com/PostHog/posthog-js/issues"
+    },
     "description": "Provides components and hooks for React integrations of PostHog.",
     "repository": {
         "type": "git",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -1,6 +1,9 @@
 {
     "name": "@posthog/rollup-plugin",
     "version": "1.4.5",
+    "bugs": {
+        "url": "https://github.com/PostHog/posthog-js/issues"
+    },
     "description": "PostHog Rollup plugin",
     "repository": {
         "type": "git",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,9 @@
 {
     "name": "@posthog/types",
     "version": "1.386.3",
+    "bugs": {
+        "url": "https://github.com/PostHog/posthog-js/issues"
+    },
     "description": "Type definitions for the PostHog JavaScript SDK",
     "license": "MIT",
     "main": "dist/index.js",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,9 @@
 {
   "name": "posthog-js-lite",
   "version": "4.6.62",
+  "bugs": {
+    "url": "https://github.com/PostHog/posthog-js/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,9 @@
 {
     "name": "@posthog/webpack-plugin",
     "version": "1.5.22",
+    "bugs": {
+        "url": "https://github.com/PostHog/posthog-js/issues"
+    },
     "description": "Webpack plugin for Posthog 🦔",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Problem

Several published package manifests were missing npm `bugs` metadata, so npm tooling has no package-level issue URL to resolve.

## Changes

- Added `bugs.url` pointing to `https://github.com/PostHog/posthog-js/issues` to public packages that were missing it.
- Left existing `bugs` metadata untouched.
- Added a patch changeset for the affected packages.

Additional affected packages not listed below: `@posthog/core`, `@posthog/mcp`, and `@posthog/plugin-utils`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [x] posthog-js-lite (web lite)
- [x] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [x] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [x] @posthog/next
- [x] @posthog/nextjs-config
- [x] @posthog/nuxt
- [x] @posthog/rollup-plugin
- [x] @posthog/webpack-plugin
- [x] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Generated a changeset file

<!-- For more details check RELEASING.md -->
