### PR TITLE
chore: Generate versioned references only on release

### DIFF
--- a/.github/workflows/generate-references.yml
+++ b/.github/workflows/generate-references.yml
@@ -44,24 +44,29 @@ jobs:
           PACKAGE_NAME: ${{ github.event.inputs.package_name }}
         run: pnpm exec turbo --filter="$PACKAGE_NAME" generate-references
 
-      - name: Check for changes in references
+      - name: Check for changes in latest references
         id: changes
         env:
           PACKAGE_NAME: ${{ github.event.inputs.package_name }}
           PACKAGE_PATH: ${{ github.event.inputs.package_path }}
         run: |
-          PACKAGE_DIR="$PACKAGE_PATH/references/"
-          if [ -n "$(git status --porcelain "$PACKAGE_DIR")" ]; then
+          PACKAGE_DIR="$PACKAGE_PATH/references"
+          LATEST_REFERENCES=$(find "$PACKAGE_DIR" -maxdepth 1 -name '*-references-latest.json' -print)
+          if [ -z "$LATEST_REFERENCES" ]; then
+            echo "No latest reference file found in $PACKAGE_DIR" >&2
+            exit 1
+          fi
+          if [ -n "$(git status --porcelain -- $LATEST_REFERENCES)" ]; then
             echo "changed=true" >> $GITHUB_OUTPUT
-            echo "New references generated for $PACKAGE_NAME:"
-            git status --porcelain "$PACKAGE_DIR"
+            echo "New latest references generated for $PACKAGE_NAME:"
+            git status --porcelain -- $LATEST_REFERENCES
           else
             echo "changed=false" >> $GITHUB_OUTPUT
-            echo "No new references generated for $PACKAGE_NAME"
+            echo "No new latest references generated for $PACKAGE_NAME"
           fi
           
       - uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
         if: steps.changes.outputs.changed == 'true'
         with:
           commit_message: "Update generated references"
-          file_pattern: "packages/*/references/**"
+          file_pattern: "packages/*/references/*-references-latest.json"

--- a/.github/workflows/generated-files-notice.yml
+++ b/.github/workflows/generated-files-notice.yml
@@ -34,9 +34,12 @@ jobs:
           The following paths are auto-generated and are usually updated
           by tooling, not by hand:
 
-            * packages/*/references/**
+            * packages/*/references/*-references-latest.json
                 api-extractor output, updated by the "Generate References"
                 workflow (.github/workflows/generate-references.yml).
+
+            * packages/*/references/*-references-[0-9]*.json
+                versioned api-extractor output, updated by the release workflow.
 
             * packages/**/CHANGELOG.md
                 Changesets output, updated by the release bot's

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
 
             - name: Update versions and changelogs
               run: |
-                  pnpm bump && pnpm generate-references
+                  pnpm bump && pnpm generate-references:versioned
               env:
                   GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "package:watch": "export PACKAGE_DEST=$(pwd)/target && turbo watch package",
         "bump": "pnpm changeset version",
         "generate-references": "pnpm turbo --filter=posthog-js --filter=posthog-node --filter=posthog-react-native generate-references",
