### PR TITLE
fix(browser): support unset capture option

### DIFF
--- a/.changeset/fix-capture-options-unset.md
+++ b/.changeset/fix-capture-options-unset.md
@@ -1,0 +1,6 @@
+---
+'posthog-js': patch
+'@posthog/types': patch
+---
+
+Add `$unset` to capture options and pass it through in browser capture payloads.

--- a/packages/browser/src/__tests__/posthog-core.test.ts
+++ b/packages/browser/src/__tests__/posthog-core.test.ts
@@ -114,6 +114,16 @@ describe('posthog core', () => {
             expect(actual['token']).toBeUndefined()
         })
 
+        it('passes $unset capture option through', () => {
+            const { posthog, beforeSendMock } = setup()
+
+            posthog.capture(eventName, eventProperties, { $unset: ['email'] })
+
+            expect(beforeSendMock.mock.calls[0][0]).toMatchObject({
+                $unset: ['email'],
+            })
+        })
+
         describe('rate limiting', () => {
             it('includes information about remaining rate limit', () => {
                 const { posthog, beforeSendMock } = setup()

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1349,6 +1349,10 @@ export class PostHog implements PostHogInterface {
         if (setProperties) {
             data.$set = options?.$set
         }
+        const unsetProperties = options?.$unset
+        if (unsetProperties) {
+            data.$unset = options?.$unset
+        }
         // $groupidentify doesn't process person $set_once on the server, so don't mark
         // initial person props as sent. This ensures they're included with subsequent
         // $identify calls.

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -1351,7 +1351,7 @@ export class PostHog implements PostHogInterface {
         }
         const unsetProperties = options?.$unset
         if (unsetProperties) {
-            data.$unset = options?.$unset
+            data.$unset = unsetProperties
         }
         // $groupidentify doesn't process person $set_once on the server, so don't mark
         // initial person props as sent. This ensures they're included with subsequent

--- a/packages/types/src/capture.ts
+++ b/packages/types/src/capture.ts
@@ -46,6 +46,7 @@ export interface CaptureResult {
     properties: Properties
     $set?: Properties
     $set_once?: Properties
+    $unset?: string[]
     timestamp?: Date
 }
 
@@ -61,6 +62,11 @@ export interface CaptureOptions {
      * Will set person properties but only once, it will NOT override previous values
      */
     $set_once?: Properties
+
+    /**
+     * Used to unset person properties
+     */
+    $unset?: string[]
 
     /**
      * Used to override the desired endpoint for the captured event


### PR DESCRIPTION
## Problem

`CaptureOptions` in `@posthog/types` did not include `$unset`, even though the browser SDK docs show using `$unset` to remove person properties from a capture call. TypeScript users could not pass `$unset` without a type error.

Closes #2086

## Changes

- Add `$unset?: string[]` to `CaptureOptions` and `CaptureResult`.
- Pass `options.$unset` through to browser capture payloads.
- Add unit test coverage for `$unset` capture options.
- Add a changeset for `posthog-js` and `@posthog/types`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
