### PR TITLE
fix(flags): drop ip query param from flags requests

### DIFF
--- a/.changeset/flags-drop-ip-param.md
+++ b/.changeset/flags-drop-ip-param.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Stop sending the `ip` query parameter on feature flag requests. The flags endpoint ignores it, and some ad blockers match `/flags…ip=` to block flag evaluation on any domain. Dropping it from flag requests avoids the block with no functional change. Event and session recording requests are unchanged.

--- a/packages/browser/references/posthog-js-references-1.386.8.json
+++ b/packages/browser/references/posthog-js-references-1.386.8.json
@@ -3526,6 +3526,10 @@
           "name": "noRetries"
         },
         {
+          "type": "boolean",
+          "name": "skipIPParam"
+        },
+        {
           "type": "number",
           "name": "timeout"
         },

--- a/packages/browser/references/posthog-js-references-1.386.8.json
+++ b/packages/browser/references/posthog-js-references-1.386.8.json
@@ -3526,10 +3526,6 @@
           "name": "noRetries"
         },
         {
-          "type": "boolean",
-          "name": "skipIPParam"
-        },
-        {
           "type": "number",
           "name": "timeout"
         },

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -3526,6 +3526,10 @@
           "name": "noRetries"
         },
         {
+          "type": "boolean",
+          "name": "skipIPParam"
+        },
+        {
           "type": "number",
           "name": "timeout"
         },

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -1049,6 +1049,13 @@ describe('featureflags', () => {
             expect(instance._send_request.mock.calls[0][0].data.disable_flags).toBe(undefined)
         })
 
+        it('sends the flags request with skipIPParam so the ip query param is omitted', () => {
+            featureFlags.reloadFeatureFlags()
+            jest.runOnlyPendingTimers()
+
+            expect(instance._send_request.mock.calls[0][0].skipIPParam).toBe(true)
+        })
+
         it('should call /flags with flags disabled if advanced_disable_feature_flags is set', () => {
             instance.config.advanced_disable_feature_flags = true
             // Call _callFlagsEndpoint directly because reloadFeatureFlags() returns early
@@ -3193,6 +3200,12 @@ describe('getRemoteConfigPayload', () => {
         })
 
         featureFlags = new PostHogFeatureFlags(instance)
+    })
+
+    it('sends the request with skipIPParam so the ip query param is omitted', () => {
+        featureFlags.getRemoteConfigPayload('test-flag', jest.fn())
+
+        expect(instance._send_request).toHaveBeenCalledWith(expect.objectContaining({ skipIPParam: true }))
     })
 
     it('should include evaluation_contexts when configured', () => {

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -1693,3 +1693,17 @@ describe('posthog core', () => {
         expect(() => posthog.webPerformance._forceAllowLocalhost).not.toThrow()
     })
 })
+
+describe('_send_request skipIPParam', () => {
+    it('omits the ip query param when skipIPParam is set, and keeps it otherwise', async () => {
+        const posthog = await createPosthogInstance(uuidv7(), { persistence: 'memory' })
+
+        const flagsRequest = { url: 'http://localhost/flags/?v=2', skipIPParam: true }
+        posthog._send_request(flagsRequest)
+        expect(flagsRequest.url).toBe('http://localhost/flags/?v=2')
+
+        const eventRequest = { url: 'http://localhost/e/' }
+        posthog._send_request(eventRequest)
+        expect(eventRequest.url).toContain('ip=0')
+    })
+})

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -1704,6 +1704,6 @@ describe('_send_request skipIPParam', () => {
 
         const eventRequest = { url: 'http://localhost/e/' }
         posthog._send_request(eventRequest)
-        expect(eventRequest.url).toContain('ip=0')
+        expect(eventRequest.url).toMatch(/[?&]ip=/)
     })
 })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1083,10 +1083,12 @@ export class PostHog implements PostHogInterface {
         }
 
         options.transport = options.transport || this.config.api_transport