+        "generate-references:versioned": "GENERATE_VERSIONED_REFERENCES=1 pnpm turbo --filter=posthog-js --filter=posthog-node --filter=posthog-react-native generate-references",
         "check:public-api": "node scripts/check-public-api.js"
     },
     "pnpm": {

--- a/packages/browser/scripts/generate-docs.js
+++ b/packages/browser/scripts/generate-docs.js
@@ -6,6 +6,7 @@ const { HOG_REF, PROPERTIES_EXAMPLE, PROPERTY_EXAMPLE } = require('../../../scri
 // Read package.json to get version
 const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8'));
 const version = packageJson.version;
+const shouldWriteVersionedReferences = process.env.GENERATE_VERSIONED_REFERENCES === '1';
 
 const config = {
     packageDir: path.resolve(__dirname, '..'),  // packages/browser
@@ -34,13 +35,15 @@ if (!fs.existsSync(referencesDir)) {
     fs.mkdirSync(referencesDir, { recursive: true });
 }
 
-// Generate versioned file
 const output = generateApiSpecs(config);
 
-// Write versioned file
-const versionedPath = path.resolve(__dirname, `../references/posthog-js-references-${version}.json`);
-fs.writeFileSync(versionedPath, JSON.stringify(output, null, 2));
-
-// Copy to latest file
+// Always update the rolling public API reference used by CI and docs previews.
 const latestPath = path.resolve(__dirname, '../references/posthog-js-references-latest.json');
 fs.writeFileSync(latestPath, JSON.stringify(output, null, 2));
+
+// Versioned references are release artifacts. Avoid writing them during normal generation
+// so PRs don't accidentally commit package-version-specific reference files.
+if (shouldWriteVersionedReferences) {
+    const versionedPath = path.resolve(__dirname, `../references/posthog-js-references-${version}.json`);
+    fs.writeFileSync(versionedPath, JSON.stringify(output, null, 2));
+}

--- a/packages/node/scripts/generate-docs.mjs
+++ b/packages/node/scripts/generate-docs.mjs
@@ -4,9 +4,9 @@ import { generateApiSpecs } from '../../../scripts/docs/parser.js'
 import { HOG_REF } from '../../../scripts/docs/constants.js'
 
 // Read package.json to get version
-const packageJson = JSON.parse(fs.readFileSync(path.resolve(import.meta.dirname, '../package.json'), 'utf8'));
-const version = packageJson.version;
-const shouldWriteVersionedReferences = process.env.GENERATE_VERSIONED_REFERENCES === '1';
+const packageJson = JSON.parse(fs.readFileSync(path.resolve(import.meta.dirname, '../package.json'), 'utf8'))
+const version = packageJson.version
+const shouldWriteVersionedReferences = process.env.GENERATE_VERSIONED_REFERENCES === '1'
 
 // Node-specific configuration
 const NODE_SPEC_INFO = {
@@ -35,8 +35,6 @@ const NODE_TYPE_EXAMPLES = {
 "user@example.com" | { name: "John", age: 25 }`,
 }
 
-const __dirname = import.meta.dirname
-
 const config = {
   packageDir: path.resolve(import.meta.dirname, '..'), // packages/node
   apiJsonPath: path.resolve(import.meta.dirname, '../docs/posthog-node.api.json'),
@@ -50,20 +48,20 @@ const config = {
 }
 
 // Ensure references directory exists
-const referencesDir = path.resolve(__dirname, '../references');
+const referencesDir = path.resolve(import.meta.dirname, '../references')
 if (!fs.existsSync(referencesDir)) {
-    fs.mkdirSync(referencesDir, { recursive: true });
+  fs.mkdirSync(referencesDir, { recursive: true })
 }
 
 const output = generateApiSpecs(config)
 
 // Always update the rolling public API reference used by CI and docs previews.
-const latestPath = path.resolve(__dirname, '../references/posthog-node-references-latest.json');
-fs.writeFileSync(latestPath, JSON.stringify(output, null, 2));
+const latestPath = path.resolve(import.meta.dirname, '../references/posthog-node-references-latest.json')
+fs.writeFileSync(latestPath, JSON.stringify(output, null, 2))
 
 // Versioned references are release artifacts. Avoid writing them during normal generation
 // so PRs don't accidentally commit package-version-specific reference files.
 if (shouldWriteVersionedReferences) {
-  const versionedPath = path.resolve(__dirname, `../references/posthog-node-references-${version}.json`);
-  fs.writeFileSync(versionedPath, JSON.stringify(output, null, 2));
+  const versionedPath = path.resolve(import.meta.dirname, `../references/posthog-node-references-${version}.json`)
+  fs.writeFileSync(versionedPath, JSON.stringify(output, null, 2))
 }

--- a/packages/node/scripts/generate-docs.mjs
+++ b/packages/node/scripts/generate-docs.mjs
@@ -6,6 +6,7 @@ import { HOG_REF } from '../../../scripts/docs/constants.js'
 // Read package.json to get version
 const packageJson = JSON.parse(fs.readFileSync(path.resolve(import.meta.dirname, '../package.json'), 'utf8'));
 const version = packageJson.version;
+const shouldWriteVersionedReferences = process.env.GENERATE_VERSIONED_REFERENCES === '1';
 
 // Node-specific configuration
 const NODE_SPEC_INFO = {
@@ -54,13 +55,15 @@ if (!fs.existsSync(referencesDir)) {
     fs.mkdirSync(referencesDir, { recursive: true });
 }
 
-// Generate versioned file
 const output = generateApiSpecs(config)
 
-// Write versioned file
-const versionedPath = path.resolve(__dirname, `../references/posthog-node-references-${version}.json`);
-fs.writeFileSync(versionedPath, JSON.stringify(output, null, 2));
-
-// Copy to latest file
+// Always update the rolling public API reference used by CI and docs previews.
 const latestPath = path.resolve(__dirname, '../references/posthog-node-references-latest.json');
 fs.writeFileSync(latestPath, JSON.stringify(output, null, 2));
+
+// Versioned references are release artifacts. Avoid writing them during normal generation
+// so PRs don't accidentally commit package-version-specific reference files.
+if (shouldWriteVersionedReferences) {
+  const versionedPath = path.resolve(__dirname, `../references/posthog-node-references-${version}.json`);
+  fs.writeFileSync(versionedPath, JSON.stringify(output, null, 2));
+}

--- a/packages/react-native/scripts/generate-docs.js
+++ b/packages/react-native/scripts/generate-docs.js
@@ -6,6 +6,7 @@ const { HOG_REF } = require('../../../scripts/docs/constants');
 // Read package.json to get version
 const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8'));
 const version = packageJson.version;
+const shouldWriteVersionedReferences = process.env.GENERATE_VERSIONED_REFERENCES === '1';
 
 // React Native-specific configuration
 const REACT_NATIVE_SPEC_INFO = {
@@ -52,13 +53,15 @@ if (!fs.existsSync(referencesDir)) {
     fs.mkdirSync(referencesDir, { recursive: true });
 }
 
-// Generate versioned file
 const output = generateApiSpecs(config);
 
-// Write versioned file
-const versionedPath = path.resolve(__dirname, `../references/posthog-react-native-references-${version}.json`);
-fs.writeFileSync(versionedPath, JSON.stringify(output, null, 2));
-
-// Copy to latest file
+// Always update the rolling public API reference used by CI and docs previews.
 const latestPath = path.resolve(__dirname, '../references/posthog-react-native-references-latest.json');
 fs.writeFileSync(latestPath, JSON.stringify(output, null, 2));
+
+// Versioned references are release artifacts. Avoid writing them during normal generation
+// so PRs don't accidentally commit package-version-specific reference files.
+if (shouldWriteVersionedReferences) {
+    const versionedPath = path.resolve(__dirname, `../references/posthog-react-native-references-${version}.json`);
+    fs.writeFileSync(versionedPath, JSON.stringify(output, null, 2));
+}

--- a/scripts/check-public-api.js
+++ b/scripts/check-public-api.js
@@ -15,7 +15,7 @@ try {
 }
 
 if (status) {
-    console.error('Public API references are out of date. Run `pnpm generate-references` and commit the updated files.')
+    console.error('Public API references are out of date. Run `pnpm generate-references` and commit the updated latest reference files.')
     console.error(status)
 
     try {

--- a/turbo.json
+++ b/turbo.json
@@ -61,7 +61,8 @@
         },
         "generate-references": {
             "dependsOn": ["build"],
-            "cache": false
+            "cache": false,
+            "env": ["GENERATE_VERSIONED_REFERENCES"]
         }
     }
 }


### PR DESCRIPTION
## Problem

Normal public API reference generation currently writes both rolling `*-references-latest.json` files and package-versioned reference files. That can make regular docs/CI reference updates accidentally include release-specific artifacts.

## Changes

- Make package reference generation always update only the `latest` reference file by default.
- Add `GENERATE_VERSIONED_REFERENCES=1` and a root `generate-references:versioned` script for release-time versioned artifacts.
- Update the release workflow to generate versioned references after version bumps.
- Narrow generated-reference checks, auto-commits, and generated-file notices to distinguish latest vs versioned reference files.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
