### PR TITLE
fix(rrweb): avoid CSP violations for style mutation diffs

### DIFF
--- a/.changeset/quiet-spiders-dance.md
+++ b/.changeset/quiet-spiders-dance.md
@@ -1,0 +1,6 @@
+---
+'@posthog/rrweb': patch
+'posthog-js': patch
+---
+
+Avoid `style-src-attr` CSP violations when diffing rrweb style mutations.

--- a/.changeset/quiet-spiders-dance.md
+++ b/.changeset/quiet-spiders-dance.md
@@ -1,5 +1,5 @@
 ---
-'@posthog/rrweb': patch
+'posthog-js': patch
 ---
 
 Avoid `style-src-attr` CSP violations when diffing rrweb style mutations.

--- a/.changeset/quiet-spiders-dance.md
+++ b/.changeset/quiet-spiders-dance.md
@@ -1,6 +1,5 @@
 ---
 '@posthog/rrweb': patch
-'posthog-js': patch
 ---
 
 Avoid `style-src-attr` CSP violations when diffing rrweb style mutations.

--- a/packages/rrweb/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/rrweb/src/record/mutation.ts
@@ -687,7 +687,7 @@ export default class MutationBuffer {
             }
             const old = this.unattachedDoc.createElement('span');
             if (m.oldValue) {
-              old.setAttribute('style', m.oldValue);
+              old.style.cssText = m.oldValue;
             }
             for (const pname of Array.from(target.style)) {
               const newValue = target.style.getPropertyValue(pname);

--- a/packages/rrweb/rrweb/test/integration.test.ts
+++ b/packages/rrweb/rrweb/test/integration.test.ts
@@ -325,6 +325,47 @@ describe('record integration tests', function (this: ISuite) {
     await assertSnapshot(snapshots);
   });
 
+  it('does not trigger style-src-attr CSP violations while diffing style mutations', async () => {
+    const page: puppeteer.Page = await browser.newPage();
+    const client = await page.target().createCDPSession();
+    const cspViolations: string[] = [];
+    const collectCSPViolation = (text: string) => {
+      if (text.includes('style-src-attr')) {
+        cspViolations.push(text);
+      }
+    };
+
+    await client.send('Log.enable');
+    client.on('Log.entryAdded', ({ entry }) => collectCSPViolation(entry.text));
+    page.on('console', (message) => collectCSPViolation(message.text()));
+
+    await page.goto('about:blank');
+    await page.setContent(`
+      <!doctype html>
+      <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline'; style-src 'self'; style-src-attr 'none'">
+      <body>
+        <div id="target"></div>
+        <script>
+          ${code}
+          ${generateRecordSnippet({})}
+        </script>
+      </body>
+    `);
+
+    await page.evaluate(() => {
+      (document.getElementById('target') as HTMLElement).style.color = 'green';
+    });
+    await waitForRAF(page);
+    await page.evaluate(() => {
+      (document.getElementById('target') as HTMLElement).style.color = 'blue';
+    });
+    await waitForRAF(page);
+
+    expect(cspViolations).toEqual([]);
+    await client.detach();
+    await page.close();
+  });
+
   it('can freeze mutations', async () => {
     const page: puppeteer.Page = await browser.newPage();
     await page.goto('about:blank');


### PR DESCRIPTION
## Problem

Fixes #3906.

Strict CSP configurations with `style-src-attr` disabled report violations during session recording whenever rrweb diffs a `style` attribute mutation. The recorder parsed the previous style value by calling `setAttribute('style', oldValue)` on a throwaway element, which still triggers CSP evaluation.

## Changes

- Parse the previous style value with `old.style.cssText = m.oldValue` instead of `setAttribute('style', ...)` so CSSOM can diff styles without triggering `style-src-attr`.
- Added a Puppeteer-backed rrweb integration test that records style mutations under `style-src-attr 'none'` and asserts no CSP violation is emitted.
- Added a patch changeset for `posthog-js`, which bundles the rrweb recorder into the browser SDK during release.

Validation:

- `pnpm --filter @posthog/rrweb build`
- `PUPPETEER_HEADLESS=true pnpm --filter @posthog/rrweb exec vitest run test/integration.test.ts -t "does not trigger style-src-attr"`
- Standalone Puppeteer reproduction against the rebuilt rrweb bundle: `cspViolationCount: 0`
- `pnpm eslint packages/rrweb/rrweb/src/record/mutation.ts packages/rrweb/rrweb/test/integration.test.ts`

## Release info Sub-libraries affected

### Libraries affected

- [ ] All of them
- [x] posthog-js (web)
- [ ] posthog-js-lite (web lite)
- [ ] posthog-node
- [ ] posthog-react-native
- [ ] @posthog/react-native-plugin
- [ ] @posthog/react
- [ ] @posthog/ai
- [ ] @posthog/convex
- [ ] @posthog/next
- [ ] @posthog/nextjs-config
- [ ] @posthog/nuxt
- [ ] @posthog/rollup-plugin
- [ ] @posthog/webpack-plugin
- [ ] @posthog/types

## Checklist

- [x] Tests for new code
- [x] Accounted for the impact of any changes across different platforms
- [x] Accounted for backwards compatibility of any changes (no breaking changes!)
- [x] Took care not to unnecessarily increase the bundle size

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the pi coding agent in a dedicated worktree. The fix keeps the existing style-diffing behavior but switches the parsing mechanism from a style attribute write to CSSOM `cssText`, which the focused Puppeteer reproduction confirmed avoids `style-src-attr` CSP reports.


