### PR TITLE
fix(browser): type merged feature flag values

### DIFF
--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -340,10 +340,14 @@ export class PostHogFeatureFlags implements Extension {
         options?: { merge?: boolean }
     ): void {
         // Merge against the raw stored flags/payloads, not the override-applied getters.
-        const existingFlags = options?.merge ? (this._prop(ENABLED_FEATURE_FLAGS) ?? {}) : {}
-        const existingPayloads = options?.merge ? (this._prop(PERSISTENCE_FEATURE_FLAG_PAYLOADS) ?? {}) : {}
-        const finalFlags = { ...existingFlags, ...flags }
-        const finalPayloads = { ...existingPayloads, ...payloads }
+        const existingFlags: Record<string, boolean | string> = options?.merge
+            ? (this._prop(ENABLED_FEATURE_FLAGS) ?? {})
+            : {}
+        const existingPayloads: Record<string, JsonType> = options?.merge
+            ? (this._prop(PERSISTENCE_FEATURE_FLAG_PAYLOADS) ?? {})
+            : {}
+        const finalFlags: Record<string, boolean | string> = { ...existingFlags, ...flags }
+        const finalPayloads: Record<string, JsonType> = { ...existingPayloads, ...payloads }
 
         // Convert simple flags to v4 format to avoid deprecation warning
         const flagDetails: Record<string, FeatureFlagDetail> = {}


### PR DESCRIPTION
## Problem

The release workflow failed while building `posthog-js` after two recently merged flag changes interacted. `updateFlags(..., { merge: true })` now reads existing flags from raw persistence, which is untyped, and the follow-up refactor passes those merged values into core flag helpers that expect `FeatureFlagValue`.

## Changes

- Type the raw persisted flags and payloads used during `updateFlags` merge.
- Type the final merged flag and payload maps so `Object.entries(finalFlags)` yields boolean/string values instead of `unknown`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [ ] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to investigate the release TypeScript failure, isolate the interaction between the two flag PRs, and make the smallest type-only fix in `packages/browser/src/posthog-featureflags.ts`. Validation attempted `pnpm --filter posthog-js typecheck`; the original feature flag error is resolved, but local typecheck still reports unrelated `$unset` type errors in `packages/browser/src/posthog-core.ts`.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds explicit type annotations to intermediate variables in `updateFlags` merge logic so that values read from untyped persistence are properly narrowed before being passed to typed flag helpers.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 65ad82419176e9388aba7e6a2f9ee5a6af6059eb.</sup>
<!-- /MENDRAL_SUMMARY -->