### PR TITLE
chore(core): remove unused getFlagDetailsFromFlagsAndPayloads

### DIFF
--- a/.changeset/remove-unused-flag-details-helper.md
+++ b/.changeset/remove-unused-flag-details-helper.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: remove the unused internal `getFlagDetailsFromFlagsAndPayloads` helper from `@posthog/core`. It had no callers (only its own test) and was not part of the package's public exports, so there is no consumer-facing change.

--- a/packages/core/src/__tests__/featureFlagUtils.spec.ts
+++ b/packages/core/src/__tests__/featureFlagUtils.spec.ts
@@ -1,7 +1,6 @@
 import {
   getFlagValuesFromFlags,
   getPayloadsFromFlags,
-  getFlagDetailsFromFlagsAndPayloads,
   getFeatureFlagValue,
   normalizeFlagsResponse,
 } from '@/featureFlagUtils'
@@ -159,76 +158,6 @@ describe('featureFlagUtils', () => {
       }
 
       expect(getPayloadsFromFlags(flags)).toEqual({})
-    })
-  })
-
-  describe('getFlagDetailsFromFlagsAndPayloads', () => {
-    it('should convert v1 flags and payloads to flag details', () => {
-      const flagsResponse: PostHogFlagsResponse = {
-        featureFlags: {
-          'flag-1': true,
-          'flag-2': 'variant-1',
-          'flag-3': false,
-        },
-        featureFlagPayloads: {
-          'flag-1': { key: 'value1' },
-          'flag-2': { key: 'value2' },
-        },
-        flags: {},
-        errorsWhileComputingFlags: false,
-      }
-
-      const result = getFlagDetailsFromFlagsAndPayloads(flagsResponse)
-
-      expect(result).toEqual({
-        'flag-1': {
-          key: 'flag-1',
-          enabled: true,
-          variant: undefined,
-          reason: undefined,
-          metadata: {
-            id: undefined,
-            version: undefined,
-            payload: '{"key":"value1"}',
-            description: undefined,
-          },
-        },
-        'flag-2': {
-          key: 'flag-2',
-          enabled: true,
-          variant: 'variant-1',
-          reason: undefined,
-          metadata: {
-            id: undefined,
-            version: undefined,
-            payload: '{"key":"value2"}',
-            description: undefined,
-          },
-        },
-        'flag-3': {
-          key: 'flag-3',
-          enabled: false,
-          variant: undefined,
-          reason: undefined,
-          metadata: {
-            id: undefined,
-            version: undefined,
-            payload: undefined,
-            description: undefined,
-          },
-        },
-      })
-    })
-
-    it('should handle empty flags and payloads', () => {
-      const flagsResponse: PostHogFlagsResponse = {
-        featureFlags: {},
-        featureFlagPayloads: {},
-        flags: {},
-        errorsWhileComputingFlags: false,
-      }
-
-      expect(getFlagDetailsFromFlagsAndPayloads(flagsResponse)).toEqual({})
     })
   })
 

--- a/packages/core/src/featureFlagUtils.ts
+++ b/packages/core/src/featureFlagUtils.ts
@@ -102,35 +102,6 @@ export const getPayloadsFromFlags = (
   )
 }
 
-/**
- * Get the flag details from the legacy v1 flags and payloads. As such, it will lack the reason, id, version, and description.
- * @param flagsResponse - The flags response
- * @returns The flag details
- */
-export const getFlagDetailsFromFlagsAndPayloads = (
-  flagsResponse: PostHogFeatureFlagsResponse
-): PostHogFlagsResponse['flags'] => {
-  const flags = flagsResponse.featureFlags ?? {}
-  const payloads = flagsResponse.featureFlagPayloads ?? {}
-  return Object.fromEntries(
-    Object.entries(flags).map(([key, value]) => [
-      key,
-      {
-        key: key,
-        enabled: typeof value === 'string' ? true : value,
-        variant: typeof value === 'string' ? value : undefined,
-        reason: undefined,
-        metadata: {
-          id: undefined,
-          version: undefined,
-          payload: payloads?.[key] ? JSON.stringify(payloads[key]) : undefined,
-          description: undefined,
-        },
-      },
-    ])
-  )
-}
-
 export const getFeatureFlagValue = (detail: FeatureFlagDetail | undefined): FeatureFlagValue | undefined => {
   return detail === undefined ? undefined : (detail.variant ?? detail.enabled)
 }


### PR DESCRIPTION
## Problem

`getFlagDetailsFromFlagsAndPayloads` in `@posthog/core` is dead code — nothing calls it except its own test. Git history shows it never had a production caller: it arrived with the posthog-js-lite monorepo migration (#2042, ~July 2025) alongside a test but was never wired up. The real v1→v4 flag conversion goes through `createFlagsResponseFromFlagsAndPayloads` / `normalizeFlagsResponse`. It's also not part of the package's public exports, so nothing external can reach it.

Found while doing a code-reuse pass on an unrelated feature branch.

## Changes

Delete the function and its two test cases. Nothing else touched.

## Release info Sub-libraries affected

### Libraries affected

No version bump — this is internal-only `@posthog/core` code that isn't a public export, so there's no consumer-facing change. Empty changeset included.

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code — N/A (removal); the rest of the suite stays green
- [x] Accounted for the impact of any changes across different platforms — internal, no behavior change
- [x] Accounted for backwards compatibility of any changes (no breaking changes!) — not a public export
- [x] Took care not to unnecessarily increase the bundle size — slightly reduces it

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file — empty changeset (no release)
