### PR TITLE
ci: include staged public API reference diffs

### DIFF
--- a/scripts/check-public-api.js
+++ b/scripts/check-public-api.js
@@ -19,9 +19,34 @@ if (status) {
     console.error(status)
 
     try {
-        const diff = execFileSync('git', ['diff', '--no-ext-diff', '--no-color', '--', ...referencePaths], {
-            encoding: 'utf8',
-        }).trim()
+        const trackedDiff = execFileSync(
+            'git',
+            ['diff', '--no-ext-diff', '--no-color', 'HEAD', '--', ...referencePaths],
+            {
+                encoding: 'utf8',
+            }
+        ).trim()
+        const untrackedDiffs = status
+            .split('\n')
+            .filter((line) => line.startsWith('?? '))
+            .map((line) => line.slice(3))
+            .map((path) => {
+                try {
+                    return execFileSync(
+                        'git',
+                        ['diff', '--no-ext-diff', '--no-color', '--no-index', '--', '/dev/null', path],
+                        {
+                            encoding: 'utf8',
+                        }
+                    ).trim()
+                } catch (error) {
+                    if (error.status === 1 && error.stdout) {
+                        return error.stdout.trim()
+                    }
+                    throw error
+                }
+            })
+        const diff = [trackedDiff, ...untrackedDiffs].filter(Boolean).join('\n\n')
         if (diff) {
             console.error(`\nPublic API reference diff:\n${diff}`)
         }


### PR DESCRIPTION
## Problem

The public API reference check prints a helpful diff when generated references are out of date, but it used plain `git diff`. That misses staged tracked changes, so CI can report changed references without showing the diff context reviewers need.

## Changes

- Use `git diff HEAD` for tracked reference files so staged and unstaged changes are included.
- Include diffs for untracked reference files with `git diff --no-index /dev/null <file>`.
- Verified locally with clean, unstaged tracked, staged tracked, and untracked reference scenarios.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
