### PR TITLE
chore: Move pnpm settings and refresh Browserslist

### DIFF
--- a/examples/example-expo-53/package.json
+++ b/examples/example-expo-53/package.json
@@ -54,10 +54,5 @@
         "eslint-config-expo": "~9.2.0",
         "typescript": "~5.8.3"
     },
-    "pnpm": {
-        "overrides": {
-            "node-forge": "1.3.2"
-        }
-    },
     "private": true
 }

--- a/examples/example-expo-53/pnpm-workspace.yaml
+++ b/examples/example-expo-53/pnpm-workspace.yaml
@@ -2,5 +2,8 @@ pnpmfile: ../.pnpmfile.cjs
 nodeLinker: hoisted
 minimumReleaseAge: 10080
 
+overrides:
+  node-forge: 1.3.2
+
 blockExoticSubdeps: true
 trustPolicy: no-downgrade

--- a/examples/example-web/package.json
+++ b/examples/example-web/package.json
@@ -3,11 +3,6 @@
     "version": "0.1.0",
     "private": true,
     "packageManager": "pnpm@10.15.0",
-    "pnpm": {
-        "overrides": {
-            "node-forge": "1.3.2"
-        }
-    },
     "dependencies": {
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^13.0.0",

--- a/examples/example-web/pnpm-workspace.yaml
+++ b/examples/example-web/pnpm-workspace.yaml
@@ -5,6 +5,9 @@ onlyBuiltDependencies:
   - core-js
   - core-js-pure
 
+overrides:
+  node-forge: 1.3.2
+
 nodeLinker: hoisted
 pnpmfile: ../.pnpmfile.cjs
 minimumReleaseAge: 10080

--- a/package.json
+++ b/package.json
@@ -22,14 +22,6 @@
         "generate-references:versioned": "GENERATE_VERSIONED_REFERENCES=1 pnpm turbo --filter=posthog-js --filter=posthog-node --filter=posthog-react-native generate-references",
         "check:public-api": "node scripts/check-public-api.js"
     },
-    "pnpm": {
-        "overrides": {
-            "node-forge": "1.3.2"
-        },
-        "onlyBuiltDependencies": [
-            "sharp"
-        ]
-    },
     "devDependencies": {
         "@changesets/changelog-github": "^0.5.2",
         "@changesets/cli": "^2.29.8",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -109,7 +109,7 @@
         "@types/sinon": "^17.0.1",
         "@types/web": "^0.0.222",
         "babel-jest": "^29.7.0",
-        "browserslist": "^4.24.5",
+        "browserslist": "^4.28.2",
         "compare-versions": "^6.1.0",
         "cssnano": "^7.0.7",
         "date-fns": "^3.6.0",

--- a/packages/browser/playground/nuxtjs/package.json
+++ b/packages/browser/playground/nuxtjs/package.json
@@ -15,10 +15,5 @@
     "dependencies": {
         "posthog-js": "file:../../dist/"
     },
-    "packageManager": "pnpm@10.12.4",
-    "pnpm": {
-        "overrides": {
-            "node-forge": "1.3.2"
-        }
-    }
+    "packageManager": "pnpm@10.12.4"
 }

--- a/packages/browser/playground/nuxtjs/pnpm-workspace.yaml
+++ b/packages/browser/playground/nuxtjs/pnpm-workspace.yaml
@@ -1,5 +1,8 @@
 pnpmfile: ../.pnpmfile.cjs
 minimumReleaseAge: 10080
 
+overrides:
+  node-forge: 1.3.2
+
 blockExoticSubdeps: true
 trustPolicy: no-downgrade

--- a/packages/browser/playground/react-router/package.json
+++ b/packages/browser/playground/react-router/package.json
@@ -30,10 +30,5 @@
         "typescript": "^5.7.2",
         "vite": "^5.4.21",
         "vite-tsconfig-paths": "^5.1.4"
-    },
-    "pnpm": {
-        "overrides": {
-            "posthog-js": "link:../.."
-        }
     }
 }

--- a/packages/browser/playground/react-router/pnpm-workspace.yaml
+++ b/packages/browser/playground/react-router/pnpm-workspace.yaml
@@ -1,5 +1,8 @@
 pnpmfile: ../.pnpmfile.cjs
 minimumReleaseAge: 10080
 
+overrides:
+  posthog-js: link:../..
+
 blockExoticSubdeps: true
 trustPolicy: no-downgrade

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,8 +407,8 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0(@babel/core@7.28.5)
       browserslist:
-        specifier: ^4.24.5
-        version: 4.24.5
+        specifier: ^4.28.2
+        version: 4.28.2
       compare-versions:
         specifier: ^6.1.0
         version: 6.1.0
