### PR TITLE
fix(surveys): re-validate eligibility when the popup delay fires

### DIFF
--- a/.changeset/surveys-revalidate-eligibility-on-delay.md
+++ b/.changeset/surveys-revalidate-eligibility-on-delay.md
@@ -1,0 +1,7 @@
+---
+'posthog-js': patch
+---
+
+Surveys: re-check eligibility when a popover's display delay elapses, instead of only re-checking the URL.
+
+A survey with a display delay could be queued while a visitor was still anonymous (the targeting flag passed for the anonymous profile), and then displayed after the delay even though `identify()` had reloaded feature flags and the survey's internal targeting flag was now false for the identified profile (e.g. a "show once per user" survey the person had already dismissed). The delayed display now re-runs the full display predicate (eligibility, URL/device/selector conditions, event/action trigger, and feature flags) before rendering, so a survey that became ineligible during the delay is no longer shown. Pending delayed surveys are also cancelled promptly when a later evaluation cycle finds them ineligible.

--- a/packages/browser/playwright/mocked/surveys/delay-eligibility-recheck.spec.ts
+++ b/packages/browser/playwright/mocked/surveys/delay-eligibility-recheck.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from '../utils/posthog-playwright-test-base'
+import { start } from '../utils/setup'
+import { WindowWithPostHog } from '../utils/posthog-playwright-test-base'
+import { FlagsResponse } from '@/types'
+
+// Regression test for a "show once per user" survey re-appearing to users who had already
+// dismissed it. The survey's internal targeting flag passes while the visitor is still
+// anonymous, so it is queued with its display delay; identify() then reloads flags and the
+// flag flips to false for the identified profile. The delayed display must re-check
+// eligibility and NOT show the survey.
+
+const INTERNAL_TARGETING_FLAG = 'survey-targeting-recheck-test'
+
+const openTextQuestion = {
+    type: 'open',
+    question: 'What feedback do you have for us?',
+    description: 'plain text description',
+    id: 'open_text_1',
+}
+
+const makeSurvey = (id: string) => ({
+    id,
+    name: 'Delayed targeted survey',
+    description: 'description',
+    type: 'popover',
+    start_date: '2021-01-01T00:00:00Z',
+    questions: [openTextQuestion],
+    internal_targeting_flag_key: INTERNAL_TARGETING_FLAG,
+    appearance: { surveyPopupDelaySeconds: 2 },
+})
+
+// A complete `/flags` response with the internal targeting flag set to `enabled`.
+const flagsResponseWith = (enabled: boolean): Partial<FlagsResponse> =>
+    ({
+        editorParams: {},
+        flags: {
+            [INTERNAL_TARGETING_FLAG]: {
+                key: INTERNAL_TARGETING_FLAG,
+                enabled,
+                variant: undefined,
+                reason: {
+                    code: enabled ? 'condition_match' : 'no_condition_match',
+                    condition_index: 0,
+                    description: 'test',
+                },
+                metadata: { id: 1, version: 1, description: undefined, payload: undefined },
+            },
+        },
+        featureFlags: { [INTERNAL_TARGETING_FLAG]: enabled },
+        featureFlagPayloads: {},
+        errorsWhileComputingFlags: false,
+        toolbarParams: {},
+        toolbarVersion: 'toolbar',
+        isAuthenticated: false,
+        siteApps: [],
+        supportedCompression: [],
+        autocaptureExceptions: false,
+        surveys: true,
+        sessionRecording: false,
+    }) as unknown as Partial<FlagsResponse>
+
+const startOptions = {
+    options: {},
+    // Anonymous load: the targeting flag is enabled, so the survey is eligible and queued.
+    flagsResponseOverrides: flagsResponseWith(true),
+    url: './playground/cypress/index.html',
+}
+
+test.describe('surveys - re-validate eligibility when the display delay elapses', () => {
+    test('does not show a delayed survey once identify() flips its targeting flag to false', async ({
+        page,
+        context,
+    }) => {
+        const survey = makeSurvey('delay-recheck-suppressed')
+        await page.route('**/surveys/**', (route) => route.fulfill({ json: { surveys: [survey] } }))
+
+        await start(startOptions, page, context)
+
+        // identify() reloads flags; replace the flags mock so the identified profile is no
+        // longer targeted (unroute first so this handler, not the anonymous one, serves the reload).
+        await context.unroute('**/flags/*')
+        await context.route('**/flags/*', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify(flagsResponseWith(false)),
+            })
+        )
+        await page.evaluate(() => (window as WindowWithPostHog).posthog?.identify('identified-user-123'))
+
+        // Wait past the 2s display delay; the survey must never render.
+        await page.waitForTimeout(3500)
+        await expect(page.locator('.PostHogSurvey-delay-recheck-suppressed').locator('.survey-form')).not.toBeVisible()
+    })
+
+    test('still shows a delayed survey that stays targeted (no identify)', async ({ page, context }) => {
+        const survey = makeSurvey('delay-recheck-control')
+        await page.route('**/surveys/**', (route) => route.fulfill({ json: { surveys: [survey] } }))
+
+        await start(startOptions, page, context)
+
+        // Flag stays enabled throughout: the survey appears once the delay elapses.
+        await expect(page.locator('.PostHogSurvey-delay-recheck-control').locator('.survey-form')).toBeVisible({
+            timeout: 8000,
+        })
+    })
+})

