### PR TITLE
fix(browser): apply CSP hook to product tour styles

### DIFF
--- a/.changeset/gentle-tours-smile.md
+++ b/.changeset/gentle-tours-smile.md
@@ -1,0 +1,5 @@
+---
+'posthog-js': patch
+---
+
+Apply CSP stylesheet preparation hook to Product Tours styles.

--- a/packages/browser/src/__tests__/extensions/product-tours-utils.test.ts
+++ b/packages/browser/src/__tests__/extensions/product-tours-utils.test.ts
@@ -7,25 +7,74 @@ import {
     hasTourWaitPeriodPassed,
     getProductTourStylesheet,
 } from '../../extensions/product-tours/product-tours-utils'
+import { PostHog } from '../../posthog-core'
 import { ProductTourStep } from '../../posthog-product-tours-types'
 import { doesTourActivateByEvent, doesTourActivateByAction } from '../../utils/product-tour-utils'
 import { LAST_SEEN_TOUR_DATE_KEY_PREFIX } from '../../extensions/product-tours/constants'
 
 describe('getProductTourStylesheet', () => {
-    it('runs the stylesheet through prepare_external_dependency_stylesheet', () => {
-        const prepareExternalDependencyStylesheet = jest.fn((stylesheet: HTMLStyleElement) => {
-            stylesheet.setAttribute('nonce', 'test-nonce')
-            return stylesheet
-        })
+    it.each([
+        {
+            name: 'no posthog instance passed',
+            setup: () => ({}),
+            expectedHookCalls: 0,
+            expectedNonce: null,
+            expectedStylesheet: true,
+        },
+        {
+            name: 'posthog without prepare_external_dependency_stylesheet configured',
+            setup: () => ({ posthog: { config: {} } as unknown as PostHog }),
+            expectedHookCalls: 0,
+            expectedNonce: null,
+            expectedStylesheet: true,
+        },
+        {
+            name: 'runs the stylesheet through prepare_external_dependency_stylesheet',
+            setup: () => {
+                const prepareExternalDependencyStylesheet = jest.fn((stylesheet: HTMLStyleElement) => {
+                    stylesheet.setAttribute('nonce', 'test-nonce')
+                    return stylesheet
+                })
+                return {
+                    posthog: {
+                        config: { prepare_external_dependency_stylesheet: prepareExternalDependencyStylesheet },
+                    } as unknown as PostHog,
+                    prepareExternalDependencyStylesheet,
+                }
+            },
+            expectedHookCalls: 1,
+            expectedNonce: 'test-nonce',
+            expectedStylesheet: true,
+        },
+        {
+            name: 'returns null when prepare_external_dependency_stylesheet returns null',
+            setup: () => {
+                const prepareExternalDependencyStylesheet = jest.fn(() => null)
+                return {
+                    posthog: {
+                        config: { prepare_external_dependency_stylesheet: prepareExternalDependencyStylesheet },
+                    } as unknown as PostHog,
+                    prepareExternalDependencyStylesheet,
+                }
+            },
+            expectedHookCalls: 1,
+            expectedNonce: null,
+            expectedStylesheet: false,
+        },
+    ])('$name', ({ setup, expectedHookCalls, expectedNonce, expectedStylesheet }) => {
+        const { posthog, prepareExternalDependencyStylesheet } = setup() as {
+            posthog?: PostHog
+            prepareExternalDependencyStylesheet?: jest.Mock
+        }
 
-        const stylesheet = getProductTourStylesheet({
-            config: { prepare_external_dependency_stylesheet: prepareExternalDependencyStylesheet },
-        } as any)
+        const stylesheet = getProductTourStylesheet(posthog)
 
-        expect(prepareExternalDependencyStylesheet).toHaveBeenCalledTimes(1)
-        expect(prepareExternalDependencyStylesheet).toHaveBeenCalledWith(stylesheet)
-        expect(stylesheet?.getAttribute('nonce')).toBe('test-nonce')
-        expect(stylesheet?.getAttribute('data-ph-product-tour-style')).toBe('true')
+        if (prepareExternalDependencyStylesheet) {
+            expect(prepareExternalDependencyStylesheet).toHaveBeenCalledTimes(expectedHookCalls)
+        }
+        expect(!!stylesheet).toBe(expectedStylesheet)
+        expect(stylesheet?.getAttribute('nonce') ?? null).toBe(expectedNonce)
+        expect(stylesheet?.getAttribute('data-ph-product-tour-style') ?? null).toBe(expectedStylesheet ? 'true' : null)
     })
 })
 

--- a/packages/browser/src/__tests__/extensions/product-tours-utils.test.ts
+++ b/packages/browser/src/__tests__/extensions/product-tours-utils.test.ts
@@ -5,10 +5,29 @@ import {
     normalizeUrl,
     resolveStepTranslation,
     hasTourWaitPeriodPassed,
+    getProductTourStylesheet,
 } from '../../extensions/product-tours/product-tours-utils'
 import { ProductTourStep } from '../../posthog-product-tours-types'
 import { doesTourActivateByEvent, doesTourActivateByAction } from '../../utils/product-tour-utils'
 import { LAST_SEEN_TOUR_DATE_KEY_PREFIX } from '../../extensions/product-tours/constants'
+
+describe('getProductTourStylesheet', () => {
+    it('runs the stylesheet through prepare_external_dependency_stylesheet', () => {
+        const prepareExternalDependencyStylesheet = jest.fn((stylesheet: HTMLStyleElement) => {
+            stylesheet.setAttribute('nonce', 'test-nonce')
+            return stylesheet
+        })
+
+        const stylesheet = getProductTourStylesheet({
+            config: { prepare_external_dependency_stylesheet: prepareExternalDependencyStylesheet },
+        } as any)
+
+        expect(prepareExternalDependencyStylesheet).toHaveBeenCalledTimes(1)
+        expect(prepareExternalDependencyStylesheet).toHaveBeenCalledWith(stylesheet)
+        expect(stylesheet?.getAttribute('nonce')).toBe('test-nonce')
+        expect(stylesheet?.getAttribute('data-ph-product-tour-style')).toBe('true')
+    })
+})
 
 describe('calculateTooltipPosition', () => {
     const mockWindow = {

--- a/packages/browser/src/extensions/product-tours/preview.tsx
+++ b/packages/browser/src/extensions/product-tours/preview.tsx
@@ -1,5 +1,6 @@
 import { render, JSX } from 'preact'
 
+import { PostHog } from '../../posthog-core'
 import { ProductTourStep, ProductTourAppearance } from '../../posthog-product-tours-types'
 import { document as _document } from '../../utils/globals'
 import { ProductTourBanner } from './components/ProductTourBanner'
@@ -16,6 +17,7 @@ export interface RenderProductTourPreviewOptions {
     stepIndex?: number
     totalSteps?: number
     style?: JSX.CSSProperties
+    posthog?: PostHog
 }
 
 export function renderProductTourPreview({
@@ -25,6 +27,7 @@ export function renderProductTourPreview({
     stepIndex = 0,
     totalSteps = 1,
     style,
+    posthog,
 }: RenderProductTourPreviewOptions): void {
     parentElement.innerHTML = ''
 
@@ -33,7 +36,7 @@ export function renderProductTourPreview({
     parentElement.appendChild(shadowHost)
     const shadow = shadowHost.attachShadow({ mode: 'open' })
 
-    const stylesheet = getProductTourStylesheet()
+    const stylesheet = getProductTourStylesheet(posthog)
     if (stylesheet) {
         shadow.appendChild(stylesheet)
     }

--- a/packages/browser/src/extensions/product-tours/product-tours-utils.ts
+++ b/packages/browser/src/extensions/product-tours/product-tours-utils.ts
@@ -1,5 +1,6 @@
 import DOMPurify from 'dompurify'
 
+import { PostHog } from '../../posthog-core'
 import {
     JSONContent,
     ProductTourAppearance,
@@ -25,8 +26,12 @@ const logger = createLogger('[Product Tours]')
 const document = _document as Document
 const window = _window as Window & typeof globalThis
 
-export function getProductTourStylesheet(): HTMLStyleElement | null {
-    const stylesheet = prepareStylesheet(document, typeof productTourStyles === 'string' ? productTourStyles : '')
+export function getProductTourStylesheet(posthog?: PostHog): HTMLStyleElement | null {
+    const stylesheet = prepareStylesheet(
+        document,
+        typeof productTourStyles === 'string' ? productTourStyles : '',
+        posthog
+    )
     stylesheet?.setAttribute('data-ph-product-tour-style', 'true')
     return stylesheet
 }

--- a/packages/browser/src/extensions/product-tours/product-tours.tsx
+++ b/packages/browser/src/extensions/product-tours/product-tours.tsx
@@ -124,7 +124,7 @@ interface TriggerListenerData {
     tour: ProductTour
 }
 
-function retrieveTourShadow(tour: ProductTour): { shadow: ShadowRoot; isNewlyCreated: boolean } {
+function retrieveTourShadow(tour: ProductTour, posthog: PostHog): { shadow: ShadowRoot; isNewlyCreated: boolean } {
     const containerClass = `${CONTAINER_CLASS}-${tour.id}`
     const existingDiv = document.querySelector(`.${containerClass}`)
 
@@ -142,7 +142,7 @@ function retrieveTourShadow(tour: ProductTour): { shadow: ShadowRoot; isNewlyCre
 
     const shadow = div.attachShadow({ mode: 'open' })
 
-    const stylesheet = getProductTourStylesheet()
+    const stylesheet = getProductTourStylesheet(posthog)
     if (stylesheet) {
         shadow.appendChild(stylesheet)
     }
@@ -157,6 +157,7 @@ function retrieveTourShadow(tour: ProductTour): { shadow: ShadowRoot; isNewlyCre
 
 function retrieveBannerShadow(
     tour: ProductTour,
+    posthog: PostHog,
     bannerConfig?: ProductTourBannerConfig
 ): { shadow: ShadowRoot; isNewlyCreated: boolean } | null {
     const containerClass = `${CONTAINER_CLASS}-${tour.id}`
@@ -180,7 +181,7 @@ function retrieveBannerShadow(
 
     const shadow = div.attachShadow({ mode: 'open' })
 
-    const stylesheet = getProductTourStylesheet()
+    const stylesheet = getProductTourStylesheet(posthog)
     if (stylesheet) {
         shadow.appendChild(stylesheet)
     }
@@ -841,7 +842,7 @@ export class ProductTourManager {
             return
         }
 
-        const { shadow } = retrieveTourShadow(this._activeTour)
+        const { shadow } = retrieveTourShadow(this._activeTour, this._instance)
 
         render(
             <ProductTourTooltip
@@ -870,7 +871,7 @@ export class ProductTourManager {
             return
         }
 
-        const result = retrieveBannerShadow(this._activeTour, step.bannerConfig)
+        const result = retrieveBannerShadow(this._activeTour, this._instance, step.bannerConfig)
 
         if (!result) {
             this._captureEvent(ProductTourEventName.BANNER_CONTAINER_SELECTOR_FAILED, {


### PR DESCRIPTION
## Problem

Product Tours injects its shadow DOM stylesheet without passing it through `prepare_external_dependency_stylesheet`. Customers using strict nonce-based CSP policies can therefore have Product Tours styles blocked even when they configure the stylesheet preparation hook.

Fixes #3907

## Changes

- Thread the PostHog instance into Product Tours stylesheet creation so `prepare_external_dependency_stylesheet` can add attributes such as a CSP nonce.
- Pass the instance from tooltip, banner, and preview rendering paths.
- Add parameterized unit coverage for Product Tours stylesheet preparation, including missing hooks and hooks returning `null`.
- Add a patch changeset for `posthog-js`.

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi after investigating issue #3907. Chose the same stylesheet preparation helper used by Surveys and kept the change scoped to passing the existing PostHog instance into Product Tours stylesheet creation, including the preview renderer API.

Validation run:

```bash
pnpm turbo --filter=posthog-js test:unit -- --runTestsByPath src/__tests__/extensions/product-tours-utils.test.ts
cd packages/browser && pnpm exec eslint src/extensions/product-tours/product-tours-utils.ts src/extensions/product-tours/product-tours.tsx src/extensions/product-tours/preview.tsx src/__tests__/extensions/product-tours-utils.test.ts
```
