### PR TITLE
fix(react-native): stabilize feature flag tests

### DIFF
--- a/packages/react-native/test/posthog.spec.ts
+++ b/packages/react-native/test/posthog.spec.ts
@@ -1208,6 +1208,9 @@ describe('PostHog React Native', () => {
           setDefaultPersonProperties: false,
           flushInterval: 0,
           preloadFeatureFlags: false,
+          disableRemoteConfig: true,
+          disableSurveys: true,
+          captureAppLifecycleEvents: false,
         })
         await posthog.ready()
         ;(globalThis as any).window.fetch.mockClear()
@@ -2241,6 +2244,9 @@ describe('Feature flag error tracking', () => {
       preloadFeatureFlags: false,
       sendFeatureFlagEvent: true,
       captureAppLifecycleEvents: false,
+      disableRemoteConfig: true,
+      disableSurveys: true,
+      disableCompression: true,
     })
   })
 
@@ -2281,15 +2287,15 @@ describe('Feature flag error tracking', () => {
     // Access a non-existent flag
     posthog.getFeatureFlag('non-existent-flag')
 
-    await waitForExpect(500, () => {
-      const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
-      const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
-      expect(captureCall).toBeDefined()
-      const body = JSON.parse(captureCall[1].body)
-      const featureFlagEvent = body.batch.find((e: any) => e.event === '$feature_flag_called')
-      expect(featureFlagEvent).toBeDefined()
-      expect(featureFlagEvent.properties.$feature_flag_error).toBe(FeatureFlagError.FLAG_MISSING)
-    })
+    await posthog.flush()
+
+    const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
+    const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
+    expect(captureCall).toBeDefined()
+    const body = JSON.parse(captureCall[1].body)
+    const featureFlagEvent = body.batch.find((e: any) => e.event === '$feature_flag_called')
+    expect(featureFlagEvent).toBeDefined()
+    expect(featureFlagEvent.properties.$feature_flag_error).toBe(FeatureFlagError.FLAG_MISSING)
   })
 
   it('should set $feature_flag_error to errors_while_computing_flags when server returns that flag', async () => {
@@ -2322,15 +2328,15 @@ describe('Feature flag error tracking', () => {
     // Access the flag that exists
     posthog.getFeatureFlag('some-flag')
 
-    await waitForExpect(500, () => {
-      const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
-      const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
-      expect(captureCall).toBeDefined()
-      const body = JSON.parse(captureCall[1].body)
-      const featureFlagEvent = body.batch.find((e: any) => e.event === '$feature_flag_called')
-      expect(featureFlagEvent).toBeDefined()
-      expect(featureFlagEvent.properties.$feature_flag_error).toBe(FeatureFlagError.ERRORS_WHILE_COMPUTING)
-    })
+    await posthog.flush()
+
+    const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
+    const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
+    expect(captureCall).toBeDefined()
+    const body = JSON.parse(captureCall[1].body)
+    const featureFlagEvent = body.batch.find((e: any) => e.event === '$feature_flag_called')
+    expect(featureFlagEvent).toBeDefined()
+    expect(featureFlagEvent.properties.$feature_flag_error).toBe(FeatureFlagError.ERRORS_WHILE_COMPUTING)
   })
 
   it('should set $feature_flag_error to quota_limited when quota limited', async () => {
@@ -2357,16 +2363,16 @@ describe('Feature flag error tracking', () => {
     const result = posthog.getFeatureFlag('any-flag')
     expect(result).toBeUndefined()
 
-    await waitForExpect(500, () => {
-      const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
-      const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
-      expect(captureCall).toBeDefined()
-      const body = JSON.parse(captureCall[1].body)
-      const featureFlagEvent = body.batch.find((e: any) => e.event === '$feature_flag_called')
-      expect(featureFlagEvent).toBeDefined()
-      // FLAG_MISSING is not tracked when quota limited since we cannot determine if the flag is truly missing
-      expect(featureFlagEvent.properties.$feature_flag_error).toBe(FeatureFlagError.QUOTA_LIMITED)
-    })
+    await posthog.flush()
+
+    const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
+    const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
+    expect(captureCall).toBeDefined()
+    const body = JSON.parse(captureCall[1].body)
+    const featureFlagEvent = body.batch.find((e: any) => e.event === '$feature_flag_called')
+    expect(featureFlagEvent).toBeDefined()
+    // FLAG_MISSING is not tracked when quota limited since we cannot determine if the flag is truly missing
+    expect(featureFlagEvent.properties.$feature_flag_error).toBe(FeatureFlagError.QUOTA_LIMITED)
   })
 
   it('should set $feature_flag_error to api_error_500 when request fails with 500', async () => {
@@ -2386,15 +2392,15 @@ describe('Feature flag error tracking', () => {
     // Access a flag when request failed
     posthog.getFeatureFlag('any-flag')
 
-    await waitForExpect(500, () => {
-      const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
-      const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
-      expect(captureCall).toBeDefined()
-      const body = JSON.parse(captureCall[1].body)
-      const featureFlagEvent = body.batch.find((e: any) => e.event === '$feature_flag_called')
-      expect(featureFlagEvent).toBeDefined()
-      expect(featureFlagEvent.properties.$feature_flag_error).toBe(FeatureFlagError.apiError(500))
-    })
+    await posthog.flush()
+
+    const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
+    const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
+    expect(captureCall).toBeDefined()
+    const body = JSON.parse(captureCall[1].body)
+    const featureFlagEvent = body.batch.find((e: any) => e.event === '$feature_flag_called')
+    expect(featureFlagEvent).toBeDefined()
+    expect(featureFlagEvent.properties.$feature_flag_error).toBe(FeatureFlagError.apiError(500))
   })
 
   it('should join multiple errors with commas', async () => {
@@ -2419,17 +2425,17 @@ describe('Feature flag error tracking', () => {
     // Access a non-existent flag when errors while computing
     posthog.getFeatureFlag('missing-flag')
 
-    await waitForExpect(500, () => {
-      const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
-      const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
-      expect(captureCall).toBeDefined()
-      const body = JSON.parse(captureCall[1].body)
-      const featureFlagEvent = body.batch.find((e: any) => e.event === '$feature_flag_called')
-      expect(featureFlagEvent).toBeDefined()
-      expect(featureFlagEvent.properties.$feature_flag_error).toBe(
-        `${FeatureFlagError.ERRORS_WHILE_COMPUTING},${FeatureFlagError.FLAG_MISSING}`
-      )
-    })
+    await posthog.flush()
+
+    const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
+    const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
+    expect(captureCall).toBeDefined()
+    const body = JSON.parse(captureCall[1].body)
+    const featureFlagEvent = body.batch.find((e: any) => e.event === '$feature_flag_called')
+    expect(featureFlagEvent).toBeDefined()
+    expect(featureFlagEvent.properties.$feature_flag_error).toBe(
+      `${FeatureFlagError.ERRORS_WHILE_COMPUTING},${FeatureFlagError.FLAG_MISSING}`
+    )
   })
 
   it('should not set $feature_flag_error when flag is found successfully', async () => {
@@ -2463,15 +2469,15 @@ describe('Feature flag error tracking', () => {
     const result = posthog.getFeatureFlag('my-flag')
     expect(result).toBe(true)
 
-    await waitForExpect(500, () => {
-      const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
-      const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
-      expect(captureCall).toBeDefined()
-      const body = JSON.parse(captureCall[1].body)
-      const featureFlagEvent = body.batch.find((e: any) => e.event === '$feature_flag_called')
-      expect(featureFlagEvent).toBeDefined()
-      // $feature_flag_error should not be present
-      expect(featureFlagEvent.properties.$feature_flag_error).toBeUndefined()
-    })
+    await posthog.flush()
+
+    const calls = ((globalThis as any).window.fetch as jest.Mock).mock.calls
+    const captureCall = calls.find((call: any[]) => call[0].includes('/batch'))
+    expect(captureCall).toBeDefined()
+    const body = JSON.parse(captureCall[1].body)
+    const featureFlagEvent = body.batch.find((e: any) => e.event === '$feature_flag_called')
+    expect(featureFlagEvent).toBeDefined()
+    // $feature_flag_error should not be present
+    expect(featureFlagEvent.properties.$feature_flag_error).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Problem

The React Native release job hit flaky `test/posthog.spec.ts` failures around feature flag behavior. Some tests asserted against all `fetch` calls while unrelated startup requests could still occur, and feature flag error tracking tests waited for auto-flush timing instead of explicitly flushing the captured event.

## Changes

- Isolate the `reloadFeatureFlags` parameter tests from unrelated remote config, survey, and lifecycle network calls.
- Make feature flag error tracking assertions deterministic by explicitly calling `posthog.flush()` after `getFeatureFlag()` instead of polling for an auto-flush.
- Disable compression in those tests so the request body can be asserted as JSON deterministically.
- No changeset: test-only change.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
