### PR TITLE
feat(replay): rotate recording session at a configurable size budget

### DIFF
--- a/.changeset/replay-size-rotation.md
+++ b/.changeset/replay-size-rotation.md
@@ -1,0 +1,9 @@
+---
+'posthog-js': minor
+---
+
+feat(replay): rotate the recording session when it reaches a size budget
+
+Adds a `session_recording.maxSessionSizeMb` option that rotates a recording to a new, linked session once the session's flushed size reaches the budget. It defaults to `300` when using the `2026-05-30` defaults (off otherwise) and is clamped to the 1–500 MiB range; it is normally only changed after interaction with the PostHog support team.
+
+The previous session is linked to the new one via the existing `$session_ending` / `$session_starting` events, and a `$session_size_rotation` custom event marks the point at which the rotation happened. This bounds any single recording so it stays playable and within ingestion limits, without dropping data or interrupting recording.

--- a/packages/browser/src/__tests__/config.test.ts
+++ b/packages/browser/src/__tests__/config.test.ts
@@ -34,6 +34,22 @@ describe('config', () => {
                 content_ignorelist: DEFAULT_CONTENT_IGNORELIST_WITH_STEPPERS,
                 ignore_text_selection: true,
             })
+            expect(posthog.config.session_recording).toStrictEqual({
+                strictMinimumDuration: true,
+                maxSessionSizeMb: 300,
+            })
+        })
+
+        it('does not set maxSessionSizeMb before the 2026-05-30 defaults', () => {
+            const posthog = new PostHog()
+            posthog._init('test-token', { defaults: '2025-11-30' })
+            expect(posthog.config.session_recording.maxSessionSizeMb).toBeUndefined()
+        })
+
+        it('lets an explicit maxSessionSizeMb override the date-gated default', () => {
+            const posthog = new PostHog()
+            posthog._init('test-token', { defaults: '2026-05-30', session_recording: { maxSessionSizeMb: 100 } })
+            expect(posthog.config.session_recording.maxSessionSizeMb).toEqual(100)
         })
 
         it('merges a partial rageclick object with the date-gated defaults', () => {

--- a/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
+++ b/packages/browser/src/__tests__/extensions/replay/lazy-sessionrecording.test.ts
@@ -4096,6 +4096,72 @@ describe('Lazy SessionRecording', () => {
             expect(tryAddCustomEvent).toHaveBeenCalledTimes(3)
         })
 
+        it('emits session linking events on session maximum size', () => {
+            const tryAddCustomEvent = sessionRecording['_lazyLoadedSessionRecording']['_tryAddCustomEvent'] as any
+            tryAddCustomEvent.mockClear()
+
+            const newSessionId = 'new-session-id-size'
+            const newWindowId = 'new-window-id-size'
+
+            sessionManager['_sessionIdChangedHandlers'].forEach((handler) => {
+                handler(newSessionId, newWindowId, {
+                    noSessionId: false,
+                    activityTimeout: false,
+                    sessionPastMaximumLength: false,
+                    sessionMaximumSize: true,
+                })
+            })
+
+            expect(tryAddCustomEvent).toHaveBeenCalledWith(
+                '$session_ending',
+                expect.objectContaining({ currentSessionId: sessionId, nextSessionId: newSessionId })
+            )
+            expect(tryAddCustomEvent).toHaveBeenCalledWith(
+                '$session_starting',
+                expect.objectContaining({ previousSessionId: sessionId, nextSessionId: newSessionId })
+            )
+        })
+
+        describe('size-based rotation', () => {
+            const oneMb = 1024 * 1024
+            let recorder: any
+            let rotateSpy: jest.SpyInstance
+
+            beforeEach(() => {
+                recorder = sessionRecording['_lazyLoadedSessionRecording']
+                config.session_recording.maxSessionSizeMb = 1
+                rotateSpy = jest.spyOn(sessionManager, 'rotateSessionForReplaySize').mockImplementation(() => {})
+                ;(recorder['_tryAddCustomEvent'] as any).mockClear()
+            })
+
+            it('rotates and emits $session_size_rotation once the budget is reached', () => {
+                recorder['_flushedSizeTracker'].trackSize(recorder.sessionId, 2 * oneMb)
+
+                recorder['_maybeRotateForSessionSize']()
+
+                expect(recorder['_tryAddCustomEvent']).toHaveBeenCalledWith(
+                    '$session_size_rotation',
+                    expect.objectContaining({ thresholdBytes: oneMb, sizeBytes: expect.any(Number) })
+                )
+                expect(rotateSpy).toHaveBeenCalledTimes(1)
+            })
+
+            it('does not rotate below the budget', () => {
+                recorder['_maybeRotateForSessionSize']()
+
+                expect(rotateSpy).not.toHaveBeenCalled()
+            })
+
+            it('does not rotate when maxSessionSizeMb is unset', () => {
+                config.session_recording.maxSessionSizeMb = undefined
+                recorder['_flushedSizeTracker'].trackSize(recorder.sessionId, 10 * oneMb)
+
+                recorder['_maybeRotateForSessionSize']()
+
+                expect(rotateSpy).not.toHaveBeenCalled()
+            })
+        })
+
         it('includes flushed_size with actual data size in session ending event', () => {
             const tryAddCustomEvent = sessionRecording['_lazyLoadedSessionRecording']['_tryAddCustomEvent'] as any
 

--- a/packages/browser/src/__tests__/sessionid.test.ts
+++ b/packages/browser/src/__tests__/sessionid.test.ts
@@ -1198,4 +1198,34 @@ describe('Session ID manager', () => {
             jest.useRealTimers()
         })
     })
+
+    describe('rotateSessionForReplaySize', () => {
+        it('mints a new session and notifies handlers with sessionMaximumSize (not a reset)', () => {
+            const sessionIdManager = sessionIdMgr(persistence)
+            sessionIdManager.checkAndGetSessionAndWindowId(undefined, timestamp)
+            const handler = jest.fn()
+            sessionIdManager.onSessionId(handler)
+            handler.mockClear() // ignore the immediate emit on registration
+            ;(uuidv7 as jest.Mock).mockReturnValue('rotated-id')
+
+            sessionIdManager.rotateSessionForReplaySize()
+
+            expect(handler).toHaveBeenCalledTimes(1)
+            expect(handler).toHaveBeenCalledWith(
+                'rotated-id',
+                'rotated-id',
+                expect.objectContaining({ sessionMaximumSize: true, noSessionId: false })
+            )
+        })
+
+        it('persists the rotated session id so it is read back', () => {
+            const sessionIdManager = sessionIdMgr(persistence)
+            sessionIdManager.checkAndGetSessionAndWindowId(undefined, timestamp)
+            ;(uuidv7 as jest.Mock).mockReturnValue('rotated-id')
+
+            sessionIdManager.rotateSessionForReplaySize()
+
+            expect(sessionIdManager.checkAndGetSessionAndWindowId(true, now).sessionId).toEqual('rotated-id')
+        })
+    })
 })

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -487,6 +487,35 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         return this._instance.sessionManager
     }
 
