### PR TITLE
refactor(flags): browser reuses core parsePayload

### DIFF
--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -37,7 +37,7 @@ import {
     PERSISTENCE_OVERRIDE_FEATURE_FLAG_PAYLOADS,
 } from './constants'
 
-import { isUndefined, isArray, isNull } from '@posthog/core'
+import { isUndefined, isArray, isNull, parsePayload } from '@posthog/core'
 import { createLogger } from './utils/logger'
 import { getTimezone } from './utils/event-utils'
 
@@ -867,20 +867,11 @@ export class PostHogFeatureFlags implements Extension {
             return undefined
         }
 
-        let parsedPayload = payload
-        if (!isUndefined(payload)) {
-            try {
-                parsedPayload = JSON.parse(payload as any)
-            } catch {
-                // payload is already parsed or not valid JSON, keep as-is
-            }
-        }
-
         return {
             key,
             enabled: !!flagValue,
             variant: typeof flagValue === 'string' ? flagValue : undefined,
-            payload: parsedPayload,
+            payload: parsePayload(payload),
         }
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { getFeatureFlagValue } from './featureFlagUtils'
+export { getFeatureFlagValue, parsePayload } from './featureFlagUtils'
 export {
   gzipCompress,
   isGzipData,


### PR DESCRIPTION
## Problem

`posthog-js`'s `getFeatureFlagPayload` reimplements payload JSON parsing inline (a `try/catch` around `JSON.parse`), duplicating `@posthog/core`'s `parsePayload`. Duplicated logic like this is how the two flag implementations drift apart.

## Changes

- Export `parsePayload` from `@posthog/core`.
- Use it in `posthog-js`'s `getFeatureFlagPayload` instead of the inline parse block.

Pure refactor, **no behavior change** (core's `parsePayload` returns non-strings as-is, parses strings, and falls back on parse failure — equivalent to the inline logic). Full feature-flag suite still passing (171).

I vetted other dedup candidates and left them out on purpose: `getFeatureFlagValue` doesn't fit (the browser's `getFeatureFlagResult` returns `FeatureFlagResult`, not core's `FeatureFlagDetail`), and `normalizeFlagsResponse` / `id: 0` vs `undefined` / payload storage format have genuinely diverged — those are behavior reconciliations, not free swaps.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (n/a — internal refactor, no user-facing change)
