### PR TITLE
ci: show public API reference diff

### DIFF
--- a/scripts/check-public-api.js
+++ b/scripts/check-public-api.js
@@ -17,6 +17,18 @@ try {
 if (status) {
     console.error('Public API references are out of date. Run `pnpm generate-references` and commit the updated files.')
     console.error(status)
+
+    try {
+        const diff = execFileSync('git', ['diff', '--no-ext-diff', '--no-color', '--', ...referencePaths], {
+            encoding: 'utf8',
+        }).trim()
+        if (diff) {
+            console.error(`\nPublic API reference diff:\n${diff}`)
+        }
+    } catch (error) {
+        console.error('Failed to print public API reference diff:', error.message)
+    }
+
     process.exit(1)
 }
 


### PR DESCRIPTION
## Problem

When the public API baseline check fails, it only reports which reference snapshot files changed. Reviewers still need to inspect CI artifacts or reproduce locally to see what public API changed.

## Changes

- Print a no-color `git diff` for changed public API reference files when `pnpm check:public-api` fails.
- Keep the existing concise status output and preserve the original failure exit code.

## Release info Sub-libraries affected

### Libraries affected

<!-- Please mark which libraries will require a version bump. -->

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
