### PR TITLE
fix(ai): use UUID v7 for trace IDs

### DIFF
--- a/.changeset/silver-otters-trace.md
+++ b/.changeset/silver-otters-trace.md
@@ -1,0 +1,5 @@
+---
+'@posthog/ai': patch
+---
+
+Use UUID v7 for generated AI trace identifiers.

--- a/packages/ai/src/captureAiGeneration.ts
+++ b/packages/ai/src/captureAiGeneration.ts
@@ -1,5 +1,4 @@
 import { EventMessage, PostHog } from 'posthog-node'
-import { v4 as uuidv4 } from 'uuid'
 import { uuidv7, ErrorTracking as CoreErrorTracking } from '@posthog/core'
 import { version } from '../package.json'
 import type { TokenUsage } from './types'
@@ -99,7 +98,7 @@ export const captureAiGeneration = async (client: PostHog, options: CaptureAiGen
 
   warnIfPostHogAiGateway(options.baseURL)
 
-  const traceId = options.traceId ?? uuidv4()
+  const traceId = options.traceId ?? uuidv7()
   const eventType = options.eventType ?? AIEvent.Generation
   const privacyMode = options.privacyMode ?? false
   const usage = options.usage ?? {}

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -9,7 +9,7 @@ import type {
   FormattedImageContent,
   FormattedDocumentContent,
 } from './types'
-import { v4 as uuidv4 } from 'uuid'
+import { uuidv7 } from '@posthog/core'
 import { isString } from './typeGuards'
 import { redactBase64DataUrl } from './sanitization'
 
@@ -624,7 +624,7 @@ function addDefaults(params: MonitoringEventProperties): MonitoringEventProperti
   return {
     ...params,
     privacyMode: params.privacyMode ?? false,
-    traceId: params.traceId ?? uuidv4(),
+    traceId: params.traceId ?? uuidv7(),
   }
 }
 

--- a/packages/ai/src/vercel/middleware.ts
+++ b/packages/ai/src/vercel/middleware.ts
@@ -10,7 +10,7 @@ import type {
   LanguageModelV3Prompt,
   LanguageModelV3StreamPart,
 } from '@ai-sdk/provider'
