### PR TITLE
fix(react): filter disabled bootstrap active flags

### DIFF
--- a/.changeset/tall-flags-smile.md
+++ b/.changeset/tall-flags-smile.md
@@ -1,0 +1,5 @@
+---
+'@posthog/react': patch
+---
+
+Filter disabled bootstrap feature flags from useActiveFeatureFlags.

--- a/examples/example-convex/convex/example.test.ts
+++ b/examples/example-convex/convex/example.test.ts
@@ -70,11 +70,12 @@ function firstBatchEvent(): Record<string, unknown> {
 }
 
 async function finishScheduledFunctions(t: ReturnType<typeof initConvexTest>) {
-    // Run only the Convex scheduler timer that was pending before this call. `runAllTimers()` also
-    // executes timers created by the scheduled action itself, such as PostHog request timeout/retry
-    // timers, which can make these tests race or hang under fake timers.
-    await jest.runOnlyPendingTimersAsync()
-    await t.finishInProgressScheduledFunctions()
+    // Let convex-test advance scheduler timers and wait for each scheduled function to finish.
+    // A single timer pass can race with the scheduled action starting, which makes assertions
+    // observe no PostHog batch call or leaves scheduled writes running during the next test.
+    await t.finishAllScheduledFunctions(() => {
+        jest.runOnlyPendingTimers()
+    })
 }
 
 describe('capture', () => {

--- a/packages/react/src/hooks/__tests__/featureFlags.test.tsx
+++ b/packages/react/src/hooks/__tests__/featureFlags.test.tsx
@@ -103,7 +103,11 @@ describe('feature flag hooks', () => {
         expect(result.current).toEqual(['example_feature_true', 'multivariate_feature', 'example_feature_payload'])
     })
 
-    it('should only return enabled bootstrap feature flags as active', () => {
+    it.each([
+        ['enabled_flag', true],
+        ['disabled_flag', false],
+        ['multivariate_flag', true],
+    ])('should report bootstrap feature flag %s active status as %s', (flag, expected) => {
         const client = {
             onFeatureFlags: () => () => {},
             config: {
@@ -127,7 +131,7 @@ describe('feature flag hooks', () => {
         )
 
         const { result } = renderHook(() => useActiveFeatureFlags(), { wrapper })
-        expect(result.current).toEqual(['enabled_flag', 'multivariate_flag'])
+        expect(result.current.includes(flag)).toBe(expected)
     })
 
     it.each([

--- a/packages/react/src/hooks/__tests__/featureFlags.test.tsx
+++ b/packages/react/src/hooks/__tests__/featureFlags.test.tsx
@@ -103,6 +103,33 @@ describe('feature flag hooks', () => {
         expect(result.current).toEqual(['example_feature_true', 'multivariate_feature', 'example_feature_payload'])
     })
 
+    it('should only return enabled bootstrap feature flags as active', () => {
+        const client = {
+            onFeatureFlags: () => () => {},
+            config: {
+                bootstrap: {
+                    featureFlags: {
+                        enabled_flag: true,
+                        disabled_flag: false,
+                        multivariate_flag: 'variant-a',
+                    },
+                },
+            },
+            featureFlags: {
+                getFlags: () => [],
+                hasLoadedFlags: false,
+            } as unknown as PostHog['featureFlags'],
+        } as unknown as PostHog
+
+        // eslint-disable-next-line react/display-name
+        const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+            <PostHogProvider client={client}>{children}</PostHogProvider>
+        )
+
+        const { result } = renderHook(() => useActiveFeatureFlags(), { wrapper })
+        expect(result.current).toEqual(['enabled_flag', 'multivariate_flag'])
+    })
+
     it.each([
         ['example_feature_true', true],
         ['example_feature_false', false],

--- a/packages/react/src/hooks/useActiveFeatureFlags.ts
+++ b/packages/react/src/hooks/useActiveFeatureFlags.ts
@@ -14,7 +14,9 @@ export function useActiveFeatureFlags(): string[] {
 
     // if the client is not loaded yet and we have a bootstrapped value, use it
     if (!client?.featureFlags?.hasLoadedFlags && bootstrap?.featureFlags) {
-        return Object.keys(bootstrap.featureFlags)
+        return Object.entries(bootstrap.featureFlags)
+            .filter(([, value]) => value)
+            .map(([key]) => key)
     }
 
     return featureFlags


### PR DESCRIPTION
## Problem

`useActiveFeatureFlags()` returned all bootstrapped feature flag keys while flags were still loading, including flags explicitly set to `false`. This made disabled bootstrapped flags appear active. Fixes #3904.

## Changes

- Filter bootstrapped feature flags by enabled/truthy values before returning active flags.
- Keep multivariate string values active.
- Add parameterized React hook unit tests covering enabled, disabled, and multivariate bootstrap flags.
- Stabilize the Convex example unit-test scheduler helper by using `convex-test`'s `finishAllScheduledFunctions` loop, fixing the CI race where scheduled PostHog component actions were not always complete before assertions.
- Add a patch changeset for `@posthog/react`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [ ] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [x] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi after investigating issue #3904. Chose the smallest behavior change: match the existing active-flag semantics by excluding false bootstrap values while preserving true and multivariate string values. Updated the tests to use parameterized cases after review feedback. Follow-up CI investigation found a Convex example test race in the unit-test job and switched the scheduler helper to the `convex-test` helper that advances timers and waits for scheduled work in a loop.
