### PR TITLE
fix(browser): remove unused ip query parameter

### DIFF
--- a/.changeset/quiet-pumas-listen.md
+++ b/.changeset/quiet-pumas-listen.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Stop adding the unused `ip` query parameter to browser SDK requests.

--- a/packages/browser/playwright/mocked/session-recording/session-recording-network-recorder.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-recording-network-recorder.spec.ts
@@ -149,10 +149,7 @@ test.beforeEach(async ({ context }) => {
                 expect(hasEntry(/http:\/\/localhost:\d+\/playground\/cypress\//, 'navigation')).toBe(true)
                 expect(hasEntry(/https:\/\/localhost:\d+\/static\/array.js/, 'script')).toBe(true)
                 expect(
-                    hasEntry(
-                        /https:\/\/localhost:\d+\/array\/test%20token\/config\?_=\d+&ver=1\.\d\d\d\.\d+/,
-                        'fetch'
-                    )
+                    hasEntry(/https:\/\/localhost:\d+\/array\/test%20token\/config\?_=\d+&ver=1\.\d\d\d\.\d+/, 'fetch')
                 ).toBe(true)
                 expect(
                     hasEntry(/https:\/\/localhost:\d+\/static\/(lazy-)?recorder.js\?v=1\.\d\d\d\.\d+/, 'script')

--- a/packages/browser/playwright/mocked/session-recording/session-recording-network-recorder.spec.ts
+++ b/packages/browser/playwright/mocked/session-recording/session-recording-network-recorder.spec.ts
@@ -150,7 +150,7 @@ test.beforeEach(async ({ context }) => {
                 expect(hasEntry(/https:\/\/localhost:\d+\/static\/array.js/, 'script')).toBe(true)
                 expect(
                     hasEntry(
-                        /https:\/\/localhost:\d+\/array\/test%20token\/config\?ip=0&_=\d+&ver=1\.\d\d\d\.\d+/,
+                        /https:\/\/localhost:\d+\/array\/test%20token\/config\?_=\d+&ver=1\.\d\d\d\.\d+/,
                         'fetch'
                     )
                 ).toBe(true)

--- a/packages/browser/references/posthog-js-references-latest.json
+++ b/packages/browser/references/posthog-js-references-latest.json
@@ -3565,10 +3565,6 @@
           "name": "noRetries"
         },
         {
-          "type": "boolean",
-          "name": "skipIPParam"
-        },
-        {
           "type": "number",
           "name": "timeout"
         },

--- a/packages/browser/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
+++ b/packages/browser/src/__tests__/extensions/exception-autocapture/exception-observer.test.ts
@@ -155,7 +155,7 @@ describe('Exception Observer', () => {
 
             expect(sendRequestSpy).toHaveBeenCalled()
             const request = sendRequestSpy.mock.calls[0][0]
-            expect(request.url).toBe('http://localhost/e/?ip=0')
+            expect(request.url).toBe('http://localhost/e/')
             expect(request.data).toMatchObject({
                 event: '$exception',
                 properties: {

--- a/packages/browser/src/__tests__/featureflags.test.ts
+++ b/packages/browser/src/__tests__/featureflags.test.ts
@@ -1049,13 +1049,6 @@ describe('featureflags', () => {
             expect(instance._send_request.mock.calls[0][0].data.disable_flags).toBe(undefined)
         })
 
-        it('sends the flags request with skipIPParam so the ip query param is omitted', () => {
-            featureFlags.reloadFeatureFlags()
-            jest.runOnlyPendingTimers()
-
-            expect(instance._send_request.mock.calls[0][0].skipIPParam).toBe(true)
-        })
-
         it('should call /flags with flags disabled if advanced_disable_feature_flags is set', () => {
             instance.config.advanced_disable_feature_flags = true
             // Call _callFlagsEndpoint directly because reloadFeatureFlags() returns early
@@ -3200,12 +3193,6 @@ describe('getRemoteConfigPayload', () => {
         })
 
         featureFlags = new PostHogFeatureFlags(instance)
-    })
-
-    it('sends the request with skipIPParam so the ip query param is omitted', () => {
-        featureFlags.getRemoteConfigPayload('test-flag', jest.fn())
-
-        expect(instance._send_request).toHaveBeenCalledWith(expect.objectContaining({ skipIPParam: true }))
     })
 
     it('should include evaluation_contexts when configured', () => {

--- a/packages/browser/src/__tests__/posthog-core-also.test.ts
+++ b/packages/browser/src/__tests__/posthog-core-also.test.ts
@@ -1710,16 +1710,12 @@ describe('posthog core', () => {
     })
 })
 
-describe('_send_request skipIPParam', () => {
-    it('omits the ip query param when skipIPParam is set, and keeps it otherwise', async () => {
+describe('_send_request', () => {
+    it('does not add an ip query param', async () => {
         const posthog = await createPosthogInstance(uuidv7(), { persistence: 'memory' })
-
-        const flagsRequest = { url: 'http://localhost/flags/?v=2', skipIPParam: true }
-        posthog._send_request(flagsRequest)
-        expect(flagsRequest.url).toBe('http://localhost/flags/?v=2')
 
         const eventRequest = { url: 'http://localhost/e/' }
         posthog._send_request(eventRequest)
-        expect(eventRequest.url).toMatch(/[?&]ip=/)
+        expect(eventRequest.url).toBe('http://localhost/e/')
     })
 })

--- a/packages/browser/src/posthog-core.ts
+++ b/packages/browser/src/posthog-core.ts
@@ -40,7 +40,7 @@ import {
 import { ProductTourEventName, ProductTourEventProperties } from './posthog-product-tours-types'
 import { RateLimiter } from './rate-limiter'
 import { RemoteConfigLoader } from './remote-config'
-import { extendURLParams, request, SUPPORTS_REQUEST } from './request'
+import { request, SUPPORTS_REQUEST } from './request'
 import { DEFAULT_FLUSH_INTERVAL_MS, RequestQueue } from './request-queue'
 import { RetryQueue } from './retry-queue'
 import { ScrollManager } from './scroll-manager'
@@ -1090,12 +1090,6 @@ export class PostHog implements PostHogInterface {
         }
 
         options.transport = options.transport || this.config.api_transport
-        if (!options.skipIPParam) {
-            options.url = extendURLParams(options.url, {
-                // Whether to detect ip info or not
-                ip: this.config.ip ? 1 : 0,
-            })
-        }
         options.headers = {
             ...this.config.request_headers,
             ...options.headers,

--- a/packages/browser/src/posthog-featureflags.ts
+++ b/packages/browser/src/posthog-featureflags.ts
@@ -603,8 +603,6 @@ export class PostHogFeatureFlags implements Extension {
             method: 'POST',
             url,
             data,
-            // Some ad blockers block /flags requests that carry the `ip` query param; it's unused server-side here.
-            skipIPParam: true,
             compression: this._config.disable_compression ? undefined : Compression.Base64,
             timeout: this._config.feature_flag_request_timeout_ms,
             callback: (response) => {
@@ -913,8 +911,6 @@ export class PostHogFeatureFlags implements Extension {
             method: 'POST',
             url: this._instance.requestRouter.endpointFor('flags', '/flags/?v=2'),
             data,
-            // Some ad blockers block /flags requests that carry the `ip` query param; it's unused server-side here.
-            skipIPParam: true,
             compression: this._config.disable_compression ? undefined : Compression.Base64,
             timeout: this._config.feature_flag_request_timeout_ms,
             callback: (response) => {

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -193,10 +193,6 @@ export interface RequestWithOptions {
     callback?: (response: RequestResponse) => void
     timeout?: number
     noRetries?: boolean
-    // Omit the `ip` query param from the request URL. The param is meaningful for event ingestion
-    // and session recording, but not for flags requests. Flags requests set this so the URL doesn't
-    // match ad-blocker filters that key on `/flags…ip=`.
-    skipIPParam?: boolean
     disableTransport?: ('XHR' | 'fetch' | 'sendBeacon')[]
     compression?: Compression | 'best-available'
     fetchOptions?: {

--- a/packages/browser/testcafe/helpers.js
+++ b/packages/browser/testcafe/helpers.js
@@ -19,7 +19,7 @@ export const {
 
 const HEADERS = { Authorization: `Bearer ${POSTHOG_PERSONAL_API_KEY}` }
 
-export const captureLogger = RequestLogger(/ip=0/, {
+export const captureLogger = RequestLogger(/\/(e|batch|s)\//, {
     logRequestHeaders: true,
     logRequestBody: true,
     logResponseHeaders: true,


### PR DESCRIPTION
## Problem

The browser SDK still appends an `ip` query parameter to SDK requests even though capture no longer uses it. This creates unnecessary URL surface area for ad blockers without changing ingestion behavior.

## Changes

- Stop adding the `ip` query parameter in the shared browser request path.
- Remove the now-unused `skipIPParam` request option and feature flag special-casing.
- Update browser tests and request logging matchers that expected `ip=0` in SDK request URLs.
- Add a changeset for `posthog-js`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi. Before changing the SDK, we checked capture backend usage: `/e/` and `/batch` ignore the `ip` query parameter, and `beacon=1` only changes the response status to 204 for sendBeacon requests. Based on that, this PR removes the unused browser-side `ip` query parameter logic while preserving the deprecated `ip` config field for compatibility.

Validation attempted: `pnpm --filter=posthog-js test:unit -- --runInBand src/__tests__/posthog-core-also.test.ts src/__tests__/featureflags.test.ts src/__tests__/extensions/exception-autocapture/exception-observer.test.ts`, but it could not run because this worktree has no installed `node_modules` (`jest: command not found`). CI reported a Prettier lint issue and an out-of-date public API reference; this branch now includes the Prettier formatting fix and the updated `posthog-js-references-latest.json` change from `pnpm generate-references`.