--- a/packages/browser/src/__tests__/extensions/surveys.test.ts
+++ b/packages/browser/src/__tests__/extensions/surveys.test.ts
@@ -388,6 +388,83 @@ describe('SurveyManager', () => {
         expect(addSurveyToFocusSpy).toHaveBeenCalledTimes(1)
     })
 
+    describe('re-validates eligibility when the popover delay elapses', () => {
+        const INTERNAL_FLAG = 'enabled-internal-targeting-flag-key'
+
+        const makeDelayedSurvey = (id: string): Survey => ({
+            ...mockSurveys[0],
+            id,
+            internal_targeting_flag_key: INTERNAL_FLAG,
+            appearance: { surveyPopupDelaySeconds: 30 },
+        })
+
+        const setInternalFlagEnabled = (enabled: boolean): void => {
+            mockPostHog.featureFlags.isFeatureEnabled = jest
+                .fn()
+                .mockImplementation((key: string) =>
+                    key === INTERNAL_FLAG ? enabled : (flagsResponse.featureFlags as Record<string, boolean>)[key]
+                )
+        }
+
+        afterEach(() => {
+            jest.useRealTimers()
+        })
+
+        it('does not display a survey that became ineligible during the delay (delay re-check)', () => {
+            jest.useFakeTimers()
+            const survey = makeDelayedSurvey('delayed-survey-recheck')
+            mockPostHog.surveys.getSurveys = jest.fn((cb) => cb([survey]))
+            setInternalFlagEnabled(true)
+
+            // queued while eligible: focus claimed, timer pending, not yet shown
+            surveyManager.callSurveysAndEvaluateDisplayLogic(true)
+            expect(surveyManager.getTestAPI().surveyInFocus).toBe(survey.id)
+            expect(surveyManager.getTestAPI().surveyTimeouts.has(survey.id)).toBe(true)
+
+            // identify() during the delay reloads flags; the internal targeting flag is now false
+            setInternalFlagEnabled(false)
+
+            jest.advanceTimersByTime(30000)
+
+            // the survey is dropped instead of shown: focus released, timer cleared
+            expect(surveyManager.getTestAPI().surveyInFocus).toBe(null)
+            expect(surveyManager.getTestAPI().surveyTimeouts.has(survey.id)).toBe(false)
+        })
+
+        it('still displays a survey that stays eligible through the delay (regression guard)', () => {
+            jest.useFakeTimers()
+            const survey = makeDelayedSurvey('delayed-survey-eligible')
+            mockPostHog.surveys.getSurveys = jest.fn((cb) => cb([survey]))
+            setInternalFlagEnabled(true)
+
+            surveyManager.callSurveysAndEvaluateDisplayLogic(true)
+            expect(surveyManager.getTestAPI().surveyInFocus).toBe(survey.id)
+
+            jest.advanceTimersByTime(30000)
+
+            // shown: focus is retained (released only on dismiss/close), pending timer consumed
+            expect(surveyManager.getTestAPI().surveyInFocus).toBe(survey.id)
+            expect(surveyManager.getTestAPI().surveyTimeouts.has(survey.id)).toBe(false)
+        })
+
+        it('cancels a pending survey when a later evaluation cycle finds it ineligible', () => {
+            jest.useFakeTimers()
+            const survey = makeDelayedSurvey('delayed-survey-cancel')
+            mockPostHog.surveys.getSurveys = jest.fn((cb) => cb([survey]))
+            setInternalFlagEnabled(true)
+
+            surveyManager.callSurveysAndEvaluateDisplayLogic(true)
+            expect(surveyManager.getTestAPI().surveyTimeouts.has(survey.id)).toBe(true)
+
+            // flag flips, then the 1s evaluation cycle runs again before the delay elapses
+            setInternalFlagEnabled(false)
+            surveyManager.callSurveysAndEvaluateDisplayLogic(true)
+
+            expect(surveyManager.getTestAPI().surveyTimeouts.has(survey.id)).toBe(false)
+            expect(surveyManager.getTestAPI().surveyInFocus).toBe(null)
+        })
+    })
+
     test('callSurveysAndEvaluateDisplayLogic should handle popup surveys correctly', () => {
         const handlePopoverSurveyMock = jest
             .spyOn(surveyManager as any, 'handlePopoverSurvey')

--- a/packages/browser/src/extensions/surveys.tsx
+++ b/packages/browser/src/extensions/surveys.tsx
@@ -245,7 +245,12 @@ export class SurveyManager {
             // remove survey to keep `_surveyTimeouts` as a true list of "pending" surveys
             this._surveyTimeouts.delete(survey.id)
 
-            if (!doesSurveyUrlMatch(survey)) {
+            // Re-check the full display predicate, not just the URL: eligibility can change
+            // during the delay (e.g. identify() reloads flags and the internal targeting flag
+            // flips to false), and we must not show a survey that is no longer eligible by the
+            // time the delay elapses.
+            if (!this._shouldDisplaySurvey(survey)) {
+                logger.info(`Survey ${survey.id} no longer eligible when its display delay elapsed; not displaying`)
                 return this._removeSurveyFromFocus(survey)
             }
             // rendering with surveyPopupDelaySeconds = 0 because we're already handling the timeout here
@@ -663,18 +668,28 @@ export class SurveyManager {
         })
     }
 
+    /**
+     * The full predicate for "should this survey display right now": eligibility (running,
+     * type, linked/targeting/internal flags, wait period, already-seen) plus the URL/device/
+     * selector conditions, the event/action trigger, and any feature-flag dependencies.
+     *
+     * Shared by the display loop and re-checked when a popover's delay timer fires, so a
+     * survey that became ineligible *during* the delay (e.g. an identify() reloaded flags and
+     * the internal targeting flag is now false) is not shown. Note this is purely an AND gate:
+     * adding it can only ever suppress a display, never cause an extra one.
+     */
+    private _shouldDisplaySurvey(survey: Survey): boolean {
+        return (
+            this.checkSurveyEligibility(survey).eligible &&
+            this._isSurveyConditionMatched(survey) &&
+            this._hasActionOrEventTriggeredSurvey(survey) &&
+            this._checkFlags(survey)
+        )
+    }
+
     public getActiveMatchingSurveys = (callback: SurveyCallback, forceReload = false): void => {
         this._posthog?.surveys?.getSurveys((surveys) => {
-            const targetingMatchedSurveys = surveys.filter((survey) => {
-                const eligibility = this.checkSurveyEligibility(survey)
-                return (
-                    eligibility.eligible &&
-                    this._isSurveyConditionMatched(survey) &&
-                    this._hasActionOrEventTriggeredSurvey(survey) &&
-                    this._checkFlags(survey)
-                )
-            })
-
+            const targetingMatchedSurveys = surveys.filter((survey) => this._shouldDisplaySurvey(survey))
             callback(targetingMatchedSurveys)
         }, forceReload)
     }
@@ -684,6 +699,17 @@ export class SurveyManager {
             const inAppSurveysWithDisplayLogic = surveys.filter(
                 (survey) => survey.type === SurveyType.Popover || survey.type === SurveyType.Widget
             )
+
+            // Cancel any pending (delayed, not-yet-shown) survey whose eligibility changed since
+            // it was queued — e.g. an identify() during the delay flipped its targeting flag.
+            // This frees the popover focus promptly instead of waiting for a now-stale timer to
+            // fire. Safe for already-shown surveys: their timer is gone, so cancelSurvey no-ops.
+            const matchingIds = new Set(inAppSurveysWithDisplayLogic.map((survey) => survey.id))
+            for (const pendingSurveyId of Array.from(this._surveyTimeouts.keys())) {
+                if (!matchingIds.has(pendingSurveyId)) {
+                    this.cancelSurvey(pendingSurveyId)
+                }
+            }
 
             // Create a queue of surveys sorted by their appearance delay.  We will evaluate the display logic
             // for each survey in the queue in order, and only display one survey at a time.

--- a/packages/browser/terser-mangled-names.json
+++ b/packages/browser/terser-mangled-names.json
@@ -605,6 +605,7 @@
         "_sharedState",
         "_shouldCapturePageleave",
         "_shouldDisableFlags",
+        "_shouldDisplaySurvey",
         "_shouldIncludeEvaluationEnvironments",
         "_showOrQueueTour",
         "_showPreviewWebExperiment",


### PR DESCRIPTION
## Problem

A popover survey with a display delay (for example a "show once per user" survey gated by the auto-generated internal targeting flag) could re-appear to users who had already dismissed or answered it.

A survey's eligibility is decided at the moment it is queued. On a site that calls `identify()` shortly after page load, a survey can pass eligibility against the still-**anonymous** profile (which has no dismissal history), start its display-delay timer, and then render when the delay elapses — even though `identify()` has since reloaded feature flags and the survey's internal targeting flag is now **false** for the identified profile. The delay-timer callback only re-checked `doesSurveyUrlMatch`, never eligibility, so the now-ineligible survey was shown anyway.

This was confirmed against a customer's data: an anonymous `$pageview`, then `$identify`, then `survey shown` after the configured delay, for a user whose profile was already marked dismissed.

## Changes

- Extract the full display predicate (eligibility + URL/device/selector conditions + event/action trigger + feature-flag dependencies) into a single `_shouldDisplaySurvey` helper, used by both the display loop and the delay-timer callback so the two can't drift.
- The popover delay-timer callback now re-runs `_shouldDisplaySurvey` (not just the URL check) before rendering, so a survey that became ineligible during the delay is dropped instead of shown.
- The evaluation loop now cancels any pending (delayed, not-yet-shown) survey that is no longer in the active-matching set, freeing the popover focus promptly instead of waiting for a stale timer.
- The re-check is purely an additional AND gate at render time, so it can only ever **suppress** a display, never cause an extra one. Edge cases are preserved by `checkSurveyEligibility`: in-progress surveys short-circuit to eligible (not withdrawn mid-answer) and `schedule: 'always'` surveys are unaffected.

### Scope / follow-ups (intentionally not in this PR)

- **Zero-delay surveys** are still evaluated against the pre-identify identity (there's no delay window to re-check). Deferring survey evaluation until the first identified flag load is a separate change.
- An **already-rendered** survey is not torn down if its flag flips *after* it's on screen — deliberate, to avoid a survey flashing up and vanishing.
- The same identity-timing gap likely exists in the **mobile SDK** survey display paths and is worth mirroring.

## Release info Sub-libraries affected

### Libraries affected

- [x] posthog-js (web)

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code, directed by the assignee while triaging a surveys support ticket.

- Root cause was found by querying the affected project's events (anonymous `$pageview` → `$identify` → `survey shown` after the configured 30s delay, on a profile already marked `$survey_dismissed`) and then reading the SDK display path to confirm the delay callback only re-checked the URL.
- Considered tearing down already-rendered surveys when a flag flips, but rejected it for this PR because it causes a visible flash-then-disappear; chose to re-validate at the **last responsible moment** (when the delay fires), which is monotonic-safe (can only suppress).
- Tests are unit-level and deterministic. A full browser e2e of the identify → flag-flip → delay sequence would need dynamic `/flags` routing keyed on identity and was left as a follow-up rather than shipped as a potentially flaky test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
