### PR TITLE
fix(replay): discard prior session buffer on restart across reset

### DIFF
--- a/.changeset/fix-recorder-buffer-leak-across-reset.md
+++ b/.changeset/fix-recorder-buffer-leak-across-reset.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+fix(replay): discard the prior session's buffer when start() bails out a pending stop(). On a stopSessionRecording() → reset() → identify(newUser) → startSessionRecording() sequence, stopSessionRecording() takes the async compression-drain path, deferring its buffer flush and teardown. start() correctly invalidates that pending cleanup so the new recorder survives, but it left the stopped session's snapshot buffer in place. The re-entrant session-id restart then flushed those previous-user snapshots under the OLD session id, producing a mixed-distinct_id session that server-side `any(distinct_id)` attribution resolves to the wrong person — recordings showing the previous user's identity. start() now clears that stale buffer alongside invalidating the compression queue, matching the drop-trailing-data trade-off the bailed-out stop() path already accepts.

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1465,13 +1465,9 @@ describe('Lazy SessionRecording', () => {
                 expect(lazyRecorder['_compressionQueueGeneration']).toEqual(generationBefore)
             })
 
-            // Reproduces the wrong-person attribution from a stopSessionRecording() → reset() →
-            // identify(newUser) → startSessionRecording() sequence. stopSessionRecording() takes
-            // the async compression-drain path: rrweb stops but the buffer/teardown are deferred.
-            // start() bails that pending cleanup out (so the new recorder survives) — but if it
-            // leaves the stopped session's buffer in place, the re-entrant onSessionId restart it
-            // triggers flushes those prior-user snapshots under the OLD session id. Server-side
-            // any(distinct_id) attribution then resolves that mixed session to the wrong person.
+            // #3822: stopSessionRecording() → reset() → identify() → startSessionRecording()
+            // leaked the prior session's buffer (flushed under the old session id), mis-attributing
+            // the recording. start() must discard it when bailing out the pending stop.
             it('discards the prior session buffer when start() bails out a pending stop()', () => {
                 const lazyRecorder = sessionRecording['_lazyLoadedSessionRecording']
 
@@ -1481,19 +1477,16 @@ describe('Lazy SessionRecording', () => {
                 expect(lazyRecorder['_buffer'].data.length).toBeGreaterThan(0)
                 expect(lazyRecorder['_buffer'].sessionId).toEqual(priorSessionId)
 
-                // Mirror stopSessionRecording() taking the async compression-drain path: rrweb is
-                // stopped synchronously, but the buffer flush and teardown are deferred until the
-                // queue drains.
+                // stopSessionRecording() via the async compression-drain path: rrweb stops, but the
+                // buffer flush and teardown are deferred until the queue drains.
                 lazyRecorder['_isStoppingAfterCompression'] = true
                 lazyRecorder['_queuedCompressionEvents'] = 1
                 lazyRecorder['_compressionQueue'] = new Promise<void>(() => {})
                 lazyRecorder['_stopRecordingProducers']()
                 expect(lazyRecorder['isStarted']).toEqual(false)
 
-                // reset() clears the session id and a new user identifies before
-                // startSessionRecording() restarts the recorder. The fresh id makes start()'s
-                // checkAndGetSessionAndWindowId() fire the onSessionId restart synchronously,
-                // which (without the buffer discard) flushes the prior session's snapshots.
+                // reset() clears the session id; the fresh id then makes start()'s
+                // checkAndGetSessionAndWindowId() fire the onSessionId restart synchronously.
                 sessionManager.resetSessionId()
                 ;(posthog.capture as Mock).mockClear()
                 sessionIdGeneratorMock.mockClear()

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -1464,6 +1464,50 @@ describe('Lazy SessionRecording', () => {
                 expect(lazyRecorder['_compressionQueue']).toBe(liveQueue)
                 expect(lazyRecorder['_compressionQueueGeneration']).toEqual(generationBefore)
             })
+
+            // Reproduces the wrong-person attribution from a stopSessionRecording() → reset() →
+            // identify(newUser) → startSessionRecording() sequence. stopSessionRecording() takes
+            // the async compression-drain path: rrweb stops but the buffer/teardown are deferred.
+            // start() bails that pending cleanup out (so the new recorder survives) — but if it
+            // leaves the stopped session's buffer in place, the re-entrant onSessionId restart it
+            // triggers flushes those prior-user snapshots under the OLD session id. Server-side
+            // any(distinct_id) attribution then resolves that mixed session to the wrong person.
+            it('discards the prior session buffer when start() bails out a pending stop()', () => {
+                const lazyRecorder = sessionRecording['_lazyLoadedSessionRecording']
+
+                // Establish a recording session with the prior user's data sitting in the buffer.
+                emitActiveEvent(startingTimestamp + 100)
+                const priorSessionId = lazyRecorder['_sessionId']
+                expect(lazyRecorder['_buffer'].data.length).toBeGreaterThan(0)
+                expect(lazyRecorder['_buffer'].sessionId).toEqual(priorSessionId)
+
+                // Mirror stopSessionRecording() taking the async compression-drain path: rrweb is
+                // stopped synchronously, but the buffer flush and teardown are deferred until the
+                // queue drains.
+                lazyRecorder['_isStoppingAfterCompression'] = true
+                lazyRecorder['_queuedCompressionEvents'] = 1
+                lazyRecorder['_compressionQueue'] = new Promise<void>(() => {})
+                lazyRecorder['_stopRecordingProducers']()
+                expect(lazyRecorder['isStarted']).toEqual(false)
+
+                // reset() clears the session id and a new user identifies before
+                // startSessionRecording() restarts the recorder. The fresh id makes start()'s
+                // checkAndGetSessionAndWindowId() fire the onSessionId restart synchronously,
+                // which (without the buffer discard) flushes the prior session's snapshots.
+                sessionManager.resetSessionId()
+                ;(posthog.capture as Mock).mockClear()
+                sessionIdGeneratorMock.mockClear()
+                sessionIdGeneratorMock.mockImplementation(() => 'post-reset-session-id')
+
+                lazyRecorder.start()
+
+                // No snapshot from the prior session may be flushed during the restart.
+                const leakedPriorSessionSnapshot = (posthog.capture as Mock).mock.calls.find(
+                    (call) => call[0] === '$snapshot' && call[1]?.$session_id === priorSessionId
+                )
+                expect(leakedPriorSessionSnapshot).toBeUndefined()
+                expect(lazyRecorder['isStarted']).toEqual(true)
+            })
         })
 
         describe('scheduled full snapshots', () => {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -891,15 +891,9 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         // Guarded on the stop-in-progress flag because start() is also called re-entrantly
         // on a live recorder (e.g. opt-in flows) where the queue holds the current session's
         // events and must survive.
-        //
-        // Discard the buffer too: it still holds the prior (stopped) session's snapshots, and
-        // the cleanup we just bailed out of would have cleared it. If left, the very next event
-        // for the new session flushes it under the OLD session id but with the CURRENT (new)
-        // distinct_id — and on a stop()→reset()→identify()→start() sequence that re-entrant
-        // flush is driven synchronously by checkAndGetSessionAndWindowId() below, before
-        // _sessionId is even updated. Server-side `any(distinct_id)` attribution then resolves
-        // the mixed-distinct_id session to the wrong person. Dropping the trailing prior-session
-        // data is the same trade-off the bailed-out stop() path already accepts.
+        // Discard the buffer too — the bailed-out cleanup would have cleared it. Otherwise the
+        // prior session's snapshots flush under the old session id with the new distinct_id,
+        // mis-attributing the recording (#3822).
         if (this._isStoppingAfterCompression) {
             this._invalidateCompressionQueue()
             this._clearBuffer()

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -891,8 +891,18 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         // Guarded on the stop-in-progress flag because start() is also called re-entrantly
         // on a live recorder (e.g. opt-in flows) where the queue holds the current session's
         // events and must survive.
+        //
+        // Discard the buffer too: it still holds the prior (stopped) session's snapshots, and
+        // the cleanup we just bailed out of would have cleared it. If left, the very next event
+        // for the new session flushes it under the OLD session id but with the CURRENT (new)
+        // distinct_id — and on a stop()→reset()→identify()→start() sequence that re-entrant
+        // flush is driven synchronously by checkAndGetSessionAndWindowId() below, before
+        // _sessionId is even updated. Server-side `any(distinct_id)` attribution then resolves
+        // the mixed-distinct_id session to the wrong person. Dropping the trailing prior-session
+        // data is the same trade-off the bailed-out stop() path already accepts.
         if (this._isStoppingAfterCompression) {
             this._invalidateCompressionQueue()
+            this._clearBuffer()
         }
 
         // We want to ensure the sessionManager is reset if necessary on loading the recorder


### PR DESCRIPTION
## Problem

Fixes #3822 — `stopSessionRecording()` → `reset()` → `identify(newUser)` → `startSessionRecording()` produces a recording attributed to the **previous** user. Follow-up to #3801.

`stopSessionRecording()` defers its buffer flush + teardown (compression-drain path). #3801 made `start()` invalidate that pending cleanup so the new recorder survives, but the stopped session's `_buffer` was left in place. The re-entrant `onSessionId` restart then flushes those prior-user snapshots under the old session id, and server-side `any(distinct_id)` attribution resolves the mixed session to the wrong person.

## Changes

`start()` now clears the stale buffer when bailing out a pending stop:

```ts
if (this._isStoppingAfterCompression) {
    this._invalidateCompressionQueue()
    this._clearBuffer()
}
```

Dropping the trailing prior-session data is the same trade-off the bailed-out `stop()` path already accepts. Added a regression test (fails without the fix, passes with it).

> [!NOTE]
> Verified at the unit level; not yet reproduced against a live ingest pipeline. Draft pending a confirmation on the reporter's setup.

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] No breaking changes
- [x] Ran `pnpm changeset`