### PR TITLE
fix(react-native): support skip on conflict in expo plugin

### DIFF
--- a/.changeset/sour-dingos-conflict.md
+++ b/.changeset/sour-dingos-conflict.md
@@ -1,0 +1,5 @@
+---
+'posthog-react-native': patch
+---
+
+Add Expo config plugin support for skipping duplicate sourcemap uploads.

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -8,6 +8,20 @@ SDK usage examples and code snippets live in the official documentation so they 
 
 - [React Native library docs](https://posthog.com/docs/libraries/react-native)
 
+## Expo config plugin options
+
+```json
+{
+  "expo": {
+    "plugins": [["posthog-react-native", { "skipOnConflict": true }]]
+  }
+}
+```
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `skipOnConflict` | `boolean` | Appends `--skip-on-conflict` to `posthog-cli hermes upload` on iOS and Android. Requires `posthog-cli >= 0.7.12`. |
+
 ## Questions??
 
 ### [Check out our community page.](https://posthog.com/posts)

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -8,20 +8,6 @@ SDK usage examples and code snippets live in the official documentation so they 
 
 - [React Native library docs](https://posthog.com/docs/libraries/react-native)
 
-## Expo config plugin options
-
-```json
-{
-  "expo": {
-    "plugins": [["posthog-react-native", { "skipOnConflict": true }]]
-  }
-}
-```
-
-| Option | Type | Description |
-| --- | --- | --- |
-| `skipOnConflict` | `boolean` | Appends `--skip-on-conflict` to `posthog-cli hermes upload` on iOS and Android. Requires `posthog-cli >= 0.7.12`. |
-
 ## Questions??
 
 ### [Check out our community page.](https://posthog.com/posts)

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -11,7 +11,16 @@ const POSTHOG_ANDROID_GRADLE_PLUGIN_VERSION = '1.2.0'
 const resolvePostHogReactNativePackageJsonPath =
   "[\"node\", \"--print\", \"require('path').join(require('path').dirname(require.resolve('posthog-react-native')), '..', 'tooling', 'posthog.gradle')\"].execute().text.trim()"
 
-const withAndroidPlugin = (config: any) => {
+const POSTHOG_ANDROID_SKIP_ON_CONFLICT_PROPERTY = 'posthogReactNativeSkipOnConflict'
+
+export function buildAndroidSkipOnConflictGradleLine(skipOnConflict: boolean): string | null {
+  if (!skipOnConflict) {
+    return null
+  }
+  return `project.ext.${POSTHOG_ANDROID_SKIP_ON_CONFLICT_PROPERTY} = true`
+}
+
+const withAndroidPlugin = (config: any, skipOnConflict = false) => {
   return withAppBuildGradle(config, (config: any) => {
     if (config.modResults.language !== 'groovy') {
       console.warn('Cannot configure PostHog in the app gradle because the build.gradle is not groovy')
@@ -19,8 +28,19 @@ const withAndroidPlugin = (config: any) => {
 
     const buildGradle = config.modResults.contents
     const applyFrom = `apply from: new File(${resolvePostHogReactNativePackageJsonPath})`
+    const skipOnConflictLine = buildAndroidSkipOnConflictGradleLine(skipOnConflict)
+    const applyBlock = skipOnConflictLine ? `${skipOnConflictLine}\n${applyFrom}` : applyFrom
+    const skipOnConflictPattern = new RegExp(
+      `^project\\.ext\\.${POSTHOG_ANDROID_SKIP_ON_CONFLICT_PROPERTY}\\s*=\\s*(true|false)\\n?`,
+      'm'
+    )
 
     if (buildGradle.includes(applyFrom)) {
+      let contents = buildGradle.replace(skipOnConflictPattern, '')
+      if (skipOnConflictLine) {
+        contents = contents.replace(applyFrom, `${skipOnConflictLine}\n${applyFrom}`)
+      }
+      config.modResults.contents = contents
       return config
     }
 
@@ -28,7 +48,7 @@ const withAndroidPlugin = (config: any) => {
     const pattern = /^android\s*\{/m
 
     if (buildGradle.match(pattern)) {
-      config.modResults.contents = buildGradle.replace(pattern, `${applyFrom}\n\nandroid {`)
+      config.modResults.contents = buildGradle.replace(pattern, `${applyBlock}\n\nandroid {`)
     } else {
       console.warn('PostHog: Could not find "android {" block in build.gradle')
     }
@@ -146,12 +166,15 @@ const withAndroidNativeSymbolsPlugin = (config: any) => {
 
 type BuildPhase = { shellScript: string }
 
-export function modifyExistingXcodeBuildScript(script: BuildPhase): void {
+export function modifyExistingXcodeBuildScript(script: BuildPhase, skipOnConflict = false): void {
   if (!script.shellScript.match(/(packager|scripts)\/react-native-xcode\.sh\b/)) {
     return
   }
 
+  const code = JSON.parse(script.shellScript)
+
   if (script.shellScript.includes('posthog-xcode.sh')) {
+    script.shellScript = JSON.stringify(updatePostHogSkipOnConflictArg(code, skipOnConflict))
     return
   }
 
@@ -159,8 +182,7 @@ export function modifyExistingXcodeBuildScript(script: BuildPhase): void {
     return
   }
 
-  const code = JSON.parse(script.shellScript)
-  script.shellScript = JSON.stringify(addPostHogWithBundledScriptsToBundleShellScript(code))
+  script.shellScript = JSON.stringify(addPostHogWithBundledScriptsToBundleShellScript(code, skipOnConflict))
 }
 
 const POSTHOG_REACT_NATIVE_XCODE_PATH =
@@ -169,14 +191,25 @@ const POSTHOG_REACT_NATIVE_XCODE_PATH =
 const REACT_NATIVE_XCODE_LINE =
   /^([ \t]*)(?![A-Za-z_][A-Za-z0-9_]*=)(?:\/bin\/sh\s+)?([^\n]*(?:packager|scripts)\/react-native-xcode\.sh\b[^\n]*)$/m
 
-export function addPostHogWithBundledScriptsToBundleShellScript(script: string): string {
+function updatePostHogSkipOnConflictArg(script: string, skipOnConflict: boolean): string {
+  const skipArg = '--posthog-skip-on-conflict --'
+  const withoutSkipArg = script.replace(new RegExp(`\\s*${skipArg}\\s*`, 'g'), ' ')
+  if (!skipOnConflict) {
+    return withoutSkipArg
+  }
+  return withoutSkipArg.replace(`${POSTHOG_REACT_NATIVE_XCODE_PATH} `, `${POSTHOG_REACT_NATIVE_XCODE_PATH} ${skipArg} `)
+}
+
+export function addPostHogWithBundledScriptsToBundleShellScript(script: string, skipOnConflict = false): string {
+  const postHogArgs = skipOnConflict ? '--posthog-skip-on-conflict -- ' : ''
+
   // Capture the full RN script invocation. Expo uses a backtick-wrapped
   // node --print command, so matching only up to react-native-xcode.sh cuts the
   // command substitution in half and leaves the generated shell invalid.
   return script.replace(
     REACT_NATIVE_XCODE_LINE,
     (_match: string, indent: string, rnCommand: string) =>
-      `${indent}/bin/sh ${POSTHOG_REACT_NATIVE_XCODE_PATH} ${rnCommand}`
+      `${indent}/bin/sh ${POSTHOG_REACT_NATIVE_XCODE_PATH} ${postHogArgs}${rnCommand}`
   )
 }
 
@@ -277,6 +310,11 @@ type PostHogPluginProps = {
    * Requires `posthog-cli` to be available and authenticated during release builds.
    */
   uploadNativeSymbols?: boolean | { includeSource?: boolean }
+
+  /**
+   * Whether to append `--skip-on-conflict` to `posthog-cli hermes upload` on iOS and Android.
+   */
+  skipOnConflict?: boolean
 }
 
 // Normalizes the uploadNativeSymbols prop (boolean | { includeSource }) into a
@@ -303,7 +341,7 @@ const withIosPlugin = (config: any, props: PostHogPluginProps = {}) => {
       'PBXShellScriptBuildPhase'
     )
 
-    modifyExistingXcodeBuildScript(bundleReactNativePhase)
+    modifyExistingXcodeBuildScript(bundleReactNativePhase, props.skipOnConflict === true)
 
     const nativeSymbols = resolveNativeSymbolUpload(props.uploadNativeSymbols)
     if (nativeSymbols.enabled) {
@@ -326,7 +364,7 @@ const withIosPlugin = (config: any, props: PostHogPluginProps = {}) => {
 }
 
 const withPostHogPlugin = (config: any, props: PostHogPluginProps = {}) => {
-  config = withAndroidPlugin(config)
+  config = withAndroidPlugin(config, props.skipOnConflict === true)
   // includeSource is iOS-only, so on Android we only care whether upload is enabled.
   if (resolveNativeSymbolUpload(props.uploadNativeSymbols).enabled) {
     config = withAndroidNativeSymbolsPlugin(config)
@@ -347,5 +385,6 @@ module.exports.disableUserScriptSandboxing = disableUserScriptSandboxing
 module.exports.buildDsymUploadShellScript = buildDsymUploadShellScript
 module.exports.addDsymUploadBuildPhase = addDsymUploadBuildPhase
 module.exports.resolveNativeSymbolUpload = resolveNativeSymbolUpload
+module.exports.buildAndroidSkipOnConflictGradleLine = buildAndroidSkipOnConflictGradleLine
 module.exports.addPostHogAndroidGradlePluginClasspath = addPostHogAndroidGradlePluginClasspath
 module.exports.applyPostHogAndroidGradlePlugin = applyPostHogAndroidGradlePlugin

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -313,6 +313,8 @@ type PostHogPluginProps = {
 
   /**
    * Whether to append `--skip-on-conflict` to `posthog-cli hermes upload` on iOS and Android.
+   *
+   * Default: false.
    */
   skipOnConflict?: boolean
 }

--- a/packages/react-native/src/tooling/expoconfig.ts
+++ b/packages/react-native/src/tooling/expoconfig.ts
@@ -171,9 +171,8 @@ export function modifyExistingXcodeBuildScript(script: BuildPhase, skipOnConflic
     return
   }
 
-  const code = JSON.parse(script.shellScript)
-
   if (script.shellScript.includes('posthog-xcode.sh')) {
+    const code = JSON.parse(script.shellScript)
     script.shellScript = JSON.stringify(updatePostHogSkipOnConflictArg(code, skipOnConflict))
     return
   }
@@ -182,6 +181,7 @@ export function modifyExistingXcodeBuildScript(script: BuildPhase, skipOnConflic
     return
   }
 
+  const code = JSON.parse(script.shellScript)
   script.shellScript = JSON.stringify(addPostHogWithBundledScriptsToBundleShellScript(code, skipOnConflict))
 }
 

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -277,12 +277,11 @@ describe('resolveNativeSymbolUpload', () => {
 })
 
 describe('buildAndroidSkipOnConflictGradleLine', () => {
-  it('returns no Gradle line when skipOnConflict is disabled', () => {
-    expect(buildAndroidSkipOnConflictGradleLine(false)).toBeNull()
-  })
-
-  it('serializes skipOnConflict for posthog.gradle', () => {
-    expect(buildAndroidSkipOnConflictGradleLine(true)).toBe('project.ext.posthogReactNativeSkipOnConflict = true')
+  it.each([
+    [false, null],
+    [true, 'project.ext.posthogReactNativeSkipOnConflict = true'],
+  ])('serializes skipOnConflict=%s', (skipOnConflict, expected) => {
+    expect(buildAndroidSkipOnConflictGradleLine(skipOnConflict)).toBe(expected)
   })
 })
 

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -5,6 +5,7 @@ import {
   addPostHogAndroidGradlePluginClasspath,
   addPostHogWithBundledScriptsToBundleShellScript,
   applyPostHogAndroidGradlePlugin,
+  buildAndroidSkipOnConflictGradleLine,
   buildDsymUploadShellScript,
   disableUserScriptSandboxing,
   modifyExistingXcodeBuildScript,
@@ -125,6 +126,14 @@ describe('addPostHogWithBundledScriptsToBundleShellScript', () => {
     expect(wrapped).not.toContain("` '/scripts/react-native-xcode.sh'\"`")
     expectValidShellSyntax(wrapped)
   })
+
+  it('passes skipOnConflict before the react-native-xcode.sh command', () => {
+    const original = 'node_modules/react-native/scripts/react-native-xcode.sh'
+    const wrapped = addPostHogWithBundledScriptsToBundleShellScript(original, true)
+
+    expect(wrapped).toContain('--posthog-skip-on-conflict -- node_modules/react-native/scripts/react-native-xcode.sh')
+    expectValidShellSyntax(wrapped)
+  })
 })
 
 describe('modifyExistingXcodeBuildScript', () => {
@@ -133,6 +142,25 @@ describe('modifyExistingXcodeBuildScript', () => {
     modifyExistingXcodeBuildScript(script)
     const parsed = JSON.parse(script.shellScript)
     expect(parsed).toContain('posthog-xcode.sh')
+  })
+
+  it('wraps the bundle phase shellScript with skipOnConflict', () => {
+    const script = { shellScript: JSON.stringify('"../node_modules/react-native/scripts/react-native-xcode.sh"') }
+    modifyExistingXcodeBuildScript(script, true)
+    const parsed = JSON.parse(script.shellScript)
+    expect(parsed).toContain('--posthog-skip-on-conflict --')
+  })
+
+  it('updates skipOnConflict on an already wrapped bundle phase', () => {
+    const script = { shellScript: JSON.stringify('"../node_modules/react-native/scripts/react-native-xcode.sh"') }
+    modifyExistingXcodeBuildScript(script)
+    modifyExistingXcodeBuildScript(script, true)
+    let parsed = JSON.parse(script.shellScript)
+    expect(parsed).toContain('--posthog-skip-on-conflict --')
+
+    modifyExistingXcodeBuildScript(script, false)
+    parsed = JSON.parse(script.shellScript)
+    expect(parsed).not.toContain('--posthog-skip-on-conflict --')
   })
 
   it('wraps Expo backtick bundle phase shellScript without creating invalid shell syntax', () => {
@@ -245,6 +273,16 @@ describe('resolveNativeSymbolUpload', () => {
     expect(resolveNativeSymbolUpload({ includeSource: true })).toEqual({ enabled: true, includeSource: true })
     expect(resolveNativeSymbolUpload({ includeSource: false })).toEqual({ enabled: true, includeSource: false })
     expect(resolveNativeSymbolUpload({})).toEqual({ enabled: true, includeSource: false })
+  })
+})
+
+describe('buildAndroidSkipOnConflictGradleLine', () => {
+  it('returns no Gradle line when skipOnConflict is disabled', () => {
+    expect(buildAndroidSkipOnConflictGradleLine(false)).toBeNull()
+  })
+
+  it('serializes skipOnConflict for posthog.gradle', () => {
+    expect(buildAndroidSkipOnConflictGradleLine(true)).toBe('project.ext.posthogReactNativeSkipOnConflict = true')
   })
 })
 

--- a/packages/react-native/test/expoconfig.spec.ts
+++ b/packages/react-native/test/expoconfig.spec.ts
@@ -192,6 +192,13 @@ describe('modifyExistingXcodeBuildScript', () => {
     expect(script.shellScript).toBe(firstPass)
   })
 
+  it('skips already posthog-react-native-wrapped scripts without parsing them', () => {
+    const script = { shellScript: 'posthog-react-native node_modules/react-native/scripts/react-native-xcode.sh' }
+    const original = script.shellScript
+    expect(() => modifyExistingXcodeBuildScript(script)).not.toThrow()
+    expect(script.shellScript).toBe(original)
+  })
+
   it('skips scripts that do not invoke react-native-xcode.sh', () => {
     const script = { shellScript: JSON.stringify('echo "hello"') }
     const original = script.shellScript

--- a/packages/react-native/test/posthog-xcode-parse.spec.ts
+++ b/packages/react-native/test/posthog-xcode-parse.spec.ts
@@ -119,6 +119,24 @@ describe('posthog-xcode.sh REACT_NATIVE_XCODE resolution', () => {
   })
 })
 
+describe('posthog-xcode.sh skipOnConflict upload flag', () => {
+  it('passes --skip-on-conflict only to hermes upload', () => {
+    const contents = fs.readFileSync(SCRIPT_PATH, 'utf8')
+
+    expect(contents).toContain('POSTHOG_UPLOAD_ARGS="$POSTHOG_UPLOAD_ARGS --skip-on-conflict"')
+    expect(contents).toContain(
+      'CLI_UPLOAD_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH hermes upload --directory $DERIVED_FILE_DIR $CLI_RELEASE_ARGS $POSTHOG_UPLOAD_ARGS" 2>&1)'
+    )
+    expect(contents).not.toContain('hermes clone --skip-on-conflict')
+  })
+
+  it('requires a posthog-cli version that supports --skip-on-conflict', () => {
+    const contents = fs.readFileSync(SCRIPT_PATH, 'utf8')
+
+    expect(contents).toContain('MIN_POSTHOG_CLI_VERSION="0.7.12"')
+  })
+})
+
 describe('posthog-xcode.sh posthog-cli error formatting', () => {
   it('uses multiline Xcode error formatting for clone and upload failures', () => {
     const contents = fs.readFileSync(SCRIPT_PATH, 'utf8')

--- a/packages/react-native/test/posthog-xcode-parse.spec.ts
+++ b/packages/react-native/test/posthog-xcode-parse.spec.ts
@@ -129,12 +129,6 @@ describe('posthog-xcode.sh skipOnConflict upload flag', () => {
     )
     expect(contents).not.toContain('hermes clone --skip-on-conflict')
   })
-
-  it('requires a posthog-cli version that supports --skip-on-conflict', () => {
-    const contents = fs.readFileSync(SCRIPT_PATH, 'utf8')
-
-    expect(contents).toContain('MIN_POSTHOG_CLI_VERSION="0.7.12"')
-  })
 })
 
 describe('posthog-xcode.sh posthog-cli error formatting', () => {

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -102,16 +102,6 @@ if [ -z "$PH_CLI_PATH" ] || [ ! -x "$PH_CLI_PATH" ]; then
   exit 1
 fi
 
-MIN_POSTHOG_CLI_VERSION="0.7.12"
-PH_CLI_VERSION=$("$PH_CLI_PATH" --version 2>/dev/null | awk '{print $NF}' | tr -d 'v')
-if [ -n "$PH_CLI_VERSION" ]; then
-  LOWEST=$(printf '%s\n%s\n' "$MIN_POSTHOG_CLI_VERSION" "$PH_CLI_VERSION" | sort -t. -k1,1n -k2,2n -k3,3n | head -n1)
-  if [ "$LOWEST" != "$MIN_POSTHOG_CLI_VERSION" ]; then
-    echo "error: posthog-cli >= ${MIN_POSTHOG_CLI_VERSION} required (found ${PH_CLI_VERSION}). Upgrade: npm install -g @posthog/cli@latest"
-    exit 1
-  fi
-fi
-
 # mimics how the file is defined in node_modules/react-native/scripts/react-native-xcode.sh (PACKAGER_SOURCEMAP_FILE)
 SOURCEMAP_PACKAGER_FILE="$CONFIGURATION_BUILD_DIR/$SOURCEMAP_NAME"
 

--- a/packages/react-native/tooling/posthog-xcode.sh
+++ b/packages/react-native/tooling/posthog-xcode.sh
@@ -32,6 +32,23 @@ print_command_error() {
 
 # WITH_ENVIRONMENT is executed by React Native
 
+POSTHOG_UPLOAD_ARGS=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --posthog-skip-on-conflict)
+      POSTHOG_UPLOAD_ARGS="$POSTHOG_UPLOAD_ARGS --skip-on-conflict"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 REACT_NATIVE_XCODE_DEFAULT="../node_modules/react-native/scripts/react-native-xcode.sh"
 # Accept $1 only when it actually points at a shell script; guard against the
 # Expo plugin previously passing "/bin/sh" as $1 (issue #3682).
@@ -85,7 +102,7 @@ if [ -z "$PH_CLI_PATH" ] || [ ! -x "$PH_CLI_PATH" ]; then
   exit 1
 fi
 
-MIN_POSTHOG_CLI_VERSION="0.7.8"
+MIN_POSTHOG_CLI_VERSION="0.7.12"
 PH_CLI_VERSION=$("$PH_CLI_PATH" --version 2>/dev/null | awk '{print $NF}' | tr -d 'v')
 if [ -n "$PH_CLI_VERSION" ]; then
   LOWEST=$(printf '%s\n%s\n' "$MIN_POSTHOG_CLI_VERSION" "$PH_CLI_VERSION" | sort -t. -k1,1n -k2,2n -k3,3n | head -n1)
@@ -199,7 +216,7 @@ set -x -e
 
 # Execute posthog cli upload
 set +x +e
-CLI_UPLOAD_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH hermes upload --directory $DERIVED_FILE_DIR $CLI_RELEASE_ARGS" 2>&1)
+CLI_UPLOAD_OUTPUT=$(/bin/sh -c "$PH_CLI_PATH hermes upload --directory $DERIVED_FILE_DIR $CLI_RELEASE_ARGS $POSTHOG_UPLOAD_ARGS" 2>&1)
 UPLOAD_EXIT_CODE=$?
 if [ $UPLOAD_EXIT_CODE -eq 0 ]; then
   echo "$CLI_UPLOAD_OUTPUT" | awk '{print "output: posthog-cli - " $0}'

--- a/packages/react-native/tooling/posthog.gradle
+++ b/packages/react-native/tooling/posthog.gradle
@@ -7,7 +7,6 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-import org.gradle.api.GradleException
 import org.gradle.api.logging.Logging
 
 interface InjectedExecOps {
@@ -115,7 +114,6 @@ plugins.withId('com.android.application') {
 
                         doFirst {
                             def cliPackage = PostHogCli.resolveCliPackagePath(rootDirFile, reactRoot)
-                            PostHogCli.assertMinCliVersion(cliPackage, osCompatibility, reactRoot)
                             def args = [cliPackage]
                             args.addAll(["hermes", "clone",
                                 "--minified-map-path", packagerSourcemapOutput, // The path to a sourcemap
@@ -189,8 +187,6 @@ plugins.withId('com.android.application') {
 // configuration cache. Uses its own logger (not `project.logger`) and takes
 // rootDir as a parameter so it never touches `Task.project` at execution time.
 abstract class PostHogCli {
-    static final String MIN_POSTHOG_CLI_VERSION = "0.7.12"
-
     static String resolveCliPackagePath(File rootDir, reactRoot) {
         def logger = Logging.getLogger(PostHogCli)
 
@@ -252,44 +248,6 @@ abstract class PostHogCli {
         // Finally, fallback to global install
         logger.info("falling back to global posthog-cli")
         return "posthog-cli"
-    }
-
-    static void assertMinCliVersion(String cliPackage, List<String> osCompatibility, reactRoot) {
-        def logger = Logging.getLogger(PostHogCli)
-        try {
-            def command = []
-            command.addAll(osCompatibility)
-            command.addAll([cliPackage, "--version"])
-            def process = command.execute(null, new File(reactRoot.toString()))
-            def output = process.text.trim()
-            process.waitFor()
-            def version = parseVersion(output)
-            if (version == null) {
-                logger.info("could not parse posthog-cli version from `${output}`; skipping version check")
-                return
-            }
-            if (compareVersions(version, parseVersion(MIN_POSTHOG_CLI_VERSION)) < 0) {
-                throw new GradleException("posthog-cli >= ${MIN_POSTHOG_CLI_VERSION} required (found ${version.join('.')}). Upgrade: npm install -g @posthog/cli@latest")
-            }
-        } catch (GradleException e) {
-            throw e
-        } catch (Throwable e) {
-            logger.info("could not determine posthog-cli version; skipping version check", e)
-        }
-    }
-
-    static List<Integer> parseVersion(String value) {
-        def matcher = value =~ /(\d+)\.(\d+)\.(\d+)/
-        if (!matcher.find()) return null
-        return [matcher.group(1).toInteger(), matcher.group(2).toInteger(), matcher.group(3).toInteger()]
-    }
-
-    static int compareVersions(List<Integer> left, List<Integer> right) {
-        for (int i = 0; i < 3; i++) {
-            def comparison = left[i] <=> right[i]
-            if (comparison != 0) return comparison
-        }
-        return 0
     }
 }
 

--- a/packages/react-native/tooling/posthog.gradle
+++ b/packages/react-native/tooling/posthog.gradle
@@ -7,6 +7,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
+import org.gradle.api.GradleException
 import org.gradle.api.logging.Logging
 
 interface InjectedExecOps {
@@ -92,6 +93,11 @@ plugins.withId('com.android.application') {
                             extraArgs.addAll(["--build", versionCode.toString()])
                         }
 
+                        def posthogUploadArgs = []
+                        if (project.ext.has("posthogReactNativeSkipOnConflict") && project.ext.get("posthogReactNativeSkipOnConflict") == true) {
+                            posthogUploadArgs.add("--skip-on-conflict")
+                        }
+
                         def injected = project.objects.newInstance(InjectedExecOps)
 
                         // Resolve the posthog-cli path at execution time, not during
@@ -109,6 +115,7 @@ plugins.withId('com.android.application') {
 
                         doFirst {
                             def cliPackage = PostHogCli.resolveCliPackagePath(rootDirFile, reactRoot)
+                            PostHogCli.assertMinCliVersion(cliPackage, osCompatibility, reactRoot)
                             def args = [cliPackage]
                             args.addAll(["hermes", "clone",
                                 "--minified-map-path", packagerSourcemapOutput, // The path to a sourcemap
@@ -130,6 +137,7 @@ plugins.withId('com.android.application') {
                                 "--directory", sourcemapOutput.getParent()      // The path to a sourcemap that should be uploaded.
                             ])
                             args.addAll(extraArgs)
+                            args.addAll(posthogUploadArgs)
                             logger.info("posthog-cli upload arguments: ${args}")
 
                             injected.execOps.exec {
@@ -181,6 +189,8 @@ plugins.withId('com.android.application') {
 // configuration cache. Uses its own logger (not `project.logger`) and takes
 // rootDir as a parameter so it never touches `Task.project` at execution time.
 abstract class PostHogCli {
+    static final String MIN_POSTHOG_CLI_VERSION = "0.7.12"
+
     static String resolveCliPackagePath(File rootDir, reactRoot) {
         def logger = Logging.getLogger(PostHogCli)
 
@@ -242,6 +252,44 @@ abstract class PostHogCli {
         // Finally, fallback to global install
         logger.info("falling back to global posthog-cli")
         return "posthog-cli"
+    }
+
+    static void assertMinCliVersion(String cliPackage, List<String> osCompatibility, reactRoot) {
+        def logger = Logging.getLogger(PostHogCli)
+        try {
+            def command = []
+            command.addAll(osCompatibility)
+            command.addAll([cliPackage, "--version"])
+            def process = command.execute(null, new File(reactRoot.toString()))
+            def output = process.text.trim()
+            process.waitFor()
+            def version = parseVersion(output)
+            if (version == null) {
+                logger.info("could not parse posthog-cli version from `${output}`; skipping version check")
+                return
+            }
+            if (compareVersions(version, parseVersion(MIN_POSTHOG_CLI_VERSION)) < 0) {
+                throw new GradleException("posthog-cli >= ${MIN_POSTHOG_CLI_VERSION} required (found ${version.join('.')}). Upgrade: npm install -g @posthog/cli@latest")
+            }
+        } catch (GradleException e) {
+            throw e
+        } catch (Throwable e) {
+            logger.info("could not determine posthog-cli version; skipping version check", e)
+        }
+    }
+
+    static List<Integer> parseVersion(String value) {
+        def matcher = value =~ /(\d+)\.(\d+)\.(\d+)/
+        if (!matcher.find()) return null
+        return [matcher.group(1).toInteger(), matcher.group(2).toInteger(), matcher.group(3).toInteger()]
+    }
+
+    static int compareVersions(List<Integer> left, List<Integer> right) {
+        for (int i = 0; i < 3; i++) {
+            def comparison = left[i] <=> right[i]
+            if (comparison != 0) return comparison
+        }
+        return 0
     }
 }
 


### PR DESCRIPTION
## Problem

The Expo config plugin can upload React Native Hermes sourcemaps, but it had no option to enable the CLI's `--skip-on-conflict` behavior for upload commands. Customers who hit duplicate sourcemap uploads had to patch the package locally.

## Changes

- Add a `skipOnConflict` Expo plugin option for `posthog-react-native`.
- Wire `skipOnConflict: true` into iOS sourcemap uploads by passing an internal flag to `posthog-xcode.sh`, which appends `--skip-on-conflict` only to `posthog-cli hermes upload`.
- Wire `skipOnConflict: true` into Android sourcemap uploads via `project.ext.posthogReactNativeSkipOnConflict` in `posthog.gradle`.
- Add focused tests for the new option.

Closes #3867.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [x] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi after investigating the linked GitHub issue. The implementation intentionally keeps scope to the typed `skipOnConflict` option only, rather than adding a generic upload-argument passthrough. Follow-up review feedback removed package README docs and CLI min-version checks from this PR, and kept JSON parsing scoped to the Xcode script branches that need parsed content. Verified with focused React Native tests and linting.

