### PR TITLE
feat(flags): add configurable flags_request_path

### DIFF
--- a/.changeset/flags-configurable-request-path.md
+++ b/.changeset/flags-configurable-request-path.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': minor
+'@posthog/types': minor
+---
+
+Add a `flags_request_path` config option to route feature flag requests via a custom path instead of the default `/flags`. Some ad blockers block the `/flags` path on any domain, which a reverse proxy alone doesn't fix because it only changes the host. Point `flags_request_path` at a path your reverse proxy maps to PostHog's flags endpoint to avoid the block. Defaults to `/flags/`, so existing behavior is unchanged.

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -1049,6 +1049,24 @@ describe('featureflags', () => {
             expect(instance._send_request.mock.calls[0][0].data.disable_flags).toBe(undefined)
         })
 
+        it('requests the default /flags path when flags_request_path is not set', () => {
+            featureFlags.reloadFeatureFlags()
+            jest.runOnlyPendingTimers()
+
+            expect(instance._send_request.mock.calls[0][0].url).toContain('/flags/?v=2')
+        })
+
+        it('requests a custom flags_request_path instead of /flags', () => {
+            instance.config.flags_request_path = '/api/eaH8aiyu/'
+            featureFlags.reloadFeatureFlags()
+            jest.runOnlyPendingTimers()
+
+            const url = instance._send_request.mock.calls[0][0].url
+            expect(url).toContain('/api/eaH8aiyu/?v=2')
+            // The whole point: the request URL no longer contains the ad-blocker-matched /flags/ path
+            expect(url).not.toContain('/flags/')
+        })
+
         it('should call /flags with flags disabled if advanced_disable_feature_flags is set', () => {
             instance.config.advanced_disable_feature_flags = true
             // Call _callFlagsEndpoint directly because reloadFeatureFlags() returns early
@@ -3211,6 +3229,16 @@ describe('getRemoteConfigPayload', () => {
                     evaluation_contexts: ['staging', 'backend'],
                 }),
             })
+        )
+    })
+
+    it('honors a custom flags_request_path', () => {
+        instance.config.flags_request_path = '/api/eaH8aiyu/'
+
+        featureFlags.getRemoteConfigPayload('test-flag', jest.fn())
+
+        expect(instance._send_request).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'POST', url: 'flags/api/eaH8aiyu/?v=2' })
         )
     })
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -214,6 +214,7 @@ const defaultsThatVaryByConfig = (
 export const defaultConfig = (defaults?: ConfigDefaults): PostHogConfig => ({
     api_host: 'https://us.i.posthog.com',
     flags_api_host: null,
+    flags_request_path: '/flags/',
     ui_host: null,
     asset_host: null,
     token: '',

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -593,7 +593,8 @@ export class PostHogFeatureFlags implements Extension {
             : ''
         const isPartialFlagsResponse = !!this._config.advanced_only_evaluate_survey_feature_flags
 
-        const url = this._instance.requestRouter.endpointFor('flags', '/flags/?v=2' + queryParams)
+        const flagsPath = this._config.flags_request_path || '/flags/'
+        const url = this._instance.requestRouter.endpointFor('flags', flagsPath + '?v=2' + queryParams)
 
         this._requestInFlight = true
         this._instance._send_request({
@@ -915,7 +916,10 @@ export class PostHogFeatureFlags implements Extension {
 
         this._instance._send_request({
             method: 'POST',
-            url: this._instance.requestRouter.endpointFor('flags', '/flags/?v=2'),
+            url: this._instance.requestRouter.endpointFor(
+                'flags',
+                (this._config.flags_request_path || '/flags/') + '?v=2'
+            ),
             data,
             compression: this._config.disable_compression ? undefined : Compression.Base64,
             timeout: this._config.feature_flag_request_timeout_ms,

--- a/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
+++ b/packages/types/src/__tests__/__snapshots__/config-snapshot.spec.ts.snap
@@ -8,6 +8,10 @@ exports[`config snapshot for PostHogConfig 1`] = `
     "null",
     "string"
   ],
+  "flags_request_path": [
+    "undefined",
+    "string"
+  ],
   "ui_host": [
     "null",
     "string"

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -740,6 +740,16 @@ export interface PostHogConfig {
     flags_api_host?: string | null
 
     /**
+     * Path used for feature flag requests, appended to the flags host.
+     * Override this to route flag requests via a path that ad blockers don't recognize — some block the
+     * default `/flags` path on any domain, so a reverse proxy alone (which only changes the host) doesn't help.
+     * Your reverse proxy must route this path to PostHog's flags endpoint.
+     *
+     * @default '/flags/'
+     */
+    flags_request_path?: string
+
+    /**
      * If using a reverse proxy for `api_host` then this should be the actual PostHog app URL (e.g. https://us.posthog.com).
      * This ensures that links to PostHog point to the correct host.
      *


### PR DESCRIPTION
## Problem

uBlock Origin added a filter that blocks the `/flags` request path on any domain. It matches the `/flags/` substring anywhere in the URL, not just on `*.posthog.com`. Because the match is on the path, the usual reverse-proxy workaround doesn't help: a proxy changes the host, but the SDK still requests `…/flags/?v=2`, so the request is still blocked. The flags host is already configurable via `flags_api_host`, but the `/flags/` path is hardcoded.

Fixes #3840

## Changes

Adds a `flags_request_path` config option (default `/flags/`) used when building the flags request URL, so the path can be moved off `/flags`.

```js
posthog.init('<token>', {
    api_host: 'https://your-proxy.example.com',
    flags_request_path: '/api/eaH8aiyu/', // your proxy routes this to PostHog's /flags
})
```

New optional `flags_request_path` on `PostHogConfig` (`@posthog/types`), defaulting to `/flags/` in `defaultConfig`. Both flag request call sites in `posthog-featureflags.ts` (the main flag load and `getRemoteConfigPayload`) use the configured path and fall back to `/flags/`. It is backwards compatible: unset or default behaves exactly as before, and the request is byte-identical to `…/flags/?v=2…`.

This is the SDK half of the fix. It immediately helps anyone running their own reverse proxy who can add a rewrite rule mapping the custom path to PostHog's `/flags`. It does not by itself fix PostHog Cloud or the managed reverse proxy, which only rewrite the host and not the path. That needs a companion server-side change to accept flag requests on an alternate path, and this PR is the prerequisite for it.

One constraint worth noting: the new path must not contain the literal `flags` substring, since the filter matches it anywhere. So `/api/<random>/` works but `/api/flags/` would not.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file