### PR TITLE
test: trigger public API baseline check

### DIFF
--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -4056,6 +4056,19 @@ export class PostHog implements PostHogInterface {
     }
 
     /**
+     * Temporary public API used to validate public API baseline checks.
+     *
+     * {@label Initialization}
+     *
+     * @public
+     *
+     * @returns True when the SDK is loaded.
+     */
+    public getPublicApiBaselineCheckProbe(): boolean {
+        return this.__loaded
+    }
+
+    /**
      * Capture written user feedback for a LLM trace. Numeric values are converted to strings.
      *
      * {@label LLM analytics}

--- a/scripts/check-public-api.js
+++ b/scripts/check-public-api.js
@@ -17,6 +17,18 @@ try {
 if (status) {
     console.error('Public API references are out of date. Run `pnpm generate-references` and commit the updated files.')
     console.error(status)
+
+    try {
+        const diff = execFileSync('git', ['diff', '--no-ext-diff', '--no-color', '--', ...referencePaths], {
+            encoding: 'utf8',
+        }).trim()
+        if (diff) {
+            console.error(`\nPublic API reference diff:\n${diff}`)
+        }
+    } catch (error) {
+        console.error('Failed to print public API reference diff:', error.message)
+    }
+
     process.exit(1)
 }
 


### PR DESCRIPTION
## Problem

This draft PR is intentionally exercising the public API baseline CI added in #3834. It adds a public API surface without committing the generated reference baseline, so the CI check should catch the out-of-date baseline and now print the actual reference diff.

## Changes

- Adds a temporary public `PostHog#getPublicApiBaselineCheckProbe()` method.
- Intentionally does **not** update `packages/browser/references/*` baseline files.
- Updates `scripts/check-public-api.js` to print the generated public API reference diff when the baseline is out of date.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [ ] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
