### PR TITLE
refactor(flags): browser reuses core flag helpers (enabled/variant + parsePayload)

### DIFF
--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -37,7 +37,7 @@ import {
     PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS,
 } from './constants'
 
-import { isUndefined, isArray, isNull } from '@posthog/core'
+import { isUndefined, isArray, isNull, getEnabledFromValue, getVariantFromValue, parsePayload } from '@posthog/core'
 import { createLogger } from './utils/logger'
 import { getTimezone } from './utils/event-utils'
 
@@ -348,11 +348,10 @@ export class PostHogFeatureFlags implements Extension {
         // Convert simple flags to v4 format to avoid deprecation warning
         const flagDetails: Record<string, FeatureFlagDetail> = {}
         for (const [key, value] of Object.entries(finalFlags)) {
-            const isVariant = typeof value === 'string'
             flagDetails[key] = {
                 key,
-                enabled: isVariant ? true : Boolean(value),
-                variant: isVariant ? value : undefined,
+                enabled: getEnabledFromValue(value),
+                variant: getVariantFromValue(value),
                 reason: undefined,
                 // id: 0 indicates manually injected flags (not from server evaluation)
                 metadata: !isUndefined(finalPayloads?.[key])
@@ -867,20 +866,11 @@ export class PostHogFeatureFlags implements Extension {
             return undefined
         }
 
-        let parsedPayload = payload
-        if (!isUndefined(payload)) {
-            try {
-                parsedPayload = JSON.parse(payload as any)
-            } catch {
-                // payload is already parsed or not valid JSON, keep as-is
-            }
-        }
-
         return {
             key,
             enabled: !!flagValue,
             variant: typeof flagValue === 'string' ? flagValue : undefined,
-            payload: parsedPayload,
+            payload: parsePayload(payload),
         }
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { getFeatureFlagValue } from './featureFlagUtils'
+export { getFeatureFlagValue, getEnabledFromValue, getVariantFromValue, parsePayload } from './featureFlagUtils'
 export {
   gzipCompress,
   isGzipData,


### PR DESCRIPTION
## Problem

`posthog-js` and `@posthog/core` each implement feature flags, and the browser reimplements logic core already provides — the enabled/variant computation (`isVariant ? true : Boolean(value)`) and payload JSON parsing (an inline `try/catch` around `JSON.parse`). Duplicated logic like this is how the two flag implementations drift apart.

## Changes

- Export `getEnabledFromValue`, `getVariantFromValue`, and `parsePayload` from `@posthog/core`.
- Use them in `posthog-js` instead of local reimplementations:
  - `updateFlags` → `getEnabledFromValue` / `getVariantFromValue`
  - `getFeatureFlagPayload` → `parsePayload`

Pure refactor, **no behavior change** (full feature-flag suite still passing). Independent of the bug fix in #3870 — touches different lines of `updateFlags`.

Other dedup candidates were vetted and left out on purpose: `getFeatureFlagValue` doesn't fit (the browser's `getFeatureFlagResult` returns `FeatureFlagResult`, not core's `FeatureFlagDetail`), and `normalizeFlagsResponse` / `id: 0` vs `undefined` / payload storage format have genuinely diverged — those are behavior reconciliations, not free swaps.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (n/a — internal refactor, no user-facing change)