-import { v4 as uuidv4 } from 'uuid'
+import { uuidv7 } from '@posthog/core'
 import { PostHog } from 'posthog-node'
 import {
   CostOverride,
@@ -460,7 +460,7 @@ export const wrapVercelLanguageModel = <T extends LanguageModel>(
   phClient: PostHog,
   options: ClientOptions
 ): T => {
-  const traceId = options.posthogTraceId ?? uuidv4()
+  const traceId = options.posthogTraceId ?? uuidv7()
   const mergedOptions = {
     ...options,
     posthogTraceId: traceId,

--- a/packages/ai/tests/azure-openai.test.ts
+++ b/packages/ai/tests/azure-openai.test.ts
@@ -4,6 +4,8 @@ import openaiModule from 'openai'
 
 let mockAzureEmbeddingResponse: any = {}
 
+const UUIDV7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
 jest.mock('posthog-node', () => {
   return {
     PostHog: jest.fn().mockImplementation(() => {
@@ -708,7 +710,7 @@ describe('PostHogAzureOpenAI - Embeddings test suite', () => {
 
       // Should have a generated trace ID
       expect(typeof properties['$ai_trace_id']).toBe('string')
-      expect(properties['$ai_trace_id']).toHaveLength(36) // UUID v4 length
+      expect(properties['$ai_trace_id']).toMatch(UUIDV7_REGEX)
     })
 
     conditionalTest('embeddings with custom trace ID', async () => {

--- a/packages/ai/tests/azure-openai.test.ts
+++ b/packages/ai/tests/azure-openai.test.ts
@@ -1,10 +1,9 @@
 import { PostHog } from 'posthog-node'
 import { PostHogAzureOpenAI } from '../src/openai/azure'
 import openaiModule from 'openai'
+import { UUIDV7_REGEX } from './test-utils'
 
 let mockAzureEmbeddingResponse: any = {}
-
-const UUIDV7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 
 jest.mock('posthog-node', () => {
   return {

--- a/packages/ai/tests/captureAiGeneration.test.ts
+++ b/packages/ai/tests/captureAiGeneration.test.ts
@@ -2,6 +2,7 @@ import { PostHog } from 'posthog-node'
 import { captureAiGeneration } from '../src/captureAiGeneration'
 import { AIEvent } from '../src/utils'
 import { version } from '../package.json'
+import { UUIDV7_REGEX } from './test-utils'
 
 jest.mock('posthog-node')
 
@@ -11,8 +12,6 @@ const baseRequiredOptions = {
   input: 'hello',
   output: 'world',
 }
-
-const UUIDV7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 
 const buildClient = (overrides: Partial<{ enableExceptionAutocapture: boolean; privacy_mode: boolean }> = {}) =>
   ({

--- a/packages/ai/tests/captureAiGeneration.test.ts
+++ b/packages/ai/tests/captureAiGeneration.test.ts
@@ -12,6 +12,8 @@ const baseRequiredOptions = {
   output: 'world',
 }
 
+const UUIDV7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
 const buildClient = (overrides: Partial<{ enableExceptionAutocapture: boolean; privacy_mode: boolean }> = {}) =>
   ({
     capture: jest.fn(),
@@ -83,7 +85,7 @@ describe('captureAiGeneration', () => {
     await captureAiGeneration(client, baseRequiredOptions)
 
     const event = (client.capture as jest.Mock).mock.calls[0][0]
-    expect(event.properties.$ai_trace_id).toEqual(expect.any(String))
+    expect(event.properties.$ai_trace_id).toMatch(UUIDV7_REGEX)
     expect(event.distinctId).toBe(event.properties.$ai_trace_id)
     // Anonymous events disable person processing
     expect(event.properties.$process_person_profile).toBe(false)

--- a/packages/ai/tests/test-utils.ts
+++ b/packages/ai/tests/test-utils.ts
@@ -23,3 +23,5 @@ export async function waitForAsyncOperations(): Promise<void> {
 export async function flushPromises(): Promise<void> {
   await new Promise(process.nextTick)
 }
+
+export const UUIDV7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/

--- a/packages/ai/tests/utils.test.ts
+++ b/packages/ai/tests/utils.test.ts
@@ -1,6 +1,5 @@
 import { toContentString, getTokensSource, extractPosthogParams } from '../src/utils'
-
-const UUIDV7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+import { UUIDV7_REGEX } from './test-utils'
 
 describe('extractPosthogParams', () => {
   it('defaults missing trace IDs to UUID v7', () => {

--- a/packages/ai/tests/utils.test.ts
+++ b/packages/ai/tests/utils.test.ts
@@ -1,4 +1,16 @@
-import { toContentString, getTokensSource } from '../src/utils'
+import { toContentString, getTokensSource, extractPosthogParams } from '../src/utils'
+
+const UUIDV7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+describe('extractPosthogParams', () => {
+  it('defaults missing trace IDs to UUID v7', () => {
+    const { providerParams, posthogParams } = extractPosthogParams({ prompt: 'hello' } as { prompt: string })
+
+    expect(providerParams).toEqual({ prompt: 'hello' })
+    expect(posthogParams.traceId).toMatch(UUIDV7_REGEX)
+    expect(posthogParams.privacyMode).toBe(false)
+  })
+})
 
 describe('getTokensSource', () => {
   it.each([


### PR DESCRIPTION
## Problem

Generated AI trace IDs in `@posthog/ai` still used UUID v4, while other SDK-generated event/session IDs have moved to UUID v7 for time-ordered identifiers.

## Changes

- Use `uuidv7()` from the existing `@posthog/core` dependency for default AI trace IDs.
- Update the shared AI parameter defaults, `captureAiGeneration`, and the Vercel AI SDK wrapper.
- Update tests that validate generated AI trace IDs to assert UUID v7 format.
- Add a changeset for `@posthog/ai`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [x] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by a delegated worker agent using the local repository tools. The change keeps the migration scoped to generated `@posthog/ai` trace IDs and reuses `@posthog/core`'s existing UUID v7 helper rather than adding a new dependency.
