### PR TITLE
fix(ai): wrap responses.stream() so posthog params are tracked (#3583)

### DIFF
--- a/.changeset/responses-stream-trace-id.md
+++ b/.changeset/responses-stream-trace-id.md
@@ -1,0 +1,5 @@
+---
+"@posthog/ai": patch
+---
+
+Wrap the OpenAI/Azure `responses.stream()` method so `posthogTraceId` (and the other `posthog*` params) are stripped before reaching the API and the streamed generation is captured. Previously `responses.stream()` was unwrapped, so a top-level `posthog_trace_id` caused a `400 Unknown parameter` and the generation was never associated with a trace.

--- a/packages/ai/src/openai/azure.ts
+++ b/packages/ai/src/openai/azure.ts
@@ -11,6 +11,7 @@ import {
 import { captureAiGeneration } from '../captureAiGeneration'
 import type { APIPromise } from 'openai'
 import type { Stream } from 'openai/streaming'
+import type { ResponseStream, ResponseStreamParams } from 'openai/lib/responses/ResponseStream'
 import type { ParsedResponse } from 'openai/resources/responses/responses'
 import type { ResponseCreateParamsWithTools, ExtractParsedContentFromParams } from 'openai/lib/ResponsesParser'
 import type { FormattedMessage, FormattedContent, FormattedFunctionCall } from '../types'
@@ -532,6 +533,93 @@ export class WrappedResponses extends AzureOpenAI.Responses {
 
       return wrappedPromise
     }
+  }
+
+  public stream<Params extends ResponseStreamParams, ParsedT = ExtractParsedContentFromParams<Params>>(
+    body: Params & MonitoringParams,
+    options?: RequestOptions
+  ): ResponseStream<ParsedT> {
+    const { providerParams: openAIParams, posthogParams } = extractPosthogParams(body)
+    const startTime = Date.now()
+
+    // Strip the posthog* params before the body reaches Azure OpenAI; otherwise
+    // they reach the API and cause `400 Unknown parameter` (see #3583).
+    const responseStream = super.stream<Params, ParsedT>(openAIParams, options)
+
+    // `responses.stream()` accepts either inline params or a stream-by-id
+    // payload; only the inline form carries model/input/instructions, so read
+    // them optionally and fall back to the resolved response.
+    const streamParams = openAIParams as Partial<ResponsesCreateParamsBase>
+
+    // Stamp the first streamed token without consuming the caller's stream:
+    // event listeners are additive and don't pull the async iterator. Uses the
+    // same first-token detection as the streaming `create` path.
+    let firstTokenTime: number | undefined
+    responseStream.on('event', (event) => {
+      if (firstTokenTime === undefined && isResponseTokenChunk(event)) {
+        firstTokenTime = Date.now()
+      }
+    })
+
+    // Observe completion without disturbing the caller's consumption: the
+    // ResponseStream is self-driving and finalResponse() resolves from the
+    // accumulated events independently of the user's async iteration.
+    responseStream
+      .finalResponse()
+      .then(
+        async (result) => {
+          const latency = (Date.now() - startTime) / 1000
+          const timeToFirstToken = firstTokenTime !== undefined ? (firstTokenTime - startTime) / 1000 : undefined
+          await captureAiGeneration(this.phClient, {
+            ...posthogParams,
+            model: streamParams.model ?? result.model,
+            provider: 'azure',
+            input: formatOpenAIResponsesInput(streamParams.input, streamParams.instructions),
+            output: result.output,
+            latency,
+            timeToFirstToken,
+            baseURL: this.baseURL,
+            modelParameters: getModelParams(streamParams as ResponsesCreateParamsBase & MonitoringParams),
+            httpStatus: 200,
+            usage: {
+              inputTokens: result.usage?.input_tokens ?? 0,
+              outputTokens: result.usage?.output_tokens ?? 0,
+              reasoningTokens: result.usage?.output_tokens_details?.reasoning_tokens ?? 0,
+              cacheReadInputTokens: result.usage?.input_tokens_details?.cached_tokens ?? 0,
+            },
+            completionId: result.id,
+            providerMetadata: buildProviderMetadata({ requestId: extractRequestId(result) }),
+          })
+        },
+        async (error: unknown) => {
+          const httpStatus =
+            error && typeof error === 'object' && 'status' in error
+              ? ((error as { status?: number }).status ?? 500)
+              : 500
+
+          await captureAiGeneration(this.phClient, {
+            ...posthogParams,
+            model: streamParams.model,
+            provider: 'azure',
+            input: formatOpenAIResponsesInput(streamParams.input, streamParams.instructions),
+            output: [],
+            latency: 0,
+            baseURL: this.baseURL,
+            modelParameters: getModelParams(streamParams as ResponsesCreateParamsBase & MonitoringParams),
+            httpStatus,
+            usage: {
+              inputTokens: 0,
+              outputTokens: 0,
+            },
+            error,
+          })
+        }
+      )
+      // Swallow capture-side failures so instrumentation never surfaces an
+      // unhandled rejection or affects the caller's own stream handling.
+      .catch(() => undefined)
+
+    return responseStream
   }
 
   public parse<Params extends ResponseCreateParamsWithTools, ParsedT = ExtractParsedContentFromParams<Params>>(

--- a/packages/ai/src/openai/index.ts
+++ b/packages/ai/src/openai/index.ts
@@ -13,6 +13,7 @@ import {
 import { captureAiGeneration } from '../captureAiGeneration'
 import type { APIPromise } from 'openai'
 import type { Stream } from 'openai/streaming'
+import type { ResponseStream, ResponseStreamParams } from 'openai/lib/responses/ResponseStream'
 import type { ParsedResponse } from 'openai/resources/responses/responses'
 import type { ResponseCreateParamsWithTools, ExtractParsedContentFromParams } from 'openai/lib/ResponsesParser'
 import type { FormattedMessage, FormattedContent, FormattedFunctionCall } from '../types'
@@ -650,6 +651,100 @@ export class WrappedResponses extends Responses {
 
       return preserveAPIPromiseHelpers(parentPromise, wrappedPromise)
     }
+  }
+
+  public stream<Params extends ResponseStreamParams, ParsedT = ExtractParsedContentFromParams<Params>>(
+    body: Params & MonitoringParams,
+    options?: RequestOptions
+  ): ResponseStream<ParsedT> {
+    const { providerParams: openAIParams, posthogParams } = extractPosthogParams(body)
+    const startTime = Date.now()
+
+    // Strip the posthog* params before handing the body to OpenAI; otherwise
+    // they reach the API and cause `400 Unknown parameter` (see #3583).
+    const responseStream = super.stream<Params, ParsedT>(openAIParams, options)
+
+    // `responses.stream()` accepts either inline params or a stream-by-id
+    // payload; only the inline form carries model/input/instructions, so read
+    // them optionally and fall back to the resolved response.
+    const streamParams = openAIParams as Partial<ResponsesCreateParamsBase>
+
+    // Stamp the first streamed token without consuming the caller's stream:
+    // event listeners are additive and don't pull the async iterator. Uses the
+    // same first-token detection as the streaming `create` path.
+    let firstTokenTime: number | undefined
+    responseStream.on('event', (event) => {
+      if (firstTokenTime === undefined && isResponseTokenChunk(event)) {
+        firstTokenTime = Date.now()
+      }
+    })
+
+    // Observe completion to capture the generation without disturbing the
+    // caller's consumption: `responses.stream()` returns a self-driving
+    // ResponseStream whose finalResponse() resolves from the accumulated
+    // events independently of the user's async iteration.
+    responseStream
+      .finalResponse()
+      .then(
+        async (result) => {
+          const latency = (Date.now() - startTime) / 1000
+          const availableTools = extractAvailableToolCalls('openai', streamParams)
+          const formattedOutput = formatResponseOpenAI({ output: result.output })
+          const timeToFirstToken = firstTokenTime !== undefined ? (firstTokenTime - startTime) / 1000 : undefined
+          await captureAiGenerationAfterSuccess(this.phClient, {
+            ...posthogParams,
+            model: streamParams.model ?? result.model,
+            provider: 'openai',
+            input: formatOpenAIResponsesInput(sanitizeOpenAIResponse(streamParams.input), streamParams.instructions),
+            output: formattedOutput,
+            latency,
+            timeToFirstToken,
+            baseURL: this.baseURL,
+            modelParameters: getModelParams(streamParams as ResponsesCreateParamsBase & MonitoringParams),
+            httpStatus: 200,
+            usage: {
+              inputTokens: result.usage?.input_tokens ?? 0,
+              outputTokens: result.usage?.output_tokens ?? 0,
+              reasoningTokens: result.usage?.output_tokens_details?.reasoning_tokens ?? 0,
+              cacheReadInputTokens: result.usage?.input_tokens_details?.cached_tokens ?? 0,
+              webSearchCount: calculateWebSearchCount(result),
+              rawUsage: result.usage,
+            },
+            stopReason: result.status ?? undefined,
+            tools: availableTools,
+            completionId: result.id,
+            providerMetadata: buildProviderMetadata({ requestId: extractRequestId(result) }),
+          })
+        },
+        async (error: unknown) => {
+          const httpStatus =
+            error && typeof error === 'object' && 'status' in error
+              ? ((error as { status?: number }).status ?? 500)
+              : 500
+
+          await captureAiGeneration(this.phClient, {
+            ...posthogParams,
+            model: streamParams.model,
+            provider: 'openai',
+            input: formatOpenAIResponsesInput(sanitizeOpenAIResponse(streamParams.input), streamParams.instructions),
+            output: [],
+            latency: 0,
+            baseURL: this.baseURL,
+            modelParameters: getModelParams(streamParams as ResponsesCreateParamsBase & MonitoringParams),
+            httpStatus,
+            usage: {
+              inputTokens: 0,
+              outputTokens: 0,
+            },
+            error,
+          })
+        }
+      )
+      // Swallow capture-side failures so instrumentation never surfaces an
+      // unhandled rejection or affects the caller's own stream handling.
+      .catch(() => undefined)
+
+    return responseStream
   }
 
   public parse<Params extends ResponseCreateParamsWithTools, ParsedT = ExtractParsedContentFromParams<Params>>(

--- a/packages/ai/tests/azure-openai.test.ts
+++ b/packages/ai/tests/azure-openai.test.ts
@@ -332,6 +332,40 @@ describe('PostHogAzureOpenAI - Embeddings test suite', () => {
     }
   )
 
+  conditionalTest('responses stream captures an error generation when the stream fails (#3583)', async () => {
+    const streamError: any = new Error('Stream failed')
+    streamError.status = 503
+
+    const ResponsesMock: any = openaiModule.Responses
+    ResponsesMock.prototype.stream = jest.fn().mockImplementation(() => ({
+      on: () => undefined,
+      finalResponse: () => Promise.reject(streamError),
+      [Symbol.asyncIterator]() {
+        return { next: () => Promise.reject(streamError) }
+      },
+    }))
+
+    client.responses.stream({
+      model: 'gpt-4',
+      input: 'Hello',
+      posthogTraceId: 'trace_azure_err',
+      posthogDistinctId: 'test-id',
+    } as any)
+
+    // Capture runs in a detached chain off finalResponse(); flush microtasks.
+    await flushPromises()
+    await flushPromises()
+
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    const { properties } = captureArgs[0]
+    expect(properties['$ai_provider']).toBe('azure')
+    expect(properties['$ai_trace_id']).toBe('trace_azure_err')
+    expect(properties['$ai_http_status']).toBe(503)
+    expect(properties['$ai_is_error']).toBe(true)
+    expect(properties['$ai_error']).toContain('503')
+  })
+
   conditionalTest('groups', async () => {
     const mockAzureChatResponse = {
       id: 'test-response-id',

--- a/packages/ai/tests/azure-openai.test.ts
+++ b/packages/ai/tests/azure-openai.test.ts
@@ -1,6 +1,7 @@
 import { PostHog } from 'posthog-node'
 import { PostHogAzureOpenAI } from '../src/openai/azure'
 import openaiModule from 'openai'
+import { flushPromises } from './test-utils'
 
 let mockAzureEmbeddingResponse: any = {}
 
@@ -260,6 +261,76 @@ describe('PostHogAzureOpenAI - Embeddings test suite', () => {
     expect(typeof properties['$ai_latency']).toBe('number')
     expect(properties['foo']).toBe('bar')
   })
+
+  conditionalTest(
+    'responses stream is wrapped: captures the generation and strips posthog params (#3583)',
+    async () => {
+      // Regression for #3583: responses.stream() was unwrapped on Azure too, so
+      // posthog_trace_id reached the API (400) and no generation was captured.
+      const mockAzureResponsesResult = {
+        id: 'resp_stream_test',
+        _request_id: 'req_test-responses-stream',
+        model: 'gpt-4',
+        status: 'completed',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello from the Azure Responses stream!' }],
+          },
+        ],
+        usage: { input_tokens: 20, output_tokens: 10, total_tokens: 30 },
+      }
+
+      const streamParams: any[] = []
+      const ResponsesMock: any = openaiModule.Responses
+      ResponsesMock.prototype.stream = jest.fn().mockImplementation((params: any) => {
+        streamParams.push(params)
+        return {
+          on: (event: string, cb: (e: any) => void) => {
+            if (event === 'event') {
+              cb({ type: 'response.output_text.delta', delta: 'Hello' })
+            }
+          },
+          finalResponse: () => Promise.resolve(mockAzureResponsesResult),
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'response.completed', response: mockAzureResponsesResult } as any
+          },
+        }
+      })
+
+      const stream = client.responses.stream({
+        model: 'gpt-4',
+        input: 'Hello',
+        posthogTraceId: 'trace_azure_stream',
+        posthogDistinctId: 'test-id',
+      } as any)
+
+      // The wrapper returns the underlying helper untouched.
+      expect(typeof (stream as any).finalResponse).toBe('function')
+
+      // Capture runs in a detached chain off finalResponse(); flush microtasks.
+      await flushPromises()
+      await flushPromises()
+
+      // posthog params are stripped before the body reaches Azure OpenAI.
+      expect(streamParams).toHaveLength(1)
+      expect(streamParams[0]).not.toHaveProperty('posthogTraceId')
+      expect(streamParams[0]).not.toHaveProperty('posthog_trace_id')
+
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      const { distinctId, event, properties } = captureArgs[0]
+      expect(distinctId).toBe('test-id')
+      expect(event).toBe('$ai_generation')
+      expect(properties['$ai_provider']).toBe('azure')
+      expect(properties['$ai_trace_id']).toBe('trace_azure_stream')
+      expect(properties['$ai_completion_id']).toBe('resp_stream_test')
+      expect(properties['$ai_input_tokens']).toBe(20)
+      expect(properties['$ai_output_tokens']).toBe(10)
+      expect(typeof properties['$ai_time_to_first_token']).toBe('number')
+    }
+  )
 
   conditionalTest('groups', async () => {
     const mockAzureChatResponse = {

--- a/packages/ai/tests/openai.test.ts
+++ b/packages/ai/tests/openai.test.ts
@@ -745,6 +745,112 @@ describe('PostHogOpenAI - Jest test suite', () => {
     expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
   })
 
+  conditionalTest(
+    'responses stream is wrapped: captures the generation and strips posthog params (#3583)',
+    async () => {
+      // Regression for #3583: responses.stream() was not wrapped, so posthog_trace_id
+      // reached the API (400 Unknown parameter) and no generation was captured.
+      const mockResponsesResult = {
+        id: 'resp_stream_test',
+        _request_id: 'req_test-responses-stream',
+        model: 'gpt-4',
+        status: 'completed',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Hello from the Responses stream!' }],
+          },
+        ],
+        usage: { input_tokens: 12, output_tokens: 7, total_tokens: 19 },
+      } as any
+
+      const streamParams: any[] = []
+      const ResponsesMock: any = openaiModule.Responses || class MockResponses {}
+      ResponsesMock.prototype.stream = jest.fn().mockImplementation((params: any) => {
+        streamParams.push(params)
+        // Minimal stand-in for OpenAI's ResponseStream: emits a first-token event
+        // (for TTFT), finalResponse() resolves with the final Response, and the
+        // helper stays async-iterable for the caller.
+        return {
+          on: (event: string, cb: (e: any) => void) => {
+            if (event === 'event') {
+              cb({ type: 'response.output_text.delta', delta: 'Hello' })
+            }
+          },
+          finalResponse: () => Promise.resolve(mockResponsesResult),
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'response.completed', response: mockResponsesResult } as any
+          },
+        }
+      })
+
+      const stream = client.responses.stream({
+        model: 'gpt-4',
+        input: 'Tell me about PostHog',
+        posthogTraceId: 'trace_stream_123',
+        posthogDistinctId: 'test-user',
+      } as any)
+
+      // The wrapper returns the underlying helper untouched.
+      expect(typeof (stream as any).finalResponse).toBe('function')
+
+      // Capture runs in a detached chain off finalResponse(); flush microtasks.
+      await flushPromises()
+      await flushPromises()
+
+      // 1) posthog params are stripped before the body reaches OpenAI (fixes the 400).
+      expect(streamParams).toHaveLength(1)
+      expect(streamParams[0]).not.toHaveProperty('posthogTraceId')
+      expect(streamParams[0]).not.toHaveProperty('posthog_trace_id')
+      expect(streamParams[0].model).toBe('gpt-4')
+
+      // 2) the generation is captured and associated with the requested trace.
+      expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+      const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+      const { properties } = captureArgs[0]
+      expect(properties['$ai_trace_id']).toBe('trace_stream_123')
+      expect(properties['$ai_completion_id']).toBe('resp_stream_test')
+      expect(properties['$ai_input_tokens']).toBe(12)
+      expect(properties['$ai_output_tokens']).toBe(7)
+      // 3) first-token timing is captured from the streamed events.
+      expect(typeof properties['$ai_time_to_first_token']).toBe('number')
+    }
+  )
+
+  conditionalTest('responses stream captures an error generation when the stream fails (#3583)', async () => {
+    const streamError: any = new Error('Stream failed')
+    streamError.status = 503
+
+    const ResponsesMock: any = openaiModule.Responses || class MockResponses {}
+    ResponsesMock.prototype.stream = jest.fn().mockImplementation(() => ({
+      on: () => undefined,
+      finalResponse: () => Promise.reject(streamError),
+      [Symbol.asyncIterator]() {
+        return { next: () => Promise.reject(streamError) }
+      },
+    }))
+
+    client.responses.stream({
+      model: 'gpt-4',
+      input: 'Tell me about PostHog',
+      posthogTraceId: 'trace_err',
+      posthogDistinctId: 'test-user',
+    } as any)
+
+    // Capture runs in a detached chain off finalResponse(); flush microtasks.
+    await flushPromises()
+    await flushPromises()
+
+    expect(mockPostHogClient.capture).toHaveBeenCalledTimes(1)
+    const [captureArgs] = (mockPostHogClient.capture as jest.Mock).mock.calls
+    const { properties } = captureArgs[0]
+    expect(properties['$ai_trace_id']).toBe('trace_err')
+    expect(properties['$ai_http_status']).toBe(503)
+    expect(properties['$ai_is_error']).toBe(true)
+    expect(properties['$ai_error']).toContain('503')
+  })
+
   conditionalTest('responses parse with instructions parameter', async () => {
     const response = await client.responses.parse({
       model: 'gpt-4o-2024-08-06',


### PR DESCRIPTION
## Problem

Fixes #3583.

`PostHogOpenAI` / `PostHogAzureOpenAI` wrap `responses.create` (and `responses.parse`) but **not `responses.stream()`**. Because the streaming helper was unwrapped:

- a top-level `posthogTraceId` was forwarded straight to the API → `400 Unknown parameter: 'posthog_trace_id'`, and
- the streamed generation was never captured, so it couldn't be associated with a trace.

## Fix

Add a `stream()` override to `WrappedResponses` in both `src/openai/index.ts` and `src/openai/azure.ts`. It mirrors the existing `create` path:

1. `extractPosthogParams(body)` strips the `posthog*` params before the body reaches OpenAI (fixes the 400).
2. The generation is captured via `captureAiGeneration`, reusing the same formatting/usage helpers `create` uses.

### Design note: `ResponseStream` vs `Stream`

`responses.stream()` does not return a plain `Stream` like `create({ stream: true })` does — it returns OpenAI's `ResponseStream` helper, so the `.tee()` approach `create` uses doesn't apply. Instead I observe completion via `finalResponse()`, which resolves from the self-driving stream's accumulated events **independently of the caller's iteration**, so instrumentation never consumes or disturbs the user's stream. `time_to_first_token` is captured with an additive `.on('event', …)` listener (same first-token detection as the streaming `create` path), which is also non-disruptive.

The capture observation is fully detached and swallows its own errors, so it never surfaces an unhandled rejection or interferes with the caller's own error handling.

## Tests

- `responses.stream` captures the generation, associates the requested `posthogTraceId`, and strips the `posthog*` params from the body sent to OpenAI (OpenAI + Azure).
- Error path: a failing stream still captures an error generation with the right `$ai_http_status` / `$ai_is_error`.
- `time_to_first_token` is captured.

All assertions fail on revert of the source change. `tsc`, `eslint`, and the OpenAI/Azure suites pass.