+    // The size budget (in bytes) after which the current recording session is rotated,
+    // or undefined when size-based rotation is disabled. Configured in MiB and clamped to
+    // the supported 1-500 range (see SessionRecordingOptions.maxSessionSizeMb).
+    private get _maxSessionSizeBytes(): number | undefined {
+        const configuredMb = this._instance.config.session_recording?.maxSessionSizeMb
+        if (!isNumber(configuredMb)) {
+            return undefined
+        }
+        const clampedMb = Math.min(500, Math.max(1, configuredMb))
+        return clampedMb * 1024 * 1024
+    }
+
+    private _maybeRotateForSessionSize(): void {
+        const maxBytes = this._maxSessionSizeBytes
+        if (!maxBytes) {
+            return
+        }
+
+        const currentSize = this._flushedSizeTracker?.currentTrackedSize(this.sessionId) ?? 0
+        if (currentSize < maxBytes) {
+            return
+        }
+
+        // mark where the old session reached its budget, then rotate to a new linked session.
+        // the new session's tracker starts at zero, so this won't immediately re-fire.
+        this._tryAddCustomEvent('$session_size_rotation', { sizeBytes: currentSize, thresholdBytes: maxBytes })
+        this._sessionManager.rotateSessionForReplaySize()
+    }
+
     private get _sessionIdleThresholdMilliseconds(): number {
         return this._instance.config.session_recording.session_idle_threshold_ms || RECORDING_IDLE_THRESHOLD_MS
     }
