### PR TITLE
fix(browser): limit statusCode 0 retries

### DIFF
--- a/.changeset/quick-badgers-retry.md
+++ b/.changeset/quick-badgers-retry.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Limit retries for transport failures without an HTTP response.

--- a/packages/browser/src/__tests__/retry-queue.test.ts
+++ b/packages/browser/src/__tests__/retry-queue.test.ts
@@ -167,8 +167,12 @@ describe('RetryQueue', () => {
         expect(retryQueue.length).toEqual(0)
     })
 
-    it('does not enqueue statusCode 0 requests after 3 retries and logs the likely causes', () => {
-        assignableWindow.POSTHOG_DEBUG = true
+    it.each([
+        { retriesPerformedSoFar: 2, expectedQueueLength: 1, expectedNextRetries: 3 },
+        { retriesPerformedSoFar: 3, expectedQueueLength: 0, expectedLogRetries: 3 },
+        { retriesPerformedSoFar: 5, expectedQueueLength: 0, expectedLogRetries: 5 },
+    ])('handles statusCode 0 requests after $retriesPerformedSoFar retries', (testCase) => {
+        assignableWindow.POSTHOG_DEBUG = !!testCase.expectedLogRetries
         const cb = jest.fn()
         mockPosthog._send_request.mockImplementation(({ callback }) => {
             callback?.({ statusCode: 0 })
@@ -176,32 +180,24 @@ describe('RetryQueue', () => {
 
         retryQueue.retriableRequest({
             url: '/e',
-            data: { event: 'maxretries', timestamp: now },
+            data: { event: 'status-0-retry', timestamp: now },
             callback: cb,
-            retriesPerformedSoFar: 3,
+            retriesPerformedSoFar: testCase.retriesPerformedSoFar,
         })
 
-        expect(retryQueue.length).toEqual(0)
-        expect(cb).toHaveBeenCalledWith({ statusCode: 0 })
-        expect(assignableWindow.console.warn).toHaveBeenCalledWith(
-            '[PostHog.js]',
-            'Request failed before receiving an HTTP response; this can happen due to network issues, CORS, browser blocking, or ad blockers. Stopped retrying after 3 retries.'
-        )
-    })
+        expect(retryQueue.length).toEqual(testCase.expectedQueueLength)
 
-    it('keeps retrying statusCode 0 requests below 3 retries', () => {
-        mockPosthog._send_request.mockImplementation(({ callback }) => {
-            callback?.({ statusCode: 0 })
-        })
-
-        retryQueue.retriableRequest({
-            url: '/e',
-            data: { event: 'retryable', timestamp: now },
-            retriesPerformedSoFar: 2,
-        })
-
-        expect(retryQueue.length).toEqual(1)
-        expect(retryQueue['_queue'][0].requestOptions.retriesPerformedSoFar).toEqual(3)
+        if (testCase.expectedNextRetries) {
+            expect(retryQueue['_queue'][0].requestOptions.retriesPerformedSoFar).toEqual(testCase.expectedNextRetries)
+            expect(cb).not.toHaveBeenCalled()
+            expect(assignableWindow.console.warn).not.toHaveBeenCalled()
+        } else {
+            expect(cb).toHaveBeenCalledWith({ statusCode: 0 })
+            expect(assignableWindow.console.warn).toHaveBeenCalledWith(
+                '[PostHog.js]',
+                `Request failed before receiving an HTTP response; this can happen due to network issues, CORS, browser blocking, or ad blockers. Stopped retrying after ${testCase.expectedLogRetries} retries.`
+            )
+        }
     })
 
     it('only calls the callback when successful', () => {

--- a/packages/browser/src/__tests__/retry-queue.test.ts
+++ b/packages/browser/src/__tests__/retry-queue.test.ts
@@ -15,6 +15,7 @@ describe('RetryQueue', () => {
 
         jest.useFakeTimers()
         jest.setSystemTime(now)
+        assignableWindow.POSTHOG_DEBUG = false
         jest.spyOn(assignableWindow.console, 'warn').mockImplementation()
     })
 
@@ -164,6 +165,43 @@ describe('RetryQueue', () => {
         })
 
         expect(retryQueue.length).toEqual(0)
+    })
+
+    it('does not enqueue statusCode 0 requests after 3 retries and logs the likely causes', () => {
+        assignableWindow.POSTHOG_DEBUG = true
+        const cb = jest.fn()
+        mockPosthog._send_request.mockImplementation(({ callback }) => {
+            callback?.({ statusCode: 0 })
+        })
+
+        retryQueue.retriableRequest({
+            url: '/e',
+            data: { event: 'maxretries', timestamp: now },
+            callback: cb,
+            retriesPerformedSoFar: 3,
+        })
+
+        expect(retryQueue.length).toEqual(0)
+        expect(cb).toHaveBeenCalledWith({ statusCode: 0 })
+        expect(assignableWindow.console.warn).toHaveBeenCalledWith(
+            '[PostHog.js]',
+            'Request failed before receiving an HTTP response; this can happen due to network issues, CORS, browser blocking, or ad blockers. Stopped retrying after 3 retries.'
+        )
+    })
+
+    it('keeps retrying statusCode 0 requests below 3 retries', () => {
+        mockPosthog._send_request.mockImplementation(({ callback }) => {
+            callback?.({ statusCode: 0 })
+        })
+
+        retryQueue.retriableRequest({
+            url: '/e',
+            data: { event: 'retryable', timestamp: now },
+            retriesPerformedSoFar: 2,
+        })
+
+        expect(retryQueue.length).toEqual(1)
+        expect(retryQueue['_queue'][0].requestOptions.retriesPerformedSoFar).toEqual(3)
     })
 
     it('only calls the callback when successful', () => {

--- a/packages/browser/src/retry-queue.ts
+++ b/packages/browser/src/retry-queue.ts
@@ -90,7 +90,7 @@ export class RetryQueue {
 
                     if (response.statusCode === 0) {
                         logger.warn(
-                            `Request failed before receiving an HTTP response; this can happen due to network issues, CORS, browser blocking, or ad blockers. Stopped retrying after ${STATUS_CODE_ZERO_MAX_RETRIES} retries.`
+                            `Request failed before receiving an HTTP response; this can happen due to network issues, CORS, browser blocking, or ad blockers. Stopped retrying after ${retriesPerformedSoFar ?? 0} retries.`
                         )
                     }
                 }

--- a/packages/browser/src/retry-queue.ts
+++ b/packages/browser/src/retry-queue.ts
@@ -8,6 +8,8 @@ import { extendURLParams } from './request'
 import { addEventListener } from './utils'
 
 const thirtyMinutes = 30 * 60 * 1000
+const DEFAULT_MAX_RETRIES = 10
+const STATUS_CODE_ZERO_MAX_RETRIES = 3
 
 /**
  * Generates a jitter-ed exponential backoff delay in milliseconds
@@ -76,12 +78,20 @@ export class RetryQueue {
             ...options,
             callback: (response) => {
                 if (response.statusCode !== 200 && (response.statusCode < 400 || response.statusCode >= 500)) {
-                    if ((retriesPerformedSoFar ?? 0) < 10) {
+                    const maxRetries = response.statusCode === 0 ? STATUS_CODE_ZERO_MAX_RETRIES : DEFAULT_MAX_RETRIES
+
+                    if ((retriesPerformedSoFar ?? 0) < maxRetries) {
                         this._enqueue({
                             retriesPerformedSoFar,
                             ...options,
                         })
                         return
+                    }
+
+                    if (response.statusCode === 0) {
+                        logger.warn(
+                            `Request failed before receiving an HTTP response; this can happen due to network issues, CORS, browser blocking, or ad blockers. Stopped retrying after ${STATUS_CODE_ZERO_MAX_RETRIES} retries.`
+                        )
                     }
                 }
 


### PR DESCRIPTION
## Problem

When a browser request fails before receiving an HTTP response, the SDK reports `statusCode: 0`. This can happen due to network issues, CORS, browser blocking, or ad blockers. These failures currently use the same retry cap as server errors, which creates too much retry traffic in blocked-request scenarios like 
Closes #1598.

## Changes

- Keep the existing 10-retry cap for normal retryable failures.
- Cap `statusCode: 0` retries at 3.
- Log a warning when `statusCode: 0` retries are exhausted, explaining the likely causes.
- Add retry queue tests for the new cap and warning.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi after investigating #1598. The chosen approach keeps existing retry behavior for HTTP/server failures, while shortening retries for transport-level failures that never receive an HTTP response. Validation included a focused Jest run for `retry-queue.test.ts` and ESLint on the changed files.
