### PR TITLE
chore: Mark internal tooling packages private

### DIFF
--- a/tooling/changelog/package.json
+++ b/tooling/changelog/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@posthog-tooling/changelog",
+    "private": true,
     "main": "./dist/index.js",
     "type": "module",
     "scripts": {

--- a/tooling/eslint-plugin-posthog-js/package.json
+++ b/tooling/eslint-plugin-posthog-js/package.json
@@ -1,5 +1,6 @@
 {
     "name": "eslint-plugin-posthog-js",
+    "private": true,
     "main": "index.js",
     "type": "commonjs"
 }


### PR DESCRIPTION
## Problem

Internal tooling packages that are not published to npm were not explicitly marked as private, which can make license/package audits look like they are missing metadata for publishable packages.

## Changes

- Mark `@posthog-tooling/changelog` as private.
- Mark `eslint-plugin-posthog-js` as private.
- No changeset: these are internal tooling packages and are not part of the npm publish matrix.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