@@ -1044,7 +1073,8 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         const wasLikelyReset = changeReason.noSessionId
         const shouldLinkSessions =
-            !wasLikelyReset && (changeReason.activityTimeout || changeReason.sessionPastMaximumLength)
+            !wasLikelyReset &&
+            (changeReason.activityTimeout || changeReason.sessionPastMaximumLength || changeReason.sessionMaximumSize)
 
         // Capture old IDs before start() updates them
         const oldSessionId = this._sessionId
@@ -1562,7 +1592,10 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
         }
 
         // buffer is empty, we clear it in case the session id has changed
-        return this._clearBuffer()
+        const flushedBuffer = this._clearBuffer()
+        // rotate after clearing so the rotation custom events land in the fresh buffer
+        this._maybeRotateForSessionSize()
+        return flushedBuffer
     }
 
     private _hasPassedMinimumDuration = (): boolean => {

--- a/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
+++ b/packages/browser/src/extensions/replay/external/lazy-loaded-session-recorder.ts
@@ -112,6 +112,11 @@ export const SESSION_RECORDING_BATCH_KEY = 'recordings'
 const LOGGER_PREFIX = '[SessionRecording]'
 const logger = createLogger(LOGGER_PREFIX)
 
+const BYTES_PER_MIB = 1024 * 1024
+// supported range for session_recording.maxSessionSizeMb; 500 is a hard SDK ceiling
+const MIN_SESSION_SIZE_MB = 1
+const MAX_SESSION_SIZE_MB = 500
+
 interface QueuedRRWebEvent {
     rrwebMethod: () => void
     attempt: number
@@ -492,11 +497,11 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
     // the supported 1-500 range (see SessionRecordingOptions.maxSessionSizeMb).
     private get _maxSessionSizeBytes(): number | undefined {
         const configuredMb = this._instance.config.session_recording?.maxSessionSizeMb
-        if (!isNumber(configuredMb)) {
+        if (!isNumber(configuredMb) || !Number.isFinite(configuredMb)) {
             return undefined
         }
-        const clampedMb = Math.min(500, Math.max(1, configuredMb))
-        return clampedMb * 1024 * 1024
+        const clampedMb = Math.min(MAX_SESSION_SIZE_MB, Math.max(MIN_SESSION_SIZE_MB, configuredMb))
+        return clampedMb * BYTES_PER_MIB
     }
 
     private _maybeRotateForSessionSize(): void {
@@ -512,7 +517,12 @@ export class LazyLoadedSessionRecording implements LazyLoadedSessionRecordingInt
 
         // mark where the old session reached its budget, then rotate to a new linked session.
         // the new session's tracker starts at zero, so this won't immediately re-fire.
-        this._tryAddCustomEvent('$session_size_rotation', { sizeBytes: currentSize, thresholdBytes: maxBytes })
+        // overshootBytes makes the (multi-tab undercount driven) late-firing observable.
+        this._tryAddCustomEvent('$session_size_rotation', {
+            sizeBytes: currentSize,
+            thresholdBytes: maxBytes,
+            overshootBytes: currentSize - maxBytes,
+        })
         this._sessionManager.rotateSessionForReplaySize()
     }
 

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -201,7 +201,12 @@ const defaultsThatVaryByConfig = (
               ? { content_ignorelist: true }
               : true,
     capture_pageview: defaults && defaults >= '2025-05-24' ? 'history_change' : true,
-    session_recording: defaults && defaults >= '2025-11-30' ? { strictMinimumDuration: true } : {},
+    session_recording:
+        defaults && defaults >= '2026-05-30'
+            ? { strictMinimumDuration: true, maxSessionSizeMb: 300 }
+            : defaults && defaults >= '2025-11-30'
+              ? { strictMinimumDuration: true }
+              : {},
     external_scripts_inject_target: defaults && defaults >= '2026-01-30' ? 'head' : 'body',
     internal_or_test_user_hostname: defaults && defaults >= '2026-01-30' ? /^(localhost|127\.0\.0\.1)$/ : undefined,
     persistence_save_debounce_ms: defaults && defaults >= '2026-05-30' ? 250 : 0,

--- a/packages/browser/src/sessionid.ts
+++ b/packages/browser/src/sessionid.ts
@@ -307,6 +307,28 @@ export class SessionIdManager {
         this._setSessionId(null, null, null)
     }
 
+    // Force a session rotation because the recording reached its size budget.
+    // Unlike resetSessionId() — which nulls the id and reads downstream as a
+    // posthog.reset() (noSessionId), suppressing session linking — this mints a
+    // fresh session immediately and notifies handlers with sessionMaximumSize so
+    // the recorder links the old and new sessions instead of treating it as a wipe.
+    rotateSessionForReplaySize(): void {
+        const timestamp = new Date().getTime()
+        const sessionId = this._sessionIdGenerator()
+        const windowId = this._windowIdGenerator()
+        this._setWindowId(windowId)
+        this._setSessionId(sessionId, timestamp, timestamp)
+        this._resetIdleTimer()
+        const changeReason = {
+            noSessionId: false,
+            activityTimeout: false,
+            sessionPastMaximumLength: false,
+            crossTabAdoption: false,
+            sessionMaximumSize: true,
+        }
+        this._sessionIdChangedHandlers.forEach((handler) => handler(sessionId, windowId, changeReason))
+    }
+
     /**
      * Cleans up resources used by SessionIdManager.
      * Should be called when the SessionIdManager is no longer needed to prevent memory leaks.

--- a/packages/browser/src/sessionid.ts
+++ b/packages/browser/src/sessionid.ts
@@ -312,6 +312,8 @@ export class SessionIdManager {
     // posthog.reset() (noSessionId), suppressing session linking — this mints a
     // fresh session immediately and notifies handlers with sessionMaximumSize so
     // the recorder links the old and new sessions instead of treating it as a wipe.
+    // Handlers run synchronously (as on the checkAndGetSessionAndWindowId rotation
+    // path); they must not synchronously flush, or rotation would re-enter itself.
     rotateSessionForReplaySize(): void {
         const timestamp = new Date().getTime()
         const sessionId = this._sessionIdGenerator()

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -649,7 +649,8 @@ export interface SessionRecordingOptions {
      * session id, linked to the previous one via the `$session_ending` / `$session_starting`
      * events. The point at which it rotates is recorded as a `$session_size_rotation` custom event.
      *
-     * Accepts values between 1 and 500. Values outside that range are clamped.
+     * Accepts values between 1 and 500. Values outside that range are clamped (so `0` becomes
+     * `1`, not "off" — leave it `undefined` to disable size-based rotation).
      * Normally only changed after interaction with the PostHog support team.
      *
      * When `defaults` is `'2026-05-30'` or later this defaults to `300`; otherwise size-based

--- a/packages/types/src/posthog-config.ts
+++ b/packages/types/src/posthog-config.ts
@@ -641,6 +641,23 @@ export interface SessionRecordingOptions {
      * @default undefined
      */
     sampleRate?: number
+
+    /**
+     * ADVANCED: the maximum size in MiB a single recording session may reach before the SDK
+     * rotates to a new, linked session. This keeps any one recording bounded so it stays
+     * playable and within ingestion limits; recording continues uninterrupted under a new
+     * session id, linked to the previous one via the `$session_ending` / `$session_starting`
+     * events. The point at which it rotates is recorded as a `$session_size_rotation` custom event.
+     *
+     * Accepts values between 1 and 500. Values outside that range are clamped.
+     * Normally only changed after interaction with the PostHog support team.
+     *
+     * When `defaults` is `'2026-05-30'` or later this defaults to `300`; otherwise size-based
+     * rotation is off.
+     *
+     * @default undefined
+     */
+    maxSessionSizeMb?: number
 }
 
 // we used to call a request that was sent to the queue with options attached `RequestQueueOptions`

--- a/packages/types/src/session-recording.ts
+++ b/packages/types/src/session-recording.ts
@@ -106,6 +106,8 @@ export type SessionIdChangedCallback = (
         sessionPastMaximumLength: boolean
         /** This tab picked up a session rotation another tab had already written to storage, instead of minting its own. */
         crossTabAdoption?: boolean
+        /** The recording reached its configured size budget, so the SDK rotated to a new linked session. */
+        sessionMaximumSize?: boolean
     }
 ) => void
 


### PR DESCRIPTION
## Problem

Per-session replay size has an extreme tail: web p99.9 is ~338 MiB, ~0.06% of web sessions exceed 500 MiB, and the largest run into the tens of GiB. A small number of unbounded sessions hold a large share of replay storage, strain the player, and push ingestion limits. We want to bound any single recording without losing data or interrupting recording.

## Changes

Adds size-based **session rotation**. When a recording session's flushed bytes reach a configurable budget, the SDK rotates to a new, linked session rather than stopping — so no single recording exceeds the budget, but the recording continues and nothing is dropped.

- **New option `session_recording.maxSessionSizeMb`** — defaults to `300` under the `2026-05-30` defaults bundle (off otherwise), clamped to the **1–500 MiB** range. It carries a comment noting it is normally only changed after interaction with the PostHog support team.
- **Rotation is linked, not a reset** — a new `sessionMaximumSize` change reason drives `SessionIdManager.rotateSessionForReplaySize()`, which mints a fresh session and fires the existing `$session_ending` / `$session_starting` linking events (so the player can stitch the timeline back together). Deliberately *not* `resetSessionId()`, which reads downstream as a `posthog.reset()` and would suppress linking.
- **A `$session_size_rotation` custom event** marks the point in the recording where the budget was reached (`{ sizeBytes, thresholdBytes }`).
- Built on the session-scoped flushed-size tracker that shipped in #3868. The budget check runs after the buffer flush + clear, so the rotation events land in the fresh buffer rather than being discarded.

Units are MiB (matching the server-side `size` column and the SDK's `$sdk_debug_replay_flushed_size`).

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [x] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul directed this, sized the cutoff against cross-team replay data (US + EU, via Metabase), and chose the parameters: a **300 MiB** default with a **1–500 MiB** range, rotation (not hard-stop, so customers keep their data), a session-ended event, and an in-recording custom event marking the rotation point. The threshold and behaviour were chosen because rotation neither saves storage nor meaningfully changes revenue at this scale — its purpose is bounding per-session size, so the value is a guardrail tunable by support rather than a pricing lever.

Decisions made along the way:
- Rotate via a dedicated `sessionMaximumSize` change reason rather than reusing `resetSessionId()`, because the latter suppresses the `$session_ending` linking the player needs.
- Run the budget check *after* `_clearBuffer()` so the rotation custom events aren't discarded with the flushed buffer.
- Default gated behind the `2026-05-30` defaults bundle (off for existing integrations until they opt in), matching how `split_storage` / `persistence_save_debounce_ms` shipped.
- Remote-config override deferred to a follow-up (needs a backend change); this PR is local-config + bundle default only.

Verification (run locally, not manual browser testing): 353 tests pass across the recorder, sessionid, config, and flushed-size-tracker suites — including new coverage for the 300 default, the clamp, the rotation method minting a linked (non-reset) session, and the recorder emitting `$session_size_rotation` + rotating at the budget. Lint clean; `@posthog/types` typechecks.

Note: the underlying session-scoped flushed-size tracker merged separately in #3868; this PR is the rotation feature on top of it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
