### PR TITLE
ci: Reuse integration test fork condition

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,8 @@ jobs:
   browsers:
     name: Test on ${{ matrix.tests.name }}
     runs-on: ubuntu-22.04
+    env:
+      CAN_RUN_INTEGRATION_TESTS: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
     strategy:
       fail-fast: false
@@ -40,36 +42,36 @@ jobs:
 
     steps:
       - name: Skip fork PR
-        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS != 'true' }}
         run: echo "Skipping ${{ matrix.tests.name }} integration tests for fork PRs because required secrets are unavailable."
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' }}
         with:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' }}
         with:
           build: false
 
       - uses: ./.github/actions/is-affected
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' }}
         id: is-affected
         with:
           package-name: posthog-js
 
       - name: Build packages
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
         run: pnpm build
 
       - name: Install Playwright Browsers
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
         run: pnpm exec playwright install ${{ matrix.tests.install }} --with-deps --only-shell
         working-directory: packages/browser
 
       - name: Run ${{ matrix.tests.name }} test
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.is-affected.outputs.is-affected == 'true' }}
+        if: ${{ env.CAN_RUN_INTEGRATION_TESTS == 'true' && steps.is-affected.outputs.is-affected == 'true' }}
         timeout-minutes: 30
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Problem

Follow-up to PR #3833: the integration workflow repeated the same fork-PR condition on each gated step, making the workflow harder to scan and update.

## Changes

- Added a job-level `CAN_RUN_INTEGRATION_TESTS` environment value that captures whether the PR comes from the main repository.
- Reused that value across the skip step and the gated integration-test setup/build/run steps.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
