### PR TITLE
feat(replay): capture native fullscreen transitions in session replay

### DIFF
--- a/.changeset/replay-native-fullscreen.md
+++ b/.changeset/replay-native-fullscreen.md
@@ -1,0 +1,9 @@
+---
+"@posthog/rrweb-types": patch
+"@posthog/rrweb": patch
+"posthog-js": patch
+---
+
+Capture native Fullscreen API transitions in session replay. Entering native fullscreen (`element.requestFullscreen()`) is rendered by the browser via the UA `:fullscreen` pseudo-class with no DOM mutation, so the recorder previously captured nothing and replays showed the element at its pre-fullscreen size with drifted click coordinates. The recorder now emits a reserved custom event on `fullscreenchange` (standard plus `webkit`/`moz`/`MS` prefixes), and the replayer re-applies fullscreen layout to the element on playback (including when scrubbing into a fullscreen region) via a reserved `rr_fullscreen` attribute, consistent with rrweb's existing `rr_*` attribute namespace.
+
+Known limitation: fullscreen of an element inside a same-origin iframe is recorded against the `<iframe>` element rather than the inner element, so replay pins the iframe.

--- a/packages/rrweb/rrweb/src/record/index.ts
+++ b/packages/rrweb/rrweb/src/record/index.ts
@@ -26,6 +26,8 @@ import {
   EventType,
   type eventWithoutTime,
   type eventWithTime,
+  FullscreenCustomEventTag,
+  type fullscreenEventPayload,
   IncrementalSource,
   type listenerHandler,
   type mutationCallbackParam,
@@ -679,9 +681,51 @@ function record<T = eventWithTime>(
       findAndRemoveIframeBuffer(iframeEl);
     });
 