-        options.url = extendURLParams(options.url, {
-            // Whether to detect ip info or not
-            ip: this.config.ip ? 1 : 0,
-        })
+        if (!options.skipIPParam) {
+            options.url = extendURLParams(options.url, {
+                // Whether to detect ip info or not
+                ip: this.config.ip ? 1 : 0,
+            })
+        }
         options.headers = {
             ...this.config.request_headers,
             ...options.headers,

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -600,6 +600,8 @@ export class PostHogFeatureFlags implements Extension {
             method: 'POST',
             url,
             data,
+            // Some ad blockers block /flags requests that carry the `ip` query param; it's unused server-side here.
+            skipIPParam: true,
             compression: this._config.disable_compression ? undefined : Compression.Base64,
             timeout: this._config.feature_flag_request_timeout_ms,
             callback: (response) => {
@@ -917,6 +919,8 @@ export class PostHogFeatureFlags implements Extension {
             method: 'POST',
             url: this._instance.requestRouter.endpointFor('flags', '/flags/?v=2'),
             data,
+            // Some ad blockers block /flags requests that carry the `ip` query param; it's unused server-side here.
+            skipIPParam: true,
             compression: this._config.disable_compression ? undefined : Compression.Base64,
             timeout: this._config.feature_flag_request_timeout_ms,
             callback: (response) => {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -193,6 +193,9 @@ export interface RequestWithOptions {
     callback?: (response: RequestResponse) => void
     timeout?: number
     noRetries?: boolean
+    // Omit the `ip` query param from the request URL. The param is only meaningful for event ingestion;
+    // flags requests set this so the URL doesn't match ad-blocker filters that key on `/flags…ip=`.
+    skipIPParam?: boolean
     disableTransport?: ('XHR' | 'fetch' | 'sendBeacon')[]
     compression?: Compression | 'best-available'
     fetchOptions?: {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -193,8 +193,9 @@ export interface RequestWithOptions {
     callback?: (response: RequestResponse) => void
     timeout?: number
     noRetries?: boolean
-    // Omit the `ip` query param from the request URL. The param is only meaningful for event ingestion;
-    // flags requests set this so the URL doesn't match ad-blocker filters that key on `/flags…ip=`.
+    // Omit the `ip` query param from the request URL. The param is meaningful for event ingestion
+    // and session recording, but not for flags requests. Flags requests set this so the URL doesn't
+    // match ad-blocker filters that key on `/flags…ip=`.
     skipIPParam?: boolean
     disableTransport?: ('XHR' | 'fetch' | 'sendBeacon')[]
     compression?: Compression | 'best-available'


### PR DESCRIPTION
## Problem

uBlock Origin added a filter, `/flags/*^ip=`, that blocks PostHog flag evaluation on any domain. It matches two things anywhere in the request URL: the `/flags/` path and an `ip=` query param. The SDK appends `ip=0` to every request in `_send_request`, so flag requests look like `/flags/?v=2&ip=0`, which the filter matches. A reverse proxy doesn't help, because the filter keys on the path and param rather than the host.

Fixes #3840

## Changes

The `ip` query param is vestigial on the flags endpoint. The server derives the client IP from the connection and honors the `$geoip_disable` property in the body, so this query param has no effect on flag evaluation. Removing it from flag requests breaks the filter match with no behavior change.

- Add a `skipIPParam` option to the internal request options.
- `_send_request` skips appending `ip` when it is set.
- Both flag request paths set it: the main flag load and `getRemoteConfigPayload`.
- Event and session recording requests are unchanged and still send `ip`.

One note on durability: this defeats the filter as written today, which requires the `ip=` token. If uBlock later drops that condition and matches `/flags/` alone, a path-level change would be needed too. This is the smallest fix that unblocks flag evaluation now, including on PostHog Cloud, with no proxy or server-side change required.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file