@@ -7339,6 +7339,11 @@ packages:
     resolution: {integrity: sha512-PxSsosKQjI38iXkmb3d0Y32efqyA0uW4s41u4IVBsLlWLhCiYNpH/AfNOVWRqCQBlD8TFJTz6OUWNd4DFJCnmw==}
     hasBin: true
 
+  baseline-browser-mapping@2.10.35:
+    resolution: {integrity: sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   basic-auth@2.0.1:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
@@ -7444,6 +7449,11 @@ packages:
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -7581,6 +7591,9 @@ packages:
 
   caniuse-lite@1.0.30001759:
     resolution: {integrity: sha512-Pzfx9fOKoKvevQf8oCXoyNRQ5QyxJj+3O0Rqx2V5oxT61KGx8+n6hV/IUyJeifUci2clnmmKVpvtiqRzgiWjSw==}
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
   capture-exit@2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
@@ -8664,6 +8677,9 @@ packages:
 
   electron-to-chromium@1.5.266:
     resolution: {integrity: sha512-kgWEglXvkEfMH7rxP5OSZZwnaDWT7J9EoZCujhnpLbfi0bbNtRkgdX2E3gt0Uer11c61qCYktB3hwkAS325sJg==}
+
+  electron-to-chromium@1.5.375:
+    resolution: {integrity: sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==}
 
   elegant-spinner@1.0.1:
     resolution: {integrity: sha512-B+ZM+RXvRqQaAmkMlO/oSe5nMUOaUnyfGYCEHoR8wrXsZR2mA0XVibsxV1bvTwxdRWah1PkQqso2EzhILGHtEQ==}
@@ -12216,6 +12232,9 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+
   node-stream-zip@1.15.0:
     resolution: {integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==}
     engines: {node: '>=0.12.0'}
@@ -15544,6 +15563,12 @@ packages:
 
   update-browserslist-db@1.2.2:
     resolution: {integrity: sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -24037,6 +24062,8 @@ snapshots:
 
   baseline-browser-mapping@2.9.2: {}
 
+  baseline-browser-mapping@2.10.35: {}
+
   basic-auth@2.0.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -24190,6 +24217,14 @@ snapshots:
       electron-to-chromium: 1.5.266
       node-releases: 2.0.27
       update-browserslist-db: 1.2.2(browserslist@4.28.1)
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.35
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.375
+      node-releases: 2.0.47
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   browserstack-local@1.5.1:
     dependencies:
@@ -24366,6 +24401,8 @@ snapshots:
   caniuse-lite@1.0.30001755: {}
 
   caniuse-lite@1.0.30001759: {}
+
+  caniuse-lite@1.0.30001799: {}
 
   capture-exit@2.0.0:
     dependencies:
@@ -25587,6 +25624,8 @@ snapshots:
   electron-to-chromium@1.5.150: {}
 
   electron-to-chromium@1.5.266: {}
+
+  electron-to-chromium@1.5.375: {}
 
   elegant-spinner@1.0.1: {}
 
@@ -31128,6 +31167,8 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  node-releases@2.0.47: {}
+
   node-stream-zip@1.15.0: {}
 
   nopt@8.1.0:
@@ -35375,6 +35416,12 @@ snapshots:
   update-browserslist-db@1.2.2(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,12 @@ catalog:
 
 minimumReleaseAge: 10080
 
+onlyBuiltDependencies:
+  - sharp
+
+overrides:
+  node-forge: 1.3.2
+
 minimumReleaseAgeExclude:
   - "@posthog/cli"
   - "posthog-react-native-session-replay"


### PR DESCRIPTION
## Problem

Recent pnpm versions no longer read the `pnpm` field from `package.json`, so the repository was warning that `pnpm.overrides` and `pnpm.onlyBuiltDependencies` were ignored. The browser package also emitted a stale Browserslist/caniuse-lite data warning.

## Changes

- Move pnpm settings from `package.json` files into the appropriate `pnpm-workspace.yaml` files.
- Preserve existing overrides for `node-forge` and the React Router playground `posthog-js` link override.
- Preserve root `onlyBuiltDependencies` for `sharp`.
- Refresh the browser package Browserslist dependency and lockfile entries so `pnpm --filter=posthog-js exec browserslist` no longer warns.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was prepared with the pi coding agent. The investigation found pnpm 10.23 warning about ignored `package.json#pnpm` settings and stale Browserslist data. The implementation keeps the same pnpm settings but moves them to workspace config files, and refreshes only the Browserslist-related browser package dependency/lockfile entries needed to remove the warning.

Validation performed:

```bash
pnpm install --frozen-lockfile --ignore-scripts
pnpm --filter=posthog-js exec browserslist
rg -n '"pnpm"\\s*:' -g 'package.json' .
git diff --check
```