+    // Native fullscreen produces no DOM mutation (the browser styles the element
+    // via the UA `:fullscreen` pseudo-class), so we record the transition as a
+    // custom event the replayer can act on. We track the last id because on exit
+    // `fullscreenElement` is already null.
+    let lastFullscreenId = -1;
+    const emitFullscreen = (payload: fullscreenEventPayload) =>
+      wrappedEmit({
+        type: EventType.Custom,
+        data: { tag: FullscreenCustomEventTag, payload },
+      });
+    const emitFullscreenChange = () => {
+      const doc = document as Document & {
+        webkitFullscreenElement?: Element | null;
+        mozFullScreenElement?: Element | null;
+        msFullscreenElement?: Element | null;
+      };
+      const fullscreenEl =
+        doc.fullscreenElement ??
+        doc.webkitFullscreenElement ??
+        doc.mozFullScreenElement ??
+        doc.msFullscreenElement ??
+        null;
+      // -1 covers both "no element is fullscreen" and "fullscreen element is
+      // blocked/ignored" (not in the mirror); both clear any prior fullscreen.
+      const id = fullscreenEl ? mirror.getId(fullscreenEl) : -1;
+      if (id === lastFullscreenId) return; // no change
+      // Exit the previous element first. The browser can switch fullscreen
+      // directly from one element to another without passing through null, so
+      // this also fires on a direct switch — not just on a plain exit.
+      if (lastFullscreenId !== -1) {
+        emitFullscreen({ id: lastFullscreenId, enter: false });
+      }
+      lastFullscreenId = id;
+      if (id !== -1) {
+        emitFullscreen({ id, enter: true });
+      }
+    };
+
     const init = () => {
       takeFullSnapshot();
       handlers.push(observe(document));
+      handlers.push(on('fullscreenchange', emitFullscreenChange));
+      handlers.push(on('webkitfullscreenchange', emitFullscreenChange));
+      handlers.push(on('mozfullscreenchange', emitFullscreenChange));
+      handlers.push(on('MSFullscreenChange', emitFullscreenChange));
       recording = true;
     };
     if (['interactive', 'complete'].includes(document.readyState)) {

--- a/packages/rrweb/rrweb/src/replay/index.ts
+++ b/packages/rrweb/rrweb/src/replay/index.ts
@@ -38,12 +38,14 @@ import type { playerConfig, missingNodeMap } from '../types';
 import {
   NodeType,
   EventType,
+  FullscreenCustomEventTag,
   IncrementalSource,
   MouseInteractions,
   ReplayerEvents,
 } from '@posthog/rrweb-types';
 import type {
   attributes,
+  fullscreenEventPayload,
   fullSnapshotEvent,
   eventWithTime,
   playerMetaData,
@@ -736,13 +738,52 @@ export class Replayer {
     }
   };
 
+  // We can't (and shouldn't) call requestFullscreen inside the sandboxed replay
+  // iframe, so we emulate it: a marker attribute drives the `[rr_fullscreen]`
+  // rule injected via getInjectStyleRules, pinning the element to fill the
+  // viewport (already resized to screen size via the recorded resize). The
+  // attribute survives `style`-attribute mutations replayed onto the same node,
+  // and a full-snapshot rebuild drops it for free.
+  private applyFullscreen(payload: unknown) {
+    const data = payload as Partial<fullscreenEventPayload> | null;
+    if (
+      !data ||
+      typeof data.id !== 'number' ||
+      typeof data.enter !== 'boolean'
+    ) {
+      return;
+    }
+    const node = this.mirror.getNode(data.id);
+    if (!node || node.nodeType !== Node.ELEMENT_NODE) {
+      return;
+    }
+    const el = node as HTMLElement;
+    if (data.enter) {
+      el.setAttribute('rr_fullscreen', '');
+    } else {
+      el.removeAttribute('rr_fullscreen');
+    }
+  }
+
+  private clearFullscreen() {
+    this.iframe.contentDocument
+      ?.querySelectorAll('[rr_fullscreen]')
+      .forEach((el) => el.removeAttribute('rr_fullscreen'));
+  }
+
   private applyEventsSynchronously = (events: Array<eventWithTime>) => {
     for (const event of events) {
       switch (event.type) {
         case EventType.DomContentLoaded:
         case EventType.Load:
-        case EventType.Custom:
           continue;
+        case EventType.Custom:
+          // Fullscreen carries DOM state that must survive scrubbing; other
+          // custom events are side-effect-free signals and stay skipped.
+          if (event.data.tag !== FullscreenCustomEventTag) {
+            continue;
+          }
+          break;
         case EventType.FullSnapshot:
         case EventType.Meta:
         case EventType.Plugin:
@@ -768,8 +809,16 @@ export class Replayer {
            * emit custom-event and pass the event object.
            *
            * This will add more value to the custom event and allows the client to react for custom-event.
+           *
+           * Skip the external emit during sync catch-up to preserve existing
+           * behaviour; we still apply fullscreen state so scrubbing renders it.
            */
-          this.emitter.emit(ReplayerEvents.CustomEvent, event);
+          if (!isSync) {
+            this.emitter.emit(ReplayerEvents.CustomEvent, event);
+          }
+          if (event.data.tag === FullscreenCustomEventTag) {
+            this.applyFullscreen(event.data.payload);
+          }
         };
         break;
       case EventType.Meta:
@@ -781,6 +830,10 @@ export class Replayer {
         break;
       case EventType.FullSnapshot:
         castFn = () => {
+          // Fullscreen is applied imperatively, outside the snapshot/mutation
+          // model, so reset it whenever the base snapshot is (re)entered — e.g.
+          // scrubbing backward — otherwise the marker leaks past its region.
+          this.clearFullscreen();
           if (this.firstFullSnapshot) {
             if (this.firstFullSnapshot === event) {
               // we've already built this exact FullSnapshot when the player was mounted, and haven't built any other FullSnapshot since

--- a/packages/rrweb/rrweb/src/replay/styles/inject-style.ts
+++ b/packages/rrweb/rrweb/src/replay/styles/inject-style.ts
@@ -1,6 +1,9 @@
 const rules: (blockClass: string) => string[] = (blockClass: string) => [
   `.${blockClass} { background: currentColor }`,
   'noscript { display: none !important; }',
+  // Emulate native fullscreen on playback: native fullscreen produces no DOM
+  // mutation, so the recorder marks the element with `rr_fullscreen` instead.
+  '[rr_fullscreen] { position: fixed !important; inset: 0 !important; width: 100% !important; height: 100% !important; margin: 0 !important; max-width: none !important; max-height: none !important; z-index: 2147483647 !important; }',
 ];
 
 export default rules;

--- a/packages/rrweb/rrweb/test/__snapshots__/replayer.test.ts.snap
+++ b/packages/rrweb/rrweb/test/__snapshots__/replayer.test.ts.snap
@@ -50,6 +50,8 @@ file-cid-0
 
 noscript { display: none !important; }
 
+[rr_fullscreen] { position: fixed !important; inset: 0px !important; width: 100% !important; height: 100% !important; margin: 0px !important; max-width: none !important; max-height: none !important; z-index: 2147483647 !important; }
+
 html.rrweb-paused *, html.rrweb-paused ::before, html.rrweb-paused ::after { animation-play-state: paused !important; }
 
 
@@ -130,6 +132,8 @@ file-cid-0
 
 noscript { display: none !important; }
 
+[rr_fullscreen] { position: fixed !important; inset: 0px !important; width: 100% !important; height: 100% !important; margin: 0px !important; max-width: none !important; max-height: none !important; z-index: 2147483647 !important; }
+
 html.rrweb-paused *, html.rrweb-paused ::before, html.rrweb-paused ::after { animation-play-state: paused !important; }
 
 
@@ -202,6 +206,8 @@ file-cid-0
 
 noscript { display: none !important; }
 
+[rr_fullscreen] { position: fixed !important; inset: 0px !important; width: 100% !important; height: 100% !important; margin: 0px !important; max-width: none !important; max-height: none !important; z-index: 2147483647 !important; }
+
 html.rrweb-paused *, html.rrweb-paused ::before, html.rrweb-paused ::after { animation-play-state: paused !important; }
 "
 `;
@@ -253,6 +259,8 @@ file-cid-0
 
 noscript { display: none !important; }
 
+[rr_fullscreen] { position: fixed !important; inset: 0px !important; width: 100% !important; height: 100% !important; margin: 0px !important; max-width: none !important; max-height: none !important; z-index: 2147483647 !important; }
+
 html.rrweb-paused *, html.rrweb-paused ::before, html.rrweb-paused ::after { animation-play-state: paused !important; }
 "
 `;
@@ -303,6 +311,8 @@ file-cid-0
 .rr-block { background: currentcolor; }
 
 noscript { display: none !important; }
+
+[rr_fullscreen] { position: fixed !important; inset: 0px !important; width: 100% !important; height: 100% !important; margin: 0px !important; max-width: none !important; max-height: none !important; z-index: 2147483647 !important; }
 
 html.rrweb-paused *, html.rrweb-paused ::before, html.rrweb-paused ::after { animation-play-state: paused !important; }
 "

--- a/packages/rrweb/rrweb/test/fullscreen.test.ts
+++ b/packages/rrweb/rrweb/test/fullscreen.test.ts
@@ -1,0 +1,240 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type * as puppeteer from 'puppeteer';
+import { vi } from 'vitest';
+import {
+  EventType,
+  FullscreenCustomEventTag,
+  type customEvent,
+  type eventWithTime,
+  type fullscreenEventPayload,
+  type listenerHandler,
+  type recordOptions,
+} from '@posthog/rrweb-types';
+import { launchPuppeteer, waitForRAF } from './utils';
+
+interface IWindow extends Window {
+  rrweb: {
+    record: ((
+      options: recordOptions<eventWithTime>,
+    ) => listenerHandler | undefined) & {
+      mirror: { getId: (n: Node | null) => number };
+    };
+    Replayer: new (
+      events: eventWithTime[],
+      config?: Record<string, unknown>,
+    ) => {
+      pause: (timeOffset: number) => void;
+      iframe: HTMLIFrameElement;
+    };
+  };
+  emit: (e: eventWithTime) => void;
+  replayer: InstanceType<IWindow['rrweb']['Replayer']>;
+}
+
+const CONTENT = `
+  <!DOCTYPE html>
+  <html>
+    <body>
+      <div id="target"></div>
+      <div id="target2"></div>
+    </body>
+  </html>
+`;
+
+const fullscreenEvents = (events: eventWithTime[]) =>
+  events.filter(
+    (e): e is customEvent<fullscreenEventPayload> & { timestamp: number } =>
+      e.type === EventType.Custom &&
+      e.data.tag === FullscreenCustomEventTag,
+  );
+
+describe('record/replay native fullscreen', () => {
+  vi.setConfig({ testTimeout: 15_000 });
+
+  let browser: puppeteer.Browser;
+  let code: string;
+  let page: puppeteer.Page;
+  let events: eventWithTime[];
+
+  beforeAll(async () => {
+    browser = await launchPuppeteer();
+    code = fs.readFileSync(
+      path.resolve(__dirname, '../dist/rrweb.umd.cjs'),
+      'utf8',
+    );
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+  });
+
+  beforeEach(async () => {
+    page = await browser.newPage();
+    await page.goto('about:blank');
+    await page.setContent(CONTENT);
+    await page.evaluate(code);
+    events = [];
+    await page.exposeFunction('emit', (e: eventWithTime) => {
+      if (e.type === EventType.DomContentLoaded || e.type === EventType.Load) {
+        return;
+      }
+      events.push(e);
+    });
+  });
+
+  afterEach(async () => {
+    await page.close();
+  });
+
+  // Drives a real `fullscreenchange` by shadowing `document.fullscreenElement`,
+  // which is what the browser sets on native fullscreen (without any DOM change).
+  const recordFullscreenSession = async (): Promise<number> => {
+    const targetId = await page.evaluate(() => {
+      const { record } = (window as unknown as IWindow).rrweb;
+      record({ emit: (window as unknown as IWindow).emit });
+      const target = document.getElementById('target') as HTMLElement;
+      return (window as unknown as IWindow).rrweb.record.mirror.getId(target);
+    });
+
+    await page.evaluate(() => {
+      const target = document.getElementById('target') as HTMLElement;
+      Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true,
+        get: () => target,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+    await page.waitForTimeout(50);
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true,
+        get: () => null,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+    await page.waitForTimeout(50);
+
+    return targetId;
+  };
+
+  it('records fullscreen enter/exit as custom events carrying the element id', async () => {
+    const targetId = await recordFullscreenSession();
+
+    const fs = fullscreenEvents(events);
+    expect(fs).toHaveLength(2);
+
+    const [enter, exit] = fs;
+    expect(enter.data.payload).toEqual({ id: targetId, enter: true });
+    expect(exit.data.payload).toEqual({ id: targetId, enter: false });
+    expect(targetId).toBeGreaterThan(0);
+    expect(enter.timestamp).toBeLessThan(exit.timestamp);
+  });
+
+  it('emits nothing when the fullscreen element is not in the mirror', async () => {
+    await page.evaluate(() => {
+      const { record } = (window as unknown as IWindow).rrweb;
+      record({ emit: (window as unknown as IWindow).emit });
+      // A detached element was never serialized, so it has no mirror id.
+      const orphan = document.createElement('div');
+      Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true,
+        get: () => orphan,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+    await page.waitForTimeout(50);
+
+    expect(fullscreenEvents(events)).toHaveLength(0);
+  });
+
+  it('emits exit then enter when fullscreen switches directly between elements', async () => {
+    const ids = await page.evaluate(() => {
+      const { rrweb } = window as unknown as IWindow;
+      rrweb.record({ emit: (window as unknown as IWindow).emit });
+      return {
+        a: rrweb.record.mirror.getId(document.getElementById('target')),
+        b: rrweb.record.mirror.getId(document.getElementById('target2')),
+      };
+    });
+
+    await page.evaluate(() => {
+      const a = document.getElementById('target');
+      Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true,
+        get: () => a,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+    await page.waitForTimeout(20);
+    // Switch straight to another element without exiting first — the browser
+    // changes fullscreenElement directly, never passing through null.
+    await page.evaluate(() => {
+      const b = document.getElementById('target2');
+      Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true,
+        get: () => b,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+    await page.waitForTimeout(50);
+
+    const payloads = fullscreenEvents(events).map((e) => e.data.payload);
+    expect(payloads).toEqual([
+      { id: ids.a, enter: true },
+      { id: ids.a, enter: false },
+      { id: ids.b, enter: true },
+    ]);
+  });
+
+  it('replays fullscreen by toggling the marker attribute on the element', async () => {
+    await recordFullscreenSession();
+
+    const fs = fullscreenEvents(events);
+    const baseline = events[0].timestamp;
+    const enterOffset = fs[0].timestamp - baseline;
+    const exitOffset = fs[1].timestamp - baseline;
+
+    await page.evaluate(`window.events = ${JSON.stringify(events)}`);
+    await page.evaluate(`
+      const { Replayer } = window.rrweb;
+      window.replayer = new Replayer(window.events, { skipInactive: false });
+    `);
+
+    const stateAt = async (offset: number) => {
+      await page.evaluate((o: number) => {
+        (window as unknown as IWindow).replayer.pause(o);
+      }, offset);
+      await waitForRAF(page);
+      return page.evaluate(() => {
+        const replayer = (window as unknown as IWindow).replayer;
+        const doc = replayer.iframe.contentDocument as Document;
+        const el = doc.getElementById('target') as HTMLElement;
+        const win = replayer.iframe.contentWindow as Window;
+        return {
+          hasMarker: el.hasAttribute('rr_fullscreen'),
+          // The injected `[rr_fullscreen]` rule pins the element when marked.
+          isPinned: win.getComputedStyle(el).position === 'fixed',
+        };
+      });
+    };
+
+    const activeOffset = Math.floor((enterOffset + exitOffset) / 2);
+    const beforeOffset = Math.max(enterOffset - 1, 0);
+    const off = { hasMarker: false, isPinned: false };
+    const on = { hasMarker: true, isPinned: true };
+
+    // Seeked in order — the replayer is stateful, so the "re-enter" checkpoint
+    // both asserts and sets up the subsequent backward scrub.
+    const checkpoints = [
+      { name: 'before enter', offset: beforeOffset, expected: off },
+      { name: 'during fullscreen', offset: activeOffset, expected: on },
+      { name: 'after exit', offset: exitOffset + 1, expected: off },
+      { name: 're-enter (scrub back to fullscreen)', offset: activeOffset, expected: on },
+      { name: 'backward scrub to before enter', offset: beforeOffset, expected: off },
+    ];
+    for (const { name, offset, expected } of checkpoints) {
+      expect(await stateAt(offset), name).toEqual(expected);
+    }
+  });
+});

--- a/packages/rrweb/types/src/index.ts
+++ b/packages/rrweb/types/src/index.ts
@@ -51,6 +51,20 @@ export type customEvent<T = unknown> = {
   };
 };
 
+/**
+ * Reserved custom-event tag emitted by the recorder when an element enters or
+ * exits the native Fullscreen API. Native fullscreen is rendered by the UA
+ * `:fullscreen` pseudo-class with no DOM mutation, so rrweb captures nothing —
+ * this event lets the replayer re-apply fullscreen layout on playback.
+ */
+export const FullscreenCustomEventTag = 'rrweb/fullscreen';
+
+export type fullscreenEventPayload = {
+  /** mirror id of the element that went fullscreen */
+  id: number;
+  enter: boolean;
+};
+
 export type pluginEvent<T = unknown> = {
   type: EventType.Plugin;
   data: {


### PR DESCRIPTION
## Problem

Native fullscreen (`element.requestFullscreen()`) is rendered by the browser via the UA `:fullscreen` pseudo-class — it produces **no DOM mutation**. rrweb records DOM mutations, so when a page enters native fullscreen the recorder captures nothing: on replay the element stays at its pre-fullscreen size/position, and recorded mouse coordinates (relative to the now-larger fullscreen viewport) no longer line up with it, so clicks appear to land on unrelated elements.

This is a long-standing rrweb limitation — see upstream [rrweb-io/rrweb#950](https://github.com/rrweb-io/rrweb/issues/950) (same root cause for a `<video>` element), which was closed without a fix. It commonly bites apps that fullscreen a `<canvas>` (e.g. WebGL/Unity games).

## Changes

- **Record** (`record/index.ts`): a `fullscreenchange` / `webkitfullscreenchange` listener emits a reserved `rrweb/fullscreen` custom event carrying the fullscreened element's mirror id and an enter/exit flag. This records the real transition — nothing is faked at capture time.
- **Replay** (`replay/index.ts`): on that custom event the replayer re-applies fullscreen layout to the mirrored element via a marker attribute (`rr_fullscreen`) plus a single injected `!important` stylesheet rule (`position: fixed; inset: 0; …`). We can't call real `requestFullscreen` inside the sandboxed replay iframe, so this emulates it. The marker survives `style`-attribute mutations replayed onto the same node, and a full-snapshot rebuild drops it for free. Custom events are no longer skipped during synchronous catch-up, so scrubbing into a fullscreen region renders correctly.
- **Types** (`@posthog/rrweb-types`): exports the shared `FullscreenCustomEventTag` constant and `fullscreenEventPayload` type.
- **Tests**: new `test/fullscreen.test.ts` covers the record side (custom events fire with the correct element id) and the replay side (marker + stylesheet toggle across enter / active / exit while scrubbing).

### Notes / limitations

- Recorder-side, so it only helps recordings made **after** the SDK upgrade — it does not retroactively fix existing recordings.
- If an element inside a same-origin iframe goes fullscreen, `document.fullscreenElement` is the iframe element, so the iframe is fullscreened on replay (acceptable, slightly coarse).
- Approximation, not pixel-perfect, when the screen aspect ratio differs from the element's.

## Release info

### Libraries affected

- [x] posthog-js (web)

Changeset (`patch`) covers `@posthog/rrweb-types`, `@posthog/rrweb`, and `posthog-js`.

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size
- [x] Ran `pnpm changeset` to generate a changeset file