### PR TITLE
fix(flags): type finalFlags to fix TS2345 build break in updateFlags

### DIFF
--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -342,7 +342,7 @@ export class PostHogFeatureFlags implements Extension {
         // Merge against the raw stored flags/payloads, not the override-applied getters.
         const existingFlags = options?.merge ? (this._prop(ENABLED_FEATURE_FLAGS) ?? {}) : {}
         const existingPayloads = options?.merge ? (this._prop(PERSISTENCE_FEATURE_FLAG_PAYLOADS) ?? {}) : {}
-        const finalFlags = { ...existingFlags, ...flags }
+        const finalFlags: Record<string, boolean | string> = { ...existingFlags, ...flags }
         const finalPayloads = { ...existingPayloads, ...payloads }
 
         // Convert simple flags to v4 format to avoid deprecation warning


### PR DESCRIPTION
## Problem

The approved `posthog-js` release failed its version-bump step because typecheck broke:

```
src/posthog-featureflags.ts(353,46): error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'FeatureFlagValue'.
src/posthog-featureflags.ts(354,46): error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'FeatureFlagValue'.
```

`PostHogFeatureFlags._prop` returns `any`, so spreading the stored flags into `finalFlags` in `updateFlags` widened its entry values to `unknown`. Passing those to `getEnabledFromValue` / `getVariantFromValue` (which expect `FeatureFlagValue = string | boolean`) failed to compile.

## Changes

Annotated `finalFlags` as `Record<string, boolean | string>` so its entry values keep the expected `FeatureFlagValue` type. Pure type annotation — no runtime behavior change. `pnpm typecheck` now passes clean for the browser package.

## Why

Unblocks the already-approved release that failed to bump versions.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread where the release bot reported the failing version bump. Reproduced the two `TS2345` errors, traced them to `_prop`'s `any` return widening the spread result to `unknown`, and fixed by annotating `finalFlags`. Verified by building the `@posthog/types`, `@posthog/core`, and rrweb workspace deps and running `pnpm typecheck` in `packages/browser` to a clean exit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A3UEVDDNF/p1781702860389329?thread_ts=1781702860.389329&cid=C0A3UEVDDNF)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds an explicit type annotation to `finalFlags` in `updateFlags` to prevent TypeScript from widening the spread result to `unknown` (caused by `_prop` returning `any`), fixing a TS2345 build break that blocked the release.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ed967695dd0277363242020e322453772a38f1e6.</sup>
<!-- /MENDRAL_SUMMARY -->